### PR TITLE
[FEATURE] Rejeter la finalisation de la session si un motif d'abandon a été saisi pour un candidat qui a fini son test (PIX-5149)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -328,6 +328,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.SessionWithoutStartedCertificationError) {
     return new HttpErrors.BadRequestError(error.message);
   }
+  if (error instanceof DomainErrors.SessionWithAbortReasonOnCompletedCertificationCourseError) {
+    return new HttpErrors.ConflictError(error.message);
+  }
   if (error instanceof DomainErrors.SessionStartedDeletionError) {
     return new HttpErrors.ConflictError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -867,6 +867,14 @@ class SessionWithoutStartedCertificationError extends DomainError {
   }
 }
 
+class SessionWithAbortReasonOnCompletedCertificationCourseError extends DomainError {
+  constructor(
+    message = 'Le champ “Raison de l’abandon” a été renseigné pour un candidat qui a terminé son test de certification entre temps. La session ne peut donc pas être finalisée. Merci de rafraîchir la page avant de finaliser.'
+  ) {
+    super(message);
+  }
+}
+
 class SessionAlreadyPublishedError extends DomainError {
   constructor(message = 'La session est déjà publiée.') {
     super(message);
@@ -1308,6 +1316,7 @@ module.exports = {
   SessionNotAccessible,
   SessionStartedDeletionError,
   SessionWithoutStartedCertificationError,
+  SessionWithAbortReasonOnCompletedCertificationCourseError,
   SiecleXmlImportError,
   SupervisorAccessNotAuthorizedError,
   TargetProfileInvalidError,

--- a/api/lib/domain/usecases/finalize-session.js
+++ b/api/lib/domain/usecases/finalize-session.js
@@ -1,11 +1,17 @@
-const { SessionAlreadyFinalizedError, SessionWithoutStartedCertificationError } = require('../errors');
+const {
+  SessionAlreadyFinalizedError,
+  SessionWithoutStartedCertificationError,
+  SessionWithAbortReasonOnCompletedCertificationCourseError,
+} = require('../errors');
 const SessionFinalized = require('../events/SessionFinalized');
+const bluebird = require('bluebird');
 
 module.exports = async function finalizeSession({
   sessionId,
   examinerGlobalComment,
   certificationReports,
   sessionRepository,
+  certificationCourseRepository,
   certificationReportRepository,
   hasIncident,
   hasJoiningIssue,
@@ -14,12 +20,31 @@ module.exports = async function finalizeSession({
 
   const hasNoStartedCertification = await sessionRepository.hasNoStartedCertification(sessionId);
 
+  const uncompletedCertificationCount = await sessionRepository.countUncompletedCertifications(sessionId);
+
+  const abortReasonCount = _countAbortReasons(certificationReports);
+
   if (isSessionAlreadyFinalized) {
     throw new SessionAlreadyFinalizedError('Cannot finalize session more than once');
   }
 
   if (hasNoStartedCertification) {
     throw new SessionWithoutStartedCertificationError();
+  }
+
+  if (
+    _hasAbortReasonForCompletedCertificationCourse({
+      abortReasonCount,
+      uncompletedCertificationCount,
+    })
+  ) {
+    await _removeAbortReasonFromCompletedCertificationCourses({
+      certificationCourseRepository,
+      certificationReports,
+      sessionId,
+    });
+
+    throw new SessionWithAbortReasonOnCompletedCertificationCourseError();
   }
 
   certificationReports.forEach((certifReport) => certifReport.validateForFinalization());
@@ -43,3 +68,36 @@ module.exports = async function finalizeSession({
     sessionTime: finalizedSession.time,
   });
 };
+
+function _hasAbortReasonForCompletedCertificationCourse({ abortReasonCount, uncompletedCertificationCount }) {
+  return abortReasonCount > uncompletedCertificationCount;
+}
+
+function _countAbortReasons(certificationReports) {
+  return certificationReports.filter(({ abortReason }) => abortReason).length;
+}
+
+async function _removeAbortReasonFromCompletedCertificationCourses({
+  certificationCourseRepository,
+  certificationReports,
+  sessionId,
+}) {
+  const sessionCertificationCourses = await certificationCourseRepository.findCertificationCoursesBySessionId({
+    sessionId,
+  });
+  for (const sessionCertificationCourse of sessionCertificationCourses) {
+    await bluebird.mapSeries(
+      certificationReports,
+      async ({ certificationCourseId: abortReasonCertificationCourseId, abortReason }) => {
+        if (
+          sessionCertificationCourse.getId() === abortReasonCertificationCourseId &&
+          abortReason &&
+          sessionCertificationCourse.isCompleted()
+        ) {
+          sessionCertificationCourse.unabort();
+          await certificationCourseRepository.update(sessionCertificationCourse);
+        }
+      }
+    );
+  }
+}

--- a/api/lib/infrastructure/repositories/sessions/session-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-repository.js
@@ -200,6 +200,15 @@ module.exports = {
     const result = await knex.select(1).from('certification-courses').where('sessionId', sessionId).first();
     return !result;
   },
+
+  async countUncompletedCertifications(sessionId) {
+    const { count } = await knex
+      .count('id')
+      .from('certification-courses')
+      .where({ sessionId, completedAt: null })
+      .first();
+    return count;
+  },
 };
 
 function _toDomain(results) {

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -309,6 +309,16 @@ describe('Integration | API | Controller Error', function () {
         "L'invitation à rejoindre l'organisation a déjà été acceptée ou annulée."
       );
     });
+
+    it('responds Bad Request when a SessionWithAbortReasonOnCompletedCertificationCourseError error occurs', async function () {
+      routeHandler.throws(new DomainErrors.SessionWithAbortReasonOnCompletedCertificationCourseError());
+      const response = await server.requestObject(request);
+
+      expect(response.statusCode).to.equal(CONFLICT_ERROR);
+      expect(responseDetail(response)).to.equal(
+        'Le champ “Raison de l’abandon” a été renseigné pour un candidat qui a terminé son test de certification entre temps. La session ne peut donc pas être finalisée. Merci de rafraîchir la page avant de finaliser.'
+      );
+    });
   });
 
   context('403 Forbidden', function () {

--- a/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
@@ -870,4 +870,35 @@ describe('Integration | Repository | Session', function () {
       });
     });
   });
+
+  describe('#countUncompletedCertifications', function () {
+    context('when session has at least one uncompleted certification course', function () {
+      it('should return the count of uncompleted certification courses', async function () {
+        // given
+        const sessionId = databaseBuilder.factory.buildSession({}).id;
+        const userId1 = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCandidate({ sessionId, userId: userId1 });
+        databaseBuilder.factory.buildCertificationCourse({
+          sessionId,
+          userId: userId1,
+          completedAt: null,
+        });
+        const userId2 = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCandidate({ sessionId, userId: userId2 });
+        databaseBuilder.factory.buildCertificationCourse({
+          sessionId,
+          userId: userId2,
+          completedAt: null,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const unfinishedCertificationsCount = await sessionRepository.countUncompletedCertifications(sessionId);
+
+        // then
+        expect(unfinishedCertificationsCount).to.equal(2);
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -146,6 +146,10 @@ describe('Unit | Domain | Errors', function () {
     expect(errors.SessionWithoutStartedCertificationError).to.exist;
   });
 
+  it('should export a SessionWithAbortReasonOnCompletedCertificationCourseError', function () {
+    expect(errors.SessionWithAbortReasonOnCompletedCertificationCourseError).to.exist;
+  });
+
   it('should export a TargetProfileInvalidError', function () {
     expect(errors.TargetProfileInvalidError).to.exist;
   });

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -69,6 +69,10 @@ export default class SessionsFinalizeController extends Controller {
       await this.session.save({ adapterOptions: { finalization: true } });
       this.showSuccessNotification('Les informations de la session ont été transmises avec succès.');
     } catch (err) {
+      if (err.errors?.[0]?.status === '409') {
+        this.showConfirmModal = false;
+        return this.showErrorNotification(err.errors[0].detail);
+      }
       if (_isSessionNotStartedError(err)) {
         this.showErrorNotification(
           "Cette session n'a pas débuté, vous ne pouvez pas la finaliser. Vous pouvez néanmoins la supprimer."

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -446,5 +446,35 @@ module('Acceptance | Session Finalization', function (hooks) {
         assert.dom(screen.getByText('Nom du site')).exists();
       });
     });
+
+    module(
+      'When certificationPointOfContact tries to finalize a session with abort reason on completed certification',
+      function () {
+        test('it should close confirmation modal and show an error', async function (assert) {
+          // given
+          this.server.put(
+            `/sessions/${session.id}/finalization`,
+            () => ({
+              errors: [
+                {
+                  detail: 'Perdu, essaie encore',
+                  status: '409',
+                },
+              ],
+            }),
+            409
+          );
+          // when
+          const screen = await visitScreen(`/sessions/${session.id}/finalisation`);
+
+          await click(screen.getByRole('button', { name: 'Finaliser' }));
+          await click(screen.getByText('Confirmer la finalisation'));
+
+          // then
+          assert.dom(screen.getByText('Perdu, essaie encore')).exists();
+          assert.dom(screen.queryByText('Confirmer la finalisation')).doesNotExist();
+        });
+      }
+    );
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Il est possible pour un surveillant de finaliser une session avec une raison d'abandon pour un candidat aillant terminé son test de certification

## :robot: Solution
Rejeter la finalisation de la session si un motif d'abandon a été saisi pour un candidat qui a fini son test 


## :100: Pour tester
- Créer une session de certification
- Entrer en test de certification
- Ouvrir la page de finalisation et selectioner une raison d'abandon
- Aller jusqu'au bout du test de certification avec le candidat
- Sur la page de finalisation, ne pas rafraichir la page et tenter de finaliser la session avec la raison d'abandon toujours renseignée
- Constater l'impossibilité de finaliser avec le message d'erreur suivant : 
  - "Le champ “Raison de l’abandon” a été renseigné pour un candidat qui a terminé son test de certification. La session ne peut donc pas être finalisée. Merci de rafraîchir la page avant de finaliser."