### PR TITLE
[FEATURE] Rendre les profils cibles facultatif dans le script OGA (PIX-5821).

### DIFF
--- a/api/lib/domain/validators/organization-with-tags-and-target-profiles-script.js
+++ b/api/lib/domain/validators/organization-with-tags-and-target-profiles-script.js
@@ -56,9 +56,6 @@ const schema = Joi.object({
   createdBy: Joi.number().required().messages({
     'number.base': "L'id du créateur doit être un nombre",
   }),
-  targetProfiles: Joi.string().required().messages({
-    'string.empty': 'Les profiles cibles ne sont pas renseignés.',
-  }),
 });
 
 module.exports = {

--- a/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -264,10 +264,6 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           attribute: 'createdBy',
           message: "L'id du créateur doit être un nombre",
         },
-        {
-          attribute: 'targetProfiles',
-          message: 'Les profiles cibles ne sont pas renseignés.',
-        },
       ]);
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il existe un script pour créer des organisations avec leurs profils cibles en masse. Les profils cibles sont actuellement obligatoire et ne devrait pas l'être.

## :robot: Solution
Enlever la validation sur le champ des profils cibles.

## :rainbow: Remarques
RAS

## :100: Pour tester
Créer un CSV `OGA.csv` avec le texte suivant et sauvegarder le dans un répertoire.

```
type,externalId,name,provinceCode,credit,emailInvitations,emailForSCOActivation,organizationInvitationRole,locale,tags,createdBy,documentationUrl,targetProfiles,isManagingStudents,identityProviderForCampaigns,DPOFirstName,DPOLastName,DPOEmail
PRO,1,Test 1,,,sco.admin @  exa mplE.net,superadmin@example.net,ADMIN,fr-fr,CFA,1,http://test.com,,,,Annie,Mâle,superadmin@example.net
PRO,2,Test 2,,,sco.admin@ExAmple.net,,ADMIN,,CFA,1,http://test.com,4_5_7,,,,,
PRO,3,Test 3,,,sco.admin@example.net,,ADMIN,fr-fr,CFA,1,http://test.com,,,POLE_EMPLOI,Djamal,Dormi,sco.admin@example.net
SCO,4,Test 4,,,sco.admin@example.net,superadmin@example.net,ADMIN,fr-fr,CFA,1,http://test.com,4_5_7,,GAR,,Djabouz,superadmin@example.net
PRO,5,Test 5,,,sco.admin@example.net,,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,,,,,
SCO,6,Test 6,,,sco.admin@example.net,,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,true,,,,
PRO,7,Test 7,,,sco.admin@example.net,,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,,,,,
PRO,8,Test 8,,,sco.admin@example.net,,MEMBER,,CFA,1,http://test.com,4_5_7,,CNAV,,,
SUP,9,Test 9,,,sco.admin@example.net,superadmin@example.net,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,,,,,
PRO,10,Test 10,,,sco.admin@example.net,,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,,,,,
PRO,11,Test 11,,,sco.admin@example.net,,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,,,,,
PRO,12,Test 12,,0,sco.admin@example.net,,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,,,,,
```

Lancer la commande `node scripts/create-organizations-with-tags-and-target-profiles.js /repertoire/OGA.csv`

Vérifier que les orga Test 1 et Test 3 n'ont pas de profils cibles dans la table `target-profile-shares`