### PR TITLE
[BUGFIX] Utiliser le nombre de participants remonté par la pagination des participants (PIX-5650)

### DIFF
--- a/orga/app/templates/authenticated/organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/organization-participants/list.hbs
@@ -2,7 +2,7 @@
 
 <div class="organization-participant-list-page">
   <OrganizationParticipant::Header @participantCount={{@model.meta.participantCount}} />
-  {{#if this.currentUser.prescriber.hasParticipants}}
+  {{#if @model.meta.participantCount}}
     <OrganizationParticipant::List
       @participants={{@model}}
       @triggerFiltering={{this.triggerFiltering}}

--- a/orga/mirage/handlers/find-filtered-paginated-organization-participants.js
+++ b/orga/mirage/handlers/find-filtered-paginated-organization-participants.js
@@ -19,6 +19,7 @@ export function findFilteredPaginatedOrganizationParticipants(schema, request) {
     pageSize: pagination.pageSize,
     rowCount,
     pageCount: Math.ceil(rowCount / pagination.pageSize),
+    participantCount: rowCount,
   };
   return json;
 }

--- a/orga/tests/acceptance/organization-participant-list_test.js
+++ b/orga/tests/acceptance/organization-participant-list_test.js
@@ -38,7 +38,7 @@ module('Acceptance | Organization Participant List', function (hooks) {
 
         // when
         server.create('organization-participant', { organizationId, firstName: 'Xavier', lastName: 'Charles' });
-        createPrescriberByUser(user, 1);
+
         await authenticateSession(user.id);
         await visit('/participants');
 


### PR DESCRIPTION
## :unicorn: Problème
Le nombre de participants remonté par l'appel au prescriber n'est pas cohérent avec la remontée des données de la liste des participants

## :robot: Solution
Utiliser le nombre de participants remonté par la liste de la page pour afficher l'empty state

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter sur PixOrga , pro.admin@example.net, vérifier que l'empty state s'affiche correctement