### PR TITLE
[FEATURE] Rendre certains champs facultatifs dans le script OGA (PIX-5825).

### DIFF
--- a/api/lib/domain/validators/organization-with-tags-and-target-profiles-script.js
+++ b/api/lib/domain/validators/organization-with-tags-and-target-profiles-script.js
@@ -23,9 +23,6 @@ const schema = Joi.object({
   tags: Joi.string().required().messages({
     'string.empty': 'Les tags ne sont pas renseignés.',
   }),
-  documentationUrl: Joi.string().uri().required().messages({
-    'string.empty': "L'url de documentation n'est pas renseignée.",
-  }),
   locale: Joi.string().required().valid('fr-fr', 'fr', 'en').default('fr-fr').messages({
     'string.empty': "La locale n'est pas renseignée.",
     'any.only': "La locale doit avoir l'une des valeurs suivantes : fr-fr, fr ou en",
@@ -40,7 +37,7 @@ const schema = Joi.object({
   credit: Joi.number().required().messages({
     'number.base': 'Le crédit doit être un entier.',
   }),
-  emailInvitations: Joi.string().email().messages({
+  emailInvitations: Joi.string().email().allow('', null).messages({
     'string.email': "L'email fourni n'est pas valide.",
   }),
   emailForSCOActivation: Joi.string().email().allow('', null).messages({
@@ -49,10 +46,12 @@ const schema = Joi.object({
   DPOEmail: Joi.string().email().allow('', null).messages({
     'string.email': "L'email fourni n'est pas valide.",
   }),
-  organizationInvitationRole: Joi.string().valid(Membership.roles.ADMIN, Membership.roles.MEMBER).required().messages({
-    'string.empty': 'Le rôle n’est pas renseigné.',
-    'any.only': "Le rôle fourni doit avoir l'une des valeurs suivantes : ADMIN ou MEMBER",
-  }),
+  organizationInvitationRole: Joi.string()
+    .allow('', null)
+    .valid(Membership.roles.ADMIN, Membership.roles.MEMBER)
+    .messages({
+      'any.only': "Le rôle fourni doit avoir l'une des valeurs suivantes : ADMIN ou MEMBER",
+    }),
   createdBy: Joi.number().required().messages({
     'number.base': "L'id du créateur doit être un nombre",
   }),

--- a/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
+++ b/api/tests/integration/domain/usecases/create-organizations-with-tags-and-target-profiles_test.js
@@ -237,10 +237,6 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
           message: 'Les tags ne sont pas renseignés.',
         },
         {
-          attribute: 'documentationUrl',
-          message: "L'url de documentation n'est pas renseignée.",
-        },
-        {
           attribute: 'locale',
           message: "La locale doit avoir l'une des valeurs suivantes : fr-fr, fr ou en",
         },
@@ -251,14 +247,6 @@ describe('Integration | UseCases | create-organizations-with-tags-and-target-pro
         {
           attribute: 'credit',
           message: 'Le crédit doit être un entier.',
-        },
-        {
-          attribute: 'organizationInvitationRole',
-          message: "Le rôle fourni doit avoir l'une des valeurs suivantes : ADMIN ou MEMBER",
-        },
-        {
-          attribute: 'organizationInvitationRole',
-          message: 'Le rôle n’est pas renseigné.',
         },
         {
           attribute: 'createdBy',


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il existe un script pour créer des organisations en masse. Certains champs étaient obligatoire et ne devrait plus l'être.

## :robot: Solution
Enlever la validation sur ces champs.

## :rainbow: Remarques
RAS

## :100: Pour tester
Créer un CSV `OGA.csv` avec le texte suivant et sauvegarder le dans un répertoire.

```
type,externalId,name,provinceCode,credit,emailInvitations,emailForSCOActivation,organizationInvitationRole,locale,tags,createdBy,documentationUrl,targetProfiles,isManagingStudents,identityProviderForCampaigns,DPOFirstName,DPOLastName,DPOEmail
PRO,1,Test 1,,,sco.admin @  exa mplE.net,superadmin@example.net,ADMIN,fr-fr,CFA,1,http://test.com,,,,Annie,Mâle,superadmin@example.net
PRO,2,Test 2,,,sco.admin@ExAmple.net,,ADMIN,,CFA,1,,4_5_7,,,,,
PRO,3,Test 3,,,sco.admin@example.net,,ADMIN,fr-fr,CFA,1,http://test.com,,,POLE_EMPLOI,Djamal,Dormi,sco.admin@example.net
SCO,4,Test 4,,,,superadmin@example.net,,fr-fr,CFA,1,,,,GAR,,Djabouz,superadmin@example.net
PRO,5,Test 5,,,sco.admin@example.net,,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,,,,,
SCO,6,Test 6,,,sco.admin@example.net,,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,true,,,,
PRO,7,Test 7,,,sco.admin@example.net,,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,,,,,
PRO,8,Test 8,,,sco.admin@example.net,,MEMBER,,CFA,1,http://test.com,4_5_7,,CNAV,,,
SUP,9,Test 9,,,sco.admin@example.net,superadmin@example.net,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,,,,,
PRO,10,Test 10,,,sco.admin@example.net,,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,,,,,
PRO,11,Test 11,,,sco.admin@example.net,,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,,,,,
PRO,12,Test 12,,0,sco.admin@example.net,,MEMBER,fr-fr,CFA,1,http://test.com,4_5_7,,,,,
```

Lancer la commande `node scripts/create-organizations-with-tags-and-target-profiles.js /repertoire/OGA.csv`