### PR TITLE
[BUGFIX] Ne plus retirer un prescrit importé de l'onglet "élèves/étudiants" si on supprime toutes ses participations (PIX-5811)

### DIFF
--- a/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
@@ -104,7 +104,11 @@ module.exports = {
       ])
       .from('organization-learners')
       .leftJoin('subquery', 'subquery.organizationLearnerId', 'organization-learners.id')
-      .leftJoin('campaign-participations', 'campaign-participations.organizationLearnerId', 'organization-learners.id')
+      .leftJoin('campaign-participations', function () {
+        this.on('campaign-participations.organizationLearnerId', 'organization-learners.id')
+          .andOn('campaign-participations.isImproved', '=', knex.raw('false'))
+          .andOn('campaign-participations.deletedAt', knex.raw('is'), knex.raw('null'));
+      })
       .leftJoin('users', 'users.id', 'organization-learners.userId')
       .leftJoin('authentication-methods', function () {
         this.on('users.id', 'authentication-methods.userId').andOnVal(
@@ -117,13 +121,6 @@ module.exports = {
           'campaigns.organizationId',
           'organization-learners.organizationId'
         );
-      })
-      .where(function (qb) {
-        qb.where({ 'campaign-participations.id': null });
-        qb.orWhere({
-          'campaign-participations.isImproved': false,
-          'campaign-participations.deletedAt': null,
-        });
       })
       .where('organization-learners.isDisabled', false)
       .where('organization-learners.organizationId', organizationId)

--- a/api/lib/infrastructure/repositories/sup-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sup-organization-participant-repository.js
@@ -81,19 +81,16 @@ module.exports = {
       ])
       .from('organization-learners')
       .leftJoin('subquery', 'subquery.organizationLearnerId', 'organization-learners.id')
-      .leftJoin('campaign-participations', 'campaign-participations.organizationLearnerId', 'organization-learners.id')
+      .leftJoin('campaign-participations', function () {
+        this.on('campaign-participations.organizationLearnerId', 'organization-learners.id')
+          .andOn('campaign-participations.isImproved', '=', knex.raw('false'))
+          .andOn('campaign-participations.deletedAt', knex.raw('is'), knex.raw('null'));
+      })
       .leftJoin('campaigns', function () {
         this.on('campaigns.id', 'campaign-participations.campaignId').andOn(
           'campaigns.organizationId',
           'organization-learners.organizationId'
         );
-      })
-      .where(function (qb) {
-        qb.where({ 'campaign-participations.id': null });
-        qb.orWhere({
-          'campaign-participations.isImproved': false,
-          'campaign-participations.deletedAt': null,
-        });
       })
       .where('organization-learners.isDisabled', false)
       .where('organization-learners.organizationId', organizationId)

--- a/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
@@ -132,6 +132,31 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
       ]);
     });
 
+    it('should return sco participants with deleted participations', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const campaignId = databaseBuilder.factory.buildCampaign({
+        organizationId: organization.id,
+      }).id;
+      const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+        isDisabled: false,
+        organizationId: organization.id,
+      }).id;
+
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId, deletedAt: new Date() });
+
+      await databaseBuilder.commit();
+
+      // when
+      const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+        organizationId: organization.id,
+      });
+
+      // then
+      expect(data).to.have.lengthOf(1);
+      expect(data[0].id).to.equal(organizationLearnerId);
+    });
+
     describe('When organizationLearner is filtered', function () {
       it('should return sco participants filtered by search', async function () {
         // given

--- a/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
@@ -95,6 +95,31 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
       expect(data[0].id).to.equal(organizationLearner.id);
     });
 
+    it('should return sup participants with deleted participations', async function () {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const campaignId = databaseBuilder.factory.buildCampaign({
+        organizationId: organization.id,
+      }).id;
+      const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+        isDisabled: false,
+        organizationId: organization.id,
+      }).id;
+
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, organizationLearnerId, deletedAt: new Date() });
+
+      await databaseBuilder.commit();
+
+      // when
+      const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+        organizationId: organization.id,
+      });
+
+      // then
+      expect(data).to.have.lengthOf(1);
+      expect(data[0].id).to.equal(organizationLearnerId);
+    });
+
     it('should order organizationLearners by lastName and then by firstName with no sensitive case', async function () {
       // given
       const organization = databaseBuilder.factory.buildOrganization();


### PR DESCRIPTION
## :unicorn: Problème
Dans [cette PR](https://github.com/1024pix/pix/pull/4875), on a ajouté le nombre de participants/étudiants/élèves dans le titre de la page.

Pour l’onglet élèves/étudiants (orga SCO et SUP avec import), si on supprime toutes les participations pour un élève/un étudiant, il n’apparaît plus dans la liste. Il reste importé, actif, mais n’est plus visible. Dans le cas des élèves qui se connectent via identifiant par exemple, ils ne sont donc plus gérables par le prescripteur (réinitialisation du mot de passe notamment). Si l’élève/étudiant peut se connecter à son compte et participer à une autre campagne, il apparaît de nouveau dans la liste.

Cela créé également un delta entre le nombre total d'élèves/étudiants affiché en haut de page et le total affiché à côté du bouton “effacer les filtres”
## :robot: Solution
Ne plus retirer un prescrit importé de la liste élèves/étudiants même si toutes ses participations à des campagnes de l’Orga ont été supprimé.

Afficher le même nombre d'élèves/étudiants en haut de page et à côté du filtre même si des participations sont supprimées (le nombre de l’import)
## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter avec un compte SUP ou SCO 
- Supprimer toute les participations pour un participant X de toutes ses campaigns dans l'onglet activités de la page Campaigns
- Constater que le participant est toujours affiché dans les page étudiants ou élèves avec 0 participations
- Constater que le nombre de participant en haut de la page ET à côté du button "effacer les filtres ET le nombre de participants affichés dans la liste sont égaux. 