### PR TITLE
[TECH] Tracer les réponses ne pouvant être insérées en BDD à cause d'un encodage incorrect

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -198,6 +198,7 @@ module.exports = (function () {
       isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: isFeatureEnabled(
         process.env.FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS
       ),
+      logAnswers: isFeatureEnabled(process.env.FT_LOG_ANSWERS),
     },
 
     infra: {
@@ -322,6 +323,7 @@ module.exports = (function () {
     config.featureToggles.isPixAppTutoFiltersEnabled = false;
     config.featureToggles.isSsoAccountReconciliationEnabled = false;
     config.featureToggles.isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled = false;
+    config.featureToggles.logAnswers = false;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'sendinblue';

--- a/api/lib/infrastructure/repositories/answer-repository.js
+++ b/api/lib/infrastructure/repositories/answer-repository.js
@@ -121,8 +121,10 @@ module.exports = {
       try {
         result = await trx('answers').insert(answerForDB).returning(COLUMNS);
       } catch (error) {
-        const errorMessage = `INSERT INTO answers failed with values ${JSON.stringify(answerForDB)}`;
-        monitoringTools.logErrorWithCorrelationIds({ message: errorMessage });
+        if (config.featureToggles.logAnswers) {
+          const errorMessage = `INSERT INTO answers failed with values ${JSON.stringify(answerForDB)}`;
+          monitoringTools.logErrorWithCorrelationIds({ message: errorMessage });
+        }
         throw error;
       }
       const [savedAnswerDTO] = result;

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -25,6 +25,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
             'is-pix-app-tuto-filters-enabled': false,
             'is-sso-account-reconciliation-enabled': false,
             'is-clea-results-retrieval-by-habilitated-certification-centers-enabled': false,
+            'log-answers': false,
           },
         },
       };

--- a/api/tests/integration/infrastructure/repositories/answer-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/answer-repository_test.js
@@ -1,8 +1,10 @@
-const { expect, knex, domainBuilder, databaseBuilder, catchErr } = require('../../../test-helper');
+const { expect, knex, domainBuilder, databaseBuilder, catchErr, sinon } = require('../../../test-helper');
 const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
 const { ChallengeAlreadyAnsweredError, NotFoundError } = require('../../../../lib/domain/errors');
 const answerRepository = require('../../../../lib/infrastructure/repositories/answer-repository');
+const monitoringTools = require('../../../../lib/infrastructure/monitoring-tools');
+const config = require('../../../../lib/config');
 
 describe('Integration | Repository | answerRepository', function () {
   describe('#get', function () {
@@ -521,7 +523,7 @@ describe('Integration | Repository | answerRepository', function () {
       });
     });
 
-    context('when something goes wrong during the saving of the knowledge elements', function () {
+    context("when user doesn't exist", function () {
       it('should not have saved anything', async function () {
         // given
         const answerToSave = domainBuilder.buildAnswer({
@@ -545,6 +547,37 @@ describe('Integration | Repository | answerRepository', function () {
         const knowledgeElementsInDB = await knex('knowledge-elements');
         expect(answerInDB).to.have.length(0);
         expect(knowledgeElementsInDB).to.have.length(0);
+      });
+
+      context('when feature toogle is active', function () {
+        it('should log the values to be inserted in a custom error message', async function () {
+          // given
+          config.featureToggles.logAnswers = true;
+          sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
+
+          databaseBuilder.factory.buildUser({ id: 456 });
+          const answerToSave = domainBuilder.buildAnswer({
+            id: null,
+            assessmentId: 123,
+            value: 'test\u0000',
+          });
+          const knowledgeElement = domainBuilder.buildKnowledgeElement({
+            id: null,
+            createdAt: null,
+            assessmentId: 123,
+            userId: 456,
+          });
+          databaseBuilder.factory.buildAssessment({ id: 123 });
+          await databaseBuilder.commit();
+
+          const errorMessage =
+            'INSERT INTO answers failed with values {"value":"test\\u0000","timeout":null,"challengeId":"recChallenge123","assessmentId":123,"timeSpent":20,"isFocusedOut":false,"result":"ok","resultDetails":"null\\n"}';
+          // when
+          await catchErr(answerRepository.saveWithKnowledgeElements)(answerToSave, [knowledgeElement]);
+
+          // then
+          expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({ message: errorMessage });
+        });
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Des insertions sortent en erreur sur `answers` avec ce message
``` sql
/* path: /api/answers */ insert into "answers" ("assessmentId", "challengeId", "isFocusedOut", "result", "resultDetails", "timeSpent", "timeout", "value") values ($1, $2, $3, $4, $5, $6, $7, $8) returning "id", "result", "resultDetails", "timeout", "value", "assessmentId", "challengeId", "timeSpent" - invalid byte sequence for encoding "UTF8": 0x00
```
Cela semble être dû à la présence de caractères incorrects dans la réponse de l'utilisateur (champ `value` dans le payload).
https://stackoverflow.com/questions/1347646/postgres-error-on-insert-error-invalid-byte-sequence-for-encoding-utf8-0x0

La PR https://github.com/1024pix/pix/pull/2441 devait apporter une solution, mais cela ne semble pas être le cas


## :robot: Solution
Pour déterminer la cause, en cas d'erreur, tracer les valeurs candidates à l'insertion

## :rainbow: Remarques
Ce n'est pas testable au mieux car ce n'est pas reproduit

## :100: Pour tester

Activer le FT
```
FT_LOG_ANSWERS=true
```

Modifier le code pour ajouter un caractère incorrect avant l'insertion dans la BDD
Fichier `api/lib/infrastructure/repositories/answer-repository.js`
```js
// à ajouter
answerForDB.value = answerForDB.value + '\u0000';

result = await trx('answers').insert(answerForDB).returning(COLUMNS);
```

Répondre à une question

Vérifiez que la log API mentionne les valeurs
```shell
[16:10:56] ERROR: INSERT INTO answers failed with values {"value":"#ABAND#\u0000","timeout":null,"challengeId":"recBzswglMDjdzrNp","assessmentId":"108452","timeSpent":154,"isFocusedOut":false,"result":"aband","resultDetails":"null\n"}
```
