### PR TITLE
[BUGFIX] Corriger le calcul de la date de début et ajouter la compétence 2.2 dans les exports CPF (PIX-5827)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -288,8 +288,8 @@ module.exports = (function () {
       },
       plannerJob: {
         chunkSize: process.env.CPF_PLANNER_JOB_CHUNK_SIZE || 50000,
-        monthsToProcess: process.env.CPF_PLANNER_JOB_MONTHS_TO_PROCESS || 1,
-        minimumReliabilityPeriod: process.env.CPF_PLANNER_JOB_MINIMUM_RELIABILITY_PERIOD || 3,
+        monthsToProcess: _getNumber(process.env.CPF_PLANNER_JOB_MONTHS_TO_PROCESS, 1),
+        minimumReliabilityPeriod: _getNumber(process.env.CPF_PLANNER_JOB_MINIMUM_RELIABILITY_PERIOD, 3),
         cron: process.env.CPF_PLANNER_JOB_CRON || '0 0 1 1 *',
       },
       sendEmailJob: {

--- a/api/lib/domain/read-models/EuropeanNumericLevelFactory.js
+++ b/api/lib/domain/read-models/EuropeanNumericLevelFactory.js
@@ -6,7 +6,7 @@ class EuropeanNumericLevelFactory {
   static buildFromCompetenceMarks(competenceMarks) {
     const europeanNumericLevels = [];
     competenceMarks.forEach(({ competenceCode, level }) => {
-      if (['3.4', '4.1', '4.2', '5.1', '5.2'].includes(competenceCode)) {
+      if (['2.2', '3.4', '4.1', '4.2', '5.1', '5.2'].includes(competenceCode)) {
         europeanNumericLevels.push(EuropeanNumericLevel.from({ competenceCode, level }));
       }
 

--- a/api/tests/unit/domain/read-models/EuropeanNumericLevelFactory_test.js
+++ b/api/tests/unit/domain/read-models/EuropeanNumericLevelFactory_test.js
@@ -5,7 +5,7 @@ const EuropeanNumericLevel = require('../../../../lib/domain/read-models/Europea
 describe('Unit | Domain | Read-models | EuropeanNumericLevelFactory', function () {
   describe('static #buildFromCompetenceMarks', function () {
     // eslint-disable-next-line mocha/no-setup-in-describe
-    ['3.4', '4.1', '4.2', '5.1', '5.2'].forEach((competenceCode) => {
+    ['2.2', '3.4', '4.1', '4.2', '5.1', '5.2'].forEach((competenceCode) => {
       it(`should build an EuropeanNumericLevel with for competence '${competenceCode}'`, function () {
         // given
         const competenceMark = { competenceCode, level: 4 };


### PR DESCRIPTION
## :unicorn: Problème
La date de début à prendre en compte lors de la récupération de session est calculée à partir de deux variables d'environnements qui sont des entiers. Cependant, les variables d'environnement  sont des chaînes de caractères et cela fausse le calcul. De plus, la compétence 2.2 n'était pas prise en compte lors de la création du fichier d'export. 

## :robot: Solution
- Interpréter les variables d'environnement en tant que nombre.
- Ajouter la compétence 2.2

## :100: Pour tester
Les données envoyées par le job:

![Selection_086](https://user-images.githubusercontent.com/1216570/193549475-6c4f19e7-4556-4646-84c6-a31797866140.png)

La présence de la compétence 2.2:
![Selection_088](https://user-images.githubusercontent.com/1216570/193549604-e67d24c1-72e1-4c43-b53a-52f2fc0627f1.png)
