### PR TITLE
[TECH] Rendre des pages de Pix Certif plus accessible (+ testing library dans les tests) (PIX-5546).

### DIFF
--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -45,7 +45,7 @@ module.exports = function (environment) {
         },
         GATEWAY_TIMEOUT: {
           CODE: '504',
-          MESSAGE: 'Le service subi des ralentissements. Veuillez réessayer ultérieurement.',
+          MESSAGE: 'Le service subit des ralentissements. Veuillez réessayer ultérieurement.',
         },
         UNAUTHORIZED: { CODE: '401', MESSAGE: "L'adresse e-mail et/ou le mot de passe saisis sont incorrects." },
         FORBIDDEN: '403',

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -1,8 +1,8 @@
 <div class="panel">
   <div class="panel-header">
-    <div class="panel-header__title">
+    <h3 class="panel-header__title">
       Liste des candidats ({{@certificationCandidates.length}})
-    </div>
+    </h3>
     {{#if @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
       <PixButtonLink
         @route="authenticated.sessions.add-student"

--- a/certif/app/components/import-candidates.hbs
+++ b/certif/app/components/import-candidates.hbs
@@ -4,19 +4,20 @@
       <div class="panel-actions__header-icon">
         <FaIcon @icon="info" />
       </div>
-      <div class="panel-actions__header-title">Inscrire des candidats</div>
+      <h3 class="panel-actions__header-title">Inscrire des candidats</h3>
     </div>
     <div class="panel-actions__action-row">
       <div class="panel-actions__action-icon">
         <FaIcon @icon="file-download" />
       </div>
       <div class="panel-actions__description">
-        <div class="panel-actions__title">Télécharger le modèle de liste des candidats</div>
-        <div>Pour inscrire des candidats à la session, renseignez leurs informations (Nom, Prénom, …) dans ce document.
+        <h4 class="panel-actions__title">Télécharger le modèle de liste des candidats</h4>
+        <p class="panel-actions-description__information">Pour inscrire des candidats à la session, renseignez leurs
+          informations (Nom, Prénom, …) dans ce document.
           <br />
           Lors du premier téléchargement, le modèle de liste des candidats est vide. Il contiendra ensuite les
           informations des candidats inscrits à la session.
-        </div>
+        </p>
       </div>
       <div class="panel-actions__button">
         <PixButtonLink
@@ -36,14 +37,14 @@
           <FaIcon @icon="cloud-upload-alt" />
         </div>
         <div class="panel-actions__description">
-          <div class="panel-actions__title">Importer la liste des candidats</div>
-          <div>
+          <h4 class="panel-actions__title">Importer la liste des candidats</h4>
+          <p class="panel-actions-description__information">
             Sélectionnez la liste des candidats préalablement remplie.
             <br />
             <strong>
               Attention, tout nouvel import efface la liste des candidats existante.
             </strong>
-          </div>
+          </p>
         </div>
         <div class="panel-actions__button">
           <FileUpload

--- a/certif/app/components/login-form.hbs
+++ b/certif/app/components/login-form.hbs
@@ -1,60 +1,55 @@
-<div class="login-form">
+<div class="login">
 
-  <div>
+  <header class="login__header">
     <img src="/pix-certif-logo.svg" alt="Pix Certif" />
-  </div>
 
-  <div>
+    <h1 class="login-header__title">Connectez-vous</h1>
 
-    <h1 class="login-form__title">Connectez-vous</h1>
-
-    <p class="login-form__information paragraph">
+    <p class="login-header__information paragraph">
       L'accès à Pix Certif est limité aux centres de certification Pix.
     </p>
+  </header>
 
-    {{#if this.isErrorMessagePresent}}
-      <div id="login-form-error-message" class="login-form__error-message error-message">
-        {{this.errorMessage}}
-      </div>
-    {{/if}}
+  <main class="login__main">
 
-    <form {{on "submit" this.authenticate}}>
+    <form class="login-main__form" {{on "submit" this.authenticate}}>
 
-      <div class="login-form__input-container">
-        <PixInput
-          @id="login-email"
-          name="login"
-          @label="Adresse e-mail"
-          autocomplete="email"
-          type="email"
-          required="true"
-          {{on "input" this.setEmail}}
-        />
-      </div>
+      <p class="login-main-form__mandatory-information paragraph">
+        Tous les champs sont obligatoires.
+      </p>
 
-      <div class="login-form__input-container">
-        <PixInputPassword
-          @id="login-password"
-          name="password"
-          @label="Mot de passe"
-          autocomplete="current-password"
-          required="true"
-          {{on "input" this.setPassword}}
-        />
-      </div>
+      <PixInput
+        @id="login-email"
+        name="login"
+        @label="Adresse e-mail"
+        autocomplete="email"
+        type="email"
+        required="true"
+        {{on "input" this.setEmail}}
+      />
 
-      <div class="login-form__input-container">
-        <PixButton @type="submit">
-          Je me connecte
-        </PixButton>
-      </div>
+      <PixInputPassword
+        @id="login-password"
+        name="password"
+        @label="Mot de passe"
+        autocomplete="current-password"
+        required="true"
+        {{on "input" this.setPassword}}
+      />
 
-      <div class="login-form__forgotten-password one-line-text">
+      {{#if this.isErrorMessagePresent}}
+        <div class="error-message">
+          <p>{{this.errorMessage}}</p>
+        </div>
+      {{/if}}
+
+      <PixButton @type="submit">
+        Je me connecte
+      </PixButton>
+
+      <div class="login-main-form__forgotten-password">
         <a href="https://app.pix.fr/mot-de-passe-oublie" target="_blank" rel="noopener noreferrer">Mot de passe oublié ?</a>
       </div>
-
     </form>
-
-  </div>
-
+  </main>
 </div>

--- a/certif/app/components/session-summary-list.hbs
+++ b/certif/app/components/session-summary-list.hbs
@@ -31,7 +31,11 @@
             <th class="table__column table__column--small">
               Statut
             </th>
-            <th class="table__column table__column--small"></th>
+            <th class="table__column table__column--small" scope="col">
+              <span class="sr-only">
+                Actions
+              </span>
+            </th>
           </tr>
         </thead>
 

--- a/certif/app/components/session-summary-list.hbs
+++ b/certif/app/components/session-summary-list.hbs
@@ -4,31 +4,31 @@
       <table>
         <thead>
           <tr>
-            <th class="table__column table__column--small">
+            <th class="table__column table__column--small" scope="col">
               Numéro de session
             </th>
-            <th class="table__column table__column--small">
+            <th class="table__column table__column--small" scope="col">
               Nom du site
             </th>
-            <th class="table__column table__column--small">
+            <th class="table__column table__column--small" scope="col">
               Salle
             </th>
-            <th class="table__column table__column--small">
+            <th class="table__column table__column--small" scope="col">
               Date
             </th>
-            <th class="table__column table__column--small">
+            <th class="table__column table__column--small" scope="col">
               Heure
             </th>
-            <th class="table__column table__column--small">
+            <th class="table__column table__column--small" scope="col">
               Surveillant(s)
             </th>
-            <th class="table__column table__column">
+            <th class="table__column table__column" scope="col">
               Candidats inscrits
             </th>
-            <th class="table__column table__column">
+            <th class="table__column table__column" scope="col">
               Certifications passées
             </th>
-            <th class="table__column table__column--small">
+            <th class="table__column table__column--small" scope="col">
               Statut
             </th>
             <th class="table__column table__column--small" scope="col">
@@ -85,7 +85,6 @@
                       @icon="trash-alt"
                       aria-label="Supprimer la session {{sessionSummary.id}}"
                       disabled={{false}}
-                      aria-describedby="tooltip-delete-session-button"
                       @withBackground={{true}}
                       @triggerAction={{fn
                         this.openSessionDeletionConfirmModal

--- a/certif/app/styles/components/login-form.scss
+++ b/certif/app/styles/components/login-form.scss
@@ -1,8 +1,5 @@
-.login-form {
-  display: flex;
-  flex-direction: column;
+.login {
   margin: auto;
-  align-items: center;
   background-color: $pix-neutral-0;
   border-radius: 10px;
   padding: 20px 30px;
@@ -12,8 +9,18 @@
     padding: 40px 60px;
   }
 
-  &__title {
+  &__header {
     text-align: center;
+  }
+
+  &__main {
+    width: 100%;
+  }
+}
+
+.login-header {
+
+  &__title {
     font-family: $font-open-sans;
     font-weight: 400;
     font-size: 2rem;
@@ -24,32 +31,32 @@
 
   &__information {
     margin-bottom: 32px;
-    text-align: center;
     font-family: $font-roboto;
     max-width: 400px;
     width: 100%;
   }
+}
 
-  &__error-message {
-    margin-bottom: 10px;
-    text-align: center;
-    font-size: 0.875rem;
-  }
+.login-main {
 
-  &__input-container {
+  &__form {
     display: flex;
     flex-direction: column;
-    align-items: stretch;
-    margin-bottom: 16px;
+    gap: $spacing-s;
+  }
+}
+
+.login-main-form {
+
+  &__mandatory-information {
+    text-align: center;
+    font-family: $font-roboto;
+    color: $pix-neutral-80;
   }
 
   &__button {
     margin-top: 8px;
     font-size: 0.875rem;
-  }
-
-  form {
-    margin: auto;
   }
 
   &__forgotten-password {
@@ -66,63 +73,6 @@
       &:visited {
         text-decoration: underline;
         color: $pix-communication-dark;
-      }
-    }
-  }
-
-  &__input-field {
-    display: flex;
-    height: 42px;
-    border-radius: 3px;
-    align-items: center;
-    background-color: $pix-neutral-0;
-    border: 2px solid $pix-neutral-20;
-
-    &:focus-within {
-      border: 2px solid $pix-communication-dark;
-    }
-
-    input {
-      height: 40px;
-      flex-grow: 1;
-      border: none;
-      border-radius: 3px;
-      outline: none;
-      padding: 0 10px;
-      font-size: 1rem;
-
-      &:focus {
-        outline: 0;
-        border: none;
-      }
-
-      &::-ms-clear,
-      &::-ms-reveal {
-        display: none;
-      }
-    }
-  }
-
-  &__icon {
-    height: 20px;
-    width: 38px;
-    display: flex;
-    border: none;
-    background: none;
-    padding: 0;
-  }
-
-  &-icon {
-
-    &__eye {
-      color: $pix-neutral-45;
-      transition: 0.5s;
-      font-size: 1.1rem;
-      margin-top: 2px;
-
-      &:hover {
-        color: $pix-neutral-80;
-        cursor: pointer;
       }
     }
   }

--- a/certif/app/styles/components/login-session-supervisor-form.scss
+++ b/certif/app/styles/components/login-session-supervisor-form.scss
@@ -15,7 +15,7 @@
   }
 
   &__title {
-    color: $pix-neutral-30;
+    color: $pix-neutral-50;
     font-size: 0.8rem;
     font-weight: normal;
     margin: 8px 0 0;
@@ -31,7 +31,7 @@
   }
 
   &__required-fields-notice {
-    color: $pix-neutral-30;
+    color: $pix-neutral-50;
     font-size: 0.8rem;
     margin: 8px 0 24px;
   }
@@ -54,7 +54,7 @@
   }
 
   &__description {
-    color: $pix-neutral-30;
+    color: $pix-neutral-50;
     font-size: 0.8rem;
     margin: 0;
     text-align: center;

--- a/certif/app/styles/globals/forms.scss
+++ b/certif/app/styles/globals/forms.scss
@@ -52,9 +52,9 @@ input[type="number"] {
 }
 
 .error-message {
-  color: red;
+  color: $pix-error-70;
   font-family: $font-roboto;
-  font-size: 0.75rem;
+  font-size: 0.875rem;
 }
 
 .select {

--- a/certif/app/styles/globals/panels.scss
+++ b/certif/app/styles/globals/panels.scss
@@ -19,7 +19,7 @@
     border-bottom: 2px solid transparent;
     outline: none;
     cursor: pointer;
-    color: $pix-neutral-35;
+    color: $pix-neutral-50;
     font-family: $font-roboto;
     font-size: 0.9rem;
     font-weight: 500;

--- a/certif/app/styles/globals/texts.scss
+++ b/certif/app/styles/globals/texts.scss
@@ -5,12 +5,6 @@
   line-height: 20px;
 }
 
-.one-line-text {
-  color: $pix-neutral-45;
-  font-family: $font-roboto;
-  font-size: 0.75rem;
-}
-
 .label-text {
   color: $pix-neutral-35;
   font-family: $font-roboto;

--- a/certif/app/styles/pages/authenticated/sessions.scss
+++ b/certif/app/styles/pages/authenticated/sessions.scss
@@ -7,21 +7,24 @@
     max-width: 500px;
   }
 
+  &__mandatory-information {
+    padding-bottom: $spacing-m;
+    color: $pix-neutral-70;
+  }
+
   &__field {
     display: flex;
     flex-direction: column;
     margin-bottom: 30px;
   }
 
-  &__validation {
-    margin-top: 32px;
+  &__actions {
+    margin-top: $spacing-l;
+    margin-bottom: 0;
     display: flex;
-    align-items: center;
     justify-content: flex-end;
-
-    .pix-button {
-      margin-left: 16px;
-    }
+    gap: $spacing-m;
+    list-style: none;
   }
 
   &__error {

--- a/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
@@ -17,8 +17,9 @@
 }
 
 .panel-actions__header-title {
-  margin-left: 2.5rem;
+  margin: 0 0 0 2rem;
   font-size: 1.3rem;
+  font-weight: 400;
 }
 
 .panel-actions__header-icon {
@@ -63,12 +64,12 @@
   flex-flow: column nowrap;
   margin-left: 1.25rem;
   width: 65%;
-  color: $pix-neutral-45;
+  color: $pix-neutral-50;
   font-size: 0.8rem;
 }
 
 .panel-actions__title {
-  margin-bottom: 0.625rem;
+  margin: 0;
   font-weight: bold;
   color: $pix-neutral-70;
 }
@@ -92,10 +93,17 @@
   font-size: 1.5rem;
 }
 
+.panel-actions-description  {
+
+  &__information {
+    margin-bottom: 0;
+  }
+}
+
 .panel-header {
   display: flex;
   align-items: center;
-  color: $pix-neutral-40;
+  color: $pix-neutral-50;
   padding: 16px 0;
   margin: 0 16px;
 

--- a/certif/app/styles/pages/terms-of-service.scss
+++ b/certif/app/styles/pages/terms-of-service.scss
@@ -56,10 +56,6 @@
     flex-direction: row;
     justify-content: flex-end;
     margin: 0 100px;
-
-    .pix-button {
-      margin-left: 16px;
-    }
   }
 
   &__submit {

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -10,14 +10,14 @@
 
     <div class="session-details-header__datetime">
       <div class="session-details-header-datetime__date">
-        <h4 class="label-text session-details-content__label">Date</h4>
+        <h2 class="label-text session-details-content__label">Date</h2>
         <span class="content-text content-text--big session-details-header-datetime__text">
           {{moment-format this.session.date "dddd DD MMM YYYY" allow-empty=true locale="fr"}}
         </span>
       </div>
 
       <div>
-        <h4 class="label-text session-details-content__label">Heure de début (heure locale)</h4>
+        <h2 class="label-text session-details-content__label">Heure de début (heure locale)</h2>
         <span class="content-text content-text--big session-details-header-datetime__text">
           {{moment-format this.session.time "HH:mm" "HH:mm:ss" allow-empty=true}}
         </span>

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -1,7 +1,7 @@
 <div class="panel session-details-container">
   <div class="session-details-row">
     <div class="session-details-content session-details-content--multiple session-details-content--copyable">
-      <h4 class="label-text session-details-content__label">Numéro de session</h4>
+      <h3 class="label-text session-details-content__label">Numéro de session</h3>
       <div class="session-details-content__clipboard" {{on "mouseout" this.removeSessionNumberTooltip}}>
         <span class="content-text content-text--bold session-details-content__text">{{this.session.id}}</span>
         {{#if (is-clipboard-supported)}}
@@ -11,7 +11,7 @@
                 @clipboardText={{this.session.id}}
                 @success={{this.showSessionIdTooltip}}
                 @classNames="icon-button session-details-content__clipboard-button"
-                aria-label="Copier le code d'accès"
+                aria-label="Copier le code du numéro de session"
               >
                 <FaIcon @icon="copy" prefix="fas" />
               </CopyButton>
@@ -23,9 +23,9 @@
     </div>
 
     <div class="session-details-content session-details-content--multiple session-details-content--copyable">
-      <h4 class="label-text session-details-content__label">Code d'accès
+      <h3 class="label-text session-details-content__label">Code d'accès
         <div class="session-details-content__sub-label">Candidat</div>
-      </h4>
+      </h3>
       <div class="session-details-content__clipboard" {{on "mouseout" this.removeAccessCodeTooltip}}>
         <span class="content-text content-text--bold session-details-content__text">{{this.session.accessCode}}</span>
         {{#if (is-clipboard-supported)}}
@@ -36,7 +36,7 @@
                 @clipboardText={{this.session.accessCode}}
                 @success={{this.showAccessCodeTooltip}}
                 @classNames="icon-button session-details-content__clipboard-button"
-                aria-label="Copier le code d'accès"
+                aria-label="Copier le code d'accès pour le candidat"
               >
                 <FaIcon @icon="copy" prefix="fas" />
               </CopyButton>
@@ -49,10 +49,10 @@
 
     {{#if this.supervisorPasswordShouldBeDisplayed}}
       <div class="session-details-content session-details-content--multiple session-details-content--copyable">
-        <h4 class="label-text session-details-content__label">
+        <h3 class="label-text session-details-content__label">
           Mot de passe de session
           <div class="session-details-content__sub-label">Surveillant</div>
-        </h4>
+        </h3>
         <div class="session-details-content__clipboard" {{on "mouseout" this.removeSupervisorPasswordTooltip}}>
           <span class="content-text content-text--bold session-details-content__text">
             C-{{this.session.supervisorPassword}}
@@ -69,7 +69,7 @@
                   @clipboardText={{this.session.supervisorPassword}}
                   @success={{this.showSupervisorPasswordTooltip}}
                   @classNames="icon-button session-details-content__clipboard-button"
-                  aria-label="Copier le code d'accès"
+                  aria-label="Copier le mot de passe de session pour le surveillant"
                 >
                   <FaIcon @icon="copy" prefix="fas" />
                 </CopyButton>
@@ -82,17 +82,17 @@
     {{/if}}
 
     <div class="session-details-content session-details-content--multiple">
-      <h4 class="label-text session-details-content__label">Nom du site</h4>
+      <h3 class="label-text session-details-content__label">Nom du site</h3>
       <span class="content-text session-details-content__text">{{this.session.address}}</span>
     </div>
 
     <div class="session-details-content session-details-content--multiple">
-      <h4 class="label-text session-details-content__label">Salle</h4>
+      <h3 class="label-text session-details-content__label">Salle</h3>
       <span class="content-text session-details-content__text">{{this.session.room}}</span>
     </div>
 
     <div class="session-details-content session-details-content--multiple">
-      <h4 class="label-text session-details-content__label">Surveillant(s)</h4>
+      <h3 class="label-text session-details-content__label">Surveillant(s)</h3>
       <span class="content-text session-details-content__text">{{this.session.examiner}}</span>
     </div>
 
@@ -100,7 +100,7 @@
 
   <div class="session-details-row">
     <div class="session-details-content session-details-content--single">
-      <h4 class="label-text session-details-content__label">Observations</h4>
+      <h3 class="label-text session-details-content__label">Observations</h3>
       <p class="content-text session-details-content__text">
         {{this.session.description}}
       </p>

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -127,7 +127,11 @@
       </div>
     {{else}}
       <div class="session-details-buttons">
-        <PixButtonLink @route="authenticated.sessions.update" @model={{this.session.id}}>
+        <PixButtonLink
+          @route="authenticated.sessions.update"
+          @model={{this.session.id}}
+          aria-label="Modifier les informations de la session {{this.session.id}}"
+        >
           Modifier
         </PixButtonLink>
       </div>

--- a/certif/app/templates/authenticated/sessions/new.hbs
+++ b/certif/app/templates/authenticated/sessions/new.hbs
@@ -3,9 +3,17 @@
   <h1 class="page__title page-title">Création d'une session de certification</h1>
 
   <form {{on "submit" this.createSession}} class="session-form">
+    <p class="session-form__mandatory-information">
+      Les champs marqués de
+      <abbr title="obligatoire" class="mandatory-mark">*</abbr>
+      sont obligatoires.
+    </p>
 
     <div class="session-form__field">
-      <label for="session-address" class="label">Nom du site</label>
+      <label for="session-address" class="label">
+        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        Nom du site
+      </label>
       <Input
         id="session-address"
         name="session-address"
@@ -22,7 +30,10 @@
     </div>
 
     <div class="session-form__field">
-      <label for="session-room" class="label">Nom de la salle</label>
+      <label for="session-room" class="label">
+        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        Nom de la salle
+      </label>
       <Input
         id="session-room"
         name="session-room"
@@ -39,7 +50,10 @@
     </div>
 
     <div class="session-form__field">
-      <label for="session-date" class="label">Date de début</label>
+      <label for="session-date" class="label">
+        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        Date de début
+      </label>
       <EmberFlatpickr
         @id="session-date"
         @altFormat="d/m/Y"
@@ -59,7 +73,10 @@
     </div>
 
     <div class="session-form__field">
-      <label for="session-time" class="label">Heure de début (heure locale)</label>
+      <label for="session-time" class="label">
+        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        Heure de début (heure locale)
+      </label>
       <EmberFlatpickr
         @id="session-time"
         @onChange={{this.onTimePicked}}
@@ -80,7 +97,10 @@
     </div>
 
     <div class="session-form__field">
-      <label for="session-examiner" class="label">Surveillant(s)</label>
+      <label for="session-examiner" class="label">
+        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        Surveillant(s)
+      </label>
       <Input
         id="session-examiner"
         name="session-examiner"
@@ -97,7 +117,7 @@
     </div>
 
     <div class="session-form__field">
-      <label for="session-description" class="label">Observations (optionnel)</label>
+      <label for="session-description" class="label">Observations</label>
       <Textarea
         id="session-description"
         name="session-description"
@@ -108,18 +128,23 @@
       />
     </div>
 
-    <div class="session-form__validation">
-      <PixButton
-        data-test-id="session-form__cancel-button"
-        @backgroundColor="transparent-light"
-        @triggerAction={{this.cancel}}
-      >
-        Annuler
-      </PixButton>
-      <PixButton data-test-id="session-form__submit-button" @type="submit">
-        Créer la session
-      </PixButton>
-    </div>
+    <ul class="session-form__actions">
+      <li>
+        <PixButton
+          data-test-id="session-form__cancel-button"
+          @backgroundColor="transparent-light"
+          @triggerAction={{this.cancel}}
+          aria-label="Annuler la création de session et retourner vers la page précédente"
+        >
+          Annuler
+        </PixButton>
+      </li>
+      <li>
+        <PixButton @type="submit">
+          Créer la session
+        </PixButton>
+      </li>
+    </ul>
 
   </form>
 </div>

--- a/certif/app/templates/authenticated/sessions/update.hbs
+++ b/certif/app/templates/authenticated/sessions/update.hbs
@@ -3,9 +3,17 @@
   <h1 class="page__title page-title">Modification d'une session de certification</h1>
 
   <form {{on "submit" this.updateSession}} class="session-form">
+    <p class="session-form__mandatory-information">
+      Les champs marqués de
+      <abbr title="obligatoire" class="mandatory-mark">*</abbr>
+      sont obligatoires.
+    </p>
 
     <div class="session-form__field">
-      <label for="session-address" class="label">Nom du site</label>
+      <label for="session-address" class="label">
+        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        Nom du site
+      </label>
       <Input
         id="session-address"
         name="session-address"
@@ -22,7 +30,10 @@
     </div>
 
     <div class="session-form__field">
-      <label for="session-room" class="label">Nom de la salle</label>
+      <label for="session-room" class="label">
+        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        Nom de la salle
+      </label>
       <Input
         id="session-room"
         name="session-room"
@@ -39,7 +50,10 @@
     </div>
 
     <div class="session-form__field">
-      <label for="session-date" class="label">Date de début</label>
+      <label for="session-date" class="label">
+        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        Date de début
+      </label>
       <EmberFlatpickr
         @id="session-date"
         @altFormat="d/m/Y"
@@ -59,7 +73,10 @@
     </div>
 
     <div class="session-form__field">
-      <label for="session-time" class="label">Heure de début (heure locale)</label>
+      <label for="session-time" class="label">
+        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        Heure de début (heure locale)
+      </label>
       <EmberFlatpickr
         @id="session-time"
         @onChange={{this.onTimePicked}}
@@ -81,7 +98,10 @@
     </div>
 
     <div class="session-form__field">
-      <label for="session-examiner" class="label">Surveillant(s)</label>
+      <label for="session-examiner" class="label">
+        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        Surveillant(s)
+      </label>
       <Input
         id="session-examiner"
         name="session-examiner"
@@ -98,7 +118,7 @@
     </div>
 
     <div class="session-form__field">
-      <label for="session-description" class="label">Observations (optionnel)</label>
+      <label for="session-description" class="label">Observations</label>
       <Textarea
         id="session-description"
         name="session-description"
@@ -109,18 +129,23 @@
       />
     </div>
 
-    <div class="session-form__validation">
-      <PixButton
-        data-test-id="session-form__cancel-button"
-        @triggerAction={{this.cancel}}
-        @backgroundColor="transparent-light"
-      >
-        Annuler
-      </PixButton>
-      <PixButton data-test-id="session-form__submit-button" @type="submit">
-        Modifier la session
-      </PixButton>
-    </div>
+    <ul class="session-form__actions">
+      <li>
+        <PixButton
+          data-test-id="session-form__cancel-button"
+          @triggerAction={{this.cancel}}
+          @backgroundColor="transparent-light"
+          aria-label="Annuler la modification de la session et retourner vers la page précédente"
+        >
+          Annuler
+        </PixButton>
+      </li>
+      <li>
+        <PixButton @type="submit">
+          Modifier la session
+        </PixButton>
+      </li>
+    </ul>
 
   </form>
 </div>

--- a/certif/app/templates/terms-of-service.hbs
+++ b/certif/app/templates/terms-of-service.hbs
@@ -3,18 +3,18 @@
   <div class="terms-of-service-form">
 
     <div class="terms-of-service-form__logo">
-      <img src="/pix-certif-logo.svg" alt="PixCertif" />
+      <img src="/pix-certif-logo.svg" alt="Pix Certif" />
     </div>
 
-    <div class="terms-of-service-form__title">
+    <h1 class="terms-of-service-form__title">
       CONDITIONS GÉNÉRALES D'UTILISATION DE LA PLATEFORME PIX CERTIF
-    </div>
+    </h1>
 
     <hr class="terms-of-service-form__line" />
 
     <div class="terms-of-service-form__text">
 
-      <h3>Article 1. Préambule</h3>
+      <h2 class="pix-h4">Article 1. Préambule</h2>
 
       <p>
         Le Groupement d’intérêt public (GIP) « Pix », approuvé par arrêté du 27 avril 2017 portant approbation de la
@@ -48,7 +48,7 @@
         mise en œuvre.
       </p>
 
-      <h3>Article 2. Définitions</h3>
+      <h2 class="pix-h4">Article 2. Définitions</h2>
 
       <ul>
         {{! template-lint-disable no-whitespace-within-word }}
@@ -126,13 +126,13 @@
         </li>
       </ul>
 
-      <h3>Article 3. Objet</h3>
+      <h2 class="pix-h4">Article 3. Objet</h2>
 
       <p>
         Les présentes ont pour objet de définir les conditions d’accès et d’utilisation, par les utilisateurs, de Pix
         Certif et des services.
       </p>
-      <h3>Article 4. Entrée en vigueur - Durée</h3>
+      <h2 class="pix-h4">Article 4. Entrée en vigueur - Durée</h2>
       <p>
         Les présentes conditions générales sont applicables pendant toute la durée de l’utilisation par l’utilisateur.
       </p>
@@ -141,9 +141,9 @@
         par son centre de rattachement.
       </p>
 
-      <h3>Article 5. Acceptation et opposabilité des conditions générales</h3>
+      <h2 class="pix-h4">Article 5. Acceptation et opposabilité des conditions générales</h2>
 
-      <h4>5.1 Acceptation</h4>
+      <h3>5.1 Acceptation</h3>
       <p>
         Les utilisateurs peuvent utiliser les services Pix Certif sous réserve de l’acceptation préalable des présentes
         conditions générales d’utilisation et de l’engagement qu’ils respectent les prérequis suivants :
@@ -210,7 +210,7 @@
         des prescriptions définies au sein des présentes conditions d’utilisation.
       </p>
 
-      <h4>5.2 Modification</h4>
+      <h3>5.2 Modification</h3>
       <p>
         Les conditions générales sont susceptibles d’être modifiées ou aménagées à tout moment par le GIP Pix, notamment
         afin de faire évoluer les services.
@@ -233,7 +233,7 @@
         acceptation par ce dernier des nouvelles conditions d’utilisation.
       </p>
 
-      <h4>5.3 Opposabilité</h4>
+      <h3>5.3 Opposabilité</h3>
       <p>
         Les présentes conditions d’utilisation sont opposables à l’utilisateur dès leur acceptation par ce dernier lors
         de la création d’un compte utilisateur ou avant tout premier accès aux services.
@@ -251,7 +251,7 @@
         utilisation antérieure.
       </p>
 
-      <h3>Article 6. Compte utilisateur</h3>
+      <h2 class="pix-h4">Article 6. Compte utilisateur</h2>
 
       <p>
         La procédure de création d’un compte utilisateur comprend les étapes suivantes.
@@ -311,7 +311,7 @@
         définir un nouveau mot de passe qui devra lui aussi être conforme aux spécifications susvisées.
       </p>
 
-      <h3>Article 7. Description des services</h3>
+      <h2 class="pix-h4">Article 7. Description des services</h2>
 
       <p>
         Pix Certif permet à l’utilisateur de bénéficier des services suivants :
@@ -335,7 +335,7 @@
         </li>
       </ul>
 
-      <h3>Article 8. Accès à Pix Certif</h3>
+      <h2 class="pix-h4">Article 8. Accès à Pix Certif</h2>
 
       <p>
         Les services sont normalement accessibles 24/24 heures, 7/7 jours.
@@ -356,7 +356,7 @@
         précisément possible le problème rencontré le cas échéant sur la base de documents associés : support@pix.fr.
       </p>
 
-      <h3>Article 9. Spécificités techniques</h3>
+      <h2 class="pix-h4">Article 9. Spécificités techniques</h2>
 
       <p>
         Le GIP Pix s’efforce de fournir un service de qualité. Il permet aux utilisateurs d'utiliser les services mis à
@@ -391,7 +391,7 @@
         </li>
       </ul>
 
-      <h3>Article 10. Gestion des sessions de certification</h3>
+      <h2 class="pix-h4">Article 10. Gestion des sessions de certification</h2>
 
       <p>
         Il appartient à l’utilisateur de s’assurer avec le ou les centres au(x)quel(s) il est rattaché, au minimum 2
@@ -401,7 +401,7 @@
         rattachement
       </p>
 
-      <h3>Article 11. Utilisation</h3>
+      <h2 class="pix-h4">Article 11. Utilisation</h2>
 
       <p>
         L’utilisateur s’engage à n’utiliser les services que dans les seules conditions définies aux présentes
@@ -423,7 +423,7 @@
         données à caractère personnel et à la vie privée.
       </p>
 
-      <h3>Article 12. Sécurité</h3>
+      <h2 class="pix-h4">Article 12. Sécurité</h2>
 
       <p>
         Le GIP Pix fait ses meilleurs efforts, conformément aux règles de l’art, pour sécuriser la plateforme au regard
@@ -477,9 +477,9 @@
         infrastructures de Pix Certif.
       </p>
 
-      <h3>Article 13. Maintenance et support</h3>
+      <h2 class="pix-h4">Article 13. Maintenance et support</h2>
 
-      <h4>13.1 Support et assistance auprès de l’utilisateur</h4>
+      <h3>13.1 Support et assistance auprès de l’utilisateur</h3>
       <p>
         Le GIP Pix assure un support de nature exclusivement technique auprès de l’utilisateur qui se charge de remonter
         les éventuels dysfonctionnements des services constatés par lui-même.
@@ -491,7 +491,7 @@
         Le GIP Pix met à disposition des utilisateurs une FAQ permettant de répondre aux besoins les plus courants.
       </p>
 
-      <h4>13.2 Maintenance évolutive</h4>
+      <h3>13.2 Maintenance évolutive</h3>
       <p>
         Les services sont susceptibles d’évoluer dans le temps, pour tenir compte des évolutions technologiques, des
         besoins des centres et des utilisateurs.
@@ -511,9 +511,9 @@
         modification, suppression ou interruption des services.
       </p>
 
-      <h3>Article 14. Responsabilité</h3>
+      <h2 class="pix-h4">Article 14. Responsabilité</h2>
 
-      <h4>14.1 Responsabilité de l’utilisateur</h4>
+      <h3>14.1 Responsabilité de l’utilisateur</h3>
       <p>
         L’utilisateur accède et utilise les services à ses propres risques et sous sa responsabilité et celle du centre
         qui l’a habilité, en accord avec la législation française en vigueur ainsi qu’avec les présentes conditions
@@ -548,7 +548,7 @@
         l’utilisateur.
       </p>
 
-      <h4>14.2 Responsabilité du GIP Pix</h4>
+      <h3>14.2 Responsabilité du GIP Pix</h3>
       <p>
         Le GIP Pix s’efforcera de réaliser les opérations qui lui incombent relatives au compte utilisateur et aux
         services, conformément aux règles de l’art.
@@ -622,7 +622,7 @@
         présentes relations contractuelles.
       </p>
 
-      <h3>Article 15. Propriété intellectuelle</h3>
+      <h2 class="pix-h4">Article 15. Propriété intellectuelle</h2>
 
       <p>
         Le GIP Pix est, et reste, propriétaire exclusif des éléments protégés des services selon les termes du Code de
@@ -651,7 +651,7 @@
         ou non expressément autorisée par le GIP Pix au titre des présentes conditions d’utilisation est illicite.
       </p>
 
-      <h3>Article 16. Liens hypertextes</h3>
+      <h2 class="pix-h4">Article 16. Liens hypertextes</h2>
 
       <p>
         Le GIP Pix se réserve la possibilité de mettre en place des hyperliens sur Pix Certif donnant accès à des pages
@@ -669,9 +669,9 @@
         de la plateforme Pix requiert l’autorisation préalable et écrite du GIP Pix.
       </p>
 
-      <h3>Article 17. Données à caractère personnel</h3>
+      <h2 class="pix-h4">Article 17. Données à caractère personnel</h2>
 
-      <h4>17.1 Information de l’utilisation</h4>
+      <h3>17.1 Information de l’utilisation</h3>
       <p>
         Dans le cadre de ses rapports avec les utilisateurs, le GIP Pix, en qualité de responsable de traitement, peut
         être amené à traiter les données à caractère personnel suivantes relatives à l’identité d’un utilisateur, à
@@ -739,7 +739,7 @@
         moment.
       </p>
 
-      <h4>17.2 Sous-traitance</h4>
+      <h3>17.2 Sous-traitance</h3>
       <p>
         L’utilisateur est susceptible de traiter les données à caractère personnel des candidats en qualité de
         sous-traitant du centre (ou de sous-traitant de second rang du GIP Pix), le centre étant lui-même sous-traitant
@@ -760,9 +760,9 @@
         L’utilisateur peut demander communication de cette convention auprès du centre.
       </p>
 
-      <h3>18. Résolution et résiliation</h3>
+      <h2 class="pix-h4">18. Résolution et résiliation</h2>
 
-      <h4>18.1 Désinscription</h4>
+      <h3>18.1 Désinscription</h3>
       <p>
         L’accès aux services par l’utilisateur est effectif et valide tant que l’utilisateur :
       </p>
@@ -779,7 +779,7 @@
         de tout accès et de toute utilisation des services.
       </p>
 
-      <h4>18.2 Suspension et exclusion</h4>
+      <h3>18.2 Suspension et exclusion</h3>
       <p>
         En cas de manquement aux obligations des présentes conditions d’utilisation par l’utilisateur, le GIP Pix se
         réserve le droit, sans indemnité ni remboursement, huit (8) jours après l’envoi à l’utilisateur d’un courrier
@@ -794,7 +794,7 @@
         tout ou partie des services, sans préjudice de toute action de droit commun qui pourrait lui être ouverte.
       </p>
 
-      <h3>19. Convention de preuve</h3>
+      <h2 class="pix-h4">19. Convention de preuve</h2>
 
       <p>
         L’acceptation en ligne des présentes conditions d’utilisation par voie électronique a entre les parties la même
@@ -810,7 +810,7 @@
         durable pouvant être produit à titre de preuve.
       </p>
 
-      <h3>20. Nullité</h3>
+      <h2 class="pix-h4">20. Nullité</h2>
 
       <p>
         Si une ou plusieurs stipulations des présentes conditions d’utilisation sont tenues pour non valides ou
@@ -818,7 +818,7 @@
         chose jugée d’une juridiction compétente, les autres stipulations garderont toute leur force et leur portée.
       </p>
 
-      <h3>21. Loi applicable</h3>
+      <h2 class="pix-h4">21. Loi applicable</h2>
 
       <p>
         Les présentes conditions d’utilisation sont régies par la loi française. Il en est ainsi pour les règles de fond
@@ -829,7 +829,8 @@
 
     <div class="terms-of-service-form__actions">
       <PixButtonLink @route="logout" @backgroundColor="transparent-light">Annuler</PixButtonLink>
-      <PixButton @triggerAction={{this.submit}}>J’accepte les conditions d’utilisation</PixButton>
+      <PixButton class="terms-of-service-form__submit" @triggerAction={{this.submit}}>J’accepte les conditions
+        d’utilisation</PixButton>
     </div>
 
   </div>

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -50,7 +50,7 @@ module.exports = function (environment) {
         },
         GATEWAY_TIMEOUT: {
           CODE: '504',
-          MESSAGE: 'Le service subi des ralentissements. Veuillez réessayer ultérieurement.',
+          MESSAGE: 'Le service subit des ralentissements. Veuillez réessayer ultérieurement.',
         },
         UNAUTHORIZED: { CODE: '401', MESSAGE: "L'adresse e-mail et/ou le mot de passe saisis sont incorrects." },
         FORBIDDEN: '403',

--- a/certif/tests/acceptance/session-details-parameters_test.js
+++ b/certif/tests/acceptance/session-details-parameters_test.js
@@ -57,14 +57,14 @@ module('Acceptance | Session Details Parameters', function (hooks) {
         module('when the session is CREATED', function () {
           test('it should not display the finalize button if no candidate has joined the session', async function (assert) {
             // given
-            const sessionCreated = server.create('session', { status: CREATED });
+            const sessionCreated = server.create('session', { id: 123, status: CREATED });
             server.createList('certification-candidate', 2, { isLinked: false, sessionId: sessionCreated.id });
 
             // when
             const screen = await visit(`/sessions/${sessionCreated.id}`);
 
             // then
-            assert.dom(screen.getByRole('link', { name: 'Modifier' })).exists();
+            assert.dom(screen.getByRole('link', { name: 'Modifier les informations de la session 123' })).exists();
             assert.dom(screen.queryByRole('button', { name: 'Finaliser la session' })).doesNotExist();
           });
 

--- a/certif/tests/acceptance/session-list_test.js
+++ b/certif/tests/acceptance/session-list_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
-import { click, currentURL, visit } from '@ember/test-helpers';
-import { visit as visitScreen } from '@1024pix/ember-testing-library';
+import { click, currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import {
   createCertificationPointOfContactWithCustomCenters,
@@ -104,10 +104,10 @@ module('Acceptance | Session List', function (hooks) {
           date: '2020-01-01',
           time: '14:00',
         });
-        await visit('/sessions/liste');
+        const screen = await visit('/sessions/liste');
 
         // when
-        await click('[aria-label="Session de certification"]');
+        await click(screen.getByRole('link', { name: 'Session 123' }));
 
         // then
         assert.strictEqual(currentURL(), '/sessions/123');
@@ -157,7 +157,7 @@ module('Acceptance | Session List', function (hooks) {
           date: '2020-02-02',
           time: '16:00',
         });
-        const screen = await visitScreen('/sessions/liste');
+        const screen = await visit('/sessions/liste');
         await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
 
         // when
@@ -191,7 +191,7 @@ module('Acceptance | Session List', function (hooks) {
           }),
           400
         );
-        const screen = await visitScreen('/sessions/liste');
+        const screen = await visit('/sessions/liste');
         await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
 
         // when
@@ -224,7 +224,7 @@ module('Acceptance | Session List', function (hooks) {
           }),
           422
         );
-        const screen = await visitScreen('/sessions/liste');
+        const screen = await visit('/sessions/liste');
         await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
 
         // when
@@ -257,7 +257,7 @@ module('Acceptance | Session List', function (hooks) {
           }),
           422
         );
-        const screen = await visitScreen('/sessions/liste');
+        const screen = await visit('/sessions/liste');
         await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
 
         // when
@@ -285,7 +285,7 @@ module('Acceptance | Session List', function (hooks) {
           time: '14:00',
         });
 
-        const screen = await visitScreen('/sessions/liste');
+        const screen = await visit('/sessions/liste');
         await click(screen.getByRole('link', { name: 'Aller à la page suivante' }));
         await click(screen.getByRole('link', { name: 'Session 26' }));
 

--- a/certif/tests/acceptance/session-new_test.js
+++ b/certif/tests/acceptance/session-new_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { click, currentURL, visit, fillIn } from '@ember/test-helpers';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from '../helpers/test-init';
 
@@ -15,9 +16,7 @@ module('Acceptance | Session creation', function (hooks) {
     await visit('/sessions/creation');
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/connexion');
+    assert.strictEqual(currentURL(), '/connexion');
   });
 
   module('when the user is authenticated', (hooks) => {
@@ -49,9 +48,7 @@ module('Acceptance | Session creation', function (hooks) {
         await visit('/sessions/creation');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/espace-ferme');
+        assert.strictEqual(currentURL(), '/espace-ferme');
       });
     });
 
@@ -61,23 +58,23 @@ module('Acceptance | Session creation', function (hooks) {
       const sessionFormattedTime = '02/02/2019 13:45';
       const sessionTime = new Date(sessionFormattedTime);
 
-      await visit('/sessions/creation');
-      assert.dom('#session-address').exists();
-      assert.dom('#session-room').exists();
-      assert.dom('#session-date').exists();
-      assert.dom('#session-time').exists();
-      assert.dom('#session-examiner').exists();
-      assert.dom('#session-description').exists();
-      assert.dom('[data-test-id="session-form__submit-button"]').exists();
-      assert.dom('#session-description').hasAttribute('maxLength', '350');
+      const screen = await visit('/sessions/creation');
+      assert.dom(screen.getByRole('textbox', { name: 'Nom de la salle' })).exists();
+      assert.dom(screen.getByRole('textbox', { name: 'Surveillant(s)' })).exists();
+      assert.dom(screen.getByRole('textbox', { name: 'Nom du site' })).exists();
+      assert.dom(screen.getByRole('textbox', { name: 'Observations' })).hasAttribute('maxLength', '350');
+      assert.dom(screen.getByRole('textbox', { name: 'Heure de début (heure locale)' })).exists();
+      assert.dom(screen.getByText('Date de début')).exists();
+      assert.dom(screen.getByRole('button', { name: 'Créer la session' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
 
-      await fillIn('#session-address', 'My address');
-      await fillIn('#session-room', 'My room');
-      await fillIn('#session-examiner', 'My examiner');
-      await fillIn('#session-description', 'My description');
+      await fillIn(screen.getByRole('textbox', { name: 'Nom du site' }), 'My address');
+      await fillIn(screen.getByRole('textbox', { name: 'Nom de la salle' }), 'My room');
+      await fillIn(screen.getByRole('textbox', { name: 'Surveillant(s)' }), 'My examiner');
+      await fillIn(screen.getByRole('textbox', { name: 'Observations' }), 'My description');
       await setFlatpickrDate('#session-date', sessionDate);
-      await setFlatpickrDate('#session-time', sessionTime);
-      await click('[data-test-id="session-form__submit-button"]');
+      await setFlatpickrDate(screen.getByRole('textbox', { name: 'Heure de début (heure locale)' }), sessionTime);
+      await click(screen.getByRole('button', { name: 'Créer la session' }));
 
       // then
       const session = server.schema.sessions.findBy({ date: sessionDate });
@@ -93,10 +90,10 @@ module('Acceptance | Session creation', function (hooks) {
     test('it should go back to sessions list on cancel without creating any sessions', async function (assert) {
       // given
       const previousSessionsCount = server.schema.sessions.all().length;
-      await visit('/sessions/creation');
+      const screen = await visit('/sessions/creation');
 
       // when
-      await click('[data-test-id="session-form__cancel-button"]');
+      await click(screen.getByRole('button', { name: 'Annuler' }));
 
       // then
       const actualSessionsCount = server.schema.sessions.all().length;

--- a/certif/tests/acceptance/session-new_test.js
+++ b/certif/tests/acceptance/session-new_test.js
@@ -66,7 +66,11 @@ module('Acceptance | Session creation', function (hooks) {
       assert.dom(screen.getByRole('textbox', { name: 'Heure de début (heure locale)' })).exists();
       assert.dom(screen.getByText('Date de début')).exists();
       assert.dom(screen.getByRole('button', { name: 'Créer la session' })).exists();
-      assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
+      assert
+        .dom(
+          screen.getByRole('button', { name: 'Annuler la création de session et retourner vers la page précédente' })
+        )
+        .exists();
 
       await fillIn(screen.getByRole('textbox', { name: 'Nom du site' }), 'My address');
       await fillIn(screen.getByRole('textbox', { name: 'Nom de la salle' }), 'My room');
@@ -93,7 +97,9 @@ module('Acceptance | Session creation', function (hooks) {
       const screen = await visit('/sessions/creation');
 
       // when
-      await click(screen.getByRole('button', { name: 'Annuler' }));
+      await click(
+        screen.getByRole('button', { name: 'Annuler la création de session et retourner vers la page précédente' })
+      );
 
       // then
       const actualSessionsCount = server.schema.sessions.all().length;

--- a/certif/tests/acceptance/session-update_test.js
+++ b/certif/tests/acceptance/session-update_test.js
@@ -91,7 +91,9 @@ module('Acceptance | Session Update', function (hooks) {
     await fillIn(screen.getByRole('textbox', { name: 'Surveillant(s)' }), newExaminer);
 
     // when
-    await click(screen.getByRole('button', { name: 'Annuler' }));
+    await click(
+      screen.getByRole('button', { name: 'Annuler la modification de la session et retourner vers la page précédente' })
+    );
 
     // then
     session.reload();

--- a/certif/tests/acceptance/session-update_test.js
+++ b/certif/tests/acceptance/session-update_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { click, currentURL, visit, fillIn } from '@ember/test-helpers';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from '../helpers/test-init';
 
@@ -38,9 +39,7 @@ module('Acceptance | Session Update', function (hooks) {
       await visit(`/sessions/${session.id}/modification`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/espace-ferme');
+      assert.strictEqual(currentURL(), '/espace-ferme');
     });
   });
 
@@ -49,15 +48,16 @@ module('Acceptance | Session Update', function (hooks) {
     const session = server.create('session');
 
     // when
-    await visit(`/sessions/${session.id}/modification`);
+    const screen = await visit(`/sessions/${session.id}/modification`);
 
     // then
-    assert.dom('#session-room').hasValue(session.room);
-    assert.dom('#session-examiner').hasValue(session.examiner);
-    assert.dom('#session-address').hasValue(session.address);
-    assert.dom('#session-description').hasValue(session.description);
+    assert.dom(screen.getByRole('textbox', { name: 'Nom de la salle' })).hasValue(session.room);
+    assert.dom(screen.getByRole('textbox', { name: 'Surveillant(s)' })).hasValue(session.examiner);
+    assert.dom(screen.getByRole('textbox', { name: 'Nom du site' })).hasValue(session.address);
+    assert.dom(screen.getByRole('textbox', { name: 'Observations' })).hasValue(session.description);
+    assert.dom(screen.getByRole('textbox', { name: 'Heure de début (heure locale)' })).hasValue(session.time);
+    assert.dom(screen.getByText('Date de début')).exists();
     assert.dom('#session-date').hasValue(session.date);
-    assert.dom('#session-time').hasValue(session.time);
   });
 
   test('it should allow to update a session and redirect to the session details', async function (assert) {
@@ -66,24 +66,18 @@ module('Acceptance | Session Update', function (hooks) {
     const newRoom = 'New room';
     const newExaminer = 'New examiner';
 
-    await visit(`/sessions/${session.id}/modification`);
-    await fillIn('#session-room', newRoom);
-    await fillIn('#session-examiner', newExaminer);
+    const screen = await visit(`/sessions/${session.id}/modification`);
+    await fillIn(screen.getByRole('textbox', { name: 'Nom de la salle' }), newRoom);
+    await fillIn(screen.getByRole('textbox', { name: 'Surveillant(s)' }), newExaminer);
 
     // when
-    await click('[data-test-id="session-form__submit-button"]');
+    await click(screen.getByRole('button', { name: 'Modifier la session' }));
 
     // then
     session.reload();
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(session.room, newRoom);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(session.examiner, newExaminer);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), `/sessions/${session.id}`);
+    assert.strictEqual(session.room, newRoom);
+    assert.strictEqual(session.examiner, newExaminer);
+    assert.strictEqual(currentURL(), `/sessions/${session.id}`);
   });
 
   test('it should not update a session when cancel button is clicked and redirect to the session #1 details', async function (assert) {
@@ -92,23 +86,17 @@ module('Acceptance | Session Update', function (hooks) {
     const newRoom = 'New room';
     const newExaminer = 'New examiner';
 
-    await visit(`/sessions/${session.id}/modification`);
-    await fillIn('#session-room', newRoom);
-    await fillIn('#session-examiner', newExaminer);
+    const screen = await visit(`/sessions/${session.id}/modification`);
+    await fillIn(screen.getByRole('textbox', { name: 'Nom de la salle' }), newRoom);
+    await fillIn(screen.getByRole('textbox', { name: 'Surveillant(s)' }), newExaminer);
 
     // when
-    await click('[data-test-id="session-form__cancel-button"]');
+    await click(screen.getByRole('button', { name: 'Annuler' }));
 
     // then
     session.reload();
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(session.room, 'beforeRoom');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(session.examiner, 'beforeExaminer');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), `/sessions/${session.id}`);
+    assert.strictEqual(session.room, 'beforeRoom');
+    assert.strictEqual(session.examiner, 'beforeExaminer');
+    assert.strictEqual(currentURL(), `/sessions/${session.id}`);
   });
 });

--- a/certif/tests/integration/components/login-form_test.js
+++ b/certif/tests/integration/components/login-form_test.js
@@ -26,22 +26,16 @@ module('Integration | Component | login-form', function (hooks) {
     sessionStub = this.owner.lookup('service:session');
   });
 
-  test('it should ask for email and password', async function (assert) {
+  test('it should display login form', async function (assert) {
     // when
     const screen = await renderScreen(hbs`{{login-form}}`);
 
     // then
+    assert.dom(screen.getByRole('img', { name: 'Pix Certif' })).exists();
     assert.dom(screen.getByRole('heading', { name: 'Connectez-vous' })).exists();
     assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail' })).exists();
-    assert.dom(screen.getByText('Adresse e-mail')).exists();
-  });
-
-  test('it should not display error message', async function (assert) {
-    // when
-    await renderScreen(hbs`{{login-form}}`);
-
-    // then
-    assert.dom('#login-form-error-message').doesNotExist();
+    assert.dom(screen.getByRole('button', { name: 'Je me connecte' })).exists();
+    assert.dom(screen.getByLabelText('Mot de passe')).exists();
   });
 
   test('it should call authentication service with appropriate parameters', async function (assert) {
@@ -56,7 +50,7 @@ module('Integration | Component | login-form', function (hooks) {
     const sessionServiceObserver = this.owner.lookup('service:session');
     const screen = await renderScreen(hbs`{{login-form}}`);
     await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail' }), 'pix@example.net');
-    await fillIn('#login-password', 'JeMeLoggue1024');
+    await fillIn(screen.getByLabelText('Mot de passe'), 'JeMeLoggue1024');
 
     //  when
     await click(screen.getByRole('button', { name: 'Je me connecte' }));
@@ -84,14 +78,13 @@ module('Integration | Component | login-form', function (hooks) {
 
     sessionStub.authenticate.callsFake(() => reject(invalidCredentialsErrorMessage));
     const screen = await renderScreen(hbs`{{login-form}}`);
-    await fillIn('#login-email', 'pix@example.net');
-    await fillIn('#login-password', 'Mauvais mot de passe');
+    await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail' }), 'pix@example.net');
+    await fillIn(screen.getByLabelText('Mot de passe'), 'Mauvais mot de passe');
 
     //  when
     await click(screen.getByRole('button', { name: 'Je me connecte' }));
 
     // then
-    assert.dom('#login-form-error-message').exists();
     assert.dom(screen.getByText(ENV.APP.API_ERROR_MESSAGES.UNAUTHORIZED.MESSAGE)).exists();
   });
 
@@ -105,14 +98,13 @@ module('Integration | Component | login-form', function (hooks) {
 
     sessionStub.authenticate.callsFake(() => reject(notLinkedToOrganizationErrorMessage));
     const screen = await renderScreen(hbs`{{login-form}}`);
-    await fillIn('#login-email', 'pix@example.net');
-    await fillIn('#login-password', 'JeMeLoggue1024');
+    await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail' }), 'pix@example.net');
+    await fillIn(screen.getByLabelText('Mot de passe'), 'JeMeLoggue1024');
 
     //  when
     await click(screen.getByRole('button', { name: 'Je me connecte' }));
 
     // then
-    assert.dom('#login-form-error-message').exists();
     assert.dom(screen.getByText(errorMessages.NOT_LINKED_CERTIFICATION_MSG)).exists();
   });
 
@@ -132,14 +124,13 @@ module('Integration | Component | login-form', function (hooks) {
 
     sessionStub.authenticate.callsFake(() => reject(gatewayTimeoutErrorMessage));
     const screen = await renderScreen(hbs`{{login-form}}`);
-    await fillIn('#login-email', 'pix@example.net');
-    await fillIn('#login-password', 'JeMeLoggue1024');
+    await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail' }), 'pix@example.net');
+    await fillIn(screen.getByLabelText('Mot de passe'), 'JeMeLoggue1024');
 
     //  when
     await click(screen.getByRole('button', { name: 'Je me connecte' }));
 
     // then
-    assert.dom('#login-form-error-message').exists();
     assert.dom(screen.getByText(ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.MESSAGE)).exists();
   });
 
@@ -152,13 +143,12 @@ module('Integration | Component | login-form', function (hooks) {
     sessionStub.authenticate.callsFake(() => reject(msgErrorNotLinkedCertification));
     const screen = await renderScreen(hbs`{{login-form}}`);
     await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail' }), 'pix@example.net');
-    await fillIn('#login-password', 'JeMeLoggue1024');
+    await fillIn(screen.getByLabelText('Mot de passe'), 'JeMeLoggue1024');
 
     //  when
     await click(screen.getByRole('button', { name: 'Je me connecte' }));
 
     // then
-    assert.dom('#login-form-error-message').exists();
     assert.dom(screen.getByText(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE)).exists();
   });
 });

--- a/certif/tests/integration/components/login-session-supervisor-form_test.js
+++ b/certif/tests/integration/components/login-session-supervisor-form_test.js
@@ -15,9 +15,11 @@ module('Integration | Component | login-session-supervisor-form', function (hook
     const screen = await renderScreen(hbs`<LoginSessionSupervisorForm @onFormSubmit={{this.onFormSubmit}}/>`);
 
     // then
-    assert.dom(screen.getByLabelText('Numéro de la session')).exists();
+    assert.dom(screen.getByRole('heading', { name: 'Espace Surveillant' })).exists();
+    assert.dom(screen.getByRole('heading', { name: 'Surveiller une session' })).exists();
+    assert.dom(screen.getByRole('spinbutton', { name: 'Numéro de la session' })).exists();
     assert.dom(screen.getByLabelText('Mot de passe de la session Exemple : C-12345')).exists();
-    assert.dom(screen.getByText('Surveiller la session')).exists();
+    assert.dom(screen.getByRole('button', { name: 'Surveiller la session' })).exists();
   });
 
   module('On click on supervise button', function () {
@@ -28,10 +30,12 @@ module('Integration | Component | login-session-supervisor-form', function (hook
       await fillIn(screen.getByLabelText('Mot de passe de la session Exemple : C-12345'), '12345');
 
       // when
-      await click(screen.getByText('Surveiller la session'));
+      await click(screen.getByRole('button', { name: 'Surveiller la session' }));
 
       // then
-      assert.contains('Les champs "Numéro de la session" et "Mot de passe de session" sont obligatoires.');
+      assert
+        .dom(screen.getByText('Les champs "Numéro de la session" et "Mot de passe de session" sont obligatoires.'))
+        .exists();
     });
 
     test('it should display an error message when the supervisor password is empty', async function (assert) {
@@ -41,21 +45,23 @@ module('Integration | Component | login-session-supervisor-form', function (hook
       await fillIn(screen.getByLabelText('Numéro de la session'), '12345');
 
       // when
-      await click(screen.getByText('Surveiller la session'));
+      await click(screen.getByRole('button', { name: 'Surveiller la session' }));
 
       // then
-      assert.contains('Les champs "Numéro de la session" et "Mot de passe de session" sont obligatoires.');
+      assert
+        .dom(screen.getByText('Les champs "Numéro de la session" et "Mot de passe de session" sont obligatoires.'))
+        .exists();
     });
 
     test('it should call onFormSubmit when all the fields are filled', async function (assert) {
       // given
       this.onFormSubmit = sinon.stub();
       const screen = await renderScreen(hbs`<LoginSessionSupervisorForm @onFormSubmit={{this.onFormSubmit}} />`);
-      await fillIn(screen.getByLabelText('Numéro de la session'), '12345');
+      await fillIn(screen.getByRole('spinbutton', { name: 'Numéro de la session' }), '12345');
       await fillIn(screen.getByLabelText('Mot de passe de la session Exemple : C-12345'), '6789');
 
       // when
-      await click(screen.getByText('Surveiller la session'));
+      await click(screen.getByRole('button', { name: 'Surveiller la session' }));
 
       // then
       sinon.assert.calledWith(this.onFormSubmit, { sessionId: '12345', supervisorPassword: '6789' });

--- a/certif/tests/integration/components/session-summary-list_test.js
+++ b/certif/tests/integration/components/session-summary-list_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
-import { render, click } from '@ember/test-helpers';
-import { render as renderScreen } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
@@ -19,7 +19,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
     this.sessionSummaries = sessionSummaries;
 
     // when
-    const screen = await renderScreen(hbs`<SessionSummaryList
+    const screen = await render(hbs`<SessionSummaryList
                   @sessionSummaries={{this.sessionSummaries}}
                   @goToSessionDetails={{this.goToSessionDetailsSpy}} />`);
 
@@ -32,6 +32,8 @@ module('Integration | Component | session-summary-list', function (hooks) {
     assert.dom(screen.getByRole('columnheader', { name: 'Surveillant(s)' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'Candidats inscrits' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'Certifications passées' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Statut' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Actions' })).exists();
   });
 
   module('When there are no sessions to display', function () {
@@ -42,12 +44,12 @@ module('Integration | Component | session-summary-list', function (hooks) {
       this.sessionSummaries = sessionSummaries;
 
       // when
-      await render(hbs`<SessionSummaryList
+      const screen = await render(hbs`<SessionSummaryList
                   @sessionSummaries={{this.sessionSummaries}}
                   @goToSessionDetails={{this.goToSessionDetailsSpy}} />`);
 
       // then
-      assert.contains('Aucune session trouvée');
+      assert.dom(screen.getByText('Aucune session trouvée')).exists();
     });
   });
 
@@ -68,13 +70,14 @@ module('Integration | Component | session-summary-list', function (hooks) {
       this.sessionSummaries = sessionSummaries;
 
       // when
-      const screen = await renderScreen(hbs`<SessionSummaryList
+      const screen = await render(hbs`<SessionSummaryList
                   @sessionSummaries={{this.sessionSummaries}}
                   @goToSessionDetails={{this.goToSessionDetailsSpy}} />`);
 
       // then
-      assert.notContains('Aucune session trouvée');
-      assert.strictEqual(screen.getAllByRole('row', { name: 'Session de certification' }).length, 2);
+      assert.dom(screen.queryByText('Aucune session trouvée')).doesNotExist();
+      assert.dom(screen.getByRole('link', { name: 'Session 123' })).exists();
+      assert.dom(screen.getByRole('link', { name: 'Session 456' })).exists();
     });
 
     test('it should display all the attributes of the session summary in the row', async function (assert) {
@@ -98,20 +101,19 @@ module('Integration | Component | session-summary-list', function (hooks) {
       this.sessionSummaries = sessionSummaries;
 
       // when
-      await render(hbs`<SessionSummaryList
+      const screen = await render(hbs`<SessionSummaryList
                   @sessionSummaries={{this.sessionSummaries}}
                   @goToSessionDetails={{this.goToSessionDetailsSpy}} />`);
 
       // then
-      assert.contains('123');
-      assert.contains('TicTac');
-      assert.contains('Jambon');
-      assert.contains('01/12/2020');
-      assert.contains('15:00');
-      assert.contains('Bibiche');
-      assert.contains('3');
-      assert.contains('2');
-      assert.contains('Finalisée');
+      assert.dom(screen.getByRole('cell', { name: 'TicTac' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Jambon' })).exists();
+      assert.dom(screen.getByRole('cell', { name: '01/12/2020' })).exists();
+      assert.dom(screen.getByRole('cell', { name: '15:00' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Bibiche' })).exists();
+      assert.dom(screen.getByRole('cell', { name: '3' })).exists();
+      assert.dom(screen.getByRole('cell', { name: '2' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Finalisée' })).exists();
     });
 
     test('it should call goToSessionDetails function with session Id when clicking on a row', async function (assert) {
@@ -126,7 +128,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
         rowCount: 1,
       };
       this.sessionSummaries = sessionSummaries;
-      const screen = await renderScreen(hbs`<SessionSummaryList
+      const screen = await render(hbs`<SessionSummaryList
                   @sessionSummaries={{this.sessionSummaries}}
                   @goToSessionDetails={{this.goToSessionDetailsSpy}} />`);
 
@@ -152,7 +154,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
       this.sessionSummaries = sessionSummaries;
 
       // when
-      const screen = await renderScreen(hbs`<SessionSummaryList
+      const screen = await render(hbs`<SessionSummaryList
                   @sessionSummaries={{this.sessionSummaries}}
                   @goToSessionDetails={{this.goToSessionDetailsSpy}} />`);
 
@@ -177,7 +179,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
         this.sessionSummaries = sessionSummaries;
 
         // when
-        const screen = await renderScreen(hbs`<SessionSummaryList
+        const screen = await render(hbs`<SessionSummaryList
                   @sessionSummaries={{this.sessionSummaries}}
                   @goToSessionDetails={{this.goToSessionDetailsSpy}} />`);
 
@@ -201,7 +203,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
         this.sessionSummaries = sessionSummaries;
 
         // when
-        const screen = await renderScreen(hbs`<SessionSummaryList
+        const screen = await render(hbs`<SessionSummaryList
                   @sessionSummaries={{this.sessionSummaries}}
                   @goToSessionDetails={{this.goToSessionDetailsSpy}} />`);
 
@@ -222,9 +224,10 @@ module('Integration | Component | session-summary-list', function (hooks) {
           });
           this.sessionSummaries = [sessionSummary];
 
-          const screen = await renderScreen(hbs`<SessionSummaryList
+          const screen = await render(hbs`<SessionSummaryList
                   @sessionSummaries={{this.sessionSummaries}}
-                  @goToSessionDetails={{this.goToSessionDetailsSpy}}/>`);
+                  @goToSessionDetails={{this.goToSessionDetailsSpy}}
+                  />`);
 
           // when
           await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
@@ -252,7 +255,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
             });
             this.sessionSummaries = [sessionSummary];
 
-            const screen = await renderScreen(hbs`<SessionSummaryList
+            const screen = await render(hbs`<SessionSummaryList
                     @sessionSummaries={{this.sessionSummaries}}
                     @goToSessionDetails={{this.goToSessionDetailsSpy}}/>`);
 
@@ -281,7 +284,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
             });
             this.sessionSummaries = [sessionSummary];
 
-            const screen = await renderScreen(hbs`<SessionSummaryList
+            const screen = await render(hbs`<SessionSummaryList
                     @sessionSummaries={{this.sessionSummaries}}
                     @goToSessionDetails={{this.goToSessionDetailsSpy}}/>`);
 
@@ -312,7 +315,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
             });
             this.sessionSummaries = [sessionSummary];
 
-            const screen = await renderScreen(hbs`<SessionSummaryList
+            const screen = await render(hbs`<SessionSummaryList
                       @sessionSummaries={{this.sessionSummaries}}
                       @goToSessionDetails={{this.goToSessionDetailsSpy}}/>`);
 
@@ -341,7 +344,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
             };
             this.sessionSummaries = sessionSummaries;
 
-            const screen = await renderScreen(hbs`<SessionSummaryList
+            const screen = await render(hbs`<SessionSummaryList
                   @sessionSummaries={{this.sessionSummaries}}
                   @goToSessionDetails={{this.goToSessionDetailsSpy}}/>`);
             await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));

--- a/certif/tests/integration/components/user-logged-menu_test.js
+++ b/certif/tests/integration/components/user-logged-menu_test.js
@@ -69,6 +69,16 @@ module('Integration | Component | user-logged-menu', function (hooks) {
   });
 
   module('when menu is closed', function () {
+    test('([a11y] should indicate that the menu is not displayed', async function (assert) {
+      // when
+      const screen = await renderScreen(hbs`<UserLoggedMenu/>`);
+      await click(screen.getByRole('link', { name: 'Buffy Summers Sunnydale' }));
+      await click(screen.getByRole('link', { name: 'Buffy Summers Sunnydale' }));
+
+      // then
+      assert.dom(screen.getByRole('link', { name: 'Buffy Summers Sunnydale' })).hasAria('expanded', 'false');
+    });
+
     test('should hide the disconnect link', async function (assert) {
       // when
       const screen = await renderScreen(hbs`<UserLoggedMenu/>`);
@@ -81,14 +91,13 @@ module('Integration | Component | user-logged-menu', function (hooks) {
   });
 
   module('when menu is open', function () {
-    test('should display the chevron-up icon', async function (assert) {
+    test('([a11y] should indicate that the menu is displayed', async function (assert) {
       // when
       const screen = await renderScreen(hbs`<UserLoggedMenu/>`);
       await click(screen.getByRole('link', { name: 'Buffy Summers Sunnydale' }));
 
       // then
-      assert.dom('.fa-chevron-up').exists();
-      assert.dom('.fa-chevron-down').doesNotExist();
+      assert.dom(screen.getByRole('link', { name: 'Buffy Summers Sunnydale' })).hasAria('expanded', 'true');
     });
 
     test('should display the disconnect link', async function (assert) {
@@ -127,10 +136,8 @@ module('Integration | Component | user-logged-menu', function (hooks) {
       await click(screen.getByRole('link', { name: 'Buffy Summers Sunnydale' }));
 
       // then
-      assert.dom(screen.getByText('Torreilles')).exists();
-      assert.dom(screen.getByText('(externalId1)')).exists();
-      assert.dom(screen.getByText('Paris')).exists();
-      assert.dom(screen.getByText('(ILPlEUT)')).exists();
+      assert.dom(screen.getByRole('button', { name: 'Torreilles (externalId1)' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Paris (ILPlEUT)' })).exists();
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Certains tests sur Pix Certif dépendent encore du style css ou s'assurent du contenu sans passer par l'élément html associé. Choses que fait testing library. 
Des points d'accessibilité sont également à améliorer sur certaines pages de l'application.

## :robot: Solution
Utiliser testing  library et corriger quelques points d’accessibilité.

## :rainbow: Remarques

Accessibilité : 

- Le tableau des sessions comporte une colonne sans nom. Il est obligatoire de renseigner le nom des colonnes, même si on ne souhaite pas l'afficher car le lecteur d'écran pourra quand même le lire. ( => Nom : Actions )
- Des soucis de contraste de couleur ont été corrigés 
- Ajout d'un message pour les champs obligatoire dans la page de connexion/ modif et création de sessions
- Ajout des balises header et main dans la page de connexion (audit)
- Les boutons des pages de création et update des sessions de certif sont placé dans une liste 
- Les boutons "annuler" des pages de création et update des sessions comportent désormais un aria-label explicitant leur action car ils déclenchent un changement de page donc l’utilisateur doit en être informé

## :100: Pour tester
 **Page de connexion** : 
- Mettre une adresse email et mot de passe aléatoires pour recevoir un message d'erreur. 
- S'assurer que le rouge de l'erreur passe sur Wave et qu'il s'affiche désormais en dessous des champs
- S'assurer que le message suivant apparaisse : "Tous les champs sont obligatoires."

AVANT : 
<img width="248" alt="Capture d’écran 2022-10-04 à 16 18 01" src="https://user-images.githubusercontent.com/58915422/193843872-e744d0d5-a72e-4e25-b800-127f5964008b.png">

APRES :
<img width="248" alt="Capture d’écran 2022-10-04 à 16 19 01" src="https://user-images.githubusercontent.com/58915422/193844065-ec89304e-d12a-44f1-8308-243f8e6c75bb.png">

 **Page des CGU** : 
- se connecter avec sco.admin@example.net
- constater qu'un h1 existe suivi de h2 et h3 pour les sous parties

AVANT :
<img width="453" alt="Capture d’écran 2022-10-12 à 16 30 02" src="https://user-images.githubusercontent.com/58915422/195370935-f4cf4e3f-2243-42c6-b3b1-9346fef80647.png">

APRES :
<img width="453" alt="Capture d’écran 2022-10-12 à 16 30 09" src="https://user-images.githubusercontent.com/58915422/195370942-3db4a5b4-1fac-4d77-b529-e3e36c707177.png">

**Page espace surveillant (/connexion-espace-surveillant)** : 
- Se connecter avec certifpro@example.net
- Aller sur l'espace via le menu ou /connexion-espace-surveillant
- S'assurer que le gris passe sur Wave

AVANT : 
<img width="248" alt="Capture d’écran 2022-10-04 à 16 22 52" src="https://user-images.githubusercontent.com/58915422/193845086-87435d0d-251d-4421-b398-737d6e205bfb.png">

APRES :
<img width="248" alt="Capture d’écran 2022-10-04 à 16 22 59" src="https://user-images.githubusercontent.com/58915422/193845124-f833a531-446a-4568-b4a3-5b8d4567e8af.png">

**Page tableau de sessions de certif** : 
- Se connecter avec certifpro@example.net
- Constater que le nom de la dernière colonne est visuellement masqué mais lu par le lecteur d'écran. (MAC : Lancer Voice Over, charger la page et le laisser lire le tableau)
- ℹ️ Une erreur apparaît ponctuellement sur Wave dans ce tableau concernant le tooltip de suppression de session. Pourtant le label est bien rattaché à l'élément (à creuser)

**Page de détail d'une session (/sessions/106161)** 
- S'assurer que le gris passe sur Wave
- Problématique de heading h1 qui passe à un h4 : maintenant nous avons du h1 h2 et h3
- Lancer Voice Over : Les bouton permettant de copier les codes précisent davantage d'informations. Le bouton modifier également

AVANT:
<img width="551" alt="Capture d’écran 2022-10-04 à 16 27 44" src="https://user-images.githubusercontent.com/58915422/193846696-df212a98-d1e0-43fb-94c8-a4aa3655aba4.png">

APRES:
<img width="551" alt="Capture d’écran 2022-10-04 à 16 27 50" src="https://user-images.githubusercontent.com/58915422/193849654-6e46ba11-e15b-46ea-9017-d9d27c942001.png">


**Page de modification d'une session** ET **Page de création d'une session** 
- Constater qu'un message indique les champs obligatoire et que les champs en question ont l'astérisque.
- ℹ️ Wave indique une erreur de label sur le champ de la date mais ce datepicker n'est de pas base pas très accessible, il devrait être changé.

