### PR TITLE
[FEATURE] Admin: Afficher les informations du DPO sur la page de détails d'un centre de certification (PIX-5266)

### DIFF
--- a/admin/app/adapters/certification-center-membership.js
+++ b/admin/app/adapters/certification-center-membership.js
@@ -1,6 +1,8 @@
 import ApplicationAdapter from './application';
 
 export default class CertificationCenterMembershipAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+
   urlForQuery(query) {
     if (query.filter.certificationCenterId) {
       const { certificationCenterId } = query.filter;

--- a/admin/app/adapters/certification-center.js
+++ b/admin/app/adapters/certification-center.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+
+export default class CertificationCenterAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+}

--- a/admin/app/components/certification-centers/information.hbs
+++ b/admin/app/components/certification-centers/information.hbs
@@ -99,6 +99,12 @@
           <span>{{@certificationCenter.externalId}}</span><br />
         </div>
         <div class="property">
+          <ul>
+            <li>Nom du DPO : {{@certificationCenter.dataProtectionOfficerFullName}}</li>
+            <li>Adresse e-mail du DPO : {{@certificationCenter.dataProtectionOfficerEmail}}</li>
+          </ul>
+        </div>
+        <div class="property">
           <label class="field__label">Espace surveillant :</label>
           <span aria-label="Espace surveillant">{{@certificationCenter.supervisorAccessLabel}}</span><br />
         </div>

--- a/admin/app/models/certification-center.js
+++ b/admin/app/models/certification-center.js
@@ -11,6 +11,9 @@ export default class CertificationCenter extends Model {
   @attr() type;
   @attr() externalId;
   @attr('boolean') isSupervisorAccessEnabled;
+  @attr() dataProtectionOfficerFirstName;
+  @attr() dataProtectionOfficerLastName;
+  @attr() dataProtectionOfficerEmail;
 
   @hasMany('habilitation') habilitations;
 
@@ -20,5 +23,14 @@ export default class CertificationCenter extends Model {
 
   get supervisorAccessLabel() {
     return this.isSupervisorAccessEnabled ? 'oui' : 'non';
+  }
+
+  get dataProtectionOfficerFullName() {
+    const fullName = [];
+
+    if (this.dataProtectionOfficerFirstName) fullName.push(this.dataProtectionOfficerFirstName);
+    if (this.dataProtectionOfficerLastName) fullName.push(this.dataProtectionOfficerLastName);
+
+    return fullName.join(' ');
   }
 }

--- a/admin/app/styles/components/certification-centers/information.scss
+++ b/admin/app/styles/components/certification-centers/information.scss
@@ -26,6 +26,11 @@
       &:last-child {
         border-bottom: none;
       }
+
+      ul {
+        padding: 0;
+        list-style: none;
+      }
     }
   }
 

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -99,13 +99,13 @@ export default function () {
 
   this.get('/admin/users');
 
-  this.get('/certification-centers');
-  this.get('/certification-centers/:id');
-  this.get('/certification-centers/:id/certification-center-memberships', (schema, request) => {
+  this.get('/admin/certification-centers');
+  this.get('/admin/certification-centers/:id');
+  this.get('/admin/certification-centers/:id/certification-center-memberships', (schema, request) => {
     const certificationCenterId = request.params.id;
     return schema.certificationCenterMemberships.where({ certificationCenterId });
   });
-  this.post('/certification-centers', (schema, request) => {
+  this.post('/admin/certification-centers', (schema, request) => {
     const params = JSON.parse(request.requestBody);
     const name = params.data.attributes.name;
     const type = params.data.attributes.type;
@@ -113,7 +113,7 @@ export default function () {
 
     return schema.certificationCenters.create({ name, type, externalId });
   });
-  this.post('/certification-centers/:id/certification-center-memberships', (schema, request) => {
+  this.post('/admin/certification-centers/:id/certification-center-memberships', (schema, request) => {
     const certificationCenterId = request.params.id;
     const params = JSON.parse(request.requestBody);
     const { email } = params;
@@ -127,7 +127,7 @@ export default function () {
     });
   });
 
-  this.delete('/certification-center-memberships/:id', (schema, request) => {
+  this.delete('/admin/certification-center-memberships/:id', (schema, request) => {
     const certificationCenterMembershipId = request.params.id;
     schema.db.certificationCenterMemberships.remove(certificationCenterMembershipId);
     return new Response(204);

--- a/admin/tests/acceptance/authenticated/certification-centers/form_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/form_test.js
@@ -26,7 +26,7 @@ module('Acceptance | Certification Centers | Form', function (hooks) {
     const name = 'name';
     const type = { label: 'Organisation professionnelle', value: 'PRO' };
     const externalId = 'externalId';
-    this.server.post('/certification-centers', (schema, request) => {
+    this.server.post('/admin/certification-centers', (schema, request) => {
       const { name, type, externalId, isSupervisorAccessEnabled } = JSON.parse(request.requestBody).data.attributes;
       return schema.certificationCenters.create({ id: 99, name, type, externalId, isSupervisorAccessEnabled });
     });

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -269,7 +269,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       });
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
       await clickByName('Editer les informations');
-      this.server.patch(`/certification-centers/${certificationCenter.id}`, () => new Response({}), 204);
+      this.server.patch(`/admin/certification-centers/${certificationCenter.id}`, () => new Response({}), 204);
 
       // when
       await fillByLabel('Nom du centre', 'nouveau nom');
@@ -299,7 +299,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
       await clickByName('Editer les informations');
-      this.server.patch(`/certification-centers/${certificationCenter.id}`, () => new Response({}), 204);
+      this.server.patch(`/admin/certification-centers/${certificationCenter.id}`, () => new Response({}), 204);
 
       // when
       await fillByLabel('Nom du centre', 'Centre des réussites');
@@ -322,7 +322,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
         externalId: 'ABCDEF',
         type: 'SCO',
       });
-      this.server.patch(`/certification-centers/${certificationCenter.id}`, () => new Response({}), 422);
+      this.server.patch(`/admin/certification-centers/${certificationCenter.id}`, () => new Response({}), 422);
       const screen = await visit(`/certification-centers/${certificationCenter.id}`);
       await clickByName('Editer les informations');
 

--- a/admin/tests/integration/components/certification-centers/information_test.js
+++ b/admin/tests/integration/components/certification-centers/information_test.js
@@ -30,6 +30,9 @@ module('Integration | Component | certification-centers/information', function (
       type: 'SCO',
       externalId: 'AX129',
       isSupervisorAccessEnabled: false,
+      dataProtectionOfficerFirstName: 'Lucky',
+      dataProtectionOfficerLastName: 'Number',
+      dataProtectionOfficerEmail: 'lucky@example.net',
       habilitations: [availableHabilitations.firstObject],
     });
     this.certificationCenter = certificationCenter;
@@ -47,6 +50,8 @@ module('Integration | Component | certification-centers/information', function (
     assert.dom(screen.getByText('Centre SCO')).exists();
     assert.dom(screen.getByText('AX129')).exists();
     assert.strictEqual(screen.getByLabelText('Espace surveillant').textContent, 'non');
+    assert.dom(screen.getByText('Nom du DPO : Lucky Number')).exists();
+    assert.dom(screen.getByText('Adresse e-mail du DPO : lucky@example.net')).exists();
     assert.dom(screen.getByLabelText('Habilité pour Pix+Droit')).exists();
     assert.dom(screen.getByLabelText('Non-habilité pour Cléa')).exists();
   });

--- a/admin/tests/unit/adapters/certification-center-membership_test.js
+++ b/admin/tests/unit/adapters/certification-center-membership_test.js
@@ -17,16 +17,14 @@ module('Unit | Adapter | certificationCenterMembership', function (hooks) {
       const query = { filter: { certificationCenterId: '1' } };
       const url = await adapter.urlForQuery(query);
 
-      assert.ok(url.endsWith('/api/certification-centers/1/certification-center-memberships'));
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(query.filter.certificationCenterId, undefined);
+      assert.ok(url.endsWith('/api/admin/certification-centers/1/certification-center-memberships'));
+      assert.strictEqual(query.filter.certificationCenterId, undefined);
     });
   });
 
   module('#createRecord', function () {
     module('when createByEmail is true', function () {
-      test('should call /api/certification-centers/id/certification-center-memberships', async function (assert) {
+      test('should call /api/admin/certification-centers/id/certification-center-memberships', async function (assert) {
         // given
         const certificationCenterId = 1;
         const email = 'user@example.net';
@@ -38,7 +36,7 @@ module('Unit | Adapter | certificationCenterMembership', function (hooks) {
             email,
           },
         };
-        const expectedUrl = `http://localhost:3000/api/certification-centers/${certificationCenterId}/certification-center-memberships`;
+        const expectedUrl = `http://localhost:3000/api/admin/certification-centers/${certificationCenterId}/certification-center-memberships`;
         const expectedMethod = 'POST';
         const expectedPayload = { data: { email } };
 

--- a/api/lib/application/certification-center-memberships/index.js
+++ b/api/lib/application/certification-center-memberships/index.js
@@ -2,7 +2,35 @@ const certificationCenterMembershipController = require('./certification-center-
 const securityPreHandlers = require('../security-pre-handlers');
 
 exports.register = async function (server) {
+  const adminRoutes = [
+    {
+      method: 'DELETE',
+      path: '/api/admin/certification-center-memberships/{id}',
+      config: {
+        handler: certificationCenterMembershipController.disable,
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
+            '- Désactivation d‘un lien entre un utilisateur et un centre de certification\n',
+        ],
+        tags: ['api', 'certification-center-membership'],
+      },
+    },
+  ];
+
   server.route([
+    ...adminRoutes,
     {
       method: 'POST',
       path: '/api/certification-center-memberships',
@@ -23,30 +51,6 @@ exports.register = async function (server) {
         notes: [
           "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
             '- Création d‘un lien entre un utilisateur et un centre de certification\n',
-        ],
-        tags: ['api', 'certification-center-membership'],
-      },
-    },
-    {
-      method: 'DELETE',
-      path: '/api/certification-center-memberships/{id}',
-      config: {
-        handler: certificationCenterMembershipController.disable,
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
-          },
-        ],
-        notes: [
-          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
-            '- Désactivation d‘un lien entre un utilisateur et un centre de certification\n',
         ],
         tags: ['api', 'certification-center-membership'],
       },

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -30,9 +30,11 @@ module.exports = {
     return certificationCenterSerializer.serialize(updatedCertificationCenter);
   },
 
-  getById(request) {
+  async getCertificationCenterDetails(request) {
     const certificationCenterId = request.params.id;
-    return usecases.getCertificationCenter({ id: certificationCenterId }).then(certificationCenterSerializer.serialize);
+
+    const certificationCenterDetails = await usecases.getCertificationCenter({ id: certificationCenterId });
+    return certificationCenterSerializer.serialize(certificationCenterDetails);
   },
 
   async findPaginatedFilteredCertificationCenters(request) {

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -1,6 +1,7 @@
 const usecases = require('../../domain/usecases');
 
 const certificationCenterSerializer = require('../../infrastructure/serializers/jsonapi/certification-center-serializer');
+const certificationCenterForAdminSerializer = require('../../infrastructure/serializers/jsonapi/certification-center-for-admin-serializer');
 const certificationCenterMembershipSerializer = require('../../infrastructure/serializers/jsonapi/certification-center-membership-serializer');
 const divisionSerializer = require('../../infrastructure/serializers/jsonapi/division-serializer');
 const studentCertificationSerializer = require('../../infrastructure/serializers/jsonapi/student-certification-serializer');
@@ -34,7 +35,7 @@ module.exports = {
     const certificationCenterId = request.params.id;
 
     const certificationCenterDetails = await usecases.getCertificationCenter({ id: certificationCenterId });
-    return certificationCenterSerializer.serialize(certificationCenterDetails);
+    return certificationCenterForAdminSerializer.serialize(certificationCenterDetails);
   },
 
   async findPaginatedFilteredCertificationCenters(request) {

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -4,58 +4,10 @@ const Joi = require('joi');
 const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function (server) {
-  server.route([
-    {
-      method: 'POST',
-      path: '/api/certification-centers',
-      config: {
-        handler: certificationCenterController.create,
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
-          },
-        ],
-        notes: [
-          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
-            '- Création d‘un nouveau centre de certification\n',
-        ],
-        tags: ['api', 'certification-center'],
-      },
-    },
-    {
-      method: 'PATCH',
-      path: '/api/certification-centers/{id}',
-      config: {
-        handler: certificationCenterController.update,
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
-          },
-        ],
-        notes: [
-          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
-            '- Création d‘un nouveau centre de certification\n',
-        ],
-        tags: ['api', 'certification-center'],
-      },
-    },
+  const adminRoutes = [
     {
       method: 'GET',
-      path: '/api/certification-centers',
+      path: '/api/admin/certification-centers',
       config: {
         handler: certificationCenterController.findPaginatedFilteredCertificationCenters,
         pre: [
@@ -79,7 +31,7 @@ exports.register = async function (server) {
     },
     {
       method: 'GET',
-      path: '/api/certification-centers/{id}',
+      path: '/api/admin/certification-centers/{id}',
       config: {
         pre: [
           {
@@ -102,6 +54,122 @@ exports.register = async function (server) {
         notes: [
           "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
             "- Récupération d'un centre de certification\n",
+        ],
+        tags: ['api', 'certification-center'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/admin/certification-centers/{certificationCenterId}/certification-center-memberships',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            certificationCenterId: identifiersType.certificationCenterId,
+          }),
+        },
+        handler: certificationCenterController.findCertificationCenterMembershipsByCertificationCenter,
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
+            "- Récupération de tous les membres d'un centre de certification.\n",
+        ],
+        tags: ['api', 'admin', 'certification-center-membership'],
+      },
+    },
+
+    {
+      method: 'POST',
+      path: '/api/admin/certification-centers/{certificationCenterId}/certification-center-memberships',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            certificationCenterId: identifiersType.certificationCenterId,
+          }),
+          payload: Joi.object().required().keys({
+            email: Joi.string().email().required(),
+          }),
+        },
+        handler: certificationCenterController.createCertificationCenterMembershipByEmail,
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
+            "- Création d‘un nouveau membre d'un centre de certification,\n" +
+            "à partir de l'adresse e-mail d'un utilisateur.",
+        ],
+        tags: ['api', 'certification-center-membership'],
+      },
+    },
+
+    {
+      method: 'PATCH',
+      path: '/api/admin/certification-centers/{id}',
+      config: {
+        handler: certificationCenterController.update,
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
+            '- Création d‘un nouveau centre de certification\n',
+        ],
+        tags: ['api', 'certification-center'],
+      },
+    },
+  ];
+
+  server.route([
+    ...adminRoutes,
+    {
+      method: 'POST',
+      path: '/api/certification-centers',
+      config: {
+        handler: certificationCenterController.create,
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
+            '- Création d‘un nouveau centre de certification\n',
         ],
         tags: ['api', 'certification-center'],
       },
@@ -165,35 +233,6 @@ exports.register = async function (server) {
     },
     {
       method: 'GET',
-      path: '/api/certification-centers/{certificationCenterId}/certification-center-memberships',
-      config: {
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
-          },
-        ],
-        validate: {
-          params: Joi.object({
-            certificationCenterId: identifiersType.certificationCenterId,
-          }),
-        },
-        handler: certificationCenterController.findCertificationCenterMembershipsByCertificationCenter,
-        notes: [
-          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
-            "- Récupération de tous les membres d'un centre de certification.\n",
-        ],
-        tags: ['api', 'admin', 'certification-center-membership'],
-      },
-    },
-    {
-      method: 'GET',
       path: '/api/certification-centers/{certificationCenterId}/members',
       config: {
         pre: [
@@ -213,39 +252,6 @@ exports.register = async function (server) {
             "- Récupération de tous les membres d'un centre de certification.\n",
         ],
         tags: ['api', 'certification-center', 'members'],
-      },
-    },
-    {
-      method: 'POST',
-      path: '/api/certification-centers/{certificationCenterId}/certification-center-memberships',
-      config: {
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
-          },
-        ],
-        validate: {
-          params: Joi.object({
-            certificationCenterId: identifiersType.certificationCenterId,
-          }),
-          payload: Joi.object().required().keys({
-            email: Joi.string().email().required(),
-          }),
-        },
-        handler: certificationCenterController.createCertificationCenterMembershipByEmail,
-        notes: [
-          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
-            "- Création d‘un nouveau membre d'un centre de certification,\n" +
-            "à partir de l'adresse e-mail d'un utilisateur.",
-        ],
-        tags: ['api', 'certification-center-membership'],
       },
     },
   ]);

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -50,7 +50,7 @@ exports.register = async function (server) {
             id: identifiersType.certificationCenterId,
           }),
         },
-        handler: certificationCenterController.getById,
+        handler: certificationCenterController.getCertificationCenterDetails,
         notes: [
           "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
             "- Récupération d'un centre de certification\n",

--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -80,4 +80,10 @@ module.exports = {
       },
     },
   },
+
+  CERTIFICATION_CENTER_TYPES: {
+    SUP: 'SUP',
+    SCO: 'SCO',
+    PRO: 'PRO',
+  },
 };

--- a/api/lib/domain/models/CertificationCenterForAdmin.js
+++ b/api/lib/domain/models/CertificationCenterForAdmin.js
@@ -1,6 +1,6 @@
 const { CERTIFICATION_CENTER_TYPES } = require('../constants');
 
-class CertificationCenter {
+class CertificationCenterForAdmin {
   constructor({
     id,
     name,
@@ -10,6 +10,9 @@ class CertificationCenter {
     updatedAt,
     habilitations = [],
     isSupervisorAccessEnabled = false,
+    dataProtectionOfficerFirstName,
+    dataProtectionOfficerLastName,
+    dataProtectionOfficerEmail,
   } = {}) {
     this.id = id;
     this.name = name;
@@ -19,6 +22,9 @@ class CertificationCenter {
     this.updatedAt = updatedAt;
     this.habilitations = habilitations;
     this.isSupervisorAccessEnabled = isSupervisorAccessEnabled;
+    this.dataProtectionOfficerFirstName = dataProtectionOfficerFirstName;
+    this.dataProtectionOfficerLastName = dataProtectionOfficerLastName;
+    this.dataProtectionOfficerEmail = dataProtectionOfficerEmail;
   }
 
   get isSco() {
@@ -30,5 +36,5 @@ class CertificationCenter {
   }
 }
 
-module.exports = CertificationCenter;
+module.exports = CertificationCenterForAdmin;
 module.exports.types = CERTIFICATION_CENTER_TYPES;

--- a/api/lib/domain/usecases/get-certification-center.js
+++ b/api/lib/domain/usecases/get-certification-center.js
@@ -1,3 +1,3 @@
-module.exports = function getCertificationCenter({ id, certificationCenterRepository }) {
-  return certificationCenterRepository.get(id);
+module.exports = function getCertificationCenter({ id, certificationCenterForAdminRepository }) {
+  return certificationCenterForAdminRepository.get(id);
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -42,6 +42,7 @@ const dependencies = {
   certificationCandidateForSupervisingRepository: require('../../infrastructure/repositories/certification-candidate-for-supervising-repository'),
   certificationCandidatesOdsService: require('../../domain/services/certification-candidates-ods-service'),
   certificationCenterMembershipRepository: require('../../infrastructure/repositories/certification-center-membership-repository'),
+  certificationCenterForAdminRepository: require('../../infrastructure/repositories/certification-center-for-admin-repository'),
   certificationCenterRepository: require('../../infrastructure/repositories/certification-center-repository'),
   certificationChallengeRepository: require('../../infrastructure/repositories/certification-challenge-repository'),
   certificationChallengesService: require('../../domain/services/certification-challenges-service'),

--- a/api/lib/infrastructure/repositories/certification-center-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-for-admin-repository.js
@@ -1,0 +1,69 @@
+const { knex } = require('../../../db/knex-database-connection');
+const CertificationCenterForAdmin = require('../../domain/models/CertificationCenterForAdmin');
+const ComplementaryCertification = require('../../domain/models/ComplementaryCertification');
+const { NotFoundError } = require('../../domain/errors');
+
+module.exports = {
+  async get(id) {
+    const certificationCenter = await knex('certification-centers')
+      .select({
+        id: 'certification-centers.id',
+        name: 'certification-centers.name',
+        type: 'certification-centers.type',
+        externalId: 'certification-centers.externalId',
+        isSupervisorAccessEnabled: 'certification-centers.isSupervisorAccessEnabled',
+        dataProtectionOfficerFirstName: 'data-protection-officers.firstName',
+        dataProtectionOfficerLastName: 'data-protection-officers.lastName',
+        dataProtectionOfficerEmail: 'data-protection-officers.email',
+        createdAt: 'certification-centers.createdAt',
+        updatedAt: 'certification-centers.updatedAt',
+      })
+      .leftJoin(
+        'data-protection-officers',
+        'data-protection-officers.certificationCenterId',
+        'certification-centers.id'
+      )
+      .where('certification-centers.id', id)
+      .first();
+
+    if (!certificationCenter) {
+      throw new NotFoundError(`Certification center with id: ${id} not found`);
+    }
+
+    const habilitations = await knex('complementary-certification-habilitations')
+      .select({
+        id: 'complementary-certification-habilitations.complementaryCertificationId',
+        label: 'complementary-certifications.label',
+        key: 'complementary-certifications.key',
+      })
+      .join(
+        'complementary-certifications',
+        'complementary-certifications.id',
+        'complementary-certification-habilitations.complementaryCertificationId'
+      )
+      .where('complementary-certification-habilitations.certificationCenterId', id)
+      .orderBy('complementary-certification-habilitations.complementaryCertificationId', 'asc');
+
+    certificationCenter.habilitations = habilitations.map((habilitation) => {
+      return new ComplementaryCertification({
+        id: habilitation.id,
+        key: habilitation.key,
+        label: habilitation.label,
+      });
+    });
+
+    return new CertificationCenterForAdmin({
+      id: certificationCenter.id,
+      name: certificationCenter.name,
+      type: certificationCenter.type,
+      externalId: certificationCenter.externalId,
+      habilitations: certificationCenter.habilitations,
+      isSupervisorAccessEnabled: certificationCenter.isSupervisorAccessEnabled,
+      dataProtectionOfficerFirstName: certificationCenter.dataProtectionOfficerFirstName,
+      dataProtectionOfficerLastName: certificationCenter.dataProtectionOfficerLastName,
+      dataProtectionOfficerEmail: certificationCenter.dataProtectionOfficerEmail,
+      createdAt: certificationCenter.createdAt,
+      updatedAt: certificationCenter.updatedAt,
+    });
+  },
+};

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer.js
@@ -1,0 +1,36 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(certificationCenters, meta) {
+    return new Serializer('certification-centers', {
+      attributes: [
+        'name',
+        'type',
+        'externalId',
+        'createdAt',
+        'certificationCenterMemberships',
+        'isSupervisorAccessEnabled',
+        'dataProtectionOfficerFirstName',
+        'dataProtectionOfficerLastName',
+        'dataProtectionOfficerEmail',
+        'habilitations',
+      ],
+      certificationCenterMemberships: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        nullIfMissing: true,
+        relationshipLinks: {
+          related(record, current, parent) {
+            return `/api/admin/certification-centers/${parent.id}/certification-center-memberships`;
+          },
+        },
+      },
+      habilitations: {
+        include: true,
+        ref: 'id',
+        attributes: ['key', 'label'],
+      },
+      meta,
+    }).serialize(certificationCenters);
+  },
+};

--- a/api/tests/acceptance/application/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-controller_test.js
@@ -22,7 +22,7 @@ describe('Acceptance | API | Certification Center', function () {
     beforeEach(async function () {
       request = {
         method: 'GET',
-        url: '/api/certification-centers',
+        url: '/api/admin/certification-centers',
       };
     });
 
@@ -245,7 +245,7 @@ describe('Acceptance | API | Certification Center', function () {
     });
   });
 
-  describe('GET /api/certification-centers/{id}', function () {
+  describe('GET /api/admin/certification-centers/{id}', function () {
     let expectedCertificationCenter;
     beforeEach(async function () {
       expectedCertificationCenter = databaseBuilder.factory.buildCertificationCenter({});
@@ -253,7 +253,7 @@ describe('Acceptance | API | Certification Center', function () {
       await databaseBuilder.commit();
       request = {
         method: 'GET',
-        url: '/api/certification-centers/' + expectedCertificationCenter.id,
+        url: '/api/admin/certification-centers/' + expectedCertificationCenter.id,
       };
     });
 
@@ -281,7 +281,7 @@ describe('Acceptance | API | Certification Center', function () {
 
       it('should return notFoundError when the certificationCenter not exist', async function () {
         // given
-        request.url = '/api/certification-centers/112334';
+        request.url = '/api/admin/certification-centers/112334';
 
         // when
         const response = await server.inject(request);
@@ -448,7 +448,7 @@ describe('Acceptance | API | Certification Center', function () {
     });
   });
 
-  describe('GET /api/certification-centers/{id}/certification-center-memberships', function () {
+  describe('GET /api/admin/certification-centers/{id}/certification-center-memberships', function () {
     context('when certification center membership is linked to the certification center', function () {
       it('should return 200 HTTP status', async function () {
         // given
@@ -466,7 +466,7 @@ describe('Acceptance | API | Certification Center', function () {
             authorization: generateValidRequestAuthorizationHeader(),
           },
           method: 'GET',
-          url: `/api/certification-centers/${certificationCenter.id}/certification-center-memberships`,
+          url: `/api/admin/certification-centers/${certificationCenter.id}/certification-center-memberships`,
         });
 
         // then
@@ -494,7 +494,7 @@ describe('Acceptance | API | Certification Center', function () {
             authorization: generateValidRequestAuthorizationHeader(),
           },
           method: 'GET',
-          url: `/api/certification-centers/${certificationCenter.id}/certification-center-memberships`,
+          url: `/api/admin/certification-centers/${certificationCenter.id}/certification-center-memberships`,
         });
 
         // then
@@ -599,7 +599,7 @@ describe('Acceptance | API | Certification Center', function () {
     });
   });
 
-  describe('POST /api/certification-centers/{certificationCenterId}/certification-center-memberships', function () {
+  describe('POST /api/admin/certification-centers/{certificationCenterId}/certification-center-memberships', function () {
     let certificationCenterId;
     let email;
 
@@ -614,7 +614,7 @@ describe('Acceptance | API | Certification Center', function () {
           authorization: generateValidRequestAuthorizationHeader(),
         },
         method: 'POST',
-        url: `/api/certification-centers/${certificationCenterId}/certification-center-memberships`,
+        url: `/api/admin/certification-centers/${certificationCenterId}/certification-center-memberships`,
         payload: { email },
       };
 
@@ -662,7 +662,7 @@ describe('Acceptance | API | Certification Center', function () {
     context('when certification center does not exist', function () {
       it('should return 404 HTTP status code', async function () {
         // given
-        request.url = '/api/certification-centers/1/certification-center-memberships';
+        request.url = '/api/admin/certification-centers/1/certification-center-memberships';
 
         // when
         const response = await server.inject(request);

--- a/api/tests/acceptance/application/certification-center-membership-route_test.js
+++ b/api/tests/acceptance/application/certification-center-membership-route_test.js
@@ -111,7 +111,7 @@ describe('Acceptance | API | Certification Center Membership', function () {
     });
   });
 
-  describe('DELETE /api/certification-center-memberships/{id}', function () {
+  describe('DELETE /api/admin/certification-center-memberships/{id}', function () {
     it('should return 200 HTTP status', async function () {
       // given
       const now = new Date();
@@ -129,7 +129,7 @@ describe('Acceptance | API | Certification Center Membership', function () {
 
       const options = {
         method: 'DELETE',
-        url: `/api/certification-center-memberships/${certificationCenterMembershipId}`,
+        url: `/api/admin/certification-center-memberships/${certificationCenterMembershipId}`,
         headers: { authorization: generateValidRequestAuthorizationHeader() },
       };
 

--- a/api/tests/integration/infrastructure/repositories/certification-center-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-for-admin-repository_test.js
@@ -1,0 +1,141 @@
+const { expect, databaseBuilder, domainBuilder, catchErr, sinon } = require('../../../test-helper');
+const certificationCenterForAdminRepository = require('../../../../lib/infrastructure/repositories/certification-center-for-admin-repository');
+const CertificationCenterForAdmin = require('../../../../lib/domain/models/CertificationCenterForAdmin');
+const { NotFoundError } = require('../../../../lib/domain/errors');
+
+describe('Integration | Repository | certification-center-for-admin', function () {
+  let clock, now;
+
+  beforeEach(function () {
+    now = new Date('2021-11-16');
+    clock = sinon.useFakeTimers(now);
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  describe('#get', function () {
+    context('when the certification center is found', function () {
+      it('should return the certification center of the given id with the right properties', async function () {
+        // given
+        databaseBuilder.factory.buildCertificationCenter({
+          id: 1,
+          name: 'certificationCenterName',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+          type: CertificationCenterForAdmin.types.SUP,
+          externalId: 'externalId',
+          isSupervisorAccessEnabled: true,
+          updatedAt: now,
+        });
+        databaseBuilder.factory.buildCertificationCenter({ id: 2 });
+        const dataProtectionOfficer = databaseBuilder.factory.buildDataProtectionOfficer.withCertificationCenterId({
+          firstName: 'Justin',
+          lastName: 'Ptipeu',
+          email: 'justin.ptipeu@example.net',
+          certificationCenterId: 1,
+        });
+
+        const expectedCertificationCenter = domainBuilder.buildCertificationCenterForAdmin({
+          id: 1,
+          name: 'certificationCenterName',
+          type: CertificationCenterForAdmin.types.SUP,
+          externalId: 'externalId',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+          complementaryCertifications: [],
+          isSupervisorAccessEnabled: true,
+          dataProtectionOfficerFirstName: dataProtectionOfficer.firstName,
+          dataProtectionOfficerLastName: dataProtectionOfficer.lastName,
+          dataProtectionOfficerEmail: dataProtectionOfficer.email,
+          updatedAt: now,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const certificationCenter = await certificationCenterForAdminRepository.get(1);
+
+        // then
+        expect(certificationCenter).to.deepEqualInstance(expectedCertificationCenter);
+      });
+
+      it('should return habilitations along with certification centers if there is any', async function () {
+        // given
+        databaseBuilder.factory.buildCertificationCenter({
+          id: 1,
+          name: 'certificationCenterName',
+          type: CertificationCenterForAdmin.types.SUP,
+          externalId: 'externalId',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+          updatedAt: now,
+        });
+        const dataProtectionOfficer = databaseBuilder.factory.buildDataProtectionOfficer.withCertificationCenterId({
+          firstName: 'Justin',
+          lastName: 'Ptipeu',
+          email: 'justin.ptipeu@example.net',
+          certificationCenterId: 1,
+        });
+
+        databaseBuilder.factory.buildComplementaryCertification({
+          id: 12345,
+          label: 'Complementary certification test 1',
+          key: 'COMP_1',
+        });
+        databaseBuilder.factory.buildComplementaryCertification({
+          id: 6789,
+          label: 'Complementary certification test 2',
+          key: 'COMP_2',
+        });
+        databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+          certificationCenterId: 1,
+          complementaryCertificationId: 12345,
+        });
+        databaseBuilder.factory.buildComplementaryCertificationHabilitation({
+          certificationCenterId: 1,
+          complementaryCertificationId: 6789,
+        });
+
+        const expectedComplementaryCertification1 = domainBuilder.buildComplementaryCertification({
+          id: 12345,
+          label: 'Complementary certification test 1',
+          key: 'COMP_1',
+        });
+        const expectedComplementaryCertification2 = domainBuilder.buildComplementaryCertification({
+          id: 6789,
+          label: 'Complementary certification test 2',
+          key: 'COMP_2',
+        });
+        const expectedCertificationCenter = domainBuilder.buildCertificationCenterForAdmin({
+          id: 1,
+          name: 'certificationCenterName',
+          type: CertificationCenterForAdmin.types.SUP,
+          externalId: 'externalId',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+          dataProtectionOfficerFirstName: dataProtectionOfficer.firstName,
+          dataProtectionOfficerLastName: dataProtectionOfficer.lastName,
+          dataProtectionOfficerEmail: dataProtectionOfficer.email,
+          habilitations: [expectedComplementaryCertification2, expectedComplementaryCertification1],
+          updatedAt: now,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const certificationCenter = await certificationCenterForAdminRepository.get(1);
+
+        expect(certificationCenter).to.deepEqualInstance(expectedCertificationCenter);
+      });
+    });
+
+    context('the certification center could not be found', function () {
+      it('should throw a NotFound error', async function () {
+        // when
+        const nonExistentId = 1;
+        const error = await catchErr(certificationCenterForAdminRepository.get)(nonExistentId);
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+      });
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-certification-center-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-center-for-admin.js
@@ -1,0 +1,29 @@
+const CertificationCenterForAdmin = require('../../../../lib/domain/models/CertificationCenterForAdmin');
+
+module.exports = function buildCertificationCenterForAdmin({
+  id = 1,
+  name = 'name',
+  type = CertificationCenterForAdmin.types.SUP,
+  externalId = 'externalId',
+  isSupervisorAccessEnabled = false,
+  createdAt = new Date('2020-01-01'),
+  updatedAt,
+  dataProtectionOfficerFirstName,
+  dataProtectionOfficerLastName,
+  dataProtectionOfficerEmail,
+  habilitations = [],
+} = {}) {
+  return new CertificationCenterForAdmin({
+    id,
+    name,
+    type,
+    externalId,
+    isSupervisorAccessEnabled,
+    updatedAt,
+    createdAt,
+    dataProtectionOfficerFirstName,
+    dataProtectionOfficerLastName,
+    dataProtectionOfficerEmail,
+    habilitations,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -37,6 +37,7 @@ module.exports = {
   buildSCOCertificationCandidate: require('./build-sco-certification-candidate'),
   buildCertificationAttestation: require('./build-certification-attestation'),
   buildCertificationCenter: require('./build-certification-center'),
+  buildCertificationCenterForAdmin: require('./build-certification-center-for-admin'),
   buildCertificationCenterMembership: require('./build-certification-center-membership'),
   buildCertificationChallenge: require('./build-certification-challenge'),
   buildCertificationChallengeWithType: require('./build-certification-challenge-with-type'),

--- a/api/tests/unit/application/certification-centers/index_test.js
+++ b/api/tests/unit/application/certification-centers/index_test.js
@@ -164,9 +164,9 @@ describe('Unit | Router | certification-center-router', function () {
     });
   });
 
-  describe('GET /api/certification-centers/{certificationCenterId}/certification-center-memberships', function () {
+  describe('GET /api/admin/certification-centers/{certificationCenterId}/certification-center-memberships', function () {
     const method = 'GET';
-    const url = '/api/certification-centers/1/certification-center-memberships';
+    const url = '/api/admin/certification-centers/1/certification-center-memberships';
 
     it('should exist', async function () {
       //given
@@ -191,7 +191,7 @@ describe('Unit | Router | certification-center-router', function () {
       // when
       const result = await httpTestServer.request(
         method,
-        '/api/certification-centers/invalid/certification-center-memberships'
+        '/api/admin/certification-centers/invalid/certification-center-memberships'
       );
 
       // then
@@ -199,9 +199,9 @@ describe('Unit | Router | certification-center-router', function () {
     });
   });
 
-  describe('POST /api/certification-centers/{certificationCenterId}/certification-center-memberships', function () {
+  describe('POST /api/admin/certification-centers/{certificationCenterId}/certification-center-memberships', function () {
     const method = 'POST';
-    const url = '/api/certification-centers/1/certification-center-memberships';
+    const url = '/api/admin/certification-centers/1/certification-center-memberships';
     const email = 'user@example.net';
     const payload = { email };
 
@@ -227,7 +227,7 @@ describe('Unit | Router | certification-center-router', function () {
       // when
       const result = await httpTestServer.request(
         method,
-        '/api/certification-centers/invalid/certification-center-memberships'
+        '/api/admin/certification-centers/invalid/certification-center-memberships'
       );
 
       // then

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer_test.js
@@ -1,0 +1,73 @@
+const { expect, domainBuilder } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/certification-center-for-admin-serializer');
+
+describe('Unit | Serializer | JSONAPI | certification-center-for-admin-serializer', function () {
+  describe('#serialize', function () {
+    it('should convert a CertificationCenterForAdmin model object into JSON API data', function () {
+      // given
+      const complementaryCertification = domainBuilder.buildComplementaryCertification({
+        id: 1,
+        label: 'Pix+surf',
+        key: 'SURF',
+      });
+      const certificationCenter = domainBuilder.buildCertificationCenterForAdmin({
+        id: 12,
+        name: 'Centre des dés',
+        type: 'SCO',
+        createdAt: new Date('2018-01-01T05:43:10Z'),
+        externalId: '12345',
+        isSupervisorAccessEnabled: true,
+        dataProtectionOfficerFirstName: 'Justin',
+        dataProtectionOfficerLastName: 'Ptipeu',
+        dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
+        habilitations: [complementaryCertification],
+      });
+
+      // when
+      const serializedCertificationCenter = serializer.serialize(certificationCenter);
+
+      // then
+      expect(serializedCertificationCenter).to.deep.equal({
+        data: {
+          type: 'certification-centers',
+          id: '12',
+          attributes: {
+            name: 'Centre des dés',
+            type: 'SCO',
+            'external-id': '12345',
+            'is-supervisor-access-enabled': true,
+            'data-protection-officer-first-name': 'Justin',
+            'data-protection-officer-last-name': 'Ptipeu',
+            'data-protection-officer-email': 'justin.ptipeu@example.net',
+            'created-at': new Date('2018-01-01T05:43:10Z'),
+          },
+          relationships: {
+            'certification-center-memberships': {
+              links: {
+                related: `/api/admin/certification-centers/${certificationCenter.id}/certification-center-memberships`,
+              },
+            },
+            habilitations: {
+              data: [
+                {
+                  id: '1',
+                  type: 'habilitations',
+                },
+              ],
+            },
+          },
+        },
+        included: [
+          {
+            id: '1',
+            type: 'habilitations',
+            attributes: {
+              key: 'SURF',
+              label: 'Pix+surf',
+            },
+          },
+        ],
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Actuellement il n'y a pas moyen d'avoir les informations du data protection officer lié à un centre de certification.

## :robot: Solution

Afficher les informations (prénom, nom et email) du DPO lié au centre de certification.

## :rainbow: Remarques

Faire des tests de non regression sur PixCertif

## :100: Pour tester

#### Avec un DPO

- Se connecter sur Pix Admin
- Ouvrir la page de détails d'un centre de certification (1)
- Constatez l'affichage des informations du data protection officer lié à ce centre

#### Sans DPO

- Se connecter sur Pix Admin
- Ouvrir la page de détails d'un centre de certification (différent de 1)
- Constatez qu'aucune information concernant un DPO est affichée