### PR TITLE
[BUGFIX] Retourner une erreur lorsque le téléchargement des résultats n'est pas sur le bon type de campagne (PIX-5822)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -373,6 +373,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.SessionNotAccessible) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }
+  if (error instanceof DomainErrors.CampaignTypeError) {
+    return new HttpErrors.PreconditionFailedError(error.message);
+  }
   if (error instanceof DomainErrors.InvalidVerificationCodeError) {
     return new HttpErrors.ForbiddenError(error.message, error.code);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -241,6 +241,12 @@ class UserNotAuthorizedToGetCampaignResultsError extends DomainError {
   }
 }
 
+class CampaignTypeError extends DomainError {
+  constructor(message = "Ce type de campagne n'est pas autorisé.") {
+    super(message);
+  }
+}
+
 class UserNotAuthorizedToGetCertificationCoursesError extends DomainError {
   constructor(message = "Cet utilisateur n'est pas autorisé à récupérer ces certification courses.") {
     super(message);
@@ -1203,6 +1209,7 @@ module.exports = {
   UncancellableOrganizationInvitationError,
   CampaignCodeError,
   CampaignParticipationDeletedError,
+  CampaignTypeError,
   CancelledOrganizationInvitationError,
   CandidateNotAuthorizedToJoinSessionError,
   CandidateNotAuthorizedToResumeCertificationTestError,

--- a/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -3,7 +3,7 @@ const moment = require('moment');
 const bluebird = require('bluebird');
 
 const constants = require('../../infrastructure/constants');
-const { UserNotAuthorizedToGetCampaignResultsError } = require('../errors');
+const { UserNotAuthorizedToGetCampaignResultsError, CampaignTypeError } = require('../errors');
 const csvSerializer = require('../../infrastructure/serializers/csv/csv-serializer');
 const CampaignLearningContent = require('../models/CampaignLearningContent');
 const CampaignStages = require('../read-models/campaign/CampaignStages');
@@ -27,6 +27,10 @@ module.exports = async function startWritingCampaignAssessmentResultsToStream({
   const translate = i18n.__;
 
   await _checkCreatorHasAccessToCampaignOrganization(userId, campaign.organizationId, userRepository);
+
+  if (!campaign.isAssessment()) {
+    throw new CampaignTypeError();
+  }
 
   const targetProfile = await targetProfileRepository.getByCampaignId(campaign.id);
   const learningContent = await learningContentRepository.findByCampaignId(campaign.id, i18n.getLocale());

--- a/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -1,5 +1,5 @@
 const moment = require('moment');
-const { UserNotAuthorizedToGetCampaignResultsError } = require('../errors');
+const { UserNotAuthorizedToGetCampaignResultsError, CampaignTypeError } = require('../errors');
 const CampaignProfilesCollectionExport = require('../../infrastructure/serializers/csv/campaign-profiles-collection-export');
 
 async function _checkCreatorHasAccessToCampaignOrganization(userId, organizationId, userRepository) {
@@ -28,6 +28,10 @@ module.exports = async function startWritingCampaignProfilesCollectionResultsToS
   const translate = i18n.__;
 
   await _checkCreatorHasAccessToCampaignOrganization(userId, campaign.organizationId, userRepository);
+
+  if (!campaign.isProfilesCollection()) {
+    throw new CampaignTypeError();
+  }
 
   const [allPixCompetences, organization, campaignParticipationResultDatas] = await Promise.all([
     competenceRepository.listPixCompetencesOnly({ locale: i18n.getLocale() }),

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -294,10 +294,9 @@ describe('Acceptance | API | Campaign Controller', function () {
     beforeEach(async function () {
       const userId = databaseBuilder.factory.buildUser().id;
       organization = databaseBuilder.factory.buildOrganization();
-      targetProfile = databaseBuilder.factory.buildTargetProfile();
       campaign = databaseBuilder.factory.buildCampaign({
         organizationId: organization.id,
-        targetProfileId: targetProfile.id,
+        type: 'PROFILES_COLLECTION',
       });
       accessToken = _createTokenWithAccessId(userId);
 

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -28,6 +28,7 @@ const {
   CertificationEndedByFinalizationError,
   SessionStartedDeletionError,
   CertificationAttestationGenerationError,
+  CampaignTypeError,
 } = require('../../../lib/domain/errors');
 const HttpErrors = require('../../../lib/application/http-errors.js');
 
@@ -492,6 +493,19 @@ describe('Unit | Application | ErrorManager', function () {
 
       // then
       expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(error.message);
+    });
+
+    it('should instantiate PreconditionFailedError when CampaignTypeError', async function () {
+      // given
+      const error = new CampaignTypeError();
+      sinon.stub(HttpErrors, 'PreconditionFailedError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.PreconditionFailedError).to.have.been.calledWithExactly(error.message);
     });
   });
 });

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -90,6 +90,10 @@ describe('Unit | Domain | Errors', function () {
     expect(errors.AuthenticationMethodAlreadyExistsError).to.exist;
   });
 
+  it('should export a CampaignTypeError', function () {
+    expect(errors.CampaignTypeError).to.exist;
+  });
+
   it('should export a SessionNotAccessible error', function () {
     expect(errors.SessionNotAccessible).to.exist;
   });


### PR DESCRIPTION
## :unicorn: Problème
Des erreurs sont susceptible de remonter lorsque l'on appel directement la route de téléchargement des résultats (via un script par exemple)

## :robot: Solution
Remonter une erreur lorsque la campagne utiliser pour le téléchargements des résultats n'est pas fait avec le bon type de campagne

## :rainbow: Remarques
RAS

## :100: Pour tester
lancer un curl et vérifier que l'erreur est bien remonté 

`curl 'https://<review-app>.pix.fr/api/campaigns/{id}/csv-assessment-results?accessToken=<token>'`

`curl 'https://<review-app>.pix.fr/api/campaigns/{id}/csv-profiles-collection-results?accessToken=<token>'`

remonte bien une erreur 412 lorsque l'utilisateur a accès à la campagne, mais utilise le mauvais endpoint
Ps: prendre le token du bouton d'export et non celui du user car ce ne sont pas les mêmes