### PR TITLE
[FEATURE] Permettre de ne pas saisir de nombres négatifs dans un champ dans une épreuve sur Pix App (PIX-5815)

### DIFF
--- a/mon-pix/app/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/components/challenge-item-qroc.hbs
@@ -58,19 +58,20 @@
                 disabled={{this.isAnswerFieldDisabled}}
               />
             {{else if (eq @challenge.format "nombre")}}
-              <input
-                class="challenge-response__proposal challenge-response__proposal--number"
-                data-test="challenge-response-proposal-selector"
-                type="number"
-                id="qroc_input"
-                {{on "keyup" this.answerChanged}}
+              <PixInput
+                @id="qroc_input"
                 name={{block.randomName}}
+                type="number"
+                min="0"
+                data-test="challenge-response-proposal-selector"
                 placeholder={{block.placeholder}}
-                autocomplete="nope"
-                value="{{this.userAnswer}}"
+                @value="{{this.userAnswer}}"
+                aria-label={{block.ariaLabel}}
                 data-uid="qroc-proposal-uid"
                 disabled={{this.isAnswerFieldDisabled}}
+                {{on "keyup" this.answerChanged}}
               />
+
             {{else}}
               <input
                 class="challenge-response__proposal"

--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -21,7 +21,12 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
   }
 
   _hasError() {
-    return this._getAnswerValue().length < 1;
+    if (this._getAnswerValue().length < 1) {
+      return true;
+    } else if (this.args.challenge.format === 'nombre') {
+      return this._getAnswerValue() < 0;
+    }
+    return false;
   }
 
   _getAnswerValue() {
@@ -33,7 +38,7 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
     if (this.args.challenge.autoReply) {
       errorMessage = 'pages.challenge.skip-error-message.qroc-auto-reply';
     } else if (this.args.challenge.format === 'nombre') {
-      errorMessage = 'pages.challenge.skip-error-message.qroc-number';
+      errorMessage = 'pages.challenge.skip-error-message.qroc-positive-number';
     } else {
       errorMessage = 'pages.challenge.skip-error-message.qroc';
     }

--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -63,10 +63,6 @@
       width: 100%;
     }
 
-    &--number {
-      width: 100px;
-    }
-
     &--selector {
       display: inline-block;
     }
@@ -110,6 +106,9 @@ form .challenge-response {
   }
 
   .qroc-proposal {
+    display: flex;
+    align-items: center;
+    gap: $spacing-xs;
 
     .qroc_input-label {
       display: inline;

--- a/mon-pix/tests/integration/components/challenge-item-qroc_test.js
+++ b/mon-pix/tests/integration/components/challenge-item-qroc_test.js
@@ -82,7 +82,7 @@ describe('Integration | Component | Challenge item QROC', function () {
       );
 
       // then
-      expect(find('.challenge-response__proposal').getAttribute('type')).to.equal('number');
+      expect(find('[id="qroc_input"]').getAttribute('type')).to.equal('number');
     });
   });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -543,7 +543,7 @@
         "qcu": "To validate, select an answer. Otherwise, click Skip.",
         "qroc": "To validate, please fill in the text field. Otherwise, click Skip.",
         "qroc-auto-reply": "You did not answer correctly. Try again or skip to the next question.",
-        "qroc-number": "Please enter a number, or skip the question.",
+        "qroc-positive-number": "Please enter a number greater than or equal to 0, or skip the question.",
         "qrocm": "To validate, please complete all answer fields. Otherwise, click Skip."
       },
       "statement": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -543,7 +543,7 @@
         "qcu": "Pour valider, sélectionnez une réponse. Sinon, passez.",
         "qroc": "Pour valider, veuillez remplir le champ texte. Sinon, passez.",
         "qroc-auto-reply": "“Vous pouvez valider” s‘affiche quand l‘épreuve est réussie. Essayez encore ou passez.",
-        "qroc-number": "Pour valider, veuillez saisir un nombre sinon passez.",
+        "qroc-positive-number": "Pour valider, veuillez saisir un nombre supérieur ou égal à 0 sinon passez.",
         "qrocm": "Pour valider, veuillez remplir tous les champs réponse. Sinon, passez."
       },
       "statement": {


### PR DESCRIPTION
## :unicorn: Problème
Au niveau d’une question attendant une réponse devant comporter uniquement des chiffres, l'utilisateur pouvait valider des nombres négatifs.

## :robot: Solution
Ajout d'un `min=0` ainsi que d'un message d'erreur lors de la validation.

## :100: Pour tester
- Aller sur un QROC avec un input nombre.
- Vérifier que les lettres et nombres négatifs ne sont pas autorisés. 
- Vérifier que les nombres positifs sont acceptés.
