### PR TITLE
[FEATURE] Refactorer la sélection du niveau jury d'une certification complémentaire (PIX-5800).

### DIFF
--- a/api/lib/application/complementary-certification-course-results/index.js
+++ b/api/lib/application/complementary-certification-course-results/index.js
@@ -1,5 +1,4 @@
 const Joi = require('joi');
-const Badge = require('../../domain/models/Badge');
 const identifiersType = require('../../domain/types/identifiers-type');
 const securityPreHandlers = require('../security-pre-handlers');
 const complementaryCertificationCourseResultsController = require('./complementary-certification-course-results-controller');
@@ -14,21 +13,7 @@ exports.register = async function (server) {
           payload: Joi.object({
             data: {
               attributes: {
-                juryLevel: Joi.string()
-                  .valid(
-                    Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-                    Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
-                    Badge.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-                    Badge.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-                    Badge.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-                    Badge.keys.PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
-                    Badge.keys.PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
-                    Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
-                    Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
-                    Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
-                    'REJECTED'
-                  )
-                  .required(),
+                juryLevel: Joi.string().required(),
                 complementaryCertificationCourseId: identifiersType.complementaryCertificationCourseId,
               },
             },

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -462,6 +462,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.UnprocessableEntityError(error.message);
   }
 
+  if (error instanceof DomainErrors.InvalidJuryLevelError) {
+    return new HttpErrors.BadRequestError(error.message);
+  }
+
   return new HttpErrors.BaseHttpError(error.message);
 }
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -1186,6 +1186,12 @@ class CertificationAttestationGenerationError extends DomainError {
   }
 }
 
+class InvalidJuryLevelError extends DomainError {
+  constructor(message = 'Le niveau jury renseigné est invalide.') {
+    super(message);
+  }
+}
+
 module.exports = {
   AccountRecoveryDemandNotCreatedError,
   AccountRecoveryDemandExpired,
@@ -1267,6 +1273,7 @@ module.exports = {
   InvalidCertificationIssueReportForSaving,
   InvalidExternalUserTokenError,
   InvalidExternalAPIResponseError,
+  InvalidJuryLevelError,
   InvalidMembershipOrganizationRoleError,
   InvalidPasswordForUpdateEmailError,
   InvalidResultRecipientTokenError,

--- a/api/lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertification.js
+++ b/api/lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertification.js
@@ -11,6 +11,10 @@ class ComplementaryCertificationCourseResultsForJuryCertification {
     this.label = label;
   }
 
+  static from({ id, partnerKey, acquired, label }) {
+    return new ComplementaryCertificationCourseResultsForJuryCertification({ id, partnerKey, acquired, label });
+  }
+
   get status() {
     return this.acquired ? complementaryCertificationStatus.ACQUIRED : complementaryCertificationStatus.REJECTED;
   }

--- a/api/lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.js
+++ b/api/lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.js
@@ -29,6 +29,8 @@ const pixEdu2ndDegreeBadges = [
   PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
 ];
 
+const { EXTERNAL, PIX } = require('../models/ComplementaryCertificationCourseResult').sources;
+
 class ComplementaryCertificationCourseResultsForJuryCertificationWithExternal {
   constructor({
     complementaryCertificationCourseId,
@@ -53,10 +55,10 @@ class ComplementaryCertificationCourseResultsForJuryCertificationWithExternal {
       return;
     }
     const pixComplementaryCertificationCourseResult = complementaryCertificationCourseResultsWithExternal.find(
-      ({ source }) => source === 'PIX'
+      ({ source }) => source === PIX
     );
     const externalComplementaryCertificationCourseResult = complementaryCertificationCourseResultsWithExternal.find(
-      ({ source }) => source === 'EXTERNAL'
+      ({ source }) => source === EXTERNAL
     );
 
     return new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({

--- a/api/lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.js
+++ b/api/lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.js
@@ -41,8 +41,8 @@ class ComplementaryCertificationCourseResultsForJuryCertificationWithExternal {
     allowedExternalLevels,
   }) {
     this.complementaryCertificationCourseId = complementaryCertificationCourseId;
-    this.pixSection = new PixEduSection({ partnerKey: pixPartnerKey, label: pixLabel, acquired: pixAcquired });
-    this.externalSection = new PixEduSection({
+    this.pixSection = new Section({ partnerKey: pixPartnerKey, label: pixLabel, acquired: pixAcquired });
+    this.externalSection = new Section({
       partnerKey: externalPartnerKey,
       label: externalLabel,
       acquired: externalAcquired,
@@ -121,7 +121,7 @@ class ComplementaryCertificationCourseResultsForJuryCertificationWithExternal {
   }
 }
 
-class PixEduSection {
+class Section {
   constructor({ partnerKey, label, acquired }) {
     this.partnerKey = partnerKey;
     this.label = label;

--- a/api/lib/domain/usecases/save-jury-complementary-certification-course-result.js
+++ b/api/lib/domain/usecases/save-jury-complementary-certification-course-result.js
@@ -1,4 +1,4 @@
-const { NotFoundError } = require('../errors');
+const { NotFoundError, InvalidJuryLevelError } = require('../errors');
 const ComplementaryCertificationCourseResult = require('../models/ComplementaryCertificationCourseResult');
 
 module.exports = async function saveJuryComplementaryCertificationCourseResult({
@@ -18,6 +18,14 @@ module.exports = async function saveJuryComplementaryCertificationCourseResult({
   }
 
   const { partnerKey: pixPartnerKey } = pixSourceComplementaryCertificationCourseResult;
+
+  const allowedJuryLevels = await complementaryCertificationCourseResultRepository.getAllowedJuryLevelByBadgeKey({
+    key: pixPartnerKey,
+  });
+
+  if (![...allowedJuryLevels, 'REJECTED'].includes(juryLevel)) {
+    throw new InvalidJuryLevelError();
+  }
 
   const externalComplementaryCertificationCourseResult = ComplementaryCertificationCourseResult.buildFromJuryLevel({
     juryLevel,

--- a/api/lib/domain/usecases/save-jury-complementary-certification-course-result.js
+++ b/api/lib/domain/usecases/save-jury-complementary-certification-course-result.js
@@ -6,21 +6,18 @@ module.exports = async function saveJuryComplementaryCertificationCourseResult({
   juryLevel,
   complementaryCertificationCourseResultRepository,
 }) {
-  const complementaryCertificationCourseResults =
-    await complementaryCertificationCourseResultRepository.getFromComplementaryCertificationCourseId({
+  const pixSourceComplementaryCertificationCourseResult =
+    await complementaryCertificationCourseResultRepository.getPixSourceResultByComplementaryCertificationCourseId({
       complementaryCertificationCourseId,
     });
 
-  const pixEduAndFromPixSourceComplementaryCertificationCourseResult = complementaryCertificationCourseResults.find(
-    (complementaryCertificationCourseResult) =>
-      complementaryCertificationCourseResult.isPixEdu() && complementaryCertificationCourseResult.isFromPixSource()
-  );
-
-  if (!pixEduAndFromPixSourceComplementaryCertificationCourseResult) {
-    throw new NotFoundError("Aucun résultat Pix+ Edu n'a été trouvé pour cette certification.");
+  if (!pixSourceComplementaryCertificationCourseResult) {
+    throw new NotFoundError(
+      "Aucun résultat de certification Pix n'a été trouvé pour cette certification complémentaire."
+    );
   }
 
-  const { partnerKey: pixPartnerKey } = pixEduAndFromPixSourceComplementaryCertificationCourseResult;
+  const { partnerKey: pixPartnerKey } = pixSourceComplementaryCertificationCourseResult;
 
   const externalComplementaryCertificationCourseResult = ComplementaryCertificationCourseResult.buildFromJuryLevel({
     juryLevel,

--- a/api/lib/infrastructure/repositories/complementary-certification-course-result-repository.js
+++ b/api/lib/infrastructure/repositories/complementary-certification-course-result-repository.js
@@ -2,25 +2,9 @@ const ComplementaryCertificationCourseResult = require('../../domain/models/Comp
 const { knex } = require('../../../db/knex-database-connection');
 
 module.exports = {
-  async getFromComplementaryCertificationCourseId({ complementaryCertificationCourseId }) {
-    const complementaryCertificationCourseResults = await knex
-      .select('complementary-certification-course-results.*')
-      .from('complementary-certification-course-results')
-      .where({ complementaryCertificationCourseId });
-
-    return complementaryCertificationCourseResults.map((complementaryCertificationCourseResult) =>
-      ComplementaryCertificationCourseResult.from({
-        complementaryCertificationCourseId: complementaryCertificationCourseResult.complementaryCertificationCourseId,
-        partnerKey: complementaryCertificationCourseResult.partnerKey,
-        acquired: complementaryCertificationCourseResult.acquired,
-        source: complementaryCertificationCourseResult.source,
-      })
-    );
-  },
-
   async getPixSourceResultByComplementaryCertificationCourseId({ complementaryCertificationCourseId }) {
     const result = await knex
-      .select('complementary-certification-course-results.*')
+      .select('*')
       .from('complementary-certification-course-results')
       .where({ complementaryCertificationCourseId, source: ComplementaryCertificationCourseResult.sources.PIX })
       .first();

--- a/api/lib/infrastructure/repositories/complementary-certification-course-result-repository.js
+++ b/api/lib/infrastructure/repositories/complementary-certification-course-result-repository.js
@@ -18,6 +18,18 @@ module.exports = {
     );
   },
 
+  async getPixSourceResultByComplementaryCertificationCourseId({ complementaryCertificationCourseId }) {
+    const result = await knex
+      .select('complementary-certification-course-results.*')
+      .from('complementary-certification-course-results')
+      .where({ complementaryCertificationCourseId, source: ComplementaryCertificationCourseResult.sources.PIX })
+      .first();
+
+    if (!result) return null;
+
+    return ComplementaryCertificationCourseResult.from(result);
+  },
+
   async save({ complementaryCertificationCourseId, partnerKey, acquired, source }) {
     return knex('complementary-certification-course-results')
       .insert({ partnerKey, acquired, complementaryCertificationCourseId, source })

--- a/api/lib/infrastructure/repositories/complementary-certification-course-result-repository.js
+++ b/api/lib/infrastructure/repositories/complementary-certification-course-result-repository.js
@@ -14,6 +14,12 @@ module.exports = {
     return ComplementaryCertificationCourseResult.from(result);
   },
 
+  async getAllowedJuryLevelByBadgeKey({ key }) {
+    return knex('badges')
+      .pluck('key')
+      .where('targetProfileId', '=', knex('badges').select('targetProfileId').where({ key }));
+  },
+
   async save({ complementaryCertificationCourseId, partnerKey, acquired, source }) {
     return knex('complementary-certification-course-results')
       .insert({ partnerKey, acquired, complementaryCertificationCourseId, source })

--- a/api/lib/infrastructure/repositories/jury-certification-repository.js
+++ b/api/lib/infrastructure/repositories/jury-certification-repository.js
@@ -27,6 +27,7 @@ module.exports = {
         'complementary-certification-course-results.*',
         'complementary-certification-courses.id',
         'complementary-certification-badges.label',
+        'complementary-certification-badges.level',
         'complementary-certifications.hasExternalJury'
       )
       .leftJoin(

--- a/api/lib/infrastructure/repositories/jury-certification-repository.js
+++ b/api/lib/infrastructure/repositories/jury-certification-repository.js
@@ -26,7 +26,8 @@ module.exports = {
       .select(
         'complementary-certification-course-results.*',
         'complementary-certification-courses.id',
-        'complementary-certification-badges.label'
+        'complementary-certification-badges.label',
+        'complementary-certifications.hasExternalJury'
       )
       .leftJoin(
         'complementary-certification-courses',
@@ -35,6 +36,11 @@ module.exports = {
       )
       .leftJoin('badges', 'badges.key', 'complementary-certification-course-results.partnerKey')
       .leftJoin('complementary-certification-badges', 'complementary-certification-badges.badgeId', 'badges.id')
+      .leftJoin(
+        'complementary-certifications',
+        'complementary-certifications.id',
+        'complementary-certification-badges.complementaryCertificationId'
+      )
       .where({
         certificationCourseId: juryCertificationDTO.certificationCourseId,
       });
@@ -131,9 +137,7 @@ async function _toDomainWithComplementaryCertifications({
 
 function _toComplementaryCertificationCourseResultForJuryCertification(complementaryCertificationCourseResults) {
   const [complementaryCertificationCourseResultsWithExternal, commonComplementaryCertificationCourseResults] =
-    _.partition(complementaryCertificationCourseResults, (ccr) => {
-      return ccr.partnerKey.startsWith('PIX_EDU');
-    });
+    _.partition(complementaryCertificationCourseResults, 'hasExternalJury');
 
   const complementaryCertificationCourseResultsForJuryCertificationWithExternal =
     ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.from(

--- a/api/lib/infrastructure/repositories/jury-certification-repository.js
+++ b/api/lib/infrastructure/repositories/jury-certification-repository.js
@@ -145,10 +145,7 @@ function _toComplementaryCertificationCourseResultForJuryCertification(complemen
     );
 
   const commonComplementaryCertificationCourseResultsForJuryCertification =
-    commonComplementaryCertificationCourseResults.map(
-      ({ id, partnerKey, acquired, label }) =>
-        new ComplementaryCertificationCourseResultsForJuryCertification({ id, partnerKey, acquired, label })
-    );
+    commonComplementaryCertificationCourseResults.map(ComplementaryCertificationCourseResultsForJuryCertification.from);
 
   return [
     complementaryCertificationCourseResultsForJuryCertificationWithExternal,

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -11,7 +11,6 @@ const createServer = require('../../../server');
 const { CertificationIssueReportCategories } = require('../../../lib/domain/models/CertificationIssueReportCategory');
 const CertificationAssessment = require('../../../lib/domain/models/CertificationAssessment');
 const KnowledgeElement = require('../../../lib/domain/models/KnowledgeElement');
-const Badge = require('../../../lib/domain/models/Badge');
 
 describe('Acceptance | API | Certification Course', function () {
   let server;
@@ -192,15 +191,15 @@ describe('Acceptance | API | Certification Course', function () {
         completedAt: new Date('2020-02-01'),
       });
       const pixDroitComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
-        name: 'Pix+ Droit',
+        name: 'Pix+ Foot',
         hasExternalJury: false,
       }).id;
-      databaseBuilder.factory.buildBadge({ id: 123, key: Badge.keys.PIX_DROIT_EXPERT_CERTIF });
+      databaseBuilder.factory.buildBadge({ id: 123, key: 'PIX_FOOT_1' });
       databaseBuilder.factory.buildComplementaryCertificationBadge({
         id: 567,
         badgeId: 123,
         complementaryCertificationId: pixDroitComplementaryCertificationId,
-        label: 'Pix+ Droit Expert',
+        label: 'PIX_FOOT_1',
       });
       databaseBuilder.factory.buildComplementaryCertificationCourse({
         id: 456,
@@ -211,48 +210,48 @@ describe('Acceptance | API | Certification Course', function () {
       });
       databaseBuilder.factory.buildComplementaryCertificationCourseResult({
         id: 789,
-        partnerKey: Badge.keys.PIX_DROIT_EXPERT_CERTIF,
+        partnerKey: 'PIX_FOOT_1',
         acquired: true,
         complementaryCertificationCourseId: 456,
         source: 'PIX',
       });
 
       const pixEduComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
-        name: 'Pix+ Édu 1er degré',
+        name: 'Pix+ Boxe',
         hasExternalJury: true,
       }).id;
       databaseBuilder.factory.buildTargetProfile({ id: 1212 });
       databaseBuilder.factory.buildBadge({
         id: 456,
-        key: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+        key: 'PIX_BOXE_1',
         targetProfileId: 1212,
       });
       databaseBuilder.factory.buildBadge({
         id: 457,
-        key: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+        key: 'PIX_BOXE_2',
         targetProfileId: 1212,
       });
       databaseBuilder.factory.buildBadge({
         id: 458,
-        key: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+        key: 'PIX_BOXE_3',
         targetProfileId: 1212,
       });
 
       databaseBuilder.factory.buildComplementaryCertificationBadge({
         badgeId: 456,
         complementaryCertificationId: pixEduComplementaryCertificationId,
-        label: 'Pix+ Édu 1er degré Confirmé',
+        label: 'Pix Boxe 1',
       });
       databaseBuilder.factory.buildComplementaryCertificationBadge({
         id: 789,
         badgeId: 457,
         complementaryCertificationId: pixEduComplementaryCertificationId,
-        label: 'Pix+ Édu 1er degré Avancé',
+        label: 'Pix Boxe 2',
       });
       databaseBuilder.factory.buildComplementaryCertificationBadge({
         badgeId: 458,
         complementaryCertificationId: pixEduComplementaryCertificationId,
-        label: 'Pix+ Édu 1er degré Expert',
+        label: 'Pix Boxe 3',
       });
       databaseBuilder.factory.buildComplementaryCertificationCourse({
         id: 654,
@@ -263,14 +262,14 @@ describe('Acceptance | API | Certification Course', function () {
       });
       databaseBuilder.factory.buildComplementaryCertificationCourseResult({
         id: 987,
-        partnerKey: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+        partnerKey: 'PIX_BOXE_2',
         acquired: true,
         complementaryCertificationCourseId: 654,
         source: 'PIX',
       });
       databaseBuilder.factory.buildComplementaryCertificationCourseResult({
         id: 986,
-        partnerKey: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+        partnerKey: 'PIX_BOXE_2',
         acquired: false,
         complementaryCertificationCourseId: 654,
         source: 'EXTERNAL',
@@ -372,7 +371,7 @@ describe('Acceptance | API | Certification Course', function () {
           id: '456',
           type: 'commonComplementaryCertificationCourseResults',
           attributes: {
-            label: 'Pix+ Droit Expert',
+            label: 'PIX_FOOT_1',
             status: 'Validée',
           },
         },
@@ -382,22 +381,22 @@ describe('Acceptance | API | Certification Course', function () {
           attributes: {
             'allowed-external-levels': [
               {
-                label: 'Pix+ Édu 1er degré Confirmé',
-                value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME',
+                label: 'Pix Boxe 1',
+                value: 'PIX_BOXE_1',
               },
               {
-                label: 'Pix+ Édu 1er degré Avancé',
-                value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE',
+                label: 'Pix Boxe 2',
+                value: 'PIX_BOXE_2',
               },
               {
-                label: 'Pix+ Édu 1er degré Expert',
-                value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT',
+                label: 'Pix Boxe 3',
+                value: 'PIX_BOXE_3',
               },
             ],
             'complementary-certification-course-id': 654,
             'external-result': 'Rejetée',
             'final-result': 'Rejetée',
-            'pix-result': 'Pix+ Édu 1er degré Avancé',
+            'pix-result': 'Pix Boxe 2',
           },
         },
       ]);

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -175,16 +175,6 @@ describe('Acceptance | API | Certification Course', function () {
       // given
       databaseBuilder.factory.buildUser({ id: 789 });
       databaseBuilder.factory.buildSession({ id: 456 });
-      databaseBuilder.factory.buildBadge({ id: 123, key: Badge.keys.PIX_DROIT_EXPERT_CERTIF });
-      databaseBuilder.factory.buildBadge({ id: 456, key: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE });
-      const pixDroitComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
-        name: 'Pix+ Droit',
-        hasExternalJury: false,
-      }).id;
-      const pixEduComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
-        name: 'Pix+ Édu 1er degré',
-        hasExternalJury: true,
-      }).id;
       databaseBuilder.factory.buildCertificationCourse({
         id: 123,
         sessionId: 456,
@@ -201,6 +191,11 @@ describe('Acceptance | API | Certification Course', function () {
         createdAt: new Date('2020-01-01'),
         completedAt: new Date('2020-02-01'),
       });
+      const pixDroitComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
+        name: 'Pix+ Droit',
+        hasExternalJury: false,
+      }).id;
+      databaseBuilder.factory.buildBadge({ id: 123, key: Badge.keys.PIX_DROIT_EXPERT_CERTIF });
       databaseBuilder.factory.buildComplementaryCertificationBadge({
         id: 567,
         badgeId: 123,
@@ -221,11 +216,43 @@ describe('Acceptance | API | Certification Course', function () {
         complementaryCertificationCourseId: 456,
         source: 'PIX',
       });
+
+      const pixEduComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
+        name: 'Pix+ Édu 1er degré',
+        hasExternalJury: true,
+      }).id;
+      databaseBuilder.factory.buildTargetProfile({ id: 1212 });
+      databaseBuilder.factory.buildBadge({
+        id: 456,
+        key: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+        targetProfileId: 1212,
+      });
+      databaseBuilder.factory.buildBadge({
+        id: 457,
+        key: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+        targetProfileId: 1212,
+      });
+      databaseBuilder.factory.buildBadge({
+        id: 458,
+        key: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+        targetProfileId: 1212,
+      });
+
       databaseBuilder.factory.buildComplementaryCertificationBadge({
-        id: 789,
         badgeId: 456,
         complementaryCertificationId: pixEduComplementaryCertificationId,
+        label: 'Pix+ Édu 1er degré Confirmé',
+      });
+      databaseBuilder.factory.buildComplementaryCertificationBadge({
+        id: 789,
+        badgeId: 457,
+        complementaryCertificationId: pixEduComplementaryCertificationId,
         label: 'Pix+ Édu 1er degré Avancé',
+      });
+      databaseBuilder.factory.buildComplementaryCertificationBadge({
+        badgeId: 458,
+        complementaryCertificationId: pixEduComplementaryCertificationId,
+        label: 'Pix+ Édu 1er degré Expert',
       });
       databaseBuilder.factory.buildComplementaryCertificationCourse({
         id: 654,

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -179,9 +179,11 @@ describe('Acceptance | API | Certification Course', function () {
       databaseBuilder.factory.buildBadge({ id: 456, key: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE });
       const pixDroitComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
         name: 'Pix+ Droit',
+        hasExternalJury: false,
       }).id;
       const pixEduComplementaryCertificationId = databaseBuilder.factory.buildComplementaryCertification({
         name: 'Pix+ Édu 1er degré',
+        hasExternalJury: true,
       }).id;
       databaseBuilder.factory.buildCertificationCourse({
         id: 123,

--- a/api/tests/acceptance/application/complementary-certification-course-results/complementary-certification-course-results-controller_test.js
+++ b/api/tests/acceptance/application/complementary-certification-course-results/complementary-certification-course-results-controller_test.js
@@ -6,7 +6,6 @@ const {
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
 const ComplementaryCertificationCourseResult = require('../../../../lib/domain/models/ComplementaryCertificationCourseResult');
-const Badge = require('../../../../lib/domain/models/Badge');
 
 describe('Acceptance | API | Certifications', function () {
   describe('POST /api/admin/complementary-certification-course-results', function () {
@@ -14,11 +13,11 @@ describe('Acceptance | API | Certifications', function () {
       // given
       const server = await createServer();
       const badge = databaseBuilder.factory.buildBadge({
-        key: Badge.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
+        key: 'BADGE_KEY',
       });
       databaseBuilder.factory.buildComplementaryCertification({
         id: 1,
-        name: 'Pix+Edu',
+        name: 'Pix+ Test',
       });
       databaseBuilder.factory.buildCertificationCourse({
         id: 456,

--- a/api/tests/integration/application/complementary-certification-course-results/complementary-certification-course-results-controller_test.js
+++ b/api/tests/integration/application/complementary-certification-course-results/complementary-certification-course-results-controller_test.js
@@ -1,6 +1,7 @@
 const { expect, sinon, HttpTestServer } = require('../../../test-helper');
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 const usecases = require('../../../../lib/domain/usecases');
+const { InvalidJuryLevelError } = require('../../../../lib/domain/errors');
 const moduleUnderTest = require('../../../../lib/application/complementary-certification-course-results');
 
 describe('Integration | Application | complementary-certification-course-results | complementary-certification-course-results-controller', function () {
@@ -65,7 +66,7 @@ describe('Integration | Application | complementary-certification-course-results
 
     context('Error cases', function () {
       context('when juryLevel is not valid', function () {
-        it('should resolve a 400 HTTP response', async function () {
+        it('should resolve a 400 HTTP response by joi validation', async function () {
           // given
           const payload = {
             data: {
@@ -87,6 +88,31 @@ describe('Integration | Application | complementary-certification-course-results
 
           // then
           expect(response.statusCode).to.equal(400);
+        });
+
+        it('should resolve a 400 HTTP response', async function () {
+          // given
+          const payload = {
+            data: {
+              attributes: {
+                juryLevel: 'PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE',
+                complementaryCertificationCourseId: 123456,
+              },
+            },
+          };
+          usecases.saveJuryComplementaryCertificationCourseResult.rejects(new InvalidJuryLevelError());
+          securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.callsFake((request, h) => h.response(true));
+
+          // when
+          const response = await httpTestServer.request(
+            'POST',
+            '/api/admin/complementary-certification-course-results',
+            payload
+          );
+
+          // then
+          expect(response.statusCode).to.equal(400);
+          expect(response.result.errors[0].detail).to.equal('Le niveau jury renseigné est invalide.');
         });
       });
 

--- a/api/tests/integration/application/complementary-certification-course-results/complementary-certification-course-results-controller_test.js
+++ b/api/tests/integration/application/complementary-certification-course-results/complementary-certification-course-results-controller_test.js
@@ -24,72 +24,33 @@ describe('Integration | Application | complementary-certification-course-results
 
   describe('#saveJuryComplementaryCertificationCourseResult', function () {
     context('Success cases', function () {
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      [
-        'PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE',
-        'PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME',
-        'PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME',
-        'PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE',
-        'PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT',
-        'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE',
-        'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME',
-        'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME',
-        'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE',
-        'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT',
-        'REJECTED',
-      ].forEach((juryLevel) => {
-        it(`should resolve a 200 HTTP response for ${juryLevel} juryLevel`, async function () {
-          // given
-          const payload = {
-            data: {
-              attributes: {
-                juryLevel,
-                complementaryCertificationCourseId: 123456,
-              },
+      it(`should resolve a 200 HTTP response`, async function () {
+        // given
+        const payload = {
+          data: {
+            attributes: {
+              juryLevel: 'JURY_LEVEL',
+              complementaryCertificationCourseId: 123456,
             },
-          };
-          usecases.saveJuryComplementaryCertificationCourseResult.resolves();
-          securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.callsFake((request, h) => h.response(true));
+          },
+        };
+        usecases.saveJuryComplementaryCertificationCourseResult.resolves();
+        securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.callsFake((request, h) => h.response(true));
 
-          // when
-          const response = await httpTestServer.request(
-            'POST',
-            '/api/admin/complementary-certification-course-results',
-            payload
-          );
+        // when
+        const response = await httpTestServer.request(
+          'POST',
+          '/api/admin/complementary-certification-course-results',
+          payload
+        );
 
-          // then
-          expect(response.statusCode).to.equal(200);
-        });
+        // then
+        expect(response.statusCode).to.equal(200);
       });
     });
 
     context('Error cases', function () {
       context('when juryLevel is not valid', function () {
-        it('should resolve a 400 HTTP response by joi validation', async function () {
-          // given
-          const payload = {
-            data: {
-              attributes: {
-                juryLevel: 'INVALID_JURY_LEVEL',
-                complementaryCertificationCourseId: 123456,
-              },
-            },
-          };
-          usecases.saveJuryComplementaryCertificationCourseResult.resolves();
-          securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.callsFake((request, h) => h.response(true));
-
-          // when
-          const response = await httpTestServer.request(
-            'POST',
-            '/api/admin/complementary-certification-course-results',
-            payload
-          );
-
-          // then
-          expect(response.statusCode).to.equal(400);
-        });
-
         it('should resolve a 400 HTTP response', async function () {
           // given
           const payload = {

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-course-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-course-result-repository_test.js
@@ -2,7 +2,6 @@ const { expect, databaseBuilder, domainBuilder } = require('../../../test-helper
 const { knex } = require('../../../../lib/infrastructure/bookshelf');
 const _ = require('lodash');
 const complementaryCertificationCourseResultRepository = require('../../../../lib/infrastructure/repositories/complementary-certification-course-result-repository');
-const Badge = require('../../../../lib/domain/models/Badge');
 const ComplementaryCertificationCourseResult = require('../../../../lib/domain/models/ComplementaryCertificationCourseResult');
 
 describe('Integration | Repository | complementary-certification-courses-result-repository', function () {
@@ -99,7 +98,7 @@ describe('Integration | Repository | complementary-certification-courses-result-
         // given
         databaseBuilder.factory.buildComplementaryCertification({
           id: 1,
-          name: 'Pix+Edu',
+          name: 'Pix+ Test',
         });
         databaseBuilder.factory.buildCertificationCourse({ id: 99 });
         databaseBuilder.factory.buildComplementaryCertificationCourse({
@@ -109,7 +108,7 @@ describe('Integration | Repository | complementary-certification-courses-result-
         });
 
         databaseBuilder.factory.buildBadge({
-          key: Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          key: 'PIX_TEST_1',
         });
 
         await databaseBuilder.commit();
@@ -117,7 +116,7 @@ describe('Integration | Repository | complementary-certification-courses-result-
         const complementaryCertificationCourseResult = domainBuilder.buildComplementaryCertificationCourseResult({
           acquired: true,
           complementaryCertificationCourseId: 999,
-          partnerKey: Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          partnerKey: 'PIX_TEST_1',
           source: ComplementaryCertificationCourseResult.sources.PIX,
         });
 
@@ -129,7 +128,7 @@ describe('Integration | Repository | complementary-certification-courses-result-
           .where({
             acquired: true,
             complementaryCertificationCourseId: 999,
-            partnerKey: Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+            partnerKey: 'PIX_TEST_1',
             source: ComplementaryCertificationCourseResult.sources.PIX,
           })
           .first();
@@ -137,7 +136,7 @@ describe('Integration | Repository | complementary-certification-courses-result-
         expect(_.omit(savedComplementaryCertificationCourseResult, 'id')).to.deep.equal({
           acquired: true,
           complementaryCertificationCourseId: 999,
-          partnerKey: Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          partnerKey: 'PIX_TEST_1',
           source: ComplementaryCertificationCourseResult.sources.PIX,
         });
       });
@@ -148,7 +147,7 @@ describe('Integration | Repository | complementary-certification-courses-result-
         // given
         databaseBuilder.factory.buildComplementaryCertification({
           id: 1,
-          name: 'Pix+Edu',
+          name: 'Pix+ Test',
         });
         databaseBuilder.factory.buildCertificationCourse({ id: 99 });
         databaseBuilder.factory.buildComplementaryCertificationCourse({
@@ -157,18 +156,13 @@ describe('Integration | Repository | complementary-certification-courses-result-
           complementaryCertificationId: 1,
         });
 
-        databaseBuilder.factory.buildBadge({
-          key: Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-        });
-
-        databaseBuilder.factory.buildBadge({
-          key: Badge.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-        });
+        databaseBuilder.factory.buildBadge({ key: 'PIX_TEST_1' });
+        databaseBuilder.factory.buildBadge({ key: 'PIX_TEST_2' });
 
         databaseBuilder.factory.buildComplementaryCertificationCourseResult({
           acquired: true,
           complementaryCertificationCourseId: 999,
-          partnerKey: Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
+          partnerKey: 'PIX_TEST_1',
           source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
         });
 
@@ -177,7 +171,7 @@ describe('Integration | Repository | complementary-certification-courses-result-
         const complementaryCertificationCourseResult = domainBuilder.buildComplementaryCertificationCourseResult({
           acquired: true,
           complementaryCertificationCourseId: 999,
-          partnerKey: Badge.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+          partnerKey: 'PIX_TEST_2',
           source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
         });
 
@@ -195,7 +189,7 @@ describe('Integration | Repository | complementary-certification-courses-result-
         expect(_.omit(results[0], 'id')).to.deep.equal({
           acquired: true,
           complementaryCertificationCourseId: 999,
-          partnerKey: Badge.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
+          partnerKey: 'PIX_TEST_2',
           source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
         });
       });

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-course-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-course-result-repository_test.js
@@ -67,6 +67,90 @@ describe('Integration | Repository | complementary-certification-courses-result-
     });
   });
 
+  describe('#getPixSourceResultByComplementaryCertificationCourseId', function () {
+    context(
+      'when there is a Pix source ComplementaryCertificationCourseResult for the complementary certification course',
+      function () {
+        it('returns the ComplementaryCertificationCourseResult', async function () {
+          // given
+          databaseBuilder.factory.buildComplementaryCertification({
+            id: 1,
+            name: 'Pix+ Test',
+          });
+          databaseBuilder.factory.buildCertificationCourse({ id: 99 });
+          databaseBuilder.factory.buildComplementaryCertificationCourse({
+            id: 999,
+            certificationCourseId: 99,
+            complementaryCertificationId: 1,
+          });
+          databaseBuilder.factory.buildBadge({ key: 'PIX_TEST_1' });
+          databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+            complementaryCertificationCourseId: 999,
+            partnerKey: 'PIX_TEST_1',
+            source: ComplementaryCertificationCourseResult.sources.PIX,
+            acquired: true,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const result =
+            await complementaryCertificationCourseResultRepository.getPixSourceResultByComplementaryCertificationCourseId(
+              {
+                complementaryCertificationCourseId: 999,
+              }
+            );
+
+          // then
+          expect(result).to.deepEqualInstance(
+            domainBuilder.buildComplementaryCertificationCourseResult({
+              acquired: true,
+              complementaryCertificationCourseId: 999,
+              partnerKey: 'PIX_TEST_1',
+              source: ComplementaryCertificationCourseResult.sources.PIX,
+            })
+          );
+        });
+      }
+    );
+
+    context(
+      'when there is no Pix source ComplementaryCertificationCourseResult for the complementary certification course',
+      function () {
+        it('returns null', async function () {
+          // given
+          databaseBuilder.factory.buildComplementaryCertification({
+            id: 1,
+            name: 'Pix+ Test',
+          });
+          databaseBuilder.factory.buildCertificationCourse({ id: 99 });
+          databaseBuilder.factory.buildComplementaryCertificationCourse({
+            id: 999,
+            certificationCourseId: 99,
+            complementaryCertificationId: 1,
+          });
+          databaseBuilder.factory.buildBadge({ key: 'PIX_TEST_1' });
+          databaseBuilder.factory.buildComplementaryCertificationCourseResult({
+            complementaryCertificationCourseId: 999,
+            partnerKey: 'PIX_TEST_1',
+            source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
+            acquired: true,
+          });
+          await databaseBuilder.commit();
+          // when
+          const result =
+            await complementaryCertificationCourseResultRepository.getPixSourceResultByComplementaryCertificationCourseId(
+              {
+                complementaryCertificationCourseId: 99,
+              }
+            );
+
+          // then
+          expect(result).to.be.null;
+        });
+      }
+    );
+  });
+
   describe('#save', function () {
     afterEach(function () {
       return knex('complementary-certification-course-results').delete();

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-course-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-course-result-repository_test.js
@@ -6,67 +6,6 @@ const Badge = require('../../../../lib/domain/models/Badge');
 const ComplementaryCertificationCourseResult = require('../../../../lib/domain/models/ComplementaryCertificationCourseResult');
 
 describe('Integration | Repository | complementary-certification-courses-result-repository', function () {
-  describe('#getFromComplementaryCertificationCourseId', function () {
-    describe('when a ComplementaryCertificationCourseResult matches the complementaryCertificationCourseId', function () {
-      it('returns ComplementaryCertificationCourseResult as an array', async function () {
-        // given
-        databaseBuilder.factory.buildComplementaryCertification({
-          id: 1,
-          name: 'Pix+Edu',
-        });
-        databaseBuilder.factory.buildCertificationCourse({ id: 99 });
-        databaseBuilder.factory.buildComplementaryCertificationCourse({
-          id: 999,
-          certificationCourseId: 99,
-          complementaryCertificationId: 1,
-        });
-
-        databaseBuilder.factory.buildBadge({
-          key: Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-        });
-
-        databaseBuilder.factory.buildComplementaryCertificationCourseResult({
-          complementaryCertificationCourseId: 999,
-          partnerKey: Badge.keys.PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-          source: ComplementaryCertificationCourseResult.sources.PIX,
-          acquired: true,
-        });
-
-        await databaseBuilder.commit();
-
-        // when
-        const [result] =
-          await complementaryCertificationCourseResultRepository.getFromComplementaryCertificationCourseId({
-            complementaryCertificationCourseId: 999,
-          });
-
-        // then
-        expect(result).to.deepEqualInstance(
-          domainBuilder.buildComplementaryCertificationCourseResult({
-            acquired: true,
-            complementaryCertificationCourseId: 999,
-            partnerKey: 'PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE',
-            source: ComplementaryCertificationCourseResult.sources.PIX,
-          })
-        );
-      });
-    });
-
-    describe('when no ComplementaryCertificationCourseResult matches the complementaryCertificationCourseId', function () {
-      it('returns an empty array', async function () {
-        // when
-        const result = await complementaryCertificationCourseResultRepository.getFromComplementaryCertificationCourseId(
-          {
-            complementaryCertificationCourseId: 99,
-          }
-        );
-
-        // then
-        expect(result).to.deep.equal([]);
-      });
-    });
-  });
-
   describe('#getPixSourceResultByComplementaryCertificationCourseId', function () {
     context(
       'when there is a Pix source ComplementaryCertificationCourseResult for the complementary certification course',

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-course-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-course-result-repository_test.js
@@ -89,6 +89,28 @@ describe('Integration | Repository | complementary-certification-courses-result-
     );
   });
 
+  describe('#getAllowedJuryLevelByBadgeKey', function () {
+    it('should return the allowed jury level for a partner key', async function () {
+      // given
+      databaseBuilder.factory.buildTargetProfile({ id: 123 });
+      databaseBuilder.factory.buildBadge({ id: 1212, key: 'KEY_1', targetProfileId: 123 });
+
+      databaseBuilder.factory.buildTargetProfile({ id: 456 });
+      databaseBuilder.factory.buildBadge({ id: 1213, key: 'KEY_2', targetProfileId: 456 });
+      databaseBuilder.factory.buildBadge({ id: 1214, key: 'KEY_3', targetProfileId: 456 });
+
+      await databaseBuilder.commit();
+
+      // when
+      const allowedBadgeKeys = await complementaryCertificationCourseResultRepository.getAllowedJuryLevelByBadgeKey({
+        key: 'KEY_2',
+      });
+
+      // then
+      expect(allowedBadgeKeys).to.deep.equal(['KEY_2', 'KEY_3']);
+    });
+  });
+
   describe('#save', function () {
     afterEach(function () {
       return knex('complementary-certification-course-results').delete();

--- a/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
@@ -50,10 +50,12 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
       const complementaryDroitCertificationId = databaseBuilder.factory.buildComplementaryCertification({
         id: 23,
         name: 'Pix+ Droit',
+        hasExternalJury: false,
       }).id;
       const complementaryEduCertificationId = databaseBuilder.factory.buildComplementaryCertification({
         id: 24,
         name: 'Pix+ Édu',
+        hasExternalJury: true,
       }).id;
 
       databaseBuilder.factory.buildComplementaryCertificationBadge({

--- a/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
@@ -1,7 +1,6 @@
 const { expect, databaseBuilder, domainBuilder, catchErr } = require('../../../test-helper');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const juryCertificationRepository = require('../../../../lib/infrastructure/repositories/jury-certification-repository');
-const Badge = require('../../../../lib/domain/models/Badge');
 
 describe('Integration | Infrastructure | Repository | Jury Certification', function () {
   describe('#get', function () {
@@ -23,11 +22,6 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
       // given
       databaseBuilder.factory.buildUser({ id: 789 });
       databaseBuilder.factory.buildSession({ id: 456 });
-      const pixEduBadgeId = databaseBuilder.factory.buildBadge({
-        key: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
-      }).id;
-      const pixDroitBadgeId = databaseBuilder.factory.buildBadge({ key: Badge.keys.PIX_DROIT_EXPERT_CERTIF }).id;
-
       databaseBuilder.factory.buildCertificationCourse({ id: 2, sessionId: 456 });
       databaseBuilder.factory.buildAssessment({ certificationCourseId: 2 });
       databaseBuilder.factory.buildCertificationCourse({
@@ -47,29 +41,38 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
         isPublished: false,
         isCancelled: false,
       });
-      const complementaryDroitCertificationId = databaseBuilder.factory.buildComplementaryCertification({
-        id: 23,
-        name: 'Pix+ Droit',
-        hasExternalJury: false,
-      }).id;
-      const complementaryEduCertificationId = databaseBuilder.factory.buildComplementaryCertification({
-        id: 24,
-        name: 'Pix+ Édu',
-        hasExternalJury: true,
-      }).id;
 
-      databaseBuilder.factory.buildComplementaryCertificationBadge({
-        id: 3454,
-        complementaryCertificationId: complementaryEduCertificationId,
-        badgeId: pixEduBadgeId,
-        label: 'Pix+ Edu label',
+      databaseBuilder.factory.buildComplementaryCertification({
+        id: 23,
+        name: 'Complementary certification without external jury',
+        hasExternalJury: false,
+      });
+      databaseBuilder.factory.buildComplementaryCertification({
+        id: 24,
+        name: 'Complementary certification with external jury',
+        hasExternalJury: true,
+      });
+
+      databaseBuilder.factory.buildBadge({
+        id: 123,
+        key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_WITH_EXTERNAL_JURY',
+      });
+      databaseBuilder.factory.buildBadge({
+        id: 456,
+        key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_WITHOUT_EXTERNAL_JURY',
       });
 
       databaseBuilder.factory.buildComplementaryCertificationBadge({
+        id: 3454,
+        complementaryCertificationId: 24,
+        badgeId: 123,
+        label: 'Badge for complementary certification with external jury',
+      });
+      databaseBuilder.factory.buildComplementaryCertificationBadge({
         id: 7678,
-        complementaryCertificationId: complementaryDroitCertificationId,
-        badgeId: pixDroitBadgeId,
-        label: 'Pix+ Droit label',
+        complementaryCertificationId: 23,
+        badgeId: 456,
+        label: 'Badge for complementary certification without external jury',
       });
 
       databaseBuilder.factory.buildComplementaryCertificationCourse({
@@ -88,14 +91,13 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
       databaseBuilder.factory.buildComplementaryCertificationCourseResult({
         complementaryCertificationCourseId: 123,
         source: 'PIX',
-        partnerKey: Badge.keys.PIX_DROIT_EXPERT_CERTIF,
+        partnerKey: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_WITHOUT_EXTERNAL_JURY',
         acquired: true,
       });
-
       databaseBuilder.factory.buildComplementaryCertificationCourseResult({
         complementaryCertificationCourseId: 456,
         source: 'PIX',
-        partnerKey: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+        partnerKey: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_WITH_EXTERNAL_JURY',
         acquired: true,
       });
 
@@ -162,8 +164,8 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
           {
             acquired: true,
             id: 123,
-            partnerKey: 'PIX_DROIT_EXPERT_CERTIF',
-            label: 'Pix+ Droit label',
+            partnerKey: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_WITHOUT_EXTERNAL_JURY',
+            label: 'Badge for complementary certification without external jury',
           },
         ],
         complementaryCertificationCourseResultsWithExternal: {
@@ -175,8 +177,8 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
           },
           pixSection: {
             acquired: true,
-            partnerKey: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE',
-            label: 'Pix+ Edu label',
+            partnerKey: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_WITH_EXTERNAL_JURY',
+            label: 'Badge for complementary certification with external jury',
           },
         },
       });

--- a/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
@@ -53,13 +53,16 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
         hasExternalJury: true,
       });
 
+      databaseBuilder.factory.buildTargetProfile({ id: 5656 });
       databaseBuilder.factory.buildBadge({
         id: 123,
         key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_WITH_EXTERNAL_JURY',
+        targetProfileId: 5656,
       });
       databaseBuilder.factory.buildBadge({
         id: 456,
         key: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_WITHOUT_EXTERNAL_JURY',
+        targetProfileId: 5656,
       });
 
       databaseBuilder.factory.buildComplementaryCertificationBadge({
@@ -180,6 +183,16 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
             partnerKey: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_WITH_EXTERNAL_JURY',
             label: 'Badge for complementary certification with external jury',
           },
+          allowedExternalLevels: [
+            {
+              value: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_WITH_EXTERNAL_JURY',
+              label: 'Badge for complementary certification with external jury',
+            },
+            {
+              value: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_WITHOUT_EXTERNAL_JURY',
+              label: 'Badge for complementary certification without external jury',
+            },
+          ],
         },
       });
       expect(juryCertification).to.deepEqualInstance(expectedJuryCertification);

--- a/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
@@ -70,6 +70,7 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
         complementaryCertificationId: 24,
         badgeId: 123,
         label: 'Badge for complementary certification with external jury',
+        level: 2,
       });
       databaseBuilder.factory.buildComplementaryCertificationBadge({
         id: 7678,
@@ -177,11 +178,13 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
             acquired: false,
             partnerKey: undefined,
             label: undefined,
+            level: undefined,
           },
           pixSection: {
             acquired: true,
             partnerKey: 'BADGE_FOR_COMPLEMENTARY_CERTIFICATION_WITH_EXTERNAL_JURY',
             label: 'Badge for complementary certification with external jury',
+            level: 2,
           },
           allowedExternalLevels: [
             {

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification-course-result-for-certification-with-external.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification-course-result-for-certification-with-external.js
@@ -7,9 +7,11 @@ module.exports = function buildPixEduComplementaryCertificationCourseResultsForJ
   pixPartnerKey = PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
   pixLabel = 'Pix+ Édu 1er degré Avancé',
   pixAcquired = true,
+  pixLevel = 2,
   externalPartnerKey = PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
   externalLabel = 'Pix+ Édu 1er degré Expert',
   externalAcquired = true,
+  externalLevel = 1,
   allowedExternalLevels = [],
 } = {}) {
   return new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
@@ -17,9 +19,11 @@ module.exports = function buildPixEduComplementaryCertificationCourseResultsForJ
     pixPartnerKey,
     pixLabel,
     pixAcquired,
+    pixLevel,
     externalPartnerKey,
     externalLabel,
     externalAcquired,
+    externalLevel,
     allowedExternalLevels,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-complementary-certification-course-result-for-certification-with-external.js
+++ b/api/tests/tooling/domain-builder/factory/build-complementary-certification-course-result-for-certification-with-external.js
@@ -10,6 +10,7 @@ module.exports = function buildPixEduComplementaryCertificationCourseResultsForJ
   externalPartnerKey = PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
   externalLabel = 'Pix+ Édu 1er degré Expert',
   externalAcquired = true,
+  allowedExternalLevels = [],
 } = {}) {
   return new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
     complementaryCertificationCourseId,
@@ -19,5 +20,6 @@ module.exports = function buildPixEduComplementaryCertificationCourseResultsForJ
     externalPartnerKey,
     externalLabel,
     externalAcquired,
+    allowedExternalLevels,
   });
 };

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -29,6 +29,7 @@ const {
   SessionStartedDeletionError,
   CertificationAttestationGenerationError,
   CampaignTypeError,
+  InvalidJuryLevelError,
 } = require('../../../lib/domain/errors');
 const HttpErrors = require('../../../lib/application/http-errors.js');
 
@@ -506,6 +507,19 @@ describe('Unit | Application | ErrorManager', function () {
 
       // then
       expect(HttpErrors.PreconditionFailedError).to.have.been.calledWithExactly(error.message);
+    });
+
+    it('should instantiate BadRequestError when InvalidJuryLevelError', async function () {
+      // given
+      const error = new InvalidJuryLevelError();
+      sinon.stub(HttpErrors, 'BadRequestError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message);
     });
   });
 });

--- a/api/tests/unit/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal_test.js
+++ b/api/tests/unit/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal_test.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable mocha/no-setup-in-describe */
 const ComplementaryCertificationCourseResultsForJuryCertificationWithExternal = require('../../../../lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal');
-const { expect, domainBuilder, catchErr } = require('../../../test-helper');
+const { expect, domainBuilder } = require('../../../test-helper');
 const {
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
@@ -68,172 +68,25 @@ describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJur
         expect(finalResult).to.equal('Rejetée');
       });
 
-      [
-        {
-          pixPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-          pixLabel: 'Pix+ Édu 2nd degré Initié (entrée dans le métier)',
-          externalPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-          externalLabel: 'Pix+ Édu 2nd degré Initié (entrée dans le métier)',
-          expectedFinalResult: 'Pix+ Édu 2nd degré Initié (entrée dans le métier)',
-        },
-        {
-          pixPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-          pixLabel: 'Pix+ Édu 2nd degré Initié (entrée dans le métier)',
-          externalPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
-          externalLabel: 'Pix+ Édu 2nd degré Confirme',
-          expectedFinalResult: 'Pix+ Édu 2nd degré Initié (entrée dans le métier)',
-        },
-        {
-          pixPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
-          pixLabel: 'Pix+ Édu 2nd degré Confirmé',
-          externalPartnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
-          externalLabel: 'Pix+ Édu 2nd degré Confirmé',
-          expectedFinalResult: 'Pix+ Édu 2nd degré Confirmé',
-        },
-        {
-          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-          pixLabel: 'Pix+ Édu 2nd degré Confirmé',
-          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-          externalLabel: 'Pix+ Édu 2nd degré Confirmé',
-          expectedFinalResult: 'Pix+ Édu 2nd degré Confirmé',
-        },
-        {
-          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-          pixLabel: 'Pix+ Édu 2nd degré Confirmé',
-          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-          externalLabel: 'Pix+ Édu 2nd degré Avancé',
-          expectedFinalResult: 'Pix+ Édu 2nd degré Confirmé',
-        },
-        {
-          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-          pixLabel: 'Pix+ Édu 2nd degré Confirmé',
-          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-          externalLabel: 'Pix+ Édu 2nd degré Expert',
-          expectedFinalResult: 'Pix+ Édu 2nd degré Confirmé',
-        },
-        {
-          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-          pixLabel: 'Pix+ Édu 2nd degré Avancé',
-          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-          externalLabel: 'Pix+ Édu 2nd degré Avancé',
-          expectedFinalResult: 'Pix+ Édu 2nd degré Avancé',
-        },
-        {
-          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-          pixLabel: 'Pix+ Édu 2nd degré Avancé',
-          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-          externalLabel: 'Pix+ Édu 2nd degré Expert',
-          expectedFinalResult: 'Pix+ Édu 2nd degré Avancé',
-        },
-        {
-          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-          pixLabel: 'Pix+ Édu 2nd degré Expert',
-          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-          externalLabel: 'Pix+ Édu 2nd degré Expert',
-          expectedFinalResult: 'Pix+ Édu 2nd degré Expert',
-        },
-        {
-          pixPartnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
-          pixLabel: 'Pix+ Édu 1er degré Initié (entrée dans le métier)',
-          externalPartnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
-          externalLabel: 'Pix+ Édu 1er degré Initié (entrée dans le métier)',
-          expectedFinalResult: 'Pix+ Édu 1er degré Initié (entrée dans le métier)',
-        },
-        {
-          pixPartnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
-          pixLabel: 'Pix+ Édu 1er degré Initié (entrée dans le métier)',
-          externalPartnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
-          externalLabel: 'Pix+ Édu 1er degré Confirme',
-          expectedFinalResult: 'Pix+ Édu 1er degré Initié (entrée dans le métier)',
-        },
-        {
-          pixPartnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
-          pixLabel: 'Pix+ Édu 1er degré Confirmé',
-          externalPartnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
-          externalLabel: 'Pix+ Édu 1er degré Confirmé',
-          expectedFinalResult: 'Pix+ Édu 1er degré Confirmé',
-        },
-        {
-          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
-          pixLabel: 'Pix+ Édu 1er degré Confirmé',
-          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
-          externalLabel: 'Pix+ Édu 1er degré Confirmé',
-          expectedFinalResult: 'Pix+ Édu 1er degré Confirmé',
-        },
-        {
-          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
-          pixLabel: 'Pix+ Édu 1er degré Confirmé',
-          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
-          externalLabel: 'Pix+ Édu 1er degré Avancé',
-          expectedFinalResult: 'Pix+ Édu 1er degré Confirmé',
-        },
-        {
-          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
-          pixLabel: 'Pix+ Édu 1er degré Confirmé',
-          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
-          externalLabel: 'Pix+ Édu 1er degré Expert',
-          expectedFinalResult: 'Pix+ Édu 1er degré Confirmé',
-        },
-        {
-          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
-          pixLabel: 'Pix+ Édu 1er degré Avancé',
-          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
-          externalLabel: 'Pix+ Édu 1er degré Avancé',
-          expectedFinalResult: 'Pix+ Édu 1er degré Avancé',
-        },
-        {
-          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
-          pixLabel: 'Pix+ Édu 1er degré Avancé',
-          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
-          externalLabel: 'Pix+ Édu 1er degré Expert',
-          expectedFinalResult: 'Pix+ Édu 1er degré Avancé',
-        },
-        {
-          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
-          pixLabel: 'Pix+ Édu 1er degré Expert',
-          externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
-          externalLabel: 'Pix+ Édu 1er degré Expert',
-          expectedFinalResult: 'Pix+ Édu 1er degré Expert',
-        },
-      ].forEach(({ pixPartnerKey, pixLabel, externalPartnerKey, externalLabel, expectedFinalResult }) => {
-        it(`should return ${expectedFinalResult} when the 'PIX' source level is ${pixPartnerKey} and the 'EXTERNAL' source level is ${externalPartnerKey}`, function () {
-          // given
-          const complementaryCertificationCourseResultForJuryCertificationWithExternal =
-            domainBuilder.buildComplementaryCertificationCourseResultForJuryCertificationWithExternal({
-              pixPartnerKey,
-              pixLabel,
-              pixAcquired: true,
-              externalPartnerKey,
-              externalLabel,
-              externalAcquired: true,
-            });
-
-          // when
-          const finalResult = complementaryCertificationCourseResultForJuryCertificationWithExternal.finalResult;
-
-          // then
-          expect(finalResult).to.equal(expectedFinalResult);
-        });
-      });
-
-      it('should throw an Error when partner key are not from the same degrees', async function () {
+      it(`should return the section with the lowest level`, function () {
         // given
         const complementaryCertificationCourseResultForJuryCertificationWithExternal =
           domainBuilder.buildComplementaryCertificationCourseResultForJuryCertificationWithExternal({
-            pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+            pixPartnerKey: 'BADGE_KEY_1',
+            pixLabel: 'Badge Key 1',
             pixAcquired: true,
-            externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
+            pixLevel: 4,
+            externalPartnerKey: 'BADGE_KEY_2',
+            externalLabel: 'Badge Key 2',
             externalAcquired: true,
+            externalLevel: 2,
           });
 
         // when
-        const myFunc = () => complementaryCertificationCourseResultForJuryCertificationWithExternal.finalResult;
-        const error = await catchErr(myFunc)();
+        const finalResult = complementaryCertificationCourseResultForJuryCertificationWithExternal.finalResult;
 
         // then
-        expect(error.message).to.equal(
-          `Badges edu incoherent !!! ${PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE} et ${PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT}`
-        );
+        expect(finalResult).to.equal('Badge Key 2');
       });
     });
   });

--- a/api/tests/unit/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal_test.js
+++ b/api/tests/unit/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal_test.js
@@ -1,7 +1,6 @@
 // eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable mocha/no-setup-in-describe */
 const ComplementaryCertificationCourseResultsForJuryCertificationWithExternal = require('../../../../lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal');
-const { getLabelByBadgeKey } = require('../../../../lib/domain/read-models/CertifiableBadgeLabels');
 const { expect, domainBuilder, catchErr } = require('../../../test-helper');
 const {
   PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
@@ -245,21 +244,32 @@ describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJur
       const complementaryCertificationCourseResultsWithExternal = [
         domainBuilder.buildComplementaryCertificationCourseResult({
           complementaryCertificationCourseId: 1234,
-          partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+          partnerKey: 'KEY_1',
           acquired: true,
           source: 'PIX',
         }),
         domainBuilder.buildComplementaryCertificationCourseResult({
           complementaryCertificationCourseId: 1234,
-          partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+          partnerKey: 'KEY_2',
           acquired: false,
           source: 'EXTERNAL',
         }),
       ];
+      const badgeKeyAndLabelsGroupedByTargetProfile = [
+        [
+          { key: 'KEY_3', label: 'Key 3' },
+          { key: 'KEY_4', label: 'Key 4' },
+        ],
+        [
+          { key: 'KEY_1', label: 'Key 1' },
+          { key: 'KEY_2', label: 'Key 2' },
+        ],
+      ];
 
       // when
       const result = ComplementaryCertificationCourseResultsForJuryCertificationWithExternal.from(
-        complementaryCertificationCourseResultsWithExternal
+        complementaryCertificationCourseResultsWithExternal,
+        badgeKeyAndLabelsGroupedByTargetProfile
       );
 
       // then
@@ -267,9 +277,13 @@ describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJur
         new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
           pixAcquired: true,
           externalAcquired: false,
-          pixPartnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
-          externalPartnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
+          pixPartnerKey: 'KEY_1',
+          externalPartnerKey: 'KEY_2',
           complementaryCertificationCourseId: 1234,
+          allowedExternalLevels: [
+            { value: 'KEY_1', label: 'Key 1' },
+            { value: 'KEY_2', label: 'Key 2' },
+          ],
         })
       );
     });
@@ -470,176 +484,5 @@ describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJur
         });
       });
     });
-  });
-
-  describe('#allowedExternalLevels', function () {
-    [
-      {
-        partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
-        expectedLevels: [
-          {
-            value: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE),
-          },
-          {
-            value: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME),
-          },
-        ],
-      },
-      {
-        partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
-        expectedLevels: [
-          {
-            value: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE),
-          },
-          {
-            value: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME),
-          },
-        ],
-      },
-      {
-        partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
-        expectedLevels: [
-          {
-            value: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME),
-          },
-          {
-            value: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE),
-          },
-          {
-            value: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT),
-          },
-        ],
-      },
-      {
-        partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
-        expectedLevels: [
-          {
-            value: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME),
-          },
-          {
-            value: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE),
-          },
-          {
-            value: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT),
-          },
-        ],
-      },
-      {
-        partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
-        expectedLevels: [
-          {
-            value: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME),
-          },
-          {
-            value: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE),
-          },
-          {
-            value: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT),
-          },
-        ],
-      },
-      {
-        partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-        expectedLevels: [
-          {
-            value: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE),
-          },
-          {
-            value: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME),
-          },
-        ],
-      },
-      {
-        partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
-        expectedLevels: [
-          {
-            value: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE),
-          },
-          {
-            value: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME),
-          },
-        ],
-      },
-      {
-        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-        expectedLevels: [
-          {
-            value: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME),
-          },
-          {
-            value: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE),
-          },
-          {
-            value: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT),
-          },
-        ],
-      },
-      {
-        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-        expectedLevels: [
-          {
-            value: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME),
-          },
-          {
-            value: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE),
-          },
-          {
-            value: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT),
-          },
-        ],
-      },
-      {
-        partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-        expectedLevels: [
-          {
-            value: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME),
-          },
-          {
-            value: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE),
-          },
-          {
-            value: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-            label: getLabelByBadgeKey(PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT),
-          },
-        ],
-      },
-    ].forEach(({ partnerKey, expectedLevels }) =>
-      context(`when partner key is ${partnerKey}`, function () {
-        it(`should return an array of allowed labels and statuses`, function () {
-          // when
-          const allowedExternalLevels = new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
-            pixPartnerKey: partnerKey,
-          }).allowedExternalLevels;
-
-          // then
-          expect(allowedExternalLevels).to.deep.equal(expectedLevels);
-        });
-      })
-    );
   });
 });

--- a/api/tests/unit/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal_test.js
+++ b/api/tests/unit/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal_test.js
@@ -1,19 +1,5 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
-/* eslint-disable mocha/no-setup-in-describe */
 const ComplementaryCertificationCourseResultsForJuryCertificationWithExternal = require('../../../../lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertificationWithExternal');
 const { expect, domainBuilder } = require('../../../test-helper');
-const {
-  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-  PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
-  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-  PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
-  PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
-  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
-  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
-  PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
-} = require('../../../../lib/domain/models/Badge').keys;
 
 describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJuryCertificationWithExternal', function () {
   describe('#finalResult', function () {
@@ -22,7 +8,7 @@ describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJur
         // given
         const complementaryCertificationCourseResultForJuryCertificationWithExternal =
           domainBuilder.buildComplementaryCertificationCourseResultForJuryCertificationWithExternal({
-            pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+            pixPartnerKey: 'KEY',
             pixAcquired: true,
             externalPartnerKey: null,
           });
@@ -39,7 +25,7 @@ describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJur
       // given
       const complementaryCertificationCourseResultForJuryCertificationWithExternal =
         domainBuilder.buildComplementaryCertificationCourseResultForJuryCertificationWithExternal({
-          pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+          pixPartnerKey: 'KEY',
           pixAcquired: false,
         });
 
@@ -55,9 +41,9 @@ describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJur
         // given
         const complementaryCertificationCourseResultForJuryCertificationWithExternal =
           domainBuilder.buildComplementaryCertificationCourseResultForJuryCertificationWithExternal({
-            pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+            pixPartnerKey: 'KEY_1',
             pixAcquired: true,
-            externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
+            externalPartnerKey: 'KEY_2',
             externalAcquired: false,
           });
 
@@ -158,74 +144,20 @@ describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJur
     });
 
     context('when pix section is evaluated', function () {
-      [
-        {
-          partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-          acquired: true,
-          label: 'Pix+ Édu 2nd degré Initié (entrée dans le métier)',
-        },
-        {
-          partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
-          acquired: true,
-          label: 'Pix+ Édu 2nd degré Confirmé',
-        },
-        {
-          partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-          acquired: true,
-          label: 'Pix+ Édu 2nd degré Confirmé',
-        },
-        {
-          partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE,
-          acquired: true,
-          label: 'Pix+ Édu 2nd degré Avancé',
-        },
-        {
-          partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT,
-          acquired: true,
-          label: 'Pix+ Édu 2nd degré Expert',
-        },
-        {
-          partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
-          acquired: true,
-          label: 'Pix+ Édu 1er degré Initié (entrée dans le métier)',
-        },
-        {
-          partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
-          acquired: true,
-          label: 'Pix+ Édu 1er degré Confirmé',
-        },
-        {
-          partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
-          acquired: true,
-          label: 'Pix+ Édu 1er degré Confirmé',
-        },
-        {
-          partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
-          acquired: true,
-          label: 'Pix+ Édu 1er degré Avancé',
-        },
-        {
-          partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT,
-          acquired: true,
-          label: 'Pix+ Édu 1er degré Expert',
-        },
-        { partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT, acquired: false, label: 'Rejetée' },
-      ].forEach(({ partnerKey, acquired, label }) => {
-        it(`should return ${label} when pix section partner key is ${partnerKey} and acquired is ${acquired}`, function () {
-          // given
-          const complementaryCertificationCourseResultsForJuryCertificationWithExternal =
-            new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
-              pixPartnerKey: partnerKey,
-              pixLabel: label,
-              pixAcquired: acquired,
-            });
+      it(`should return the pix label`, function () {
+        // given
+        const complementaryCertificationCourseResultsForJuryCertificationWithExternal =
+          new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
+            pixPartnerKey: 'KEY',
+            pixLabel: 'Key label',
+            pixAcquired: true,
+          });
 
-          // when
-          const pixResult = complementaryCertificationCourseResultsForJuryCertificationWithExternal.pixResult;
+        // when
+        const pixResult = complementaryCertificationCourseResultsForJuryCertificationWithExternal.pixResult;
 
-          // then
-          expect(pixResult).to.equal(label);
-        });
+        // then
+        expect(pixResult).to.equal('Key label');
       });
     });
   });
@@ -236,7 +168,7 @@ describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJur
         // given
         const complementaryCertificationCourseResultsForJuryCertificationWithExternal =
           new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
-            pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+            pixPartnerKey: 'KEY',
             pixAcquired: false,
           });
 
@@ -253,7 +185,7 @@ describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJur
         // given
         const complementaryCertificationCourseResultsForJuryCertificationWithExternal =
           new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
-            pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
+            pixPartnerKey: 'KEY',
             pixAcquired: true,
           });
 
@@ -267,54 +199,22 @@ describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJur
 
     context('when pix section is acquired and external section is evaluated', function () {
       context('when acquired is true', function () {
-        [
-          {
-            partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_INITIE,
-            label: 'Pix+ Édu 2nd degré Initié (entrée dans le métier)',
-          },
-          {
-            partnerKey: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME,
-            label: 'Pix+ Édu 2nd degré Confirmé',
-          },
-          {
-            partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_CONFIRME,
-            label: 'Pix+ Édu 2nd degré Confirmé',
-          },
-          { partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE, label: 'Pix+ Édu 2nd degré Avancé' },
-          { partnerKey: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_EXPERT, label: 'Pix+ Édu 2nd degré Expert' },
-          {
-            partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_INITIE,
-            label: 'Pix+ Édu 1er degré Initié (entrée dans le métier)',
-          },
-          {
-            partnerKey: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME,
-            label: 'Pix+ Édu 1er degré Confirmé',
-          },
-          {
-            partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME,
-            label: 'Pix+ Édu 1er degré Confirmé',
-          },
-          { partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE, label: 'Pix+ Édu 1er degré Avancé' },
-          { partnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT, label: 'Pix+ Édu 1er degré Expert' },
-        ].forEach(({ partnerKey, label }) => {
-          it(`should return ${label} when external section partner key is ${partnerKey}`, function () {
-            // given
-            const complementaryCertificationCourseResultsForJuryCertificationWithExternal =
-              new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
-                pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
-                pixAcquired: true,
-                externalPartnerKey: partnerKey,
-                externalLabel: label,
-                externalAcquired: true,
-              });
+        it(`should return the external label`, function () {
+          // given
+          const complementaryCertificationCourseResultsForJuryCertificationWithExternal =
+            new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
+              pixPartnerKey: 'KEY_1',
+              pixAcquired: true,
+              externalPartnerKey: 'KEY_2',
+              externalLabel: 'Key 2 label',
+              externalAcquired: true,
+            });
 
-            // when
-            const externalResult =
-              complementaryCertificationCourseResultsForJuryCertificationWithExternal.externalResult;
+          // when
+          const externalResult = complementaryCertificationCourseResultsForJuryCertificationWithExternal.externalResult;
 
-            // then
-            expect(externalResult).to.equal(label);
-          });
+          // then
+          expect(externalResult).to.equal('Key 2 label');
         });
       });
 
@@ -323,9 +223,9 @@ describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJur
           // given
           const complementaryCertificationCourseResultsForJuryCertificationWithExternal =
             new ComplementaryCertificationCourseResultsForJuryCertificationWithExternal({
-              pixPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+              pixPartnerKey: 'KEY_1',
               pixAcquired: true,
-              externalPartnerKey: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
+              externalPartnerKey: 'KEY_2',
               externalAcquired: false,
             });
 

--- a/api/tests/unit/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertification_test.js
+++ b/api/tests/unit/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertification_test.js
@@ -1,4 +1,4 @@
-const { expect } = require('../../../test-helper');
+const { expect, domainBuilder } = require('../../../test-helper');
 const ComplementaryCertificationCourseResultsForJuryCertification = require('../../../../lib/domain/read-models/ComplementaryCertificationCourseResultsForJuryCertification');
 
 describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJuryCertification', function () {
@@ -29,6 +29,34 @@ describe('Unit | Domain | Models | ComplementaryCertificationCourseResultsForJur
         // then
         expect(status).to.equal('Rejetée');
       });
+    });
+  });
+
+  describe('#from', function () {
+    it('should return an instance of ComplementaryCertificationCourseResultsForJuryCertification', function () {
+      // given
+      const id = 121;
+      const partnerKey = 'KEY';
+      const acquired = true;
+      const label = 'label';
+
+      // when
+      const result = ComplementaryCertificationCourseResultsForJuryCertification.from({
+        id,
+        partnerKey,
+        acquired,
+        label,
+      });
+
+      // then
+      expect(result).to.deepEqualInstance(
+        domainBuilder.buildComplementaryCertificationCourseResultForJuryCertification({
+          id,
+          partnerKey,
+          acquired,
+          label,
+        })
+      );
     });
   });
 });

--- a/api/tests/unit/domain/usecases/save-jury-complementary-certification-course-result_test.js
+++ b/api/tests/unit/domain/usecases/save-jury-complementary-certification-course-result_test.js
@@ -3,7 +3,6 @@ const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper
 const saveJuryComplementaryCertificationCourseResult = require('../../../../lib/domain/usecases/save-jury-complementary-certification-course-result');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const ComplementaryCertificationCourseResult = require('../../../../lib/domain/models/ComplementaryCertificationCourseResult');
-const Badge = require('../../../../lib/domain/models/Badge');
 
 describe('Unit | UseCase | save-jury-complementary-certification-course-results', function () {
   describe('#saveJuryComplementaryCertificationCourseResult', function () {
@@ -12,97 +11,59 @@ describe('Unit | UseCase | save-jury-complementary-certification-course-results'
     beforeEach(function () {
       complementaryCertificationCourseResultRepository = {
         save: sinon.stub(),
-        getFromComplementaryCertificationCourseId: sinon.stub(),
+        getPixSourceResultByComplementaryCertificationCourseId: sinon.stub(),
       };
     });
 
-    context('when no Pix Edu complementaryCertificationCourseResult is found', function () {
+    context('when no ComplementaryCertificationCourseResult from PIX source is found', function () {
       it('should throw an error', async function () {
         // given
-        const complementaryCertificationCourseId = 12345;
-        const juryLevel = 'juryLevel';
-        complementaryCertificationCourseResultRepository.getFromComplementaryCertificationCourseId
-          .withArgs({ complementaryCertificationCourseId })
-          .resolves([]);
+        complementaryCertificationCourseResultRepository.getPixSourceResultByComplementaryCertificationCourseId
+          .withArgs({ complementaryCertificationCourseId: 12345 })
+          .resolves(null);
 
         // when
         const error = await catchErr(saveJuryComplementaryCertificationCourseResult)({
-          complementaryCertificationCourseId,
-          juryLevel,
+          complementaryCertificationCourseId: 12345,
+          juryLevel: 'JURY_LEVEL',
           complementaryCertificationCourseResultRepository,
         });
 
         // then
         expect(error).to.be.instanceOf(NotFoundError);
-        expect(error.message).to.be.equal("Aucun résultat Pix+ Edu n'a été trouvé pour cette certification.");
+        expect(error.message).to.be.equal(
+          "Aucun résultat de certification Pix n'a été trouvé pour cette certification complémentaire."
+        );
       });
     });
 
-    context('when no Pix Edu complementaryCertificationCourseResult from PIX source is found', function () {
-      it('should throw an error', async function () {
-        // given
-        const complementaryCertificationCourseId = 12345;
-        const juryLevel = Badge.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE;
-        const pixEduComplementaryCertificationCourseResult = domainBuilder.buildComplementaryCertificationCourseResult({
-          juryLevel,
-          source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
-        });
-        complementaryCertificationCourseResultRepository.getFromComplementaryCertificationCourseId
-          .withArgs({ complementaryCertificationCourseId })
-          .resolves([pixEduComplementaryCertificationCourseResult]);
-
-        // when
-        const error = await catchErr(saveJuryComplementaryCertificationCourseResult)({
-          complementaryCertificationCourseId,
-          juryLevel,
-          complementaryCertificationCourseResultRepository,
-        });
-
-        // then
-        expect(error).to.be.instanceOf(NotFoundError);
-        expect(error.message).to.be.equal("Aucun résultat Pix+ Edu n'a été trouvé pour cette certification.");
-      });
-    });
-
-    context('when a Pix Edu complementaryCertificationCourseResult from PIX source is found', function () {
+    context('when a ComplementaryCertificationCourseResult from PIX source is found', function () {
       it('should save the result', async function () {
         // given
-        const complementaryCertificationCourseId = 1234;
-        const partnerKey = Badge.keys.PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE;
-
-        const pixEduComplementaryCertificationCourseResult = domainBuilder.buildComplementaryCertificationCourseResult({
-          partnerKey,
-          complementaryCertificationCourseId,
-          source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
-        });
-        const pixEduAndFromPixSourceComplementaryCertificationCourseResult =
-          domainBuilder.buildComplementaryCertificationCourseResult({
-            partnerKey,
-            complementaryCertificationCourseId,
-            source: ComplementaryCertificationCourseResult.sources.PIX,
-          });
-        complementaryCertificationCourseResultRepository.getFromComplementaryCertificationCourseId
-          .withArgs({ complementaryCertificationCourseId })
-          .resolves([
-            pixEduComplementaryCertificationCourseResult,
-            pixEduAndFromPixSourceComplementaryCertificationCourseResult,
-          ]);
+        complementaryCertificationCourseResultRepository.getPixSourceResultByComplementaryCertificationCourseId
+          .withArgs({ complementaryCertificationCourseId: 1234 })
+          .resolves(
+            domainBuilder.buildComplementaryCertificationCourseResult({
+              partnerKey: 'KEY_1',
+              complementaryCertificationCourseId: 1234,
+              source: ComplementaryCertificationCourseResult.sources.PIX,
+            })
+          );
 
         // when
         await saveJuryComplementaryCertificationCourseResult({
-          complementaryCertificationCourseId,
-          juryLevel: partnerKey,
+          complementaryCertificationCourseId: 1234,
+          juryLevel: 'KEY_2',
           complementaryCertificationCourseResultRepository,
         });
 
         // then
         expect(complementaryCertificationCourseResultRepository.save).to.have.been.calledWith(
           new ComplementaryCertificationCourseResult({
-            partnerKey,
+            partnerKey: 'KEY_2',
             source: ComplementaryCertificationCourseResult.sources.EXTERNAL,
             acquired: true,
-            complementaryCertificationCourseId:
-              pixEduAndFromPixSourceComplementaryCertificationCourseResult.complementaryCertificationCourseId,
+            complementaryCertificationCourseId: 1234,
           })
         );
       });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
@@ -62,6 +62,20 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
             externalPartnerKey: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
             externalLabel: 'Pix+ Édu 1er degré Avancé',
             externalAcquired: true,
+            allowedExternalLevels: [
+              {
+                label: 'Pix+ Édu 1er degré Confirmé',
+                value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME',
+              },
+              {
+                label: 'Pix+ Édu 1er degré Avancé',
+                value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE',
+              },
+              {
+                label: 'Pix+ Édu 1er degré Expert',
+                value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT',
+              },
+            ],
           }),
       });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
@@ -58,10 +58,12 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
             complementaryCertificationCourseId: 1234,
             pixPartnerKey: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
             pixLabel: 'Pix+ Édu 1er degré Avancé',
+            pixLevel: 3,
             pixAcquired: true,
             externalPartnerKey: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
             externalLabel: 'Pix+ Édu 1er degré Avancé',
             externalAcquired: true,
+            externalLevel: 4,
             allowedExternalLevels: [
               {
                 label: 'Pix+ Édu 1er degré Confirmé',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-certification-serializer_test.js
@@ -1,6 +1,5 @@
 const { expect, domainBuilder } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/jury-certification-serializer');
-const Badge = require('../../../../../lib/domain/models/Badge');
 
 describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function () {
   describe('#serialize', function () {
@@ -42,40 +41,36 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
         commonComplementaryCertificationCourseResults: [
           domainBuilder.buildComplementaryCertificationCourseResultForJuryCertification({
             id: 12,
-            partnerKey: Badge.keys.PIX_DROIT_EXPERT_CERTIF,
+            partnerKey: 'BADGE_KEY_1',
             acquired: true,
-            label: 'Pix+ Droit Expert',
+            label: 'Badge Key 1',
           }),
           domainBuilder.buildComplementaryCertificationCourseResultForJuryCertification({
             id: 14,
-            partnerKey: Badge.keys.PIX_EMPLOI_CLEA_V3,
+            partnerKey: 'BADGE_KEY_2',
             acquired: true,
-            label: 'CléA Numérique',
+            label: 'Badge Key 2',
           }),
         ],
         complementaryCertificationCourseResultsWithExternal:
           domainBuilder.buildComplementaryCertificationCourseResultForJuryCertificationWithExternal({
             complementaryCertificationCourseId: 1234,
-            pixPartnerKey: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
-            pixLabel: 'Pix+ Édu 1er degré Avancé',
-            pixLevel: 3,
+            pixPartnerKey: 'BADGE_KEY_3',
+            pixLabel: 'Badge Key 3',
             pixAcquired: true,
-            externalPartnerKey: Badge.keys.PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE,
-            externalLabel: 'Pix+ Édu 1er degré Avancé',
+            pixLevel: 2,
+            externalPartnerKey: 'BADGE_KEY_4',
+            externalLabel: 'Badge Key 4',
             externalAcquired: true,
             externalLevel: 4,
             allowedExternalLevels: [
               {
-                label: 'Pix+ Édu 1er degré Confirmé',
-                value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME',
+                label: 'Badge Key 3',
+                value: 'BADGE_KEY_3',
               },
               {
-                label: 'Pix+ Édu 1er degré Avancé',
-                value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE',
-              },
-              {
-                label: 'Pix+ Édu 1er degré Expert',
-                value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT',
+                label: 'Badge Key 4',
+                value: 'BADGE_KEY_4',
               },
             ],
           }),
@@ -146,7 +141,7 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
             type: 'commonComplementaryCertificationCourseResults',
             id: '12',
             attributes: {
-              label: 'Pix+ Droit Expert',
+              label: 'Badge Key 1',
               status: 'Validée',
             },
           },
@@ -154,7 +149,7 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
             type: 'commonComplementaryCertificationCourseResults',
             id: '14',
             attributes: {
-              label: 'CléA Numérique',
+              label: 'Badge Key 2',
               status: 'Validée',
             },
           },
@@ -164,22 +159,18 @@ describe('Unit | Serializer | JSONAPI | jury-certification-serializer', function
             attributes: {
               'allowed-external-levels': [
                 {
-                  label: 'Pix+ Édu 1er degré Confirmé',
-                  value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_CONFIRME',
+                  label: 'Badge Key 3',
+                  value: 'BADGE_KEY_3',
                 },
                 {
-                  label: 'Pix+ Édu 1er degré Avancé',
-                  value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE',
-                },
-                {
-                  label: 'Pix+ Édu 1er degré Expert',
-                  value: 'PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_EXPERT',
+                  label: 'Badge Key 4',
+                  value: 'BADGE_KEY_4',
                 },
               ],
               'complementary-certification-course-id': 1234,
-              'pix-result': 'Pix+ Édu 1er degré Avancé',
-              'external-result': 'Pix+ Édu 1er degré Avancé',
-              'final-result': 'Pix+ Édu 1er degré Avancé',
+              'pix-result': 'Badge Key 3',
+              'external-result': 'Badge Key 4',
+              'final-result': 'Badge Key 3',
             },
           },
           {


### PR DESCRIPTION
## :unicorn: Problème
La récupération et la sélection du niveau jury d'une certification complémentaire est, aujourd'hui, spécifique aux certifications complémentaires Pix+ Édu. De ce fait, le code utilise abondamment la clé des badges Pix+ Édu. Dans le cadre du refacto des certifications complémentaires et, afin de permettre l'ajout d'une certification complémentaires mutli jury sans ajout de code, il devient nécessaire de ne plus utiliser de clés de badge spécifiques.

## :robot: Solution
- Refactorer toute la gestion du niveau jury.

## :100: Pour tester
- Créer une session et ajouter un candidat pour une certification Pix+ Édu.
- Répondre aux questions.
- Finaliser et publier la session
- Vérifier la liste des niveau jury disponibles
- Rejeter le niveau jury et voir que le niveau final se met à jour
- Attribuer un niveau jury et voir que le niveau final se met à jour.