### PR TITLE
[FEATURE] Pouvoir identifier qui est le référent Pix d'un centre de certification (PIX-5795)

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer.js
@@ -34,10 +34,10 @@ module.exports = {
     return new Serializer('members', {
       transform: function (record) {
         const { id, firstName, lastName } = record.user;
-        return { id, firstName, lastName };
+        return { id, firstName, lastName, isReferer: record.isReferer };
       },
       ref: 'id',
-      attributes: ['firstName', 'lastName'],
+      attributes: ['firstName', 'lastName', 'isReferer'],
     }).serialize(certificationCenterMemberships);
   },
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-membership-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-membership-serializer_test.js
@@ -92,6 +92,7 @@ describe('Unit | Serializer | JSONAPI | certification-center-membership-serializ
             attributes: {
               'first-name': user.firstName,
               'last-name': user.lastName,
+              'is-referer': certificationCenterMembership.isReferer,
             },
           },
         ],

--- a/certif/app/components/members-list.hbs
+++ b/certif/app/components/members-list.hbs
@@ -6,6 +6,7 @@
           <tr>
             <th class="table__column table__column--small">Nom</th>
             <th class="table__column table__column--small">Prénom</th>
+            <th class="table__column table__column--small">Référent</th>
           </tr>
         </thead>
 
@@ -14,6 +15,26 @@
             <tr aria-label="Membres du centre de certification">
               <td>{{member.lastName}}</td>
               <td>{{member.firstName}}</td>
+              {{#if member.isReferer}}
+                <td>
+                  <div class="members-list__is-referer">
+                    <PixTag class="members-list__tag" @color="blue-light">
+                      Référent Pix
+                    </PixTag>
+                    <PixTooltip class="members-list__tool-tip" @isWide="true" @position="bottom">
+                      <:triggerElement>
+                        <span tabindex="0">
+                          <FaIcon @icon="info-circle" />
+                        </span>
+                      </:triggerElement>
+                      <:tooltip>
+                        Le référent Pix est le contact privilégié des équipes de Pix. Il est le responsable du bon
+                        déroulement des sessions de certification.
+                      </:tooltip>
+                    </PixTooltip>
+                  </div>
+                </td>
+              {{/if}}
             </tr>
           {{/each}}
         </tbody>

--- a/certif/app/components/members-list.hbs
+++ b/certif/app/components/members-list.hbs
@@ -6,7 +6,9 @@
           <tr>
             <th class="table__column table__column--small">Nom</th>
             <th class="table__column table__column--small">Prénom</th>
-            <th class="table__column table__column--small">Référent</th>
+            {{#if this.shouldDisplayRefererColumn}}
+              <th class="table__column table__column--small">Référent</th>
+            {{/if}}
           </tr>
         </thead>
 
@@ -15,7 +17,7 @@
             <tr aria-label="Membres du centre de certification">
               <td>{{member.lastName}}</td>
               <td>{{member.firstName}}</td>
-              {{#if member.isReferer}}
+              {{#if (and this.shouldDisplayRefererColumn member.isReferer)}}
                 <td>
                   <div class="members-list__is-referer">
                     <PixTag class="members-list__tag" @color="blue-light">

--- a/certif/app/components/members-list.js
+++ b/certif/app/components/members-list.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class MembersList extends Component {
+  @service featureToggles;
+
+  get shouldDisplayRefererColumn() {
+    return this.featureToggles.featureToggles.isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled;
+  }
+}

--- a/certif/app/models/member.js
+++ b/certif/app/models/member.js
@@ -3,4 +3,5 @@ import Model, { attr } from '@ember-data/model';
 export default class Member extends Model {
   @attr('string') firstName;
   @attr('string') lastName;
+  @attr('boolean') isReferer;
 }

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -33,6 +33,7 @@
 @import "components/login-session-supervisor-form.scss";
 @import "components/finalize";
 @import "components/new-certification-candidate-modal";
+@import "components/members-list";
 @import "components/finalization-confirmation-modal";
 @import "components/session-delete-confirm-modal";
 @import "components/session-finalization-step-container";

--- a/certif/app/styles/components/members-list.scss
+++ b/certif/app/styles/components/members-list.scss
@@ -1,0 +1,17 @@
+.members-list {
+
+  &__is-referer {
+    display: flex;
+  }
+
+  &__tag {
+    margin-right: 12px;
+    font-weight: 500;
+    font-size: 12px;
+  }
+
+  &__tool-tip {
+    font-size: 18px;
+    font-weight: 900;
+  }
+}

--- a/certif/tests/integration/components/members-list_test.js
+++ b/certif/tests/integration/components/members-list_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 
@@ -15,14 +15,14 @@ module('Integration | Component | members-list', function (hooks) {
     this.set('members', members);
 
     // when
-    await render(hbs`<MembersList @members={{this.members}} />`);
+    const screen = await renderScreen(hbs`<MembersList @members={{this.members}} />`);
 
     // then
-    assert.contains('Nom');
-    assert.contains('Prénom');
-    assert.contains('Maria');
-    assert.contains('Carré');
-    assert.contains('John');
-    assert.contains('Williams');
+    assert.dom(screen.getByText('Nom')).exists();
+    assert.dom(screen.getByText('Prénom')).exists();
+    assert.dom(screen.getByText('Maria')).exists();
+    assert.dom(screen.getByText('Carré')).exists();
+    assert.dom(screen.getByText('John')).exists();
+    assert.dom(screen.getByText('Williams')).exists();
   });
 });

--- a/certif/tests/integration/components/members-list_test.js
+++ b/certif/tests/integration/components/members-list_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
+import Service from '@ember/service';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
@@ -9,8 +10,12 @@ module('Integration | Component | members-list', function (hooks) {
 
   test('it should show members firstName and lastName', async function (assert) {
     // given
-    const certifMember1 = EmberObject.create({ firstName: 'Maria', lastName: 'Carré' });
-    const certifMember2 = EmberObject.create({ firstName: 'John', lastName: 'Williams' });
+    class FeatureTogglesStub extends Service {
+      featureToggles = { isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: false };
+    }
+    this.owner.register('service:featureToggles', FeatureTogglesStub);
+    const certifMember1 = EmberObject.create({ firstName: 'Maria', lastName: 'Carré', isReferer: false });
+    const certifMember2 = EmberObject.create({ firstName: 'John', lastName: 'Williams', isReferer: false });
     const members = [certifMember1, certifMember2];
     this.set('members', members);
 
@@ -18,43 +23,71 @@ module('Integration | Component | members-list', function (hooks) {
     const screen = await renderScreen(hbs`<MembersList @members={{this.members}} />`);
 
     // then
-    assert.dom(screen.getByText('Nom')).exists();
-    assert.dom(screen.getByText('Prénom')).exists();
-    assert.dom(screen.getByText('Maria')).exists();
-    assert.dom(screen.getByText('Carré')).exists();
-    assert.dom(screen.getByText('John')).exists();
-    assert.dom(screen.getByText('Williams')).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Nom' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Prénom' })).exists();
+    assert.dom(screen.getByRole('cell', { name: 'Maria' })).exists();
+    assert.dom(screen.getByRole('cell', { name: 'Carré' })).exists();
+    assert.dom(screen.getByRole('cell', { name: 'John' })).exists();
+    assert.dom(screen.getByRole('cell', { name: 'Williams' })).exists();
   });
 
-  module('when a member is referer', function () {
-    test('it should show the referer tag', async function (assert) {
-      // given
-      const certifMember1 = EmberObject.create({ firstName: 'Maria', lastName: 'Carré' });
-      const certifMember2 = EmberObject.create({ firstName: 'John', lastName: 'Williams', isReferer: true });
-      const members = [certifMember1, certifMember2];
-      this.set('members', members);
+  module('when FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS is enabled', function () {
+    module('when a member is referer', function () {
+      test('it should show the referer tag', async function (assert) {
+        // given
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: true };
+        }
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+        const certifMember1 = EmberObject.create({ firstName: 'Maria', lastName: 'Carré', isReferer: false });
+        const certifMember2 = EmberObject.create({ firstName: 'John', lastName: 'Williams', isReferer: true });
+        const members = [certifMember1, certifMember2];
+        this.set('members', members);
 
-      // when
-      const screen = await renderScreen(hbs`<MembersList @members={{this.members}} />`);
+        // when
+        const screen = await renderScreen(hbs`<MembersList @members={{this.members}} />`);
 
-      // then
-      assert.dom(screen.getByText('Référent Pix')).exists();
+        // then
+        assert.dom(screen.getByRole('cell', { name: 'Référent Pix' })).exists();
+      });
+    });
+
+    module('when there is no referer', function () {
+      test('it should not show the referer tag', async function (assert) {
+        // given
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: true };
+        }
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+        const certifMember1 = EmberObject.create({ firstName: 'Maria', lastName: 'Carré', isReferer: false });
+        const members = [certifMember1];
+        this.set('members', members);
+
+        // when
+        const screen = await renderScreen(hbs`<MembersList @members={{this.members}} />`);
+
+        // then
+        assert.dom(screen.queryByRole('cell', { name: 'Référent Pix' })).doesNotExist();
+      });
     });
   });
 
-  module('when there is no referer', function () {
+  module('when FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS is not enabled', function () {
     test('it should not show the referer tag', async function (assert) {
       // given
-      const certifMember1 = EmberObject.create({ firstName: 'Maria', lastName: 'Carré', isReferer: false });
-      const certifMember2 = EmberObject.create({ firstName: 'John', lastName: 'Williams', isReferer: false });
-      const members = [certifMember1, certifMember2];
+      class FeatureTogglesStub extends Service {
+        featureToggles = { isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: false };
+      }
+      this.owner.register('service:featureToggles', FeatureTogglesStub);
+      const certifMember1 = EmberObject.create({ firstName: 'Maria', lastName: 'Carré', isReferer: true });
+      const members = [certifMember1];
       this.set('members', members);
 
       // when
       const screen = await renderScreen(hbs`<MembersList @members={{this.members}} />`);
 
       // then
-      assert.dom(screen.queryByText('Référent Pix')).doesNotExist();
+      assert.dom(screen.queryByRole('cell', { name: 'Référent Pix' })).doesNotExist();
     });
   });
 });

--- a/certif/tests/integration/components/members-list_test.js
+++ b/certif/tests/integration/components/members-list_test.js
@@ -25,4 +25,36 @@ module('Integration | Component | members-list', function (hooks) {
     assert.dom(screen.getByText('John')).exists();
     assert.dom(screen.getByText('Williams')).exists();
   });
+
+  module('when a member is referer', function () {
+    test('it should show the referer tag', async function (assert) {
+      // given
+      const certifMember1 = EmberObject.create({ firstName: 'Maria', lastName: 'Carré' });
+      const certifMember2 = EmberObject.create({ firstName: 'John', lastName: 'Williams', isReferer: true });
+      const members = [certifMember1, certifMember2];
+      this.set('members', members);
+
+      // when
+      const screen = await renderScreen(hbs`<MembersList @members={{this.members}} />`);
+
+      // then
+      assert.dom(screen.getByText('Référent Pix')).exists();
+    });
+  });
+
+  module('when there is no referer', function () {
+    test('it should not show the referer tag', async function (assert) {
+      // given
+      const certifMember1 = EmberObject.create({ firstName: 'Maria', lastName: 'Carré', isReferer: false });
+      const certifMember2 = EmberObject.create({ firstName: 'John', lastName: 'Williams', isReferer: false });
+      const members = [certifMember1, certifMember2];
+      this.set('members', members);
+
+      // when
+      const screen = await renderScreen(hbs`<MembersList @members={{this.members}} />`);
+
+      // then
+      assert.dom(screen.queryByText('Référent Pix')).doesNotExist();
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'épix de récupération des résultats Cléa par les CDC habilités, un référent Pix va devoir être désigné dans chaque centre habilité CléA, car il le responsable de la mise à dispo des certificats Cléa aux candidats ayant obtenus leur certif CléA numérique by Pix. Pour le moment, il n’est pas possible d’identifier qui est le référent Pix désigné pour un centre.

## :robot: Solution
Dans Pix certif > page “Equipe”, uniquement pour les CDC habilités CléA numérique : 

- ajouter une colonne “Référent” : visible uniquement si au moins 1 référent a été identifié pour le CDC 

- afficher un tag “Référent Pix” pour le membre de l’espace désigné comme référent

- afficher un tooltip pour rappeler ce qu’est un référent Pix

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Activer le toggle   FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS
- Mettre isReferer à true en base pour un membre d'un espace pix certif
- Dans Pix-certif, se rendre sur la page "Equipe" et constater l'affichage suivant

![image](https://user-images.githubusercontent.com/37305474/193767096-5f6697d8-eb1d-4e8a-b33f-f7e3e4c106a5.png)

