### PR TITLE
[BUGFIX] Corriger l'affichage du nombre de sujets pour un profil-cible lors de la création d'une campagne (PIX-5829).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign/target-profile-for-specifier-repository.js
+++ b/api/lib/infrastructure/repositories/campaign/target-profile-for-specifier-repository.js
@@ -3,7 +3,7 @@ const skillDataSource = require('../../datasources/learning-content/skill-dataso
 const TargetProfileForSpecifier = require('../../../domain/read-models/campaign/TargetProfileForSpecifier');
 const bluebird = require('bluebird');
 const _ = require('lodash');
-const { uniqBy } = require('lodash');
+const { uniq, uniqBy } = require('lodash');
 
 async function availableForOrganization(organizationId) {
   const targetProfileRows = await _fetchTargetProfiles(organizationId);
@@ -46,7 +46,7 @@ function _fetchTargetProfiles(organizationId) {
 async function _buildTargetProfileForSpecifier(row) {
   let tubeCount;
   if (row.tubeIds?.[0] != null) {
-    tubeCount = row.tubeIds.length;
+    tubeCount = uniq(row.tubeIds).length;
   } else {
     // TODO remove it after target profile tube migration to target-profile_tubes
     const skills = await skillDataSource.findByRecordIds(row.skillIds);

--- a/api/tests/integration/infrastructure/repositories/campaign/target-profile-for-specifier-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign/target-profile-for-specifier-repository_test.js
@@ -26,7 +26,33 @@ describe('Integration | Infrastructure | Repository | target-profile-for-campaig
           expect(targetProfileForSpecifier.tubeCount).to.equal(2);
         });
       });
+      // TODO remove it after target profile tube migration to target-profile_tubes
+      context('when target profile has skills and tubes', function () {
+        it('returns the count of tube', async function () {
+          const skill1 = domainBuilder.buildSkill({ id: 'skill1', tubeId: 'tube1' });
+          const skill2 = domainBuilder.buildSkill({ id: 'skill2', tubeId: 'tube2' });
+          const skill3 = domainBuilder.buildSkill({ id: 'skill3', tubeId: 'tube2' });
+          const tube1 = domainBuilder.buildTube({ id: 'tube1', skills: [skill1] });
+          const tube2 = domainBuilder.buildTube({ id: 'tube2', skills: [skill2, skill3] });
+          const { id: targetProfileId } = databaseBuilder.factory.buildTargetProfile({});
+          databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'tube1' });
+          databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'tube2' });
+          databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: skill1.id });
+          databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: skill2.id });
+          databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: skill3.id });
 
+          const { id: organizationId } = databaseBuilder.factory.buildOrganization();
+
+          mockLearningContent({ skills: [skill1, skill2, skill3], tubes: [tube1, tube2] });
+          await databaseBuilder.commit();
+
+          const [targetProfileForSpecifier] = await TargetProfileForSpecifierRepository.availableForOrganization(
+            organizationId
+          );
+
+          expect(targetProfileForSpecifier.tubeCount).to.equal(2);
+        });
+      });
       context('when target profile has tubes', function () {
         it('returns the count of tube', async function () {
           const { id: targetProfileId } = databaseBuilder.factory.buildTargetProfile({});


### PR DESCRIPTION
## :unicorn: Problème
Nous affichons un nombre erroné lors de l'affichage du nombre de sujet pour un profile cible lors de la création d'une campagne .

## :robot: Solution
Supprimer les doublons avant le calcule du nombre de sujets.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se rendre sur la page de création d'une campagne et sélectionner un profile cible créer à partir de sujet par niveau. Vérifier que le nombre de sujet est cohérent.
