### PR TITLE
[BUGFIX] Empêcher le crash de l'API lors de l'appel /api/account-recovery (PIX-5830).

### DIFF
--- a/api/lib/domain/usecases/account-recovery/update-user-for-account-recovery.js
+++ b/api/lib/domain/usecases/account-recovery/update-user-for-account-recovery.js
@@ -32,14 +32,14 @@ module.exports = async function updateUserForAccountRecovery({
         shouldChangePassword: false,
       }),
     });
-    authenticationMethodRepository.create(
+    await authenticationMethodRepository.create(
       {
         authenticationMethod: authenticationMethodFromPix,
       },
       domainTransaction
     );
   } else {
-    authenticationMethodRepository.updateChangedPassword(
+    await authenticationMethodRepository.updateChangedPassword(
       {
         userId,
         hashedPassword,


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, lorsqu'un utilisateur ayant 2 méthodes de connexions GAR et POLE_EMPLOI, tente de finaliser sa récupération de compte lié à une sortie SCO, une erreur est soulevée mais elle n'est pas gérée par Hapi, ce qui entraine l'arrêt du processus node et donc du container.

Nous avons remarqué qu'il manquait l'utilisation du mot clé `await` sur 2 appels au repository qui retournent une Promise.

## :robot: Solution

Ajouter le mot clé manquant `await` sur ces 2 appels.

## :rainbow: Remarques

Le fait qu'un utilisateur aient les méthodes de connexions GAR et POLE_EMPLOI (par exemple) est lié à une ancienne version du code de réconciliation. Cet état ne devrait plus arriver à l'avenir.

## :100: Pour tester

- Aller en BDD et modifier les `authentication-methods` de l'utilisateur `George de Cambridge` pour avoir une méthode GAR et POLE_EMPLOI uniquement
- Ouvrir la page de sortie sco : https://app-pr5022.review.pix.fr/recuperer-mon-compte
- Fournir toutes les informations demandées (infos dans la tables `organization-learners`)
- Saisir votre adresse e-mail pour recevoir le mail avec un lien
- Si vous ne recevez pas de message, récupérez le code dans la table des demandes de récupération de compte (`account-recovery-demands`)
- Ouvrir le lien, ou la page avec le code récupéré : https://app-pr5022.review.pix.fr/recuperer-mon-compte/__code
- Fournir un nouveau mot de passe et valider
- Constatez qu'un message d'erreur "Oups .." s'affiche
- Constatez au niveau des logs de l'api que le container est toujours actif
