### PR TITLE
[TECH] Eviter les faux positifs d'erreur au démarrage du serveur API

### DIFF
--- a/api/lib/infrastructure/logger.js
+++ b/api/lib/infrastructure/logger.js
@@ -23,10 +23,4 @@ const logger = pino(
   prettyPrint
 );
 
-logger.error('ERROR logs enabled');
-logger.warn('WARN logs enabled');
-logger.info('INFO logs enabled');
-logger.debug('DEBUG logs enabled');
-logger.trace('TRACE logs enabled');
-
 module.exports = logger;

--- a/api/lib/infrastructure/logger.js
+++ b/api/lib/infrastructure/logger.js
@@ -23,4 +23,14 @@ const logger = pino(
   prettyPrint
 );
 
+if (logSettings.enabled) {
+  // we use console.log because the logger itself will not log any message
+  // eslint-disable-next-line no-console
+  console.log(`Logging level: ${logSettings.logLevel}`);
+} else {
+  // we use console.log because the logger itself will not log any message is loggingLevel is below INFO
+  // eslint-disable-next-line no-console
+  console.log(`Logging is disabled`);
+}
+
 module.exports = logger;


### PR DESCRIPTION
## :unicorn: Problème
Un appel à chaque niveau de log a lieu au démarrage.

```shell
> pix-api@3.267.0 start
> node index.js

[10:22:19] ERROR: ERROR logs enabled
[10:22:19] WARN: WARN logs enabled
[10:22:19] INFO: INFO logs enabled
```

Cela fait apparaître cet évènement dans le monitoring, alors que c'est un comportement normal.
 
Le logger n'est pas testé automatiquement, on peut penser que cela tient lieu de test manuel.

## :robot: Solution
Supprimer ces appels.
Pour connaître la capacité de logging, tracer la configuration (actif/niveau).

## :rainbow: Remarques
Si on veut tester le logger, il y a probablement un test automatisé possible.

## :100: Pour tester
Vérifier que la commande suivante ne renvoie aucune occurence
`scalingo --region osc-fr1 --app pix-api-review-pr5023 logs --lines 1000 | grep error`

Démarrer en local et vérifier les messages suivants
```
npm start
`Logging level: info`

LOG_ENABLED=false npm start
```


