### PR TITLE
[FEATURE] Réajuster l'affichage des détails de session à la maquette (PIX-5788)

### DIFF
--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -64,9 +64,6 @@
   }
 }
 
-$details-content-padding: 8px;
-$details-content-margin: 8px;
-
 .session-details-content {
   display: flex;
   flex-direction: column;
@@ -74,14 +71,19 @@ $details-content-margin: 8px;
 
   &--multiple {
     border-right: 1px solid $pix-neutral-20;
-    padding: $details-content-padding + $details-content-margin;
+    padding: 0 24px;
+    margin: 16px 0;
     white-space: nowrap;
+
+    &:last-child {
+      border-right: 0;
+    }
   }
 
   &--copyable {
     background: $pix-neutral-5;
-    margin: $details-content-margin;
-    padding: $details-content-padding 16px;
+    margin: 16px 0 16px 8px;
+    padding: 8px 16px;
     border-radius: 4px;
     border: 0;
   }


### PR DESCRIPTION
## :unicorn: Problème
Dans la page détails d’une session dans Pix Certif, nous avons un bloc d’informations reprenant les éléments suivants : numéro de session, code d’accès candidat, mot de passe de session surveillant, nom du site, salle et surveillant(s).

Un premier séparateur apparait entre le nom du site et la salle, un deuxième se situe entre la salle et les surveillant(s).

Dans le cadre de l’audit design Pix Certif, il a été remonté un problème de groupement / distinctions entre items à ce niveau. En effet, les séparateurs coupent le contenu du même bloc d'info en faisant toute la hauteur du bloc.

## :robot: Solution
Modifier les séparateurs pour ne pas qu’ils ferment le bloc de contenu (en faisant toute la hauteur), permettre dans le même temps d'avoir un séparateur plus naturel à plus petite résolution.

Maquette : [Détail d'une session sur Figma](https://www.figma.com/file/IWVcwbasXoFUQPhIG097XT/Pix-Certif?node-id=307%3A6535)

## :100: Pour tester
- Se connecter à Pix Certif.
- Ouvrir le détail d'une session de Certification.
- Vérifier que les séparateurs et les marges correspondent à ceux de la maquette.