### PR TITLE
[FEATURE] Ajouter les informations de lieu de naissance dans l'export XML (PIX-5876)

### DIFF
--- a/api/lib/domain/read-models/CpfCertificationResult.js
+++ b/api/lib/domain/read-models/CpfCertificationResult.js
@@ -9,6 +9,7 @@ class CpfCertificationResult {
     sex,
     birthINSEECode,
     birthPostalCode,
+    birthplace,
     publishedAt,
     pixScore,
     competenceMarks,
@@ -20,6 +21,7 @@ class CpfCertificationResult {
     this.sex = sex;
     this.birthINSEECode = birthINSEECode;
     this.birthPostalCode = birthPostalCode;
+    this.birthplace = birthplace;
     this.publishedAt = publishedAt;
     this.pixScore = pixScore;
     this.competenceMarks = competenceMarks;

--- a/api/lib/domain/read-models/CpfCertificationResult.js
+++ b/api/lib/domain/read-models/CpfCertificationResult.js
@@ -36,6 +36,12 @@ class CpfCertificationResult {
     if (this.birthINSEECode === 'NULL' || this.birthINSEECode.length !== 5) return null;
     return this.birthINSEECode;
   }
+
+  get countryCode() {
+    if (!this.birthINSEECode) return null;
+    if (!this.birthINSEECode.startsWith('99')) return null;
+    return this.birthINSEECode.slice(2);
+  }
 }
 
 module.exports = CpfCertificationResult;

--- a/api/lib/domain/read-models/CpfCertificationResult.js
+++ b/api/lib/domain/read-models/CpfCertificationResult.js
@@ -44,6 +44,12 @@ class CpfCertificationResult {
     if (!this.birthINSEECode.startsWith('99')) return null;
     return this.birthINSEECode.slice(2);
   }
+
+  get postalCode() {
+    if (!this.birthPostalCode) return null;
+    if (this.birthPostalCode === 'NULL' || this.birthPostalCode.length !== 5) return null;
+    return this.birthPostalCode;
+  }
 }
 
 module.exports = CpfCertificationResult;

--- a/api/lib/domain/read-models/CpfCertificationResult.js
+++ b/api/lib/domain/read-models/CpfCertificationResult.js
@@ -28,6 +28,12 @@ class CpfCertificationResult {
   get europeanNumericLevels() {
     return EuropeanNumericLevelFactory.buildFromCompetenceMarks(this.competenceMarks);
   }
+
+  get inseeCode() {
+    if (!this.birthINSEECode) return null;
+    if (this.birthINSEECode === 'NULL' || this.birthINSEECode.length !== 5) return null;
+    return this.birthINSEECode;
+  }
 }
 
 module.exports = CpfCertificationResult;

--- a/api/lib/domain/read-models/CpfCertificationResult.js
+++ b/api/lib/domain/read-models/CpfCertificationResult.js
@@ -10,6 +10,7 @@ class CpfCertificationResult {
     birthINSEECode,
     birthPostalCode,
     birthplace,
+    birthCountry,
     publishedAt,
     pixScore,
     competenceMarks,
@@ -22,6 +23,7 @@ class CpfCertificationResult {
     this.birthINSEECode = birthINSEECode;
     this.birthPostalCode = birthPostalCode;
     this.birthplace = birthplace;
+    this.birthCountry = birthCountry;
     this.publishedAt = publishedAt;
     this.pixScore = pixScore;
     this.competenceMarks = competenceMarks;

--- a/api/lib/domain/services/cpf-certification-xml-export-service.js
+++ b/api/lib/domain/services/cpf-certification-xml-export-service.js
@@ -52,6 +52,7 @@ function buildXmlExport({ cpfCertificationResults, writableStream, opts = {} }) 
         sex,
         inseeCode,
         birthPostalCode,
+        birthplace,
         europeanNumericLevels,
       }) {
         const [yearOfBirth, monthOfBirth, dayOfBirth] = birthdate.split('-');
@@ -108,7 +109,9 @@ function buildXmlExport({ cpfCertificationResults, writableStream, opts = {} }) 
                       .ele('cpf:codePostal', { 'xsi:nil': true }).up()
                     .up();
         }
-        xmlBuilder.up().up().up().up();
+        xmlBuilder.up()
+          .ele('cpf:libelleCommuneNaissance').txt(birthplace).up();
+        xmlBuilder.up().up().up();
       }
     )
     .then(() => {

--- a/api/lib/domain/services/cpf-certification-xml-export-service.js
+++ b/api/lib/domain/services/cpf-certification-xml-export-service.js
@@ -53,6 +53,7 @@ function buildXmlExport({ cpfCertificationResults, writableStream, opts = {} }) 
         inseeCode,
         birthPostalCode,
         birthplace,
+        countryCode,
         europeanNumericLevels,
       }) {
         const [yearOfBirth, monthOfBirth, dayOfBirth] = birthdate.split('-');
@@ -111,6 +112,10 @@ function buildXmlExport({ cpfCertificationResults, writableStream, opts = {} }) 
         }
         xmlBuilder.up()
           .ele('cpf:libelleCommuneNaissance').txt(birthplace).up();
+        if (countryCode) {
+          xmlBuilder.ele('cpf:codePaysNaissance').txt(countryCode).up();
+        }
+
         xmlBuilder.up().up().up();
       }
     )

--- a/api/lib/domain/services/cpf-certification-xml-export-service.js
+++ b/api/lib/domain/services/cpf-certification-xml-export-service.js
@@ -50,7 +50,7 @@ function buildXmlExport({ cpfCertificationResults, writableStream, opts = {} }) 
         lastName,
         birthdate,
         sex,
-        birthINSEECode,
+        inseeCode,
         birthPostalCode,
         europeanNumericLevels,
       }) {
@@ -95,9 +95,9 @@ function buildXmlExport({ cpfCertificationResults, writableStream, opts = {} }) 
               .ele('cpf:sexe').txt(sex).up()
               .ele('cpf:codeCommuneNaissance')
 
-        if (birthINSEECode) {
+        if (inseeCode) {
           xmlBuilder.ele('cpf:codeInseeNaissance')
-                      .ele('cpf:codeInsee').txt(birthINSEECode).up()
+                      .ele('cpf:codeInsee').txt(inseeCode).up()
                     .up();
         } else if (birthPostalCode) {
           xmlBuilder.ele('cpf:codePostalNaissance')

--- a/api/lib/domain/services/cpf-certification-xml-export-service.js
+++ b/api/lib/domain/services/cpf-certification-xml-export-service.js
@@ -51,7 +51,7 @@ function buildXmlExport({ cpfCertificationResults, writableStream, opts = {} }) 
         birthdate,
         sex,
         inseeCode,
-        birthPostalCode,
+        postalCode,
         birthplace,
         countryCode,
         birthCountry,
@@ -102,9 +102,9 @@ function buildXmlExport({ cpfCertificationResults, writableStream, opts = {} }) 
           xmlBuilder.ele('cpf:codeInseeNaissance')
                       .ele('cpf:codeInsee').txt(inseeCode).up()
                     .up();
-        } else if (birthPostalCode) {
+        } else if (postalCode) {
           xmlBuilder.ele('cpf:codePostalNaissance')
-                      .ele('cpf:codePostal').txt(birthPostalCode).up()
+                      .ele('cpf:codePostal').txt(postalCode).up()
                     .up();
         } else {
           xmlBuilder.ele('cpf:codePostalNaissance')

--- a/api/lib/domain/services/cpf-certification-xml-export-service.js
+++ b/api/lib/domain/services/cpf-certification-xml-export-service.js
@@ -54,6 +54,7 @@ function buildXmlExport({ cpfCertificationResults, writableStream, opts = {} }) 
         birthPostalCode,
         birthplace,
         countryCode,
+        birthCountry,
         europeanNumericLevels,
       }) {
         const [yearOfBirth, monthOfBirth, dayOfBirth] = birthdate.split('-');
@@ -115,6 +116,7 @@ function buildXmlExport({ cpfCertificationResults, writableStream, opts = {} }) 
         if (countryCode) {
           xmlBuilder.ele('cpf:codePaysNaissance').txt(countryCode).up();
         }
+        xmlBuilder.ele('cpf:libellePaysNaissance').txt(birthCountry).up();
 
         xmlBuilder.up().up().up();
       }

--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -19,6 +19,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         birthINSEECode: '75116',
         birthPostalCode: null,
         birthplace: 'PARIS',
+        birthCountry: 'FRANCE',
         isPublished: true,
         sessionId: firstPublishedSessionId,
       });
@@ -51,6 +52,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         birthINSEECode: null,
         birthPostalCode: '75008',
         birthplace: 'PARIS',
+        birthCountry: 'FRANCE',
         isPublished: true,
         sessionId: firstPublishedSessionId,
       });
@@ -84,6 +86,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         birthINSEECode: '75114',
         birthplace: 'PARIS 14',
         birthPostalCode: null,
+        birthCountry: 'FRANCE',
         isPublished: true,
         sessionId: secondPublishedSessionId,
       });
@@ -260,6 +263,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         birthINSEECode: '75116',
         birthPostalCode: null,
         birthplace: 'PARIS 16',
+        birthCountry: 'FRANCE',
         isPublished: true,
         sessionId: firstPublishedSessionId,
       }).id;
@@ -292,6 +296,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         birthINSEECode: null,
         birthPostalCode: '75008',
         birthplace: 'PARIS',
+        birthCountry: 'FRANCE',
         isPublished: true,
         sessionId: firstPublishedSessionId,
       });
@@ -325,6 +330,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         birthINSEECode: '75114',
         birthPostalCode: null,
         birthplace: 'PARIS 14',
+        birthCountry: 'FRANCE',
         isPublished: true,
         sessionId: secondPublishedSessionId,
       });
@@ -368,6 +374,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
           birthINSEECode: null,
           birthPostalCode: '75008',
           birthplace: 'PARIS',
+          birthCountry: 'FRANCE',
           pixScore: 112,
           publishedAt: new Date('2022-01-04'),
           competenceMarks: [
@@ -392,6 +399,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
           birthINSEECode: '75114',
           birthPostalCode: null,
           birthplace: 'PARIS 14',
+          birthCountry: 'FRANCE',
           pixScore: 268,
           publishedAt: new Date('2022-01-10'),
           competenceMarks: [
@@ -416,6 +424,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
           birthINSEECode: '75116',
           birthPostalCode: null,
           birthplace: 'PARIS 16',
+          birthCountry: 'FRANCE',
           pixScore: 132,
           publishedAt: new Date('2022-01-04'),
           competenceMarks: [
@@ -451,6 +460,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         birthINSEECode: '75116',
         birthPostalCode: null,
         birthplace: 'PARIS 16',
+        birthCountry: 'FRANCE',
         isPublished: true,
         sessionId: firstPublishedSessionId,
       }).id;
@@ -483,6 +493,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         birthINSEECode: null,
         birthPostalCode: '75008',
         birthplace: 'PARIS',
+        birthCountry: 'FRANCE',
         isPublished: true,
         sessionId: firstPublishedSessionId,
       });
@@ -516,6 +527,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         birthINSEECode: '75114',
         birthPostalCode: null,
         birthplace: 'PARIS 14',
+        birthCountry: 'FRANCE',
         isPublished: true,
         sessionId: secondPublishedSessionId,
       });
@@ -559,6 +571,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
           birthINSEECode: '75116',
           birthPostalCode: null,
           birthplace: 'PARIS 16',
+          birthCountry: 'FRANCE',
           pixScore: 132,
           publishedAt: new Date('2022-01-04'),
           competenceMarks: [
@@ -594,6 +607,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         birthINSEECode: '75116',
         birthPostalCode: null,
         birthplace: 'PARIS 16',
+        birthCountry: 'FRANCE',
         isPublished: true,
         sessionId,
       });
@@ -842,6 +856,7 @@ function createCertificationCourseWithCompetenceMarks({
     birthINSEECode: '75116',
     birthPostalCode: null,
     birthplace: 'PARIS 16',
+    birthCountry: 'FRANCE',
     isPublished: isPublished,
     sessionId: publishedSessionId,
     isCancelled: certificationCourseCancelled,

--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -18,6 +18,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         sex: 'M',
         birthINSEECode: '75116',
         birthPostalCode: null,
+        birthplace: 'PARIS',
         isPublished: true,
         sessionId: firstPublishedSessionId,
       });
@@ -49,6 +50,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         sex: 'M',
         birthINSEECode: null,
         birthPostalCode: '75008',
+        birthplace: 'PARIS',
         isPublished: true,
         sessionId: firstPublishedSessionId,
       });
@@ -80,6 +82,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         birthdate: '2004-03-04',
         sex: 'F',
         birthINSEECode: '75114',
+        birthplace: 'PARIS 14',
         birthPostalCode: null,
         isPublished: true,
         sessionId: secondPublishedSessionId,
@@ -256,6 +259,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         sex: 'M',
         birthINSEECode: '75116',
         birthPostalCode: null,
+        birthplace: 'PARIS 16',
         isPublished: true,
         sessionId: firstPublishedSessionId,
       }).id;
@@ -287,6 +291,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         sex: 'M',
         birthINSEECode: null,
         birthPostalCode: '75008',
+        birthplace: 'PARIS',
         isPublished: true,
         sessionId: firstPublishedSessionId,
       });
@@ -319,6 +324,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         sex: 'F',
         birthINSEECode: '75114',
         birthPostalCode: null,
+        birthplace: 'PARIS 14',
         isPublished: true,
         sessionId: secondPublishedSessionId,
       });
@@ -361,6 +367,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
           sex: 'M',
           birthINSEECode: null,
           birthPostalCode: '75008',
+          birthplace: 'PARIS',
           pixScore: 112,
           publishedAt: new Date('2022-01-04'),
           competenceMarks: [
@@ -384,6 +391,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
           sex: 'F',
           birthINSEECode: '75114',
           birthPostalCode: null,
+          birthplace: 'PARIS 14',
           pixScore: 268,
           publishedAt: new Date('2022-01-10'),
           competenceMarks: [
@@ -407,6 +415,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
           sex: 'M',
           birthINSEECode: '75116',
           birthPostalCode: null,
+          birthplace: 'PARIS 16',
           pixScore: 132,
           publishedAt: new Date('2022-01-04'),
           competenceMarks: [
@@ -441,6 +450,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         sex: 'M',
         birthINSEECode: '75116',
         birthPostalCode: null,
+        birthplace: 'PARIS 16',
         isPublished: true,
         sessionId: firstPublishedSessionId,
       }).id;
@@ -472,6 +482,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         sex: 'M',
         birthINSEECode: null,
         birthPostalCode: '75008',
+        birthplace: 'PARIS',
         isPublished: true,
         sessionId: firstPublishedSessionId,
       });
@@ -504,6 +515,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         sex: 'F',
         birthINSEECode: '75114',
         birthPostalCode: null,
+        birthplace: 'PARIS 14',
         isPublished: true,
         sessionId: secondPublishedSessionId,
       });
@@ -546,6 +558,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
           sex: 'M',
           birthINSEECode: '75116',
           birthPostalCode: null,
+          birthplace: 'PARIS 16',
           pixScore: 132,
           publishedAt: new Date('2022-01-04'),
           competenceMarks: [
@@ -580,6 +593,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         sex: 'M',
         birthINSEECode: '75116',
         birthPostalCode: null,
+        birthplace: 'PARIS 16',
         isPublished: true,
         sessionId,
       });
@@ -827,6 +841,7 @@ function createCertificationCourseWithCompetenceMarks({
     sex,
     birthINSEECode: '75116',
     birthPostalCode: null,
+    birthplace: 'PARIS 16',
     isPublished: isPublished,
     sessionId: publishedSessionId,
     isCancelled: certificationCourseCancelled,

--- a/api/tests/tooling/domain-builder/factory/build-cpf-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-cpf-certification-result.js
@@ -8,6 +8,7 @@ module.exports = function buildCpfCertificationResult({
   sex = 'M',
   birthINSEECode = '75115',
   birthPostalCode = '75015',
+  birthplace = 'PARIS',
   publishedAt = new Date(),
   pixScore = 100,
   competenceMarks = [
@@ -23,6 +24,7 @@ module.exports = function buildCpfCertificationResult({
     sex,
     birthINSEECode,
     birthPostalCode,
+    birthplace,
     publishedAt,
     pixScore,
     competenceMarks,

--- a/api/tests/tooling/domain-builder/factory/build-cpf-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-cpf-certification-result.js
@@ -9,6 +9,7 @@ module.exports = function buildCpfCertificationResult({
   birthINSEECode = '75115',
   birthPostalCode = '75015',
   birthplace = 'PARIS',
+  birthCountry = 'FRANCE',
   publishedAt = new Date(),
   pixScore = 100,
   competenceMarks = [
@@ -25,6 +26,7 @@ module.exports = function buildCpfCertificationResult({
     birthINSEECode,
     birthPostalCode,
     birthplace,
+    birthCountry,
     publishedAt,
     pixScore,
     competenceMarks,

--- a/api/tests/unit/domain/read-models/CpfCertificationResult_test.js
+++ b/api/tests/unit/domain/read-models/CpfCertificationResult_test.js
@@ -1,0 +1,70 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+
+describe('Unit | Domain | Read-Models | CpfCertificationResult', function () {
+  context('#inseeCode', function () {
+    context('when birth insee code is null', function () {
+      it('should return null', function () {
+        // given
+        const cpfCertificationResult = domainBuilder.buildCpfCertificationResult({ birthINSEECode: null });
+
+        // when
+        const inseeCode = cpfCertificationResult.inseeCode;
+
+        // then
+        expect(inseeCode).to.be.null;
+      });
+    });
+
+    context('when birth insee code equals "NULL"', function () {
+      it('should return null', function () {
+        // given
+        const cpfCertificationResult = domainBuilder.buildCpfCertificationResult({ birthINSEECode: 'NULL' });
+
+        // when
+        const inseeCode = cpfCertificationResult.inseeCode;
+
+        // then
+        expect(inseeCode).to.be.null;
+      });
+    });
+
+    context('when birth insee code length is greater than 5', function () {
+      it('should return null', function () {
+        // given
+        const cpfCertificationResult = domainBuilder.buildCpfCertificationResult({ birthINSEECode: '154640' });
+
+        // when
+        const inseeCode = cpfCertificationResult.inseeCode;
+
+        // then
+        expect(inseeCode).to.be.null;
+      });
+    });
+
+    context('when birth insee code length is lower than 5', function () {
+      it('should return null', function () {
+        // given
+        const cpfCertificationResult = domainBuilder.buildCpfCertificationResult({ birthINSEECode: '99' });
+
+        // when
+        const inseeCode = cpfCertificationResult.inseeCode;
+
+        // then
+        expect(inseeCode).to.be.null;
+      });
+    });
+
+    context('when birth insee code is not "NULL" and has the right length', function () {
+      it('should return the birth insee code', function () {
+        // given
+        const cpfCertificationResult = domainBuilder.buildCpfCertificationResult({ birthINSEECode: '75115' });
+
+        // when
+        const inseeCode = cpfCertificationResult.inseeCode;
+
+        // then
+        expect(inseeCode).to.equal('75115');
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/read-models/CpfCertificationResult_test.js
+++ b/api/tests/unit/domain/read-models/CpfCertificationResult_test.js
@@ -67,4 +67,45 @@ describe('Unit | Domain | Read-Models | CpfCertificationResult', function () {
       });
     });
   });
+
+  context('#countryCode', function () {
+    context('when birth insee code is null', function () {
+      it('should return null', function () {
+        // given
+        const cpfCertificationResult = domainBuilder.buildCpfCertificationResult({ birthINSEECode: null });
+
+        // when
+        const countryCode = cpfCertificationResult.countryCode;
+
+        // then
+        expect(countryCode).to.be.null;
+      });
+    });
+
+    context('when birth insee code does not start by "99"', function () {
+      it('should return null', function () {
+        // given
+        const cpfCertificationResult = domainBuilder.buildCpfCertificationResult({ birthINSEECode: '75115' });
+
+        // when
+        const countryCode = cpfCertificationResult.countryCode;
+
+        // then
+        expect(countryCode).to.be.null;
+      });
+    });
+
+    context('when birth insee code starts by "99"', function () {
+      it('should return the 3 last characters', function () {
+        // given
+        const cpfCertificationResult = domainBuilder.buildCpfCertificationResult({ birthINSEECode: '99250' });
+
+        // when
+        const countryCode = cpfCertificationResult.countryCode;
+
+        // then
+        expect(countryCode).to.equal('250');
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/read-models/CpfCertificationResult_test.js
+++ b/api/tests/unit/domain/read-models/CpfCertificationResult_test.js
@@ -108,4 +108,71 @@ describe('Unit | Domain | Read-Models | CpfCertificationResult', function () {
       });
     });
   });
+
+  context('#postalCode', function () {
+    context('when birth postal code is null', function () {
+      it('should return null', function () {
+        // given
+        const cpfCertificationResult = domainBuilder.buildCpfCertificationResult({ birthPostalCode: null });
+
+        // when
+        const postalCode = cpfCertificationResult.postalCode;
+
+        // then
+        expect(postalCode).to.be.null;
+      });
+    });
+
+    context('when birth postal code equals "NULL"', function () {
+      it('should return null', function () {
+        // given
+        const cpfCertificationResult = domainBuilder.buildCpfCertificationResult({ birthPostalCode: 'NULL' });
+
+        // when
+        const postalCode = cpfCertificationResult.postalCode;
+
+        // then
+        expect(postalCode).to.be.null;
+      });
+    });
+
+    context('when birth postal code length is greater than 5', function () {
+      it('should return null', function () {
+        // given
+        const cpfCertificationResult = domainBuilder.buildCpfCertificationResult({ birthPostalCode: '154640' });
+
+        // when
+        const postalCode = cpfCertificationResult.postalCode;
+
+        // then
+        expect(postalCode).to.be.null;
+      });
+    });
+
+    context('when birth postal code length is lower than 5', function () {
+      it('should return null', function () {
+        // given
+        const cpfCertificationResult = domainBuilder.buildCpfCertificationResult({ birthPostalCode: '99' });
+
+        // when
+        const postalCode = cpfCertificationResult.postalCode;
+
+        // then
+        expect(postalCode).to.be.null;
+      });
+    });
+
+    context('when birth postal code is not "NULL" and has the right length', function () {
+      it('should return the birth postal code', function () {
+        // given
+        const cpfCertificationResult = domainBuilder.buildCpfCertificationResult({ birthPostalCode: '75115' });
+
+        // when
+        const postalCode = cpfCertificationResult.postalCode;
+
+        // then
+        expect(postalCode).to.equal('75115');
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/services/cpf-certification-xml-export-service_test.js
+++ b/api/tests/unit/domain/services/cpf-certification-xml-export-service_test.js
@@ -36,6 +36,7 @@ describe('Unit | Services | cpf-certification-xml-export-service', function () {
         birthINSEECode: null,
         birthPostalCode: '75002',
         birthplace: 'PARIS',
+        birthCountry: 'FRANCE',
         publishedAt: '2022-01-03',
         pixScore: 324,
         competenceMarks: [
@@ -53,6 +54,7 @@ describe('Unit | Services | cpf-certification-xml-export-service', function () {
         birthINSEECode: '99109',
         birthPostalCode: null,
         birthplace: 'BERLIN',
+        birthCountry: 'ALLEMAGNE',
         publishedAt: '2022-01-07',
         pixScore: 512,
         competenceMarks: [
@@ -197,6 +199,9 @@ function _getExpectedXmlExport() {
                     <cpf:libelleCommuneNaissance>
                       PARIS
                     </cpf:libelleCommuneNaissance>
+                    <cpf:libellePaysNaissance>
+                      FRANCE
+                    </cpf:libellePaysNaissance>
                   </cpf:titulaire>
                 </cpf:identificationTitulaire>
               </cpf:passageCertification>
@@ -301,6 +306,9 @@ function _getExpectedXmlExport() {
                     <cpf:codePaysNaissance>
                       109
                     </cpf:codePaysNaissance>
+                    <cpf:libellePaysNaissance>
+                      ALLEMAGNE
+                    </cpf:libellePaysNaissance>
                   </cpf:titulaire>
                 </cpf:identificationTitulaire>
               </cpf:passageCertification>

--- a/api/tests/unit/domain/services/cpf-certification-xml-export-service_test.js
+++ b/api/tests/unit/domain/services/cpf-certification-xml-export-service_test.js
@@ -35,6 +35,7 @@ describe('Unit | Services | cpf-certification-xml-export-service', function () {
         sex: 'M',
         birthINSEECode: null,
         birthPostalCode: '75002',
+        birthplace: 'PARIS',
         publishedAt: '2022-01-03',
         pixScore: 324,
         competenceMarks: [
@@ -51,6 +52,7 @@ describe('Unit | Services | cpf-certification-xml-export-service', function () {
         sex: 'F',
         birthINSEECode: '75114',
         birthPostalCode: null,
+        birthplace: 'PARIS 14',
         publishedAt: '2022-01-07',
         pixScore: 512,
         competenceMarks: [
@@ -192,6 +194,9 @@ function _getExpectedXmlExport() {
                         </cpf:codePostal>
                       </cpf:codePostalNaissance>
                     </cpf:codeCommuneNaissance>
+                    <cpf:libelleCommuneNaissance>
+                      PARIS
+                    </cpf:libelleCommuneNaissance>
                   </cpf:titulaire>
                 </cpf:identificationTitulaire>
               </cpf:passageCertification>
@@ -290,6 +295,9 @@ function _getExpectedXmlExport() {
                         </cpf:codeInsee>
                       </cpf:codeInseeNaissance>
                     </cpf:codeCommuneNaissance>
+                    <cpf:libelleCommuneNaissance>
+                      PARIS 14
+                    </cpf:libelleCommuneNaissance>
                   </cpf:titulaire>
                 </cpf:identificationTitulaire>
               </cpf:passageCertification>

--- a/api/tests/unit/domain/services/cpf-certification-xml-export-service_test.js
+++ b/api/tests/unit/domain/services/cpf-certification-xml-export-service_test.js
@@ -50,9 +50,9 @@ describe('Unit | Services | cpf-certification-xml-export-service', function () {
         lastName: 'Porée',
         birthdate: '1992-11-03',
         sex: 'F',
-        birthINSEECode: '75114',
+        birthINSEECode: '99109',
         birthPostalCode: null,
-        birthplace: 'PARIS 14',
+        birthplace: 'BERLIN',
         publishedAt: '2022-01-07',
         pixScore: 512,
         competenceMarks: [
@@ -291,13 +291,16 @@ function _getExpectedXmlExport() {
                     <cpf:codeCommuneNaissance>
                       <cpf:codeInseeNaissance>
                         <cpf:codeInsee>
-                          75114
+                          99109
                         </cpf:codeInsee>
                       </cpf:codeInseeNaissance>
                     </cpf:codeCommuneNaissance>
                     <cpf:libelleCommuneNaissance>
-                      PARIS 14
+                      BERLIN
                     </cpf:libelleCommuneNaissance>
+                    <cpf:codePaysNaissance>
+                      109
+                    </cpf:codePaysNaissance>
                   </cpf:titulaire>
                 </cpf:identificationTitulaire>
               </cpf:passageCertification>


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous n'envoyons au CPF que les informations de lieu de naissance obligatoires (code postal ou code insee de la ville de naissance). Ces seules informations vont rendre l'identification du candidat difficile pour le CPF. De plus, lors de l'envoi du fichier au CPF, on s'est aperçu que nos utilisateurs avaient parfois des données "fantaisistes" dans la colonne `birthInseeCode`. 

## :robot: Solution
- Se prémunir des valeurs de code Insee de la ville de naissance non conformes.
- Ajouter les valeurs de lieu de naissance manquantes.

## :100: Pour tester
Des `certification-courses` ont été ajoutés avec les informations suivantes: 
```
    [
      { birthINSEECode: '75115', birthPostalCode: null, birthplace: 'PARIS 15', birthCountry: 'FRANCE' },
      { birthINSEECode: null, birthPostalCode: '75018', birthplace: 'PARIS', birthCountry: 'FRANCE' },
      { birthINSEECode: '99139', birthPostalCode: null, birthplace: 'LISBONNE', birthCountry: 'PORTUGAL' },
      { birthINSEECode: '154640', birthPostalCode: null, birthplace: 'CHIQUINQUIRA', birthCountry: 'COLOMBIE' },
      { birthINSEECode: 'NULL', birthPostalCode: '06088', birthplace: 'NICE', birthCountry: 'FRANCE' },
      { birthINSEECode: '99', birthPostalCode: null, birthplace: 'LUGANO', birthCountry: 'SUISSE' },
      { birthINSEECode: '99', birthPostalCode: 'NULL', birthplace: 'ZNAMENKA', birthCountry: 'UKRAINE' },
    ]
```

Voici le fichier xml qui a été généré:
[pix-cpf-export-20221007-151011578.zip](https://github.com/1024pix/pix/files/9734589/pix-cpf-export-20221007-151011578.zip)
