### PR TITLE
[BUGFIX] Supprimer la hauteur fixe pour les boutons de la bannière des tutos.

### DIFF
--- a/mon-pix/app/styles/pages/_user-tutorials.scss
+++ b/mon-pix/app/styles/pages/_user-tutorials.scss
@@ -91,7 +91,7 @@
     list-style: none;
     margin: 0;
     padding: 0;
-    height: 45px;
+    min-height: 45px;
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, sur l'écran des tutos, on constate que le bouton "Filtres" dépasse de la bannière : 
![image](https://user-images.githubusercontent.com/26234185/193853575-3b7f38b1-3f7e-4dfc-8ad9-f01fdd928eb8.png)

## :robot: Solution
Supprimer la hauteur fixe de la bannière

## :rainbow: Remarques
Pas de remarque

## :100: Pour tester
- Se rendre sur la RA
- se mettre en mode Mobile (choisir par exemple un Pixel 5)
- Constater que le bouton "Filtres" ne dépasse plus de la bannière
