### PR TITLE
[FEATURE] Ajouter le filtre de certificabilité pour les organisations Pro (PIX-5559)

### DIFF
--- a/api/lib/application/organizations/helpers.js
+++ b/api/lib/application/organizations/helpers.js
@@ -1,0 +1,17 @@
+const certificabilityByLabel = {
+  'not-available': null,
+  eligible: true,
+  'non-eligible': false,
+};
+
+function mapCertificabilityByLabel(certificabilityFilter) {
+  let result = certificabilityFilter;
+  if (!Array.isArray(certificabilityFilter)) {
+    result = [certificabilityFilter];
+  }
+  return result.map((value) => certificabilityByLabel[value]);
+}
+
+module.exports = {
+  mapCertificabilityByLabel,
+};

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -936,6 +936,7 @@ exports.register = async (server) => {
             'page[size]': Joi.number().integer().empty(''),
             'page[number]': Joi.number().integer().empty(''),
             'filter[fullName]': Joi.string().empty(''),
+            'filter[certificability][]': [Joi.string(), Joi.array().items(Joi.string())],
           }),
         },
         handler: organizationController.getPaginatedParticipantsForAnOrganization,

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -932,6 +932,11 @@ exports.register = async (server) => {
           params: Joi.object({
             id: identifiersType.organizationId,
           }),
+          query: Joi.object({
+            'page[size]': Joi.number().integer().empty(''),
+            'page[number]': Joi.number().integer().empty(''),
+            'filter[fullName]': Joi.string().empty(''),
+          }),
         },
         handler: organizationController.getPaginatedParticipantsForAnOrganization,
         tags: ['api', 'organization-participants'],

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -30,11 +30,7 @@ const certificationResultUtils = require('../../infrastructure/utils/csv/certifi
 const certificationAttestationPdf = require('../../infrastructure/utils/pdf/certification-attestation-pdf');
 const organizationForAdminSerializer = require('../../infrastructure/serializers/jsonapi/organization-for-admin-serializer');
 
-const certificabilityByLabel = {
-  'not-available': null,
-  eligible: true,
-  'non-eligible': false,
-};
+const { mapCertificabilityByLabel } = require('./helpers');
 
 module.exports = {
   async getOrganizationDetails(request) {
@@ -255,10 +251,7 @@ module.exports = {
       filter.divisions = [filter.divisions];
     }
     if (filter.certificability) {
-      if (!Array.isArray(filter.certificability)) {
-        filter.certificability = [filter.certificability];
-      }
-      filter.certificability = filter.certificability.map((value) => certificabilityByLabel[value]);
+      filter.certificability = mapCertificabilityByLabel(filter.certificability);
     }
     const { data: scoOrganizationParticipants, meta } = await usecases.findPaginatedFilteredScoParticipants({
       organizationId,
@@ -386,10 +379,7 @@ module.exports = {
     const { page, filter: filters } = queryParamsUtils.extractParameters(request.query);
 
     if (filters.certificability) {
-      if (!Array.isArray(filters.certificability)) {
-        filters.certificability = [filters.certificability];
-      }
-      filters.certificability = filters.certificability.map((value) => certificabilityByLabel[value]);
+      filters.certificability = mapCertificabilityByLabel(filters.certificability);
     }
 
     const results = await usecases.getPaginatedParticipantsForAnOrganization({

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -383,12 +383,21 @@ module.exports = {
 
   async getPaginatedParticipantsForAnOrganization(request) {
     const organizationId = request.params.id;
-    const options = queryParamsUtils.extractParameters(request.query);
+    const { page, filter: filters } = queryParamsUtils.extractParameters(request.query);
+
+    if (filters.certificability) {
+      if (!Array.isArray(filters.certificability)) {
+        filters.certificability = [filters.certificability];
+      }
+      filters.certificability = filters.certificability.map((value) => certificabilityByLabel[value]);
+    }
+
     const results = await usecases.getPaginatedParticipantsForAnOrganization({
       organizationId,
-      page: options.page,
-      filters: options.filter,
+      page,
+      filters,
     });
+
     return organizationParticipantsSerializer.serialize(results);
   },
 

--- a/api/tests/integration/infrastructure/repositories/organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-participant-repository_test.js
@@ -210,7 +210,10 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
           organizationId,
           participationAttributes: { createdAt: '2022-03-14' },
         }).id;
-        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId, type: 'PROFILES_COLLECTION' }).id;
+        const campaignId = databaseBuilder.factory.buildCampaign({
+          organizationId,
+          type: CampaignTypes.PROFILES_COLLECTION,
+        }).id;
         databaseBuilder.factory.buildCampaignParticipation({
           organizationLearnerId,
           campaignId,
@@ -225,7 +228,7 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
         });
 
         //then
-        expect(campaignType).to.equal('PROFILES_COLLECTION');
+        expect(campaignType).to.equal(CampaignTypes.PROFILES_COLLECTION);
       });
 
       it('should return the status of the most recent participation', async function () {
@@ -508,13 +511,13 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
           // given
           buildLearnerWithParticipation({
             organizationId,
-            participationAttributes: { isCertifiable: true, status: 'SHARED' },
-            campaignAttributes: { type: 'PROFILES_COLLECTION' },
+            participationAttributes: { isCertifiable: true, status: CampaignParticipationStatuses.SHARED },
+            campaignAttributes: { type: CampaignTypes.PROFILES_COLLECTION },
           });
           buildLearnerWithParticipation({
             organizationId,
-            participationAttributes: { isCertifiable: false, status: 'SHARED' },
-            campaignAttributes: { type: 'PROFILES_COLLECTION' },
+            participationAttributes: { isCertifiable: false, status: CampaignParticipationStatuses.SHARED },
+            campaignAttributes: { type: CampaignTypes.PROFILES_COLLECTION },
           });
           await databaseBuilder.commit();
 
@@ -533,18 +536,18 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
           // given
           buildLearnerWithParticipation({
             organizationId,
-            participationAttributes: { isCertifiable: false, status: 'SHARED' },
-            campaignAttributes: { type: 'PROFILES_COLLECTION' },
+            participationAttributes: { isCertifiable: false, status: CampaignParticipationStatuses.SHARED },
+            campaignAttributes: { type: CampaignTypes.PROFILES_COLLECTION },
           });
           buildLearnerWithParticipation({
             organizationId,
-            participationAttributes: { isCertifiable: null, status: 'STARTED' },
-            campaignAttributes: { type: 'PROFILES_COLLECTION' },
+            participationAttributes: { isCertifiable: null, status: CampaignParticipationStatuses.STARTED },
+            campaignAttributes: { type: CampaignTypes.PROFILES_COLLECTION },
           });
           buildLearnerWithParticipation({
             organizationId,
-            participationAttributes: { isCertifiable: true, status: 'SHARED' },
-            campaignAttributes: { type: 'PROFILES_COLLECTION' },
+            participationAttributes: { isCertifiable: true, status: CampaignParticipationStatuses.SHARED },
+            campaignAttributes: { type: CampaignTypes.PROFILES_COLLECTION },
           });
           await databaseBuilder.commit();
 

--- a/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
@@ -372,7 +372,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           });
         });
 
-        context('when one value are given', function () {
+        context('when two values are given', function () {
           it('should return sco participants which match with given values', async function () {
             const organizationId = databaseBuilder.factory.buildOrganization().id;
             const campaignId = databaseBuilder.factory.buildCampaign({

--- a/api/tests/unit/application/organizations/helpers.js
+++ b/api/tests/unit/application/organizations/helpers.js
@@ -1,0 +1,48 @@
+const { expect } = require('../../../test-helper');
+const { mapCertificabilityByLabel } = require('../../../../lib/application/organizations/helpers');
+
+describe('Unit | Application | Organizations | helpers', function () {
+  it('map the certificability eligible value', async function () {
+    // given
+    const certificabilityFilter = 'eligible';
+
+    // when
+    const result = mapCertificabilityByLabel(certificabilityFilter);
+
+    // then
+    expect(result).to.deep.equal([true]);
+  });
+
+  it('map the certificability non-eligible value', async function () {
+    // given
+    const certificabilityFilter = 'non-eligible';
+
+    // when
+    const result = mapCertificabilityByLabel(certificabilityFilter);
+
+    // then
+    expect(result).to.deep.equal([false]);
+  });
+
+  it('map the certificability not-available value', async function () {
+    // given
+    const certificabilityFilter = 'not-available';
+
+    // when
+    const result = mapCertificabilityByLabel(certificabilityFilter);
+
+    // then
+    expect(result).to.deep.equal([null]);
+  });
+
+  it('map multiple certificability values', async function () {
+    // given
+    const certificabilityFilter = ['not-available', 'eligible'];
+
+    // when
+    const result = mapCertificabilityByLabel(certificabilityFilter);
+
+    // then
+    expect(result).to.deep.equal([null, true]);
+  });
+});

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -1355,21 +1355,27 @@ describe('Unit | Application | Organizations | organization-controller', functio
   });
 
   describe('#getPaginatedParticipantsForAnOrganization', function () {
+    const connectedUserId = 1;
+    const organizationId = 145;
+
+    let request;
+
+    beforeEach(function () {
+      request = {
+        auth: { credentials: { userId: connectedUserId } },
+        params: { id: organizationId },
+      };
+
+      sinon.stub(usecases, 'getPaginatedParticipantsForAnOrganization');
+      sinon.stub(organizationParticipantsSerializer, 'serialize');
+    });
+
     it('should call the usecase to get the participants of the organization', async function () {
-      const organizationId = 1;
       const parameters = { page: 2, filter: { fullName: 'name' } };
       const organizationLearner = domainBuilder.buildOrganizationLearner();
       domainBuilder.buildCampaignParticipation({ organizationLearnerId: organizationLearner.id });
 
-      const request = {
-        params: { id: organizationId },
-        auth: {
-          credentials: {
-            userId: 1,
-          },
-        },
-        query: parameters,
-      };
+      request.query = parameters;
 
       const participant = {
         id: organizationLearner.id,
@@ -1388,15 +1394,14 @@ describe('Unit | Application | Organizations | organization-controller', functio
       const expectedResponse = { data: serializedOrganizationParticipants, meta: {} };
 
       sinon.stub(queryParamsUtils, 'extractParameters').withArgs(request.query).returns(parameters);
-      sinon
-        .stub(usecases, 'getPaginatedParticipantsForAnOrganization')
+
+      usecases.getPaginatedParticipantsForAnOrganization
         .withArgs({ organizationId, page: 2, filters: parameters.filter })
         .returns({
           organizationParticipants: [participant],
           pagination: expectedPagination,
         });
-      sinon
-        .stub(organizationParticipantsSerializer, 'serialize')
+      organizationParticipantsSerializer.serialize
         .withArgs({
           organizationParticipants: [participant],
           pagination: expectedPagination,
@@ -1408,6 +1413,98 @@ describe('Unit | Application | Organizations | organization-controller', functio
 
       // then
       expect(response).to.deep.equal(expectedResponse);
+    });
+
+    it('map the certificability eligible value', async function () {
+      // given
+      request = {
+        auth: { credentials: { userId: connectedUserId } },
+        params: { id: organizationId },
+        query: {
+          'filter[certificability][]': 'eligible',
+        },
+      };
+      usecases.getPaginatedParticipantsForAnOrganization.resolves({ data: [] });
+      organizationParticipantsSerializer.serialize.returns({});
+
+      // when
+      await organizationController.getPaginatedParticipantsForAnOrganization(request, hFake);
+
+      // then
+      expect(usecases.getPaginatedParticipantsForAnOrganization).to.have.been.calledWith({
+        organizationId,
+        filters: { certificability: [true] },
+        page: {},
+      });
+    });
+
+    it('map the certificability non-eligible value', async function () {
+      // given
+      request = {
+        auth: { credentials: { userId: connectedUserId } },
+        params: { id: organizationId },
+        query: {
+          'filter[certificability][]': 'non-eligible',
+        },
+      };
+      usecases.getPaginatedParticipantsForAnOrganization.resolves({ data: [] });
+      organizationParticipantsSerializer.serialize.returns({});
+
+      // when
+      await organizationController.getPaginatedParticipantsForAnOrganization(request, hFake);
+
+      // then
+      expect(usecases.getPaginatedParticipantsForAnOrganization).to.have.been.calledWith({
+        organizationId,
+        filters: { certificability: [false] },
+        page: {},
+      });
+    });
+
+    it('map the certificability not-available value', async function () {
+      // given
+      request = {
+        auth: { credentials: { userId: connectedUserId } },
+        params: { id: organizationId },
+        query: {
+          'filter[certificability][]': 'not-available',
+        },
+      };
+      usecases.getPaginatedParticipantsForAnOrganization.resolves({ data: [] });
+      organizationParticipantsSerializer.serialize.returns({});
+
+      // when
+      await organizationController.getPaginatedParticipantsForAnOrganization(request, hFake);
+
+      // then
+      expect(usecases.getPaginatedParticipantsForAnOrganization).to.have.been.calledWith({
+        organizationId,
+        filters: { certificability: [null] },
+        page: {},
+      });
+    });
+
+    it('map the all certificability values', async function () {
+      // given
+      request = {
+        auth: { credentials: { userId: connectedUserId } },
+        params: { id: organizationId },
+        query: {
+          'filter[certificability][]': ['eligible', 'not-available'],
+        },
+      };
+      usecases.getPaginatedParticipantsForAnOrganization.resolves({ data: [] });
+      organizationParticipantsSerializer.serialize.returns({});
+
+      // when
+      await organizationController.getPaginatedParticipantsForAnOrganization(request, hFake);
+
+      // then
+      expect(usecases.getPaginatedParticipantsForAnOrganization).to.have.been.calledWith({
+        organizationId,
+        filters: { certificability: [true, null] },
+        page: {},
+      });
     });
   });
 });

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -803,13 +803,13 @@ describe('Unit | Application | Organizations | organization-controller', functio
       expect(response).to.deep.equal(serializedScoOrganizationParticipant);
     });
 
-    it('map the certificability eligible value', async function () {
+    it('map all certificability values', async function () {
       // given
       request = {
         auth: { credentials: { userId: connectedUserId } },
         params: { id: organizationId },
         query: {
-          'filter[certificability][]': 'eligible',
+          'filter[certificability][]': ['eligible', 'non-eligible', 'not-available'],
         },
       };
       usecases.findPaginatedFilteredScoParticipants.resolves({ data: [] });
@@ -821,76 +821,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       // then
       expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWith({
         organizationId,
-        filter: { certificability: [true] },
-        page: {},
-      });
-    });
-
-    it('map the certificability non-eligible value', async function () {
-      // given
-      request = {
-        auth: { credentials: { userId: connectedUserId } },
-        params: { id: organizationId },
-        query: {
-          'filter[certificability][]': 'non-eligible',
-        },
-      };
-      usecases.findPaginatedFilteredScoParticipants.resolves({ data: [] });
-      scoOrganizationParticipantsSerializer.serialize.returns({});
-
-      // when
-      await organizationController.findPaginatedFilteredScoParticipants(request, hFake);
-
-      // then
-      expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWith({
-        organizationId,
-        filter: { certificability: [false] },
-        page: {},
-      });
-    });
-
-    it('map the certificability not-available value', async function () {
-      // given
-      request = {
-        auth: { credentials: { userId: connectedUserId } },
-        params: { id: organizationId },
-        query: {
-          'filter[certificability][]': 'not-available',
-        },
-      };
-      usecases.findPaginatedFilteredScoParticipants.resolves({ data: [] });
-      scoOrganizationParticipantsSerializer.serialize.returns({});
-
-      // when
-      await organizationController.findPaginatedFilteredScoParticipants(request, hFake);
-
-      // then
-      expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWith({
-        organizationId,
-        filter: { certificability: [null] },
-        page: {},
-      });
-    });
-
-    it('map the all certificability values', async function () {
-      // given
-      request = {
-        auth: { credentials: { userId: connectedUserId } },
-        params: { id: organizationId },
-        query: {
-          'filter[certificability][]': ['eligible', 'not-available'],
-        },
-      };
-      usecases.findPaginatedFilteredScoParticipants.resolves({ data: [] });
-      scoOrganizationParticipantsSerializer.serialize.returns({});
-
-      // when
-      await organizationController.findPaginatedFilteredScoParticipants(request, hFake);
-
-      // then
-      expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWith({
-        organizationId,
-        filter: { certificability: [true, null] },
+        filter: { certificability: [true, false, null] },
         page: {},
       });
     });
@@ -1415,13 +1346,13 @@ describe('Unit | Application | Organizations | organization-controller', functio
       expect(response).to.deep.equal(expectedResponse);
     });
 
-    it('map the certificability eligible value', async function () {
+    it('map all certificability values', async function () {
       // given
       request = {
         auth: { credentials: { userId: connectedUserId } },
         params: { id: organizationId },
         query: {
-          'filter[certificability][]': 'eligible',
+          'filter[certificability][]': ['eligible', 'non-eligible', 'not-available'],
         },
       };
       usecases.getPaginatedParticipantsForAnOrganization.resolves({ data: [] });
@@ -1433,76 +1364,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       // then
       expect(usecases.getPaginatedParticipantsForAnOrganization).to.have.been.calledWith({
         organizationId,
-        filters: { certificability: [true] },
-        page: {},
-      });
-    });
-
-    it('map the certificability non-eligible value', async function () {
-      // given
-      request = {
-        auth: { credentials: { userId: connectedUserId } },
-        params: { id: organizationId },
-        query: {
-          'filter[certificability][]': 'non-eligible',
-        },
-      };
-      usecases.getPaginatedParticipantsForAnOrganization.resolves({ data: [] });
-      organizationParticipantsSerializer.serialize.returns({});
-
-      // when
-      await organizationController.getPaginatedParticipantsForAnOrganization(request, hFake);
-
-      // then
-      expect(usecases.getPaginatedParticipantsForAnOrganization).to.have.been.calledWith({
-        organizationId,
-        filters: { certificability: [false] },
-        page: {},
-      });
-    });
-
-    it('map the certificability not-available value', async function () {
-      // given
-      request = {
-        auth: { credentials: { userId: connectedUserId } },
-        params: { id: organizationId },
-        query: {
-          'filter[certificability][]': 'not-available',
-        },
-      };
-      usecases.getPaginatedParticipantsForAnOrganization.resolves({ data: [] });
-      organizationParticipantsSerializer.serialize.returns({});
-
-      // when
-      await organizationController.getPaginatedParticipantsForAnOrganization(request, hFake);
-
-      // then
-      expect(usecases.getPaginatedParticipantsForAnOrganization).to.have.been.calledWith({
-        organizationId,
-        filters: { certificability: [null] },
-        page: {},
-      });
-    });
-
-    it('map the all certificability values', async function () {
-      // given
-      request = {
-        auth: { credentials: { userId: connectedUserId } },
-        params: { id: organizationId },
-        query: {
-          'filter[certificability][]': ['eligible', 'not-available'],
-        },
-      };
-      usecases.getPaginatedParticipantsForAnOrganization.resolves({ data: [] });
-      organizationParticipantsSerializer.serialize.returns({});
-
-      // when
-      await organizationController.getPaginatedParticipantsForAnOrganization(request, hFake);
-
-      // then
-      expect(usecases.getPaginatedParticipantsForAnOrganization).to.have.been.calledWith({
-        organizationId,
-        filters: { certificability: [true, null] },
+        filters: { certificability: [true, false, null] },
         page: {},
       });
     });

--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -13,6 +13,16 @@
     @ariaLabel={{t "pages.organization-participants.filters.type.fullName.title"}}
     @triggerFiltering={{@triggerFiltering}}
   />
+  <Ui::MultiSelectFilter
+    @field="certificability"
+    @title={{t "pages.organization-participants.filters.type.certificability.label"}}
+    @onSelect={{@triggerFiltering}}
+    @selectedOption={{@certificabilityFilter}}
+    @options={{@certificabilityOptions}}
+    @placeholder={{t "pages.organization-participants.filters.type.certificability.label"}}
+    @ariaLabel={{t "pages.organization-participants.filters.type.certificability.aria-label"}}
+    @emptyMessage={{t "pages.organization-participants.filters.type.certificability.empty"}}
+  />
 </PixFilterBanner>
 <div class="panel">
   <table class="table content-text content-text--small">

--- a/orga/app/controllers/authenticated/organization-participants/list.js
+++ b/orga/app/controllers/authenticated/organization-participants/list.js
@@ -4,10 +4,13 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class ListController extends Controller {
+  @service currentUser;
+  @service intl;
+
   @tracked pageNumber = 1;
   @tracked pageSize = 25;
   @tracked fullName = null;
-  @service currentUser;
+  @tracked certificability = [];
 
   @action
   triggerFiltering(fieldName, value) {
@@ -19,5 +22,23 @@ export default class ListController extends Controller {
   resetFilters() {
     this.pageNumber = null;
     this.fullName = null;
+    this.certificability = [];
+  }
+
+  get certificabilityOptions() {
+    return [
+      {
+        value: 'not-available',
+        label: this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.not-available'),
+      },
+      {
+        value: 'eligible',
+        label: this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible'),
+      },
+      {
+        value: 'non-eligible',
+        label: this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.non-eligible'),
+      },
+    ];
   }
 }

--- a/orga/app/routes/authenticated/organization-participants/list.js
+++ b/orga/app/routes/authenticated/organization-participants/list.js
@@ -6,6 +6,7 @@ export default class ListRoute extends Route {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
     fullName: { refreshModel: true },
+    certificability: { refreshModel: true },
   };
 
   @service currentUser;
@@ -15,6 +16,7 @@ export default class ListRoute extends Route {
       filter: {
         organizationId: this.currentUser.organization.id,
         fullName: params.fullName,
+        certificability: params.certificability,
       },
       page: {
         number: params.pageNumber,
@@ -28,6 +30,7 @@ export default class ListRoute extends Route {
       controller.pageNumber = 1;
       controller.pageSize = 25;
       controller.fullName = null;
+      controller.certificability = null;
     }
   }
 }

--- a/orga/app/templates/authenticated/organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/organization-participants/list.hbs
@@ -8,6 +8,8 @@
       @triggerFiltering={{this.triggerFiltering}}
       @onResetFilter={{this.resetFilters}}
       @fullName={{this.fullName}}
+      @certificabilityFilter={{this.certificability}}
+      @certificabilityOptions={{this.certificabilityOptions}}
     />
   {{else}}
     <OrganizationParticipant::NoParticipantPanel />

--- a/orga/tests/acceptance/organization-participant-list_test.js
+++ b/orga/tests/acceptance/organization-participant-list_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { currentURL, visit } from '@ember/test-helpers';
+import { currentURL, click } from '@ember/test-helpers';
+import { visit, clickByText } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import setupIntl from '../helpers/setup-intl';
 import authenticateSession from '../helpers/authenticate-session';
@@ -45,6 +46,26 @@ module('Acceptance | Organization Participant List', function (hooks) {
         // then
         assert.notContains(this.intl.t('pages.organization-participants.empty-state.message'));
         assert.contains('Charles');
+      });
+
+      test('it should filter by certificability', async function (assert) {
+        // given
+        const organizationId = user.memberships.models.firstObject.organizationId;
+
+        server.create('organization-participant', { organizationId, firstName: 'Jean', lastName: 'Charles' });
+
+        await authenticateSession(user.id);
+        const { getByPlaceholderText } = await visit('/participants');
+
+        // when
+        const select = getByPlaceholderText(
+          this.intl.t('pages.organization-participants.filters.type.certificability.label')
+        );
+        await click(select);
+        await clickByText(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible'));
+
+        // then
+        assert.strictEqual(decodeURI(currentURL()), '/participants?certificability=["eligible"]');
       });
     });
   });

--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { render, fillByLabel } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { render, fillByLabel, clickByName } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 import sinon from 'sinon';
@@ -165,7 +166,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     assert.contains('02/01/2022');
   });
 
-  test('it filters participant when the input is filled', async function (assert) {
+  test('it should trigger filtering with fullName search', async function (assert) {
     // given
     const participants = [
       {
@@ -184,6 +185,31 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     await fillByLabel('Recherche sur le nom et prénom', 'Karam');
     // then
     sinon.assert.calledWith(this.triggerFiltering, 'fullName', 'Karam');
+    assert.ok(true);
+  });
+
+  test('it should trigger filtering with certificability', async function (assert) {
+    // given
+    const triggerFiltering = sinon.spy();
+    this.set('triggerFiltering', triggerFiltering);
+    this.set('participants', []);
+    this.set('certificabilityOptions', [{ value: 'eligible', label: 'Certifiable' }]);
+    this.set('certificability', []);
+
+    const { getByPlaceholderText, findByRole } = await render(
+      hbs`<OrganizationParticipant::List @participants={{participants}} @triggerFiltering={{triggerFiltering}} @certificabilityOptions={{certificabilityOptions}} @certificability={{certificability}} />`
+    );
+
+    // when
+    const select = await getByPlaceholderText(
+      this.intl.t('pages.organization-participants.filters.type.certificability.label')
+    );
+    await click(select);
+    await findByRole('menu');
+    await clickByName(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible'));
+
+    // then
+    sinon.assert.calledWithExactly(triggerFiltering, 'certificability', ['eligible']);
     assert.ok(true);
   });
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -666,6 +666,11 @@
         "title": "Filters",
         "participations-count": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count} participants}}",
         "type": {
+          "certificability": {
+            "aria-label": "Enter a status for certificability",
+            "empty": "No status",
+            "label": "Search by certificability"
+          },
           "fullName": {
             "title": "Search by lastname and firstname",
             "placeholder": "Lastname, firstname"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -666,6 +666,11 @@
         "participations-count": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count} participants}}",
         "title": "Filtres",
         "type": {
+        "certificability": {
+          "aria-label": "Enter un statut de certification",
+          "empty": "Pas de status",
+          "label": "Rechercher par certificabilité"
+        },
           "fullName": {
             "title": "Recherche sur le nom et prénom",
             "placeholder": "Nom, prénom"


### PR DESCRIPTION
## :unicorn: Problème
Suite à l’ajout de la liste de participants au sein de Pix Orga, un des besoins qui est remonté est de pouvoir consulter dans cette liste les participants certifiable en un clic et ceux qui ne le sont pas afin de pouvoir réaliser des actions complémentaires (comme des parcours ou contacter la personne)…
Cependant l’affichage et le filtre sur cette donnée sur l’intégralité des participants d’une orga soulève pas mal de questions au niveau performances.
Cette information est calculé : on doit récupéré tous les envois profils, prendre le plus récent, et voir si la personne à au moins un niveau 1 dans 5 compétence. Et ça pour tous les participants d’une organisation.
C’est pourquoi après un benchmark avec la team prescription, nous avons décidé de stocker cette valeur pour mieux l’exploiter dans Pix Orga par la suite.

## :robot: Solution
Maintenant que la colonne est disponible, nous pouvons ajouter le filtre sur cette colonne (multiselect) dans le bandeau de filtre dans l’onglet PARTICIPANTS. On peut filtrer sur 3 valeurs :

“Certifiable”

“Non certifiable”

“Non communiqué” car le participant n’a pas réalisé d’envoi profil

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à Pix orga en tant que PRO
- Se rendre sur la page "Participants"
- Tester le filtre avec une seule valeurs, plusieurs valeurs et tester le bouton "Effacer les filtres"