### PR TITLE
[BUGFIX] Corrige la récupération des profils cible d'une organisation (PIX-5961)

### DIFF
--- a/api/lib/domain/read-models/campaign/TargetProfileForSpecifier.js
+++ b/api/lib/domain/read-models/campaign/TargetProfileForSpecifier.js
@@ -1,9 +1,9 @@
 class TargetProfileForSpecifier {
-  constructor({ id, name, tubeCount, thematicResults, hasStage, description, category }) {
+  constructor({ id, name, tubeCount, thematicResultCount, hasStage, description, category }) {
     this.id = id;
     this.name = name;
     this.tubeCount = tubeCount;
-    this.thematicResultCount = thematicResults.length;
+    this.thematicResultCount = thematicResultCount;
     this.hasStage = hasStage;
     this.description = description;
     this.category = category;

--- a/api/lib/infrastructure/repositories/campaign/target-profile-for-specifier-repository.js
+++ b/api/lib/infrastructure/repositories/campaign/target-profile-for-specifier-repository.js
@@ -2,8 +2,7 @@ const { knex } = require('../../../../db/knex-database-connection');
 const skillDataSource = require('../../datasources/learning-content/skill-datasource');
 const TargetProfileForSpecifier = require('../../../domain/read-models/campaign/TargetProfileForSpecifier');
 const bluebird = require('bluebird');
-const _ = require('lodash');
-const { uniq, uniqBy } = require('lodash');
+const { uniqBy } = require('lodash');
 
 async function availableForOrganization(organizationId) {
   const targetProfileRows = await _fetchTargetProfiles(organizationId);
@@ -16,49 +15,51 @@ function _fetchTargetProfiles(organizationId) {
     .select('targetProfileId')
     .from('target-profile-shares')
     .where({ organizationId });
-  return (
-    knex('target-profiles')
-      .select([
-        'target-profiles.id',
-        'target-profiles.name',
-        'target-profiles.description',
-        'target-profiles.category',
-        knex.raw('ARRAY_AGG("skillId") AS "skillIds"'),
-        knex.raw('ARRAY_AGG("badges"."id")  AS "badgeIds"'),
-        knex.raw('ARRAY_AGG("stages"."id")  AS "stageIds"'),
-        knex.raw('ARRAY_AGG("target-profile_tubes"."tubeId")  AS "tubeIds"'),
-      ])
+  return knex('target-profiles')
+    .select([
+      'target-profiles.id',
+      'target-profiles.name',
+      'target-profiles.description',
+      'target-profiles.category',
       // TODO remove it after target profile tube migration to target-profile_tubes
-      .leftJoin('target-profiles_skills', 'target-profiles_skills.targetProfileId', 'target-profiles.id')
-      .leftJoin('target-profile_tubes', 'target-profile_tubes.targetProfileId', 'target-profiles.id')
-      .leftJoin('badges', 'badges.targetProfileId', 'target-profiles.id')
-      .leftJoin('stages', 'stages.targetProfileId', 'target-profiles.id')
-      .where({ outdated: false })
-      .where((qb) => {
-        qb.orWhere({ isPublic: true });
-        qb.orWhere({ ownerOrganizationId: organizationId });
-        qb.orWhereIn('target-profiles.id', selectTargetProfileSharesIdsBelongToOrganization);
-      })
-      .groupBy('target-profiles.id')
-  );
+      knex
+        .select(knex.raw('ARRAY_AGG("skillId")'))
+        .from('target-profiles_skills')
+        .whereRaw('"target-profiles_skills"."targetProfileId"="target-profiles".id')
+        .as('skillIds'),
+      knex.count('id').from('badges').whereRaw('badges."targetProfileId"="target-profiles".id').as('countBadges'),
+      knex.count('id').from('stages').whereRaw('stages."targetProfileId"="target-profiles".id').as('countStages'),
+      knex
+        .count('tubeId')
+        .from('target-profile_tubes')
+        .whereRaw('"target-profile_tubes"."targetProfileId"="target-profiles".id')
+        .as('countTubes'),
+    ])
+    .where({ outdated: false })
+    .where((qb) => {
+      qb.orWhere({ isPublic: true });
+      qb.orWhere({ ownerOrganizationId: organizationId });
+      qb.orWhereIn('target-profiles.id', selectTargetProfileSharesIdsBelongToOrganization);
+    })
+    .groupBy('target-profiles.id');
 }
 
 async function _buildTargetProfileForSpecifier(row) {
   let tubeCount;
-  if (row.tubeIds?.[0] != null) {
-    tubeCount = uniq(row.tubeIds).length;
+  if (row.countTubes > 0) {
+    tubeCount = row.countTubes;
   } else {
     // TODO remove it after target profile tube migration to target-profile_tubes
     const skills = await skillDataSource.findByRecordIds(row.skillIds);
     tubeCount = uniqBy(skills, 'tubeId').length;
   }
-  const thematicResultsIds = _.uniq(row.badgeIds).filter((id) => id);
-  const hasStage = row.stageIds.some((stage) => stage);
+  const thematicResultCount = row.countBadges;
+  const hasStage = row.countStages > 0;
   return new TargetProfileForSpecifier({
     id: row.id,
     name: row.name,
     tubeCount,
-    thematicResults: thematicResultsIds,
+    thematicResultCount,
     hasStage,
     description: row.description,
     category: row.category,

--- a/api/tests/integration/infrastructure/repositories/campaign/target-profile-for-specifier-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign/target-profile-for-specifier-repository_test.js
@@ -142,7 +142,7 @@ describe('Integration | Infrastructure | Repository | target-profile-for-campaig
         const { id: targetProfileId2 } = databaseBuilder.factory.buildTargetProfile({ name: 'name2' });
         databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfileId1, skillId: skill1.id });
         databaseBuilder.factory.buildTargetProfileTube({ targetProfileId: targetProfileId2, tubeId: 'tube2' });
-        const badge = databaseBuilder.factory.buildBadge({ targetProfileId: targetProfileId1 });
+        databaseBuilder.factory.buildBadge({ targetProfileId: targetProfileId1 });
         databaseBuilder.factory.buildStage({ targetProfileId: targetProfileId2 });
         mockLearningContent({ skills: [skill1] });
 
@@ -152,7 +152,7 @@ describe('Integration | Infrastructure | Repository | target-profile-for-campaig
           id: targetProfileId1,
           name: 'name1',
           tubeCount: 1,
-          thematicResults: [badge],
+          thematicResultCount: 1,
           hasStage: false,
           description: null,
           category: 'OTHER',
@@ -161,7 +161,7 @@ describe('Integration | Infrastructure | Repository | target-profile-for-campaig
           id: targetProfileId2,
           name: 'name2',
           tubeCount: 1,
-          thematicResults: [],
+          thematicResultCount: 0,
           hasStage: true,
           description: null,
           category: 'OTHER',

--- a/api/tests/unit/domain/read-models/campaign/TargetProfileForSpecifier_test.js
+++ b/api/tests/unit/domain/read-models/campaign/TargetProfileForSpecifier_test.js
@@ -1,98 +1,26 @@
-const { expect, domainBuilder } = require('../../../../test-helper');
+const { expect } = require('../../../../test-helper');
 const TargetProfileForSpecifier = require('../../../../../lib/domain/read-models/campaign/TargetProfileForSpecifier');
 
 describe('TargetProfileForSpecifier', function () {
-  describe('#thematicResultCount', function () {
-    it('returns the number of thematic result', function () {
-      const thematicResults = [domainBuilder.buildBadge(), domainBuilder.buildBadge()];
+  describe('#constructor', function () {
+    it('returns the properties', function () {
       const targetProfile = new TargetProfileForSpecifier({
         id: 1,
         name: 'name',
         tubeCount: 0,
-        thematicResults,
+        thematicResultCount: 2,
         hasStage: true,
-        description: null,
-      });
-
-      expect(targetProfile.thematicResultCount).to.equal(2);
-    });
-  });
-
-  describe('#hasStage', function () {
-    context('when hasStage is true', function () {
-      it('returns true', function () {
-        const targetProfile = new TargetProfileForSpecifier({
-          id: 1,
-          name: 'name',
-          tubeCount: 0,
-          thematicResults: [],
-          hasStage: true,
-          description: null,
-        });
-
-        expect(targetProfile.hasStage).to.equal(true);
-      });
-    });
-
-    context('when hasStage is false', function () {
-      it('returns false', function () {
-        const targetProfile = new TargetProfileForSpecifier({
-          id: 1,
-          name: 'name',
-          tubeCount: 0,
-          thematicResults: [],
-          hasStage: false,
-          description: null,
-        });
-
-        expect(targetProfile.hasStage).to.equal(false);
-      });
-    });
-  });
-
-  describe('#name', function () {
-    it('returns the name', function () {
-      const targetProfile = new TargetProfileForSpecifier({
-        id: 1,
-        name: 'name',
-        tubeCount: 0,
-        thematicResults: [],
-        hasStage: false,
         description: 'description',
+        category: 'category',
       });
 
+      expect(targetProfile.id).to.equal(1);
       expect(targetProfile.name).to.equal('name');
-    });
-  });
-
-  describe('#description', function () {
-    it('returns the description', function () {
-      const targetProfile = new TargetProfileForSpecifier({
-        id: 1,
-        name: 'name',
-        tubeCount: 0,
-        thematicResults: [],
-        hasStage: false,
-        description: 'description',
-      });
-
-      expect(targetProfile.description).to.equal('description');
-    });
-  });
-
-  describe('#category', function () {
-    it('returns the category', function () {
-      const targetProfile = new TargetProfileForSpecifier({
-        id: 1,
-        name: 'name',
-        tubeCount: 0,
-        thematicResults: [],
-        hasStage: false,
-        description: 'description',
-        category: 'SUBJECT',
-      });
-
-      expect(targetProfile.category).to.equal('SUBJECT');
+      expect(targetProfile.tubeCount).to.equal(0);
+      expect(targetProfile.thematicResultCount).to.equal(2);
+      expect(targetProfile.hasStage).to.eql(true);
+      expect(targetProfile.description).to.eql('description');
+      expect(targetProfile.category).to.eql('category');
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign/target-profile-for-specifier-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign/target-profile-for-specifier-serializer_test.js
@@ -1,17 +1,15 @@
-const { expect, domainBuilder } = require('../../../../../test-helper');
+const { expect } = require('../../../../../test-helper');
 const serializer = require('../../../../../../lib/infrastructure/serializers/jsonapi/campaign/target-profile-for-specifier-serializer');
 const TargetProfileForSpecifier = require('../../../../../../lib/domain/read-models/campaign/TargetProfileForSpecifier');
 
 describe('Unit | Serializer | JSONAPI | target-profile-for-specifier-serializer', function () {
   describe('#serialize', function () {
     it('should serialize target profile to JSONAPI', function () {
-      const thematicResults = [domainBuilder.buildBadge()];
-
       const targetProfile = new TargetProfileForSpecifier({
         id: 132,
         name: 'name',
         tubeCount: 2,
-        thematicResults,
+        thematicResultCount: 1,
         hasStage: true,
         description: 'description',
         category: 'SUBJECT',


### PR DESCRIPTION
## :unicorn: Problème
La récupération des profils cibles d'une organisation demande quelques information de sujets/badges/stages/acquis. La façon de les récupérer avec des left join récupère trop d'éléments dupliqué ou null que nous sommes obligé de refiltrer ensuite.

Pour certaines organisations, le volume de données intermédiaires généré est tellement important que cela provoque l'épuisement de la mémoire disponible dans le conteneur.

## :robot: Solution
Faire des sous requetes pour simplifier tout cela.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- En se connectant sur Pix orga, aller sur la page de création de parcours, et voir la liste des profils cible rempli.
- Une autre façon de voir l'évolution est de faire des explain analyse sur la base de production, voici les résultats:
  - Le code actuel: https://explain.dalibo.com/plan/495225edcg4a9eb8#plan
  - La version presque proposé: https://explain.dalibo.com/plan/5hh0211d4f0a49bg (quelques petit changements sont apparus depuis au niveau des sous requêtes)
