### PR TITLE
[DOCUMENTATION] Clarifier le contexte du projet pour les contributions externes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,18 @@
 # Contribuer à Pix
 
+L'organisation GitHub [1024pix](https://github.com/1024pix) héberge le code utilisé dans le projet [Pix](https://pix.fr)
+. Les dépots GitHub de l'organisation sont en évolution rapide et développés par plusieurs équipes dédiées chez Pix. Le
+dépot GitHub [1024pix/pix](https://github.com/1024pix/pix) est la source canonique de nos équipes. Les développements
+que nous réalisons sont exclusivement dédiés a l'amélioration de la platforme [Pix](https://pix.fr) et nous ne
+travaillons pas a l'heure actuelle a une version générique utilisable par toute et tous pour d'autres usages.
+
+Cela signifie que nous ne pouvons pas promettre que les contributions externes seront sur un pied d'égalité avec les
+contributions internes. Les revues de code prennent du temps, et le travail nécessaire à Pix est prioritaire. Nous ne
+pouvons pas non plus promettre que nous accepterons toutes les contributions de fonctionnalités. Même si le code est
+déjà écrit, les revues et la maintenance ont un coût. Au sein de Pix, nous disposons d'une équipe de gestion des
+produits qui évalue soigneusement les fonctionnalités que nous devons proposer ou non, et de nombreuses idées générées
+en interne ne sont finalement pas retenues.
+
 Pour toute contribution, il est essentiel de respecter *a minima* les points suivants.
 
 ## Règles de bonnes conduites pour déclarer les problèmes


### PR DESCRIPTION
## :unicorn: Problème
Le code du projet Pix est Open Source. Il est aujourd'hui assez peu clair dans la documentation du dépôt le contexte dans lequel est développé Pix. Les règles de contributions externes n'étant pas spécifiées, des contributions inutiles pourraient apparaître générant du bruit pour les équipes de développement et de la frustration pour les contributeurs.

## :robot: Solution
Introduire dans notre guide de contribution des indications du contexte dans lequel est développé le projet.

## :rainbow: Remarques
L'objectif n'est pas d'interdire les contributions externes mais plutôt de clarifier ce qui n'est pas dit aujourd'hui :)

J'ai hésité à également préciser notre pratique de l'egoless programming, à voir où le caller 🤔 

## :100: Pour tester
N/A