### PR TITLE
[FEATURE] Aligner le style du bouton modifier du détail d'une session avec la maquette (PIX-5779)

### DIFF
--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -111,7 +111,7 @@
     {{#if this.sessionHasStarted}}
       <div class="session-details-buttons">
         <PixButtonLink @route="authenticated.sessions.update" @model={{this.session.id}} @backgroundColor="grey">
-          Modifier
+          {{t "pages.sessions.details.action.edit"}}
         </PixButtonLink>
       </div>
       <div class="session-details-buttons session-details-buttons--push-right">
@@ -128,7 +128,7 @@
     {{else}}
       <div class="session-details-buttons">
         <PixButtonLink @route="authenticated.sessions.update" @model={{this.session.id}} @backgroundColor="grey">
-          Modifier
+          {{t "pages.sessions.details.action.edit"}}
         </PixButtonLink>
       </div>
     {{/if}}

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -127,7 +127,7 @@
       </div>
     {{else}}
       <div class="session-details-buttons">
-        <PixButtonLink @route="authenticated.sessions.update" @model={{this.session.id}}>
+        <PixButtonLink @route="authenticated.sessions.update" @model={{this.session.id}} @backgroundColor="grey">
           Modifier
         </PixButtonLink>
       </div>

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -33,6 +33,11 @@
           "enrolled-candidates": "<span>{enrolledCandidatesCount} candidats</span> sont inscrits à cette session",
           "disclaimer": "Attention, cette action est irréversible."
         }
+      },
+      "details": {
+        "action": {
+          "edit": "Modify"
+        }
       }
     },
     "session-supervising": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -33,6 +33,11 @@
           "enrolled-candidates": "<span>{enrolledCandidatesCount} {enrolledCandidatesCount, plural,one {candidat} other {candidats}}</span> {enrolledCandidatesCount, plural,one {est inscrit} other {sont inscrits}} à cette session",
           "disclaimer": "Attention, cette action est irréversible."
         }
+      },
+      "details": {
+        "action": {
+          "edit": "Modifier"
+        }
       }
     },
     "session-supervising": {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Sur la page détail d’une session sur Pix Certif, un bouton modifier en bas de la page permet la modification  des informations d'une session de certification.

Selon l’audit design Pix Certif, le bouton n'est pas raccord avec le DS.

## :bat: Solution
Mettre à jour le bouton tertiary sur le principe documenté dans le DS : https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=56%3A23

## :spider_web: Remarques
Il faut modifier le style du PixButtonLink dans PixUI

## :ghost: Pour tester
