### PR TITLE
[BUGFIX] App: Ne pas rediriger un utilisateur GAR sur la page de connexion (PIX-5950)

### DIFF
--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -15,6 +15,10 @@ export default class ApplicationRoute extends Route {
   }
 
   async beforeModel(transition) {
+    // Set the locale to en otherwise ember-intl will use en-us
+    // There is no translation file en-us.json
+    this.intl.setLocale('en');
+
     this.headData.description = this.intl.t('application.description');
 
     await this.featureToggles.load().catch();

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -83,7 +83,9 @@ export default class CurrentSessionService extends SessionService {
 
   async _checkForURLAuthentication(transition) {
     if (transition.to.queryParams && transition.to.queryParams.externalUser) {
-      // Logout user when a new external user is authenticated.
+      // Logout user when a new external user is authenticated
+      // without redirecting the use to the login page.
+      this.skipRedirectAfterSessionInvalidation = true;
       await this._logoutUser();
     }
 

--- a/mon-pix/tests/unit/routes/application_test.js
+++ b/mon-pix/tests/unit/routes/application_test.js
@@ -28,7 +28,7 @@ describe('Unit | Route | application', function () {
     expect(SplashServiceStub.hideCount).to.equal(1);
   });
 
-  describe('#beforeEach', function () {
+  describe('#beforeModel', function () {
     let featureTogglesServiceStub, sessionServiceStub;
     beforeEach(function () {
       const catchStub = sinon.stub();


### PR DESCRIPTION
## :jack_o_lantern: Problème

Actuellement, lorsqu'un élève utilisant le GAR se connecte et qu'une session précédente est encore disponible, la précédente session sera invalidée en entrainant une redirection vers la page de connexion de Pix. Ce qui ne devrait pas arriver lors d'une connexion d'un élève via le GAR.

## :bat: Solution

Ne pas faire de redirection vers la page de connexion une fois la session invalidée.

## :spider_web: Remarques

- Un problème lié à la récupération des fichiers de traductions a été réglé
- Il faudrait sortir les méthodes `_checkForURLAuthentication` et `_checkAnonymousAccess` qui se trouvent dans le fichiers `services/session.js#handleUserLanguageAndLocale` car elles ne concernent pas la gestion des langues, et surtout pour pouvoir les tester plus facilement

## :ghost: Pour tester

- Se connecter sur Pix App avec un compte standard
- Ne pas se déconnecter pour garder une session ouverte
- Se connecter via le GAR
- Constatez que la redirection vers la page de connexion ne se fait plus
