### PR TITLE
[PERFORMANCE] Ajout d'un index sur la colonne targetProfileId de la table target-profile_tubes

### DIFF
--- a/api/db/migrations/20221010075029_add-index-to-target-profile-tube.js
+++ b/api/db/migrations/20221010075029_add-index-to-target-profile-tube.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'target-profile_tubes';
+const COLUMN_NAME = 'targetProfileId';
+
+exports.up = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.index(COLUMN_NAME);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.dropIndex(COLUMN_NAME);
+  });
+};


### PR DESCRIPTION
## :jack_o_lantern: Problème
Un index manque sur la table target-profile_tubes#targetProfileId. Elle est utilisé entre autre lors de la récupération des profils cible pour une organisation.

## :bat: Solution
Ajouter un index.

## :ghost: Pour tester

