### PR TITLE
[FEATURE] App: Définir "fr" comme langue par défaut

### DIFF
--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -15,9 +15,17 @@ export default class ApplicationRoute extends Route {
   }
 
   async beforeModel(transition) {
-    // Set the locale to en otherwise ember-intl will use en-us
-    // There is no translation file en-us.json
-    this.intl.setLocale('en');
+    /*
+    Ce code permet de définir une locale par défaut différente de celle d'ember-intl.
+
+    Ember-intl utilise "en-us" comme locale par défaut.
+
+    Si aucun fichier de traduction n'existe dans le dossier spécifié dans la configuration d'ember-intl,
+    on obtient une URL de ce type : "/?lang=Missing%20translation%20%22current-lang%22%20for%20locale%20%22en-us%22".
+
+    Pour régler ce problème, il faut définir une locale ayant un fichier dans le dossier de traduction.
+     */
+    this.intl.setLocale('fr');
 
     this.headData.description = this.intl.t('application.description');
 

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -84,7 +84,7 @@ export default class CurrentSessionService extends SessionService {
   async _checkForURLAuthentication(transition) {
     if (transition.to.queryParams && transition.to.queryParams.externalUser) {
       // Logout user when a new external user is authenticated
-      // without redirecting the use to the login page.
+      // without redirecting the user to the login page.
       this.skipRedirectAfterSessionInvalidation = true;
       await this._logoutUser();
     }

--- a/mon-pix/tests/unit/routes/application_test.js
+++ b/mon-pix/tests/unit/routes/application_test.js
@@ -2,12 +2,10 @@ import Service from '@ember/service';
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
-import setupIntl from '../../helpers/setup-intl';
 import sinon from 'sinon';
 
 describe('Unit | Route | application', function () {
   setupTest();
-  setupIntl();
 
   it('hides the splash when the route is activated', function () {
     // Given
@@ -33,6 +31,7 @@ describe('Unit | Route | application', function () {
 
     beforeEach(function () {
       const catchStub = sinon.stub();
+
       featureTogglesServiceStub = Service.create({
         load: sinon.stub().resolves(catchStub),
       });
@@ -42,6 +41,22 @@ describe('Unit | Route | application', function () {
       oidcIdentityProvidersStub = Service.create({
         load: sinon.stub().resolves(),
       });
+
+      this.intl = this.owner.lookup('service:intl');
+    });
+
+    it('should set "fr" locale as default', async function () {
+      // given
+      const route = this.owner.lookup('route:application');
+      route.set('featureToggles', featureTogglesServiceStub);
+      route.set('session', sessionServiceStub);
+      route.set('oidcIdentityProviders', oidcIdentityProvidersStub);
+
+      // when
+      await route.beforeModel();
+
+      // then
+      expect(this.intl.primaryLocale).to.equal('fr');
     });
 
     it('should set the head description', async function () {

--- a/mon-pix/tests/unit/routes/application_test.js
+++ b/mon-pix/tests/unit/routes/application_test.js
@@ -29,7 +29,8 @@ describe('Unit | Route | application', function () {
   });
 
   describe('#beforeModel', function () {
-    let featureTogglesServiceStub, sessionServiceStub;
+    let featureTogglesServiceStub, sessionServiceStub, oidcIdentityProvidersStub;
+
     beforeEach(function () {
       const catchStub = sinon.stub();
       featureTogglesServiceStub = Service.create({
@@ -38,6 +39,9 @@ describe('Unit | Route | application', function () {
       sessionServiceStub = Service.create({
         handleUserLanguageAndLocale: sinon.stub().resolves(),
       });
+      oidcIdentityProvidersStub = Service.create({
+        load: sinon.stub().resolves(),
+      });
     });
 
     it('should set the head description', async function () {
@@ -45,6 +49,7 @@ describe('Unit | Route | application', function () {
       const route = this.owner.lookup('route:application');
       route.set('featureToggles', featureTogglesServiceStub);
       route.set('session', sessionServiceStub);
+      route.set('oidcIdentityProviders', oidcIdentityProvidersStub);
 
       // when
       await route.beforeModel();
@@ -58,6 +63,7 @@ describe('Unit | Route | application', function () {
       const route = this.owner.lookup('route:application');
       route.set('featureToggles', featureTogglesServiceStub);
       route.set('session', sessionServiceStub);
+      route.set('oidcIdentityProviders', oidcIdentityProvidersStub);
 
       // when
       await route.beforeModel();
@@ -71,6 +77,7 @@ describe('Unit | Route | application', function () {
       const route = this.owner.lookup('route:application');
       route.set('featureToggles', featureTogglesServiceStub);
       route.set('session', sessionServiceStub);
+      route.set('oidcIdentityProviders', oidcIdentityProvidersStub);
       const transition = { from: 'inscription' };
       // when
       await route.beforeModel(transition);


### PR DESCRIPTION
## :jack_o_lantern: Problème

Lors de l'invalidation d'une session, une redirection vers la page de connexion est faite. Avant cette redirection, on génère le chemin vers cette page en récupérant la langue courante. C'est à ce moment que ember-intl utilise la locale `en-us` par défaut, qui n'existe pas pour l'application et fourni le chemin suivant : `/?lang=Missing%20translation%20%22current-lang%22%20for%20locale%20%22en-us%22`

## :bat: Solution

Définir `fr` comme locale par défaut à l'initialisation de l'application.

## :spider_web: Remarques

Suite de la PR #5036.

## :ghost: Pour tester

- Se connecter sur Pix App avec un compte standard
- Ne pas se déconnecter pour garder une session ouverte
- Se connecter via le GAR
- Constatez que la redirection vers la page de connexion ne se fait plus
