### PR TITLE
[FEATURE] Afficher un message dans le tableau des élèves quand l'organisation n'a aucun élève (PIX-5569).

### DIFF
--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -68,10 +68,27 @@ function _buildMiddleSchools({ databaseBuilder }) {
     identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
     createdBy: middleSchoolsCreator.id,
   });
+  databaseBuilder.factory.buildOrganization({
+    id: 31,
+    type: 'SCO',
+    name: 'Collège de la vie',
+    isManagingStudents: true,
+    email: 'sco.generic.account@example.net',
+    externalId: SCO_COLLEGE_EXTERNAL_ID,
+    documentationUrl: 'https://pix.fr/',
+    provinceCode: '12',
+    identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
+    createdBy: middleSchoolsCreator.id,
+  });
 
   databaseBuilder.factory.buildMembership({
     userId: SCO_ADMIN_ID,
     organizationId: SCO_MIDDLE_SCHOOL_ID,
+    organizationRole: Membership.roles.ADMIN,
+  });
+  databaseBuilder.factory.buildMembership({
+    userId: SCO_ADMIN_ID,
+    organizationId: 31,
     organizationRole: Membership.roles.ADMIN,
   });
 

--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -146,12 +146,16 @@
       </tbody>
     {{/if}}
   </table>
-
-  {{#unless @students}}
+  {{#if (eq @students.meta.participantCount 0)}}
+    <Ui::EmptyState
+      @infoText={{t "pages.sco-organization-participants.no-participants"}}
+      @actionText={{t "pages.sco-organization-participants.no-participants-action"}}
+    />
+  {{else if (not @students)}}
     <div class="table__empty content-text">
       {{t "pages.sco-organization-participants.table.empty"}}
     </div>
-  {{/unless}}
+  {{/if}}
 </div>
 
 <ScoOrganizationParticipant::ManageAuthenticationMethodModal

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -385,4 +385,32 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
         .exists();
     });
   });
+
+  module('when there is participants but no results with filters', function () {
+    test('it should display a message telling if there is no rows display', async function (assert) {
+      // given
+      const students = [];
+      students.meta = { participantCount: 1 };
+      this.set('students', students);
+      // when
+      await render(hbs`<ScoOrganizationParticipant::List @students={{students}} @onFilter={{noop}}/>`);
+
+      // then
+      assert.contains('Aucun élève.');
+    });
+  });
+
+  module('when there is no participants in the organization', function () {
+    test('it should display a message telling to use import', async function (assert) {
+      // given
+      const students = [];
+      students.meta = { participantCount: 0 };
+      this.set('students', students);
+      // when
+      await render(hbs`<ScoOrganizationParticipant::List @students={{students}} @onFilter={{noop}}/>`);
+
+      // then
+      assert.contains('L’administrateur doit importer la base élèves en cliquant sur le bouton importer.');
+    });
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -827,6 +827,8 @@
           }
         }
       },
+      "no-participants": "No students yet!",
+      "no-participants-action": "The administrator must import the students database by clicking on the import button.",
       "filter": {
         "certificability": {
           "aria-label": "Enter a status for certificability",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -827,6 +827,8 @@
           }
         }
       },
+      "no-participants": "Aucun élève pour l’instant !",
+      "no-participants-action": "L’administrateur doit importer la base élèves en cliquant sur le bouton importer.",
       "filter": {
         "certificability": {
           "aria-label": "Enter un statut de certification",


### PR DESCRIPTION
## :jack_o_lantern: Problème
Lorsqu'une organisation scolaire n'a pas d'élève le tableau affiche le message "aucun élève".
Ce qui ne donne pas d'indication sur ce qu'il faut faire pour avoir des élèves.

## :bat: Solution
Affichier un message invitant l'administrateur de l'organisation à importer des élèves.

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
Aller sur une orga sco sans élèves et constater la présence du message.
