### PR TITLE
[BUGFIX] Réparer l'alignement de l'intitulé de champ et de son input dans une épreuve QROC de type phrase (PIX-5970)

### DIFF
--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -18,6 +18,7 @@
   }
 
   label {
+    flex-shrink: 0;
     font-weight: $font-normal;
   }
 


### PR DESCRIPTION
## :jack_o_lantern: Problème
![image](https://user-images.githubusercontent.com/7335131/194883762-891b0cd3-dbfc-4733-8298-e078e503d30d.png)

Dans les QROC de type phrase, l'intitulé de champ faisait un retour à la ligne bizarre.

## :bat: Solution

Réparer le flex en indiquant que l'intitulé perd la priorité de shrink.


## :ghost: Pour tester

Sur la RA, aller sur le challenge `challengeId=recZk5cdFVPPg10t9` et vérifier que l'intitulé du champ soit sur une seule ligne.
