### PR TITLE
[A11Y] Ajouter une description au tableau complexe de la liste des élèves (Pix-4253) 

### DIFF
--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -47,6 +47,7 @@
 
 <div class="panel">
   <table class="table content-text content-text--small">
+    <caption class="sr-only">{{t "pages.sco-organization-participants.table.description"}}</caption>
     <colgroup class="table__column">
       <col />
       <col />

--- a/orga/app/routes/authenticated/organization-participants/list.js
+++ b/orga/app/routes/authenticated/organization-participants/list.js
@@ -30,7 +30,7 @@ export default class ListRoute extends Route {
       controller.pageNumber = 1;
       controller.pageSize = 25;
       controller.fullName = null;
-      controller.certificability = null;
+      controller.certificability = [];
     }
   }
 }

--- a/orga/app/routes/authenticated/sco-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sco-organization-participants/list.js
@@ -36,7 +36,7 @@ export default class ListRoute extends Route {
       controller.search = null;
       controller.divisions = [];
       controller.connexionType = null;
-      controller.certificability = null;
+      controller.certificability = [];
       controller.pageNumber = null;
       controller.pageSize = null;
     }

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -93,6 +93,17 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       .exists();
   });
 
+  test('[A11Y] it should have a description for screen-readers', async function (assert) {
+    // given
+    this.set('students', []);
+
+    // when
+    await render(hbs`<ScoOrganizationParticipant::List @students={{students}} @onFilter={{noop}}/>`);
+
+    // then
+    assert.contains(this.intl.t('pages.sco-organization-participants.table.description'));
+  });
+
   test('it should display participant as eligible for certification when the participant is certifiable', async function (assert) {
     // given
     this.set('students', [

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -882,6 +882,7 @@
           "login-method": "Log in method(s)",
           "participation-count": "Number of participations"
         },
+        "description": "Table of students, sorted by name. For students who have provided an email address or a username, you can manage the allowed login modes and reset the student's password through a menu in an additional column",
         "empty": "No students.",
         "row-title": "Student"
       }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -882,6 +882,7 @@
           "login-method": "Méthode(s) de connexion",
           "participation-count": "Nombre de participations"
         },
+        "description": "Tableau des élèves trié par nom. Pour les élèves ayant fourni une adresse e-mail ou un identifiant, vous pouvez, via un menu situé dans une colonne supplémentaire, gérer les modes de connexion autorisés et réinitialiser le mot de passe de l'élève",
         "empty": "Aucun élève.",
         "row-title": "Élève"
       }


### PR DESCRIPTION
## :jack_o_lantern: Problème
Suite à un audit accessibilité, il nous a été remonté que les tableaux complexes (avec des actions à l'intérieur et/ou des sous-colonnes) devaient avoir une description qui sera lue par les lecteurs d'écran pour donner plus d'info sur le tableau.

## :bat: Solution
Ajouter une description au tableau de la liste des élèves

## :spider_web: Remarques
BSR: fix du souci avec le filtre certificability

## :ghost: Pour tester
- se connecter à pix orga avec une oga sco et aller sur la page des élèves
- soit lancer un lecteur d'écran et aller sur le tbl et entendre la description qui est lue
- soit aller sur le tableau et voir dans l'arbre des éléments html, ma présence d'une caption
