### PR TITLE
[TECH] Supprime les caractères null dans les réponses envoyées

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/answer-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/answer-serializer.js
@@ -52,5 +52,5 @@ module.exports = {
 };
 
 function _cleanValue(value) {
-  return value.replace('\u0000', '');
+  return value.replaceAll('\u0000', '');
 }

--- a/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
@@ -80,7 +80,7 @@ describe('Unit | Serializer | JSONAPI | answer-serializer', function () {
         data: {
           type: 'answers',
           attributes: {
-            value: 'test\u0000',
+            value: 'test\u0000\u0000',
             result: null,
             'result-details': null,
             timeout: null,


### PR DESCRIPTION
## :jack_o_lantern: Problème
Certaines insertions de réponses tombent en erreur parce que leur contenu n'est pas valide

## :bat: Solution
Supprimer le caractère null, même si il est présent plusieurs fois

## :spider_web: Remarques
Cette PR est l'évolution de celle-ci, puisque le problème survient toujours : https://github.com/1024pix/pix/pull/2441

## :ghost: Pour tester

Répondre à une question avec deux caractères null, avec la PR l'answer doit être acceptée, sans cette PR l'envoi de l'answer doit retourner une erreur

--- 

Pour tester "facilement", on peut modifier le test d'acceptance `api/tests/acceptance/application/answers/answer-controller-save_test.js` 
en remplaçant ligne 89: 

```
              type: 'answers',
              attributes: {
                value: 'correct\u0000\u0000',
              },
```
et ligne 148 
`it.only('should return persisted answer', async function () {`

Puis en lançant les tests (`npm run test:api:acceptance`) on aura : 

- Avec le patch, une erreur puisque `correct` (la valeur en BDD) ne sera pas égale à `correct\u0000\u0000` (la valeur dans le payload de l'answer) : l'answer a bien été enregistrée

- Sans le patch, une erreur d'`id` non trouvé puisque l'answer ne sera pas enregistrée

