### PR TITLE
[A11Y] Ajouter une description au tableau de la liste des étudiants (Pix-5973)

### DIFF
--- a/orga/app/components/sup-organization-participant/list.hbs
+++ b/orga/app/components/sup-organization-participant/list.hbs
@@ -40,6 +40,7 @@
 </PixFilterBanner>
 <div class="panel">
   <table class="table content-text content-text--small">
+    <caption class="sr-only">{{t "pages.sup-organization-participants.table.description"}}</caption>
     <thead>
       <tr>
         <Table::Header @size="wide">

--- a/orga/tests/integration/components/sup-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list_test.js
@@ -119,7 +119,7 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
     this.set('students', students);
 
     // when
-    await render(hbs`<ScoOrganizationParticipant::List @students={{students}} @onFilter={{noop}}/>`);
+    await render(hbs`<SupOrganizationParticipant::List @students={{students}} @onFilter={{noop}}/>`);
 
     // then
     assert.contains(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible'));
@@ -141,7 +141,7 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
     this.set('students', students);
 
     // when
-    await render(hbs`<ScoOrganizationParticipant::List @students={{students}} @onFilter={{noop}}/>`);
+    await render(hbs`<SupOrganizationParticipant::List @students={{students}} @onFilter={{noop}}/>`);
 
     // then
     assert.contains('03/01/2022');

--- a/orga/tests/integration/components/sup-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list_test.js
@@ -147,6 +147,28 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
     assert.contains('03/01/2022');
   });
 
+  test('[A11Y] it should have a description for screen-readers', async function (assert) {
+    // given
+    const students = [
+      {
+        lastParticipationDate: new Date('2022-01-03'),
+        campaignName: 'SUP - Campagne de collecte de profils',
+        campaignType: 'PROFILES_COLLECTION',
+        participationStatus: 'SHARED',
+        isCertifiable: true,
+        certifiableAt: new Date('2022-01-03'),
+      },
+    ];
+
+    this.set('students', students);
+
+    // when
+    await render(hbs`<SupOrganizationParticipant::List @students={{students}} @onFilter={{noop}}/>`);
+
+    // then
+    assert.contains(this.intl.t('pages.sup-organization-participants.table.description'));
+  });
+
   module('when user is filtering some users', function () {
     test('it should trigger filtering with lastname', async function (assert) {
       const triggerFiltering = sinon.spy();

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -924,6 +924,7 @@
             }
           }
         },
+        "description": "Table of students, sorted by name.You can edit the student's number through a menu in an additional column",
         "empty": "No students.",
         "filter": {
           "actions": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -924,6 +924,7 @@
             }
           }
         },
+        "description": "Tableau des étudiants trié par nom. Vous pouvez, via un menu situé dans une colonne supplémentaire, modifier le numéro étudiant.",
         "empty": "Aucun étudiant.",
         "filter": {
           "aria-label":"Filtrer les étudiants",


### PR DESCRIPTION
## :jack_o_lantern: Problème
Suite à un audit accessibilité, il nous a été remonté que les tableaux complexes (avec des actions à l'intérieur et/ou des sous-colonnes) devaient avoir une description qui sera lue par les lecteurs d'écran pour donner plus d'info sur le tableau.

## :bat: Solution
Ajouter une description au tableau de la liste des étudiants

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
- se connecter à pix orga avec une oga sup et aller sur la page des élèves
- soit lancer un lecteur d'écran et aller sur le tbl et entendre la description qui est lue
- soit aller sur le tableau et voir dans l'arbre des éléments html, ma présence d'une caption
