### PR TITLE
[BUGFIX] Réparer la création d'un nouveau centre de certification dans Pix Admin (PIX-5976)

### DIFF
--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -6,6 +6,30 @@ const identifiersType = require('../../domain/types/identifiers-type');
 exports.register = async function (server) {
   const adminRoutes = [
     {
+      method: 'POST',
+      path: '/api/admin/certification-centers',
+      config: {
+        handler: certificationCenterController.create,
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
+            '- Création d‘un nouveau centre de certification\n',
+        ],
+        tags: ['api', 'certification-center'],
+      },
+    },
+    {
       method: 'GET',
       path: '/api/admin/certification-centers',
       config: {
@@ -150,30 +174,6 @@ exports.register = async function (server) {
 
   server.route([
     ...adminRoutes,
-    {
-      method: 'POST',
-      path: '/api/certification-centers',
-      config: {
-        handler: certificationCenterController.create,
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
-          },
-        ],
-        notes: [
-          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
-            '- Création d‘un nouveau centre de certification\n',
-        ],
-        tags: ['api', 'certification-center'],
-      },
-    },
     {
       method: 'GET',
       path: '/api/certification-centers/{certificationCenterId}/sessions/{sessionId}/students',

--- a/api/tests/acceptance/application/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-controller_test.js
@@ -160,12 +160,12 @@ describe('Acceptance | API | Certification Center', function () {
     });
   });
 
-  describe('POST /api/certification-centers', function () {
+  describe('POST /api/admin/certification-centers', function () {
     beforeEach(async function () {
       const complementaryCertification = databaseBuilder.factory.buildComplementaryCertification();
       request = {
         method: 'POST',
-        url: '/api/certification-centers',
+        url: '/api/admin/certification-centers',
         payload: {
           data: {
             type: 'certification-center',


### PR DESCRIPTION
## :jack_o_lantern: Problème
Depuis le refacto des routes api liées au centre de certification (#5016), la création d'un centre de certification ne fonctionne plus.


## :bat: Solution
Mettre la route d'ajout des centre de certification sous /admin

## :ghost: Pour tester
- Se connecter à Pix-admin
- Créer avec succès un nouveau centre de certification
