### PR TITLE
[TECH] Passage à la version 19.0.1 de Pix UI (PIX-5978)

### DIFF
--- a/mon-pix/app/components/account-recovery/confirmation-step.hbs
+++ b/mon-pix/app/components/account-recovery/confirmation-step.hbs
@@ -40,12 +40,9 @@
     </li>
   </ul>
 
-  <PixCheckbox
-    @id="pix-certify"
-    @label={{t "pages.account-recovery.find-sco-record.confirmation-step.certify-account"}}
-    {{on "change" this.onChange}}
-    @labelSize="small"
-  />
+  <PixCheckbox @id="pix-certify" {{on "change" this.onChange}} @labelSize="small">
+    {{t "pages.account-recovery.find-sco-record.confirmation-step.certify-account"}}
+  </PixCheckbox>
 
   <div class="account-recovery__content--actions">
     <PixButton @isBorderVisible={{true}} @triggerAction={{@cancelAccountRecovery}} @backgroundColor="transparent-light">

--- a/mon-pix/app/components/account-recovery/update-sco-record-form.hbs
+++ b/mon-pix/app/components/account-recovery/update-sco-record-form.hbs
@@ -28,12 +28,9 @@
     />
 
     <div class="update-sco-record-form__cgu-container">
-      <PixCheckbox
-        @id="checkbox"
-        @label={{t "common.cgu.label"}}
-        @screenReaderOnly="true"
-        {{on "change" this.onChange}}
-      />
+      <PixCheckbox @id="checkbox" @screenReaderOnly="true" {{on "change" this.onChange}}>
+        {{t "common.cgu.label"}}
+      </PixCheckbox>
       <p class="account-recovery__content--information-text--details">
         {{t "common.cgu.accept"}}
         <a href={{this.cguUrl}} class="link" target="_blank" rel="noopener noreferrer">

--- a/mon-pix/app/components/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.hbs
@@ -9,12 +9,9 @@
       }}
     </p>
     <div class="login-or-register-oidc-form__cgu-container">
-      <PixCheckbox
-        @id="checkbox"
-        @label={{t "common.cgu.label"}}
-        @screenReaderOnly="true"
-        {{on "change" this.onChange}}
-      />
+      <PixCheckbox @id="checkbox" @screenReaderOnly="true" {{on "change" this.onChange}}>
+        {{t "common.cgu.label"}}
+      </PixCheckbox>
       <p class="login-or-register-oidc-form__cgu-label">
         {{t "common.cgu.accept"}}
         <a href={{this.cguUrl}} class="link" target="_blank" rel="noopener noreferrer">

--- a/mon-pix/app/components/authentication/terms-of-service-oidc.hbs
+++ b/mon-pix/app/components/authentication/terms-of-service-oidc.hbs
@@ -18,12 +18,9 @@
       </p>
     </div>
 
-    <PixCheckbox
-      @id="pix-cgu"
-      @label={{t "pages.terms-of-service-oidc.cgu" htmlSafe=true}}
-      {{on "change" this.onChange}}
-      aria-label={{t "common.cgu.label"}}
-    />
+    <PixCheckbox @id="pix-cgu" {{on "change" this.onChange}} aria-label={{t "common.cgu.label"}}>
+      {{t "pages.terms-of-service-oidc.cgu" htmlSafe=true}}
+    </PixCheckbox>
 
     {{#if this.errorMessage}}
       <PixMessage @type="error">

--- a/mon-pix/app/components/certification-results-page.hbs
+++ b/mon-pix/app/components/certification-results-page.hbs
@@ -14,12 +14,9 @@
 
     <div class="result-content__warning-container">
       <div class="result-content__checked-supervisor">
-        <PixCheckbox
-          @id="checkbox"
-          @label={{t "pages.certification-results.not-finished.checkbox-label"}}
-          @screenReaderOnly="true"
-          {{on "change" this.onChange}}
-        />
+        <PixCheckbox @id="checkbox" @screenReaderOnly="true" {{on "change" this.onChange}}>
+          {{t "pages.certification-results.not-finished.checkbox-label"}}
+        </PixCheckbox>
 
         <span class="result-content__warning-text">
           {{t "pages.certification-results.not-finished.warning-text"}}

--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -108,11 +108,12 @@
         </p>
         <PixCheckbox
           @id="checkbox"
-          @label={{t "common.cgu.label"}}
           @screenReaderOnly="true"
           {{on "change" this.onChange}}
           aria-describedby="sign-up-cgu-error-message"
-        />
+        >
+          {{t "common.cgu.label"}}
+        </PixCheckbox>
       </div>
       {{#if @user.errors.cgu}}
         <div class="sign-form__validation-error" aria-live="polite" id="sign-up-cgu-error-message">

--- a/mon-pix/app/components/user-tutorials/filters/item-checkbox.hbs
+++ b/mon-pix/app/components/user-tutorials/filters/item-checkbox.hbs
@@ -1,8 +1,5 @@
 <li class="tutorials-filters-areas-competences__item-checkbox">
-  <PixCheckbox
-    @id={{@item.id}}
-    @label={{@item.name}}
-    {{on "input" (fn @handleFilterChange @type @item.id)}}
-    @checked={{this.isChecked}}
-  />
+  <PixCheckbox @id={{@item.id}} {{on "input" (fn @handleFilterChange @type @item.id)}} @checked={{this.isChecked}}>
+    {{@item.name}}
+  </PixCheckbox>
 </li>

--- a/mon-pix/app/templates/terms-of-service.hbs
+++ b/mon-pix/app/templates/terms-of-service.hbs
@@ -15,7 +15,10 @@
       {{t "pages.terms-of-service.message"}}
     </div>
 
-    <PixCheckbox @id="pix-cgu" @label={{t "pages.terms-of-service.cgu" htmlSafe=true}} {{on "change" this.onChange}} />
+    <PixCheckbox @id="pix-cgu" {{on "change" this.onChange}}>
+      {{t "pages.terms-of-service.cgu" htmlSafe=true}}
+    </PixCheckbox>
+
     {{#if this.showErrorTermsOfServiceNotSelected}}
       <div class="terms-of-service-form-conditions__validation-error">
         {{t "pages.terms-of-service.form.error-message"}}

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^18.2.0",
+        "@1024pix/pix-ui": "^19.0.1",
         "@ember/jquery": "^2.0.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^2.0.4",
@@ -33,7 +33,6 @@
         "dotenv": "^16.0.1",
         "ember-api-actions": "^0.2.9",
         "ember-auto-import": "^1.12.2",
-        "ember-burger-menu": "^3.3.4",
         "ember-cli": "^3.28.5",
         "ember-cli-app-version": "^5.0.0",
         "ember-cli-autoprefixer": "^2.0.0",
@@ -457,9 +456,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-18.2.0.tgz",
-      "integrity": "sha512-lpObapOsP4L26fKv9XAoVT6df+t1fRzWuvTLBgSqRm0O9CQt7HJO4N0CT6uqJtdSPt74Z4qFiUn7NnOVke0Pdg==",
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-19.0.1.tgz",
+      "integrity": "sha512-x3LisKbHYr6U9eQGBAxAF1nmhBAifvhMZBj+bRKOn/lv8CLJ74XvWasMrAkt4GQIY/OeyUaakF1Mx8xRaLeOzw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -37978,9 +37977,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-18.0.2.tgz",
-      "integrity": "sha512-1qZVEXze048T7uZYUoKYIDBuEN9SDHrRGv5vqrNx8DNSFlu7ve4Edrw1JYtKcOcDgK1R7t/wfbrUh3M89upIag==",
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-19.0.1.tgz",
+      "integrity": "sha512-x3LisKbHYr6U9eQGBAxAF1nmhBAifvhMZBj+bRKOn/lv8CLJ74XvWasMrAkt4GQIY/OeyUaakF1Mx8xRaLeOzw==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^18.2.0",
+    "@1024pix/pix-ui": "^19.0.1",
     "@ember/jquery": "^2.0.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.4",


### PR DESCRIPTION
## :jack_o_lantern: Problème
Nous souhaitons utiliser la dernière version de pix ui.

## :bat: Solution
Nous passons d'abord à la version 19.0.1 qui introduit un breaking change, et nous passerons à la version 20 qui introduit également un breaking change dans une autre PR. Nous serons alors sur la version la plus récente de Pix UI.

## :spider_web: Remarques
Nous n'avons pas eu à prendre en compte l'upgrade concernant le composant `PixMultiSelect` car il n'y en a pas sur mon-pix.

## :ghost: Pour tester
Tester les écrans suivants et constater qu'il n'y a pas de regressions concernant les checkbox :

- Etape de confirmation de récupération de compte
- Page de création de compte
- Autre écran qui contient une checkbox