### PR TITLE
[FEATURE] Permettre de cacher la page "Mes formations" lors de son développement (PIX-5981).

### DIFF
--- a/api/db/database-builder/factory/build-target-profile-training.js
+++ b/api/db/database-builder/factory/build-target-profile-training.js
@@ -1,10 +1,9 @@
 const databaseBuffer = require('../database-buffer');
-const { buildTargetProfile, buildTraining } = require('./index');
 
 module.exports = function buildTargetProfileTraining({
   id = databaseBuffer.getNextId(),
-  trainingId = buildTraining().id,
-  targetProfileId = buildTargetProfile().id,
+  trainingId,
+  targetProfileId,
 } = {}) {
   const values = {
     id,

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -196,6 +196,7 @@ module.exports = (function () {
     },
 
     featureToggles: {
+      isPixAppTrainingsPageEnabled: isFeatureEnabled(process.env.FT_TRAININGS_PAGE),
       isPixAppTutoFiltersEnabled: isFeatureEnabled(process.env.FT_TUTOS_V2_1_FILTERS),
       isSsoAccountReconciliationEnabled: isFeatureEnabled(process.env.FT_SSO_ACCOUNT_RECONCILIATION),
       isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: isFeatureEnabled(

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -22,6 +22,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
           id: '0',
           type: 'feature-toggles',
           attributes: {
+            'is-pix-app-trainings-page-enabled': false,
             'is-pix-app-tuto-filters-enabled': false,
             'is-sso-account-reconciliation-enabled': false,
             'is-clea-results-retrieval-by-habilitated-certification-centers-enabled': false,


### PR DESCRIPTION
## :jack_o_lantern: Problème
Nous souhaitons faire la page "Mes formations" en plusieurs ticket et donc par conséquent livrer en production par petit bout. Cependant, nous voulons pas que les utilisateurs voient la page durant son développement. 

## :bat: Solution
Ajouter un FT qui aura pour but de conditionner l'affichage de la page 

## :spider_web: Remarques
Le modèle featureToggle du front sera agrémenté uniquement quand la page sera ajoutée

## :ghost: Pour tester
- Se connecter sur Pix APP
- Constater que le retour de l'appel `/feature-toggles` renvoie le nouveau FT.
