### PR TITLE
[TECH] Passage à la version 20.0.1 de Pix UI (PIX-5979)

### DIFF
--- a/mon-pix/app/styles/components/_user-account.scss
+++ b/mon-pix/app/styles/components/_user-account.scss
@@ -2,7 +2,6 @@
 
   &__title {
     margin: 0 0 8px;
-    padding-top: 55px;
     padding-bottom: 26px;
     font-family: $font-open-sans;
     font-size: 3rem;
@@ -10,6 +9,7 @@
     color: $pix-neutral-0;
     position: relative;
     right: 0;
+    text-align: center;
   }
 
   &__validation-title {
@@ -29,7 +29,7 @@
     display: flex;
     justify-content: center;
     flex-wrap: wrap;
-    max-width: 100%;
+    gap: 40px;
 
     .pix-block {
       width: auto;
@@ -41,8 +41,11 @@
     height: max-content;
 
     .user-account-menu {
-      display: flex;
-      flex-direction: column;
+      ul {
+        margin: 0;
+        padding-left: 0;
+        list-style: none;
+      }
 
       ul li {
         border-bottom: 1.5px solid $pix-neutral-10;
@@ -83,9 +86,9 @@
   }
 
   &__content.pix-block {
-    margin-left: 40px;
-    width: 645px;
+    flex-grow: 1;
     height: max-content;
+    padding: 14px 24px;
 
     @include device-is('mobile') {
       margin-left: 0;

--- a/mon-pix/app/styles/pages/_user-certifications-get.scss
+++ b/mon-pix/app/styles/pages/_user-certifications-get.scss
@@ -12,6 +12,7 @@
     display: flex;
     width: 100%;
     max-width: 980px;
+    margin-top: 32px;
   }
 
   h2 {

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^19.0.1",
+        "@1024pix/pix-ui": "^20.0.1",
         "@ember/jquery": "^2.0.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^2.0.4",
@@ -456,9 +456,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "19.0.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-19.0.1.tgz",
-      "integrity": "sha512-x3LisKbHYr6U9eQGBAxAF1nmhBAifvhMZBj+bRKOn/lv8CLJ74XvWasMrAkt4GQIY/OeyUaakF1Mx8xRaLeOzw==",
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.0.1.tgz",
+      "integrity": "sha512-4UkC7JRKb0Xy2fkq3iDj4oXoqZL1c5XHkNuE9NRc95GhWAhMfYqI5PIPUdb5XI3UDvKBcrn8qT6nsnc+aB5jlQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -37977,9 +37977,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "19.0.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-19.0.1.tgz",
-      "integrity": "sha512-x3LisKbHYr6U9eQGBAxAF1nmhBAifvhMZBj+bRKOn/lv8CLJ74XvWasMrAkt4GQIY/OeyUaakF1Mx8xRaLeOzw==",
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.0.1.tgz",
+      "integrity": "sha512-4UkC7JRKb0Xy2fkq3iDj4oXoqZL1c5XHkNuE9NRc95GhWAhMfYqI5PIPUdb5XI3UDvKBcrn8qT6nsnc+aB5jlQ==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^19.0.1",
+    "@1024pix/pix-ui": "^20.0.1",
     "@ember/jquery": "^2.0.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.4",


### PR DESCRIPTION
## :jack_o_lantern: Problème
Nous souhaitons utiliser la dernière version de pix ui.

## :bat: Solution
Nous passons à la dernière version de pix-ui en date : 20.0.1.

## :spider_web: Remarques
Ce breaking change de style a été géré :
`[BREAKING CHANGES][FEATURE] Suppression du padding dans le composant PixBlock (PIX-5971).`

## :ghost: Pour tester
Vérifier les pages :

- liées au compte utilisateur
- liées aux pages de certification
