### PR TITLE
[FEATURE] Après une connexion SSO, afficher prénom et nom qui seront utilisés pour créer un compte Pix

### DIFF
--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -82,7 +82,8 @@ module.exports = {
     } else {
       const message = "L'utilisateur n'a pas de compte Pix";
       const responseCode = 'SHOULD_VALIDATE_CGU';
-      const meta = { authenticationKey: result.authenticationKey };
+      const { authenticationKey, givenName, familyName } = result;
+      const meta = { authenticationKey, givenName, familyName };
       throw new UnauthorizedError(message, responseCode, meta);
     }
   },

--- a/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
+++ b/api/lib/domain/usecases/authentication/authenticate-oidc-user.js
@@ -33,7 +33,8 @@ module.exports = async function authenticateOidcUser({
 
   if (!userId) {
     const authenticationKey = await authenticationSessionService.save({ userInfo, sessionContent });
-    return { authenticationKey, isAuthenticationComplete: false };
+    const { firstName: givenName, lastName: familyName } = userInfo;
+    return { authenticationKey, givenName, familyName, isAuthenticationComplete: false };
   }
 
   if (!config.featureToggles.isSsoAccountReconciliationEnabled) {

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -167,7 +167,9 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
         .withArgs(identityProvider)
         .returns(oidcAuthenticationService);
       const authenticationKey = 'aaa-bbb-ccc';
-      usecases.authenticateOidcUser.resolves({ authenticationKey });
+      const givenName = 'Mélusine';
+      const familyName = 'TITEGOUTTE';
+      usecases.authenticateOidcUser.resolves({ authenticationKey, givenName, familyName });
 
       // when
       const error = await catchErr(oidcController.authenticateUser)(request, hFake);
@@ -176,7 +178,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       expect(error).to.be.an.instanceOf(UnauthorizedError);
       expect(error.message).to.equal("L'utilisateur n'a pas de compte Pix");
       expect(error.code).to.equal('SHOULD_VALIDATE_CGU');
-      expect(error.meta).to.deep.equal({ authenticationKey });
+      expect(error.meta).to.deep.equal({ authenticationKey, givenName, familyName });
     });
 
     context('when isSsoAccountReconciliationEnabled is false', function () {

--- a/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
@@ -137,8 +137,10 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
     it('should save the authentication session and return the authentication key', async function () {
       // given
       const sessionContent = _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId });
-      const key = 'aaa-bbb-ccc';
-      authenticationSessionService.save.resolves(key);
+      const authenticationKey = 'aaa-bbb-ccc';
+      const givenName = 'Mélusine';
+      const familyName = 'TITEGOUTTE';
+      authenticationSessionService.save.resolves(authenticationKey);
       userRepository.findByExternalIdentifier.resolves(null);
 
       // when
@@ -153,7 +155,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
 
       // then
       expect(authenticationSessionService.save).to.have.been.calledWith(sessionContent);
-      expect(result).to.deep.equal({ authenticationKey: key, isAuthenticationComplete: false });
+      expect(result).to.deep.equal({ authenticationKey, givenName, familyName, isAuthenticationComplete: false });
     });
 
     it('should not create an access token, save the id token in storage, or update the last logged date', async function () {
@@ -453,8 +455,8 @@ function _fakeOidcAPI({ oidcAuthenticationService, externalIdentityId }) {
     refreshToken: 'refreshToken',
   });
   const userInfo = {
-    family_name: 'Morris',
-    given_name: 'Tuck',
+    firstName: 'Mélusine',
+    lastName: 'TITEGOUTTE',
     externalIdentityId,
   };
 

--- a/mon-pix/app/components/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.hbs
@@ -2,12 +2,19 @@
 <div class="login-or-register-oidc-form__container">
   <div class="login-or-register-oidc-form__register-container">
     <h2 class="login-or-register-oidc-form__subtitle">{{t "pages.login-or-register-oidc.register-form.title"}}</h2>
-    <p class="login-or-register-oidc-form__description">
-      {{t
-        "pages.login-or-register-oidc.register-form.description"
-        identityProviderOrganizationName=this.identityProviderOrganizationName
-      }}
-    </p>
+    <div class="login-or-register-oidc-form__description">
+      <p>
+        {{! template-lint-disable "no-bare-strings" }}
+        {{t "pages.login-or-register-oidc.register-form.description"}}
+        <em>{{this.identityProviderOrganizationName}}</em>&nbsp;:
+      </p>
+      <div class="login-or-register-oidc-form__information">
+        <ul>
+          <li>{{t "pages.login-or-register-oidc.register-form.information.given-name" givenName=this.givenName}}</li>
+          <li>{{t "pages.login-or-register-oidc.register-form.information.family-name" familyName=this.familyName}}</li>
+        </ul>
+      </div>
+    </div>
     <div class="login-or-register-oidc-form__cgu-container">
       <PixCheckbox @id="checkbox" @screenReaderOnly="true" {{on "change" this.onChange}}>
         {{t "common.cgu.label"}}

--- a/mon-pix/app/components/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.js
@@ -35,6 +35,14 @@ export default class LoginOrRegisterOidcComponent extends Component {
     return this.oidcIdentityProviders[this.args.identityProviderSlug]?.organizationName;
   }
 
+  get givenName() {
+    return this.args.givenName;
+  }
+
+  get familyName() {
+    return this.args.familyName;
+  }
+
   get currentLanguage() {
     return this.intl.t('current-lang');
   }

--- a/mon-pix/app/controllers/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/controllers/authentication/login-or-register-oidc.js
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class LoginOrRegisterOidcController extends Controller {
-  queryParams = ['authenticationKey', 'identityProviderSlug'];
+  queryParams = ['authenticationKey', 'identityProviderSlug', 'givenName', 'familyName'];
 
   @service url;
   @service oidcIdentityProviders;

--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -43,7 +43,7 @@ export default class LoginOidcRoute extends Route {
     }
   }
 
-  afterModel({ shouldValidateCgu, authenticationKey, identityProviderSlug } = {}) {
+  afterModel({ shouldValidateCgu, authenticationKey, identityProviderSlug, givenName, familyName } = {}) {
     const shouldCreateAnAccountForUser = shouldValidateCgu && authenticationKey;
 
     if (!shouldCreateAnAccountForUser) return;
@@ -53,6 +53,8 @@ export default class LoginOidcRoute extends Route {
         queryParams: {
           authenticationKey,
           identityProviderSlug,
+          givenName,
+          familyName,
         },
       });
     }
@@ -76,10 +78,11 @@ export default class LoginOidcRoute extends Route {
         hostSlug: 'token',
       });
     } catch (response) {
-      const shouldValidateCgu = get(response, 'errors[0].code') === 'SHOULD_VALIDATE_CGU';
-      const authenticationKey = get(response, 'errors[0].meta.authenticationKey');
+      const apiError = get(response, 'errors[0]');
+      const shouldValidateCgu = apiError.code === 'SHOULD_VALIDATE_CGU';
+      const { authenticationKey, givenName, familyName } = apiError.meta ?? {};
       if (shouldValidateCgu && authenticationKey) {
-        return { shouldValidateCgu, authenticationKey, identityProviderSlug };
+        return { shouldValidateCgu, authenticationKey, identityProviderSlug, givenName, familyName };
       }
       throw new Error(JSON.stringify(response.errors));
     } finally {

--- a/mon-pix/app/styles/components/authentication/_login-or-register-oidc.scss
+++ b/mon-pix/app/styles/components/authentication/_login-or-register-oidc.scss
@@ -67,6 +67,29 @@
     margin: 0;
   }
 
+  &__description em {
+    color: $pix-neutral-90;
+    font-style: normal;
+    padding-left: 0.2rem;
+    padding-right: 0.2rem;
+  }
+
+  &__information {
+    color: $pix-neutral-60;
+    font-family: $font-open-sans;
+    font-weight: 600;
+    font-size: 16px;
+    margin-bottom: 2rem;
+
+    ul {
+      padding-left: 1rem;
+    }
+
+    li {
+      list-style: initial;
+    }
+  }
+
   &__register-container,
   &__login-container {
     display: flex;

--- a/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
@@ -21,6 +21,8 @@
       <Authentication::LoginOrRegisterOidc
         @identityProviderSlug={{this.identityProviderSlug}}
         @authenticationKey={{this.authenticationKey}}
+        @givenName={{this.givenName}}
+        @familyName={{this.familyName}}
         @onLogin={{this.onLogin}}
       />
     {{/if}}

--- a/mon-pix/tests/integration/components/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/integration/components/authentication/login-or-register-oidc_test.js
@@ -10,6 +10,7 @@ describe('Integration | Component | authentication | login-or-register-oidc', fu
 
   beforeEach(function () {
     this.set('identityProviderSlug', 'oidc-partner');
+
     const oidcPartner = {
       id: 'oidc-partner',
       code: 'OIDC_PARTNER',
@@ -22,6 +23,9 @@ describe('Integration | Component | authentication | login-or-register-oidc', fu
       list = [oidcPartner];
     }
     this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
+
+    this.set('givenName', 'Mélusine');
+    this.set('familyName', 'TITEGOUTTE');
   });
 
   it('should display heading', async function () {
@@ -43,7 +47,7 @@ describe('Integration | Component | authentication | login-or-register-oidc', fu
     it('should display elements for OIDC identity provider', async function () {
       // given & when
       const screen = await render(
-        hbs`<Authentication::LoginOrRegisterOidc @identityProviderSlug={{this.identityProviderSlug}} />`
+        hbs`<Authentication::LoginOrRegisterOidc @identityProviderSlug={{this.identityProviderSlug}} @givenName={{this.givenName}} @familyName={{this.familyName}}/>`
       );
 
       // then
@@ -53,19 +57,27 @@ describe('Integration | Component | authentication | login-or-register-oidc', fu
           level: 2,
         })
       ).to.exist;
-      expect(screen.getByRole('checkbox', { name: this.intl.t('common.cgu.label') })).to.exist;
-      expect(screen.getByRole('link', { name: this.intl.t('common.cgu.cgu') })).to.exist;
-      expect(screen.getByRole('link', { name: this.intl.t('common.cgu.data-protection-policy') })).to.exist;
       expect(
         screen.getByRole('button', { name: this.intl.t('pages.login-or-register-oidc.register-form.button') })
       ).to.exist;
+      expect(screen.getByText('Partenaire OIDC')).to.exist;
       expect(
         screen.getByText(
-          this.intl.t('pages.login-or-register-oidc.register-form.description', {
-            identityProviderOrganizationName: 'Partenaire OIDC',
+          this.intl.t('pages.login-or-register-oidc.register-form.information.given-name', {
+            givenName: 'Mélusine',
           })
         )
       ).to.exist;
+      expect(
+        screen.getByText(
+          this.intl.t('pages.login-or-register-oidc.register-form.information.family-name', {
+            familyName: 'TITEGOUTTE',
+          })
+        )
+      ).to.exist;
+      expect(screen.getByRole('checkbox', { name: this.intl.t('common.cgu.label') })).to.exist;
+      expect(screen.getByRole('link', { name: this.intl.t('common.cgu.cgu') })).to.exist;
+      expect(screen.getByRole('link', { name: this.intl.t('common.cgu.data-protection-policy') })).to.exist;
     });
   });
 
@@ -73,7 +85,7 @@ describe('Integration | Component | authentication | login-or-register-oidc', fu
     it('should display elements for OIDC identity provider', async function () {
       // given & when
       const screen = await render(
-        hbs`<Authentication::LoginOrRegisterOidc @identityProviderSlug={{this.identityProviderSlug}} />`
+        hbs`<Authentication::LoginOrRegisterOidc @identityProviderSlug={{this.identityProviderSlug}} @givenName={{this.givenName}} @familyName={{this.familyName}}/>`
       );
 
       // then
@@ -89,6 +101,20 @@ describe('Integration | Component | authentication | login-or-register-oidc', fu
       expect(screen.getByRole('link', { name: this.intl.t('pages.sign-in.forgotten-password') })).to.exist;
       expect(
         screen.getByRole('button', { name: this.intl.t('pages.login-or-register-oidc.login-form.button') })
+      ).to.exist;
+      expect(
+        screen.getByText(
+          this.intl.t('pages.login-or-register-oidc.register-form.information.given-name', {
+            givenName: 'Mélusine',
+          })
+        )
+      ).to.exist;
+      expect(
+        screen.getByText(
+          this.intl.t('pages.login-or-register-oidc.register-form.information.family-name', {
+            familyName: 'TITEGOUTTE',
+          })
+        )
       ).to.exist;
     });
   });

--- a/mon-pix/tests/unit/routes/authentication/login-oidc_test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-oidc_test.js
@@ -152,7 +152,12 @@ describe('Unit | Route | login-oidc', function () {
 
           // then
           sinon.assert.calledWith(route.router.replaceWith, 'authentication.login-or-register-oidc', {
-            queryParams: { authenticationKey: '123', identityProviderSlug },
+            queryParams: {
+              authenticationKey: '123',
+              identityProviderSlug,
+              givenName: undefined,
+              familyName: undefined,
+            },
           });
         });
       });
@@ -221,9 +226,14 @@ describe('Unit | Route | login-oidc', function () {
 
     it('should return values to be received by after model to validate CGUs', async function () {
       // given
-      const authenticateStub = sinon
-        .stub()
-        .rejects({ errors: [{ code: 'SHOULD_VALIDATE_CGU', meta: { authenticationKey: 'key' } }] });
+      const authenticateStub = sinon.stub().rejects({
+        errors: [
+          {
+            code: 'SHOULD_VALIDATE_CGU',
+            meta: { authenticationKey: 'key', givenName: 'Mélusine', familyName: 'TITEGOUTTE' },
+          },
+        ],
+      });
       const sessionStub = Service.create({
         authenticate: authenticateStub,
         data: {},
@@ -244,6 +254,8 @@ describe('Unit | Route | login-oidc', function () {
         shouldValidateCgu: true,
         authenticationKey: 'key',
         identityProviderSlug: 'oidc-partner',
+        givenName: 'Mélusine',
+        familyName: 'TITEGOUTTE',
       });
     });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -950,7 +950,11 @@
         "button": "Log in"
       },
       "register-form": {
-        "description": "Un compte va être créé à partir des éléments transmis par l'organisme : {identityProviderOrganizationName}",
+        "description": "Un compte va être créé à partir des éléments transmis par l'organisme",
+        "information": {
+          "given-name": "Prénom : {givenName}",
+          "family-name": "Nom : {familyName}"
+        },
         "title": "Je n’ai pas de compte Pix",
         "button": "Je créé mon compte"
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -950,7 +950,11 @@
         "button": "Je me connecte"
       },
       "register-form": {
-        "description": "Un compte va être créé à partir des éléments transmis par l'organisme : {identityProviderOrganizationName}",
+        "description": "Un compte va être créé à partir des éléments transmis par l'organisme",
+        "information": {
+          "given-name": "Prénom : {givenName}",
+          "family-name": "Nom : {familyName}"
+        },
         "title": "Je n’ai pas de compte Pix",
         "button": "Je créé mon compte"
       },


### PR DESCRIPTION
## :jack_o_lantern: Problème

Après une connexion SSO, sur la double mire, dans la partie de gauche « Je n’ai pas de compte Pix », aujourd’hui il y a la phrase « Un compte va être créé à partir des éléments transmis par l’organisme: {nom du SSO} » mais sans afficher quel est le compte avec lequel l'utilisateur vient juste de s'authentifier auprès du SSO.

Nous devons afficher les informations (nom et prénom) que nous avons reçu du SSO qui permettront à l’utilisateur de choisir s’il souhaite vraiment se créer un compte avec ces informations là.

## :bat: Solution

À la suite du nom du SSO, afficher le nom et le prénom.

## :spider_web: Remarques

### Utilisation de query params

La solution proposée passe les nom (`familyName`) et prenom (`givenName`) en queryParams, qui sont donc visibles dans l'URL et qui sont donc modifiables si l'URL est trafiqué. Ce n'est donc pas bon pour la sécurité. Cette PR propose donc une première solution simple qu'il faudra revisiter plus tard pour ne plus faire transiter ces informations par les queryParams.

La solution de faire une requête XHR _supplémentaire_ pour récupérer ces informations au niveau du front a été écartée car ces informations sont _déjà connues_ au moment où on affiche la page avec la double mire.

Une solution consistant à stocker de manière persistante ces informations, sans avoir donc à les faire passer par les queryParams, serait donc plus sûre et sûrement plus élégante. Donc revisiter techniquement plus tard.

## :ghost: Pour tester

1. Mettre `FT_SSO_ACCOUNT_RECONCILIATION=true` dans le `.env`.
2. Se connecter à pix-app avec un SSO OIDC (n'importe lequel)
3. S'authentifier auprès du SSO (si possible avec le compte d'un utilisateur ayant des accents dans son nom ou prénom)
4. Vérifier que la double mire affiche bien comme ci-dessous (les accents ne doivent pas poser de problème d'affichage) :
   ```
   Un compte va être créé à partir des éléments transmis par l'organisme NOM_DU_SSO :
   
   Prénom : PRÉNOM_DE_L_UTILISATEUR
   Nom : NOM_DE_L_UTILISATEUR
   ```
5. Vérifier qu'une telle liste de « Prénom » et « Nom » n'apparaisse pas dans d'autres cas non-souhaités qui ne seraient pas connus des développeurs ayant travaillé sur ce ticket.