### PR TITLE
[FEATURE] Ajout d'un filtre par nom et prénom dans l'onglet étudiants (PIX-5567)

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -747,8 +747,6 @@ exports.register = async (server) => {
             'page[number]': Joi.number().integer().empty(''),
             'filter[certificability][]': [Joi.string(), Joi.array().items(Joi.string())],
             'filter[groups][]': [Joi.string(), Joi.array().items(Joi.string())],
-            'filter[firstName]': Joi.string().empty(''),
-            'filter[lastName]': Joi.string().empty(''),
             'filter[search]': Joi.string().empty(''),
             'filter[studentNumber]': Joi.string().empty(''),
           }),

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -749,6 +749,7 @@ exports.register = async (server) => {
             'filter[groups][]': [Joi.string(), Joi.array().items(Joi.string())],
             'filter[firstName]': Joi.string().empty(''),
             'filter[lastName]': Joi.string().empty(''),
+            'filter[search]': Joi.string().empty(''),
             'filter[studentNumber]': Joi.string().empty(''),
           }),
         },

--- a/api/lib/infrastructure/repositories/sup-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sup-organization-participant-repository.js
@@ -5,13 +5,7 @@ const CampaignTypes = require('../../domain/models/CampaignTypes');
 const CampaignParticipationStatuses = require('../../domain/models/CampaignParticipationStatuses');
 const { filterByFullName } = require('../utils/filter-utils');
 
-function _setFilters(qb, { lastName, firstName, search, studentNumber, groups, certificability } = {}) {
-  if (lastName) {
-    qb.whereRaw('LOWER("organization-learners"."lastName") LIKE ?', `%${lastName.toLowerCase()}%`);
-  }
-  if (firstName) {
-    qb.whereRaw('LOWER("organization-learners"."firstName") LIKE ?', `%${firstName.toLowerCase()}%`);
-  }
+function _setFilters(qb, { search, studentNumber, groups, certificability } = {}) {
   if (search) {
     filterByFullName(qb, search, 'organization-learners.firstName', 'organization-learners.lastName');
   }

--- a/api/lib/infrastructure/repositories/sup-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sup-organization-participant-repository.js
@@ -3,13 +3,17 @@ const { fetchPage } = require('../utils/knex-utils');
 const SupOrganizationParticipant = require('../../domain/read-models/SupOrganizationParticipant');
 const CampaignTypes = require('../../domain/models/CampaignTypes');
 const CampaignParticipationStatuses = require('../../domain/models/CampaignParticipationStatuses');
+const { filterByFullName } = require('../utils/filter-utils');
 
-function _setFilters(qb, { lastName, firstName, studentNumber, groups, certificability } = {}) {
+function _setFilters(qb, { lastName, firstName, search, studentNumber, groups, certificability } = {}) {
   if (lastName) {
     qb.whereRaw('LOWER("organization-learners"."lastName") LIKE ?', `%${lastName.toLowerCase()}%`);
   }
   if (firstName) {
     qb.whereRaw('LOWER("organization-learners"."firstName") LIKE ?', `%${firstName.toLowerCase()}%`);
+  }
+  if (search) {
+    filterByFullName(qb, search, 'organization-learners.firstName', 'organization-learners.lastName');
   }
   if (studentNumber) {
     qb.whereRaw('LOWER("organization-learners"."studentNumber") LIKE ?', `%${studentNumber.toLowerCase()}%`);

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1291,36 +1291,6 @@ describe('Acceptance | Application | organization-controller', function () {
         expect(response.statusCode).to.equal(200);
       });
 
-      it('should filter lastName', async function () {
-        // given
-        options = {
-          method: 'GET',
-          url: `/api/organizations/${organization.id}/sup-participants?filter[lastName]=Bruce`,
-          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
-        };
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(200);
-      });
-
-      it('should filter firstName', async function () {
-        // given
-        options = {
-          method: 'GET',
-          url: `/api/organizations/${organization.id}/sup-participants?filter[firstName]=Wayne`,
-          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
-        };
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(200);
-      });
-
       context('certificability', function () {
         it('should filter certificability with one value', async function () {
           // given

--- a/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
@@ -211,6 +211,40 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
         expect(_.map(data, 'firstName')).to.deep.equal(['Bar', 'Baz']);
       });
 
+      it('should return sup participants filtered by fullname search', async function () {
+        // given
+        const organization = databaseBuilder.factory.buildOrganization();
+
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          firstName: 'Foo',
+          lastName: '1',
+        });
+
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          firstName: 'Bar',
+          lastName: 'Dupont',
+        });
+
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          firstName: 'Baz',
+          lastName: 'Dupond',
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+          organizationId: organization.id,
+          filter: { search: 'b dupon' },
+        });
+
+        // then
+        expect(_.map(data, 'firstName')).to.include.members(['Bar', 'Baz']);
+      });
+
       it('should return sup participants filtered by student number', async function () {
         // given
         const organization = databaseBuilder.factory.buildOrganization();

--- a/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
@@ -161,56 +161,6 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
     });
 
     describe('When sup participant is filtered', function () {
-      it('should return sup participants filtered by lastname', async function () {
-        // given
-        const organization = databaseBuilder.factory.buildOrganization();
-
-        databaseBuilder.factory.buildOrganizationLearner({ organizationId: organization.id, lastName: 'Grenier' });
-        databaseBuilder.factory.buildOrganizationLearner({ organizationId: organization.id, lastName: 'Avatar' });
-        databaseBuilder.factory.buildOrganizationLearner({ organizationId: organization.id, lastName: 'UvAtur' });
-        await databaseBuilder.commit();
-
-        // when
-        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
-          organizationId: organization.id,
-          filter: { lastName: 'Vat' },
-        });
-
-        // then
-        expect(_.map(data, 'lastName')).to.deep.equal(['Avatar', 'UvAtur']);
-      });
-
-      it('should return sup participants filtered by firstname', async function () {
-        // given
-        const organization = databaseBuilder.factory.buildOrganization();
-
-        databaseBuilder.factory.buildOrganizationLearner({
-          organizationId: organization.id,
-          firstName: 'Foo',
-          lastName: '1',
-        });
-        databaseBuilder.factory.buildOrganizationLearner({
-          organizationId: organization.id,
-          firstName: 'Bar',
-          lastName: '2',
-        });
-        databaseBuilder.factory.buildOrganizationLearner({
-          organizationId: organization.id,
-          firstName: 'Baz',
-          lastName: '3',
-        });
-        await databaseBuilder.commit();
-
-        // when
-        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
-          organizationId: organization.id,
-          filter: { firstName: 'ba' },
-        });
-
-        // then
-        expect(_.map(data, 'firstName')).to.deep.equal(['Bar', 'Baz']);
-      });
-
       it('should return sup participants filtered by fullname search', async function () {
         // given
         const organization = databaseBuilder.factory.buildOrganization();
@@ -243,102 +193,6 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
 
         // then
         expect(_.map(data, 'firstName')).to.include.members(['Bar', 'Baz']);
-      });
-
-      it('should return sup participants filtered by student number', async function () {
-        // given
-        const organization = databaseBuilder.factory.buildOrganization();
-
-        databaseBuilder.factory.buildOrganizationLearner({
-          organizationId: organization.id,
-          firstName: 'Foo',
-          lastName: '1',
-          studentNumber: 'FOO123',
-        });
-        databaseBuilder.factory.buildOrganizationLearner({
-          organizationId: organization.id,
-          firstName: 'Bar',
-          lastName: '2',
-          studentNumber: 'BAR123',
-        });
-        databaseBuilder.factory.buildOrganizationLearner({
-          organizationId: organization.id,
-          firstName: 'Baz',
-          lastName: '3',
-          studentNumber: 'BAZ123',
-        });
-        await databaseBuilder.commit();
-
-        // when
-        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
-          organizationId: organization.id,
-          filter: { studentNumber: 'ba' },
-        });
-
-        // then
-        expect(_.map(data, 'studentNumber')).to.deep.equal(['BAR123', 'BAZ123']);
-      });
-
-      it('should return sup participants filtered by group', async function () {
-        // given
-        const organization = databaseBuilder.factory.buildOrganization();
-
-        databaseBuilder.factory.buildOrganizationLearner({
-          organizationId: organization.id,
-          lastName: '1',
-          group: '4A',
-        });
-        databaseBuilder.factory.buildOrganizationLearner({
-          organizationId: organization.id,
-          lastName: '2',
-          group: '3B',
-        });
-        databaseBuilder.factory.buildOrganizationLearner({
-          organizationId: organization.id,
-          lastName: '3',
-          group: '3A',
-        });
-        await databaseBuilder.commit();
-
-        // when
-        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
-          organizationId: organization.id,
-          filter: { groups: ['3A', '3B'] },
-        });
-
-        // then
-        expect(_.map(data, 'group')).to.deep.equal(['3B', '3A']);
-      });
-
-      it('should return sup participants filtered by firstname AND lastname', async function () {
-        // given
-        const organization = databaseBuilder.factory.buildOrganization();
-
-        databaseBuilder.factory.buildOrganizationLearner({
-          organizationId: organization.id,
-          firstName: 'John',
-          lastName: 'Rambo',
-        });
-        databaseBuilder.factory.buildOrganizationLearner({
-          organizationId: organization.id,
-          firstName: 'Jane',
-          lastName: 'Rambo',
-        });
-        databaseBuilder.factory.buildOrganizationLearner({
-          organizationId: organization.id,
-          firstName: 'Chuck',
-          lastName: 'Norris',
-        });
-        await databaseBuilder.commit();
-
-        // when
-        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
-          organizationId: organization.id,
-          filter: { firstName: 'ja', lastName: 'ram' },
-        });
-
-        // then
-        expect(_.map(data, 'firstName')).to.deep.equal(['Jane']);
       });
 
       it('should return sup participants that are eligible for certificability', async function () {
@@ -444,6 +298,71 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
           notCommunicatedOrganizationLearner.id,
           notEligibleOrganizationLearner.id,
         ]);
+      });
+
+      it('should return sup participants filtered by student number', async function () {
+        // given
+        const organization = databaseBuilder.factory.buildOrganization();
+
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          firstName: 'Foo',
+          lastName: '1',
+          studentNumber: 'FOO123',
+        });
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          firstName: 'Bar',
+          lastName: '2',
+          studentNumber: 'BAR123',
+        });
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          firstName: 'Baz',
+          lastName: '3',
+          studentNumber: 'BAZ123',
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+          organizationId: organization.id,
+          filter: { studentNumber: 'ba' },
+        });
+
+        // then
+        expect(_.map(data, 'studentNumber')).to.deep.equal(['BAR123', 'BAZ123']);
+      });
+
+      it('should return sup participants filtered by group', async function () {
+        // given
+        const organization = databaseBuilder.factory.buildOrganization();
+
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          lastName: '1',
+          group: '4A',
+        });
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          lastName: '2',
+          group: '3B',
+        });
+        databaseBuilder.factory.buildOrganizationLearner({
+          organizationId: organization.id,
+          lastName: '3',
+          group: '3A',
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const { data } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+          organizationId: organization.id,
+          filter: { groups: ['3A', '3B'] },
+        });
+
+        // then
+        expect(_.map(data, 'group')).to.deep.equal(['3B', '3A']);
       });
 
       it('should return sup participants paginated', async function () {

--- a/api/tests/unit/domain/usecases/find-paginated-filtered-sup-participants_test.js
+++ b/api/tests/unit/domain/usecases/find-paginated-filtered-sup-participants_test.js
@@ -19,14 +19,14 @@ describe('Unit | UseCase | findPaginatedFilteredSupParticipants', function () {
   it('should fetch sup participants matching organization', async function () {
     foundSupParticipants = await findPaginatedFilteredSupParticipants({
       organizationId,
-      filter: { lastName: 'A', group: 'L1' },
+      filter: { search: 'Arm', group: 'L1' },
       page: { size: 10, number: 1 },
       supOrganizationParticipantRepository,
     });
 
     expect(supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants).to.have.been.calledWithExactly({
       organizationId,
-      filter: { lastName: 'A', group: 'L1' },
+      filter: { search: 'Arm', group: 'L1' },
       page: { size: 10, number: 1 },
     });
     expect(foundSupParticipants).to.deep.equal(expectedSupParticipants);

--- a/orga/app/components/sup-organization-participant/list.hbs
+++ b/orga/app/components/sup-organization-participant/list.hbs
@@ -27,6 +27,13 @@
     @ariaLabel={{t "pages.sup-organization-participants.filter.first-name.aria-label"}}
     @triggerFiltering={{@onFilter}}
   />
+  <Ui::SearchInputFilter
+    @field="search"
+    @value={{@searchFilter}}
+    @placeholder={{t "pages.sup-organization-participants.filter.search.label"}}
+    @ariaLabel={{t "pages.sup-organization-participants.filter.search.aria-label"}}
+    @triggerFiltering={{@onFilter}}
+  />
   <Ui::MultiSelectFilter
     @field="groups"
     @title={{t "pages.sup-organization-participants.table.column.group"}}

--- a/orga/app/components/sup-organization-participant/list.hbs
+++ b/orga/app/components/sup-organization-participant/list.hbs
@@ -14,20 +14,6 @@
     @triggerFiltering={{@onFilter}}
   />
   <Ui::SearchInputFilter
-    @field="lastName"
-    @value={{@lastNameFilter}}
-    @placeholder={{t "pages.sup-organization-participants.filter.last-name.label"}}
-    @ariaLabel={{t "pages.sup-organization-participants.filter.last-name.aria-label"}}
-    @triggerFiltering={{@onFilter}}
-  />
-  <Ui::SearchInputFilter
-    @field="firstName"
-    @value={{@firstNameFilter}}
-    @placeholder={{t "pages.sup-organization-participants.filter.first-name.label"}}
-    @ariaLabel={{t "pages.sup-organization-participants.filter.first-name.aria-label"}}
-    @triggerFiltering={{@onFilter}}
-  />
-  <Ui::SearchInputFilter
     @field="search"
     @value={{@searchFilter}}
     @placeholder={{t "pages.sup-organization-participants.filter.search.label"}}

--- a/orga/app/controllers/authenticated/sup-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sup-organization-participants/list.js
@@ -3,8 +3,6 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 
 export default class ListController extends Controller {
-  @tracked lastName = null;
-  @tracked firstName = null;
   @tracked search = null;
   @tracked studentNumber = null;
   @tracked groups = [];
@@ -20,8 +18,6 @@ export default class ListController extends Controller {
 
   @action
   onResetFilter() {
-    this.lastName = null;
-    this.firstName = null;
     this.search = null;
     this.studentNumber = null;
     this.groups = [];

--- a/orga/app/controllers/authenticated/sup-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sup-organization-participants/list.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 export default class ListController extends Controller {
   @tracked lastName = null;
   @tracked firstName = null;
+  @tracked search = null;
   @tracked studentNumber = null;
   @tracked groups = [];
   @tracked certificability = [];
@@ -21,6 +22,7 @@ export default class ListController extends Controller {
   onResetFilter() {
     this.lastName = null;
     this.firstName = null;
+    this.search = null;
     this.studentNumber = null;
     this.groups = [];
     this.certificability = [];

--- a/orga/app/routes/authenticated/sup-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sup-organization-participants/list.js
@@ -7,6 +7,7 @@ export default class ListRoute extends Route {
   queryParams = {
     lastName: { refreshModel: true },
     firstName: { refreshModel: true },
+    search: { refreshModel: true },
     studentNumber: { refreshModel: true },
     groups: { refreshModel: true },
     certificability: { refreshModel: true },
@@ -24,6 +25,7 @@ export default class ListRoute extends Route {
         organizationId,
         lastName: params.lastName,
         firstName: params.firstName,
+        search: params.search,
         studentNumber: params.studentNumber,
         groups: params.groups,
         certificability: params.certificability,
@@ -39,6 +41,7 @@ export default class ListRoute extends Route {
     if (isExiting) {
       controller.lastName = null;
       controller.firstName = null;
+      controller.search = null;
       controller.studentNumber = null;
       controller.groups = [];
       controller.certificability = [];

--- a/orga/app/routes/authenticated/sup-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sup-organization-participants/list.js
@@ -5,8 +5,6 @@ import Route from '@ember/routing/route';
 
 export default class ListRoute extends Route {
   queryParams = {
-    lastName: { refreshModel: true },
-    firstName: { refreshModel: true },
     search: { refreshModel: true },
     studentNumber: { refreshModel: true },
     groups: { refreshModel: true },
@@ -23,8 +21,6 @@ export default class ListRoute extends Route {
     return this.store.query('sup-organization-participant', {
       filter: {
         organizationId,
-        lastName: params.lastName,
-        firstName: params.firstName,
         search: params.search,
         studentNumber: params.studentNumber,
         groups: params.groups,
@@ -39,8 +35,6 @@ export default class ListRoute extends Route {
 
   resetController(controller, isExiting) {
     if (isExiting) {
-      controller.lastName = null;
-      controller.firstName = null;
       controller.search = null;
       controller.studentNumber = null;
       controller.groups = [];

--- a/orga/app/templates/authenticated/sup-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sup-organization-participants/list.hbs
@@ -6,6 +6,7 @@
     @students={{@model}}
     @lastNameFilter={{this.lastName}}
     @firstNameFilter={{this.firstName}}
+    @searchFilter={{this.search}}
     @studentNumberFilter={{this.studentNumber}}
     @groupsFilter={{this.groups}}
     @certificabilityFilter={{this.certificability}}

--- a/orga/app/templates/authenticated/sup-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sup-organization-participants/list.hbs
@@ -4,8 +4,6 @@
 
   <SupOrganizationParticipant::List
     @students={{@model}}
-    @lastNameFilter={{this.lastName}}
-    @firstNameFilter={{this.firstName}}
     @searchFilter={{this.search}}
     @studentNumberFilter={{this.studentNumber}}
     @groupsFilter={{this.groups}}

--- a/orga/tests/acceptance/sup-organization-participant-list_test.js
+++ b/orga/tests/acceptance/sup-organization-participant-list_test.js
@@ -50,7 +50,7 @@ module('Acceptance | Sup Organization Participant List', function (hooks) {
     });
 
     module('filters', function () {
-      test('it should filter students by group', async function (assert) {
+      test('it filters students by group', async function (assert) {
         // given
         const { getByPlaceholderText, findByRole } = await visit('/etudiants');
 
@@ -68,7 +68,7 @@ module('Acceptance | Sup Organization Participant List', function (hooks) {
         assert.contains('tata');
       });
 
-      test('it should filter by certificability', async function (assert) {
+      test('it filters by certificability', async function (assert) {
         // given
         const organizationId = user.memberships.models.firstObject.organizationId;
 
@@ -86,6 +86,15 @@ module('Acceptance | Sup Organization Participant List', function (hooks) {
 
         // then
         assert.strictEqual(decodeURI(currentURL()), '/etudiants?certificability=["eligible"]');
+      });
+
+      test('it filters by search', async function (assert) {
+        // when
+        await visit('/etudiants');
+        await fillByLabel('Recherche sur le nom et prénom', 'Jo');
+
+        // then
+        assert.strictEqual(currentURL(), '/etudiants?search=Jo');
       });
     });
 

--- a/orga/tests/integration/components/sup-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list_test.js
@@ -220,6 +220,22 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
       assert.ok(true);
     });
 
+    test('it should trigger filtering with search', async function (assert) {
+      // given
+      const triggerFiltering = sinon.spy();
+      this.set('triggerFiltering', triggerFiltering);
+      this.set('students', []);
+
+      await render(hbs`<SupOrganizationParticipant::List @students={{students}} @onFilter={{triggerFiltering}}/>`);
+
+      // when
+      await fillByLabel(this.intl.t('pages.sup-organization-participants.filter.search.aria-label'), 'Bob M');
+
+      // then
+      sinon.assert.calledWithExactly(triggerFiltering, 'search', 'Bob M');
+      assert.ok(true);
+    });
+
     test('it should trigger filtering with student number', async function (assert) {
       const triggerFiltering = sinon.spy();
       this.set('triggerFiltering', triggerFiltering);

--- a/orga/tests/integration/components/sup-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list_test.js
@@ -184,42 +184,6 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
   });
 
   module('when user is filtering some users', function () {
-    test('it should trigger filtering with lastname', async function (assert) {
-      const triggerFiltering = sinon.spy();
-      this.set('triggerFiltering', triggerFiltering);
-      this.set('students', []);
-      this.set('groups', []);
-
-      // when
-      await render(
-        hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}} @groups={{this.groups}}/>`
-      );
-
-      await fillByLabel('Entrer un nom', 'bob');
-
-      // then
-      sinon.assert.calledWithExactly(triggerFiltering, 'lastName', 'bob');
-      assert.ok(true);
-    });
-
-    test('it should trigger filtering with firstname', async function (assert) {
-      const triggerFiltering = sinon.spy();
-      this.set('triggerFiltering', triggerFiltering);
-      this.set('students', []);
-      this.set('groups', []);
-
-      // when
-      await render(
-        hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}} @groups={{this.groups}}/>`
-      );
-
-      await fillByLabel('Entrer un prénom', 'bob');
-
-      // then
-      sinon.assert.calledWithExactly(triggerFiltering, 'firstName', 'bob');
-      assert.ok(true);
-    });
-
     test('it should trigger filtering with search', async function (assert) {
       // given
       const triggerFiltering = sinon.spy();

--- a/orga/tests/unit/controllers/authenticated/sup-organization-participants/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/sup-organization-participants/list_test.js
@@ -40,21 +40,17 @@ module('Unit | Controller | authenticated/sup-organization-participants/list', f
   module('#onResetFilter', function () {
     test('resets every filters', async function (assert) {
       // given
-      controller.firstName = 'hey';
-      controller.lastName = 'th';
+      controller.search = 'th';
       controller.groups = ['ing'];
       controller.studentNumber = 'co';
       controller.certificability = ['ool'];
       controller.pageNumber = 1;
       controller.pageSize = 10;
-      controller.search = 'th';
 
       // when
       controller.onResetFilter();
 
       // then
-      assert.strictEqual(controller.firstName, null);
-      assert.strictEqual(controller.lastName, null);
       assert.strictEqual(controller.search, null);
       assert.deepEqual(controller.groups, []);
       assert.strictEqual(controller.studentNumber, null);

--- a/orga/tests/unit/controllers/authenticated/sup-organization-participants/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/sup-organization-participants/list_test.js
@@ -47,6 +47,7 @@ module('Unit | Controller | authenticated/sup-organization-participants/list', f
       controller.certificability = ['ool'];
       controller.pageNumber = 1;
       controller.pageSize = 10;
+      controller.search = 'th';
 
       // when
       controller.onResetFilter();
@@ -54,6 +55,7 @@ module('Unit | Controller | authenticated/sup-organization-participants/list', f
       // then
       assert.strictEqual(controller.firstName, null);
       assert.strictEqual(controller.lastName, null);
+      assert.strictEqual(controller.search, null);
       assert.deepEqual(controller.groups, []);
       assert.strictEqual(controller.studentNumber, null);
       assert.deepEqual(controller.certificability, []);

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -939,19 +939,11 @@
         "certificability": {
           "aria-label": "Enter a status for certificability",          
           "label": "Search by certificability"
-        }, 
-        "first-name": {
-          "aria-label": "Enter a first name",
-          "label": "Search by first name"
         },
         "group": {
           "aria-label": "Enter a group",
           "empty": "No group",
           "label": "Search by group"
-        },
-        "last-name": {
-          "aria-label": "Enter a last name",
-          "label": "Search by last name"
         },
         "search": {
           "aria-label": "Search by lastname and firstname",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -936,6 +936,10 @@
           "clear": "Clear filters"
         },
         "aria-label":"Filters on students",
+        "certificability": {
+          "aria-label": "Enter a status for certificability",          
+          "label": "Search by certificability"
+        }, 
         "first-name": {
           "aria-label": "Enter a first name",
           "label": "Search by first name"
@@ -949,14 +953,14 @@
           "aria-label": "Enter a last name",
           "label": "Search by last name"
         },
+        "search": {
+          "aria-label": "Search by lastname and firstname",
+          "label": "Lastname, firstname"
+        },
         "student-number": {
           "aria-label": "Enter a student number",
           "label": "Search by student number"
-        },
-        "certificability": {
-          "aria-label": "Enter a status for certificability",
-          "label": "Search by certificability"
-        },
+        }, 
         "students-count": "{count, plural, =0 {0 students} =1 {1 student} other {{count} students}}",
         "title": "Filters"
       }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -936,6 +936,10 @@
         "actions": {
           "clear": "Effacer les filtres"
         },
+        "certificability": {
+          "aria-label": "Enter un statut de certification",
+          "label": "Rechercher par certificabilité"
+        },
         "first-name": {
           "aria-label": "Entrer un prénom",
           "label": "Rechercher par prénom"
@@ -945,13 +949,13 @@
           "empty": "Aucun groupe",
           "label": "Rechercher par groupe"
         },
-        "certificability": {
-          "aria-label": "Enter un statut de certification",
-          "label": "Rechercher par certificabilité"
-        },
         "last-name": {
           "aria-label": "Entrer un nom",
           "label": "Rechercher par nom"
+        },
+        "search": {
+          "aria-label": "Recherche sur le nom et prénom",
+          "label": "Nom, prénom"
         },
         "student-number": {
           "aria-label": "Entrer un numéro étudiant",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -940,18 +940,10 @@
           "aria-label": "Enter un statut de certification",
           "label": "Rechercher par certificabilité"
         },
-        "first-name": {
-          "aria-label": "Entrer un prénom",
-          "label": "Rechercher par prénom"
-        },
         "group": {
           "aria-label": "Entrer un groupe",
           "empty": "Aucun groupe",
           "label": "Rechercher par groupe"
-        },
-        "last-name": {
-          "aria-label": "Entrer un nom",
-          "label": "Rechercher par nom"
         },
         "search": {
           "aria-label": "Recherche sur le nom et prénom",


### PR DESCRIPTION
## :jack_o_lantern: Problème
Suite à l’ajout de la liste de participants au sein de Pix Orga, un des besoins qui est remonté est de pouvoir consulter dans cette liste les participants certifiable en un clic et ceux qui ne le sont pas afin de pouvoir réaliser des actions complémentaires (comme des parcours ou contacter la personne)…
Cependant l’affichage et le filtre sur cette donnée sur l’intégralité des participants d’une orga soulève pas mal de questions au niveau performances.
Cette information est calculé : on doit récupéré tous les envois profils, prendre le plus récent, et voir si la personne à au moins un niveau 1 dans 5 compétence. Et ça pour tous les participants d’une organisation.
C’est pourquoi après un benchmark avec la team prescription, nous avons décidé de stocker cette valeur pour mieux l’exploiter dans Pix Orga par la suite.
## :bat: Solution
Maintenant que nous avons ajouté le bandeau de filtre avec tous les filtres du tableau, nous souhaiterions harmoniser les filtres Nom et Prénom et reprendre le comportement que l’on a dans les campagnes c’est à dire : un champ de recherche pour le nom et le prénom (voir capture d'écran ci-dessous) au lieu d’avoir deux champs séparés dans l’onglet ETUDIANTS.

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
- aller sur Pix Orga
- se connecter en tant que sup
- se rendre sur la page /etudiants
- tester le filtre de recherche
- tester le reset des filtres
- tester tous les autres filtres pour voir si ce n'est pas cassé
- tester de partir puis revenir sur la page pour voir si ça ne load pas dans le vide
- tada 🎉 