### PR TITLE
[FEATURE] Afficher un empty state visuel plus text dans l'onglet Etudiants (PIX-5570).

### DIFF
--- a/orga/app/components/sup-organization-participant/list.hbs
+++ b/orga/app/components/sup-organization-participant/list.hbs
@@ -136,9 +136,16 @@
     {{/if}}
   </table>
 
-  {{#unless @students}}
-    <div class="table__empty content-text">{{t "pages.sup-organization-participants.table.empty"}}</div>
-  {{/unless}}
+  {{#if (eq @students.meta.participantCount 0)}}
+    <Ui::EmptyState
+      @infoText={{t "pages.sup-organization-participants.empty-state.no-participants"}}
+      @actionText={{t "pages.sup-organization-participants.empty-state.no-participants-action"}}
+    />
+  {{else if (not @students)}}
+    <div class="table__empty content-text">
+      {{t "pages.sup-organization-participants.table.empty"}}
+    </div>
+  {{/if}}
 </div>
 
 <SupOrganizationParticipant::EditStudentNumberModal

--- a/orga/app/components/ui/empty-state.hbs
+++ b/orga/app/components/ui/empty-state.hbs
@@ -1,0 +1,5 @@
+<section class="panel empty-state">
+  <img src="{{this.rootURL}}/images/empty-state-participants.svg" alt="" role="none" />
+  <p class="participants-empty-state__text">{{@infoText}}</p>
+  <p class="participants-empty-state__text">{{@actionText}}</p>
+</section>

--- a/orga/app/styles/components/ui/empty-state.scss
+++ b/orga/app/styles/components/ui/empty-state.scss
@@ -1,0 +1,4 @@
+.participants-empty-state__text {
+  margin-bottom: $spacing-xs;
+  margin-top: 0px;
+}

--- a/orga/app/styles/components/ui/index.scss
+++ b/orga/app/styles/components/ui/index.scss
@@ -1,4 +1,5 @@
 @import "cards";
 @import "chart";
+@import "empty-state";
 @import "placeholders";
 @import "certificability-tooltip";

--- a/orga/tests/integration/components/sup-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list_test.js
@@ -285,4 +285,38 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
       assert.ok(true);
     });
   });
+
+  module('when filter result does not match current participant information', function () {
+    test('it should display a no student message', async function (assert) {
+      // given
+      const students = [];
+      students.meta = { participantCount: 1 };
+      this.set('students', students);
+      this.set('groups', []);
+      // when
+      await render(
+        hbs`<SupOrganizationParticipant::List @students={{students}} @onFilter={{noop}} @groups={{groups}}/>`
+      );
+
+      // then
+      assert.contains('Aucun étudiant.');
+    });
+  });
+
+  module('when there is no participants in the organization', function () {
+    test('it should display an import students message', async function (assert) {
+      // given
+      const students = [];
+      students.meta = { participantCount: 0 };
+      this.set('students', students);
+      this.set('groups', []);
+      // when
+      await render(
+        hbs`<SupOrganizationParticipant::List @students={{students}} @onFilter={{noop}} @groups={{groups}}/>`
+      );
+
+      // then
+      assert.contains('L’administrateur doit importer les étudiants en cliquant sur le bouton importer.');
+    });
+  });
 });

--- a/orga/tests/integration/components/ui/empty-state_test.js
+++ b/orga/tests/integration/components/ui/empty-state_test.js
@@ -1,0 +1,21 @@
+import { module, test } from 'qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Ui::EmptyState', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display a message telling if there is no participants', async function (assert) {
+    // given
+    this.set('infoText', "Aucun participant pour l'instant !");
+    this.set('actionText', 'L’administrateur doit importer la base élèves en cliquant sur le bouton importer.');
+
+    //when
+    await render(hbs`<Ui::EmptyState @infoText={{infoText}} @actionText={{actionText}}/>`);
+
+    //then
+    assert.contains("Aucun participant pour l'instant !");
+    assert.contains('L’administrateur doit importer la base élèves en cliquant sur le bouton importer.');
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -667,7 +667,7 @@
         "participations-count": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count} participants}}",
         "type": {
           "certificability": {
-            "aria-label": "Enter a status for certificability",           
+            "aria-label": "Enter a status for certificability",
             "label": "Search by certificability"
           },
           "fullName": {
@@ -829,7 +829,7 @@
       },
       "filter": {
         "certificability": {
-          "aria-label": "Enter a status for certificability",         
+          "aria-label": "Enter a status for certificability",
           "label": "Search by certificability"
         },
         "division": {
@@ -906,6 +906,10 @@
           "success": "{firstName} {lastName}'s student number has been successfully edited."
         }
       },
+      "empty-state": {
+        "no-participants": "No students yet!",
+        "no-participants-action": "The administrator must import the students database by clicking on the import button."
+      },
       "table": {
         "column": {
           "date-of-birth": "Date of birth",
@@ -950,9 +954,9 @@
           "label": "Search by student number"
         },
         "certificability": {
-          "aria-label": "Enter a status for certificability",          
+          "aria-label": "Enter a status for certificability",
           "label": "Search by certificability"
-        },  
+        },
         "students-count": "{count, plural, =0 {0 students} =1 {1 student} other {{count} students}}",
         "title": "Filters"
       }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -667,7 +667,7 @@
         "title": "Filtres",
         "type": {
           "certificability": {
-            "aria-label": "Enter un statut de certification",            
+            "aria-label": "Enter un statut de certification",
             "label": "Rechercher par certificabilité"
           },
           "fullName": {
@@ -829,7 +829,7 @@
       },
       "filter": {
         "certificability": {
-          "aria-label": "Enter un statut de certification",          
+          "aria-label": "Enter un statut de certification",
           "label": "Rechercher par certificabilité"
         },
         "division": {
@@ -905,6 +905,10 @@
           "student-number": "Numéro étudiant actuel de {firstName} {lastName} est : ",
           "success": "La modification du numéro étudiant de {firstName} {lastName} a bien été effectué."
         }
+      },
+      "empty-state": {
+        "no-participants": "Aucun étudiants pour l’instant !",
+        "no-participants-action": "L’administrateur doit importer les étudiants en cliquant sur le bouton importer."
       },
       "table": {
         "column": {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Dans le cas où l’administrateur de l'organisation SUP n'a pas encore importé des étudiants à son orga, il n'a pas de notion sur ce qu'il doit faire, Le message qui s'affiche actuellement sur la page des étudiants n'est pas suffisamment clair.

## :bat: Solution
Dans ce ticket on va ajouter un empty state composant lorsqu’il n’y a pas d'étudiants dans la liste. Ce composant contiendra les instructions précises pour importer des étudiants avec un message plus clair.

## :spider_web: Remarques
RAS

## :ghost: Pour tester

- Se connecter sur pix ORGA avec un compte sup, puis sélectionner une orga qui n'as pas encore une liste des étudiants, cette orga peut être créée sur Pix Admin et liée au compte SUP utilise dans le teste. Maintenant qu'on a une orga sup sans étudiâtes, nous pouvons aller sur pix orga -> page étudiants pour constater que [le visuel](https://www.figma.com/file/VPDkaoZIDWSCzSySQsVinm/Pix-Orga?node-id=2%3A7) est correctement affiché avec les bons messages 

    Aucun étudiants pour l’instant !
    L’administrateur doit importer les étudiants en cliquant sur le bouton importer.

    TRAD : 
    No students yet!
    The administrator must import the students database by clicking on the import button.

- Basculer vers une autre orga qui contient des étudiants puis aller sur la page des étudiants.
Essayer de filtrer par nom "toto" et constater que le message "Aucun étudiant." est bien affiché