### PR TITLE
[TECH] Supprimer la gestion spécifique de UNAUTHORIZED

### DIFF
--- a/api/lib/application/pre-response-utils.js
+++ b/api/lib/application/pre-response-utils.js
@@ -1,5 +1,5 @@
 const errorManager = require('./error-manager');
-const { BaseHttpError, UnauthorizedError } = require('./http-errors');
+const { BaseHttpError } = require('./http-errors');
 const { DomainError } = require('../domain/errors');
 
 function handleDomainAndHttpErrors(request, h) {
@@ -7,11 +7,6 @@ function handleDomainAndHttpErrors(request, h) {
 
   if (response instanceof DomainError || response instanceof BaseHttpError) {
     return errorManager.handle(request, h, response);
-  }
-
-  // Ne devrait pas etre necessaire
-  if (response.isBoom && response.output.statusCode === 401) {
-    return errorManager.handle(request, h, new UnauthorizedError(undefined, 401));
   }
 
   return h.continue;


### PR DESCRIPTION
## :jack_o_lantern: Problème
La PR https://github.com/1024pix/pix/pull/2693 a introduit une gestion d'erreur spécifique.
Son libellé m'a toujours fait frissonner.
> // Ne devrait pas etre necessaire

Elle n'est plus utilisée aujourd'hui, enfin, tous les tests passent, ce qui donne cette impression :man_shrugging: 

## :bat: Solution
La supprimer.
Et si elle est utilisée, rajouter un test.

## :spider_web: Remarques
Le commit https://github.com/1024pix/pix/commit/1df098be28cfce1388bf783a5bd991e2b180589c ne nous donne pas d'indice sur la route appelée

## :ghost: Pour tester
Voir "Remarques"
