### PR TITLE
[TECH] Faire le lien entre le bouton de téléchargement et l'appel pour l'export csv des candidats Clea (PIX-5826)

### DIFF
--- a/api/lib/application/sessions/session-with-clea-certified-candidate-controller.js
+++ b/api/lib/application/sessions/session-with-clea-certified-candidate-controller.js
@@ -8,8 +8,7 @@ module.exports = {
     const { session, cleaCertifiedCandidateData } = await usecases.getCleaCertifiedCandidateBySession({ sessionId });
     const csvResult = await certificationResultUtils.getCleaCertifiedCandidateCsv(cleaCertifiedCandidateData);
 
-    const dateWithoutTime = dayjs(session.date).format('DD/MM/YYYY');
-    const dateWithTime = dayjs(dateWithoutTime + ' ' + session.time)
+    const dateWithTime = dayjs(session.date + ' ' + session.time)
       .locale('fr')
       .format('YYYYMMDD_HHmm');
     const fileName = `${dateWithTime}_candidats_certifies_clea_${sessionId}.csv`;

--- a/api/tests/unit/application/session/session-with-clea-certified-candidate-controller_test.js
+++ b/api/tests/unit/application/session/session-with-clea-certified-candidate-controller_test.js
@@ -4,16 +4,6 @@ const certificationResultUtils = require('../../../../lib/infrastructure/utils/c
 const sessionWithCleaCertifiedCandidateController = require('../../../../lib/application/sessions/session-with-clea-certified-candidate-controller');
 
 describe('Unit | Controller | session-with-clea-certified-candidate', function () {
-  let clock;
-
-  beforeEach(function () {
-    clock = sinon.useFakeTimers(new Date('2021-01-01T14:30:00Z'));
-  });
-
-  afterEach(function () {
-    clock.restore();
-  });
-
   describe('#getCleaCertifiedCandidateDataCsv', function () {
     it('should return a response with CSV results', async function () {
       // given
@@ -22,13 +12,10 @@ describe('Unit | Controller | session-with-clea-certified-candidate', function (
           id: 1,
         },
       };
-      const session = domainBuilder.buildSession({ id: 1, date: new Date('2021-01-01'), time: '14:30' });
+      const session = domainBuilder.buildSession({ id: 1, date: '2021-01-01', time: '14:30' });
       const cleaCertifiedCandidates = [
         domainBuilder.buildCleaCertifiedCandidate({ createdAt: new Date('2021-01-01') }),
       ];
-
-      // sinon.stub(momentProto, 'format');
-      // momentProto.format.withArgs('YYYYMMDD_HHmm').returns('20210101_1430');
 
       sinon
         .stub(usecases, 'getCleaCertifiedCandidateBySession')

--- a/certif/app/components/session-clea-results-download.hbs
+++ b/certif/app/components/session-clea-results-download.hbs
@@ -21,7 +21,7 @@
         {{t "pages.sessions.detail.panel-clea.download-button"}}
       </PixButton>
       {{#if this.cleaCandidateDataDownloadErrorMessage}}
-        <p class="session-details__error-message">{{this.cleaCandidateDataDownloadErrorMessage}}</p>
+        <p class="session-details__clea-results-download-error-message">{{this.cleaCandidateDataDownloadErrorMessage}}</p>
       {{/if}}
 
     </div>

--- a/certif/app/components/session-clea-results-download.hbs
+++ b/certif/app/components/session-clea-results-download.hbs
@@ -5,7 +5,7 @@
     </div>
     <div>
       <h1 class="session-details__clea-results-download-title">
-        Des candidats ont obtenu le certificat CléA numérique
+        {{t "pages.sessions.detail.panel-clea.title"}}
       </h1>
       <p class="&__clea-results-download-description">
         Pour générer les certificats CléA numérique, téléchargez la liste des candidats, complétez-la, enregistrez-la au
@@ -14,9 +14,16 @@
           <FaIcon @icon="link" /></a>
       </p>
 
-      <PixButtonLink @href="#" class="session-details__clea-results-download-button">
-        Télécharger la liste des candidats
-      </PixButtonLink>
+      <PixButton
+        @triggerAction={{this.downloadCleaCertifiedCandidateData}}
+        class="session-details__clea-results-download-button"
+      >
+        {{t "pages.sessions.detail.panel-clea.download-button"}}
+      </PixButton>
+      {{#if this.cleaCandidateDataDownloadErrorMessage}}
+        <p class="session-details__error-message">{{this.cleaCandidateDataDownloadErrorMessage}}</p>
+      {{/if}}
+
     </div>
   </div>
 </div>

--- a/certif/app/components/session-clea-results-download.hbs
+++ b/certif/app/components/session-clea-results-download.hbs
@@ -8,9 +8,9 @@
         {{t "pages.sessions.detail.panel-clea.title"}}
       </h1>
       <p class="&__clea-results-download-description">
-        Pour générer les certificats CléA numérique, téléchargez la liste des candidats, complétez-la, enregistrez-la au
-        format .xlsx puis importez-la sur la
-        <a href="https://cleanumerique.org/" target="_blank" rel="noopener noreferrer">plateforme du CléA numérique.
+        {{t "pages.sessions.detail.panel-clea.description"}}
+        <a href="https://cleanumerique.org/" target="_blank" rel="noopener noreferrer">
+          {{t "pages.sessions.detail.panel-clea.link"}}
           <FaIcon @icon="link" /></a>
       </p>
 
@@ -21,7 +21,9 @@
         {{t "pages.sessions.detail.panel-clea.download-button"}}
       </PixButton>
       {{#if this.cleaCandidateDataDownloadErrorMessage}}
-        <p class="session-details__clea-results-download-error-message">{{this.cleaCandidateDataDownloadErrorMessage}}</p>
+        <p
+          class="session-details__clea-results-download-error-message"
+        >{{this.cleaCandidateDataDownloadErrorMessage}}</p>
       {{/if}}
 
     </div>

--- a/certif/app/components/session-clea-results-download.js
+++ b/certif/app/components/session-clea-results-download.js
@@ -1,0 +1,22 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class SessionCleaResultsDownload extends Component {
+  @service fileSaver;
+  @service session;
+  @tracked cleaCandidateDataDownloadErrorMessage = null;
+
+  @action
+  async downloadCleaCertifiedCandidateData() {
+    this.cleaCandidateDataDownloadErrorMessage = null;
+    const url = `/api/sessions/${this.args.session.id}/certified-clea-candidate-data`;
+    const token = this.session.data.authenticated.access_token;
+    try {
+      await this.fileSaver.save({ url, token });
+    } catch (error) {
+      this.cleaCandidateDataDownloadErrorMessage = error.message;
+    }
+  }
+}

--- a/certif/app/services/file-saver.js
+++ b/certif/app/services/file-saver.js
@@ -1,0 +1,56 @@
+import Service from '@ember/service';
+import fetch from 'fetch';
+
+export default class FileSaverService extends Service {
+  async save({
+    url,
+    token,
+    fetcher = _fetchData,
+    downloadFileForIEBrowser = _downloadFileForIEBrowser,
+    downloadFileForModernBrowsers = _downloadFileForModernBrowsers,
+  }) {
+    const response = await fetcher({ url, token });
+
+    if (response.status !== 200) {
+      const jsonResponse = await response.json();
+      throw jsonResponse.errors;
+    }
+
+    const fileName = _getFileNameFromHeader(response.headers);
+    const fileContent = await response.blob();
+
+    const browserIsInternetExplorer = window.document.documentMode;
+
+    browserIsInternetExplorer
+      ? downloadFileForIEBrowser({ fileContent, fileName })
+      : downloadFileForModernBrowsers({ fileContent, fileName });
+  }
+}
+
+function _fetchData({ url, token }) {
+  return fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+function _getFileNameFromHeader(headers) {
+  if (headers && headers.get('Content-Disposition')) {
+    const contentDispositionHeader = headers.get('Content-Disposition');
+    const [, fileName] = /filename\*?=['"]?([^;\r\n"']*)['"]?/.exec(contentDispositionHeader);
+    return fileName;
+  }
+}
+
+function _downloadFileForIEBrowser({ fileContent, fileName }) {
+  window.navigator.msSaveOrOpenBlob(fileContent, fileName);
+}
+
+function _downloadFileForModernBrowsers({ fileContent, fileName }) {
+  const link = document.createElement('a');
+  link.style.display = 'none';
+  link.href = URL.createObjectURL(fileContent);
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}

--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -185,7 +185,7 @@
     width: 30%;
   }
 
-  &__error-message {
+  &__clea-results-download-error-message {
     color: $error;
     max-width: 250px;
     margin-top: 15px;

--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -185,6 +185,12 @@
     width: 30%;
   }
 
+  &__error-message {
+    color: $error;
+    max-width: 250px;
+    margin-top: 15px;
+  }
+
   &__controls {
     display: flex;
     justify-content: space-between;

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -26,7 +26,7 @@
   </div>
 
   {{#if this.session.shouldDisplayCleaResultDownloadSection}}
-    <SessionCleaResultsDownload />
+    <SessionCleaResultsDownload @session={{this.session}} />
   {{/if}}
 
   <div class="panel session-details__controls">

--- a/certif/tests/acceptance/session-details_test.js
+++ b/certif/tests/acceptance/session-details_test.js
@@ -5,10 +5,12 @@ import { authenticateSession } from '../helpers/test-init';
 import { visit as visitScreen, visit } from '@1024pix/ember-testing-library';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import setupIntl from '../helpers/setup-intl';
 
 module('Acceptance | Session Details', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   hooks.afterEach(function () {
     const notificationMessagesService = this.owner.lookup('service:notifications');
@@ -191,8 +193,12 @@ module('Acceptance | Session Details', function (hooks) {
             const screen = await visit(`/sessions/${session.id}`);
 
             // then
-            assert.dom(screen.getByText('Des candidats ont obtenu le certificat CléA numérique')).exists();
-            assert.dom(screen.getByRole('link', { name: 'Télécharger la liste des candidats' })).exists();
+            assert.dom(screen.getByText(this.intl.t('pages.sessions.detail.panel-clea.title'))).exists();
+            assert
+              .dom(
+                screen.getByRole('button', { name: this.intl.t('pages.sessions.detail.panel-clea.download-button') })
+              )
+              .exists();
           });
         });
       });

--- a/certif/tests/integration/components/session-clea-results-download_test.js
+++ b/certif/tests/integration/components/session-clea-results-download_test.js
@@ -1,0 +1,45 @@
+import { render as renderScreen } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+import Service from '@ember/service';
+import sinon from 'sinon';
+import { module, test } from 'qunit';
+
+module('Integration | Component | session-clea-results-download', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module('when there is an error during the download of the candidates data', function () {
+    test('should show the error message', async function (assert) {
+      // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = { isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: false };
+      }
+      this.owner.register('service:featureToggles', FeatureTogglesStub);
+      const fileSaverSaveStub = sinon.stub();
+      class FileSaverStub extends Service {
+        save = fileSaverSaveStub;
+      }
+      this.owner.register('service:fileSaver', FileSaverStub);
+
+      fileSaverSaveStub.rejects(new Error('an error message'));
+
+      const store = this.owner.lookup('service:store');
+      const session = store.createRecord('session', {
+        hasSomeCleaAcquired: true,
+        publishedAt: '2022-01-01',
+      });
+      this.set('session', session);
+
+      const screen = await renderScreen(hbs`{{session-clea-results-download session=session}}`);
+
+      // when
+      await click(
+        screen.getByRole('button', { name: this.intl.t('pages.sessions.detail.panel-clea.download-button') })
+      );
+
+      // then
+      assert.dom(screen.getByText('an error message')).exists();
+    });
+  });
+});

--- a/certif/tests/unit/components/session-clea-results-download_test.js
+++ b/certif/tests/unit/components/session-clea-results-download_test.js
@@ -1,0 +1,54 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import sinon from 'sinon/pkg/sinon-esm';
+
+module('Unit | Component | session-clea-results-download', function (hooks) {
+  setupTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('component:session-clea-results-download');
+  });
+
+  module('#downloadCleaCertifiedCandidateData', function () {
+    test('should call the file-saver service for downloadCleaCertifiedCandidateData with the right parameters', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      component.args.session = store.createRecord('session', {
+        id: 123,
+        hasSomeCleaAcquired: true,
+        publishedAt: '2022-01-01',
+      });
+      const token = 'a token';
+
+      component.session = {
+        isAuthenticated: true,
+        data: {
+          authenticated: {
+            access_token: token,
+          },
+        },
+      };
+      component.fileSaver = {
+        save: sinon.stub(),
+      };
+
+      const event = {
+        preventDefault: sinon.stub(),
+      };
+
+      // when
+      await component.downloadCleaCertifiedCandidateData(event);
+
+      // then
+      assert.ok(
+        component.fileSaver.save.calledWith({
+          token,
+          url: `/api/sessions/${component.args.session.id}/certified-clea-candidate-data`,
+        })
+      );
+    });
+  });
+});

--- a/certif/tests/unit/services/file-saver_test.js
+++ b/certif/tests/unit/services/file-saver_test.js
@@ -1,0 +1,84 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | file-saver', function (hooks) {
+  setupTest(hooks);
+  let fileSaver;
+
+  hooks.beforeEach(function () {
+    fileSaver = this.owner.lookup('service:file-saver');
+  });
+
+  module('#save', function (hooks) {
+    const id = 123456;
+    const url = `/attestation/${id}`;
+    const token = 'mytoken';
+    const responseFileName = 'fichier.plouf';
+    const responseContent = new Blob();
+
+    let fetchStub;
+    let blobStub;
+    let downloadFileForIEBrowserStub;
+    let downloadFileForModernBrowsersStub;
+
+    hooks.beforeEach(function () {
+      fileSaver = this.owner.lookup('service:file-saver');
+      blobStub = sinon.stub().resolves(responseContent);
+      downloadFileForIEBrowserStub = sinon.stub().returns();
+      downloadFileForModernBrowsersStub = sinon.stub().returns();
+    });
+
+    module('when response has a status 200', function () {
+      test('should use fileName and fileContent from response', async function (assert) {
+        // given
+        const headers = {
+          get: sinon.stub(),
+        };
+        headers.get.withArgs('Content-Disposition').returns(`attachment; filename=${responseFileName}`);
+        const jsonStub = sinon.stub().resolves('a json');
+
+        const response = { headers, blob: blobStub, status: 200, json: jsonStub };
+        fetchStub = sinon.stub().resolves(response);
+
+        // when
+        await fileSaver.save({
+          url,
+          token,
+          fetcher: fetchStub,
+          downloadFileForIEBrowser: downloadFileForIEBrowserStub,
+          downloadFileForModernBrowsers: downloadFileForModernBrowsersStub,
+        });
+
+        // then
+        const expectedArgs = { fileContent: responseContent, fileName: responseFileName };
+        assert.ok(downloadFileForModernBrowsersStub.calledWith(expectedArgs));
+      });
+    });
+
+    module('when response has not a status 200', function () {
+      test('should throw', async function (assert) {
+        // given
+        const headers = {
+          get: sinon.stub(),
+        };
+        headers.get.withArgs('Content-Disposition').returns(`attachment; filename=${responseFileName}`);
+        const jsonStub = sinon.stub().resolves({ errors: [] });
+        const response = { headers, blob: blobStub, status: 403, json: jsonStub };
+        fetchStub = sinon.stub().resolves(response);
+
+        // when
+        const promise = fileSaver.save({
+          url,
+          token,
+          fetcher: fetchStub,
+          downloadFileForIEBrowser: downloadFileForIEBrowserStub,
+          downloadFileForModernBrowsers: downloadFileForModernBrowsersStub,
+        });
+
+        // then
+        assert.rejects(promise);
+      });
+    });
+  });
+});

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -89,6 +89,12 @@
           "enrolled-candidates": "<span>{enrolledCandidatesCount} candidats</span> sont inscrits à cette session",
           "disclaimer": "Attention, cette action est irréversible."
         }
+      },
+      "detail": {
+        "panel-clea": {
+          "title": "Des candidats ont obtenu le certificat CléA numérique",
+          "download-button": "Télécharger la liste des candidats"
+        }
       }
     },
     "session-supervising": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -93,6 +93,8 @@
       "detail": {
         "panel-clea": {
           "title": "Des candidats ont obtenu le certificat CléA numérique",
+          "description": "Pour générer les certificats CléA numérique, téléchargez la liste des candidats, complétez-la, enregistrez-la au\n format .xlsx puis importez-la sur la",
+          "link": "plateforme du CléA numérique.",
           "download-button": "Télécharger la liste des candidats"
         }
       }

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -90,6 +90,12 @@
           "enrolled-candidates": "<span>{enrolledCandidatesCount} {enrolledCandidatesCount, plural,one {candidat} other {candidats}}</span> {enrolledCandidatesCount, plural,one {est inscrit} other {sont inscrits}} à cette session",
           "disclaimer": "Attention, cette action est irréversible."
         }
+      },
+      "detail": {
+        "panel-clea": {
+          "title": "Des candidats ont obtenu le certificat CléA numérique",
+          "download-button": "Télécharger la liste des candidats"
+        }
       }
     },
     "session-supervising": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -94,6 +94,8 @@
       "detail": {
         "panel-clea": {
           "title": "Des candidats ont obtenu le certificat CléA numérique",
+          "description": "Pour générer les certificats CléA numérique, téléchargez la liste des candidats, complétez-la, enregistrez-la au\n format .xlsx puis importez-la sur la",
+          "link": "plateforme du CléA numérique.",
           "download-button": "Télécharger la liste des candidats"
         }
       }


### PR DESCRIPTION
## :jack_o_lantern: Problème
Pouvoir télécharger le csv des candidats ayant obtenu leur certification Clea Numérique lorsque l'on appuie sur le bouton créé à cet effet.

## :bat: Solution
Relier la route back de téléchargement au bouton coté front.

## :spider_web: Remarques
Ajout du service file-saver dans le projet certif

## :ghost: Pour tester
- Se connecter à Pix Certif avec le compte certifpro
- Aller sur la session généreusement créée par mes soins, id : 106212
- Constater la présence du bandeau et du bouton de téléchargement des données sur les candidats certifiés Clea Numérique, sur la page detail de la session
- Appuyer sur le bouton et télécharger le fichier csv sans encombre ! 🎉 