### PR TITLE
[TECH] Position du titre et des infos "date" et "heure de début" (PIX-5752)

### DIFF
--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -1,10 +1,10 @@
 {{page-title this.pageTitle replace=true}}
 <div class="session-details-page">
+  <PixReturnTo @route="authenticated.sessions.list">
+    Retour à la liste des sessions
+  </PixReturnTo>
   <div class="page__title session-details__header">
     <div class="session-details-header__title">
-      <PixReturnTo @route="authenticated.sessions.list">
-        Retour à la liste des sessions
-      </PixReturnTo>
       <h1 class="page-title">Session {{this.session.id}}</h1>
     </div>
 


### PR DESCRIPTION
## :jack_o_lantern: Problème
La date et l’heure de début de la session (infos de la session) ne sont pas centrées sur le titre (numéro de session).

## :bat: Solution
Changer la structure du header, sortir le “retour à la liste des sessions”, de la div page__title session-details__header, afin de centrer le titre numéro de session et la date et l’heure de la session.

## :ghost: Pour tester
- Se connecter sur Pix Certif
- Aller sur le détail d'une session 
- Constater le (magnifique) alignement du titre, et de la date/heure de début de session
