### PR TITLE
[TECH] Ne pas attendre la connexion PoleEmploi plus longtemps que ce que Scalingo permet

### DIFF
--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -13,11 +13,13 @@ class HttpResponse {
 
 module.exports = {
   async post({ url, payload, headers }) {
+    const TIMEOUT_MILLISECONDS = 5;
     const startTime = performance.now();
     let responseTime = null;
     try {
       const httpResponse = await axios.post(url, payload, {
         headers,
+        timeout: TIMEOUT_MILLISECONDS,
       });
       responseTime = performance.now() - startTime;
       logInfoWithCorrelationIds({

--- a/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
@@ -151,6 +151,67 @@ describe('Acceptance | Route | oidc | token', function () {
       expect(response.result['logout_url_uuid']).to.match(uuidPattern);
     });
 
+    context('when the PE API does not respond within timeout', function () {
+      it('should return 500', async function () {
+        // given
+        const firstName = 'John';
+        const lastName = 'Doe';
+        const externalIdentifier = 'sub';
+
+        const userId = databaseBuilder.factory.buildUser({
+          firstName,
+          lastName,
+        }).id;
+
+        databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
+          identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+          externalIdentifier,
+          accessToken: 'access_token',
+          refreshToken: 'refresh_token',
+          expiresIn: 1000,
+          userId,
+        });
+        await databaseBuilder.commit();
+
+        const idToken = jsonwebtoken.sign(
+          {
+            given_name: firstName,
+            family_name: lastName,
+            nonce: 'nonce',
+            sub: externalIdentifier,
+          },
+          'secret'
+        );
+        const getAccessTokenResponse = {
+          access_token: 'access_token',
+          id_token: idToken,
+          expires_in: 60,
+          refresh_token: 'refresh_token',
+        };
+
+        const TIMEOUT_MILLISECONDS = 5;
+        const getAccessTokenRequest = nock(settings.poleEmploi.tokenUrl)
+          .post('/')
+          .delay(TIMEOUT_MILLISECONDS)
+          .reply(200, getAccessTokenResponse);
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/oidc/token',
+          headers: { Authorization: generateValidRequestAuthorizationHeader(userId) },
+          payload,
+        });
+
+        // then
+        expect(response.statusCode).to.equal(500);
+        expect(getAccessTokenRequest.isDone()).to.be.true;
+        expect(response.payload).to.equal(
+          '{"errors":[{"status":"500","title":"Erreur lors de la récupération des tokens du partenaire.","detail":"\\"timeout of 5ms exceeded\\""}]}'
+        );
+      });
+    });
+
     context('When user has an invalid token', function () {
       it('should be rejected by API', async function () {
         // given

--- a/api/tests/unit/infrastructure/http/http-agent_test.js
+++ b/api/tests/unit/infrastructure/http/http-agent_test.js
@@ -3,6 +3,7 @@ const axios = require('axios');
 const logger = require('../../../../lib/infrastructure/logger');
 const { post, get } = require('../../../../lib/infrastructure/http/http-agent');
 
+const TIMEOUT_MILLISECONDS = 5;
 describe('Unit | Infrastructure | http | http-agent', function () {
   describe('#post', function () {
     afterEach(function () {
@@ -18,7 +19,13 @@ describe('Unit | Infrastructure | http | http-agent', function () {
         data: Symbol('data'),
         status: 'someStatus',
       };
-      sinon.stub(axios, 'post').withArgs(url, payload, { headers }).resolves(axiosResponse);
+      sinon
+        .stub(axios, 'post')
+        .withArgs(url, payload, {
+          headers,
+          timeout: TIMEOUT_MILLISECONDS,
+        })
+        .resolves(axiosResponse);
 
       // when
       const actualResponse = await post({ url, payload, headers });
@@ -46,7 +53,13 @@ describe('Unit | Infrastructure | http | http-agent', function () {
               status: 'someStatus',
             },
           };
-          sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
+          sinon
+            .stub(axios, 'post')
+            .withArgs(url, payload, {
+              headers,
+              timeout: TIMEOUT_MILLISECONDS,
+            })
+            .rejects(axiosError);
 
           // when
           const actualResponse = await post({ url, payload, headers });
@@ -75,7 +88,13 @@ describe('Unit | Infrastructure | http | http-agent', function () {
               status: 400,
             },
           };
-          sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
+          sinon
+            .stub(axios, 'post')
+            .withArgs(url, payload, {
+              headers,
+              timeout: TIMEOUT_MILLISECONDS,
+            })
+            .rejects(axiosError);
 
           const expectedResponse = {
             isSuccessful: false,


### PR DESCRIPTION
## :jack_o_lantern: Problème
En regardant la [doc d'axios](https://github.com/axios/axios#request-config), je vois qu'il n'y a pas de timeout par défaut.
> // default is `0` (no timeout)

Lorsque l'API Pix fait un appel à l'API PoleEmploi:
-  si l'API PE n'est pas disponible;
-  l'API Pix attend indéfiniment (enfon, l'OS doit finir par couper la socket).

Il faut attendre un délai raisonnable,  < 1 minute, sinon 
- le routeur Scalingo coupe la connexion
- le conteneur API, s'il a une réponse ensuite, essaye de réponder au routeur back
- qui n'écoute plus.

Bref, on continue pour rien..

## :bat: Proposition
Ajouter un timeout à tous les appels partenaire (ici, un POST).
Il peut être configuré via une variable d'environnement si on veut ajuster sans prendre de risques.

Le test devrait être effectué uniquement au niveau de `http-client`.
Là, j'ai modifié un test d'acceptance pour montrer les implications.

## :spider_web: Remarques
Ceci est une proposition, il n'y a rien de cassé en production.

## :ghost: Pour tester
:thinking: 
