### PR TITLE
[TECH] En cas d'erreur sur le format de userInfoContent, ajouter userInfoContent dans les logs

### DIFF
--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -140,6 +140,7 @@ class OidcAuthenticationService {
       const dataToLog = {
         message,
         typeOfUserInfoContent: typeof userInfoContent,
+        userInfoContent,
       };
       monitoringTools.logErrorWithCorrelationIds({ message: dataToLog });
       throw new InvalidExternalAPIResponseError(message);


### PR DESCRIPTION
## :unicorn: Problème

Bien que du logging détaillé d'erreurs ait été ajouté avec `logErrorWithCorrelationIds` du service `monitoring-tools.js` dans #4947, dans certains cas il est encore impossible de comprendre certaines erreurs lors de l'authentification des utilisateurs Pôle emploi.

Quand `userInfoContent` n'est pas au bon format (`Object`) cette info `userInfoContent` contient peut-être des messages d'erreur au format texte expliquant les problèmes. Lors de la PR précédente nous n'avions pas ajouté cette information car nous voulions obtenir au préalable l'autorisation du DPO.

## :robot: Solution

Obtention de l'autorisation auprès du DPO le 2022-10-05 et ajout de `userInfoContent` dans les logs d'erreur. 

## :rainbow: Remarques

Examiner les logs de PROD lorsque ce code aura été déployé en espérant que nous obtiendrons ainsi une meilleure compréhension des problèmes.

## :100: Pour tester

1. Vérifier que la CI passe
2. Se connecter en passant par un SSO OIDC. Cela ne validera pas qu'une erreur sera bien logguée, mais cela validera au moins qu'il n'y a pas de régression dans le cas normal.
