### PR TITLE
[A11Y] Rendre les liens vers le profils du prescrit plus explicites (PIX-5164)

### DIFF
--- a/orga/app/components/campaign/activity/participants-list.hbs
+++ b/orga/app/components/campaign/activity/participants-list.hbs
@@ -61,7 +61,14 @@
                   }}
                   @models={{array @campaign.id participation.id}}
                 >
-                  {{participation.lastName}}
+                  <span
+                    aria-label="{{t
+                      'pages.campaign-activity.table.see-results'
+                      firstName=participation.firstName
+                      lastName=participation.lastName
+                    }}"
+                  >
+                    {{participation.lastName}}</span>
                 </LinkTo>
               </td>
               <td>{{participation.firstName}}</td>

--- a/orga/tests/acceptance/campaign-activity_test.js
+++ b/orga/tests/acceptance/campaign-activity_test.js
@@ -41,7 +41,7 @@ module('Acceptance | Campaign Activity', function (hooks) {
       test('it could click on user to go to details', async function (assert) {
         // when
         await visit('/campagnes/1');
-        await clickByName('Bacri');
+        await clickByName('Voir les résultats de Bacri');
 
         // then
         assert.strictEqual(currentURL(), '/campagnes/1/evaluations/1/resultats');
@@ -59,7 +59,7 @@ module('Acceptance | Campaign Activity', function (hooks) {
       test('it could click on profile to go to details', async function (assert) {
         // when
         await visit('/campagnes/2');
-        await clickByName('Bacri');
+        await clickByName('Voir les résultats de Bacri');
 
         // then
         assert.strictEqual(currentURL(), '/campagnes/2/profils/1');

--- a/orga/tests/integration/components/campaign/activity/participants-list_test.js
+++ b/orga/tests/integration/components/campaign/activity/participants-list_test.js
@@ -1,9 +1,9 @@
 import sinon from 'sinon';
 import { module, test } from 'qunit';
-import { render, find } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
 import Service from '@ember/service';
 import EmberObject from '@ember/object';
-import { fillByLabel, clickByText } from '@1024pix/ember-testing-library';
+import { fillByLabel, clickByText, render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
@@ -31,17 +31,39 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
       },
     ]);
 
-    await render(hbs`<Campaign::Activity::ParticipantsList
-        @campaign={{this.campaign}}
-        @participations={{this.participations}}
-        @onClickParticipant={{noop}}
-        @onFilter={{noop}}
-      />`);
+    await render(
+      hbs`<Campaign::Activity::ParticipantsList @campaign={{this.campaign}} @participations={{this.participations}} @onClickParticipant={{noop}} @onFilter={{noop}} />`
+    );
 
     assert.contains('Joe');
     assert.contains('La frite');
     assert.contains('patate');
     assert.contains("En attente d'envoi");
+  });
+
+  test('[A11Y] it should have an aria label', async function (assert) {
+    this.set('campaign', { idPixLabel: 'id', type: 'ASSESSMENT' });
+
+    this.set('participations', [
+      {
+        firstName: 'Joe',
+        lastName: 'La frite',
+        status: 'TO_SHARE',
+        participantExternalId: 'patate',
+      },
+    ]);
+
+    const screen =
+      await render(hbs`<Campaign::Activity::ParticipantsList @campaign={{this.campaign}} @participations={{this.participations}} @onClickParticipant={{noop}} @onFilter={{noop}}
+      />`);
+
+    assert
+      .dom(
+        screen.getByLabelText(
+          this.intl.t('pages.campaign-activity.table.see-results', { firstName: 'Joe', lastName: 'La frite' })
+        )
+      )
+      .exists();
   });
 
   module('#deleteParticipation', function () {
@@ -62,11 +84,7 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
           },
         ];
 
-        await render(hbs`<Campaign::Activity::ParticipantsList
-            @campaign={{this.campaign}}
-            @participations={{this.participations}}
-            @onClickParticipant={{noop}}
-            @onFilter={{noop}}
+        await render(hbs`<Campaign::Activity::ParticipantsList @campaign={{this.campaign}} @participations={{this.participations}} @onClickParticipant={{noop}} @onFilter={{noop}}
           />`);
 
         assert.dom('[aria-label="Supprimer la participation"]').exists();
@@ -91,11 +109,7 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
           },
         ];
 
-        await render(hbs`<Campaign::Activity::ParticipantsList
-            @campaign={{this.campaign}}
-            @participations={{this.participations}}
-            @onClickParticipant={{noop}}
-            @onFilter={{noop}}
+        await render(hbs`<Campaign::Activity::ParticipantsList @campaign={{this.campaign}} @participations={{this.participations}} @onClickParticipant={{noop}} @onFilter={{noop}}
           />`);
 
         assert.dom('[aria-label="Supprimer la participation"]').exists();
@@ -120,11 +134,7 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
           },
         ];
 
-        await render(hbs`<Campaign::Activity::ParticipantsList
-            @campaign={{this.campaign}}
-            @participations={{this.participations}}
-            @onClickParticipant={{noop}}
-            @onFilter={{noop}}
+        await render(hbs`<Campaign::Activity::ParticipantsList @campaign={{this.campaign}} @participations={{this.participations}} @onClickParticipant={{noop}} @onFilter={{noop}}
           />`);
 
         assert.dom('[aria-label="Supprimer la participation"]').doesNotExist();
@@ -143,12 +153,7 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
       this.participations = [];
       this.selectedStatus = 'TO_SHARE';
 
-      await render(hbs`<Campaign::Activity::ParticipantsList
-        @campaign={{this.campaign}}
-        @participations={{this.participations}}
-        @selectedStatus={{selectedStatus}}
-        @onClickParticipant={{noop}}
-        @onFilter={{noop}}
+      await render(hbs`<Campaign::Activity::ParticipantsList @campaign={{this.campaign}} @participations={{this.participations}} @selectedStatus={{selectedStatus}} @onClickParticipant={{noop}} @onFilter={{noop}}
       />`);
 
       assert.strictEqual(find('[aria-label="Statut"]').selectedOptions[0].value, 'TO_SHARE');
@@ -164,11 +169,7 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
       this.participations = [];
       this.onFilter = sinon.stub();
 
-      await render(hbs`<Campaign::Activity::ParticipantsList
-          @campaign={{this.campaign}}
-          @participations={{this.participations}}
-          @onClickParticipant={{noop}}
-          @onFilter={{onFilter}}
+      await render(hbs`<Campaign::Activity::ParticipantsList @campaign={{this.campaign}} @participations={{this.participations}} @onClickParticipant={{noop}} @onFilter={{onFilter}}
         />`);
 
       await fillByLabel('Statut', 'SHARED');
@@ -191,11 +192,7 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
       this.participations = [];
       this.onFilter = sinon.stub();
 
-      await render(hbs`<Campaign::Activity::ParticipantsList
-          @campaign={{campaign}}
-          @participations={{participations}}
-          @onClickParticipant={{noop}}
-          @onFilter={{onFilter}}
+      await render(hbs`<Campaign::Activity::ParticipantsList @campaign={{this.campaign}} @participations={{this.participations}} @onClickParticipant={{noop}} @onFilter={{onFilter}}
         />`);
 
       await clickByText('Classes');
@@ -218,11 +215,7 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
       this.participations = [];
       this.onFilter = sinon.stub();
 
-      await render(hbs`<Campaign::Activity::ParticipantsList
-          @campaign={{campaign}}
-          @participations={{participations}}
-          @onClickParticipant={{noop}}
-          @onFilter={{onFilter}}
+      await render(hbs`<Campaign::Activity::ParticipantsList @campaign={{this.campaign}} @participations={{this.participations}} @onClickParticipant={{noop}} @onFilter={{onFilter}}
         />`);
 
       await clickByText('Groupes');
@@ -238,11 +231,7 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
       this.participations = [];
       this.onFilter = sinon.stub();
 
-      await render(hbs`<Campaign::Activity::ParticipantsList
-          @campaign={{campaign}}
-          @participations={{participations}}
-          @onClickParticipant={{noop}}
-          @onFilter={{onFilter}}
+      await render(hbs`<Campaign::Activity::ParticipantsList @campaign={{this.campaign}} @participations={{this.participations}} @onClickParticipant={{noop}} @onFilter={{onFilter}}
         />`);
 
       await fillByLabel('Recherche sur le nom et prénom', 'Jean');

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -290,7 +290,8 @@
         "delete-button-label": "Delete participation",
         "empty": "No participants",
         "row-title": "Participant",
-        "title": "List of participants"
+        "title": "List of participants",
+        "see-results": "See results of {firstName} {lastName}"
       },
       "status": {
         "STARTED-assessment": "In progress",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -290,7 +290,8 @@
         "delete-button-label": "Supprimer la participation",
         "empty": "Aucun participant",
         "row-title": "Participant",
-        "title": "Liste des participants"
+        "title": "Liste des participants",
+        "see-results": "Voir les résultats de {firstName} {lastName}"
       },
       "status": {
         "STARTED-assessment": "En cours",


### PR DESCRIPTION
## :jack_o_lantern: Problème
Suite à l'audit A11Y fait sur Pix Orga, il nous a été remonté que les liens du tableau des prescrits dans l'onglet Activité , n'étaient pas suffisamment explicites. en effet, on ne précisait pas qu'en cliquand sur ce lien on allait vers la page de détails de ses résultats

## :bat: Proposition
Ajouter un texte lisible seulement par les lecteurs d'écran pour informer qu'on se dirige vers la page du détails des résultats du prescrit.

## :spider_web: Remarques
Renommage d'un fichier test qui n'avait pas le même nom que le fichier hbs donc difficile de le retrouver

## :ghost: Pour tester
Aller sur pix Orga puis sur une campagne
- soit lancer un lecteur d'écran et aller sur le tbl et entendre la description du lien qui est lue
soit aller sur le tableau et voir dans l'arbre des éléments html, la présence d'un span sr-only
