### PR TITLE
[BUGFIX] Tracer une erreur détaillée de l'appel API identity provider dans le flow oidc (PIX-5784)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -402,6 +402,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.BadRequestError(error.message);
   }
 
+  if (error instanceof DomainErrors.InvalidIdentityProviderError) {
+    return new HttpErrors.BadRequestError(error.message);
+  }
+
   if (error instanceof DomainErrors.YamlParsingError) {
     return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
   }

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -129,9 +129,7 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.CampaignCodeError) {
     return new HttpErrors.NotFoundError(error.message);
   }
-  if (error instanceof DomainErrors.AuthenticationTokenRetrievalError) {
-    return new HttpErrors.InternalServerError(error.message, error.title);
-  }
+
   if (error instanceof DomainErrors.UserAlreadyExistsWithAuthenticationMethodError) {
     return new HttpErrors.ConflictError(error.message);
   }
@@ -469,7 +467,6 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.InvalidJuryLevelError) {
     return new HttpErrors.BadRequestError(error.message);
   }
-
   return new HttpErrors.BaseHttpError(error.message);
 }
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -1058,6 +1058,13 @@ class UnexpectedOidcStateError extends DomainError {
   }
 }
 
+class InvalidIdentityProviderError extends DomainError {
+  constructor(identityProvider) {
+    const message = `Identity provider ${identityProvider} is not supported.`;
+    super(message);
+  }
+}
+
 class YamlParsingError extends DomainError {
   constructor(message = "Une erreur s'est produite lors de l'interprétation des réponses.") {
     super(message);
@@ -1273,6 +1280,7 @@ module.exports = {
   InvalidCertificationIssueReportForSaving,
   InvalidExternalUserTokenError,
   InvalidExternalAPIResponseError,
+  InvalidIdentityProviderError,
   InvalidJuryLevelError,
   InvalidMembershipOrganizationRoleError,
   InvalidPasswordForUpdateEmailError,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -1032,14 +1032,6 @@ class NotImplementedError extends Error {
   }
 }
 
-class AuthenticationTokenRetrievalError extends DomainError {
-  constructor(message, status) {
-    super(message);
-    this.status = parseInt(status, 10);
-    this.title = 'Erreur lors de la récupération des tokens du partenaire.';
-  }
-}
-
 class InvalidMembershipOrganizationRoleError extends DomainError {
   constructor(message = 'Le rôle du membre est invalide.') {
     super(message);
@@ -1226,7 +1218,6 @@ module.exports = {
   AuthenticationMethodNotFoundError,
   AuthenticationMethodAlreadyExistsError,
   AuthenticationKeyExpired,
-  AuthenticationTokenRetrievalError,
   UncancellableOrganizationInvitationError,
   CampaignCodeError,
   CampaignParticipationDeletedError,

--- a/api/lib/domain/services/authentication/authentication-service-registry.js
+++ b/api/lib/domain/services/authentication/authentication-service-registry.js
@@ -1,11 +1,12 @@
 const OidcIdentityProviders = require('../../constants/oidc-identity-providers');
+const { InvalidIdentityProviderError } = require('../../errors');
 
 function lookupAuthenticationService(identityProvider) {
   const identityProviderService = Object.values(OidcIdentityProviders).find(
     (oidcIdentityProvider) => oidcIdentityProvider.code === identityProvider
   );
 
-  if (!identityProviderService) throw new Error(`Identity provider ${identityProvider} is not supported`);
+  if (!identityProviderService) throw new InvalidIdentityProviderError(identityProvider);
 
   return identityProviderService;
 }

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -1,6 +1,7 @@
 const jsonwebtoken = require('jsonwebtoken');
 const settings = require('../../../config');
 const httpAgent = require('../../../infrastructure/http/http-agent');
+const httpErrorsHelper = require('../../../infrastructure/http/errors-helper');
 const querystring = require('querystring');
 const { InvalidExternalAPIResponseError } = require('../../errors');
 const AuthenticationSessionContent = require('../../models/AuthenticationSessionContent');
@@ -70,14 +71,10 @@ class OidcAuthenticationService {
     });
 
     if (!response.isSuccessful) {
-      const errorResponse = JSON.stringify(response.data);
       const message = 'Erreur lors de la récupération des tokens du partenaire.';
-      const dataToLog = {
-        message,
-        errorDescription: errorResponse.error_description,
-        errorType: errorResponse.error,
-      };
+      const dataToLog = httpErrorsHelper.getErrorDetails(response, message);
       monitoringTools.logErrorWithCorrelationIds({ message: dataToLog });
+
       throw new InvalidExternalAPIResponseError(message);
     }
 
@@ -108,39 +105,24 @@ class OidcAuthenticationService {
     return { redirectTarget: redirectTarget.toString(), state, nonce };
   }
 
-  _validateUserInfoContent({ userInfoContent }) {
-    const missingFields = [];
-    if (!userInfoContent.family_name) {
-      missingFields.push('family_name');
-    }
-    if (!userInfoContent.given_name) {
-      missingFields.push('given_name');
-    }
-    if (!userInfoContent.sub) {
-      missingFields.push('sub');
-    }
-    const thereIsAtLeastOneRequiredMissingField = missingFields.length > 0;
-    if (thereIsAtLeastOneRequiredMissingField) {
-      throw new InvalidExternalAPIResponseError(missingFields.join(','));
-    }
-  }
+  async getUserInfoFromEndpoint({ accessToken, userInfoUrl }) {
+    const response = await httpAgent.get({
+      url: userInfoUrl,
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
 
-  async _getContentFromUserInfoEndpoint({ accessToken, userInfoUrl }) {
-    let userInfoContent;
+    if (!response.isSuccessful) {
+      const message = 'Une erreur est survenue en récupérant les informations des utilisateurs.';
+      const dataToLog = httpErrorsHelper.getErrorDetails(response, message);
 
-    try {
-      const { data } = await httpAgent.get({
-        url: userInfoUrl,
-        headers: { Authorization: `Bearer ${accessToken}` },
-      });
-      userInfoContent = data;
-    } catch (error) {
-      error.customMessage = 'Une erreur est survenue en récupérant les information des utilisateurs.';
-      monitoringTools.logErrorWithCorrelationIds({ message: error });
+      monitoringTools.logErrorWithCorrelationIds({ message: dataToLog });
+
       throw new InvalidExternalAPIResponseError(
-        'Une erreur est survenue en récupérant les information des utilisateurs.'
+        'Une erreur est survenue en récupérant les informations des utilisateurs.'
       );
     }
+
+    const userInfoContent = response.data;
 
     if (!userInfoContent || typeof userInfoContent !== 'object') {
       const message = 'Les informations utilisateur récupérées ne sont pas au format attendu.';
@@ -153,12 +135,12 @@ class OidcAuthenticationService {
       throw new InvalidExternalAPIResponseError(message);
     }
 
-    try {
-      this._validateUserInfoContent({ userInfoContent });
-    } catch (error) {
+    const userInfoContentContainsMissingFields = this.isUserInfoContentContainsMissingFields({ userInfoContent });
+
+    if (userInfoContentContainsMissingFields) {
       monitoringTools.logErrorWithCorrelationIds({
         message: "Un des champs obligatoires n'a pas été renvoyé",
-        missingFields: error,
+        missingFields: userInfoContentContainsMissingFields,
       });
       throw new InvalidExternalAPIResponseError('Les informations utilisateurs récupérées sont incorrectes.');
     }
@@ -171,12 +153,30 @@ class OidcAuthenticationService {
     };
   }
 
+  isUserInfoContentContainsMissingFields({ userInfoContent }) {
+    const missingFields = [];
+    if (!userInfoContent.family_name) {
+      missingFields.push('family_name');
+    }
+    if (!userInfoContent.given_name) {
+      missingFields.push('given_name');
+    }
+    if (!userInfoContent.sub) {
+      missingFields.push('sub');
+    }
+
+    const thereIsAtLeastOneRequiredMissingField = missingFields.length > 0;
+    return thereIsAtLeastOneRequiredMissingField ? `Champs manquants : ${missingFields.join(',')}` : false;
+  }
+
   async getUserInfo({ idToken, accessToken }) {
     const { family_name, given_name, sub, nonce } = await jsonwebtoken.decode(idToken);
     let userInfoContent;
 
-    if (!family_name || !given_name || !sub) {
-      userInfoContent = await this._getContentFromUserInfoEndpoint({ accessToken, userInfoUrl: this.userInfoUrl });
+    const isMandatoryUserInfoMissing = !family_name || !given_name || !sub;
+
+    if (isMandatoryUserInfoMissing) {
+      userInfoContent = await this.getUserInfoFromEndpoint({ accessToken, userInfoUrl: this.userInfoUrl });
     }
 
     return {

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -2,7 +2,7 @@ const jsonwebtoken = require('jsonwebtoken');
 const settings = require('../../../config');
 const httpAgent = require('../../../infrastructure/http/http-agent');
 const querystring = require('querystring');
-const { AuthenticationTokenRetrievalError, InvalidExternalAPIResponseError } = require('../../errors');
+const { InvalidExternalAPIResponseError } = require('../../errors');
 const AuthenticationSessionContent = require('../../models/AuthenticationSessionContent');
 const { v4: uuidv4 } = require('uuid');
 const DomainTransaction = require('../../../infrastructure/DomainTransaction');
@@ -71,7 +71,7 @@ class OidcAuthenticationService {
 
     if (!response.isSuccessful) {
       const errorMessage = JSON.stringify(response.data);
-      throw new AuthenticationTokenRetrievalError(errorMessage, response.code);
+      throw new InvalidExternalAPIResponseError(errorMessage, response.code);
     }
 
     return new AuthenticationSessionContent({

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -70,8 +70,15 @@ class OidcAuthenticationService {
     });
 
     if (!response.isSuccessful) {
-      const errorMessage = JSON.stringify(response.data);
-      throw new InvalidExternalAPIResponseError(errorMessage, response.code);
+      const errorResponse = JSON.stringify(response.data);
+      const message = 'Erreur lors de la récupération des tokens du partenaire.';
+      const dataToLog = {
+        message,
+        errorDescription: errorResponse.error_description,
+        errorType: errorResponse.error,
+      };
+      monitoringTools.logErrorWithCorrelationIds({ message: dataToLog });
+      throw new InvalidExternalAPIResponseError(message);
     }
 
     return new AuthenticationSessionContent({

--- a/api/lib/infrastructure/http/errors-helper.js
+++ b/api/lib/infrastructure/http/errors-helper.js
@@ -1,0 +1,24 @@
+function getErrorDetails(response, customMessage) {
+  let errorDetails;
+
+  if (typeof response.data === 'string') {
+    errorDetails = response.data.length > 0 ? response.data : 'Pas de détails disponibles';
+  }
+
+  if (typeof response.data === 'object') {
+    errorDetails = response.data.error_description
+      ? { errorDescription: response.data.error_description, errorType: response.data.error }
+      : JSON.stringify(response.data);
+  }
+
+  const dataToLog = {
+    customMessage,
+    errorDetails,
+  };
+
+  return dataToLog;
+}
+
+module.exports = {
+  getErrorDetails,
+};

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -550,6 +550,19 @@ describe('Unit | Application | ErrorManager', function () {
         // then
         expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message);
       });
+
+      it('should instantiate ServiceUnavailableError when InvalidExternalAPIResponseError', async function () {
+        // given
+        const error = new InvalidExternalAPIResponseError();
+        sinon.stub(HttpErrors, 'ServiceUnavailableError');
+        const params = { request: {}, h: hFake, error };
+
+        // when
+        await handle(params.request, params.h, params.error);
+
+        // then
+        expect(HttpErrors.ServiceUnavailableError).to.have.been.calledWithExactly(error.message);
+      });
     });
   });
 });

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -31,6 +31,7 @@ const {
   CampaignTypeError,
   InvalidJuryLevelError,
   UnexpectedOidcStateError,
+  InvalidIdentityProviderError,
 } = require('../../../lib/domain/errors');
 const HttpErrors = require('../../../lib/application/http-errors.js');
 
@@ -527,6 +528,19 @@ describe('Unit | Application | ErrorManager', function () {
       it('should instantiate BadRequestError when UnexpectedOidcStateError', async function () {
         // given
         const error = new UnexpectedOidcStateError();
+        sinon.stub(HttpErrors, 'BadRequestError');
+        const params = { request: {}, h: hFake, error };
+
+        // when
+        await handle(params.request, params.h, params.error);
+
+        // then
+        expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message);
+      });
+
+      it('should instantiate BadRequestError when InvalidIdentityProviderError', async function () {
+        // given
+        const error = new InvalidIdentityProviderError();
         sinon.stub(HttpErrors, 'BadRequestError');
         const params = { request: {}, h: hFake, error };
 

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -30,6 +30,7 @@ const {
   CertificationAttestationGenerationError,
   CampaignTypeError,
   InvalidJuryLevelError,
+  UnexpectedOidcStateError,
 } = require('../../../lib/domain/errors');
 const HttpErrors = require('../../../lib/application/http-errors.js');
 
@@ -470,19 +471,6 @@ describe('Unit | Application | ErrorManager', function () {
       expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(error.message, error.code);
     });
 
-    it('should instantiate ConflictError when DifferentExternalIdentifierError', async function () {
-      // given
-      const error = new DifferentExternalIdentifierError();
-      sinon.stub(HttpErrors, 'ConflictError');
-      const params = { request: {}, h: hFake, error };
-
-      // when
-      await handle(params.request, params.h, params.error);
-
-      // then
-      expect(HttpErrors.ConflictError).to.have.been.calledWithExactly(error.message);
-    });
-
     it('should instantiate UnprocessableEntityError when CertificationAttestationGenerationError', async function () {
       // given
       const error = new CertificationAttestationGenerationError();
@@ -520,6 +508,34 @@ describe('Unit | Application | ErrorManager', function () {
 
       // then
       expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message);
+    });
+
+    describe('SSO specific errors', function () {
+      it('should instantiate ConflictError when DifferentExternalIdentifierError', async function () {
+        // given
+        const error = new DifferentExternalIdentifierError();
+        sinon.stub(HttpErrors, 'ConflictError');
+        const params = { request: {}, h: hFake, error };
+
+        // when
+        await handle(params.request, params.h, params.error);
+
+        // then
+        expect(HttpErrors.ConflictError).to.have.been.calledWithExactly(error.message);
+      });
+
+      it('should instantiate BadRequestError when UnexpectedOidcStateError', async function () {
+        // given
+        const error = new UnexpectedOidcStateError();
+        sinon.stub(HttpErrors, 'BadRequestError');
+        const params = { request: {}, h: hFake, error };
+
+        // when
+        await handle(params.request, params.h, params.error);
+
+        // then
+        expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message);
+      });
     });
   });
 });

--- a/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
+++ b/api/tests/unit/domain/services/authentication/authentication-service-registry_test.js
@@ -1,6 +1,7 @@
 const { expect, catchErr } = require('../../../../test-helper');
 const authenticationRegistry = require('../../../../../lib/domain/services/authentication/authentication-service-registry');
 const PoleEmploiOidcAuthenticationService = require('../../../../../lib/domain/services/authentication/pole-emploi-oidc-authentication-service');
+const { InvalidIdentityProviderError } = require('../../../../../lib/domain/errors');
 
 describe('Unit | Domain | Services | authentication registry', function () {
   describe('#lookupAuthenticationService', function () {
@@ -23,7 +24,8 @@ describe('Unit | Domain | Services | authentication registry', function () {
       const error = await catchErr(authenticationRegistry.lookupAuthenticationService)(identityProvider);
 
       // then
-      expect(error.message).to.equal(`Identity provider ${identityProvider} is not supported`);
+      expect(error).to.be.an.instanceOf(InvalidIdentityProviderError);
+      expect(error.message).to.equal(`Identity provider ${identityProvider} is not supported.`);
     });
   });
 });

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -10,6 +10,7 @@ const DomainTransaction = require('../../../../../lib/infrastructure/DomainTrans
 const UserToCreate = require('../../../../../lib/domain/models/UserToCreate');
 const AuthenticationMethod = require('../../../../../lib/domain/models/AuthenticationMethod');
 const OidcIdentityProviders = require('../../../../../lib/domain/constants/oidc-identity-providers');
+const monitoringTools = require('../../../../../lib/infrastructure/monitoring-tools');
 
 describe('Unit | Domain | Services | oidc-authentication-service', function () {
   describe('#createAccessToken', function () {
@@ -116,6 +117,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const tokenUrl = 'http://oidc.net/api/token';
         const clientSecret = 'OIDC_CLIENT_SECRET';
 
+        sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
         sinon.stub(httpAgent, 'post');
         httpAgent.post.resolves({
           isSuccessful: false,
@@ -139,9 +141,8 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
 
         // then
         expect(error).to.be.an.instanceOf(InvalidExternalAPIResponseError);
-        expect(error.message).to.equal(
-          '{"error":"invalid_client","error_description":"Invalid authentication method for accessing this endpoint."}'
-        );
+        expect(error.message).to.equal('Erreur lors de la récupération des tokens du partenaire.');
+        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledOnce;
       });
     });
   });

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -5,10 +5,7 @@ const OidcAuthenticationService = require('../../../../../lib/domain/services/au
 const jsonwebtoken = require('jsonwebtoken');
 const httpAgent = require('../../../../../lib/infrastructure/http/http-agent');
 const AuthenticationSessionContent = require('../../../../../lib/domain/models/AuthenticationSessionContent');
-const {
-  AuthenticationTokenRetrievalError,
-  InvalidExternalAPIResponseError,
-} = require('../../../../../lib/domain/errors');
+const { InvalidExternalAPIResponseError } = require('../../../../../lib/domain/errors');
 const DomainTransaction = require('../../../../../lib/infrastructure/DomainTransaction');
 const UserToCreate = require('../../../../../lib/domain/models/UserToCreate');
 const AuthenticationMethod = require('../../../../../lib/domain/models/AuthenticationMethod');
@@ -113,7 +110,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
     });
 
     context('when tokens retrieval fails', function () {
-      it('should log error and throw AuthenticationTokenRetrievalError', async function () {
+      it('should log error and throw InvalidExternalAPIResponseError', async function () {
         // given
         const clientId = 'OIDC_CLIENT_ID';
         const tokenUrl = 'http://oidc.net/api/token';
@@ -141,7 +138,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         });
 
         // then
-        expect(error).to.be.an.instanceOf(AuthenticationTokenRetrievalError);
+        expect(error).to.be.an.instanceOf(InvalidExternalAPIResponseError);
         expect(error.message).to.equal(
           '{"error":"invalid_client","error_description":"Invalid authentication method for accessing this endpoint."}'
         );

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -60,6 +60,44 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
     });
   });
 
+  describe('#isUserInfoContentContainsMissingFields', function () {
+    it('should return a message with missing fields list', async function () {
+      // given
+      const oidcAuthenticationService = new OidcAuthenticationService({});
+
+      // when
+      const response = await oidcAuthenticationService.isUserInfoContentContainsMissingFields({
+        userInfoContent: {
+          given_name: 'givenName',
+          family_name: undefined,
+          nonce: 'bb041272-d6e6-457c-99fb-ff1aa02217fd',
+          sub: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+        },
+      });
+
+      // then
+      expect(response).to.equal('Champs manquants : family_name');
+    });
+
+    it('should return false', async function () {
+      // given
+      const oidcAuthenticationService = new OidcAuthenticationService({});
+
+      // when
+      const response = await oidcAuthenticationService.isUserInfoContentContainsMissingFields({
+        userInfoContent: {
+          given_name: 'givenName',
+          family_name: 'familyName',
+          nonce: 'bb041272-d6e6-457c-99fb-ff1aa02217fd',
+          sub: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+        },
+      });
+
+      // then
+      expect(response).to.equal(false);
+    });
+  });
+
   describe('#exchangeCodeForTokens', function () {
     it('should return id token', async function () {
       // given
@@ -142,7 +180,15 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(error).to.be.an.instanceOf(InvalidExternalAPIResponseError);
         expect(error.message).to.equal('Erreur lors de la récupération des tokens du partenaire.');
-        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledOnce;
+        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
+          message: {
+            customMessage: 'Erreur lors de la récupération des tokens du partenaire.',
+            errorDetails: {
+              errorDescription: 'Invalid authentication method for accessing this endpoint.',
+              errorType: 'invalid_client',
+            },
+          },
+        });
       });
     });
   });
@@ -237,7 +283,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const userInfoUrl = 'infoUrl';
 
         const oidcAuthenticationService = new OidcAuthenticationService({ userInfoUrl });
-        sinon.stub(oidcAuthenticationService, '_getContentFromUserInfoEndpoint');
+        sinon.stub(oidcAuthenticationService, 'getUserInfoFromEndpoint');
 
         // when
         await oidcAuthenticationService.getUserInfo({
@@ -246,7 +292,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         });
 
         // then
-        expect(oidcAuthenticationService._getContentFromUserInfoEndpoint).to.have.been.calledOnceWithExactly({
+        expect(oidcAuthenticationService.getUserInfoFromEndpoint).to.have.been.calledOnceWithExactly({
           accessToken: 'accessToken',
           userInfoUrl,
         });
@@ -254,23 +300,33 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
     });
   });
 
-  describe('#_getContentFromUserInfoEndpoint', function () {
+  describe('#getUserInfoFromEndpoint', function () {
+    // given
+    const userInfoUrl = 'userInfoUrl';
+    const accessToken = 'accessToken';
+
     it('should return nonce, firstName, lastName and external identity id', async function () {
       // given
-      sinon.stub(httpAgent, 'get').resolves({
-        isSuccessful: true,
-        data: {
-          given_name: 'givenName',
-          family_name: 'familyName',
-          nonce: 'bb041272-d6e6-457c-99fb-ff1aa02217fd',
-          sub: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
-        },
+      sinon
+        .stub(httpAgent, 'get')
+        .withArgs({ url: userInfoUrl, headers: { Authorization: `Bearer ${accessToken}` } })
+        .resolves({
+          isSuccessful: true,
+          data: {
+            given_name: 'givenName',
+            family_name: 'familyName',
+            nonce: 'bb041272-d6e6-457c-99fb-ff1aa02217fd',
+            sub: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+          },
+        });
+
+      const oidcAuthenticationService = new OidcAuthenticationService({
+        userInfoUrl,
+        accessToken,
       });
 
-      const oidcAuthenticationService = new OidcAuthenticationService({ userInfoUrl: 'userInfoUrl' });
-
       // when
-      const result = await oidcAuthenticationService._getContentFromUserInfoEndpoint({
+      const result = await oidcAuthenticationService.getUserInfoFromEndpoint({
         accessToken: 'accessToken',
         userInfoUrl: 'userInfoUrl',
       });
@@ -284,22 +340,103 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       });
     });
 
-    describe('when required properties are not returned by external API', function () {
+    describe('when call to external API fails with no data details', function () {
       it('should throw error', async function () {
         // given
-        sinon.stub(httpAgent, 'get').resolves({
-          isSuccessful: true,
-          data: {
-            given_name: 'givenName',
-            family_name: undefined,
-            nonce: 'bb041272-d6e6-457c-99fb-ff1aa02217fd',
-            sub: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+        sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
+        const axiosError = {
+          response: {
+            data: '',
+            status: 400,
+          },
+        };
+        sinon
+          .stub(httpAgent, 'get')
+          .withArgs({ url: userInfoUrl, headers: { Authorization: `Bearer ${accessToken}` } })
+          .resolves({ isSuccessful: false, code: axiosError.response.status, data: axiosError.response.data });
+        // See api/lib/infrastructure/http/http-agent.js to understand, axios can throw an error but httpAgent.get map it into an http response
+        const oidcAuthenticationService = new OidcAuthenticationService({ userInfoUrl, accessToken });
+
+        // when
+        let errorResponse;
+        try {
+          await oidcAuthenticationService.getUserInfoFromEndpoint({
+            accessToken: 'accessToken',
+            userInfoUrl: 'userInfoUrl',
+          });
+        } catch (error) {
+          errorResponse = error;
+        }
+
+        // then
+        expect(errorResponse).to.be.instanceOf(InvalidExternalAPIResponseError);
+        expect(errorResponse.message).to.be.equal(
+          'Une erreur est survenue en récupérant les informations des utilisateurs.'
+        );
+        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
+          message: {
+            customMessage: 'Une erreur est survenue en récupérant les informations des utilisateurs.',
+            errorDetails: 'Pas de détails disponibles',
           },
         });
+      });
+    });
+
+    describe('when returned value by external API is not a json object', function () {
+      it('should throw error', async function () {
+        // given
+        sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
+        sinon
+          .stub(httpAgent, 'get')
+          .withArgs({ url: userInfoUrl, headers: { Authorization: `Bearer ${accessToken}` } })
+          .resolves({
+            isSuccessful: true,
+            data: '',
+          });
         const oidcAuthenticationService = new OidcAuthenticationService({ userInfoUrl: 'userInfoUrl' });
 
         // when
-        const error = await catchErr(oidcAuthenticationService._getContentFromUserInfoEndpoint)({
+        const error = await catchErr(oidcAuthenticationService.getUserInfoFromEndpoint)({
+          accessToken,
+          userInfoUrl,
+        });
+
+        // then
+        expect(error).to.be.instanceOf(InvalidExternalAPIResponseError);
+        expect(error.message).to.be.equal('Les informations utilisateur récupérées ne sont pas au format attendu.');
+        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
+          message: {
+            message: 'Les informations utilisateur récupérées ne sont pas au format attendu.',
+            typeOfUserInfoContent: 'string',
+            userInfoContent: '',
+          },
+        });
+      });
+    });
+
+    describe('when required properties are not returned by external API', function () {
+      it('should throw error', async function () {
+        // given
+        sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
+        sinon
+          .stub(httpAgent, 'get')
+          .withArgs({ url: userInfoUrl, headers: { Authorization: `Bearer ${accessToken}` } })
+          .resolves({
+            isSuccessful: true,
+            data: {
+              given_name: 'givenName',
+              family_name: undefined,
+              nonce: 'bb041272-d6e6-457c-99fb-ff1aa02217fd',
+              sub: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
+            },
+          });
+        const oidcAuthenticationService = new OidcAuthenticationService({ userInfoUrl, accessToken });
+
+        // when
+        const error = await catchErr(
+          oidcAuthenticationService.getUserInfoFromEndpoint,
+          oidcAuthenticationService
+        )({
           accessToken: 'accessToken',
           userInfoUrl: 'userInfoUrl',
         });
@@ -307,46 +444,10 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         // then
         expect(error).to.be.instanceOf(InvalidExternalAPIResponseError);
         expect(error.message).to.be.equal('Les informations utilisateurs récupérées sont incorrectes.');
-      });
-    });
-
-    describe('when returned value by external API is not a json object', function () {
-      it('should throw error', async function () {
-        // given
-        sinon.stub(httpAgent, 'get').resolves({
-          isSuccessful: true,
-          data: '',
+        expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
+          message: "Un des champs obligatoires n'a pas été renvoyé",
+          missingFields: 'Champs manquants : family_name',
         });
-        const oidcAuthenticationService = new OidcAuthenticationService({ userInfoUrl: 'userInfoUrl' });
-
-        // when
-        const error = await catchErr(oidcAuthenticationService._getContentFromUserInfoEndpoint)({
-          accessToken: 'accessToken',
-          userInfoUrl: 'userInfoUrl',
-        });
-
-        // then
-        expect(error).to.be.instanceOf(InvalidExternalAPIResponseError);
-        expect(error.message).to.be.equal('Les informations utilisateur récupérées ne sont pas au format attendu.');
-      });
-    });
-
-    describe('when call to external API fails', function () {
-      it('should throw error', async function () {
-        // given
-        const anError = new Error('something bad happened');
-        sinon.stub(httpAgent, 'get').rejects(anError);
-        const oidcAuthenticationService = new OidcAuthenticationService({ userInfoUrl: 'userInfoUrl' });
-
-        // when
-        const error = await catchErr(oidcAuthenticationService._getContentFromUserInfoEndpoint)({
-          accessToken: 'accessToken',
-          userInfoUrl: 'userInfoUrl',
-        });
-
-        // then
-        expect(error).to.be.instanceOf(InvalidExternalAPIResponseError);
-        expect(error.message).to.be.equal('Une erreur est survenue en récupérant les information des utilisateurs.');
       });
     });
   });

--- a/api/tests/unit/infrastructure/http/errors-helper_test.js
+++ b/api/tests/unit/infrastructure/http/errors-helper_test.js
@@ -1,0 +1,94 @@
+const { expect } = require('../../../test-helper');
+
+const { getErrorDetails } = require('../../../../lib/infrastructure/http/errors-helper');
+
+describe('getErrorDetails', function () {
+  describe('when http error data is a string', function () {
+    it('should display the string message', function () {
+      // given
+      const errorResponse = {
+        code: null,
+        data: 'Error',
+      };
+
+      const customMessage = 'Something bad happened';
+
+      // when
+      const formattedResponse = getErrorDetails(errorResponse, customMessage);
+
+      // then
+      expect(formattedResponse).to.deep.equal({
+        customMessage,
+        errorDetails: errorResponse.data,
+      });
+    });
+  });
+
+  describe('when http error data is an empty string', function () {
+    it('should display a generic message in the formatted response', function () {
+      // given
+      const errorResponse = { code: 401, data: '', isSuccessful: false };
+      const customMessage = 'Something bad happened';
+
+      // when
+      const formattedResponse = getErrorDetails(errorResponse, customMessage);
+
+      // then
+      expect(formattedResponse).to.deep.equal({
+        customMessage,
+        errorDetails: 'Pas de détails disponibles',
+      });
+    });
+  });
+
+  describe('when http error data contains error and error description', function () {
+    it('should display it in the formatted response', function () {
+      // given
+      const errorResponse = {
+        code: 400,
+        data: {
+          error: 'invalid_client',
+          error_description: 'Invalid authentication method for accessing this endpoint.',
+        },
+      };
+
+      const customMessage = 'Something bad happened';
+
+      // when
+      const formattedResponse = getErrorDetails(errorResponse, customMessage);
+
+      // then
+      expect(formattedResponse).to.deep.equal({
+        customMessage,
+        errorDetails: {
+          errorDescription: 'Invalid authentication method for accessing this endpoint.',
+          errorType: 'invalid_client',
+        },
+      });
+    });
+  });
+
+  describe("when http error data doesn't contain error description", function () {
+    it('should display it in the formatted response', function () {
+      // given
+      const errorResponse = {
+        code: 400,
+        data: {
+          error: 'invalid_client',
+          custom_error: 'Invalid authentication method for accessing this endpoint.',
+        },
+      };
+
+      const customMessage = 'Something bad happened';
+
+      // when
+      const formattedResponse = getErrorDetails(errorResponse, customMessage);
+
+      // then
+      expect(formattedResponse).to.deep.equal({
+        customMessage,
+        errorDetails: JSON.stringify(errorResponse.data),
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :jack_o_lantern: Problème
Certaines erreurs 500 sont remontées à Datadog de manière journalière sur la route sur le POST `/api/oidc/token` sans que l'on puisse vraiment identifier la cause de manière sûre même si un faisceau d'indices laisse penser que les appels à un identity provider puisse en être la source.


![Capture d’écran 2022-10-17 à 08 57 33](https://user-images.githubusercontent.com/7688741/196109429-2576c4ca-d10b-4d0e-ba5e-574a5d125763.png)


## :bat: Proposition

Supprimer l'erreur AuthenticationTokenRetrievalError qui retourne une InternalServerError soit une 500, ce qui crée du bruit et ne permet pas de déceler cette erreur d'une expection, et la remplacer par 503 InvalidExternalAPIResponseError.

Améliorer les logs alimentant notre outil de monitoring.

## :spider_web: Remarques
Un peu peu de refacto a été effectué 

## :ghost: Pour tester
**- Avant toute chose, vérifier que vous avez bien la var d'env POLE_EMPLOI_OIDC_USER_INFO_URL en local !**
- En local, se connecter via pole emploi en ayant auparavant modifié des bouts de code dans `exchangeCodeForTokens` du service `domain/services/authentication/oidc-authentication-service.js` pour que les appels vers l'api pole emploi soient en erreur :

Modifier ou supprimer un paramètre dans 

```js
   const data = {
      client_secret: this.clientSecret,
      grant_type: 'authorization_code',
      code,
      client_id: this.clientId,
      redirect_uri: redirectUri,
    };
```
et voir les erreurs dans les logs de l'api, ex  si on écrit ` grant_type: 'authorization_code6'` on voit 
```
    msg: {
      "customMessage": "Erreur lors de la récupération des tokens du partenaire.",
      "errorDetails": {
        "errorDescription": "Unknown Grant Type, authorization_code6",
        "errorType": "unsupported_grant_type"
      }
```      
    
-Dans la méthode `getUserInfo` commenter la partie  `if (isMandatoryUserInfoMissing)` pour faire appel à l'url qui permet de récupérer les infos d'un utilisateur et puis modifier l'accès token ou l'url dans le code  pour voir des 401 (si l'access token est invalide) ou 404 (l'url est inconnue) :

    `userInfoContent = await this.getUserInfoFromEndpoint({ accessToken, userInfoUrl: this.userInfoUrl });`
    
Modifier userInfoContent plus bas pour passer dans les erreurs de validations en ayant pris soin de commenter ou supprimer toute la partie liée  à cet  userInfoContent = await this.getUserInfoFromEndpoint({ accessToken, userInfoUrl: this.userInfoUrl });

Par exemple, remplacer par
```
userInfoContent = {
   given_name: 'givenName',
   family_name: undefined,
   nonce: 'bb041272-d6e6-457c-99fb-ff1aa02217fd',
   sub: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',
}
```
    
  
