### PR TITLE
[BUGFIX] Permettre la récupération de compte SCO si l'utilisateur à une autre méthode que le GAR sur Pix App (PIX-5832).

### DIFF
--- a/api/tests/acceptance/application/account-recovery/account-recovery-route-patch_test.js
+++ b/api/tests/acceptance/application/account-recovery/account-recovery-route-patch_test.js
@@ -1,43 +1,102 @@
-const { databaseBuilder, expect } = require('../../../test-helper');
+const { databaseBuilder, expect, knex } = require('../../../test-helper');
 const createServer = require('../../../../server');
 
 describe('Acceptance | Route | Account-recovery', function () {
-  describe('PATCH /api/users/{id}/account-recovery', function () {
-    it('should return 204 HTTP status codes', async function () {
-      // given
-      const server = await createServer();
+  describe('PATCH /api/account-recovery', function () {
+    context('when user has pix authentication method', function () {
+      it("should proceed to the account recover by changing user's password and email", async function () {
+        // given
+        const server = await createServer();
+        const userId = databaseBuilder.factory.buildUser.withRawPassword({
+          email: 'old-email@example.net',
+          rawPassword: 'oldPassword',
+        }).id;
+        databaseBuilder.factory.buildAccountRecoveryDemand({
+          temporaryKey: 'SOME_SUPER_SUPER_SUPER_SUPER_LONG_TEMPORARY_KEY',
+          userId,
+          oldEmail: 'old-email@example.net',
+          newEmail: 'new-email@example.net',
+          used: false,
+        });
+        await databaseBuilder.commit();
+        const { authenticationComplement: userPasswordBefore } = await knex('authentication-methods')
+          .select('authenticationComplement')
+          .where({ userId })
+          .first();
 
-      const userId = 1234;
-      const newEmail = 'newEmail@example.net';
-      const password = 'password123#A*';
-      databaseBuilder.factory.buildUser.withRawPassword({ id: userId });
-      const accountRecoveryDemand = databaseBuilder.factory.buildAccountRecoveryDemand({
-        userId,
-        temporaryKey: 'FfgpFXgyuO062nPUPwcb8Wy3KcgkqR2p2GyEuGVaNI4=',
-        newEmail,
-        used: false,
-      });
-      const temporaryKey = accountRecoveryDemand.temporaryKey;
-      await databaseBuilder.commit();
-
-      const options = {
-        method: 'PATCH',
-        url: '/api/account-recovery',
-        payload: {
-          data: {
-            attributes: {
-              'temporary-key': temporaryKey,
-              password,
+        // when
+        const response = await server.inject({
+          method: 'PATCH',
+          url: '/api/account-recovery',
+          payload: {
+            data: {
+              attributes: {
+                'temporary-key': 'SOME_SUPER_SUPER_SUPER_SUPER_LONG_TEMPORARY_KEY',
+                password: 'password123#A*',
+              },
             },
           },
-        },
-      };
+        });
 
-      // when
-      const response = await server.inject(options);
+        // then
+        const { authenticationComplement: userPasswordAfter } = await knex('authentication-methods')
+          .select('authenticationComplement')
+          .where({ userId })
+          .first();
+        const { email: newUserEmail } = await knex('users').select('email').where({ id: userId }).first();
+        expect(response.statusCode).to.equal(204);
+        expect(newUserEmail).to.equal('new-email@example.net');
+        expect(userPasswordAfter.password).to.not.equal(userPasswordBefore.password);
+      });
+    });
 
-      // then
-      expect(response.statusCode).to.equal(204);
+    context('when user has no pix authentication method', function () {
+      it('should proceed to the account recover by create pix authentication method', async function () {
+        // given
+        const server = await createServer();
+        const userWithGarAuthenticationMethod = databaseBuilder.factory.buildUser.withoutPixAuthenticationMethod({
+          cgu: false,
+        });
+        databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
+          externalIdentifier: '123ABC',
+          userId: userWithGarAuthenticationMethod.id,
+        });
+        databaseBuilder.factory.buildAccountRecoveryDemand({
+          temporaryKey: 'SOME_SUPER_SUPER_SUPER_SUPER_LONG_TEMPORARY_KEY',
+          userId: userWithGarAuthenticationMethod.id,
+          oldEmail: null,
+          newEmail: 'new-email@example.net',
+          used: false,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const response = await server.inject({
+          method: 'PATCH',
+          url: '/api/account-recovery',
+          payload: {
+            data: {
+              attributes: {
+                'temporary-key': 'SOME_SUPER_SUPER_SUPER_SUPER_LONG_TEMPORARY_KEY',
+                password: 'password123#A*',
+              },
+            },
+          },
+        });
+
+        // then
+        const userAuthenticationMethods = await knex('authentication-methods')
+          .select('identityProvider')
+          .where({ userId: userWithGarAuthenticationMethod.id });
+        const { email: newUserEmail, cgu } = await knex('users')
+          .select('email', 'cgu')
+          .where({ id: userWithGarAuthenticationMethod.id })
+          .first();
+        expect(response.statusCode).to.equal(204);
+        expect(newUserEmail).to.equal('new-email@example.net');
+        expect(cgu).to.equal(true);
+        expect(userAuthenticationMethods).to.deepEqualArray([{ identityProvider: 'GAR' }, { identityProvider: 'PIX' }]);
+      });
     });
   });
 });


### PR DESCRIPTION
## :jack_o_lantern: Problème
Pour rappel, la sortie SCO concerne les élèves se connectant sur Pix via le GAR ou avec un username.

Dans la dernière étape de la sortie SCO, au moment où l'utilisateur change son mot de passe, on vérifie qu'il n'a qu'une seule méthode et que cette méthode est de type GAR.

- Si c'est le cas, on crée une nouvelle méthode de connexion Pix
- Si non, on suppose que l'autre méthode qui existe est une méthode Pix et on tente de la mettre jour.

Or il existe des cas d'utilisateurs ayant la méthode GAR ET une autre méthode de connexion (Pole Emploi), conséquence de l'ancienne réconciliation de compte Pôle Emploi.

## :bat: Proposition
Ne plus faire la vérification du "only GAR" mais vérifier s'il à déjà une méthode de connexion Pix. 
- Si c'est le cas, on met à jour le mot de passe.
- Si non, on créé une méthode de connexion Pix.

## :spider_web: Remarques
Compléter l'actuel test d'acceptance en couvrant nos 2 cas de figure.

 https://github.com/1024pix/pix/pull/5022

## :ghost: Pour tester
- Aller en BDD et modifier les `authentication-methods` de l'utilisateur `George de Cambridge` pour avoir une méthode GAR et POLE_EMPLOI uniquement
- Ouvrir la page de sortie sco : /recuperer-mon-compte
- Fournir toutes les informations demandées (infos dans la tables `organization-learners`)
- Saisir votre adresse e-mail pour recevoir le mail avec un lien
- Si vous ne recevez pas de message, récupérez le code dans la table des demandes de récupération de compte (`account-recovery-demands`)
- Ouvrir le lien, ou la page avec le code récupéré : https://app-pr5069.review.pix.fr/recuperer-mon-compte/__code
- Fournir un nouveau mot de passe et valider
- Constatez l'ajout de la méthode PIX en BDD + email ajouté coté user

Faire le même scénario avec un utilisateur ayant déjà le GAR et PIX
- Constater que ça ne fait que mettre à jour l'adresse email et le mot de passe.