### PR TITLE
[TECH] Monitorer les temps d'execution des jobs dans pgboss (PIX-6011).

### DIFF
--- a/api/lib/infrastructure/events/EventHandlerDependenciesBuilder.js
+++ b/api/lib/infrastructure/events/EventHandlerDependenciesBuilder.js
@@ -58,7 +58,7 @@ class EventErrorHandler {
         event,
         handlerName: this.handler.name,
         error: error?.message ? error.message + ' (see dedicated log for more information)' : undefined,
-        type: 'EVENT_LOG',
+        type: 'EVENT_LOG_ERROR',
         info: 'EventBus : Event Handling Error',
       },
     });

--- a/api/lib/infrastructure/jobs/JobDependenciesBuilder.js
+++ b/api/lib/infrastructure/jobs/JobDependenciesBuilder.js
@@ -1,11 +1,12 @@
 const logger = require('../../infrastructure/logger');
+const MonitoredJobHandler = require('./monitoring/MonitoredJobHandler');
 
 function build(classToInstanciate) {
   const dependencies = _buildDependencies();
 
-  const instance = new classToInstanciate(dependencies);
-  const handler = new JobErrorHandler(instance, logger);
-  return handler;
+  const handler = new classToInstanciate(dependencies);
+  const monitoredJobHandler = new MonitoredJobHandler(handler, logger);
+  return monitoredJobHandler;
 }
 
 function _buildDependencies() {
@@ -25,41 +26,3 @@ function _buildDependencies() {
 module.exports = {
   build,
 };
-
-class JobErrorHandler {
-  constructor(handler, logger) {
-    this.handler = handler;
-    this.logger = logger;
-  }
-
-  async handle(data) {
-    let result;
-    try {
-      this.logJobStarting(data);
-      result = await this.handler.handle(data);
-    } catch (error) {
-      this.logJobFailed(data, error);
-      throw error;
-    }
-    return result;
-  }
-
-  logJobStarting(data) {
-    this.logger.info({
-      data,
-      handlerName: this.handler.name,
-      type: 'JOB_LOG',
-      message: 'Job starting',
-    });
-  }
-
-  logJobFailed(data, error) {
-    this.logger.error({
-      data,
-      handlerName: this.handler.name,
-      error: error?.message ? error.message + ' (see dedicated log for more information)' : undefined,
-      type: 'JOB_LOG',
-      message: 'Job failed',
-    });
-  }
-}

--- a/api/lib/infrastructure/jobs/JobPgBoss.js
+++ b/api/lib/infrastructure/jobs/JobPgBoss.js
@@ -8,12 +8,13 @@ class JobPgBoss {
 
   async schedule(data) {
     await this.queryBuilder.raw(
-      'INSERT INTO pgboss.job (name, data, retryLimit, retryDelay) VALUES (:name, :data, :retryLimit, :retryDelay)',
+      'INSERT INTO pgboss.job (name, data, retryLimit, retryDelay, on_complete) VALUES (:name, :data, :retryLimit, :retryDelay, :on_complete)',
       {
         name: this.name,
         retryLimit: this.retryLimit,
         retryDelay: this.retryDelay,
         data,
+        on_complete: true,
       }
     );
   }

--- a/api/lib/infrastructure/jobs/campaign-result/ParticipationResultCalculationJobHandler.js
+++ b/api/lib/infrastructure/jobs/campaign-result/ParticipationResultCalculationJobHandler.js
@@ -1,3 +1,5 @@
+const Job = require('./ParticipationResultCalculationJob');
+
 class ParticipationResultCalculationJobHandler {
   constructor({ participantResultsSharedRepository, campaignParticipationRepository }) {
     this.participantResultsSharedRepository = participantResultsSharedRepository;
@@ -11,7 +13,7 @@ class ParticipationResultCalculationJobHandler {
   }
 
   get name() {
-    return 'ParticipationResultCalculation';
+    return Job.name;
   }
 }
 

--- a/api/lib/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiHandler.js
+++ b/api/lib/infrastructure/jobs/campaign-result/SendSharedParticipationResultsToPoleEmploiHandler.js
@@ -1,5 +1,6 @@
 const PoleEmploiPayload = require('../../externals/pole-emploi/PoleEmploiPayload');
 const PoleEmploiSending = require('../../../domain/models/PoleEmploiSending');
+const Job = require('./SendSharedParticipationResultsToPoleEmploiJob');
 
 class SendSharedParticipationResultsToPoleEmploiHandler {
   constructor({
@@ -58,7 +59,7 @@ class SendSharedParticipationResultsToPoleEmploiHandler {
   }
 
   get name() {
-    return 'SendSharedParticipationResultsToPoleEmploi';
+    return Job.name;
   }
 }
 

--- a/api/lib/infrastructure/jobs/monitoring/MonitoredJobHandler.js
+++ b/api/lib/infrastructure/jobs/monitoring/MonitoredJobHandler.js
@@ -1,0 +1,39 @@
+class MonitoredJobHandler {
+  constructor(handler, logger) {
+    this.handler = handler;
+    this.logger = logger;
+  }
+
+  async handle(data) {
+    let result;
+    try {
+      this.logJobStarting(data);
+      result = await this.handler.handle(data);
+    } catch (error) {
+      this.logJobFailed(data, error);
+      throw error;
+    }
+    return result;
+  }
+
+  logJobStarting(data) {
+    this.logger.info({
+      data,
+      handlerName: this.handler.name,
+      type: 'JOB_LOG',
+      message: 'Job Started',
+    });
+  }
+
+  logJobFailed(data, error) {
+    this.logger.error({
+      data,
+      handlerName: this.handler.name,
+      error: error?.message ? error.message + ' (see dedicated log for more information)' : undefined,
+      type: 'JOB_LOG_ERROR',
+      message: 'Job failed',
+    });
+  }
+}
+
+module.exports = MonitoredJobHandler;

--- a/api/lib/infrastructure/jobs/monitoring/MonitoredJobQueue.js
+++ b/api/lib/infrastructure/jobs/monitoring/MonitoredJobQueue.js
@@ -1,6 +1,7 @@
 const MonitoringJobHandler = require('./MonitoringJobExecutionTimeHandler');
 const logger = require('../../logger');
 const _ = require('lodash');
+const { teamSize, teamConcurrency } = require('../../../config').pgBoss;
 
 class MonitoredJobQueue {
   constructor(jobQueue) {
@@ -11,7 +12,7 @@ class MonitoredJobQueue {
     this.jobQueue.performJob(name, handlerClass);
 
     const monitoringJobHandler = new MonitoringJobHandler({ logger });
-    this.jobQueue.pgBoss.onComplete(name, (job) => {
+    this.jobQueue.pgBoss.onComplete(name, { teamSize, teamConcurrency }, (job) => {
       monitoringJobHandler.handle(job);
     });
 

--- a/api/lib/infrastructure/jobs/monitoring/MonitoredJobQueue.js
+++ b/api/lib/infrastructure/jobs/monitoring/MonitoredJobQueue.js
@@ -1,0 +1,23 @@
+const MonitoringJobHandler = require('./MonitoringJobExecutionTimeHandler');
+const logger = require('../../logger');
+
+class MonitoredJobQueue {
+  constructor(jobQueue) {
+    this.jobQueue = jobQueue;
+  }
+
+  performJob(name, handlerClass) {
+    this.jobQueue.performJob(name, handlerClass);
+
+    const monitoringJobHandler = new MonitoringJobHandler({ logger });
+    this.jobQueue.pgBoss.onComplete(name, (job) => {
+      monitoringJobHandler.handle(job);
+    });
+  }
+
+  async stop() {
+    await this.jobQueue.stop();
+  }
+}
+
+module.exports = MonitoredJobQueue;

--- a/api/lib/infrastructure/jobs/monitoring/MonitoringJobExecutionTimeHandler.js
+++ b/api/lib/infrastructure/jobs/monitoring/MonitoringJobExecutionTimeHandler.js
@@ -1,0 +1,25 @@
+const dayjs = require('dayjs');
+
+class MonitoringJobExecutionTimeHandler {
+  constructor({ logger }) {
+    this.logger = logger;
+  }
+
+  async handle(job) {
+    const createdOn = dayjs(job.data.createdOn);
+    const startedOn = dayjs(job.data.startedOn);
+    const completedOn = dayjs(job.data.completedOn);
+    const totalTime = completedOn.diff(createdOn, 'second', true);
+    const executionTime = completedOn.diff(startedOn, 'second', true);
+
+    this.logger.info({
+      event: 'pg-boss-execution-time',
+      type: 'JOB_LOG_EXEC_TIME',
+      handlerName: job.data.request.name,
+      executionTime,
+      totalTime,
+    });
+  }
+}
+
+module.exports = MonitoringJobExecutionTimeHandler;

--- a/api/worker.js
+++ b/api/worker.js
@@ -1,6 +1,5 @@
 require('dotenv').config();
 const PgBoss = require('pg-boss');
-const _ = require('lodash');
 const config = require('./lib/config');
 const logger = require('./lib/infrastructure/logger');
 const JobQueue = require('./lib/infrastructure/jobs/JobQueue');
@@ -20,15 +19,7 @@ async function runJobs() {
     max: config.pgBoss.connexionPoolMaxSize,
     ...(monitorStateIntervalSeconds ? { monitorStateIntervalSeconds } : {}),
   });
-  pgBoss.on('monitor-states', (state) => {
-    logger.info({ event: 'pg-boss-state', name: 'global' }, { ...state, queues: undefined });
-    _.each(state.queues, (queueState, queueName) => {
-      logger.info({ event: 'pg-boss-state', name: queueName }, queueState);
-    });
-  });
-  pgBoss.on('error', (err) => {
-    logger.error({ event: 'pg-boss-error' }, err);
-  });
+
   await pgBoss.start();
   const jobQueue = new JobQueue(pgBoss, dependenciesBuilder);
   const monitoredJobQueue = new MonitoredJobQueue(jobQueue);


### PR DESCRIPTION
## :jack_o_lantern: Problème
On a des mesures sur les jobs dans metabase et dans datadogn ce qui complique le suivi de ses mesures.

## :bat: Proposition
Remonté dans datadog le temps d'executions des jobs

## :spider_web: Remarques
Je sais ps si c'est intéressant de tester

## :ghost: Pour tester
Ajouter des jobs dans pgboss
Lancer le script start:job et constanter la présence dans les logs des mesures du temps d'execution des jobs.
