### PR TITLE
[BUGFIX] Améliorer le positionnement du bouton de modification d'email au format mobile (PIX-6030)

### DIFF
--- a/mon-pix/app/styles/components/_user-account.scss
+++ b/mon-pix/app/styles/components/_user-account.scss
@@ -89,8 +89,7 @@
     flex-grow: 1;
     height: max-content;
     padding: 14px 24px;
-    margin: 32px;
-    margin-left: 0;
+    margin: 32px 0;
 
     @include device-is('mobile') {
       padding: 16px;

--- a/mon-pix/app/styles/pages/_connection-methods.scss
+++ b/mon-pix/app/styles/pages/_connection-methods.scss
@@ -1,6 +1,8 @@
 .user-account-panel__item {
   display: flex;
-  align-content: flex-start;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: $spacing-m;
   border-top: $pix-neutral-15 1px solid;
   padding-top: 16px;
   padding-bottom: 16px;
@@ -25,11 +27,8 @@
 
 .user-account-panel-item__text {
   display: flex;
-
-  @include device-is('mobile') {
-    flex-direction: column;
-    padding-left: 10px;
-  }
+  flex-wrap: wrap;
+  gap: $spacing-xs;
 }
 
 .user-account-panel-item__label {
@@ -37,10 +36,6 @@
   display: flex;
   align-items: center;
   margin: 0;
-
-  @include device-is('mobile') {
-    padding-bottom: 10px;
-  }
 }
 
 .user-account-panel-item__value {
@@ -50,7 +45,6 @@
   align-items: center;
 }
 
-.user-account-panel-item__button,
 .user-account-panel-item__edit-button {
   margin-left: auto;
 }


### PR DESCRIPTION
## :jack_o_lantern: Problème
Actuellement, sur Pix App, le bouton de modification d'email sort de son container au format mobile : 

![image](https://user-images.githubusercontent.com/26234185/195897834-2f047a92-24e1-4e87-a078-c404a7d960ca.png)

## :bat: Proposition
Positionner le bouton au dessous de l'adresse email lorsqu'on passe au format mobile : 
![image](https://user-images.githubusercontent.com/26234185/195898622-a27cf442-e7f3-4332-9cc9-c41f7cee49ab.png)


## :spider_web: Remarques
Je propose de laisse le contenu de la section à gauche (voir ci-dessus) afin de rester iso avec la rubrique **"Mes informations personnelles"**

## :ghost: Pour tester
- se rendre sur Pix App dans la rubrique **mon compte**
- cliquer sur **Mes méthodes de connexion**
- passer au format mobile avec l'inspecteur du navigateur (choisir IphoneXE par exemple)
- constater que le bouton ne sort plus de son container