### PR TITLE
[TECH] Enregistrer les formations recommandées (PIX-6038).

### DIFF
--- a/api/db/migrations/20221017085933_create-user-recommended-trainings.js
+++ b/api/db/migrations/20221017085933_create-user-recommended-trainings.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'user-recommended-trainings';
+
+exports.up = (knex) => {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments().primary();
+    t.integer('userId').references('users.id').notNullable();
+    t.integer('trainingId').references('trainings.id').notNullable();
+    t.integer('campaignParticipationId').references('campaign-participations.id').notNullable();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    t.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+    t.unique(['userId', 'trainingId', 'campaignParticipationId']);
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};


### PR DESCRIPTION
## :jack_o_lantern: Problème
Nous souhaitons créer une page "Mes formations", où les utilisateurs pourront retrouver toutes les formations que nous lui recommandons. 
De plus, nous souhaitons proposer une entrée de menu : "Mes formations" uniquement si l'utilisateur a des formations recommandés. 

## :bat: Proposition
Pour limiter les calculs à la volé pour afficher l'entrée de menu et la page "Mes formations", nous ajoutons une table `user-recommended-trainings` qui a pour but de stocker les formations que nous avons recommandés. 

## :spider_web: Remarques
Nous avons ajouté une contrainte sur : `userId`, `trainingId`, `campaignParticipationId` car ça n'a pas de sens de recommander plusieurs fois la même formation pour un même user dans une même participation à une campagne.

## :ghost: Pour tester
- Lancer la migration en local : `npm run db:migrate`
- Constater que la table est bien ajoutée
- Lancer le rollback en local : `npm run db:rollback:latest`
- Constater que la table n'est plus présente.