### PR TITLE
[BUGFIX] L'erreur n'est complètement tracée lors d'un appel en erreur à un partenaire

### DIFF
--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -90,7 +90,7 @@ module.exports = {
 
       monitoringTools.logErrorWithCorrelationIds({
         metrics: { responseTime },
-        message: `End GET request to ${url} error: ${code}`,
+        message: `End GET request to ${url} error: ${code || ''} ${JSON.stringify(data)}`,
       });
 
       return new HttpResponse({

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -42,7 +42,7 @@ module.exports = {
         data = httpErr.message;
       }
 
-      const message = `End POST request to ${url} error: ${code || ''} ${data.toString()}`;
+      const message = `End POST request to ${url} error: ${code || ''} ${JSON.stringify(data)}`;
 
       monitoringTools.logErrorWithCorrelationIds({
         metrics: { responseTime },

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-modules
 const axios = require('axios');
 const { performance } = require('perf_hooks');
-const { logInfoWithCorrelationIds, logErrorWithCorrelationIds } = require('../monitoring-tools');
+const monitoringTools = require('../monitoring-tools');
 
 class HttpResponse {
   constructor({ code, data, isSuccessful }) {
@@ -20,7 +20,7 @@ module.exports = {
         headers,
       });
       responseTime = performance.now() - startTime;
-      logInfoWithCorrelationIds({
+      monitoringTools.logInfoWithCorrelationIds({
         metrics: { responseTime },
         message: `End POST request to ${url} success: ${httpResponse.status}`,
       });
@@ -42,9 +42,11 @@ module.exports = {
         data = httpErr.message;
       }
 
-      logErrorWithCorrelationIds({
+      const message = `End POST request to ${url} error: ${code || ''} ${data.toString()}`;
+
+      monitoringTools.logErrorWithCorrelationIds({
         metrics: { responseTime },
-        message: `End POST request to ${url} error: ${code || ''} ${data.toString()}`,
+        message,
       });
 
       return new HttpResponse({
@@ -61,7 +63,7 @@ module.exports = {
       const config = { data: payload, headers };
       const httpResponse = await axios.get(url, config);
       responseTime = performance.now() - startTime;
-      logInfoWithCorrelationIds({
+      monitoringTools.logInfoWithCorrelationIds({
         metrics: { responseTime },
         message: `End GET request to ${url} success: ${httpResponse.status}`,
       });
@@ -86,7 +88,7 @@ module.exports = {
         data = null;
       }
 
-      logErrorWithCorrelationIds({
+      monitoringTools.logErrorWithCorrelationIds({
         metrics: { responseTime },
         message: `End GET request to ${url} error: ${code}`,
       });

--- a/api/tests/unit/infrastructure/http/http-agent_test.js
+++ b/api/tests/unit/infrastructure/http/http-agent_test.js
@@ -152,7 +152,7 @@ describe('Unit | Infrastructure | http | http-agent', function () {
         const axiosError = {
           response: {
             data: { a: '1', b: '2' },
-            status: 'someStatus',
+            status: 400,
           },
         };
         sinon.stub(axios, 'get').withArgs(url, { data: payload, headers }).rejects(axiosError);
@@ -161,7 +161,7 @@ describe('Unit | Infrastructure | http | http-agent', function () {
         await get({ url, payload, headers });
 
         // then
-        const expected = 'End GET request to someUrl error: someStatus';
+        const expected = 'End GET request to someUrl error: 400 {"a":"1","b":"2"}';
         const { message, metrics } = monitoringTools.logErrorWithCorrelationIds.firstCall.args[0];
         expect(message).to.equal(expected);
         expect(metrics.responseTime).to.be.greaterThan(0);

--- a/api/tests/unit/infrastructure/http/http-agent_test.js
+++ b/api/tests/unit/infrastructure/http/http-agent_test.js
@@ -1,7 +1,7 @@
 const { expect, sinon } = require('../../../test-helper');
 const axios = require('axios');
-const logger = require('../../../../lib/infrastructure/logger');
 const { post, get } = require('../../../../lib/infrastructure/http/http-agent');
+const monitoringTools = require('../../../../lib/infrastructure/monitoring-tools');
 
 describe('Unit | Infrastructure | http | http-agent', function () {
   describe('#post', function () {
@@ -32,11 +32,34 @@ describe('Unit | Infrastructure | http | http-agent', function () {
     });
 
     context('when an error occurs', function () {
+      it('should log the response error data, but does not (bug)', async function () {
+        // given
+        sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
+        monitoringTools.logErrorWithCorrelationIds.resolves();
+
+        const url = 'someUrl';
+        const payload = 'somePayload';
+        const headers = { a: 'someHeaderInfo' };
+        const axiosError = {
+          response: {
+            data: { a: '1', b: '2' },
+            status: 'someStatus',
+          },
+        };
+        sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
+
+        // when
+        await post({ url, payload, headers });
+
+        // then
+        const expected = 'End POST request to someUrl error: someStatus [object Object]';
+        const { message } = monitoringTools.logErrorWithCorrelationIds.firstCall.args[0];
+        expect(message).to.equal(expected);
+      });
+
       context('when error.response exists', function () {
         it("should return the error's response status and data from the http call when failed", async function () {
           // given
-          sinon.stub(logger, 'error');
-
           const url = 'someUrl';
           const payload = 'somePayload';
           const headers = { a: 'someHeaderInfo' };
@@ -61,10 +84,8 @@ describe('Unit | Infrastructure | http | http-agent', function () {
       });
 
       context("when error.response doesn't exists", function () {
-        it("should log error and return the error's response status and success from the http call when failed", async function () {
+        it("should return the error's response status and success from the http call when failed", async function () {
           // given
-          sinon.stub(logger, 'error');
-
           const url = 'someUrl';
           const payload = 'somePayload';
           const headers = { a: 'someHeaderInfo' };
@@ -96,7 +117,6 @@ describe('Unit | Infrastructure | http | http-agent', function () {
     afterEach(function () {
       axios.get.restore();
     });
-
     it('should return the response status and success from the http call when successful', async function () {
       // given
       const url = 'someUrl';
@@ -120,6 +140,31 @@ describe('Unit | Infrastructure | http | http-agent', function () {
     });
 
     context('when an error occurs', function () {
+      it('should log the response error data, but does not (bug)', async function () {
+        // given
+        sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
+        monitoringTools.logErrorWithCorrelationIds.resolves();
+
+        const url = 'someUrl';
+        const payload = 'somePayload';
+        const headers = { a: 'someHeaderInfo' };
+        const axiosError = {
+          response: {
+            data: { a: '1', b: '2' },
+            status: 'someStatus',
+          },
+        };
+        sinon.stub(axios, 'get').withArgs(url, { data: payload, headers }).rejects(axiosError);
+
+        // when
+        await get({ url, payload, headers });
+
+        // then
+        const expected = 'End GET request to someUrl error: someStatus';
+        const { message } = monitoringTools.logErrorWithCorrelationIds.firstCall.args[0];
+        expect(message).to.equal(expected);
+      });
+
       context('when error.response exists', function () {
         it("should return the error's response status and data from the http call when failed", async function () {
           // given

--- a/api/tests/unit/infrastructure/http/http-agent_test.js
+++ b/api/tests/unit/infrastructure/http/http-agent_test.js
@@ -32,7 +32,7 @@ describe('Unit | Infrastructure | http | http-agent', function () {
     });
 
     context('when an error occurs', function () {
-      it('should log the response error data, but does not (bug)', async function () {
+      it('should log the response error data and response time', async function () {
         // given
         sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
         monitoringTools.logErrorWithCorrelationIds.resolves();
@@ -43,7 +43,7 @@ describe('Unit | Infrastructure | http | http-agent', function () {
         const axiosError = {
           response: {
             data: { a: '1', b: '2' },
-            status: 'someStatus',
+            status: 400,
           },
         };
         sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
@@ -52,9 +52,10 @@ describe('Unit | Infrastructure | http | http-agent', function () {
         await post({ url, payload, headers });
 
         // then
-        const expected = 'End POST request to someUrl error: someStatus [object Object]';
-        const { message } = monitoringTools.logErrorWithCorrelationIds.firstCall.args[0];
+        const expected = 'End POST request to someUrl error: 400 {"a":"1","b":"2"}';
+        const { message, metrics } = monitoringTools.logErrorWithCorrelationIds.firstCall.args[0];
         expect(message).to.equal(expected);
+        expect(metrics.responseTime).to.be.greaterThan(0);
       });
 
       context('when error.response exists', function () {
@@ -140,7 +141,7 @@ describe('Unit | Infrastructure | http | http-agent', function () {
     });
 
     context('when an error occurs', function () {
-      it('should log the response error data, but does not (bug)', async function () {
+      it('should log the response error data and response time', async function () {
         // given
         sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
         monitoringTools.logErrorWithCorrelationIds.resolves();
@@ -161,8 +162,9 @@ describe('Unit | Infrastructure | http | http-agent', function () {
 
         // then
         const expected = 'End GET request to someUrl error: someStatus';
-        const { message } = monitoringTools.logErrorWithCorrelationIds.firstCall.args[0];
+        const { message, metrics } = monitoringTools.logErrorWithCorrelationIds.firstCall.args[0];
         expect(message).to.equal(expected);
+        expect(metrics.responseTime).to.be.greaterThan(0);
       });
 
       context('when error.response exists', function () {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Les traces de `POST` ne mentionnent pas la réponse complète mais `[Object] object`

[Datadog](https://app.datadoghq.eu/logs?cols=host%2Cservice%2C%40metrics.responseTime&event&from_ts=1665065963232&index=%2A&live=true&messageDisplay=inline&query=status%3Aerror+%40msg%3A%22End+POST+request+to+https%3A%2F%2Fauthentification-candidat.pole-emploi.fr%2Fconnexion%2Foauth2%2Faccess_token%3Frealm%3D%252Findividu+error%3A+400+%5Bobject+Object%5D%22&stream_sort=service%2Casc&to_ts=1665670763232&viz=stream
)
## :bat: Proposition
Utiliser `JSON.stringify`

## :spider_web: Remarques
On a rajouté cette fonctionnalité sur `GET`
Dans une prochaine PR, penser à gérer le cas où la log est trop longue.

## :ghost: Pour tester
Mettre en production
