### PR TITLE
[FEATURE] Améliorer la visibilité du mot de passe dans la pop-up 'Gestion du compte Pix de l'élève' sur Pix Orga (PIX-6016)

### DIFF
--- a/orga/app/styles/components/manage-authentication-method-modal.scss
+++ b/orga/app/styles/components/manage-authentication-method-modal.scss
@@ -35,6 +35,7 @@
     input {
       width: 85%;
       box-sizing: border-box;
+      background-color: $pix-neutral-15;
     }
   }
 


### PR DESCRIPTION
## :jack_o_lantern: Problème
Suite à des feedback des utilisateurs de Pix Orga au niveau du SCO, la visibilité du mot de passe généré est mauvaise à cause du mauvais contraste.

<img width="400" src="https://user-images.githubusercontent.com/82950611/196208229-d6411a71-da68-4809-84a5-0a53f7298058.png">


## :bat: Proposition
Changement du background de l'input dans lequel se trouve le mot de passe généré pour une couleur plus claire.


## :spider_web: Remarques
Vérification du contraste avec l'extension chrome WCAG Contrast Checker. 

<img width="600" alt="Capture d’écran 2022-10-17 à 16 20 39" src="https://user-images.githubusercontent.com/82950611/196202492-221adc89-2aff-4c5c-8b15-829142a1390f.png">


## :ghost: Pour tester

- Se connecter sur Pix Orga avec les identifiants suivants : 
-- sco.admin@example.net | pix123
- Se rendre sur la page Elèves, sélectionner un élève qui possède une adresse e-mail ou un identifiant, ensuite cliquer sur les trois petits points, puis "Gérer le compte".
- Une modale s'ouvre et cliquer sur "Réinitialiser le mot de passe".
- Constater que la couleur du fond du champs "Nouveau mot de passe à usage unique" est plus claire et plus lisible.
- Vous pouvez vérifier avec l'extension [WCAG Contrast Checker](https://chrome.google.com/webstore/detail/wcag-color-contrast-check/plnahcmalebffmaghcpcmpaciebdhgdf?hl=fr).
