### PR TITLE
[FEATURE] Nouveau design page fin de parcours (PIX-5987).

### DIFF
--- a/api/lib/domain/read-models/participant-results/BadgeResult.js
+++ b/api/lib/domain/read-models/participant-results/BadgeResult.js
@@ -11,6 +11,7 @@ class BadgeResult {
     this.imageUrl = badge.imageUrl;
     this.isAcquired = acquiredBadgeIds.includes(badge.id);
     this.isAlwaysVisible = badge.isAlwaysVisible;
+    this.isCertifiable = badge.isCertifiable;
 
     this.skillSetResults = badge.badgeCompetences.map((competence) =>
       _buildCompetenceResults(competence, knowledgeElements)

--- a/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
@@ -33,6 +33,7 @@ module.exports = {
           'skillSetResults',
           'partnerCompetenceResults',
           'isAlwaysVisible',
+          'isCertifiable',
         ],
         skillSetResults: {
           ref: 'id',

--- a/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
+++ b/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
@@ -271,6 +271,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
               'image-url': '/img/banana.svg',
               'is-acquired': false,
               'is-always-visible': false,
+              'is-certifiable': false,
               key: 'PIX_BANANA',
               title: 'Banana',
               message: 'You won a Banana Badge',

--- a/api/tests/unit/domain/read-models/participant-results/BadgeResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/BadgeResult_test.js
@@ -19,6 +19,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | BadgeResult', functi
       altMessage: 'Yellow Alt Message',
       key: 'YELLOW',
       imageUrl: 'yellow.svg',
+      isCertifiable: false,
       badgeCompetences: [],
     };
 
@@ -32,6 +33,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | BadgeResult', functi
       isAcquired: true,
       key: 'YELLOW',
       imageUrl: 'yellow.svg',
+      isCertifiable: false,
     });
   });
 

--- a/api/tests/unit/domain/read-models/participant-results/BadgeResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/BadgeResult_test.js
@@ -20,12 +20,13 @@ describe('Unit | Domain | Read-Models | ParticipantResult | BadgeResult', functi
       key: 'YELLOW',
       imageUrl: 'yellow.svg',
       isCertifiable: false,
+      isAlwaysVisible: false,
       badgeCompetences: [],
     };
 
     const badgeResult = new BadgeResult(badge, participationResults);
 
-    expect(badgeResult).to.deep.include({
+    expect(badgeResult).to.deep.equal({
       id: 1,
       title: 'Badge Yellow',
       message: 'Yellow Message',
@@ -34,6 +35,8 @@ describe('Unit | Domain | Read-Models | ParticipantResult | BadgeResult', functi
       key: 'YELLOW',
       imageUrl: 'yellow.svg',
       isCertifiable: false,
+      isAlwaysVisible: false,
+      skillSetResults: [],
     });
   });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -62,6 +62,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
           key: 'Badge2 Key',
           badgeCompetences: [{ id: 31, name: 'BadgeC1', color: 'BadgeColor', skillIds: ['skill1'] }],
           isAlwaysVisible: true,
+          isCertifiable: false,
         },
       ];
 
@@ -154,6 +155,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
               key: 'Badge2 Key',
               'is-acquired': true,
               'is-always-visible': true,
+              'is-certifiable': false,
             },
             id: '3',
             type: 'campaignParticipationBadges',

--- a/mon-pix/app/components/badge-card-certifiable.hbs
+++ b/mon-pix/app/components/badge-card-certifiable.hbs
@@ -1,0 +1,19 @@
+<div
+  class="badge-card-certifiable {{unless @isAcquired 'badge-card-certifiable badge-card-certifiable--not-acquired'}}"
+>
+  <div class="badge-card-certifiable__header">
+    <div class="badge-card__status">
+      <h3>
+        <span>
+          {{#if @isAcquired}}
+            <FaIcon @icon="circle-check" class="badge-card-status__acquired-icon" />
+          {{else}}
+            <FaIcon @icon="times-circle" class="badge-card-status__not-acquired-icon" />
+          {{/if}}
+        </span>
+        {{@title}}
+      </h3>
+    </div>
+  </div>
+  <div class="badge-card-certifiable__image"><img src="{{@imageUrl}}" alt="{{@altMessage}}" /></div>
+</div>

--- a/mon-pix/app/components/badge-card-certifiable.hbs
+++ b/mon-pix/app/components/badge-card-certifiable.hbs
@@ -1,4 +1,5 @@
 <div
+  id="{{@title}}"
   class="badge-card-certifiable {{unless @isAcquired 'badge-card-certifiable badge-card-certifiable--not-acquired'}}"
 >
   <div class="badge-card-certifiable__header">

--- a/mon-pix/app/components/badge-card.hbs
+++ b/mon-pix/app/components/badge-card.hbs
@@ -1,4 +1,4 @@
-<div class="badge-card">
+<div id="{{@title}}" class="badge-card">
   <div class="badge-card__text">
     <div class="badge-card__status">
       {{#if @isAcquired}}

--- a/mon-pix/app/components/campaign-share-button.hbs
+++ b/mon-pix/app/components/campaign-share-button.hbs
@@ -1,6 +1,7 @@
 {{#if @isShared}}
   {{#if @displayPixLink}}
     <div class="skill-review-share__thanks">
+      <span><FaIcon @icon="circle-check" class="badge-card-status__acquired-icon" /></span>
       {{t "pages.skill-review.already-shared"}}
     </div>
     <a

--- a/mon-pix/app/components/campaign-share-button.hbs
+++ b/mon-pix/app/components/campaign-share-button.hbs
@@ -16,7 +16,7 @@
 {{else}}
   <PixButton
     class="skill-review-share__button"
-    @backgroundColor="green"
+    @backgroundColor="yellow"
     @shape="rounded"
     @triggerAction={{@shareCampaignParticipation}}
   >

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -191,11 +191,9 @@
   {{#if this.showDetail}}
     <PixBlock @shadow="heavy" class="skill-review__result-detail-container">
       {{#if this.showBadges}}
-        {{#unless this.hideBadgesTitle}}
-          <h2 class="skill-review-result-detail__badge-subtitle">
-            {{t "pages.skill-review.badges-title"}}
-          </h2>
-        {{/unless}}
+        <h2 class="skill-review-result-detail__badge-subtitle">
+          {{t "pages.skill-review.badges-title"}}
+        </h2>
         <div class="badge-container">
           {{#each this.orderedBadges as |badge|}}
             <BadgeCard

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -114,7 +114,7 @@
                 <div class="skill-review-share__badge-icons">
                   {{#if this.showCertifiableBadges}}
                     <div class="skill-review-share-badge-icons skill-review-share-badge-icons--certifiable">
-                      {{#each this.orderedCertifiableBadges as |badge|}}
+                      {{#each this.acquiredCertifiableBadges as |badge|}}
                         <img
                           class="skill-review-share-badge-icons__image"
                           src="{{badge.imageUrl}}"
@@ -125,7 +125,7 @@
                   {{/if}}
                   {{#if this.showNotCertifiableBadges}}
                     <div class="skill-review-share-badge-icons skill-review-share-badge-icons--not-certifiable">
-                      {{#each this.orderedNotCertifiableBadges as |badge|}}
+                      {{#each this.acquiredNotCertifiableBadges as |badge|}}
                         <img
                           class="skill-review-share-badge-icons__image"
                           src="{{badge.imageUrl}}"
@@ -217,7 +217,7 @@
 
       {{#if this.showCertifiableBadges}}
         <div class="badge-certifiable-container">
-          {{#each this.orderedCertifiableBadges as |badge|}}
+          {{#each this.acquiredCertifiableBadges as |badge|}}
             <BadgeCardCertifiable
               @title={{badge.title}}
               @message={{badge.message}}
@@ -235,7 +235,7 @@
           {{t "pages.skill-review.badges-title"}}
         </h2>
         <div class="badge-container">
-          {{#each this.orderedNotCertifiableBadges as |badge|}}
+          {{#each this.acquiredNotCertifiableBadges as |badge|}}
             <BadgeCard
               @title={{badge.title}}
               @message={{badge.message}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -117,12 +117,14 @@
                       {{#each this.acquiredCertifiableBadges as |badge|}}
                         <PixTooltip @position="top" @isInline={{true}} @id="tooltip-certifiable-{{badge.key}}">
                           <:triggerElement>
-                            <img
-                              aria-labelledby="tooltip-certifiable-{{badge.key}}"
-                              class="skill-review-share-badge-icons__image"
-                              src="{{badge.imageUrl}}"
-                              alt="{{badge.altMessage}}"
-                            />
+                            <a data-testid="tooltip-badge-anchor" href="#{{badge.title}}">
+                              <img
+                                aria-labelledby="tooltip-certifiable-{{badge.key}}"
+                                class="skill-review-share-badge-icons__image"
+                                src="{{badge.imageUrl}}"
+                                alt="{{badge.altMessage}}"
+                              />
+                            </a>
                           </:triggerElement>
                           <:tooltip>{{badge.title}}</:tooltip>
                         </PixTooltip>
@@ -134,12 +136,14 @@
                       {{#each this.acquiredNotCertifiableBadges as |badge|}}
                         <PixTooltip @position="top" @isInline={{true}} @id="tooltip-{{badge.key}}">
                           <:triggerElement>
-                            <img
-                              aria-labelledby="tooltip-{{badge.key}}"
-                              class="skill-review-share-badge-icons__image"
-                              src="{{badge.imageUrl}}"
-                              alt="{{badge.altMessage}}"
-                            />
+                            <a href="#{{badge.title}}">
+                              <img
+                                aria-labelledby="tooltip-{{badge.key}}"
+                                class="skill-review-share-badge-icons__image"
+                                src="{{badge.imageUrl}}"
+                                alt="{{badge.altMessage}}"
+                              />
+                            </a>
                           </:triggerElement>
                           <:tooltip>{{badge.title}}</:tooltip>
                         </PixTooltip>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -117,7 +117,7 @@
                       {{#each this.acquiredCertifiableBadges as |badge|}}
                         <PixTooltip @position="top" @isInline={{true}} @id="tooltip-certifiable-{{badge.key}}">
                           <:triggerElement>
-                            <a data-testid="tooltip-badge-anchor" href="#{{badge.title}}">
+                            <a href="#{{badge.title}}">
                               <img
                                 aria-labelledby="tooltip-certifiable-{{badge.key}}"
                                 class="skill-review-share-badge-icons__image"

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -111,6 +111,30 @@
                   @redirectToSignupIfUserIsAnonymous={{this.redirectToSignupIfUserIsAnonymous}}
                   @isFlashCampaign={{this.isFlashCampaign}}
                 />
+                <div class="skill-review-share__badge-icons">
+                  {{#if this.showCertifiableBadges}}
+                    <div class="skill-review-share-badge-icons skill-review-share-badge-icons--certifiable">
+                      {{#each this.orderedCertifiableBadges as |badge|}}
+                        <img
+                          class="skill-review-share-badge-icons__image"
+                          src="{{badge.imageUrl}}"
+                          alt="{{badge.altMessage}}"
+                        />
+                      {{/each}}
+                    </div>
+                  {{/if}}
+                  {{#if this.showNotCertifiableBadges}}
+                    <div class="skill-review-share-badge-icons skill-review-share-badge-icons--not-certifiable">
+                      {{#each this.orderedNotCertifiableBadges as |badge|}}
+                        <img
+                          class="skill-review-share-badge-icons__image"
+                          src="{{badge.imageUrl}}"
+                          alt="{{badge.altMessage}}"
+                        />
+                      {{/each}}
+                    </div>
+                  {{/if}}
+                </div>
               {{/if}}
             {{/if}}
           </div>
@@ -192,14 +216,15 @@
     <PixBlock @shadow="heavy" class="skill-review__result-detail-container">
 
       {{#if this.showCertifiableBadges}}
-        <div class="badge-container">
+        <div class="badge-certifiable-container">
           {{#each this.orderedCertifiableBadges as |badge|}}
-            <BadgeCard
+            <BadgeCardCertifiable
               @title={{badge.title}}
               @message={{badge.message}}
               @imageUrl={{badge.imageUrl}}
               @altMessage={{badge.altMessage}}
               @isAcquired={{badge.isAcquired}}
+              @isCertifiable={{badge.isCertifiable}}
             />
           {{/each}}
         </div>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -115,22 +115,34 @@
                   {{#if this.showCertifiableBadges}}
                     <div class="skill-review-share-badge-icons skill-review-share-badge-icons--certifiable">
                       {{#each this.acquiredCertifiableBadges as |badge|}}
-                        <img
-                          class="skill-review-share-badge-icons__image"
-                          src="{{badge.imageUrl}}"
-                          alt="{{badge.altMessage}}"
-                        />
+                        <PixTooltip @position="top" @isInline={{true}} @id="tooltip-certifiable-{{badge.key}}">
+                          <:triggerElement>
+                            <img
+                              aria-labelledby="tooltip-certifiable-{{badge.key}}"
+                              class="skill-review-share-badge-icons__image"
+                              src="{{badge.imageUrl}}"
+                              alt="{{badge.altMessage}}"
+                            />
+                          </:triggerElement>
+                          <:tooltip>{{badge.title}}</:tooltip>
+                        </PixTooltip>
                       {{/each}}
                     </div>
                   {{/if}}
                   {{#if this.showNotCertifiableBadges}}
                     <div class="skill-review-share-badge-icons skill-review-share-badge-icons--not-certifiable">
                       {{#each this.acquiredNotCertifiableBadges as |badge|}}
-                        <img
-                          class="skill-review-share-badge-icons__image"
-                          src="{{badge.imageUrl}}"
-                          alt="{{badge.altMessage}}"
-                        />
+                        <PixTooltip @position="top" @isInline={{true}} @id="tooltip-{{badge.key}}">
+                          <:triggerElement>
+                            <img
+                              aria-labelledby="tooltip-{{badge.key}}"
+                              class="skill-review-share-badge-icons__image"
+                              src="{{badge.imageUrl}}"
+                              alt="{{badge.altMessage}}"
+                            />
+                          </:triggerElement>
+                          <:tooltip>{{badge.title}}</:tooltip>
+                        </PixTooltip>
                       {{/each}}
                     </div>
                   {{/if}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -190,12 +190,27 @@
 
   {{#if this.showDetail}}
     <PixBlock @shadow="heavy" class="skill-review__result-detail-container">
-      {{#if this.showBadges}}
+
+      {{#if this.showCertifiableBadges}}
+        <div class="badge-container">
+          {{#each this.orderedCertifiableBadges as |badge|}}
+            <BadgeCard
+              @title={{badge.title}}
+              @message={{badge.message}}
+              @imageUrl={{badge.imageUrl}}
+              @altMessage={{badge.altMessage}}
+              @isAcquired={{badge.isAcquired}}
+            />
+          {{/each}}
+        </div>
+      {{/if}}
+
+      {{#if this.showNotCertifiableBadges}}
         <h2 class="skill-review-result-detail__badge-subtitle">
           {{t "pages.skill-review.badges-title"}}
         </h2>
         <div class="badge-container">
-          {{#each this.orderedBadges as |badge|}}
+          {{#each this.orderedNotCertifiableBadges as |badge|}}
             <BadgeCard
               @title={{badge.title}}
               @message={{badge.message}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -28,11 +28,7 @@ export default class SkillReview extends Component {
 
   get _isCleaBadgeAcquired() {
     const pixEmploiClea = 'PIX_EMPLOI_CLEA';
-    return this.acquiredBadges.some((badge) => badge.key === pixEmploiClea);
-  }
-
-  get hideBadgesTitle() {
-    return this._isCleaBadgeAcquired && this.acquiredBadges.length === 1;
+    return this.acquiredCertifiableBadges.some((badge) => badge.key === pixEmploiClea);
   }
 
   get showDisabledBlock() {

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -36,12 +36,12 @@ export default class SkillReview extends Component {
   }
 
   get showBadges() {
-    return this.orderedBadges.length > 0;
+    return this.orderedNotCertifiableBadges.length > 0 || this.orderedCertifiableBadges.length > 0;
   }
 
-  get acquiredBadges() {
+  get acquiredNotCertifiableBadges() {
     const badges = this.args.model.campaignParticipationResult.campaignParticipationBadges;
-    return badges.filter((badge) => badge.isAcquired);
+    return badges.filter((badge) => badge.isAcquired && !badge.isCertifiable);
   }
 
   get acquiredCertifiableBadges() {
@@ -49,9 +49,9 @@ export default class SkillReview extends Component {
     return badges.filter((badge) => badge.isAcquired && badge.isCertifiable);
   }
 
-  get notAcquiredButVisibleBadges() {
+  get notAcquiredButVisibleNotCertifiableBadges() {
     const badges = this.args.model.campaignParticipationResult.campaignParticipationBadges;
-    return badges.filter((badge) => !badge.isAcquired && badge.isAlwaysVisible);
+    return badges.filter((badge) => !badge.isAcquired && badge.isAlwaysVisible && !badge.isCertifiable);
   }
 
   get notAcquiredButVisibleCertifiableBadges() {
@@ -59,8 +59,8 @@ export default class SkillReview extends Component {
     return badges.filter((badge) => !badge.isAcquired && badge.isAlwaysVisible && badge.isCertifiable);
   }
 
-  get orderedBadges() {
-    return [...this.acquiredBadges, ...this.notAcquiredButVisibleBadges];
+  get orderedNotCertifiableBadges() {
+    return [...this.acquiredNotCertifiableBadges, ...this.notAcquiredButVisibleNotCertifiableBadges];
   }
 
   get orderedCertifiableBadges() {

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -35,8 +35,12 @@ export default class SkillReview extends Component {
     return this.args.model.campaignParticipationResult.isDisabled && !this.isShared;
   }
 
-  get showBadges() {
-    return this.orderedNotCertifiableBadges.length > 0 || this.orderedCertifiableBadges.length > 0;
+  get showNotCertifiableBadges() {
+    return this.orderedNotCertifiableBadges.length > 0;
+  }
+
+  get showCertifiableBadges() {
+    return this.orderedCertifiableBadges.length > 0;
   }
 
   get acquiredNotCertifiableBadges() {

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -48,13 +48,27 @@ export default class SkillReview extends Component {
     return badges.filter((badge) => badge.isAcquired);
   }
 
+  get acquiredCertifiableBadges() {
+    const badges = this.args.model.campaignParticipationResult.campaignParticipationBadges;
+    return badges.filter((badge) => badge.isAcquired && badge.isCertifiable);
+  }
+
   get notAcquiredButVisibleBadges() {
     const badges = this.args.model.campaignParticipationResult.campaignParticipationBadges;
     return badges.filter((badge) => !badge.isAcquired && badge.isAlwaysVisible);
   }
 
+  get notAcquiredButVisibleCertifiableBadges() {
+    const badges = this.args.model.campaignParticipationResult.campaignParticipationBadges;
+    return badges.filter((badge) => !badge.isAcquired && badge.isAlwaysVisible && badge.isCertifiable);
+  }
+
   get orderedBadges() {
     return [...this.acquiredBadges, ...this.notAcquiredButVisibleBadges];
+  }
+
+  get orderedCertifiableBadges() {
+    return [...this.acquiredCertifiableBadges, ...this.notAcquiredButVisibleCertifiableBadges];
   }
 
   get showStages() {

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -36,11 +36,11 @@ export default class SkillReview extends Component {
   }
 
   get showNotCertifiableBadges() {
-    return this.orderedNotCertifiableBadges.length > 0;
+    return this.acquiredNotCertifiableBadges.length > 0;
   }
 
   get showCertifiableBadges() {
-    return this.orderedCertifiableBadges.length > 0;
+    return this.acquiredCertifiableBadges.length > 0;
   }
 
   get acquiredNotCertifiableBadges() {
@@ -51,24 +51,6 @@ export default class SkillReview extends Component {
   get acquiredCertifiableBadges() {
     const badges = this.args.model.campaignParticipationResult.campaignParticipationBadges;
     return badges.filter((badge) => badge.isAcquired && badge.isCertifiable);
-  }
-
-  get notAcquiredButVisibleNotCertifiableBadges() {
-    const badges = this.args.model.campaignParticipationResult.campaignParticipationBadges;
-    return badges.filter((badge) => !badge.isAcquired && badge.isAlwaysVisible && !badge.isCertifiable);
-  }
-
-  get notAcquiredButVisibleCertifiableBadges() {
-    const badges = this.args.model.campaignParticipationResult.campaignParticipationBadges;
-    return badges.filter((badge) => !badge.isAcquired && badge.isAlwaysVisible && badge.isCertifiable);
-  }
-
-  get orderedNotCertifiableBadges() {
-    return [...this.acquiredNotCertifiableBadges, ...this.notAcquiredButVisibleNotCertifiableBadges];
-  }
-
-  get orderedCertifiableBadges() {
-    return [...this.acquiredCertifiableBadges, ...this.notAcquiredButVisibleCertifiableBadges];
   }
 
   get showStages() {

--- a/mon-pix/app/models/campaign-participation-badge.js
+++ b/mon-pix/app/models/campaign-participation-badge.js
@@ -8,6 +8,7 @@ export default class CampaignParticipationBadge extends Badge {
   // attributes
   @attr('boolean') isAcquired;
   @attr('boolean') isAlwaysVisible;
+  @attr('boolean') isCertifiable;
 
   // includes
   @hasMany('skillSetResult') skillSetResults;

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -29,6 +29,7 @@
 @import 'components/assessment-banner';
 @import 'components/background-banner';
 @import 'components/badge-card';
+@import 'components/badge-card-certifiable';
 @import 'components/campaign-participation-overview/card';
 @import 'components/campaign-participation-overview/grid';
 @import 'components/certification-starter';

--- a/mon-pix/app/styles/components/_badge-card-certifiable.scss
+++ b/mon-pix/app/styles/components/_badge-card-certifiable.scss
@@ -1,0 +1,36 @@
+.badge-certifiable-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin-bottom: 32px;
+}
+
+.badge-card-certifiable {
+  align-items: center;
+  background-color: $pix-success-5;
+  border-radius: 16px;
+  display: flex;
+  flex-basis: 100%;
+  flex-direction: column;
+  justify-content: center;
+  margin-bottom: 16px;
+  padding: 20px 35px;
+
+  &--not-acquired {
+    background-color: $pix-neutral-10;
+    filter: grayscale(1);
+  }
+
+  &__header {
+    text-align: center;
+  }
+
+  &__header h3 {
+    font-size: 1.25rem;
+    font-weight: $font-normal;
+  }
+
+  @include device-is('tablet') {
+    flex-basis: calc(50% - 10px);
+  }
+}

--- a/mon-pix/app/styles/components/_badge-card.scss
+++ b/mon-pix/app/styles/components/_badge-card.scss
@@ -88,12 +88,12 @@
 .badge-card-status {
 
   &__acquired-icon {
-    color: $pix-success-70;
+    color: $pix-success-50;
     margin-right: 4px;
   }
 
   &__not-acquired-icon {
-    color: $pix-neutral-45;
+    color: $pix-neutral-50;
     margin-right: 4px;
   }
 }

--- a/mon-pix/app/styles/components/_reached-stage.scss
+++ b/mon-pix/app/styles/components/_reached-stage.scss
@@ -4,7 +4,7 @@
   background: $pix-neutral-0;
   border: 1px solid rgb(231, 231, 231);
   border-radius: 16px;
-  margin: 0 auto;
+  margin: 20px auto 0 auto;
 
   &__score {
     padding: 43px 20px 20px;

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -10,11 +10,12 @@
   &__result-and-action {
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
     margin: auto;
 
     @include device-is('tablet') {
       flex-direction: row;
+      justify-content: flex-start;
     }
   }
 
@@ -358,13 +359,15 @@
 
   &__share-container {
     padding: 16px 40px 32px 40px;
-    text-align: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
 
-    &--left {
-      text-align: center;
+    @include device-is('tablet') {
 
-      @include device-is('tablet') {
-        text-align: left;
+      &--left {
+        align-items: flex-start;
       }
     }
   }
@@ -436,10 +439,6 @@
     }
   }
 
-  &__button {
-    margin: 0 auto;
-  }
-
   &__legal {
     font-family: $font-roboto;
     font-size: 0.85rem;
@@ -467,6 +466,49 @@
     font-weight: $font-bold;
     font-family: $font-open-sans;
     text-align: center;
+  }
+
+  &__badge-icons {
+    display: flex;
+    flex-direction: column;
+    height: 89px;
+    flex-basis: 100%;
+
+    @include device-is('tablet') {
+      flex-direction: row;
+    }
+  }
+
+  &__button {
+    margin: 0 auto;
+    max-width: fit-content;
+
+    @include device-is('tablet') {
+      margin: 0;
+    }
+  }
+}
+
+.skill-review-share-badge-icons {
+  display: flex;
+  justify-content: center;
+  border-radius: 16px;
+
+  &__image {
+    max-width: 70px;
+    margin: 8px 0 8px 10px;
+
+    &:last-child {
+      margin-right: 10px;
+    }
+  }
+
+  &--certifiable {
+    background-color: $pix-success-5;
+  }
+
+  &--not-certifiable {
+    background-color: $pix-neutral-10;
   }
 }
 

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -11,10 +11,12 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
     margin: auto;
 
     @include device-is('tablet') {
       flex-direction: row;
+      align-items: flex-start;
       justify-content: flex-start;
     }
   }
@@ -509,6 +511,11 @@
 
   &--not-certifiable {
     background-color: $pix-neutral-10;
+    margin: 16px 0 0 0;
+
+    @include device-is('tablet') {
+      margin: 0 0 0 16px;
+    }
   }
 }
 

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -454,7 +454,11 @@
     font-weight: $font-semi-bold;
     font-size: 1rem;
     line-height: 2rem;
-    padding: 16px 0;
+    padding: 16px;
+    margin-bottom: 16px;
+    border-radius: 4px;
+    color: $pix-success-70;
+    background-color: $pix-success-5;
   }
 
   &__error {
@@ -468,6 +472,7 @@
     font-weight: $font-bold;
     font-family: $font-open-sans;
     text-align: center;
+    margin-bottom: 16px;
   }
 
   &__badge-icons {

--- a/mon-pix/config/icons.js
+++ b/mon-pix/config/icons.js
@@ -28,6 +28,7 @@ module.exports = function () {
       'right-from-bracket',
       'right-long',
       'rotate-right',
+      'times-circle',
       'thumbs-up',
       'triangle-exclamation',
       'up-right-from-square',

--- a/mon-pix/tests/acceptance/skill-review_test.js
+++ b/mon-pix/tests/acceptance/skill-review_test.js
@@ -132,8 +132,10 @@ describe('Acceptance | Campaigns | Campaigns Result', function () {
           imageUrl: '/images/badges/Pix-emploi.svg',
           message: 'Congrats, you won a Pix Emploi badge',
           isAcquired: true,
+          isCertifiable: true,
         });
         campaignParticipationResult.update({ campaignParticipationBadges: [badge] });
+
         // when
         await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
 
@@ -156,6 +158,7 @@ describe('Acceptance | Campaigns | Campaigns Result', function () {
           imageUrl: '/images/badges/yellow.svg',
           message: 'Congrats, you won a Yellow badge',
           isAcquired: true,
+          isCertifiable: true,
         });
         const unacquiredDisplayedBadge = server.create('campaign-participation-badge', {
           altMessage: 'Yon won a green badge',
@@ -163,6 +166,7 @@ describe('Acceptance | Campaigns | Campaigns Result', function () {
           message: 'Congrats, you won a Green badge',
           isAcquired: false,
           isAlwaysVisible: true,
+          isCertifiable: false,
         });
         const unacquiredHiddenBadge = server.create('campaign-participation-badge', {
           altMessage: 'Yon won a pink badge',
@@ -170,6 +174,7 @@ describe('Acceptance | Campaigns | Campaigns Result', function () {
           message: 'Congrats, you won a pink badge',
           isAcquired: false,
           isAlwaysVisible: false,
+          isCertifiable: true,
         });
         campaignParticipationResult.update({
           campaignParticipationBadges: [acquiredBadge, unacquiredDisplayedBadge, unacquiredHiddenBadge],
@@ -214,6 +219,7 @@ describe('Acceptance | Campaigns | Campaigns Result', function () {
             altMessage: 'Vous avez validé le badge Pix Emploi.',
             imageUrl: 'url.svg',
             isAcquired: true,
+            isCertifiable: true,
             message:
               'Bravo ! Vous maîtrisez les compétences indispensables pour utiliser le numérique en milieu professionnel. Pour valoriser vos compétences avec une double certification Pix-CléA numérique, renseignez-vous auprès de votre conseiller ou de votre formateur.',
             title: 'Pix Emploi - Clea',

--- a/mon-pix/tests/acceptance/skill-review_test.js
+++ b/mon-pix/tests/acceptance/skill-review_test.js
@@ -151,7 +151,7 @@ describe('Acceptance | Campaigns | Campaigns Result', function () {
         expect(contains(this.intl.t('pages.skill-review.badges-title'))).to.not.exist;
       });
 
-      it('should display acquired badges + non acquired but isAlwaysDisplayed badges', async function () {
+      it('should display acquired badges', async function () {
         // given
         const acquiredBadge = server.create('campaign-participation-badge', {
           altMessage: 'Yon won a Yellow badge',
@@ -184,7 +184,7 @@ describe('Acceptance | Campaigns | Campaigns Result', function () {
         await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
 
         // then
-        expect(findAll('.badge-card').length).to.equal(2);
+        expect(findAll('.badge-card').length).to.equal(1);
       });
 
       describe('when campaign has stages', async function () {

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -120,7 +120,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
     });
   });
 
-  context('when the the campaign has stage', function () {
+  context('when the campaign has stage', function () {
     it('displays the stage message', async function () {
       const reachedStage = {
         get: sinon.stub(),
@@ -148,6 +148,56 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
 
       // Then
       expect(contains('Bravo !')).to.exist;
+    });
+  });
+
+  context('when the the campaign has badges', function () {
+    it('should display acquired badges in the header whether certifiable or not', async function () {
+      campaign = {
+        customResultPageButtonUrl: 'http://www.my-url.net/resultats',
+        customResultPageButtonText: 'Next step',
+        organizationName: 'Dragon & Co',
+        organizationShowNPS: false,
+      };
+      const campaignParticipationBadges = [
+        {
+          altMessage: 'Vous avez validé le badge 1.',
+          isAcquired: true,
+          isCertifiable: true,
+          message: 'Bravo ! Vous maîtrisez les compétences du badge 1',
+          title: 'Badge 1',
+        },
+        {
+          altMessage: 'Vous avez validé le badge 2.',
+          isAcquired: true,
+          isCertifiable: false,
+          message: 'Bravo ! Vous maîtrisez les compétences du badge 2',
+          title: 'Badge 2',
+        },
+        {
+          altMessage: "Vous n'avez pas validé le badge 3",
+          isAcquired: false,
+          isCertifiable: false,
+          message: 'Dommage ! Essaie encore.',
+          title: 'Badge 3',
+        },
+      ];
+      const campaignParticipationResult = {
+        isShared: false,
+        participantExternalId: '1234G56',
+        campaignParticipationBadges,
+      };
+      this.set('model', { campaign, campaignParticipationResult });
+
+      // When
+      await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+
+      // Then
+      expect(findAll('.skill-review-share-badge-icons__image')).to.have.length(2);
+      expect(find('.skill-review-share-badge-icons--certifiable')).to.exist;
+      expect(find('.skill-review-share-badge-icons--not-certifiable')).to.exist;
+      expect(find('.badge-container')).to.exist;
+      expect(find('.badge-certifiable-container')).to.exist;
     });
   });
 

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -199,6 +199,36 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       expect(find('.badge-container')).to.exist;
       expect(find('.badge-certifiable-container')).to.exist;
     });
+
+    it('should an anchor in the header badge icon linked to the badge card', async function () {
+      campaign = {
+        customResultPageButtonUrl: 'http://www.my-url.net/resultats',
+        customResultPageButtonText: 'Next step',
+        organizationName: 'Dragon & Co',
+        organizationShowNPS: false,
+      };
+      const campaignParticipationBadges = [
+        {
+          altMessage: 'Vous avez validé le badge 1.',
+          isAcquired: true,
+          isCertifiable: true,
+          message: 'Bravo ! Vous maîtrisez les compétences du badge 1',
+          title: 'Badge_1',
+        },
+      ];
+      const campaignParticipationResult = {
+        isShared: false,
+        campaignParticipationBadges,
+      };
+      this.set('model', { campaign, campaignParticipationResult });
+
+      // When
+      await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+
+      // Then
+      expect(findAll('.skill-review-share-badge-icons__image')).to.have.length(1);
+      expect(find('a[data-testid="tooltip-badge-anchor"]')).to.have.property('href').that.contains('#Badge_1');
+    });
   });
 
   describe('The trainings block', function () {

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -1,14 +1,16 @@
 import { expect } from 'chai';
 import { contains } from '../../../../../helpers/contains';
 import { clickByLabel } from '../../../../../helpers/click-by-label';
-import { find, findAll, render } from '@ember/test-helpers';
+import { findAll } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { render } from '@1024pix/ember-testing-library';
 
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 import sinon from 'sinon';
 
 describe('Integration | Component | routes/campaigns/assessment/skill-review', function () {
   let campaign;
+
   setupIntlRenderingTest();
   beforeEach(function () {
     campaign = {
@@ -23,10 +25,10 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       this.set('model', { campaign, campaignParticipationResult });
 
       // When
-      await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
       // Then
-      expect(contains(this.intl.t('pages.skill-review.actions.send'))).to.exist;
+      expect(screen.getByText(this.intl.t('pages.skill-review.actions.send'))).to.exist;
     });
 
     context('when a skill has been reset after campaign completion and before sending results', function () {
@@ -40,13 +42,13 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         adapter.share = sinon.stub().rejects({ errors: [{ status: '409' }] });
 
         // When
-        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
         await clickByLabel(this.intl.t('pages.skill-review.actions.send'));
 
         // Then
-        expect(contains(this.intl.t('pages.skill-review.not-finished'))).to.exist;
-        expect(contains(this.intl.t('pages.profile.resume-campaign-banner.accessibility.resume'))).to.exist;
-        expect(contains(this.intl.t('pages.profile.resume-campaign-banner.actions.resume'))).to.exist;
+        expect(screen.getByText(this.intl.t('pages.skill-review.not-finished'))).to.exist;
+        expect(screen.getByText(this.intl.t('pages.profile.resume-campaign-banner.accessibility.resume'))).to.exist;
+        expect(screen.getByText(this.intl.t('pages.profile.resume-campaign-banner.actions.resume'))).to.exist;
       });
     });
 
@@ -61,62 +63,73 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         adapter.share = sinon.stub().rejects({ errors: [{ status: '412' }] });
 
         // When
-        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
         await clickByLabel(this.intl.t('pages.skill-review.actions.send'));
 
         // Then
-        expect(contains(this.intl.t('pages.skill-review.error'))).to.exist;
-        expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+        expect(screen.getByText(this.intl.t('pages.skill-review.error'))).to.exist;
+        expect(screen.getByText(this.intl.t('navigation.back-to-homepage'))).to.exist;
       });
     });
   });
 
   context('When campaign is for Absolute Novice', function () {
-    beforeEach(async function () {
+    it('should show a link to main page instead of the shared button ', async function () {
       // Given
       campaign = { isForAbsoluteNovice: true, organizationShowNPS: false };
       const campaignParticipationResult = { campaignParticipationBadges: [] };
       this.set('model', { campaign, campaignParticipationResult });
 
       // When
-      await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+
+      // Then
+      expect(screen.queryByText(this.intl.t('pages.skill-review.actions.send'))).to.not.exist;
+      expect(screen.getByText(this.intl.t('pages.skill-review.actions.continue'))).to.exist;
     });
 
-    it('should show a link to main page instead of the shared button ', function () {
-      // Then
-      expect(contains(this.intl.t('pages.skill-review.actions.send'))).to.not.exist;
-      expect(contains(this.intl.t('pages.skill-review.actions.continue'))).to.exist;
-    });
+    it('should not show competence results ', async function () {
+      // Given
+      campaign = { isForAbsoluteNovice: true, organizationShowNPS: false };
+      const campaignParticipationResult = { campaignParticipationBadges: [] };
+      this.set('model', { campaign, campaignParticipationResult });
 
-    it('should not show competence results ', function () {
+      // When
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+
       // Then
-      expect(contains(this.intl.t('pages.skill-review.details.title'))).to.not.exist;
+      expect(screen.queryByText(this.intl.t('pages.skill-review.details.title'))).to.not.exist;
     });
   });
 
   context('when campaign is FLASH', function () {
     const estimatedFlashLevel = -4.98279852;
 
-    beforeEach(async function () {
+    it('should congratulate the user', async function () {
       // Given
       campaign = { isFlash: true };
       const campaignParticipationResult = { estimatedFlashLevel, isDisabled: false };
       this.set('model', { campaign, campaignParticipationResult });
 
       // When
-      await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
-    });
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
-    it('should congratulate the user', function () {
       // Then
-      expect(contains(this.intl.t('pages.skill-review.flash.abstract'))).to.exist;
+      expect(screen.getByText(this.intl.t('pages.skill-review.flash.abstract'))).to.exist;
     });
 
-    it("should display the user's flash estimated level", function () {
+    it("should display the user's flash estimated level", async function () {
+      // Given
+      campaign = { isFlash: true };
+      const campaignParticipationResult = { estimatedFlashLevel, isDisabled: false };
       const expectedPixCount = 257;
+      this.set('model', { campaign, campaignParticipationResult });
+
+      // When
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
       // Then
-      expect(contains(this.intl.t('pages.skill-review.flash.pixCount', { count: expectedPixCount }))).to.exist;
+      expect(screen.getByText(this.intl.t('pages.skill-review.flash.pixCount', { count: expectedPixCount }))).to.exist;
     });
   });
 
@@ -152,7 +165,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
   });
 
   context('when the the campaign has badges', function () {
-    it('should display acquired badges in the header whether certifiable or not', async function () {
+    it('should display acquired badges in both the header and main section whether certifiable or not', async function () {
       campaign = {
         customResultPageButtonUrl: 'http://www.my-url.net/resultats',
         customResultPageButtonText: 'Next step',
@@ -190,17 +203,17 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       this.set('model', { campaign, campaignParticipationResult });
 
       // When
-      await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
       // Then
-      expect(findAll('.skill-review-share-badge-icons__image')).to.have.length(2);
-      expect(find('.skill-review-share-badge-icons--certifiable')).to.exist;
-      expect(find('.skill-review-share-badge-icons--not-certifiable')).to.exist;
-      expect(find('.badge-container')).to.exist;
-      expect(find('.badge-certifiable-container')).to.exist;
+      expect(screen.getByRole('img', { name: 'Badge 1' })).to.exist;
+      expect(screen.getByRole('img', { name: 'Vous avez validé le badge 1.' })).to.exist;
+      expect(screen.getByRole('img', { name: 'Badge 2' })).to.exist;
+      expect(screen.getByRole('img', { name: 'Vous avez validé le badge 2.' })).to.exist;
+      expect(screen.queryByRole('img', { name: "Vous n'avez pas validé le badge 3" })).to.not.exist;
     });
 
-    it('should an anchor in the header badge icon linked to the badge card', async function () {
+    it('should add an anchor in the header badge icon linked to the badge card', async function () {
       campaign = {
         customResultPageButtonUrl: 'http://www.my-url.net/resultats',
         customResultPageButtonText: 'Next step',
@@ -213,7 +226,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
           isAcquired: true,
           isCertifiable: true,
           message: 'Bravo ! Vous maîtrisez les compétences du badge 1',
-          title: 'Badge_1',
+          title: 'Badge 1',
         },
       ];
       const campaignParticipationResult = {
@@ -223,11 +236,12 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       this.set('model', { campaign, campaignParticipationResult });
 
       // When
-      await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
       // Then
-      expect(findAll('.skill-review-share-badge-icons__image')).to.have.length(1);
-      expect(find('a[data-testid="tooltip-badge-anchor"]')).to.have.property('href').that.contains('#Badge_1');
+      expect(screen.getByRole('link', { name: 'Badge 1' }))
+        .to.have.property('href')
+        .that.contains('#Badge%201');
     });
   });
 
@@ -244,10 +258,10 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult, trainings });
 
         // when
-        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
         // then
-        expect(contains(this.intl.t('pages.skill-review.trainings.title'))).to.not.exist;
+        expect(screen.queryByText(this.intl.t('pages.skill-review.trainings.title'))).to.not.exist;
       });
     });
 
@@ -263,11 +277,11 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult, trainings });
 
         // when
-        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
         // then
-        expect(contains(this.intl.t('pages.skill-review.trainings.title'))).to.exist;
-        expect(contains(this.intl.t('pages.skill-review.trainings.description'))).to.exist;
+        expect(screen.getByText(this.intl.t('pages.skill-review.trainings.title'))).to.exist;
+        expect(screen.getByText(this.intl.t('pages.skill-review.trainings.description'))).to.exist;
       });
 
       it('should display trainings', async function () {
@@ -308,7 +322,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
     context('When the campaign is shared', function () {
       context('when the organization has a message', function () {
         context('when the organization has a logo', function () {
-          beforeEach(async function () {
+          it('should display the block for the message', async function () {
             // Given
             campaign = {
               customResultPageText: 'Bravo !',
@@ -320,23 +334,34 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
             this.set('model', { campaign, campaignParticipationResult });
 
             // When
-            await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+            const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+
+            // Then
+            expect(screen.getByText(this.intl.t('pages.skill-review.organization-message'))).to.exist;
+            expect(screen.getByText('Dragon & Co')).to.exist;
           });
 
-          it('should display the block for the message', function () {
-            // Then
-            expect(contains(this.intl.t('pages.skill-review.organization-message'))).to.exist;
-            expect(contains('Dragon & Co')).to.exist;
-          });
+          it('should show the logo of the organization', async function () {
+            // Given
+            campaign = {
+              customResultPageText: 'Bravo !',
+              organizationLogoUrl: 'www.logo-example.com',
+              organizationName: 'Dragon & Co',
+              organizationShowNPS: false,
+            };
+            const campaignParticipationResult = { isShared: true, campaignParticipationBadges: [] };
+            this.set('model', { campaign, campaignParticipationResult });
 
-          it('should show the logo of the organization ', function () {
+            // When
+            const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+
             // Then
-            expect(find('[src="www.logo-example.com"]')).to.exist;
+            expect(screen.getByRole('img', { name: 'Dragon & Co' })).to.exist;
           });
         });
 
         context('when the organization has no logo', function () {
-          beforeEach(async function () {
+          it('should display the block for the message', async function () {
             // Given
             campaign = {
               customResultPageText: 'Bravo !',
@@ -348,24 +373,36 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
             this.set('model', { campaign, campaignParticipationResult });
 
             // When
-            await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+            const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+
+            // Then
+            expect(screen.getByText('Dragon & Co')).to.exist;
+            expect(screen.getByText(this.intl.t('pages.skill-review.organization-message'))).to.exist;
           });
 
-          it('should display the block for the message', function () {
-            // Then
-            expect(contains('Dragon & Co')).to.exist;
-            expect(contains(this.intl.t('pages.skill-review.organization-message'))).to.exist;
-          });
+          it('should not display the logo of the organization ', async function () {
+            // Given
+            campaign = {
+              customResultPageText: 'Bravo !',
+              organizationLogoUrl: null,
+              organizationName: 'Dragon & Co',
+              organizationShowNPS: false,
+            };
+            const campaignParticipationResult = { isShared: true, campaignParticipationBadges: [] };
+            this.set('model', { campaign, campaignParticipationResult });
 
-          it('should not display the logo of the organization ', function () {
+            // When
+            const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+
             // Then
-            expect(find('[src="www.logo-example.com"]')).to.not.exist;
+            expect(screen.queryByRole('img', { name: 'Dragon & Co' })).to.not.exist;
           });
         });
       });
 
       context('when the organization has a customResultPageText', function () {
-        beforeEach(async function () {
+        it('should display customResultPageText', async function () {
+          // Given
           campaign = {
             customResultPageText: 'some message',
             organizationName: 'Dragon & Co',
@@ -375,12 +412,10 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
           this.set('model', { campaign, campaignParticipationResult });
 
           // When
-          await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
-        });
+          const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
-        it('should display customResultPageText', function () {
           // Then
-          expect(contains('some message')).to.exist;
+          expect(screen.getByText('some message')).to.exist;
         });
       });
 
@@ -388,7 +423,8 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         context(
           'when the participant has finished a campaign with stages and has a masteryPercentage and a participantExternalId',
           function () {
-            beforeEach(async function () {
+            it('should display the button with all params', async function () {
+              // Given
               const reachedStage = {
                 get: sinon.stub(),
               };
@@ -409,15 +445,14 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
               this.set('model', { campaign, campaignParticipationResult });
 
               // When
-              await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
-            });
+              const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
-            it('should display the button with all params', function () {
               // Then
-              expect(find('[href="http://www.my-url.net/resultats?masteryPercentage=50&externalId=1234G56&stage=75"]'))
-                .to.exist;
-              expect(find('[target="_blank"]')).to.exist;
-              expect(contains('Next step')).to.exist;
+              expect(screen.getByRole('link', { name: 'Next step' })).to.exist;
+              expect(screen.getByRole('link', { name: 'Next step' }))
+                .to.have.property('target')
+                .that.equals('_blank');
+              expect(screen.getByText('Next step')).to.exist;
             });
           }
         );
@@ -425,7 +460,8 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         context(
           'when the participant has finished a campaign with neither stages and he has neither masteryPercentage nor participantExternalId',
           function () {
-            beforeEach(async function () {
+            it('should display the button', async function () {
+              // Given
               campaign = {
                 customResultPageButtonUrl: 'http://www.my-url.net',
                 customResultPageButtonText: 'Next step',
@@ -442,21 +478,22 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
               this.set('model', { campaign, campaignParticipationResult });
 
               // When
-              await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
-            });
+              const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
-            it('should display the button', function () {
               // Then
-              expect(find('[href="http://www.my-url.net/"]')).to.exist;
-              expect(find('[target="_blank"]')).to.exist;
-              expect(contains('Next step')).to.exist;
+              expect(screen.getByRole('link', { name: 'Next step' })).to.exist;
+              expect(screen.getByRole('link', { name: 'Next step' }))
+                .to.have.property('target')
+                .that.equals('_blank');
+              expect(screen.getByText('Next step')).to.exist;
             });
           }
         );
       });
 
       context('when the organization only has a customResultPageButtonUrl', function () {
-        beforeEach(async function () {
+        it('should not display the button', async function () {
+          // Given
           campaign = {
             customResultPageButtonUrl: 'www.my-url.net',
             customResultPageButtonText: null,
@@ -470,18 +507,17 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
           this.set('model', { campaign, campaignParticipationResult });
 
           // When
-          await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
-        });
+          const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
-        it('should not display the button', function () {
           // Then
-          expect(find('[href="www.my-url.net"]')).to.not.exist;
-          expect(contains('Next step')).to.not.exist;
+          expect(screen.queryByText('link', { name: 'Next step' })).to.not.exist;
+          expect(screen.queryByText('Next step')).to.not.exist;
         });
       });
 
       context('when the organization has neither a message nor a button', function () {
-        beforeEach(async function () {
+        it('should not display the block for the message', async function () {
+          // Given
           campaign = {
             customResultPageText: null,
             customResultPageButtonUrl: null,
@@ -496,17 +532,16 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
           this.set('model', { campaign, campaignParticipationResult });
 
           // When
-          await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
-        });
+          const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
-        it('should not display the block for the message', function () {
           // Then
-          expect(contains(this.intl.t('pages.skill-review.organization-message'))).to.not.exist;
+          expect(screen.queryByText(this.intl.t('pages.skill-review.organization-message'))).to.not.exist;
         });
       });
     });
     context('when the campaign is not shared', function () {
-      beforeEach(async function () {
+      it('should not display the block for the message', async function () {
+        // Given
         campaign = {
           customResultPageButtonText: 'Bravo !',
           organizationName: 'Dragon & Co',
@@ -519,20 +554,19 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
-      });
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
-      it('should not display the block for the message', function () {
         // Then
-        expect(contains(this.intl.t('pages.skill-review.actions.send'))).to.exist;
-        expect(contains(this.intl.t('pages.skill-review.organization-message'))).to.not.exist;
+        expect(screen.getByText(this.intl.t('pages.skill-review.actions.send'))).to.exist;
+        expect(screen.queryByText(this.intl.t('pages.skill-review.organization-message'))).to.not.exist;
       });
     });
   });
 
   describe('The retry block', function () {
     context('when user can retry', function () {
-      beforeEach(async function () {
+      it('should display retry block', async function () {
+        // Given
         const campaignParticipationResult = {
           campaignParticipationBadges: [],
           canRetry: true,
@@ -540,17 +574,16 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
-      });
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
-      it('should display retry block', function () {
         // Then
-        expect(contains(this.intl.t('pages.skill-review.retry.button'))).to.exist;
+        expect(screen.getByText(this.intl.t('pages.skill-review.retry.button'))).to.exist;
       });
     });
 
     context('when user cannot retry', function () {
-      beforeEach(async function () {
+      it('should not display retry block', async function () {
+        // Given
         const campaignParticipationResult = {
           campaignParticipationBadges: [],
           canRetry: false,
@@ -558,19 +591,18 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
-      });
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
-      it('should not display retry block', function () {
         // Then
-        expect(contains(this.intl.t('pages.skill-review.retry.button'))).to.not.exist;
+        expect(screen.queryByText(this.intl.t('pages.skill-review.retry.button'))).to.not.exist;
       });
     });
   });
 
   describe('The improve block', function () {
     context('when user can improve', function () {
-      beforeEach(async function () {
+      it('should display improve block', async function () {
+        // Given
         const campaignParticipationResult = {
           campaignParticipationBadges: [],
           canImprove: true,
@@ -578,17 +610,16 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
-      });
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
-      it('should display improve block', function () {
         // Then
-        expect(contains(this.intl.t('pages.skill-review.improve.title'))).to.exist;
+        expect(screen.getByText(this.intl.t('pages.skill-review.improve.title'))).to.exist;
       });
     });
 
     context('when user cannot improve', function () {
-      beforeEach(async function () {
+      it('should not display improve block', async function () {
+        // Given
         const campaignParticipationResult = {
           campaignParticipationBadges: [],
           canImprove: false,
@@ -596,17 +627,16 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
-      });
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
-      it('should not display improve block', function () {
         // Then
-        expect(contains(this.intl.t('pages.skill-review.improve.title'))).to.not.exist;
+        expect(screen.queryByText(this.intl.t('pages.skill-review.improve.title'))).to.not.exist;
       });
     });
 
     context('when share button has been pressed but a skill has been reset', function () {
-      beforeEach(async function () {
+      it('should not display improve block', async function () {
+        // Given
         const campaignParticipationResult = {
           campaignParticipationBadges: [],
           canImprove: true,
@@ -618,18 +648,17 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         adapter.share = sinon.stub().rejects({ errors: [{ status: '409' }] });
 
         // When
-        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
         await clickByLabel(this.intl.t('pages.skill-review.actions.send'));
-      });
 
-      it('should not display improve block', function () {
         // Then
-        expect(contains(this.intl.t('pages.skill-review.improve.title'))).to.not.exist;
+        expect(screen.queryByText(this.intl.t('pages.skill-review.improve.title'))).to.not.exist;
       });
     });
 
     context('when share button has been pressed but a global error occurred', function () {
-      beforeEach(async function () {
+      it('should not display improve block', async function () {
+        // Given
         const campaignParticipationResult = {
           campaignParticipationBadges: [],
           canImprove: true,
@@ -641,20 +670,19 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         adapter.share = sinon.stub().rejects({ errors: [{ status: '412' }] });
 
         // When
-        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
         await clickByLabel(this.intl.t('pages.skill-review.actions.send'));
-      });
 
-      it('should not display improve block', function () {
         // Then
-        expect(contains(this.intl.t('pages.skill-review.improve.title'))).to.exist;
+        expect(screen.getByText(this.intl.t('pages.skill-review.improve.title'))).to.exist;
       });
     });
   });
 
   describe('The Net Promoter Score block', function () {
     context('when organizationShowNPS is true', function () {
-      beforeEach(async function () {
+      it('should display NPS Block', async function () {
+        // Given
         campaign = {
           organizationShowNPS: true,
           organizationFormNPSUrl: 'https://pix.fr',
@@ -666,39 +694,57 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+
+        // Then
+        expect(screen.getByText(this.intl.t('pages.skill-review.net-promoter-score.title'))).to.exist;
       });
 
-      it('should display NPS Block', function () {
-        expect(contains(this.intl.t('pages.skill-review.net-promoter-score.title'))).to.exist;
-      });
-      it('should display the button to access the NPS form  ', function () {
-        expect(contains(this.intl.t('pages.skill-review.net-promoter-score.link.label'))).to.exist;
-        expect(find('[href="https://pix.fr"]')).to.exist;
-        expect(find('[target="_blank"]')).to.exist;
+      it('should display the button to access the NPS form  ', async function () {
+        // Given
+        campaign = {
+          organizationShowNPS: true,
+          organizationFormNPSUrl: 'https://pix.fr',
+        };
+        const campaignParticipationResult = {
+          campaignParticipationBadges: [],
+          isShared: true,
+        };
+        this.set('model', { campaign, campaignParticipationResult });
+
+        // When
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+
+        // Then
+        expect(screen.getByText(this.intl.t('pages.skill-review.net-promoter-score.link.label'))).to.exist;
+        expect(screen.getByRole('link', { name: 'Je donne mon avis' })).to.exist;
+        expect(screen.getByRole('link', { name: 'Je donne mon avis' }))
+          .to.have.property('target')
+          .that.equals('_blank');
       });
     });
 
     context('when organizationShowNPS is false', function () {
-      beforeEach(async function () {
+      it('should not display NPS Block', async function () {
+        // Given
         const campaignParticipationResult = {
           campaignParticipationBadges: [],
         };
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
-      });
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
-      it('should not display NPS Block', function () {
-        expect(contains(this.intl.t('pages.skill-review.net-promoter-score.title'))).to.not.exist;
+        // Then
+        expect(screen.queryByText(this.intl.t('pages.skill-review.net-promoter-score.title'))).to.not.exist;
       });
     });
   });
 
   describe('The disabled block', function () {
     context('when participation is disabled and not shared', function () {
-      beforeEach(async function () {
+      it('should display disabled block', async function () {
+        // Given
         const campaignParticipationResult = {
           campaignParticipationBadges: [],
           isDisabled: true,
@@ -708,16 +754,15 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
 
         // When
         await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
-      });
 
-      it('should display disabled block', function () {
         // Then
         expect(contains("Ce parcours a été désactivé par l'organisateur.")).to.exist;
       });
     });
 
     context('when participation is disabled but already shared', function () {
-      beforeEach(async function () {
+      it('should not display disabled block', async function () {
+        // Given
         const campaignParticipationResult = {
           campaignParticipationBadges: [],
           isDisabled: true,
@@ -726,17 +771,16 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
-      });
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
-      it('should not display disabled block', function () {
         // Then
-        expect(contains('Merci, vos résultats ont bien été envoyés !')).to.exist;
+        expect(screen.getByText('Merci, vos résultats ont bien été envoyés !')).to.exist;
       });
     });
 
     context('when participation is not disabled', function () {
-      beforeEach(async function () {
+      it('should not display disabled block', async function () {
+        // Given
         const campaignParticipationResult = {
           campaignParticipationBadges: [],
           isDisabled: false,
@@ -745,12 +789,10 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
-      });
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
 
-      it('should not display disabled block', function () {
         // Then
-        expect(contains("J'envoie mes résultats")).to.exist;
+        expect(screen.getByText("J'envoie mes résultats")).to.exist;
       });
     });
   });

--- a/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
@@ -241,6 +241,71 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function ()
     });
   });
 
+  describe('#acquiredCertifiableBadges', function () {
+    it('should only return certifiable acquired badges', function () {
+      // given
+      const badges = [
+        { id: 33, isAcquired: true, isCertifiable: true },
+        { id: 34, isAcquired: false, isCertifiable: false },
+      ];
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
+
+      // when
+      const acquiredBadges = component.acquiredCertifiableBadges;
+
+      // then
+      expect(acquiredBadges).to.deep.equal([{ id: 33, isAcquired: true, isCertifiable: true }]);
+    });
+  });
+
+  describe('#notAcquiredButVisibleCertifiableBadges', function () {
+    it('should only return not acquired certifiable badges', function () {
+      // given
+      const badges = [
+        { id: 33, isAcquired: true, isCertifiable: false },
+        { id: 34, isAcquired: false, isAlwaysVisible: true, isCertifiable: true },
+        { id: 35, isAcquired: true, isAlwaysVisible: true, isCertifiable: true },
+        { id: 36, isAcquired: true, isAlwaysVisible: true, isCertifiable: false },
+        { id: 37, isAcquired: false, isAlwaysVisible: false, isCertifiable: false },
+      ];
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
+
+      // when
+      const notAcquiredBadges = component.notAcquiredButVisibleBadges;
+
+      // then
+      expect(notAcquiredBadges).to.deep.equal([
+        {
+          id: 34,
+          isAcquired: false,
+          isAlwaysVisible: true,
+          isCertifiable: true,
+        },
+      ]);
+    });
+  });
+
+  describe('#orderedCertifiableBadges', function () {
+    it('should return certifiable badges ordered by if it is acquired or not', function () {
+      // given
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = [
+        { id: 33, isAcquired: true, isAlwaysVisible: true, isCertifiable: true },
+        { id: 34, isAcquired: false, isAlwaysVisible: true, isCertifiable: true },
+        { id: 35, isAcquired: true, isAlwaysVisible: true, isCertifiable: true },
+      ];
+
+      // when
+      const orderedBadges = component.orderedCertifiableBadges;
+
+      // then
+      expect(orderedBadges).to.deep.equal([
+        { id: 33, isAcquired: true, isAlwaysVisible: true, isCertifiable: true },
+        { id: 35, isAcquired: true, isAlwaysVisible: true, isCertifiable: true },
+        { id: 34, isAcquired: false, isAlwaysVisible: true, isCertifiable: true },
+      ]);
+    });
+  });
+
   describe('#showOrganizationMessage', function () {
     it('should return true when the campaign has a customResultPageText', function () {
       // given
@@ -549,11 +614,15 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function ()
   describe('#redirectToSignupIfUserIsAnonymous', function () {
     it('should redirect to sign up page on click when user is anonymous', async function () {
       // given
-      const event = { preventDefault: () => {} };
+      const event = {
+        preventDefault: () => {},
+      };
       const session = this.owner.lookup('service:session');
+
       class currentUser extends Service {
         user = { isAnonymous: true };
       }
+
       this.owner.register('service:currentUser', currentUser);
 
       session.invalidate = sinon.stub();
@@ -568,10 +637,14 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function ()
 
     it('should redirect to home page when user is not anonymous', async function () {
       // given
-      const event = { preventDefault: () => {} };
+      const event = {
+        preventDefault: () => {},
+      };
+
       class currentUser extends Service {
         user = { isAnonymous: false };
       }
+
       this.owner.register('service:currentUser', currentUser);
 
       // when
@@ -584,9 +657,11 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function ()
     it('prevents default behaviour', async function () {
       // given
       const event = { preventDefault: sinon.stub() };
+
       class currentUser extends Service {
         user = { isAnonymous: false };
       }
+
       this.owner.register('service:currentUser', currentUser);
 
       // when

--- a/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
@@ -147,29 +147,29 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function ()
     });
   });
 
-  describe('#showBadges', function () {
+  describe('#showNotCertifiableBadges', function () {
     it('should show not certifiable badges when acquired', function () {
       // given
       const badges = [{ id: 33, isAcquired: true, isCertifiable: false }];
       component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
 
       // when
-      const shouldShowBadges = component.showBadges;
+      const shouldShowBadges = component.showNotCertifiableBadges;
 
       // then
       expect(shouldShowBadges).to.equal(true);
     });
 
-    it('should show certifiable badges when acquired', function () {
+    it('should not show certifiable badges when acquired', function () {
       // given
       const badges = [{ id: 33, isAcquired: true, isCertifiable: true }];
       component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
 
       // when
-      const shouldShowBadges = component.showBadges;
+      const shouldShowBadges = component.showNotCertifiableBadges;
 
       // then
-      expect(shouldShowBadges).to.equal(true);
+      expect(shouldShowBadges).to.equal(false);
     });
 
     it('should not show badges when not acquired', function () {
@@ -178,7 +178,7 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function ()
       component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
 
       // when
-      const shouldShowBadges = component.showBadges;
+      const shouldShowBadges = component.showNotCertifiableBadges;
 
       // then
       expect(shouldShowBadges).to.equal(false);
@@ -190,7 +190,57 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function ()
       component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
 
       // when
-      const shouldShowBadges = component.showBadges;
+      const shouldShowBadges = component.showNotCertifiableBadges;
+
+      // then
+      expect(shouldShowBadges).to.equal(false);
+    });
+  });
+
+  describe('#showCertifiableBadges', function () {
+    it('should show certifiable badges when acquired', function () {
+      // given
+      const badges = [{ id: 33, isAcquired: true, isCertifiable: true }];
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
+
+      // when
+      const shouldShowBadges = component.showCertifiableBadges;
+
+      // then
+      expect(shouldShowBadges).to.equal(true);
+    });
+
+    it('should not show not certifiable badges when acquired', function () {
+      // given
+      const badges = [{ id: 33, isAcquired: true, isCertifiable: false }];
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
+
+      // when
+      const shouldShowBadges = component.showCertifiableBadges;
+
+      // then
+      expect(shouldShowBadges).to.equal(false);
+    });
+
+    it('should not show badges when not acquired', function () {
+      // given
+      const badges = [{ id: 33, isAcquired: false }];
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
+
+      // when
+      const shouldShowBadges = component.showCertifiableBadges;
+
+      // then
+      expect(shouldShowBadges).to.equal(false);
+    });
+
+    it('should not show badges when none', function () {
+      // given
+      const badges = [];
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
+
+      // when
+      const shouldShowBadges = component.showCertifiableBadges;
 
       // then
       expect(shouldShowBadges).to.equal(false);

--- a/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
@@ -266,56 +266,6 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function ()
     });
   });
 
-  describe('#notAcquiredButVisibleNotCertifiableBadges', function () {
-    it('should only return not acquired and not certifiable badges', function () {
-      // given
-      const badges = [
-        { id: 33, isAcquired: true, isCertifiable: false },
-        { id: 34, isAcquired: false, isAlwaysVisible: true, isCertifiable: false },
-        { id: 35, isAcquired: false, isAlwaysVisible: true, isCertifiable: true },
-        { id: 36, isAcquired: false, isAlwaysVisible: false, isCertifiable: true },
-      ];
-      component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
-
-      // when
-      const notAcquiredBadges = component.notAcquiredButVisibleNotCertifiableBadges;
-
-      // then
-      expect(notAcquiredBadges).to.deep.equal([
-        {
-          id: 34,
-          isAcquired: false,
-          isAlwaysVisible: true,
-          isCertifiable: false,
-        },
-      ]);
-    });
-  });
-
-  describe('#orderedNotCertifiableBadges', function () {
-    it('should return not certifiable badges ordered by if it is acquired or not', function () {
-      // given
-      component.args.model.campaignParticipationResult.campaignParticipationBadges = [
-        { id: 33, isAcquired: true, isAlwaysVisible: true, isCertifiable: true },
-        { id: 34, isAcquired: true, isAlwaysVisible: true, isCertifiable: false },
-        { id: 35, isAcquired: false, isAlwaysVisible: true, isCertifiable: true },
-        { id: 36, isAcquired: false, isAlwaysVisible: true, isCertifiable: false },
-        { id: 37, isAcquired: true, isAlwaysVisible: false, isCertifiable: true },
-        { id: 38, isAcquired: true, isAlwaysVisible: false, isCertifiable: false },
-      ];
-
-      // when
-      const orderedBadges = component.orderedNotCertifiableBadges;
-
-      // then
-      expect(orderedBadges).to.deep.equal([
-        { id: 34, isAcquired: true, isAlwaysVisible: true, isCertifiable: false },
-        { id: 38, isAcquired: true, isAlwaysVisible: false, isCertifiable: false },
-        { id: 36, isAcquired: false, isAlwaysVisible: true, isCertifiable: false },
-      ]);
-    });
-  });
-
   describe('#acquiredCertifiableBadges', function () {
     it('should only return certifiable acquired badges', function () {
       // given
@@ -330,54 +280,6 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function ()
 
       // then
       expect(acquiredBadges).to.deep.equal([{ id: 33, isAcquired: true, isCertifiable: true }]);
-    });
-  });
-
-  describe('#notAcquiredButVisibleCertifiableBadges', function () {
-    it('should only return not acquired certifiable badges', function () {
-      // given
-      const badges = [
-        { id: 33, isAcquired: true, isCertifiable: false },
-        { id: 34, isAcquired: false, isAlwaysVisible: true, isCertifiable: true },
-        { id: 35, isAcquired: true, isAlwaysVisible: true, isCertifiable: true },
-        { id: 36, isAcquired: true, isAlwaysVisible: true, isCertifiable: false },
-        { id: 37, isAcquired: false, isAlwaysVisible: false, isCertifiable: false },
-      ];
-      component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
-
-      // when
-      const notAcquiredBadges = component.notAcquiredButVisibleCertifiableBadges;
-
-      // then
-      expect(notAcquiredBadges).to.deep.equal([
-        {
-          id: 34,
-          isAcquired: false,
-          isAlwaysVisible: true,
-          isCertifiable: true,
-        },
-      ]);
-    });
-  });
-
-  describe('#orderedCertifiableBadges', function () {
-    it('should return certifiable badges ordered by if it is acquired or not', function () {
-      // given
-      component.args.model.campaignParticipationResult.campaignParticipationBadges = [
-        { id: 33, isAcquired: true, isAlwaysVisible: true, isCertifiable: true },
-        { id: 34, isAcquired: false, isAlwaysVisible: true, isCertifiable: true },
-        { id: 35, isAcquired: true, isAlwaysVisible: true, isCertifiable: true },
-      ];
-
-      // when
-      const orderedBadges = component.orderedCertifiableBadges;
-
-      // then
-      expect(orderedBadges).to.deep.equal([
-        { id: 33, isAcquired: true, isAlwaysVisible: true, isCertifiable: true },
-        { id: 35, isAcquired: true, isAlwaysVisible: true, isCertifiable: true },
-        { id: 34, isAcquired: false, isAlwaysVisible: true, isCertifiable: true },
-      ]);
     });
   });
 

--- a/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
@@ -148,9 +148,21 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function ()
   });
 
   describe('#showBadges', function () {
-    it('should show badges when acquired', function () {
+    it('should show not certifiable badges when acquired', function () {
       // given
-      const badges = [{ id: 33, isAcquired: true }];
+      const badges = [{ id: 33, isAcquired: true, isCertifiable: false }];
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
+
+      // when
+      const shouldShowBadges = component.showBadges;
+
+      // then
+      expect(shouldShowBadges).to.equal(true);
+    });
+
+    it('should show certifiable badges when acquired', function () {
+      // given
+      const badges = [{ id: 33, isAcquired: true, isCertifiable: true }];
       component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
 
       // when
@@ -185,58 +197,71 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function ()
     });
   });
 
-  describe('#acquiredBadges', function () {
-    it('should only return acquired badges', function () {
+  describe('#acquiredNotCertifiableBadges', function () {
+    it('should only return acquired and not certifiable badges', function () {
       // given
       const badges = [
-        { id: 33, isAcquired: true },
-        { id: 34, isAcquired: false },
+        { id: 33, isAcquired: true, isCertifiable: false },
+        { id: 34, isAcquired: false, isCertifiable: true },
+        { id: 35, isAcquired: true, isCertifiable: true },
+        { id: 36, isAcquired: false, isCertifiable: false },
       ];
       component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
 
       // when
-      const acquiredBadges = component.acquiredBadges;
+      const acquiredBadges = component.acquiredNotCertifiableBadges;
 
       // then
-      expect(acquiredBadges).to.deep.equal([{ id: 33, isAcquired: true }]);
+      expect(acquiredBadges).to.deep.equal([{ id: 33, isAcquired: true, isCertifiable: false }]);
     });
   });
 
-  describe('#notAcquiredButVisibleBadges', function () {
-    it('should only return not acquired badges', function () {
+  describe('#notAcquiredButVisibleNotCertifiableBadges', function () {
+    it('should only return not acquired and not certifiable badges', function () {
       // given
       const badges = [
-        { id: 33, isAcquired: true },
-        { id: 34, isAcquired: false, isAlwaysVisible: true },
-        { id: 35, isAcquired: false, isAlwaysVisible: false },
+        { id: 33, isAcquired: true, isCertifiable: false },
+        { id: 34, isAcquired: false, isAlwaysVisible: true, isCertifiable: false },
+        { id: 35, isAcquired: false, isAlwaysVisible: true, isCertifiable: true },
+        { id: 36, isAcquired: false, isAlwaysVisible: false, isCertifiable: true },
       ];
       component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
 
       // when
-      const notAcquiredBadges = component.notAcquiredButVisibleBadges;
+      const notAcquiredBadges = component.notAcquiredButVisibleNotCertifiableBadges;
 
       // then
-      expect(notAcquiredBadges).to.deep.equal([{ id: 34, isAcquired: false, isAlwaysVisible: true }]);
+      expect(notAcquiredBadges).to.deep.equal([
+        {
+          id: 34,
+          isAcquired: false,
+          isAlwaysVisible: true,
+          isCertifiable: false,
+        },
+      ]);
     });
   });
 
-  describe('#orderedBadges', function () {
-    it('should return badges ordered by if it is acquired or not', function () {
+  describe('#orderedNotCertifiableBadges', function () {
+    it('should return not certifiable badges ordered by if it is acquired or not', function () {
       // given
       component.args.model.campaignParticipationResult.campaignParticipationBadges = [
-        { id: 33, isAcquired: true, isAlwaysVisible: true },
-        { id: 34, isAcquired: false, isAlwaysVisible: true },
-        { id: 35, isAcquired: true, isAlwaysVisible: true },
+        { id: 33, isAcquired: true, isAlwaysVisible: true, isCertifiable: true },
+        { id: 34, isAcquired: true, isAlwaysVisible: true, isCertifiable: false },
+        { id: 35, isAcquired: false, isAlwaysVisible: true, isCertifiable: true },
+        { id: 36, isAcquired: false, isAlwaysVisible: true, isCertifiable: false },
+        { id: 37, isAcquired: true, isAlwaysVisible: false, isCertifiable: true },
+        { id: 38, isAcquired: true, isAlwaysVisible: false, isCertifiable: false },
       ];
 
       // when
-      const orderedBadges = component.orderedBadges;
+      const orderedBadges = component.orderedNotCertifiableBadges;
 
       // then
       expect(orderedBadges).to.deep.equal([
-        { id: 33, isAcquired: true, isAlwaysVisible: true },
-        { id: 35, isAcquired: true, isAlwaysVisible: true },
-        { id: 34, isAcquired: false, isAlwaysVisible: true },
+        { id: 34, isAcquired: true, isAlwaysVisible: true, isCertifiable: false },
+        { id: 38, isAcquired: true, isAlwaysVisible: false, isCertifiable: false },
+        { id: 36, isAcquired: false, isAlwaysVisible: true, isCertifiable: false },
       ]);
     });
   });
@@ -271,7 +296,7 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function ()
       component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
 
       // when
-      const notAcquiredBadges = component.notAcquiredButVisibleBadges;
+      const notAcquiredBadges = component.notAcquiredButVisibleCertifiableBadges;
 
       // then
       expect(notAcquiredBadges).to.deep.equal([


### PR DESCRIPTION
## :jack_o_lantern: Problème

La finalité des RT "simples" et RT "certifiants" n'est pas la même puisque l'un porte l'éligibilité d'un utilisateur à une certification complémentaire tandis que l’autre ne la permet pas.

A l’heure actuelle, la différence entre RT ”simples” et RT  “certifiants” n’est pas visible par le design dans la page de fin de parcours et ne permet pas une identification rapide des RT “certifiants”.
 
![index](https://user-images.githubusercontent.com/36371437/197828413-d4e22971-e954-4995-be92-f22f99ee16b5.png)

## :bat: Proposition

    Sortir l'éligibilité de la section "Vos résultats thématiques" sur la page de fin de parcours en créant un encadré de couleur différente au dessus des RT “simples” tout en restant dans le 2e pavé correspondant aux RT.

        • Les RT certifiants obtenus apparaissent sur fond vert clair.
        • Les RT certifiants non obtenus apparaissent sur fond gris.

Changer la taille et la couleur du bouton “J’envoie mes résultats” pour augmenter sa visibilité.
Afficher les logos des RT obtenus par l’utilisateur dans le premier pavé sous le bouton “J’envoie mes résultats” :

       • RT “certifiants” en premier sur fond vert clair
       • RT “simples” s’affichent ensuite sur fond gris.
       • Un hover sur chaque logo doit préciser le nom du RT obtenu.
        • Ajouter une ancre sur chaque logo qui emmène vers le détail du RT plus bas.
        
Maquettes disponibles [ici](https://www.figma.com/file/y6p1FS5HKhJkMLrJN4i90P/Pix-App?node-id=1991%3A50599)

## :spider_web: Remarques

Au moment de PR, les RT non acquis ne sont pas remontés côté API comme cela aurait pu le laisser penser suite à la PR [#3504](https://github.com/1024pix/pix/pull/3504)

Deux commits différents de cette PR incluent donc l'ajout et la suppression de cette séparation. L'historique est ainsi préservé afin de pouvoir plus facilement le retrouver une fois la récupération des RT non acquis opérationnelle.

Dans le dernier commit concernant l'ajout de Testing-Library, un test fait de la résistance dans sa transition.

## :ghost: Pour tester

Sur Pix-App, se connecter avec le compte `email: toto@toto.fr / MDP:  Poiuytre123)` et rejoindre la campagne (déjà terminée avec l'obtention de 2 RT sur les 3 possibles) dont le code est : `QPMFCC228`.
Un des RT a été passé en non-certifiable afin de pouvoir constater de la présence des deux sections distinctes contenant les cartes.
Sur cette page, vérifier que :

- le header contient deux icones dans deux sections distinctes (fond vert et gris) représentant respectivement les RT acquis certifiables et RT acquis non certifiables
- Qu'une tooltip s'affiche au survol de chacune de ces icones avec le nom du RT en question
- Qu'un clic sur chacune de ces icones renvoie vers la carte du RT en question dans la section se trouvant en dessous
- Que la refonte de la nouvelle page  en ce qui concerne le header et les cartes de RT correspond aux maquettes fournies dans les différents formats (les autres sections sont hors scope de cette PR)

(L'ajout de paliers à la campagne pour tester l'ensemble des possibilités d'affichage  se fait dans la section `Clés de lecture` du profil-cible dans `pix-admin`)