### PR TITLE
[BUGFIX] Permettre aux propositions du QCM d'être sur deux lignes (PIX-6051)

### DIFF
--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -31,6 +31,7 @@
 
   &__row label {
     display: inline;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## :jack_o_lantern: Problème
Actuellement, une longue `proposition` pouvait dépasser du bloc lors d'un `QCM`.

## :bat: Proposition
- Modification du Scss.

## :spider_web: Remarques
/

## :ghost: Pour tester

- Aller sur [ un challenge de la Preview](https://app-pr5084.review.pix.fr/challenges/recWY2fgyQuc4QMu/preview)
- Vérifier que  les textes les plus longs ne dépassent pas du bloc.