### PR TITLE
[BUGFIX] Afficher la colonne référent seulement si le centre est habilité CléA (PIX-5989)

### DIFF
--- a/certif/app/components/members-list.hbs
+++ b/certif/app/components/members-list.hbs
@@ -17,23 +17,25 @@
             <tr aria-label="Membres du centre de certification">
               <td>{{member.lastName}}</td>
               <td>{{member.firstName}}</td>
-              {{#if (and this.shouldDisplayRefererColumn member.isReferer)}}
+              {{#if this.shouldDisplayRefererColumn}}
                 <td>
-                  <div class="members-list__is-referer">
-                    <PixTag class="members-list__tag" @color="blue-light">
-                      {{t "pages.team.pix-referer"}}
-                    </PixTag>
-                    <PixTooltip class="members-list__tool-tip" @isWide="true" @position="bottom">
-                      <:triggerElement>
-                        <span tabindex="0">
-                          <FaIcon @icon="info-circle" />
-                        </span>
-                      </:triggerElement>
-                      <:tooltip>
-                        {{t "pages.team.pix-referer-tooltip"}}
-                      </:tooltip>
-                    </PixTooltip>
-                  </div>
+                  {{#if member.isReferer}}
+                    <div class="members-list__is-referer">
+                      <PixTag class="members-list__tag" @color="blue-light">
+                        {{t "pages.team.pix-referer"}}
+                      </PixTag>
+                      <PixTooltip class="members-list__tool-tip" @isWide="true" @position="bottom">
+                        <:triggerElement>
+                          <span tabindex="0">
+                            <FaIcon @icon="info-circle" />
+                          </span>
+                        </:triggerElement>
+                        <:tooltip>
+                          {{t "pages.team.pix-referer-tooltip"}}
+                        </:tooltip>
+                      </PixTooltip>
+                    </div>
+                  {{/if}}
                 </td>
               {{/if}}
             </tr>

--- a/certif/app/components/members-list.hbs
+++ b/certif/app/components/members-list.hbs
@@ -4,10 +4,10 @@
       <table>
         <thead>
           <tr>
-            <th class="table__column table__column--small">{{t "pages.team.last-name"}}</th>
-            <th class="table__column table__column--small">{{t "pages.team.first-name"}}</th>
+            <th class="table__column table__column--medium">{{t "pages.team.last-name"}}</th>
+            <th class="table__column table__column--medium">{{t "pages.team.first-name"}}</th>
             {{#if this.shouldDisplayRefererColumn}}
-              <th class="table__column table__column--small">{{t "pages.team.referer"}}</th>
+              <th class="table__column table__column--medium">{{t "pages.team.referer"}}</th>
             {{/if}}
           </tr>
         </thead>

--- a/certif/app/components/members-list.js
+++ b/certif/app/components/members-list.js
@@ -5,6 +5,9 @@ export default class MembersList extends Component {
   @service featureToggles;
 
   get shouldDisplayRefererColumn() {
-    return this.featureToggles.featureToggles.isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled;
+    return (
+      this.args.hasCleaHabilitation &&
+      this.featureToggles.featureToggles.isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled
+    );
   }
 }

--- a/certif/app/templates/authenticated/team.hbs
+++ b/certif/app/templates/authenticated/team.hbs
@@ -21,14 +21,14 @@
       </div>
     </div>
   </div>
-{{/if}}
-{{#if this.shouldShowRefererSelectionModal}}
-  <SelectRefererModal
-    @toggleRefererModal={{this.toggleRefererModal}}
-    @onSelectReferer={{this.onSelectReferer}}
-    @onValidateReferer={{this.onValidateReferer}}
-    @noSelectedReferer={{not this.selectedReferer.length}}
-    @options={{this.membersSelectOptionsSortedByLastName}}
-  />
+  {{#if this.shouldShowRefererSelectionModal}}
+    <SelectRefererModal
+      @toggleRefererModal={{this.toggleRefererModal}}
+      @onSelectReferer={{this.onSelectReferer}}
+      @onValidateReferer={{this.onValidateReferer}}
+      @noSelectedReferer={{not this.selectedReferer.length}}
+      @options={{this.membersSelectOptionsSortedByLastName}}
+    />
+  {{/if}}
 {{/if}}
 <MembersList @members={{@model.members}} />

--- a/certif/app/templates/authenticated/team.hbs
+++ b/certif/app/templates/authenticated/team.hbs
@@ -21,14 +21,14 @@
       </div>
     </div>
   </div>
-  {{#if this.shouldShowRefererSelectionModal}}
-    <SelectRefererModal
-      @toggleRefererModal={{this.toggleRefererModal}}
-      @onSelectReferer={{this.onSelectReferer}}
-      @onValidateReferer={{this.onValidateReferer}}
-      @noSelectedReferer={{not this.selectedReferer.length}}
-      @options={{this.membersSelectOptionsSortedByLastName}}
-    />
-  {{/if}}
 {{/if}}
-<MembersList @members={{@model.members}} />
+{{#if this.shouldShowRefererSelectionModal}}
+  <SelectRefererModal
+    @toggleRefererModal={{this.toggleRefererModal}}
+    @onSelectReferer={{this.onSelectReferer}}
+    @onValidateReferer={{this.onValidateReferer}}
+    @noSelectedReferer={{not this.selectedReferer.length}}
+    @options={{this.membersSelectOptionsSortedByLastName}}
+  />
+{{/if}}
+<MembersList @members={{@model.members}} @hasCleaHabilitation={{this.model.hasCleaHabilitation}} />

--- a/certif/tests/integration/components/members-list_test.js
+++ b/certif/tests/integration/components/members-list_test.js
@@ -34,8 +34,8 @@ module('Integration | Component | members-list', function (hooks) {
   });
 
   module('when FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS is enabled', function () {
-    module('when a member is referer', function () {
-      test('it should show the referer tag', async function (assert) {
+    module('when certification center is habilitated CléA', function () {
+      test('it should show the referer column', async function (assert) {
         // given
         class FeatureTogglesStub extends Service {
           featureToggles = { isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: true };
@@ -45,17 +45,65 @@ module('Integration | Component | members-list', function (hooks) {
         const certifMember2 = EmberObject.create({ firstName: 'John', lastName: 'Williams', isReferer: true });
         const members = [certifMember1, certifMember2];
         this.set('members', members);
+        this.set('hasCleaHabilitation', true);
 
         // when
-        const screen = await renderScreen(hbs`<MembersList @members={{this.members}} />`);
+        const screen = await renderScreen(
+          hbs`<MembersList @members={{this.members}} @hasCleaHabilitation={{this.hasCleaHabilitation}} />`
+        );
 
         // then
-        assert.dom(screen.getByRole('cell', { name: this.intl.t('pages.team.pix-referer') })).exists();
+        assert.dom(screen.getByRole('columnheader', { name: this.intl.t('pages.team.referer') })).exists();
+      });
+
+      module('when a member is referer', function () {
+        test('it should show the referer tag', async function (assert) {
+          // given
+          class FeatureTogglesStub extends Service {
+            featureToggles = { isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: true };
+          }
+          this.owner.register('service:featureToggles', FeatureTogglesStub);
+          const certifMember1 = EmberObject.create({ firstName: 'Maria', lastName: 'Carré', isReferer: false });
+          const certifMember2 = EmberObject.create({ firstName: 'John', lastName: 'Williams', isReferer: true });
+          const members = [certifMember1, certifMember2];
+          this.set('members', members);
+          this.set('hasCleaHabilitation', true);
+
+          // when
+          const screen = await renderScreen(
+            hbs`<MembersList @members={{this.members}} @hasCleaHabilitation={{this.hasCleaHabilitation}} />`
+          );
+
+          // then
+          assert.dom(screen.getByRole('cell', { name: this.intl.t('pages.team.pix-referer') })).exists();
+        });
+      });
+
+      module('when there is no referer', function () {
+        test('it should not show the referer tag', async function (assert) {
+          // given
+          class FeatureTogglesStub extends Service {
+            featureToggles = { isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: true };
+          }
+          this.owner.register('service:featureToggles', FeatureTogglesStub);
+          const certifMember1 = EmberObject.create({ firstName: 'Maria', lastName: 'Carré', isReferer: false });
+          const members = [certifMember1];
+          this.set('members', members);
+          this.set('hasCleaHabilitation', true);
+
+          // when
+          const screen = await renderScreen(
+            hbs`<MembersList @members={{this.members}} @hasCleaHabilitation={{this.hasCleaHabilitation}} />`
+          );
+
+          // then
+          assert.dom(screen.queryByRole('cell', { name: this.intl.t('pages.team.pix-referer') })).doesNotExist();
+        });
       });
     });
 
-    module('when there is no referer', function () {
-      test('it should not show the referer tag', async function (assert) {
+    module('when certification center is not habilitated CléA', function () {
+      test('it should not show the referer column', async function (assert) {
         // given
         class FeatureTogglesStub extends Service {
           featureToggles = { isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: true };
@@ -64,12 +112,15 @@ module('Integration | Component | members-list', function (hooks) {
         const certifMember1 = EmberObject.create({ firstName: 'Maria', lastName: 'Carré', isReferer: false });
         const members = [certifMember1];
         this.set('members', members);
+        this.set('hasCleaHabilitation', false);
 
         // when
-        const screen = await renderScreen(hbs`<MembersList @members={{this.members}} />`);
+        const screen = await renderScreen(
+          hbs`<MembersList @members={{this.members}} @hasCleaHabilitation={{this.hasCleaHabilitation}} />`
+        );
 
         // then
-        assert.dom(screen.queryByRole('cell', { name: this.intl.t('pages.team.pix-referer') })).doesNotExist();
+        assert.dom(screen.queryByRole('columnheader', { name: this.intl.t('pages.team.referer') })).doesNotExist();
       });
     });
   });
@@ -84,9 +135,12 @@ module('Integration | Component | members-list', function (hooks) {
       const certifMember1 = EmberObject.create({ firstName: 'Maria', lastName: 'Carré', isReferer: true });
       const members = [certifMember1];
       this.set('members', members);
+      this.set('hasCleaHabilitation', true);
 
       // when
-      const screen = await renderScreen(hbs`<MembersList @members={{this.members}} />`);
+      const screen = await renderScreen(
+        hbs`<MembersList @members={{this.members}} @hasCleaHabilitation={{this.hasCleaHabilitation}} />`
+      );
 
       // then
       assert.dom(screen.queryByRole('cell', { name: this.intl.t('pages.team.pix-referer') })).doesNotExist();


### PR DESCRIPTION
## :jack_o_lantern: Problème
Dans l’onglet Equipe de Pix Certif, la colonne “Référent” apparaît pour tous les CDC.

Dans l’onglet Equipe de Pix Certif, le hover gris sur la ligne d’un membre de l'équipe s’arrête avant la colonne référent lorsque cette colonne est vide (bout de la ligne laissé blanc).

## :bat: Proposition
Dans l’onglet Equipe de Pix Certif, la colonne “Référent” apparaît uniquement pour les CDC habilités CléA numérique.

Dans l’onglet Equipe de Pix Certif, le hover gris sur la ligne d’un membre de l'équipe doit aller jusqu’au bout de la ligne même si le membre n’a pas la mention “référent Pix” dans la colonne “Référent”.

## :ghost: Pour tester
- Activer le toggle FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS
- Se connecter avec un centre non habilité CléA
- Constater que la colonne "Référent" n'apparait pas

![image](https://user-images.githubusercontent.com/37305474/196444470-8c922432-9c34-4404-ad5a-a81864b15552.png)
