### PR TITLE
[FEATURE] Retourner les contenus formatifs dans PixApp (PIX-6052)

### DIFF
--- a/api/db/database-builder/factory/build-user-recommended-training.js
+++ b/api/db/database-builder/factory/build-user-recommended-training.js
@@ -1,0 +1,15 @@
+const databaseBuffer = require('../database-buffer');
+
+module.exports = function buildUserRecommendedTraining({
+  id = databaseBuffer.getNextId(),
+  userId,
+  trainingId,
+  campaignParticipationId,
+  createdAt = new Date(),
+  updatedAt = new Date(),
+} = {}) {
+  return databaseBuffer.pushInsertable({
+    tableName: 'user-recommended-trainings',
+    values: { id, userId, trainingId, campaignParticipationId, createdAt, updatedAt },
+  });
+};

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -67,6 +67,7 @@ module.exports = {
   buildUser: require('./build-user'),
   buildUserOrgaSettings: require('./build-user-orga-settings'),
   buildUserSavedTutorial: require('./build-user-saved-tutorial'),
+  buildUserRecommendedTraining: require('./build-user-recommended-training'),
   campaignParticipationOverviewFactory: require('./campaign-participation-overview-factory'),
   knowledgeElementSnapshotFactory: require('./knowledge-elements-snapshot-factory'),
   poleEmploiSendingFactory: require('./pole-emploi-sending-factory'),

--- a/api/lib/domain/read-models/UserRecommendedTraining.js
+++ b/api/lib/domain/read-models/UserRecommendedTraining.js
@@ -1,0 +1,12 @@
+class UserRecommendedTraining {
+  constructor({ id, title, link, type, duration, locale } = {}) {
+    this.id = id;
+    this.title = title;
+    this.link = link;
+    this.type = type;
+    this.duration = { ...duration }; // Prevent use of PostgresInterval object
+    this.locale = locale;
+  }
+}
+
+module.exports = UserRecommendedTraining;

--- a/api/lib/domain/usecases/find-campaign-participation-trainings.js
+++ b/api/lib/domain/usecases/find-campaign-participation-trainings.js
@@ -2,24 +2,16 @@ const { UserNotAuthorizedToFindTrainings } = require('../errors');
 
 module.exports = async function findCampaignParticipationTrainings({
   userId,
-  campaignParticipationId,
   locale,
+  campaignParticipationId,
   campaignParticipationRepository,
-  campaignRepository,
-  trainingRepository,
+  userRecommendedTrainingRepository,
 }) {
   const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
 
-  if (campaignParticipation.userId !== userId) throw new UserNotAuthorizedToFindTrainings();
-
-  const { targetProfile } = await campaignRepository.get(campaignParticipation.campaign.id);
-
-  if (!targetProfile) {
-    return [];
+  if (campaignParticipation.userId !== userId) {
+    throw new UserNotAuthorizedToFindTrainings();
   }
 
-  return trainingRepository.findByTargetProfileIdAndLocale({
-    targetProfileId: targetProfile.id,
-    locale,
-  });
+  return userRecommendedTrainingRepository.findByCampaignParticipationId({ campaignParticipationId, locale });
 };

--- a/api/lib/infrastructure/repositories/user-recommended-training-repository.js
+++ b/api/lib/infrastructure/repositories/user-recommended-training-repository.js
@@ -1,5 +1,6 @@
 const { knex } = require('../../../db/knex-database-connection');
 const DomainTransaction = require('../DomainTransaction');
+const UserRecommendedTraining = require('../../domain/read-models/UserRecommendedTraining');
 
 const TABLE_NAME = 'user-recommended-trainings';
 
@@ -8,4 +9,22 @@ module.exports = {
     const knexConn = domainTransaction?.knexTransaction || knex;
     return knexConn(TABLE_NAME).insert({ userId, trainingId, campaignParticipationId });
   },
+
+  async findByCampaignParticipationId({
+    campaignParticipationId,
+    locale,
+    domainTransaction = DomainTransaction.emptyTransaction(),
+  }) {
+    const knexConn = domainTransaction?.knexTransaction || knex;
+    const trainings = await knexConn(TABLE_NAME)
+      .select('trainings.*')
+      .innerJoin('trainings', 'trainings.id', `${TABLE_NAME}.trainingId`)
+      .where({ campaignParticipationId, locale })
+      .orderBy('id', 'asc');
+    return trainings.map(_toDomain);
+  },
 };
+
+function _toDomain(training) {
+  return new UserRecommendedTraining({ ...training });
+}

--- a/api/scripts/fill-user-recommended-trainings.js
+++ b/api/scripts/fill-user-recommended-trainings.js
@@ -1,0 +1,90 @@
+require('dotenv').config();
+const logger = require('../lib/infrastructure/logger');
+const cache = require('../lib/infrastructure/caches/learning-content-cache');
+const { knex, disconnect } = require('../db/knex-database-connection');
+const { parseCsvWithHeaderAndRequiredFields } = require('./helpers/csvHelpers');
+const trainingRepository = require('../lib/infrastructure/repositories/training-repository');
+const _ = require('lodash');
+
+const REQUIRED_FIELD_NAMES = ['userId', 'campaignParticipationId', 'targetProfileId'];
+const isLaunchedFromCommandLine = require.main === module;
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+      await cache.quit();
+    }
+  }
+})();
+
+async function main() {
+  logger.info('Starting creating user-recommended-trainings.');
+
+  const filePath = process.argv[2];
+
+  logger.info('Reading and parsing csv data file... ');
+  const csvData = await parseCsvWithHeaderAndRequiredFields({ filePath, requiredFieldNames: REQUIRED_FIELD_NAMES });
+
+  const campaignParticipationsToCompute = sanitizeCampaignParticipations(csvData);
+
+  logger.info('Compute user-recommended-trainings');
+  const userRecommendedTrainingsToInsert = await getUserRecommendedTrainings({
+    campaignParticipations: campaignParticipationsToCompute,
+    trainingRepository,
+  });
+
+  logger.info(`Insert ${userRecommendedTrainingsToInsert.length} user-recommended-trainings`);
+  await insertUserRecommendedTrainings(userRecommendedTrainingsToInsert);
+}
+
+function sanitizeCampaignParticipations(raw) {
+  return raw.map(({ userId, campaignParticipationId, targetProfileId }) => {
+    return {
+      userId: Number(userId),
+      campaignParticipationId: Number(campaignParticipationId),
+      targetProfileId: Number(targetProfileId),
+    };
+  });
+}
+
+async function getUserRecommendedTrainings({ campaignParticipations, trainingRepository }) {
+  const campaignParticipationsGroupedByTargetProfileId = _.groupBy(campaignParticipations, 'targetProfileId');
+
+  const targetProfileIds = Object.keys(campaignParticipationsGroupedByTargetProfileId);
+
+  const userRecommendTrainingsGroupByTargetProfile = await Promise.all(
+    targetProfileIds.map(async (targetProfileId) => {
+      const trainings = await _getTrainings(trainingRepository, targetProfileId);
+      const campaignParticipations = campaignParticipationsGroupedByTargetProfileId[targetProfileId];
+      return _getUserRecommendedTraining(campaignParticipations, trainings);
+    })
+  );
+
+  return userRecommendTrainingsGroupByTargetProfile.flat();
+}
+
+async function _getTrainings(trainingRepository, targetProfileId) {
+  return trainingRepository.findByTargetProfileIdAndLocale({
+    targetProfileId: Number(targetProfileId),
+  });
+}
+
+function _getUserRecommendedTraining(campaignParticipations, trainings) {
+  return campaignParticipations.flatMap(({ userId, campaignParticipationId }) => {
+    return trainings.map(({ id: trainingId }) => ({ userId, campaignParticipationId, trainingId }));
+  });
+}
+
+async function insertUserRecommendedTrainings(userRecommendedTrainings) {
+  for (const userRecommendedTraining of userRecommendedTrainings) {
+    await knex('user-recommended-trainings').insert(userRecommendedTraining).onConflict().ignore();
+  }
+}
+
+module.exports = { getUserRecommendedTrainings, sanitizeCampaignParticipations, insertUserRecommendedTrainings };

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -366,24 +366,16 @@ describe('Acceptance | API | Campaign Participations', function () {
   });
 
   describe('GET /api/campaign-participations/{id}/trainings', function () {
-    let targetProfileId;
-
-    beforeEach(function () {
-      targetProfileId = 1;
-    });
-
     it('should return the campaign-participation trainings', async function () {
       // given
-      const targetProfile = databaseBuilder.factory.buildTargetProfile({ id: targetProfileId });
       const training = databaseBuilder.factory.buildTraining();
-      databaseBuilder.factory.buildTargetProfileTraining({
-        trainingId: training.id,
-        targetProfileId: targetProfile.id,
-      });
-      const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
       const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
         userId: user.id,
-        campaignId: campaign.id,
+      });
+      databaseBuilder.factory.buildUserRecommendedTraining({
+        userId: campaignParticipation.userId,
+        trainingId: training.id,
+        campaignParticipationId: campaignParticipation.id,
       });
       await databaseBuilder.commit();
       const options = {

--- a/api/tests/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -1,13 +1,14 @@
 const _ = require('lodash');
 const { expect, databaseBuilder, knex } = require('../../../test-helper');
 const userRecommendedTrainingRepository = require('../../../../lib/infrastructure/repositories/user-recommended-training-repository');
+const UserRecommendedTraining = require('../../../../lib/domain/read-models/UserRecommendedTraining');
 
 describe('Integration | Repository | user-recommended-training-repository', function () {
-  afterEach(async function () {
-    await knex('user-recommended-trainings').delete();
-  });
-
   describe('#save', function () {
+    afterEach(async function () {
+      await knex('user-recommended-trainings').delete();
+    });
+
     it('should persist userRecommendedTraining', async function () {
       // given
       const userRecommendedTraining = {
@@ -31,6 +32,73 @@ describe('Integration | Repository | user-recommended-training-repository', func
       expect(_.omit(persistedUserRecommendedTraining, ['id', 'createdAt', 'updatedAt'])).to.deep.equal(
         userRecommendedTraining
       );
+    });
+  });
+
+  describe('#findByCampaignParticipationId', function () {
+    it('should return saved recommended trainings for given campaignParticipationId and locale', async function () {
+      // given
+      const { id: campaignParticipationId, userId } = databaseBuilder.factory.buildCampaignParticipation();
+      const training = databaseBuilder.factory.buildTraining();
+      const userRecommendedTraining1 = {
+        userId,
+        trainingId: training.id,
+        campaignParticipationId,
+      };
+      const userRecommendedTraining2 = {
+        userId,
+        trainingId: databaseBuilder.factory.buildTraining().id,
+        campaignParticipationId,
+      };
+      const userRecommendedTrainingWithAnotherLocale = {
+        userId,
+        trainingId: databaseBuilder.factory.buildTraining({ locale: 'en-gb' }).id,
+        campaignParticipationId,
+      };
+      const anotherCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation();
+      const anotherUserRecommendedTraining = {
+        userId: anotherCampaignParticipation.userId,
+        trainingId: databaseBuilder.factory.buildTraining().id,
+        campaignParticipationId: anotherCampaignParticipation.id,
+      };
+      databaseBuilder.factory.buildUserRecommendedTraining(userRecommendedTraining1);
+      databaseBuilder.factory.buildUserRecommendedTraining(userRecommendedTraining2);
+      databaseBuilder.factory.buildUserRecommendedTraining(userRecommendedTrainingWithAnotherLocale);
+      databaseBuilder.factory.buildUserRecommendedTraining(anotherUserRecommendedTraining);
+      await databaseBuilder.commit();
+
+      // when
+      const result = await userRecommendedTrainingRepository.findByCampaignParticipationId({
+        campaignParticipationId,
+        locale: 'fr-fr',
+      });
+
+      // then
+      expect(result.length).to.equal(2);
+      expect(result[0]).to.be.instanceOf(UserRecommendedTraining);
+      expect(result[0]).to.deep.equal(new UserRecommendedTraining({ ...training, duration: { hours: 6 } }));
+    });
+
+    it('should return an empty array when user has no recommended training for this campaignParticipation', async function () {
+      // given
+      const { id: campaignParticipationId, userId } = databaseBuilder.factory.buildCampaignParticipation();
+      const anotherCampaignParticipation = databaseBuilder.factory.buildCampaignParticipation();
+      const userRecommendedTraining = {
+        userId,
+        trainingId: databaseBuilder.factory.buildTraining().id,
+        campaignParticipationId,
+      };
+      databaseBuilder.factory.buildUserRecommendedTraining(userRecommendedTraining);
+      await databaseBuilder.commit();
+
+      // when
+      const result = await userRecommendedTrainingRepository.findByCampaignParticipationId({
+        campaignParticipationId: anotherCampaignParticipation.id,
+        locale: 'fr-fr',
+      });
+
+      // then
+      expect(result.length).to.equal(0);
     });
   });
 });

--- a/api/tests/integration/scripts/fill-user-recommended-trainings_test.js
+++ b/api/tests/integration/scripts/fill-user-recommended-trainings_test.js
@@ -1,0 +1,139 @@
+const { expect, databaseBuilder, sinon, knex } = require('../../test-helper');
+const {
+  sanitizeCampaignParticipations,
+  getUserRecommendedTrainings,
+  insertUserRecommendedTrainings,
+} = require('../../../scripts/fill-user-recommended-trainings');
+const trainingRepository = require('../../../lib/infrastructure/repositories/training-repository');
+
+describe('Integration | Scripts | fill-user-recommended-trainings', function () {
+  describe('#sanitizeCampaignParticipations', function () {
+    it('should return value as number', function () {
+      // when
+      const result = sanitizeCampaignParticipations([
+        { userId: '123', campaignParticipationId: '456', targetProfileId: '789' },
+      ]);
+
+      // then
+      expect(result).to.deep.equal([{ userId: 123, campaignParticipationId: 456, targetProfileId: 789 }]);
+    });
+  });
+
+  describe('#getUserRecommendedTraining', function () {
+    it('should return user recommended training for given campaign participation', async function () {
+      // given
+      const targetProfileId = 5432;
+      const anotherTargetProfileId = 9876;
+      sinon.stub(trainingRepository, 'findByTargetProfileIdAndLocale').resolves([{ id: 1 }, { id: 2 }]);
+      const campaignParticipationsToCompute = [
+        {
+          userId: 123,
+          campaignParticipationId: 456,
+          targetProfileId,
+        },
+        {
+          userId: 789,
+          campaignParticipationId: 1011,
+          targetProfileId,
+        },
+        {
+          userId: 123,
+          campaignParticipationId: 6789,
+          targetProfileId: anotherTargetProfileId,
+        },
+      ];
+
+      // when
+      const userRecommendedTrainings = await getUserRecommendedTrainings({
+        campaignParticipations: campaignParticipationsToCompute,
+        trainingRepository,
+      });
+
+      // then
+      expect(trainingRepository.findByTargetProfileIdAndLocale).to.have.been.calledTwice;
+      expect(trainingRepository.findByTargetProfileIdAndLocale.firstCall).to.have.been.calledWithExactly({
+        targetProfileId,
+      });
+      expect(trainingRepository.findByTargetProfileIdAndLocale.secondCall).to.have.been.calledWithExactly({
+        targetProfileId: anotherTargetProfileId,
+      });
+      expect(userRecommendedTrainings).to.deep.equal([
+        { userId: 123, campaignParticipationId: 456, trainingId: 1 },
+        { userId: 123, campaignParticipationId: 456, trainingId: 2 },
+        { userId: 789, campaignParticipationId: 1011, trainingId: 1 },
+        { userId: 789, campaignParticipationId: 1011, trainingId: 2 },
+        { userId: 123, campaignParticipationId: 6789, trainingId: 1 },
+        { userId: 123, campaignParticipationId: 6789, trainingId: 2 },
+      ]);
+    });
+  });
+
+  describe('#insertUserRecommendedTrainings', function () {
+    afterEach(async function () {
+      await knex('user-recommended-trainings').delete();
+    });
+
+    it('should insert all user-recommended-trainings', async function () {
+      // given
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation();
+      const campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation();
+
+      const training1 = databaseBuilder.factory.buildTraining();
+      const training2 = databaseBuilder.factory.buildTraining();
+
+      await databaseBuilder.commit();
+
+      const userRecommendedTrainings = [
+        {
+          userId: campaignParticipation.userId,
+          campaignParticipationId: campaignParticipation.id,
+          trainingId: training1.id,
+        },
+        {
+          userId: campaignParticipation.userId,
+          campaignParticipationId: campaignParticipation.id,
+          trainingId: training2.id,
+        },
+        {
+          userId: campaignParticipation2.userId,
+          campaignParticipationId: campaignParticipation2.id,
+          trainingId: training1.id,
+        },
+        {
+          userId: campaignParticipation2.userId,
+          campaignParticipationId: campaignParticipation2.id,
+          trainingId: training2.id,
+        },
+      ];
+
+      // when
+      await insertUserRecommendedTrainings(userRecommendedTrainings);
+
+      // then
+      const [{ count: userRecommendedTrainingsCount }] = await knex('user-recommended-trainings').count();
+      expect(userRecommendedTrainingsCount).to.equal(userRecommendedTrainings.length);
+    });
+
+    it('should not throw an error when user-recommended-trainings already exist', async function () {
+      // given
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation();
+      const training = databaseBuilder.factory.buildTraining();
+      const userRecommendedTraining = {
+        userId: campaignParticipation.userId,
+        campaignParticipationId: campaignParticipation.id,
+        trainingId: training.id,
+      };
+      databaseBuilder.factory.buildUserRecommendedTraining(userRecommendedTraining);
+      await databaseBuilder.commit();
+
+      const userRecommendedTrainings = [userRecommendedTraining];
+
+      // when & then
+      expect(async () => {
+        await insertUserRecommendedTrainings(userRecommendedTrainings);
+      }).not.to.throw();
+      const [{ count: userRecommendedTrainingsCount }] = await knex('user-recommended-trainings').count();
+      expect(userRecommendedTrainingsCount).to.equal(1);
+    });
+  });
+});


### PR DESCRIPTION
## :jack_o_lantern: Problème
Actuellement, les contenus formatifs affichés en fin de parcours sont calculés à chaque affichage. Ce qui n'est pas optimal compte-tenu des évolutions prochaines de ces calculs et des futurs besoins.

D'autre part, pour prévenir les prochains besoins : 
- page "Mes formations" contenant les contenus formatifs recommandés
- et une entrée de menu dédiée si l'utilisateur a du contenus formatifs recommandés 
Nous stockons depuis la PR #5079 les contenus formatifs recommandés, mais nous ne l'utilisons pas.  

## :bat: Proposition
- Retourner les contenus depuis la table de jointure.
- Créer un script de reprise des données pour les utilisateurs ayant déjà eu des recommandations de contenus formatifs.

Le script prend en entrée un fichier `csv`.
```csv
userId,campaignParticipationId,targetProfileId
123,456,789
```

Le script groupe les entrées par `targetProfileId` car ça évite des appels inutiles à la méthode `trainingRepository.findByTargetProfileIdAndLocale`, car [il y a moins de targetProfileId que d'entrées.](https://metabase.pix.fr/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJuYXRpdmUiOnsicXVlcnkiOiJzZWxlY3QgXCJjYW1wYWlnbi1wYXJ0aWNpcGF0aW9uc1wiLlwiaWRcIiBhcyBcImNhbXBhaWduUGFydGljaXBhdGlvbklkXCIsIFwiY2FtcGFpZ24tcGFydGljaXBhdGlvbnNcIi5cInVzZXJJZFwiIGFzIFwidXNlcklkXCIsIFwiY2FtcGFpZ25zXCIuXCJ0YXJnZXRQcm9maWxlSWRcIiBmcm9tIFwiY2FtcGFpZ24tcGFydGljaXBhdGlvbnNcIiBcbmlubmVyIGpvaW4gXCJjYW1wYWlnbnNcIiBvbiBcImNhbXBhaWduLXBhcnRpY2lwYXRpb25zXCIuXCJjYW1wYWlnbklkXCIgPSBcImNhbXBhaWduc1wiLlwiaWRcIlxud2hlcmUgXCJ0YXJnZXRQcm9maWxlSWRcIiBpbiAoc2VsZWN0IGRpc3RpbmN0KFwidGFyZ2V0UHJvZmlsZUlkXCIpIGZyb20gXCJ0YXJnZXQtcHJvZmlsZS10cmFpbmluZ3NcIik7XG5cblxuc2VsZWN0IGNvdW50KGRpc3RpbmN0KFwidGFyZ2V0UHJvZmlsZUlkXCIpKSBmcm9tIFwidGFyZ2V0LXByb2ZpbGUtdHJhaW5pbmdzXCIgd2hlcmUgXCJ0YXJnZXRQcm9maWxlSWRcIiBpbiAoc2VsZWN0IGRpc3RpbmN0KFwidGFyZ2V0UHJvZmlsZUlkXCIpIGZyb20gXCJ0YXJnZXQtcHJvZmlsZS10cmFpbmluZ3NcIik7XG5cbiIsInRlbXBsYXRlLXRhZ3MiOnt9fSwiZGF0YWJhc2UiOjJ9LCJkaXNwbGF5IjoidGFibGUiLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319)


## :ghost: Pour tester

### Cas d'une personne passant une nouvelle campagne 
- Aller sur Pix App
- Rejoindre la campagne `PIXEDUINI`
- Aller en fin de parcours et constater que les contenus sont présents

### Cas d'une personne ayant fini sa campagne avant ce ticket
- Aller sur Pix App et se connecter avec un compte différent du premier cas de test
- Rejoindre la campagne `PIXEDUINI`
- Aller jusqu'à la fin du parcours
- En base supprimer les `user-recommended-tutorials` créés pour cette campaign-participations
- Créer le fichier csv pour le script
- Lancer le script
- Revenir sur la page de fin de parcours et constater que les contenus formatifs sont présents