### PR TITLE
[BUGFIX] Stoppe le monitoring d'oppsy a l'arrêt du serveur

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -21,6 +21,10 @@ async function _exitOnSignal(signal) {
   logger.info(`Received signal: ${signal}.`);
   logger.info('Stopping HAPI server...');
   await server.stop({ timeout: 30000 });
+  if (server.oppsy) {
+    logger.info('Stopping HAPI Oppsy server...');
+    await server.oppsy.stop();
+  }
   logger.info('Closing connexions to database...');
   await disconnect();
   logger.info('Closing connexions to cache...');

--- a/api/server.js
+++ b/api/server.js
@@ -82,6 +82,7 @@ const enableOpsMetrics = async function (server) {
   });
 
   oppsy.start(config.logging.emitOpsEventEachSeconds * 1000);
+  server.oppsy = oppsy;
 };
 
 const loadConfiguration = function () {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Si on active le monitoring oppsy avec `LOG_OPS_METRICS=true`, toutes les 15secondes nous avons un log qui affiche les métrique système. Au moment de l'arrêt du conteneur, nous ne faisons plus de `process.exit` depuis #4666.  Le `setInterval`  fonctionne toujours et empêche l'arrêt de la boucle événementiel.

## :bat: Proposition
A l'arrêt du serveur, couper également le processus opppsy.

## :spider_web: Remarques
L'instance d'oppsy est stocké dans le serveur. C'est un peu hacky.

## :ghost: Pour tester
1. Activer les logs ops avec `LOG_OPS_METRICS=true`
2. Démarrer le serveur
3. Stopper le serveur
4. Constater que le serveur s'arrête quasi immédiatement
