### PR TITLE
[FEATURE] Créer la double mire d'inscription/connexion Pix Certif (PIX-5005)

### DIFF
--- a/certif/app/components/auth/login-or-register.hbs
+++ b/certif/app/components/auth/login-or-register.hbs
@@ -1,0 +1,58 @@
+<div class="login-or-register">
+  <div class="panel login-or-register__panel">
+    <img src="/pix-certif-logo.svg" alt="Pix Certif" class="login-or-register-panel__logo" />
+    <span class="login-or-register-panel__invitation">{{t
+        "pages.login-or-register.title"
+        certificationCenterName=@certificationCenterName
+      }}</span>
+    <div class="login-or-register-panel__forms-container">
+      <div class="login-or-register-panel__form">
+        <h1 class="form-title">{{t "pages.login-or-register.register-form.title"}}</h1>
+        {{#unless this.displayRegisterForm}}
+          <PixButton
+            id="register"
+            @triggerAction={{this.toggleFormsVisibility}}
+            @backgroundColor="transparent-light"
+            @isBorderVisible={{true}}
+          >
+            {{t "pages.login-or-register.register-form.button"}}
+          </PixButton>
+        {{/unless}}
+        <div
+          class={{concat
+            "login-or-register-panel-form__expandable"
+            (if this.displayRegisterForm " login-or-register-panel-form__expandable--expanded")
+          }}
+        >
+          {{#if this.displayRegisterForm}}
+            <Auth::RegisterForm />
+          {{/if}}
+        </div>
+      </div>
+      <div class="login-or-register-panel__divider"></div>
+      <div class="login-or-register-panel__form">
+        <h1 class="form-title">{{t "pages.login-or-register.login-form.title"}}</h1>
+        {{#if this.displayRegisterForm}}
+          <PixButton
+            id="login"
+            @triggerAction={{this.toggleFormsVisibility}}
+            @backgroundColor="transparent-light"
+            @isBorderVisible={{true}}
+          >
+            {{t "pages.login-or-register.login-form.button"}}
+          </PixButton>
+        {{/if}}
+        <div
+          class={{concat
+            "login-or-register-panel-form__expandable"
+            (unless this.displayRegisterForm " login-or-register-panel-form__expandable--expanded")
+          }}
+        >
+          {{#unless this.displayRegisterForm}}
+            <Auth::ToggableLoginForm />
+          {{/unless}}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/certif/app/components/auth/login-or-register.js
+++ b/certif/app/components/auth/login-or-register.js
@@ -1,0 +1,12 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class LoginOrRegister extends Component {
+  @tracked displayRegisterForm = true;
+
+  @action
+  toggleFormsVisibility() {
+    this.displayRegisterForm = !this.displayRegisterForm;
+  }
+}

--- a/certif/app/components/auth/register-form.hbs
+++ b/certif/app/components/auth/register-form.hbs
@@ -1,0 +1,101 @@
+<div class="register-form">
+  <form {{on "submit" this.register}}>
+    <p class="login-form__information">{{t "common.form.mandatory-all-fields"}}</p>
+    <div class="input-container">
+      <PixInput
+        @id="register-firstName"
+        @label={{t "pages.login-or-register.register-form.fields.first-name.label"}}
+        name="firstName"
+        type="firstName"
+        {{on "focusout" this.validateFirstName}}
+        @errorMessage={{this.firstNameValidationMessage}}
+        required={{true}}
+        aria-required={{true}}
+        autocomplete="given-name"
+      />
+    </div>
+
+    <div class="input-container">
+      <PixInput
+        @id="register-lastName"
+        @label={{t "pages.login-or-register.register-form.fields.last-name.label"}}
+        name="lastName"
+        type="lastName"
+        {{on "focusout" this.validateLastName}}
+        @errorMessage={{this.lastNameValidationMessage}}
+        required={{true}}
+        aria-required={{true}}
+        autocomplete="family-name"
+      />
+    </div>
+
+    <div class="input-container">
+      <PixInput
+        @id="register-email"
+        @label={{t "pages.login-or-register.register-form.fields.email.label"}}
+        name="email"
+        type="email"
+        {{on "focusout" this.validateEmail}}
+        @errorMessage={{this.emailValidationMessage}}
+        required={{true}}
+        aria-required={{true}}
+        autocomplete="email"
+      />
+    </div>
+
+    <div class="input-container">
+      <PixInputPassword
+        @id="register-password"
+        name="password"
+        @label={{t "pages.login-or-register.register-form.fields.password.label"}}
+        autocomplete="current-password"
+        required={{true}}
+        aria-required={{true}}
+        {{on "input" this.validatePassword}}
+        {{on "focusout" this.validatePassword}}
+        @errorMessage={{this.passwordValidationMessage}}
+      />
+    </div>
+
+    <div class="checkbox-container input-container">
+      <Input
+        @type="checkbox"
+        @checked={{this.cgu}}
+        required={{true}}
+        aria-required={{true}}
+        aria-label="{{t 'pages.login-or-register.register-form.fields.cgu.aria-label'}}"
+        {{on "focusout" this.validateCgu}}
+      />
+      <p class="register-form__cgu-label">
+        {{t "pages.login-or-register.register-form.fields.cgu.accept"}}
+        <a href={{this.cguUrl}} class="link" target="_blank" rel="noopener noreferrer">
+          {{t "pages.login-or-register.register-form.fields.cgu.terms-of-use"}}
+        </a>
+        {{t "pages.login-or-register.register-form.fields.cgu.and"}}
+        <a href={{this.dataProtectionPolicyUrl}} class="link" target="_blank" rel="noopener noreferrer">
+          {{t "pages.login-or-register.register-form.fields.cgu.data-protection-policy"}}
+        </a>
+      </p>
+    </div>
+    {{#if this.cguValidationMessage}}
+      <p class="register-form__cgu-error" role="alert">{{this.cguValidationMessage}}</p>
+    {{/if}}
+
+    {{#if this.errorMessage}}
+      <PixMessage @type="alert">
+        {{this.errorMessage}}
+      </PixMessage>
+    {{/if}}
+
+    <div class="input-container">
+      <PixButton @type="submit" @isLoading={{this.isLoading}} class="register-form__submit-button">
+        {{t "pages.login-or-register.register-form.fields.button.label"}}
+      </PixButton>
+    </div>
+
+  </form>
+
+  <p class="legal-text register-form-legal-text">
+    {{t "pages.login-or-register.register-form.legal-text"}}
+  </p>
+</div>

--- a/certif/app/components/auth/register-form.js
+++ b/certif/app/components/auth/register-form.js
@@ -1,0 +1,91 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import isEmpty from 'lodash/isEmpty';
+import isEmailValid from '../../utils/email-validator';
+import isPasswordValid from '../../utils/password-validator';
+
+export default class RegisterForm extends Component {
+  @service intl;
+  @service url;
+
+  @tracked isLoading = false;
+  @tracked firstName = null;
+  @tracked lastName = null;
+  @tracked email = null;
+  @tracked password = null;
+  @tracked passwordValidationMessage = null;
+  @tracked emailValidationMessage = null;
+  @tracked firstNameValidationMessage = null;
+  @tracked lastNameValidationMessage = null;
+  @tracked cguValidationMessage = null;
+  @tracked errorMessage = null;
+
+  get cguUrl() {
+    return this.url.cguUrl;
+  }
+
+  get dataProtectionPolicyUrl() {
+    return this.url.dataProtectionPolicyUrl;
+  }
+
+  @action
+  async register() {
+    /* TODO */
+  }
+
+  @action
+  validatePassword(event) {
+    this.passwordValidationMessage = null;
+    this.password = event.target.value;
+    const isInvalidInput = !isPasswordValid(this.password);
+
+    if (isInvalidInput) {
+      this.passwordValidationMessage = this.intl.t('pages.login-or-register.register-form.fields.password.error');
+    }
+  }
+
+  @action
+  validateEmail(event) {
+    this.emailValidationMessage = null;
+    this.email = event.target.value?.trim().toLowerCase();
+    const isInvalidInput = !isEmailValid(this.email);
+
+    if (isInvalidInput) {
+      this.emailValidationMessage = this.intl.t('pages.login-or-register.register-form.fields.email.error');
+    }
+  }
+
+  @action
+  validateFirstName(event) {
+    this.firstNameValidationMessage = null;
+    this.firstName = event.target.value?.trim();
+    const isInvalidInput = isEmpty(this.firstName);
+
+    if (isInvalidInput) {
+      this.firstNameValidationMessage = this.intl.t('pages.login-or-register.register-form.fields.first-name.error');
+    }
+  }
+
+  @action
+  validateLastName(event) {
+    this.lastNameValidationMessage = null;
+    this.lastName = event.target.value?.trim();
+    const isInvalidInput = isEmpty(this.lastName);
+
+    if (isInvalidInput) {
+      this.lastNameValidationMessage = this.intl.t('pages.login-or-register.register-form.fields.last-name.error');
+    }
+  }
+
+  @action
+  validateCgu() {
+    this.cguValidationMessage = null;
+    const isInputChecked = Boolean(this.cgu);
+
+    if (!isInputChecked) {
+      this.cguValidationMessage = this.intl.t('pages.login-or-register.register-form.fields.cgu.error');
+    }
+  }
+}

--- a/certif/app/components/auth/toggable-login-form.hbs
+++ b/certif/app/components/auth/toggable-login-form.hbs
@@ -1,0 +1,46 @@
+<form class="login-form" {{on "submit" this.authenticate}}>
+  <p class="login-form__information">{{t "common.form.mandatory-all-fields"}}</p>
+
+  <PixInput
+    @id="login-email"
+    @label={{t "pages.login-form.email"}}
+    name="login"
+    type="email"
+    {{on "focusout" this.validateEmail}}
+    {{on "input" this.updateEmail}}
+    @errorMessage={{this.emailValidationMessage}}
+    required={{true}}
+    aria-required={{true}}
+    autocomplete="email"
+  />
+
+  <PixInputPassword
+    @id="login-password"
+    name="password"
+    @label={{t "pages.login-form.password"}}
+    autocomplete="current-password"
+    required={{true}}
+    aria-required={{true}}
+    {{on "focusout" this.validatePassword}}
+    {{on "input" this.validatePassword}}
+    @errorMessage={{this.passwordValidationMessage}}
+  />
+
+  {{#if this.isErrorMessagePresent}}
+    <PixMessage @type="alert">
+      {{this.errorMessage}}
+    </PixMessage>
+  {{/if}}
+
+  <PixButton @type="submit" @isLoading={{this.isLoading}}>
+    {{t "pages.login-form.login"}}
+  </PixButton>
+
+  <div>
+    <div class="login-form__forgotten-password">
+      <a href={{this.forgottenPasswordUrl}} target="_blank" rel="noopener noreferrer" class="link">
+        {{t "pages.login-form.forgot-password"}}
+      </a>
+    </div>
+  </div>
+</form>

--- a/certif/app/components/auth/toggable-login-form.hbs
+++ b/certif/app/components/auth/toggable-login-form.hbs
@@ -3,7 +3,7 @@
 
   <PixInput
     @id="login-email"
-    @label={{t "pages.login-form.email"}}
+    @label={{t "pages.login-or-register.login-form.fields.email.label"}}
     name="login"
     type="email"
     {{on "focusout" this.validateEmail}}
@@ -17,7 +17,7 @@
   <PixInputPassword
     @id="login-password"
     name="password"
-    @label={{t "pages.login-form.password"}}
+    @label={{t "pages.login-or-register.login-form.fields.password.label"}}
     autocomplete="current-password"
     required={{true}}
     aria-required={{true}}
@@ -33,13 +33,13 @@
   {{/if}}
 
   <PixButton @type="submit" @isLoading={{this.isLoading}}>
-    {{t "pages.login-form.login"}}
+    {{t "pages.login-or-register.login-form.login"}}
   </PixButton>
 
   <div>
     <div class="login-form__forgotten-password">
       <a href={{this.forgottenPasswordUrl}} target="_blank" rel="noopener noreferrer" class="link">
-        {{t "pages.login-form.forgot-password"}}
+        {{t "pages.login-or-register.login-form.fields.password.forgot-password"}}
       </a>
     </div>
   </div>

--- a/certif/app/components/auth/toggable-login-form.js
+++ b/certif/app/components/auth/toggable-login-form.js
@@ -36,7 +36,7 @@ export default class ToggableLoginForm extends Component {
     this.passwordValidationMessage = null;
 
     if (isInvalidInput) {
-      this.passwordValidationMessage = this.intl.t('pages.login-form.errors.empty-password');
+      this.passwordValidationMessage = this.intl.t('pages.login-or-register.login-form.fields.password.error');
     }
   }
 
@@ -48,7 +48,7 @@ export default class ToggableLoginForm extends Component {
     this.emailValidationMessage = null;
 
     if (isInvalidInput) {
-      this.emailValidationMessage = this.intl.t('pages.login-form.errors.invalid-email');
+      this.emailValidationMessage = this.intl.t('pages.login-or-register.login-form.fields.email.error');
     }
   }
 

--- a/certif/app/components/auth/toggable-login-form.js
+++ b/certif/app/components/auth/toggable-login-form.js
@@ -60,4 +60,8 @@ export default class ToggableLoginForm extends Component {
   get isFormValid() {
     return isEmailValid(this.email) && !isEmpty(this.password);
   }
+
+  get forgottenPasswordUrl() {
+    return this.url.forgottenPasswordUrl;
+  }
 }

--- a/certif/app/components/auth/toggable-login-form.js
+++ b/certif/app/components/auth/toggable-login-form.js
@@ -1,0 +1,63 @@
+import { action } from '@ember/object';
+import isEmpty from 'lodash/isEmpty';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import isEmailValid from '../../utils/email-validator';
+
+export default class ToggableLoginForm extends Component {
+  @service intl;
+  @service url;
+
+  @tracked errorMessage = null;
+  @tracked isErrorMessagePresent = false;
+  @tracked isLoading = false;
+  @tracked password = null;
+  @tracked email = null;
+  @tracked passwordValidationMessage = null;
+  @tracked emailValidationMessage = null;
+
+  @action
+  async authenticate(event) {
+    event.preventDefault();
+    this.isLoading = true;
+
+    if (!this.isFormValid) {
+      this.isLoading = false;
+      return;
+    }
+    // TODO
+  }
+
+  @action
+  validatePassword(event) {
+    this.password = event.target.value;
+    const isInvalidInput = isEmpty(this.password);
+    this.passwordValidationMessage = null;
+
+    if (isInvalidInput) {
+      this.passwordValidationMessage = this.intl.t('pages.login-form.errors.empty-password');
+    }
+  }
+
+  @action
+  validateEmail(event) {
+    this.email = event.target.value?.trim();
+    const isInvalidInput = !isEmailValid(this.email);
+
+    this.emailValidationMessage = null;
+
+    if (isInvalidInput) {
+      this.emailValidationMessage = this.intl.t('pages.login-form.errors.invalid-email');
+    }
+  }
+
+  @action
+  updateEmail(event) {
+    this.email = event.target.value?.trim();
+  }
+
+  get isFormValid() {
+    return isEmailValid(this.email) && !isEmpty(this.password);
+  }
+}

--- a/certif/app/router.js
+++ b/certif/app/router.js
@@ -16,6 +16,8 @@ export default class Router extends EmberRouter {
 Router.map(function () {
   this.route('login', { path: 'connexion' });
 
+  this.route('join', { path: 'rejoindre' });
+
   this.route('terms-of-service', { path: '/cgu' });
   this.route('login-session-supervisor', { path: '/connexion-espace-surveillant' });
   this.route('session-supervising', { path: '/sessions/:session_id/surveiller' });

--- a/certif/app/routes/join.js
+++ b/certif/app/routes/join.js
@@ -1,0 +1,9 @@
+import Route from '@ember/routing/route';
+
+export default class JoinRoute extends Route {
+  model() {
+    return {
+      certificationCenterName: 'PLACEHOLDER_CERTIF_CENTER_NAME',
+    };
+  }
+}

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -1,11 +1,26 @@
-import Service from '@ember/service';
+import Service, { inject as service } from '@ember/service';
 
 import config from 'pix-certif/config/environment';
 
 export default class Url extends Service {
   definedHomeUrl = config.rootURL;
 
+  @service currentDomain;
+  @service intl;
+
   get homeUrl() {
     return this.definedHomeUrl;
+  }
+
+  get cguUrl() {
+    const currentLanguage = this.intl.t('current-lang');
+    if (currentLanguage === 'en') return 'https://pix.org/en-gb/terms-and-conditions';
+    return `https://pix.${this.currentDomain.getExtension()}/conditions-generales-d-utilisation`;
+  }
+
+  get dataProtectionPolicyUrl() {
+    const currentLanguage = this.intl.t('current-lang');
+    if (currentLanguage === 'en') return 'https://pix.org/en-gb/personal-data-protection-policy';
+    return `https://pix.${this.currentDomain.getExtension()}/politique-protection-donnees-personnelles-app`;
   }
 }

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -23,4 +23,10 @@ export default class Url extends Service {
     if (currentLanguage === 'en') return 'https://pix.org/en-gb/personal-data-protection-policy';
     return `https://pix.${this.currentDomain.getExtension()}/politique-protection-donnees-personnelles-app`;
   }
+
+  get forgottenPasswordUrl() {
+    const currentLanguage = this.intl.t('current-lang');
+    if (currentLanguage === 'en') return 'https://app.pix.org/mot-de-passe-oublie?lang=en';
+    return `https://app.pix.${this.currentDomain.getExtension()}/mot-de-passe-oublie`;
+  }
 }

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -32,6 +32,7 @@
 @import "components/layout/footer";
 @import "components/login-form";
 @import "components/login-session-supervisor-form.scss";
+@import "components/login-or-register.scss";
 @import "components/finalize";
 @import "components/new-certification-candidate-modal";
 @import "components/members-list";

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -36,6 +36,7 @@
 @import "components/new-certification-candidate-modal";
 @import "components/members-list";
 @import "components/finalization-confirmation-modal";
+@import "components/register-form";
 @import "components/select-referer-modal";
 @import "components/session-delete-confirm-modal";
 @import "components/session-finalization-step-container";

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -23,6 +23,7 @@
 @import "pages/authenticated/sessions/details/certification-candidates-sco";
 @import "pages/authenticated/team";
 @import "pages/terms-of-service";
+@import "pages/join";
 @import "components/add-student-list";
 @import "components/certif-checkbox";
 @import "components/ember-cli-notifications-ie-fallback";

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -1,6 +1,6 @@
 @charset "utf-8";
 
-@import 'pix-design-tokens';
+@import "pix-design-tokens";
 @import "globals/errors";
 @import "globals/forms";
 @import "globals/pages";
@@ -47,6 +47,7 @@
 @import "components/session-supervising/candidate-in-list";
 @import "components/session-supervising/candidate-list";
 @import "components/session-summary-list";
+@import "components/toggable-login-form";
 @import "components/pagination-control.scss";
 @import "components/dropdown";
 @import "components/user-logged-menu";

--- a/certif/app/styles/components/login-or-register.scss
+++ b/certif/app/styles/components/login-or-register.scss
@@ -1,0 +1,91 @@
+.login-or-register {
+  margin: 20px 0;
+
+  &__panel {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    border-radius: 10px;
+    align-items: center;
+    padding: 20px 2px;
+
+    @include device-is("tablet") {
+      padding: 20px;
+    }
+
+    @include device-is("large-screen") {
+      padding: 40px 100px;
+    }
+  }
+}
+
+.login-or-register-panel {
+
+  &__logo {
+    margin: auto;
+  }
+
+  &__invitation {
+    font-family: $font-roboto;
+    font-size: 1.125rem;
+    color: $pix-neutral-100;
+    text-align: center;
+    margin-top: 24px;
+  }
+
+  &__forms-container {
+    display: flex;
+    margin-top: 10px;
+    min-height: 500px;
+    flex-flow: row;
+    justify-content: space-around;
+
+    @include device-is("large-screen") {
+      flex-flow: row;
+      justify-content: space-between;
+    }
+
+    @include device-is("mobile") {
+      flex-direction: column;
+      margin: 10px 20px 0;
+    }
+  }
+
+  &__form {
+    display: flex;
+    flex-direction: column;
+
+    @include device-is("tablet") {
+      min-width: 360px;
+    }
+  }
+
+  &__divider {
+    margin-top: 30px;
+    border-left: 1px solid $pix-neutral-30;
+
+    @include device-is("tablet") {
+      margin: 30px;
+      margin-bottom: 0;
+    }
+
+    @include device-is("large-screen") {
+      margin: 30px 60px 0;
+    }
+  }
+}
+
+.login-or-register-panel-form {
+
+  &__expandable {
+    display: flex;
+    flex-direction: column;
+    max-height: 0;
+    overflow-y: hidden;
+    transition: max-height 0.4s ease-in-out;
+
+    &--expanded {
+      max-height: 720px;
+    }
+  }
+}

--- a/certif/app/styles/components/register-form.scss
+++ b/certif/app/styles/components/register-form.scss
@@ -1,0 +1,36 @@
+.register-form {
+  max-width: 360px;
+  font-size: 0.875rem;
+  overflow-y: scroll;
+
+  &__cgu-label {
+    font-family: $font-roboto;
+    margin: 0;
+  }
+
+  &__cgu-error {
+    color: $pix-error-70;
+    font-size: 0.75rem;
+    margin-top: 4px;
+  }
+
+  &__submit-button {
+    width: 100%;
+  }
+
+  .input-container {
+    margin-top: $spacing-m;
+  }
+
+  .checkbox-container {
+    display: flex;
+
+    input[type="checkbox"] {
+      margin: 1px 6px 0 0;
+    }
+  }
+
+  .register-form-legal-text {
+    margin-top: $spacing-m;
+  }
+}

--- a/certif/app/styles/components/toggable-login-form.scss
+++ b/certif/app/styles/components/toggable-login-form.scss
@@ -1,0 +1,19 @@
+.login-form {
+  max-width: 450px;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-m;
+  font-size: 0.875rem;
+
+  &__information {
+    text-align: center;
+    margin-bottom: $spacing-s;
+    color: $pix-neutral-90;
+    font-family: $font-roboto;
+    letter-spacing: 0.0094rem;
+  }
+
+  &__forgotten-password {
+    text-align: left;
+  }
+}

--- a/certif/app/styles/globals/texts.scss
+++ b/certif/app/styles/globals/texts.scss
@@ -31,3 +31,25 @@
     font-size: 0.8125rem;
   }
 }
+
+.legal-text {
+  color: $pix-neutral-60;
+  font-family: $font-roboto;
+  font-size: 0.6875rem;
+  font-weight: 300;
+}
+
+.link {
+  outline: none;
+  border: none;
+  background-color: inherit;
+  color: $pix-primary;
+  text-decoration: none;
+
+  &:hover,
+  &:focus,
+  &:active {
+    text-decoration: underline;
+    color: $pix-primary-60;
+  }
+}

--- a/certif/app/styles/globals/titles.scss
+++ b/certif/app/styles/globals/titles.scss
@@ -4,3 +4,10 @@
   font-size: 2.25rem;
   color: $pix-neutral-80;
 }
+
+.form-title {
+  font-family: $font-open-sans;
+  font-weight: 300;
+  font-size: 1.9rem;
+  color: $pix-neutral-100;
+}

--- a/certif/app/styles/pages/join.scss
+++ b/certif/app/styles/pages/join.scss
@@ -1,0 +1,8 @@
+.join-page {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  background: $pix-certif-gradient;
+  box-shadow: 0 2px 8px 0 rgba($black, 0.1);
+  min-height: 100vh;
+}

--- a/certif/app/templates/join.hbs
+++ b/certif/app/templates/join.hbs
@@ -1,0 +1,5 @@
+{{page-title (t "pages.login-or-register.title" certificationCenterName=@model.certificationCenterName)}}
+
+<div class="join-page">
+  <Auth::LoginOrRegister @certificationCenterName={{@model.certificationCenterName}} />
+</div>

--- a/certif/app/utils/email-validator.js
+++ b/certif/app/utils/email-validator.js
@@ -1,0 +1,9 @@
+export default function isEmailValid(email) {
+  if (!email) {
+    return false;
+  }
+
+  const pattern =
+    /^(([^<>()[\].,;:\s@"]+(\.[^<>()[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/i;
+  return pattern.test(email.trim());
+}

--- a/certif/app/utils/password-validator.js
+++ b/certif/app/utils/password-validator.js
@@ -1,0 +1,7 @@
+export default function isPasswordValid(password) {
+  if (!password) {
+    return false;
+  }
+  const pattern = new RegExp('^(?=.*[a-zà-ÿ])(?=.*[A-ZÀ-ß])(?=.*[0-9]).{8,}$');
+  return pattern.test(password);
+}

--- a/certif/tests/integration/components/auth/login-or-register_test.js
+++ b/certif/tests/integration/components/auth/login-or-register_test.js
@@ -1,0 +1,82 @@
+import { module, test } from 'qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { clickByName, render } from '@1024pix/ember-testing-library';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let loginButton;
+
+  hooks.beforeEach(function () {
+    loginButton = this.intl.t('pages.login-or-register.login-form.button');
+  });
+
+  test('it should display login-or-register form', async function (assert) {
+    // when
+    const screen = await render(hbs`<Auth::LoginOrRegister/>`);
+
+    // then
+    assert.dom(screen.getByRole('img', { name: 'Pix Certif' })).exists();
+    assert
+      .dom(screen.getByRole('heading', { name: this.intl.t('pages.login-or-register.register-form.title') }))
+      .exists();
+    assert.dom(screen.getByRole('heading', { name: this.intl.t('pages.login-or-register.login-form.title') })).exists();
+    assert.dom(screen.getByRole('button', { name: this.intl.t('pages.login-or-register.login-form.button') })).exists();
+  });
+
+  test('it should displays the certification center name the user is invited to', async function (assert) {
+    // when
+    const invitationMessage = this.intl.t('pages.login-or-register.title', {
+      certificationCenterName: 'Centre de Certif',
+    });
+
+    await render(hbs`<Auth::LoginOrRegister @certificationCenterName='Centre de Certif'/>`);
+
+    // then
+    assert.dom(screen.getByText(invitationMessage)).exists();
+  });
+
+  test('it toggle the register form by default', async function (assert) {
+    // given
+    const registerButton = this.intl.t('pages.login-or-register.register-form.button');
+    const firstNameInputLabelFromRegisterForm = this.intl.t(
+      'pages.login-or-register.register-form.fields.first-name.label'
+    );
+
+    // when
+    await render(hbs`<Auth::LoginOrRegister/>`);
+
+    // then
+    assert.dom(screen.getByRole('textbox', { name: firstNameInputLabelFromRegisterForm })).exists();
+    assert.dom(screen.getByRole('button', { name: loginButton })).exists();
+    assert.dom(screen.queryByRole('button', { name: registerButton })).doesNotExist();
+  });
+
+  test('it toggle the login form on click on login button', async function (assert) {
+    // given
+    const emailInputLabelFromLoginForm = this.intl.t('pages.login-form.email');
+    await render(hbs`<Auth::LoginOrRegister/>`);
+
+    // when
+    await clickByName(loginButton);
+
+    // then
+    assert.dom(screen.getByRole('textbox', { name: emailInputLabelFromLoginForm })).exists();
+  });
+
+  test('it toggle the register form on click on register button', async function (assert) {
+    // given
+    const emailInputLabelFromRegisterForm = this.intl.t('pages.login-or-register.register-form.fields.email.label');
+    const registerButtonLabel = this.intl.t('pages.login-or-register.register-form.button');
+
+    await render(hbs`<Auth::LoginOrRegister/>`);
+
+    // when
+    await clickByName(loginButton);
+    await clickByName(registerButtonLabel);
+
+    // then
+    assert.dom(screen.getByRole('textbox', { name: emailInputLabelFromRegisterForm })).exists();
+  });
+});

--- a/certif/tests/integration/components/auth/login-or-register_test.js
+++ b/certif/tests/integration/components/auth/login-or-register_test.js
@@ -31,7 +31,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
       certificationCenterName: 'Centre de Certif',
     });
 
-    await render(hbs`<Auth::LoginOrRegister @certificationCenterName='Centre de Certif'/>`);
+    const screen = await render(hbs`<Auth::LoginOrRegister @certificationCenterName='Centre de Certif'/>`);
 
     // then
     assert.dom(screen.getByText(invitationMessage)).exists();
@@ -45,7 +45,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
     );
 
     // when
-    await render(hbs`<Auth::LoginOrRegister/>`);
+    const screen = await render(hbs`<Auth::LoginOrRegister/>`);
 
     // then
     assert.dom(screen.getByRole('textbox', { name: firstNameInputLabelFromRegisterForm })).exists();
@@ -55,8 +55,8 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
 
   test('it toggle the login form on click on login button', async function (assert) {
     // given
-    const emailInputLabelFromLoginForm = this.intl.t('pages.login-form.email');
-    await render(hbs`<Auth::LoginOrRegister/>`);
+    const emailInputLabelFromLoginForm = this.intl.t('pages.login-or-register.login-form.fields.email.label');
+    const screen = await render(hbs`<Auth::LoginOrRegister/>`);
 
     // when
     await clickByName(loginButton);
@@ -70,7 +70,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
     const emailInputLabelFromRegisterForm = this.intl.t('pages.login-or-register.register-form.fields.email.label');
     const registerButtonLabel = this.intl.t('pages.login-or-register.register-form.button');
 
-    await render(hbs`<Auth::LoginOrRegister/>`);
+    const screen = await render(hbs`<Auth::LoginOrRegister/>`);
 
     // when
     await clickByName(loginButton);

--- a/certif/tests/integration/components/auth/register-form_test.js
+++ b/certif/tests/integration/components/auth/register-form_test.js
@@ -1,0 +1,152 @@
+import { module, test } from 'qunit';
+import { fillByLabel, clickByName, render } from '@1024pix/ember-testing-library';
+import { triggerEvent } from '@ember/test-helpers';
+import sinon from 'sinon';
+import hbs from 'htmlbars-inline-precompile';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'pages.login-or-register.register-form.fields.first-name.error';
+const EMPTY_LASTNAME_ERROR_MESSAGE = 'pages.login-or-register.register-form.fields.last-name.error';
+const EMPTY_EMAIL_ERROR_MESSAGE = 'pages.login-or-register.register-form.fields.email.error';
+const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE = 'pages.login-or-register.register-form.fields.password.error';
+const CGU_ERROR_MESSAGE = 'pages.login-or-register.register-form.fields.cgu.error';
+
+module('Integration | Component | Auth::RegisterForm', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let firstNameInputLabel;
+  let lastNameInputLabel;
+  let emailInputLabel;
+  let passwordInputLabel;
+  let cguAriaLabel;
+
+  hooks.beforeEach(function () {
+    firstNameInputLabel = this.intl.t('pages.login-or-register.register-form.fields.first-name.label');
+    lastNameInputLabel = this.intl.t('pages.login-or-register.register-form.fields.last-name.label');
+    emailInputLabel = this.intl.t('pages.login-or-register.register-form.fields.email.label');
+    passwordInputLabel = this.intl.t('pages.login-or-register.register-form.fields.password.label');
+    cguAriaLabel = this.intl.t('pages.login-or-register.register-form.fields.cgu.aria-label');
+  });
+
+  test('[a11y] it should display a message that all inputs are required', async function (assert) {
+    // when
+    const screen = await render(hbs`<Auth::RegisterForm/>`);
+
+    // then
+    assert.dom(screen.getByText('Tous les champs sont obligatoires.')).exists();
+    assert.dom(screen.getByRole('textbox', { name: firstNameInputLabel })).hasAttribute('required');
+    assert.dom(screen.getByRole('textbox', { name: lastNameInputLabel })).hasAttribute('required');
+    assert.dom(screen.getByRole('textbox', { name: emailInputLabel })).hasAttribute('required');
+    assert.dom(screen.getByRole('checkbox', { name: cguAriaLabel })).hasAttribute('required');
+    assert.dom(screen.getByLabelText(passwordInputLabel)).hasAttribute('required');
+  });
+
+  test('it should display legal mentions with related links', async function (assert) {
+    // given
+    const service = this.owner.lookup('service:url');
+    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+
+    // when
+    const screen = await render(hbs`<Auth::RegisterForm/>`);
+
+    // then
+    assert
+      .dom(screen.getByText(this.intl.t('pages.login-or-register.register-form.fields.cgu.accept'), { exact: false }))
+      .exists();
+    assert
+      .dom(screen.getByText(`${this.intl.t('pages.login-or-register.register-form.fields.cgu.terms-of-use')}`))
+      .exists();
+    assert
+      .dom(screen.getByText(this.intl.t('pages.login-or-register.register-form.fields.cgu.and'), { exact: false }))
+      .exists();
+    assert
+      .dom(
+        screen.getByText(`${this.intl.t('pages.login-or-register.register-form.fields.cgu.data-protection-policy')}`)
+      )
+      .exists();
+    assert
+      .dom(screen.getByRole('link', { name: "conditions d'utilisation de Pix" }))
+      .hasAttribute('href', 'https://pix.fr/conditions-generales-d-utilisation');
+    assert
+      .dom(screen.getByRole('link', { name: 'politique de confidentialité' }))
+      .hasAttribute('href', 'https://pix.fr/politique-protection-donnees-personnelles-app');
+  });
+
+  module('errors management', function () {
+    module('when first name is not valid', () => {
+      test('it should display error message', async function (assert) {
+        // given
+        const screen = await render(hbs`<Auth::RegisterForm/>`);
+
+        // when
+        await fillByLabel(firstNameInputLabel, '');
+        const firstNameInput = screen.getByRole('textbox', { name: firstNameInputLabel });
+        await triggerEvent(firstNameInput, 'focusout');
+
+        // then
+        assert.dom(screen.getByText(this.intl.t(EMPTY_FIRSTNAME_ERROR_MESSAGE))).exists();
+      });
+    });
+
+    module('when last name is not valid', () => {
+      test('it should display error message', async function (assert) {
+        // given
+        const screen = await render(hbs`<Auth::RegisterForm/>`);
+
+        // when
+        await fillByLabel(lastNameInputLabel, '');
+        const lastNameInput = screen.getByRole('textbox', { name: lastNameInputLabel });
+        await triggerEvent(lastNameInput, 'focusout');
+
+        // then
+        assert.dom(screen.getByText(this.intl.t(EMPTY_LASTNAME_ERROR_MESSAGE))).exists();
+      });
+    });
+
+    module('when email is not valid', () => {
+      test('it should display error message', async function (assert) {
+        // given
+        const screen = await render(hbs`<Auth::RegisterForm/>`);
+
+        // when
+        await fillByLabel(emailInputLabel, 'incorrectEmailFormat');
+        const emailInput = screen.getByRole('textbox', { name: emailInputLabel });
+        await triggerEvent(emailInput, 'focusout');
+
+        // then
+        assert.dom(screen.getByText(this.intl.t(EMPTY_EMAIL_ERROR_MESSAGE))).exists();
+      });
+    });
+
+    module('when password is not valid', () => {
+      test('it should display error message', async function (assert) {
+        // given
+        const screen = await render(hbs`<Auth::RegisterForm/>`);
+
+        // when
+        await fillByLabel(passwordInputLabel, '');
+        const passwordInput = screen.getByLabelText(passwordInputLabel);
+        await triggerEvent(passwordInput, 'focusout');
+
+        // then
+        assert.dom(screen.getByText(this.intl.t(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE))).exists();
+      });
+    });
+
+    module('when cgu have not been accepted', () => {
+      test('it should display error message', async function (assert) {
+        // given
+        const screen = await render(hbs`<Auth::RegisterForm/>`);
+
+        // when
+        await clickByName(cguAriaLabel);
+        await clickByName(cguAriaLabel);
+        const cguCheckbox = screen.getByRole('checkbox', { name: cguAriaLabel });
+        await triggerEvent(cguCheckbox, 'focusout');
+
+        // then
+        assert.dom(screen.getByText(this.intl.t(CGU_ERROR_MESSAGE))).exists();
+      });
+    });
+  });
+});

--- a/certif/tests/integration/components/auth/toggable-login-form_test.js
+++ b/certif/tests/integration/components/auth/toggable-login-form_test.js
@@ -12,8 +12,8 @@ module('Integration | Component | Auth::ToggableLoginForm', function (hooks) {
   let passwordInputLabel;
 
   hooks.beforeEach(function () {
-    emailInputLabel = this.intl.t('pages.login-form.email');
-    passwordInputLabel = this.intl.t('pages.login-form.password');
+    emailInputLabel = this.intl.t('pages.login-or-register.login-form.fields.email.label');
+    passwordInputLabel = this.intl.t('pages.login-or-register.login-form.fields.password.label');
   });
 
   test('it should display email and password inputs', async function (assert) {
@@ -47,7 +47,7 @@ module('Integration | Component | Auth::ToggableLoginForm', function (hooks) {
       await triggerEvent(emailInput, 'focusout');
 
       // then
-      assert.dom(screen.getByText(this.intl.t('pages.login-form.errors.invalid-email'))).exists();
+      assert.dom(screen.getByText(this.intl.t('pages.login-or-register.login-form.fields.email.error'))).exists();
     });
 
     test('should display an empty password error message when focus-out', async function (assert) {
@@ -60,7 +60,7 @@ module('Integration | Component | Auth::ToggableLoginForm', function (hooks) {
       await triggerEvent(passwordInput, 'focusout');
 
       // then
-      assert.dom(screen.getByText(this.intl.t('pages.login-form.errors.empty-password'))).exists();
+      assert.dom(screen.getByText(this.intl.t('pages.login-or-register.login-form.fields.password.error'))).exists();
     });
   });
 });

--- a/certif/tests/integration/components/auth/toggable-login-form_test.js
+++ b/certif/tests/integration/components/auth/toggable-login-form_test.js
@@ -1,0 +1,66 @@
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+import { triggerEvent } from '@ember/test-helpers';
+import { fillByLabel, render } from '@1024pix/ember-testing-library';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Auth::ToggableLoginForm', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  let emailInputLabel;
+  let passwordInputLabel;
+
+  hooks.beforeEach(function () {
+    emailInputLabel = this.intl.t('pages.login-form.email');
+    passwordInputLabel = this.intl.t('pages.login-form.password');
+  });
+
+  test('it should display email and password inputs', async function (assert) {
+    // when
+    const screen = await render(hbs`<Auth::ToggableLoginForm/>`);
+
+    // then
+    assert.dom(screen.getByRole('textbox', { name: emailInputLabel })).exists();
+    assert.dom(screen.getByLabelText(passwordInputLabel)).exists();
+  });
+
+  test('[a11y] it should display a message that all inputs are required', async function (assert) {
+    // when
+    const screen = await render(hbs`<Auth::ToggableLoginForm/>`);
+
+    // then
+    assert.dom(screen.getByText('Tous les champs sont obligatoires.')).exists();
+    assert.dom(screen.getByRole('textbox', { name: emailInputLabel })).hasAttribute('required');
+    assert.dom(screen.getByLabelText(passwordInputLabel)).hasAttribute('required');
+  });
+
+  module('when the user fills inputs with errors', function () {
+    test('should display an invalid email error message when focus-out', async function (assert) {
+      //given
+      const invalidEmail = 'invalidEmail';
+      const screen = await render(hbs`<Auth::ToggableLoginForm/>`);
+
+      // when
+      await fillByLabel(emailInputLabel, invalidEmail);
+      const emailInput = screen.getByRole('textbox', { name: emailInputLabel });
+      await triggerEvent(emailInput, 'focusout');
+
+      // then
+      assert.dom(screen.getByText(this.intl.t('pages.login-form.errors.invalid-email'))).exists();
+    });
+
+    test('should display an empty password error message when focus-out', async function (assert) {
+      //given
+      const screen = await render(hbs`<Auth::ToggableLoginForm/>`);
+
+      // when
+      await fillByLabel(passwordInputLabel, '');
+      const passwordInput = screen.getByLabelText(passwordInputLabel);
+      await triggerEvent(passwordInput, 'focusout');
+
+      // then
+      assert.dom(screen.getByText(this.intl.t('pages.login-form.errors.empty-password'))).exists();
+    });
+  });
+});

--- a/certif/tests/unit/components/auth/toggable-login-form_test.js
+++ b/certif/tests/unit/components/auth/toggable-login-form_test.js
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Component | toggable-login-form', (hooks) => {
+  setupTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('component:auth/toggable-login-form');
+  });
+
+  module('#updateEmail', () => {
+    test('should update email without spaces', function (assert) {
+      // given
+      const emailWithSpaces = '    user@example.net  ';
+      const event = { target: { value: emailWithSpaces } };
+
+      // when
+      component.updateEmail(event);
+
+      // then
+      const expectedEmail = emailWithSpaces.trim();
+      assert.strictEqual(component.email, expectedEmail);
+    });
+  });
+});

--- a/certif/tests/unit/routes/join_test.js
+++ b/certif/tests/unit/routes/join_test.js
@@ -1,0 +1,19 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | join', function (hooks) {
+  setupTest(hooks);
+
+  module('#model', function () {
+    test('it should return certification center name', async function (assert) {
+      // given
+      const route = this.owner.lookup('route:join');
+
+      // when
+      const { certificationCenterName } = await route.model();
+
+      // then
+      assert.strictEqual(certificationCenterName, 'PLACEHOLDER_CERTIF_CENTER_NAME');
+    });
+  });
+});

--- a/certif/tests/unit/services/url_test.js
+++ b/certif/tests/unit/services/url_test.js
@@ -92,4 +92,47 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(cguUrl, expectedCguUrl);
     });
   });
+
+  module('#forgottenPasswordUrl', function () {
+    test('should get "pix.fr" url when current domain contains pix.fr', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedForgottenPasswordUrl = 'https://app.pix.fr/mot-de-passe-oublie';
+      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+
+      // when
+      const forgottenPasswordUrl = service.forgottenPasswordUrl;
+
+      // then
+      assert.strictEqual(forgottenPasswordUrl, expectedForgottenPasswordUrl);
+    });
+
+    test('should get "pix.org" english url when current language is en', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedForgottenPasswordUrl = 'https://app.pix.org/mot-de-passe-oublie?lang=en';
+      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.intl = { t: sinon.stub().returns('en') };
+
+      // when
+      const forgottenPasswordUrl = service.forgottenPasswordUrl;
+
+      // then
+      assert.strictEqual(forgottenPasswordUrl, expectedForgottenPasswordUrl);
+    });
+
+    test('should get "pix.org" french url when current language is fr', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedForgottenPasswordUrl = 'https://app.pix.org/mot-de-passe-oublie';
+      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.intl = { t: sinon.stub().returns('fr') };
+
+      // when
+      const forgottenPasswordUrl = service.forgottenPasswordUrl;
+
+      // then
+      assert.strictEqual(forgottenPasswordUrl, expectedForgottenPasswordUrl);
+    });
+  });
 });

--- a/certif/tests/unit/services/url_test.js
+++ b/certif/tests/unit/services/url_test.js
@@ -1,0 +1,95 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import setupIntl from '../../helpers/setup-intl';
+import sinon from 'sinon';
+
+module('Unit | Service | url', function (hooks) {
+  setupTest(hooks);
+  setupIntl(hooks);
+
+  module('#dataProtectionPolicyUrl', function () {
+    test('should get "pix.fr" url when current domain contains pix.fr', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedDataProtectionPolicyUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
+      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+
+      // when
+      const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
+
+      // then
+      assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
+    });
+
+    test('should get "pix.org" english url when current language is en', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedDataProtectionPolicyUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
+      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.intl = { t: sinon.stub().returns('en') };
+
+      // when
+      const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
+
+      // then
+      assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
+    });
+
+    test('should get "pix.org" french url when current language is fr', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedDataProtectionPolicyUrl = 'https://pix.org/politique-protection-donnees-personnelles-app';
+      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.intl = { t: sinon.stub().returns('fr') };
+
+      // when
+      const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
+
+      // then
+      assert.strictEqual(dataProtectionPolicyUrl, expectedDataProtectionPolicyUrl);
+    });
+  });
+
+  module('#cguUrl', function () {
+    test('should get "pix.fr" url when current domain contains pix.fr', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
+      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+
+      // when
+      const cguUrl = service.cguUrl;
+
+      // then
+      assert.strictEqual(cguUrl, expectedCguUrl);
+    });
+
+    test('should get "pix.org" english url when current language is en', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedCguUrl = 'https://pix.org/en-gb/terms-and-conditions';
+      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.intl = { t: sinon.stub().returns('en') };
+
+      // when
+      const cguUrl = service.cguUrl;
+
+      // then
+      assert.strictEqual(cguUrl, expectedCguUrl);
+    });
+
+    test('should get "pix.org" french url when current language is fr', function (assert) {
+      // given
+      const service = this.owner.lookup('service:url');
+      const expectedCguUrl = 'https://pix.org/conditions-generales-d-utilisation';
+      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.intl = { t: sinon.stub().returns('fr') };
+
+      // when
+      const cguUrl = service.cguUrl;
+
+      // then
+      assert.strictEqual(cguUrl, expectedCguUrl);
+    });
+  });
+});

--- a/certif/tests/unit/utils/email-validator_test.js
+++ b/certif/tests/unit/utils/email-validator_test.js
@@ -1,0 +1,43 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import isEmailValid from 'pix-certif/utils/email-validator';
+
+module('Unit | Utils | email validator', function (hooks) {
+  setupTest(hooks);
+
+  module('Invalid emails', function () {
+    [
+      '',
+      ' ',
+      null,
+      'INVALID_EMAIL',
+      'INVALID_EMAIL@',
+      'INVALID_EMAIL@pix',
+      'INVALID_EMAIL@pix.',
+      '@pix.fr',
+      '@pix',
+    ].forEach(function (badEmail) {
+      test(`should return false when email is invalid: ${badEmail}`, function (assert) {
+        assert.false(isEmailValid(badEmail));
+      });
+    });
+  });
+
+  module('Valid emails', function () {
+    [
+      'user@pix.fr',
+      'user@pix.fr ',
+      ' user@pix.fr',
+      ' user@pix.fr ',
+      ' user-beta@pix.fr ',
+      ' User_Beta@pix.fr ',
+      'user+beta@pix.fr',
+      'user+beta@pix.gouv.fr',
+      'user+beta@pix.beta.gouv.fr',
+    ].forEach(function (validEmail) {
+      test(`should return true if provided email is valid: ${validEmail}`, function (assert) {
+        assert.true(isEmailValid(validEmail));
+      });
+    });
+  });
+});

--- a/certif/tests/unit/utils/password-validator_test.js
+++ b/certif/tests/unit/utils/password-validator_test.js
@@ -1,0 +1,70 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import isPasswordValid from 'pix-certif/utils/password-validator';
+
+module('Unit | Utils | password validator', function (hooks) {
+  setupTest(hooks);
+
+  module('Validation rules', function () {
+    test('should contain at least 8 characters:', function (assert) {
+      assert.true(isPasswordValid('Ab123456'));
+      assert.false(isPasswordValid('A1'));
+    });
+
+    test('should contain at least one digit', function (assert) {
+      assert.false(isPasswordValid('ABCDEFGH'));
+    });
+
+    test('should contain at least one uppercase letter', function (assert) {
+      assert.false(isPasswordValid('a1234567'));
+    });
+
+    test('should contain at least one lowercase letter', function (assert) {
+      assert.false(isPasswordValid('A1234567'));
+    });
+  });
+
+  module('Invalid password', function () {
+    [
+      '',
+      ' ',
+      null,
+      '@pix',
+      '@pix.fr',
+      '1      1',
+      'password',
+      '12345678&',
+      '+!@)-=`"#&',
+      '+!@)-=`"#&1',
+      '+!@)-=`"#&1A',
+      '+!@)-=`"#&1a',
+    ].forEach(function (badPassword) {
+      test(`should return false when password is invalid: ${badPassword}`, function (assert) {
+        assert.false(isPasswordValid(badPassword));
+      });
+    });
+  });
+
+  module('Valid password', function () {
+    [
+      'PIXBETa1',
+      'PIXBETa12',
+      'NULLNuLL1',
+      '1234567Aa',
+      '12345678Ab',
+      '12345678Ab+',
+      '12345678Ab+!',
+      '12345678Ab+!@',
+      '12345678Ab+!@)-=`',
+      '12345678Ab+!@)-=`"',
+      '12345678Ab+!@)-=`"#&',
+      '1234Password avec espace',
+      '1A      a1',
+      'Aà1      ',
+    ].forEach(function (validPassword) {
+      test(`should return true if provided password is valid: ${validPassword}`, function (assert) {
+        assert.true(isPasswordValid(validPassword));
+      });
+    });
+  });
+});

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -3,6 +3,9 @@
     "actions": {
       "cancel": "Annuler",
       "delete": "Supprimer"
+    },
+    "form": {
+      "mandatory-all-fields": "All fields are required."
     }
   },
   "current-lang": "en",
@@ -16,6 +19,16 @@
   "pages": {
     "login": {
       "title": "Login"
+    },
+    "login-form": {
+      "email": "Email address",
+      "errors": {
+        "invalid-email": "Your email address is invalid.",
+        "empty-password": "Your password can't be empty."
+      },
+      "forgot-password": "Forgot your password?",
+      "login": "Log in",
+      "password": "Password"
     },
     "sessions": {
       "enrolled-candidates": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -20,20 +20,22 @@
     "login": {
       "title": "Login"
     },
-    "login-form": {
-      "email": "Email address",
-      "errors": {
-        "invalid-email": "Your email address is invalid.",
-        "empty-password": "Your password can't be empty."
-      },
-      "forgot-password": "Forgot your password?",
-      "login": "Log in",
-      "password": "Password"
-    },
     "login-or-register": {
       "title": "You have been invited to join the certification center {certificationCenterName}",
       "login-form": {
         "title": "Already have an account?",
+        "fields": {
+          "email": {
+            "label": "Email address",
+            "error": "Your email address is invalid."
+          },
+          "password": {
+            "label": "Password",
+            "error": "Your password can't be empty.",
+            "forgot-password": "Forgot your password?"
+          }
+        },
+        "login": "Log in",
         "button": "Log in"
       },
       "register-form": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -31,6 +31,11 @@
       "password": "Password"
     },
     "login-or-register": {
+      "title": "You have been invited to join the certification center {certificationCenterName}",
+      "login-form": {
+        "title": "Already have an account?",
+        "button": "Log in"
+      },
       "register-form": {
         "title": "Sign up",
         "button": "Sign up",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -30,6 +30,42 @@
       "login": "Log in",
       "password": "Password"
     },
+    "login-or-register": {
+      "register-form": {
+        "title": "Sign up",
+        "button": "Sign up",
+        "fields": {
+          "button": {
+            "label": "Sign up"
+          },
+          "cgu": {
+            "accept": "I agree to the",
+            "and": "and",
+            "aria-label": "Accept the terms of use of the Pix platform",
+            "data-protection-policy": "personal data protection policy",
+            "error": "You must agree to the Pix terms of use and personal data protection policy to create an account.",
+            "terms-of-use": "Pix terms of use"
+          },
+          "email": {
+            "error": "Please enter a valid email address.",
+            "label": "Email address"
+          },
+          "first-name": {
+            "error": "Please enter a first name.",
+            "label": "First name"
+          },
+          "last-name": {
+            "error": "Please enter a last name.",
+            "label": "Last name"
+          },
+          "password": {
+            "error": "Your password must contain at least 8 characters and include at least one uppercase letter, one lowercase letter and one number.",
+            "label": "Password"
+          }
+        },
+        "legal-text": "The information collected in this form is saved in a computer file by Pix to enable access to the service offered by Pix. They are kept for the duration of use of the service and are intended for Pix. Test results may be communicated to third parties, with your consent, if you have been invited to take a specific customised test. In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), you can exercise the right to access and rectify your data by emailing our Data Protection Officer at dpo@pix.fr."
+      }
+    },
     "sessions": {
       "enrolled-candidates": {
         "without-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec la possibilité de supprimer un candidat dans la dernière colonne.",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -21,20 +21,22 @@
     "login": {
       "title": "Connectez-vous"
     },
-    "login-form": {
-      "email": "Adresse e-mail",
-      "errors": {
-        "invalid-email": "Votre adresse e-mail n’est pas valide.",
-        "empty-password": "Le champ mot de passe est obligatoire."
-      },
-      "forgot-password": "Mot de passe oublié ?",
-      "login": "Je me connecte",
-      "password": "Mot de passe"
-    },
     "login-or-register": {
       "title": "Vous êtes invité(e) à rejoindre le centre de certification {certificationCenterName}",
       "login-form": {
         "title": "J'ai déjà un compte",
+        "fields": {
+          "email": {
+            "label": "Adresse e-mail",
+            "error": "Votre adresse e-mail n’est pas valide."
+          },
+          "password": {
+            "label": "Mot de passe",
+            "error": "Le champ mot de passe est obligatoire.",
+            "forgot-password": "Mot de passe oublié ?"
+          }
+        },
+        "login": "Je me connecte",
         "button": "Se connecter"
       },
       "register-form": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -31,6 +31,42 @@
       "login": "Je me connecte",
       "password": "Mot de passe"
     },
+    "login-or-register": {
+      "register-form": {
+        "title": "Je m’inscris",
+        "button": "S'inscrire",
+        "fields": {
+          "button": {
+            "label": "Je m'inscris"
+          },
+          "cgu": {
+            "accept": "J'accepte les",
+            "and": "et la",
+            "aria-label": "Accepter les conditions d'utilisation de Pix",
+            "data-protection-policy": "politique de confidentialité",
+            "error": "Vous devez accepter les conditions d’utilisation de Pix et la politique de confidentialité pour créer un compte.",
+            "terms-of-use": "conditions d'utilisation de Pix"
+          },
+          "email": {
+            "error": "Votre adresse e-mail n’est pas valide.",
+            "label": "Adresse e-mail"
+          },
+          "first-name": {
+            "error": "Votre prénom n’est pas renseigné.",
+            "label": "Prénom"
+          },
+          "last-name": {
+            "error": "Votre nom n’est pas renseigné.",
+            "label": "Nom"
+          },
+          "password": {
+            "error": "Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.",
+            "label": "Mot de passe"
+          }
+        },
+        "legal-text": "Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix pour permettre l’accès au service offert. Elles sont conservées pendant la durée d’utilisation du service et sont destinées à Pix. Les résultats des tests pourront être communiqués à des tiers, avec votre consentement, dans le cas où vous avez été invité à suivre un parcours spécifique. Conformément à la loi « Informatique et Libertés », vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en contactant le Délégué à la Protection des Données de Pix à dpo@pix.fr."
+      }
+    },
     "sessions": {
       "enrolled-candidates": {
         "without-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec la possibilité de supprimer un candidat dans la dernière colonne.",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -28,7 +28,7 @@
         "fields": {
           "email": {
             "label": "Adresse e-mail",
-            "error": "Votre adresse e-mail n’est pas valide."
+            "error": "Le champ adresse e-mail n’est pas valide."
           },
           "password": {
             "label": "Mot de passe",
@@ -55,15 +55,15 @@
             "terms-of-use": "conditions d'utilisation de Pix"
           },
           "email": {
-            "error": "Votre adresse e-mail n’est pas valide.",
+            "error": "Le champ adresse e-mail n’est pas valide.",
             "label": "Adresse e-mail"
           },
           "first-name": {
-            "error": "Votre prénom n’est pas renseigné.",
+            "error": "Le champ prénom est obligatoire.",
             "label": "Prénom"
           },
           "last-name": {
-            "error": "Votre nom n’est pas renseigné.",
+            "error": "Le champ nom est obligatoire.",
             "label": "Nom"
           },
           "password": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -32,6 +32,11 @@
       "password": "Mot de passe"
     },
     "login-or-register": {
+      "title": "Vous êtes invité(e) à rejoindre le centre de certification {certificationCenterName}",
+      "login-form": {
+        "title": "J'ai déjà un compte",
+        "button": "Se connecter"
+      },
       "register-form": {
         "title": "Je m’inscris",
         "button": "S'inscrire",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -4,6 +4,9 @@
       "cancel": "Annuler",
       "delete": "Supprimer",
       "quit": "Quitter"
+    },
+    "form": {
+      "mandatory-all-fields": "Tous les champs sont obligatoires."
     }
   },
   "current-lang": "fr",
@@ -17,6 +20,16 @@
   "pages": {
     "login": {
       "title": "Connectez-vous"
+    },
+    "login-form": {
+      "email": "Adresse e-mail",
+      "errors": {
+        "invalid-email": "Votre adresse e-mail n’est pas valide.",
+        "empty-password": "Le champ mot de passe est obligatoire."
+      },
+      "forgot-password": "Mot de passe oublié ?",
+      "login": "Je me connecte",
+      "password": "Mot de passe"
     },
     "sessions": {
       "enrolled-candidates": {


### PR DESCRIPTION
## :jack_o_lantern: Problème

Dans le cadre de l'epix "Pix Certif : invitation depuis Pix Admin", nous avons besoin de permettre à l'utilisateur qui suit le lien d'une invitation à rejoindre un espace Pix Certif pour qu'il puisse se connecter avec un compte existant ou en créer un nouveau.

## :bat: Proposition

Implémenter dans Pix Certif la double mire inscription/connexion sur le modèle de celle existant dans Pix Orga.

<img width="1093" alt="Capture d’écran 2022-10-20 à 15 38 08" src="https://user-images.githubusercontent.com/5627688/196964030-fae2382a-eecc-41c3-97a5-c6d2210da030.png">

## :spider_web: Remarques

- En grande partie du code copié-collé de Pix Orga
- Dans Pix Orga, la page de login et la double mire utilise un même composant pour le formulaire de login, ici il y en a pour l'instant deux distincts. Idéalement, il faudrait les fusionner.
- Le composant du formulaire s'appelle "ToggableLoginForm" pour le différencier du composant déjà existant "LoginForm".

## :ghost: Pour tester

La page ne fait pas encore d'appel à l'api pour vérifier l'invitation et récupérer le nom du centre de certif, ce sera à faire dans une prochaine PR. La page de la double mire est donc, pour l'instant, directement accessible à l'adresse `/rejoindre` sans paramètre avec un nom temporaire pour le centre de certif.

1. Se rendre sur http://certif.dev.pix.fr/rejoindre ou https://certif-pr5089.review.pix.fr/rejoindre
2. Constater la présence de la double mire (à comparer avec [la maquette](https://www.figma.com/file/wDdAJwtswAllBk0ZtMLu4Y/Acc%C3%A8s?node-id=1%3A2))
3. Vérifier le bon affichage sur mobile