### PR TITLE
[TECH] Tracer l'erreur HTTP complète lors de l'appel à un client lorsque la propriété data n'est pas alimentée

### DIFF
--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -72,7 +72,7 @@ class OidcAuthenticationService {
 
     if (!response.isSuccessful) {
       const message = 'Erreur lors de la récupération des tokens du partenaire.';
-      const dataToLog = httpErrorsHelper.getErrorDetails(response, message);
+      const dataToLog = httpErrorsHelper.serializeHttpErrorResponse(response, message);
       monitoringTools.logErrorWithCorrelationIds({ message: dataToLog });
 
       throw new InvalidExternalAPIResponseError(message);
@@ -113,7 +113,7 @@ class OidcAuthenticationService {
 
     if (!response.isSuccessful) {
       const message = 'Une erreur est survenue en récupérant les informations des utilisateurs.';
-      const dataToLog = httpErrorsHelper.getErrorDetails(response, message);
+      const dataToLog = httpErrorsHelper.serializeHttpErrorResponse(response, message);
 
       monitoringTools.logErrorWithCorrelationIds({ message: dataToLog });
 

--- a/api/lib/infrastructure/http/errors-helper.js
+++ b/api/lib/infrastructure/http/errors-helper.js
@@ -6,9 +6,7 @@ function getErrorDetails(response, customMessage) {
   }
 
   if (typeof response.data === 'object') {
-    errorDetails = response.data.error_description
-      ? { errorDescription: response.data.error_description, errorType: response.data.error }
-      : JSON.stringify(response.data);
+    errorDetails = JSON.stringify(response.data);
   }
 
   const dataToLog = {

--- a/api/lib/infrastructure/http/errors-helper.js
+++ b/api/lib/infrastructure/http/errors-helper.js
@@ -1,4 +1,4 @@
-function getErrorDetails(response, customMessage) {
+function serializeHttpErrorResponse(response, customMessage) {
   let errorDetails;
 
   if (typeof response.data === 'string') {
@@ -18,5 +18,5 @@ function getErrorDetails(response, customMessage) {
 }
 
 module.exports = {
-  getErrorDetails,
+  serializeHttpErrorResponse,
 };

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -154,17 +154,18 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const clientId = 'OIDC_CLIENT_ID';
         const tokenUrl = 'http://oidc.net/api/token';
         const clientSecret = 'OIDC_CLIENT_SECRET';
-
-        sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
-        sinon.stub(httpAgent, 'post');
-        httpAgent.post.resolves({
+        const errorResponse = {
           isSuccessful: false,
           code: 400,
           data: {
             error: 'invalid_client',
             error_description: 'Invalid authentication method for accessing this endpoint.',
           },
-        });
+        };
+
+        sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
+        sinon.stub(httpAgent, 'post');
+        httpAgent.post.resolves(errorResponse);
 
         const oidcAuthenticationService = new OidcAuthenticationService({ clientSecret, clientId, tokenUrl });
 
@@ -183,10 +184,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         expect(monitoringTools.logErrorWithCorrelationIds).to.have.been.calledWith({
           message: {
             customMessage: 'Erreur lors de la récupération des tokens du partenaire.',
-            errorDetails: {
-              errorDescription: 'Invalid authentication method for accessing this endpoint.',
-              errorType: 'invalid_client',
-            },
+            errorDetails: JSON.stringify(errorResponse.data),
           },
         });
       });

--- a/api/tests/unit/infrastructure/http/errors-helper_test.js
+++ b/api/tests/unit/infrastructure/http/errors-helper_test.js
@@ -1,8 +1,8 @@
 const { expect } = require('../../../test-helper');
 
-const { getErrorDetails } = require('../../../../lib/infrastructure/http/errors-helper');
+const { serializeHttpErrorResponse } = require('../../../../lib/infrastructure/http/errors-helper');
 
-describe('getErrorDetails', function () {
+describe('serializeHttpErrorResponse', function () {
   describe('when http error data is null', function () {
     it('should display the string message', function () {
       // given
@@ -14,7 +14,7 @@ describe('getErrorDetails', function () {
       const customMessage = 'Something bad happened';
 
       // when
-      const formattedResponse = getErrorDetails(errorResponse, customMessage);
+      const formattedResponse = serializeHttpErrorResponse(errorResponse, customMessage);
 
       // then
       expect(formattedResponse).to.deep.equal({
@@ -35,7 +35,7 @@ describe('getErrorDetails', function () {
       const customMessage = 'Something bad happened';
 
       // when
-      const formattedResponse = getErrorDetails(errorResponse, customMessage);
+      const formattedResponse = serializeHttpErrorResponse(errorResponse, customMessage);
 
       // then
       expect(formattedResponse).to.deep.equal({
@@ -52,7 +52,7 @@ describe('getErrorDetails', function () {
       const customMessage = 'Something bad happened';
 
       // when
-      const formattedResponse = getErrorDetails(errorResponse, customMessage);
+      const formattedResponse = serializeHttpErrorResponse(errorResponse, customMessage);
 
       // then
       expect(formattedResponse).to.deep.equal({
@@ -76,7 +76,7 @@ describe('getErrorDetails', function () {
       const customMessage = 'Something bad happened';
 
       // when
-      const formattedResponse = getErrorDetails(errorResponse, customMessage);
+      const formattedResponse = serializeHttpErrorResponse(errorResponse, customMessage);
 
       // then
       expect(formattedResponse).to.deep.equal({
@@ -100,7 +100,7 @@ describe('getErrorDetails', function () {
       const customMessage = 'Something bad happened';
 
       // when
-      const formattedResponse = getErrorDetails(errorResponse, customMessage);
+      const formattedResponse = serializeHttpErrorResponse(errorResponse, customMessage);
 
       // then
       expect(formattedResponse).to.deep.equal({

--- a/api/tests/unit/infrastructure/http/errors-helper_test.js
+++ b/api/tests/unit/infrastructure/http/errors-helper_test.js
@@ -3,6 +3,27 @@ const { expect } = require('../../../test-helper');
 const { getErrorDetails } = require('../../../../lib/infrastructure/http/errors-helper');
 
 describe('getErrorDetails', function () {
+  describe('when http error data is null', function () {
+    it('should display the string message', function () {
+      // given
+      const errorResponse = {
+        code: '500',
+        data: null,
+      };
+
+      const customMessage = 'Something bad happened';
+
+      // when
+      const formattedResponse = getErrorDetails(errorResponse, customMessage);
+
+      // then
+      expect(formattedResponse).to.deep.equal({
+        customMessage,
+        errorDetails: 'null',
+      });
+    });
+  });
+
   describe('when http error data is a string', function () {
     it('should display the string message', function () {
       // given
@@ -60,10 +81,7 @@ describe('getErrorDetails', function () {
       // then
       expect(formattedResponse).to.deep.equal({
         customMessage,
-        errorDetails: {
-          errorDescription: 'Invalid authentication method for accessing this endpoint.',
-          errorType: 'invalid_client',
-        },
+        errorDetails: JSON.stringify(errorResponse.data),
       });
     });
   });

--- a/api/tests/unit/infrastructure/http/http-agent_test.js
+++ b/api/tests/unit/infrastructure/http/http-agent_test.js
@@ -59,7 +59,7 @@ describe('Unit | Infrastructure | http | http-agent', function () {
       });
 
       context('when error.response exists', function () {
-        it("should return the error's response status and data from the http call when failed", async function () {
+        it("should return an http response with the error's response status as code and data from the failed http call", async function () {
           // given
           const url = 'someUrl';
           const payload = 'somePayload';
@@ -85,7 +85,7 @@ describe('Unit | Infrastructure | http | http-agent', function () {
       });
 
       context("when error.response doesn't exists", function () {
-        it("should return the error's response status and success from the http call when failed", async function () {
+        it('should return an http response with error with code 500 and data null', async function () {
           // given
           const url = 'someUrl';
           const payload = 'somePayload';
@@ -168,7 +168,7 @@ describe('Unit | Infrastructure | http | http-agent', function () {
       });
 
       context('when error.response exists', function () {
-        it("should return the error's response status and data from the http call when failed", async function () {
+        it("should return an http response with the error's response status as code and data from the failed http call", async function () {
           // given
           const url = 'someUrl';
           const payload = 'somePayload';
@@ -194,7 +194,7 @@ describe('Unit | Infrastructure | http | http-agent', function () {
       });
 
       context("when error.response doesn't exists", function () {
-        it("should return the error's response status and success from the http call when failed", async function () {
+        it('should return an http response with error with code 500 and data null', async function () {
           // given
           const url = 'someUrl';
           const payload = 'somePayload';


### PR DESCRIPTION
## :jack_o_lantern: Problème
Les appels api de serveurs à serveurs sont traités  par le http agent `api/lib/infrastructure/http/http-agent.js`
Lorsqu'un appel api est en erreur, c'est ce même fichier qui serialize la réponse obtenue.
Or, dans le cas où l'api qu'on appelle ne renvoie pas de réponse,  l'erreur renvoyée par http agent est :
```
{ 
  code: '500',
  data: null,
}
```
Ce cas n'ayant pas été géré dans https://github.com/1024pix/pix/pull/5068 il est traité ici.

## :bat: Proposition
Ajouter ce cas de test dans `errors-helper.js`

## :spider_web: Remarques
Des logs sont envoyés via `logErrorWithCorrelationIds` dans http agent et dans le service qui utilise les méthodes post et get de http agent  : `lib/domain/services/authentication/oidc-authentication-service`
Peut-être qu'un refactoring est à envisager.
C'est pourquoi, la proposition est d'utiliser `JSON.stringify(data)` dans `api/lib/infrastructure/http/errors-helper.js` pour uniformiser la façon dont les erreurs renvoyées vont être logguées


## :ghost: Pour tester
Voir la PR https://github.com/1024pix/pix/pull/5068

ou ajouter juste après
```
const response = await httpAgent.post({
      url: this.tokenUrl,
      payload: querystring.stringify(data),
      headers: { 'content-type': 'application/x-www-form-urlencoded' },
    });
```    

le bout de code suivant
```
    await this.getUserInfoFromEndpoint({ accessToken: response.data['access_token'], userInfoUrl: null });

```

C'est le get sur la route appellée par la méthode `getUserInfoFromEndpoint` qui ne renvoie pas de réponse et qu'on passe dans le cas ou http agent serialize l'erreur en une erreur générique 
```
HttpResponse { code: '500', data: null, isSuccessful: false }
```

se connecter avec pole emploi

Vérifier que l'utilisateur voit bien l'erreur `Error: [{"status":"503","title":"ServiceUnavailable","detail":"Une erreur est survenue en récupérant les informations des utilisateurs."}]`

Côté logs sur serveur, vérifier que vous voyez bien 
  ```
   msg: {
      "customMessage": "Une erreur est survenue en récupérant les informations des utilisateurs.",
      "errorDetails": "null"
    }
```    
