### PR TITLE
[FEATURE] Ajouter l'heure de début du test de certification du candidat sur l'espace surveillant. (PIX-6014)

### DIFF
--- a/api/lib/domain/models/CertificationCandidateForSupervising.js
+++ b/api/lib/domain/models/CertificationCandidateForSupervising.js
@@ -1,7 +1,16 @@
 const isNil = require('lodash/isNil');
 
 class CertificationCandidateForSupervising {
-  constructor({ id, firstName, lastName, birthdate, extraTimePercentage, authorizedToStart, assessmentStatus } = {}) {
+  constructor({
+    id,
+    firstName,
+    lastName,
+    birthdate,
+    extraTimePercentage,
+    authorizedToStart,
+    assessmentStatus,
+    startDateTime,
+  } = {}) {
     this.id = id;
     this.firstName = firstName;
     this.lastName = lastName;
@@ -9,6 +18,7 @@ class CertificationCandidateForSupervising {
     this.extraTimePercentage = !isNil(extraTimePercentage) ? parseFloat(extraTimePercentage) : extraTimePercentage;
     this.authorizedToStart = authorizedToStart;
     this.assessmentStatus = assessmentStatus;
+    this.startDateTime = startDateTime;
   }
 
   authorizeToStart() {

--- a/api/lib/infrastructure/repositories/certification-candidate-for-supervising-repository.js
+++ b/api/lib/infrastructure/repositories/certification-candidate-for-supervising-repository.js
@@ -5,7 +5,11 @@ const CertificationCandidateForSupervising = require('../../domain/models/Certif
 module.exports = {
   async get(certificationCandidateId) {
     const result = await knex('certification-candidates')
-      .select('certification-candidates.*', 'assessments.state AS assessmentStatus')
+      .select(
+        'certification-candidates.*',
+        'assessments.state AS assessmentStatus',
+        'certification-courses.createdAt AS startDateTime'
+      )
       .leftJoin('certification-courses', function () {
         this.on('certification-courses.sessionId', '=', 'certification-candidates.sessionId');
         this.on('certification-courses.userId', '=', 'certification-candidates.userId');

--- a/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-for-supervising-repository.js
@@ -22,7 +22,8 @@ module.exports = {
             'id', "certification-candidates"."id",
             'extraTimePercentage', "certification-candidates"."extraTimePercentage",
             'authorizedToStart', "certification-candidates"."authorizedToStart",
-            'assessmentStatus', "assessments"."state"
+            'assessmentStatus', "assessments"."state",
+            'startDateTime', "certification-courses"."createdAt"
           ) order by lower("certification-candidates"."lastName"), lower("certification-candidates"."firstName"))
       `),
       })

--- a/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-for-supervising-serializer.js
@@ -8,6 +8,7 @@ const attributes = [
   'extraTimePercentage',
   'authorizedToStart',
   'assessmentStatus',
+  'startDateTime',
 ];
 
 module.exports = {

--- a/api/tests/integration/infrastructure/repositories/certification-candidate-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-candidate-for-supervising-repository_test.js
@@ -20,6 +20,7 @@ describe('Integration | Repository | certification candidate for supervising', f
         const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
           userId: user.id,
           sessionId: session.id,
+          createdAt: new Date('2022-10-01T14:00:00Z'),
         });
         databaseBuilder.factory.buildAssessment({
           certificationCourseId: certificationCourse.id,
@@ -43,6 +44,7 @@ describe('Integration | Repository | certification candidate for supervising', f
             id: candidate.id,
             lastName: 'Joplin',
             assessmentStatus: 'started',
+            startDateTime: new Date('2022-10-01T14:00:00Z'),
           })
         );
       });

--- a/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-for-supervising-repository_test.js
@@ -80,6 +80,7 @@ describe('Integration | Repository | SessionForSupervising', function () {
       const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
         userId: 12345,
         sessionId: session.id,
+        createdAt: new Date('2022-10-19T13:37:00Z'),
       });
 
       databaseBuilder.factory.buildAssessment({
@@ -94,18 +95,37 @@ describe('Integration | Repository | SessionForSupervising', function () {
 
       // then
       const actualCandidates = _.map(actualSession.certificationCandidates, (item) =>
-        _.pick(item, ['sessionId', 'lastName', 'firstName', 'authorizedToStart', 'assessmentStatus'])
+        _.pick(item, ['sessionId', 'lastName', 'firstName', 'authorizedToStart', 'assessmentStatus', 'startDateTime'])
       );
       expect(actualCandidates).to.have.deep.ordered.members([
-        { lastName: 'Jackson', firstName: 'Janet', authorizedToStart: false, assessmentStatus: null },
-        { lastName: 'Jackson', firstName: 'Michael', authorizedToStart: true, assessmentStatus: null },
+        {
+          lastName: 'Jackson',
+          firstName: 'Janet',
+          authorizedToStart: false,
+          assessmentStatus: null,
+          startDateTime: null,
+        },
+        {
+          lastName: 'Jackson',
+          firstName: 'Michael',
+          authorizedToStart: true,
+          assessmentStatus: null,
+          startDateTime: null,
+        },
         {
           lastName: 'Joplin',
           firstName: 'Janis',
           authorizedToStart: true,
           assessmentStatus: Assessment.states.STARTED,
+          startDateTime: '2022-10-19T13:37:00+00:00',
         },
-        { lastName: 'Stardust', firstName: 'Ziggy', authorizedToStart: false, assessmentStatus: null },
+        {
+          lastName: 'Stardust',
+          firstName: 'Ziggy',
+          authorizedToStart: false,
+          assessmentStatus: null,
+          startDateTime: null,
+        },
       ]);
     });
 

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate-for-supervising.js
@@ -8,6 +8,7 @@ module.exports = function buildCertificationCandidateForSupervising({
   extraTimePercentage = 0.3,
   authorizedToStart = false,
   assessmentStatus = null,
+  startDateTime = new Date('2022-10-01T12:00:00Z'),
 } = {}) {
   return new CertificationCandidateForSupervising({
     id,
@@ -17,5 +18,6 @@ module.exports = function buildCertificationCandidateForSupervising({
     extraTimePercentage,
     authorizedToStart,
     assessmentStatus,
+    startDateTime,
   });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/session-for-supervising-serializer_test.js
@@ -39,6 +39,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
               'last-name': 'tata',
               'authorized-to-start': true,
               'assessment-status': Assessment.states.STARTED,
+              'start-date-time': new Date('2022-10-01T13:37:00Z'),
             },
             id: '1234',
             type: 'certification-candidate-for-supervising',
@@ -64,6 +65,7 @@ describe('Unit | Serializer | JSONAPI | session-for-supervising-serializer', fun
             extraTimePercentage: 33,
             authorizedToStart: true,
             assessmentStatus: Assessment.states.STARTED,
+            startDateTime: new Date('2022-10-01T13:37:00Z'),
           },
         ],
       });

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -24,7 +24,9 @@
     <div class="session-supervising-candidate-in-list__details">
       {{moment-format @candidate.birthdate "DD/MM/YYYY"}}
       {{#if @candidate.extraTimePercentage}}
-        · Temps majoré :
+        ·
+        {{t "pages.session-supervising.candidate-in-list.extra-time"}}
+        :
         {{@candidate.extraTimePercentage}}%
       {{/if}}
     </div>
@@ -32,15 +34,19 @@
       <span
         class="session-supervising-candidate-in-list__status session-supervising-candidate-in-list__status--started"
       >
-        En cours
+        {{t "pages.session-supervising.candidate-in-list.ongoing"}}
       </span>
-      <span class="session-supervising-candidate-in-list__start-time">Début : {{this.candidateStartTime}}</span>
+      <span class="session-supervising-candidate-in-list__start-time">{{t
+          "pages.session-supervising.candidate-in-list.start"
+        }}
+        :
+        {{this.candidateStartTime}}</span>
     {{/if}}
     {{#if @candidate.hasCompleted}}
       <span
         class="session-supervising-candidate-in-list__status session-supervising-candidate-in-list__status--completed"
       >
-        Terminé
+        {{t "pages.session-supervising.candidate-in-list.finished"}}
       </span>
     {{/if}}
   </div>
@@ -48,15 +54,19 @@
     <div class="session-supervising-candidate-in-list__menu">
       <PixIconButton
         @icon="ellipsis-v"
-        aria-label="Afficher les options du candidat"
+        aria-label={{t "pages.session-supervising.candidate-in-list.display-candidate-options"}}
         @triggerAction={{this.toggleMenu}}
       />
-      <Dropdown::Content @display={{this.isMenuOpen}} @close={{this.closeMenu}} aria-label="Options du candidat">
+      <Dropdown::Content
+        @display={{this.isMenuOpen}}
+        @close={{this.closeMenu}}
+        aria-label={{t "pages.session-supervising.candidate-in-list.candidate-options"}}
+      >
         <Dropdown::Item @onClick={{this.askUserToConfirmTestResume}}>
-          Autoriser la reprise du test
+          {{t "pages.session-supervising.candidate-in-list.resume-test-modal.allow-test-resume"}}
         </Dropdown::Item>
         <Dropdown::Item @onClick={{this.askUserToConfirmTestEnd}}>
-          Terminer le test
+          {{t "pages.session-supervising.candidate-in-list.test-end-modal.end-assessment"}}
         </Dropdown::Item>
       </Dropdown::Content>
     </div>

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -34,6 +34,7 @@
       >
         En cours
       </span>
+      <span class="session-supervising-candidate-in-list__start-time">Début : {{this.candidateStartTime}}</span>
     {{/if}}
     {{#if @candidate.hasCompleted}}
       <span

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -40,7 +40,7 @@
           "pages.session-supervising.candidate-in-list.start"
         }}
         :
-        {{this.candidateStartTime}}</span>
+        <time>{{this.candidateStartTime}}</time></span>
     {{/if}}
     {{#if @candidate.hasCompleted}}
       <span

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -3,6 +3,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
+import dayjs from 'dayjs';
 
 export default class CandidateInList extends Component {
   @service notifications;
@@ -127,11 +128,7 @@ export default class CandidateInList extends Component {
   }
 
   get candidateStartTime() {
-    const startDateTime = new Date(this.args.candidate.startDateTime).toLocaleString('fr-FR', {
-      timeZone: 'Zulu',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-    return startDateTime;
+    const startTime = dayjs(this.args.candidate.startDateTime).format('HH:mm');
+    return startTime;
   }
 }

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -98,4 +98,13 @@ export default class CandidateInList extends Component {
   get actionMethod() {
     return this.actionOnConfirmation;
   }
+
+  get candidateStartTime() {
+    const startDateTime = new Date(this.args.candidate.startDateTime).toLocaleString('fr-FR', {
+      timeZone: 'Zulu',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+    return startDateTime;
+  }
 }

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -14,6 +14,7 @@ export default class CandidateInList extends Component {
   @tracked modalConfirmationText;
   @tracked modalInstructionText;
   @tracked actionOnConfirmation;
+  @service intl;
 
   get isCheckboxToBeDisplayed() {
     return !this.args.candidate.hasStarted && !this.args.candidate.hasCompleted;
@@ -40,22 +41,36 @@ export default class CandidateInList extends Component {
 
   @action
   askUserToConfirmTestResume() {
-    this.modalDescriptionText =
-      "Si le candidat a fermé la fenêtre de son test de certification (par erreur, ou à cause d'un problème technique) et est toujours présent dans la salle de test, vous pouvez lui permettre de reprendre son test à l'endroit où il l'avait quitté.";
-    this.modalCancelText = 'Fermer';
-    this.modalConfirmationText = "Je confirme l'autorisation";
-    this.modalInstructionText = `Autoriser ${this.args.candidate.firstName} ${this.args.candidate.lastName} à reprendre son test ?`;
+    this.modalDescriptionText = this.intl.t(
+      'pages.session-supervising.candidate-in-list.resume-test-modal.description'
+    );
+    this.modalCancelText = this.intl.t('common.actions.close');
+    this.modalConfirmationText = this.intl.t('pages.session-supervising.candidate-in-list.resume-test-modal.confirm');
+    this.modalInstructionText = this.intl.t(
+      'pages.session-supervising.candidate-in-list.resume-test-modal.instruction-with-name',
+      {
+        firstName: this.args.candidate.firstName,
+        lastName: this.args.candidate.lastName,
+      }
+    );
     set(this, 'actionOnConfirmation', this.authorizeTestResume);
     this.isConfirmationModalDisplayed = true;
   }
 
   @action
   askUserToConfirmTestEnd() {
-    this.modalDescriptionText =
-      'Attention : cette action entraîne la fin de son test de certification et est irréversible.';
-    this.modalCancelText = 'Annuler';
-    this.modalConfirmationText = 'Terminer le test';
-    this.modalInstructionText = `Terminer le test de ${this.args.candidate.firstName} ${this.args.candidate.lastName} ?`;
+    this.modalDescriptionText = this.intl.t('pages.session-supervising.candidate-in-list.test-end-modal.description');
+    this.modalCancelText = this.intl.t('common.actions.cancel');
+    this.modalConfirmationText = this.intl.t(
+      'pages.session-supervising.candidate-in-list.test-end-modal.end-assessment'
+    );
+    this.modalInstructionText = this.intl.t(
+      'pages.session-supervising.candidate-in-list.test-end-modal.instruction-with-name',
+      {
+        firstName: this.args.candidate.firstName,
+        lastName: this.args.candidate.lastName,
+      }
+    );
     set(this, 'actionOnConfirmation', this.endAssessmentForCandidate);
     this.isConfirmationModalDisplayed = true;
   }
@@ -71,11 +86,17 @@ export default class CandidateInList extends Component {
     try {
       await this.args.onCandidateTestResumeAuthorization(this.args.candidate);
       this.notifications.success(
-        `Succès ! ${this.args.candidate.firstName} ${this.args.candidate.lastName} peut reprendre son test de certification.`
+        this.intl.t('pages.session-supervising.candidate-in-list.resume-test-modal.success', {
+          firstName: this.args.candidate.firstName,
+          lastName: this.args.candidate.lastName,
+        })
       );
     } catch (error) {
       this.notifications.error(
-        `Une erreur est survenue, ${this.args.candidate.firstName} ${this.args.candidate.lastName} n'a a pu être autorisé à reprendre son test.`
+        this.intl.t('pages.session-supervising.candidate-in-list.resume-test-modal.error', {
+          firstName: this.args.candidate.firstName,
+          lastName: this.args.candidate.lastName,
+        })
       );
     }
   }
@@ -86,11 +107,17 @@ export default class CandidateInList extends Component {
     try {
       await this.args.onSupervisorEndAssessment(this.args.candidate);
       this.notifications.success(
-        `Succès ! Le test de  ${this.args.candidate.firstName} ${this.args.candidate.lastName} est terminé.`
+        this.intl.t('pages.session-supervising.candidate-in-list.test-end-modal.success', {
+          firstName: this.args.candidate.firstName,
+          lastName: this.args.candidate.lastName,
+        })
       );
     } catch (error) {
       this.notifications.error(
-        `Une erreur est survenue, le test de ${this.args.candidate.firstName} ${this.args.candidate.lastName} n'a pas pu être terminé.`
+        this.intl.t('pages.session-supervising.candidate-in-list.test-end-modal.error', {
+          firstName: this.args.candidate.firstName,
+          lastName: this.args.candidate.lastName,
+        })
       );
     }
   }

--- a/certif/app/components/session-supervising/confirmation-modal.hbs
+++ b/certif/app/components/session-supervising/confirmation-modal.hbs
@@ -19,7 +19,7 @@
       @triggerAction={{@closeConfirmationModal}}
       @backgroundColor="transparent-light"
       @isBorderVisible={{true}}
-      aria-label="Annuler et fermer la fenêtre de confirmation"
+      aria-label={{t "pages.session-supervising.candidate-in-list.resume-test-modal.cancel-label"}}
     >
       {{@modalCancelText}}
     </PixButton>

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -15,6 +15,7 @@ export default class CertificationCandidateForSupervising extends Model {
   @attr('number') extraTimePercentage;
   @attr('boolean') authorizedToStart;
   @attr('string') assessmentStatus;
+  @attr('date') startDateTime;
 
   get hasStarted() {
     return this.assessmentStatus === 'started';

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -45,6 +45,12 @@
     }
   }
 
+  &__start-time {
+    color: $pix-neutral-15;
+    font-size: 0.75rem;
+    margin-left: 4px;
+  }
+
   &__menu {
     position: relative;
   }

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -22,6 +22,7 @@
         "@glimmer/tracking": "^1.1.2",
         "babel-eslint": "^10.1.0",
         "broccoli-asset-rev": "^3.0.0",
+        "dayjs": "^1.11.6",
         "ember-api-actions": "^0.2.9",
         "ember-auto-import": "^1.12.0",
         "ember-cli": "^4.6.0",
@@ -11989,6 +11990,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
+      "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ==",
+      "dev": true
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -42548,6 +42555,12 @@
       "requires": {
         "time-zone": "^1.0.0"
       }
+    },
+    "dayjs": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
+      "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ==",
+      "dev": true
     },
     "debug": {
       "version": "2.6.9",

--- a/certif/package.json
+++ b/certif/package.json
@@ -50,6 +50,7 @@
     "@glimmer/tracking": "^1.1.2",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
+    "dayjs": "^1.11.6",
     "ember-api-actions": "^0.2.9",
     "ember-auto-import": "^1.12.0",
     "ember-cli": "^4.6.0",
@@ -104,5 +105,6 @@
     "sinon": "^14.0.0",
     "stylelint": "^14.10.0",
     "stylelint-config-standard": "^27.0.0"
-  }
+  },
+  "dependencies": {}
 }

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -96,7 +96,8 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         extraTimePercentage: null,
         authorizedToStart: true,
         assessmentStatus: 'started',
-        startDateTime: new Date('2022-10-19T14:30:15Z'),
+        // eslint-disable-next-line no-restricted-syntax
+        startDateTime: new Date('2022-10-19T14:30:15'),
       });
 
       // when
@@ -108,7 +109,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       assert.dom(screen.getByText('Racoon Rocket')).exists();
       assert.dom(screen.getByText('28/07/1982')).exists();
       assert.dom(screen.getByText('En cours')).exists();
-      assert.dom(screen.getByText('Début : 14:30')).exists();
+      assert.dom(screen.getByText('14:30')).exists();
       assert.dom(screen.queryByRole('checkbox', { name: 'Racoon Rocket' })).doesNotExist();
       assert.dom(screen.queryByRole('button', { name: 'Afficher les options du candidat' })).exists();
     });

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 
@@ -7,7 +7,7 @@ import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
 module('Integration | Component | SessionSupervising::CandidateInList', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   let store;
 

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -86,7 +86,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
   });
 
   module('when the candidate has started the test', function () {
-    test('it displays the "en cours" label and the options menu button', async function (assert) {
+    test('it displays the "en cours" label, the start time and the options menu button', async function (assert) {
       // given
       this.candidate = store.createRecord('certification-candidate-for-supervising', {
         id: 789,
@@ -96,6 +96,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
         extraTimePercentage: null,
         authorizedToStart: true,
         assessmentStatus: 'started',
+        startDateTime: new Date('2022-10-19T14:30:15Z'),
       });
 
       // when
@@ -107,6 +108,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
       assert.dom(screen.getByText('Racoon Rocket')).exists();
       assert.dom(screen.getByText('28/07/1982')).exists();
       assert.dom(screen.getByText('En cours')).exists();
+      assert.dom(screen.getByText('Début : 14:30')).exists();
       assert.dom(screen.queryByRole('checkbox', { name: 'Racoon Rocket' })).doesNotExist();
       assert.dom(screen.queryByRole('button', { name: 'Afficher les options du candidat' })).exists();
     });

--- a/certif/tests/unit/models/certification-candidate-for-supervising_test.js
+++ b/certif/tests/unit/models/certification-candidate-for-supervising_test.js
@@ -15,6 +15,7 @@ module('Unit | Model | certification-candidate-for-supervising', function (hooks
       extraTimePercentage: 10,
       authorizedToStart: true,
       assessmentStatus: 'started',
+      startDateTime: new Date('2022-10-01T13:37:07Z'),
     };
 
     // when
@@ -96,6 +97,7 @@ module('Unit | Model | certification-candidate-for-supervising', function (hooks
       'extraTimePercentage',
       'authorizedToStart',
       'assessmentStatus',
+      'startDateTime',
     ]);
   }
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -2,7 +2,9 @@
   "common": {
     "actions": {
       "cancel": "Annuler",
-      "delete": "Supprimer"
+      "delete": "Supprimer",
+      "quit": "Quitter",
+      "close": "Fermer"
     },
     "form": {
       "mandatory-all-fields": "All fields are required."
@@ -109,6 +111,31 @@
       },
       "candidate-list": {
         "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} authorized {authorizedToStartCandidates, plural,one {candidate} other {candidates}}"
+      },
+      "candidate-in-list": {
+        "extra-time": "Extra time",
+        "ongoing": "In progress",
+        "finished": "Finished",
+        "display-candidate-options": "Display the candidate's options",
+        "candidate-options": "Candidate's options",
+        "start": "Start",
+        "test-end-modal": {
+          "description": "Attention : cette action entraîne la fin de son test de certification et est irréversible.",
+          "instruction-with-name": "Finish the test of {firstName} {lastName}?",
+          "end-assessment": "Finish the test",
+          "cancel-label": "Annuler et fermer la fenêtre de confirmation",
+          "success": "Success! {firstName} {lastName}'s test has been finished.",
+          "error": "An error occured, {firstName} {lastName}'s test could not be finished."
+        },
+        "resume-test-modal": {
+          "allow-test-resume": "Autoriser la reprise du test",
+          "description": "Si le candidat a fermé la fenêtre de son test de certification (par erreur, ou à cause d'un problème technique) et est toujours présent dans la salle de test, vous pouvez lui permettre de reprendre son test à l'endroit où il l'avait quitté.",
+          "instruction-with-name": "Autoriser {firstName} {lastName} à reprendre son test ?`",
+          "confirm": "Je confirme l'autorisation",
+          "cancel-label": "Annuler et fermer la fenêtre de confirmation",
+          "success": "Succès ! {firstName} {lastName} peut reprendre son test de certification.",
+          "error": "Une erreur est survenue, {firstName} {lastName} n'a a pu être autorisé à reprendre son test."
+        }
       }
     },
     "team": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -3,7 +3,8 @@
     "actions": {
       "cancel": "Annuler",
       "delete": "Supprimer",
-      "quit": "Quitter"
+      "quit": "Quitter",
+      "close": "Fermer"
     },
     "form": {
       "mandatory-all-fields": "Tous les champs sont obligatoires."
@@ -110,6 +111,31 @@
       },
       "candidate-list": {
         "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidat sélectionné} other {candidats sélectionnés}}"
+      },
+      "candidate-in-list": {
+        "extra-time": "Temps majoré",
+        "ongoing": "En cours",
+        "finished": "Terminé",
+        "display-candidate-options": "Afficher les options du candidat",
+        "candidate-options": "Options du candidat",
+        "start": "Début",
+        "test-end-modal": {
+          "description": "Attention : cette action entraîne la fin de son test de certification et est irréversible.",
+          "instruction-with-name": "Terminer le test de {firstName} {lastName} ?",
+          "end-assessment": "Terminer le test",
+          "cancel-label": "Annuler et fermer la fenêtre de confirmation",
+          "success": "Succès ! Le test de {firstName} {lastName} est terminé.",
+          "error": "Une erreur est survenue, le test de {firstName} {lastName} n'a pas pu être terminé."
+        },
+        "resume-test-modal": {
+          "allow-test-resume": "Autoriser la reprise du test",
+          "description": "Si le candidat a fermé la fenêtre de son test de certification (par erreur, ou à cause d'un problème technique) et est toujours présent dans la salle de test, vous pouvez lui permettre de reprendre son test à l'endroit où il l'avait quitté.",
+          "instruction-with-name": "Autoriser {firstName} {lastName} à reprendre son test ?",
+          "confirm": "Je confirme l'autorisation",
+          "cancel-label": "Annuler et fermer la fenêtre de confirmation",
+          "success": "Succès ! {firstName} {lastName} peut reprendre son test de certification.",
+          "error": "Une erreur est survenue, {firstName} {lastName} n'a a pu être autorisé à reprendre son test."
+        }
       }
     },
     "team": {


### PR DESCRIPTION
## :jack_o_lantern: Problème
L’espace surveillant est déjà disponible pour tous les CDC. Suite aux retours utilisateurs obtenus lors des beta tests réalisés par Pix, des axes d’amélioration ont été identifiés afin d’avoir une meilleure expérience utilisateurs.

Les certifications Pix durent 1h45 maximum (sans tiers temps) mais les candidats peuvent parfois commencer leur certification à des moments différents (exemple : problème technique ordinateur ou réseau).

Le surveillant n’a pas de moyen actuellement pour connaître l’heure exacte de début de test pour chaque candidat et ne peut donc pas s’assurer que chacun bénéficie de la durée totale prévue.

## :bat: Proposition
Pour chaque candidat listé dans l’ES, faire apparaître l’heure à laquelle il a cliqué sur “Commencer mon test” dans Pix App. Cette heure de début correspond à l'heure de création d'un certification course. 

## :spider_web: Remarques
Ajout des traductions pour cette partie de l'espace surveillant, en route vers l'internationalisation !

## :ghost: Pour tester
- Se connecter à Pix Certif (avec certifpro@example.net, par exemple)
- Créer une session de certification et y inscrire un candidat
- Se connecter à Pix App avec ce candidat et démarrer un test de certification
- Se connecter à l'espace surveillant et constater que l'heure de début de la certification du candidat apparaît à coté du tag "En cours"