### PR TITLE
[TECH] Ecrire l'état d'obtention de la certification Pix dans la table "certification-courses" lors de la publication de la certification (PIX-6071)

### DIFF
--- a/api/db/database-builder/factory/build-certification-course.js
+++ b/api/db/database-builder/factory/build-certification-course.js
@@ -27,6 +27,7 @@ module.exports = function buildCertificationCourse({
   isCancelled = false,
   abortReason = null,
   cpfFilename = null,
+  pixCertificationStatus = null,
 } = {}) {
   userId = _.isUndefined(userId) ? buildUser().id : userId;
   sessionId = _.isUndefined(sessionId) ? buildSession().id : sessionId;
@@ -54,6 +55,7 @@ module.exports = function buildCertificationCourse({
     isCancelled,
     abortReason,
     cpfFilename,
+    pixCertificationStatus,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-courses',

--- a/api/db/migrations/20221018192501_add-column-pix-certification-status-in-certification-courses-table.js
+++ b/api/db/migrations/20221018192501_add-column-pix-certification-status-in-certification-courses-table.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'certification-courses';
+const COLUMN_NAME = 'pixCertificationStatus';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).defaultTo(null);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/infrastructure/repositories/certification-repository.js
+++ b/api/lib/infrastructure/repositories/certification-repository.js
@@ -1,35 +1,29 @@
-const CertificationCourseBookshelf = require('../orm-models/CertificationCourse');
-const Bookshelf = require('../bookshelf');
+const { knex } = require('../../../db/knex-database-connection');
 const { CertificationCourseNotPublishableError } = require('../../../lib/domain/errors');
-
-async function getAssessmentResultsStatusesBySessionId(id) {
-  const collection = await CertificationCourseBookshelf.query((qb) => {
-    qb.innerJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id');
-    qb.innerJoin(
-      Bookshelf.knex.raw(
-        `"assessment-results" ar ON ar."assessmentId" = "assessments".id
-                    and ar."createdAt" = (select max(sar."createdAt") from "assessment-results" sar where sar."assessmentId" = "assessments".id)`
-      )
-    );
-    qb.where({ 'certification-courses.sessionId': id });
-  }).fetchAll({ columns: ['status'] });
-
-  return collection.map((obj) => obj.attributes.status);
-}
 
 module.exports = {
   async publishCertificationCoursesBySessionId(sessionId) {
-    const statuses = await getAssessmentResultsStatusesBySessionId(sessionId);
-    if (statuses.includes('error') || statuses.includes('started')) {
+    const latestAssessmentResultStatuses = await knex('certification-courses')
+      .pluck('assessment-results.status')
+      .where('certification-courses.sessionId', sessionId)
+      .join('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
+      .join('assessment-results', 'assessment-results.assessmentId', 'assessments.id')
+      .whereNotExists(
+        knex
+          .select(1)
+          .from({ 'last-assessment-results': 'assessment-results' })
+          .whereRaw('"last-assessment-results"."assessmentId" = assessments.id')
+          .whereRaw('"assessment-results"."createdAt" < "last-assessment-results"."createdAt"')
+      );
+
+    if (latestAssessmentResultStatuses.includes('error') || latestAssessmentResultStatuses.includes('started')) {
       throw new CertificationCourseNotPublishableError();
     }
-    await CertificationCourseBookshelf.where({ sessionId }).save(
-      { isPublished: true },
-      { method: 'update', require: false }
-    );
+
+    await knex('certification-courses').where({ sessionId }).update({ isPublished: true, updatedAt: new Date() });
   },
 
   async unpublishCertificationCoursesBySessionId(sessionId) {
-    await CertificationCourseBookshelf.where({ sessionId }).save({ isPublished: false }, { method: 'update' });
+    await knex('certification-courses').where({ sessionId }).update({ isPublished: false, updatedAt: new Date() });
   },
 };

--- a/api/lib/infrastructure/repositories/certification-repository.js
+++ b/api/lib/infrastructure/repositories/certification-repository.js
@@ -7,7 +7,7 @@ module.exports = {
       .pluck('assessment-results.status')
       .where('certification-courses.sessionId', sessionId)
       .join('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
-      .join('assessment-results', 'assessment-results.assessmentId', 'assessments.id')
+      .leftJoin('assessment-results', 'assessment-results.assessmentId', 'assessments.id')
       .whereNotExists(
         knex
           .select(1)
@@ -16,7 +16,7 @@ module.exports = {
           .whereRaw('"assessment-results"."createdAt" < "last-assessment-results"."createdAt"')
       );
 
-    if (latestAssessmentResultStatuses.includes('error') || latestAssessmentResultStatuses.includes('started')) {
+    if (latestAssessmentResultStatuses.includes('error') || latestAssessmentResultStatuses.includes(null)) {
       throw new CertificationCourseNotPublishableError();
     }
 

--- a/api/lib/infrastructure/repositories/certification-repository.js
+++ b/api/lib/infrastructure/repositories/certification-repository.js
@@ -34,6 +34,7 @@ module.exports = {
       updatedAt: new Date(),
     }));
 
+    // Trick to .batchUpdate(), which does not exist in knex per say
     await knex('certification-courses')
       .insert(certificationDataToUpdate)
       .onConflict('id')

--- a/api/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table.js
+++ b/api/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table.js
@@ -1,0 +1,148 @@
+require('dotenv').config();
+const { performance } = require('perf_hooks');
+const logger = require('../../lib/infrastructure/logger');
+const cache = require('../../lib/infrastructure/caches/learning-content-cache');
+const { knex, disconnect } = require('../../db/knex-database-connection');
+const yargs = require('yargs');
+const bluebird = require('bluebird');
+const { status } = require('../../lib/domain/models/AssessmentResult');
+const readline = require('readline');
+const DEFAULT_COUNT = 20000;
+const DEFAULT_CONCURRENCY = 2;
+
+let progression = 0;
+function _logProgression(totalCount) {
+  ++progression;
+  readline.cursorTo(process.stdout, 0);
+  process.stdout.write(`${Math.round((progression * 100) / totalCount, 2)} %`);
+}
+
+const updatePixCertificationStatus = async ({ count, concurrency }) => {
+  logger.info('\tRécupération des certifications éligibles...');
+  const eligibleCertificationIds = await _findEligibleCertifications(count);
+  logger.info(`\tOK : ${eligibleCertificationIds.length} certifications récupérées`);
+
+  logger.info('\tInscription du status dans la certification...');
+  let failedGenerations = 0;
+  await bluebird.map(
+    eligibleCertificationIds,
+    async (certificationId) => {
+      try {
+        await _updatePixCertificationStatus(certificationId);
+      } catch (err) {
+        ++failedGenerations;
+        logger.error(`Went wrong for certification ${certificationId}`);
+      }
+      _logProgression(count);
+    },
+    { concurrency }
+  );
+  logger.info(`\n\tOK, ${failedGenerations} générations de codes échouées pour cause de code en doublon`);
+};
+
+const isLaunchedFromCommandLine = require.main === module;
+
+async function main() {
+  const startTime = performance.now();
+  logger.info(`Script ${__filename} est lancé !`);
+  logger.info('Validation des arguments...');
+  const commandLineArgs = yargs
+    .option('count', {
+      description: 'Nombre de certificats pour lesquels on remplit la colonne',
+      type: 'number',
+      default: DEFAULT_COUNT,
+    })
+    .option('concurrency', {
+      description: 'Concurrence',
+      type: 'number',
+      default: DEFAULT_CONCURRENCY,
+    })
+    .help().argv;
+  const { count, concurrency } = _validateAndNormalizeArgs(commandLineArgs);
+  logger.info(`OK : Nombre de certificats - ${count} / Concurrence - ${concurrency}`);
+  await updatePixCertificationStatus({ count, concurrency });
+  const endTime = performance.now();
+  const duration = Math.round(endTime - startTime);
+  logger.info(`Script fini en ${duration * 1000} secondes.`);
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+      await cache.quit();
+    }
+  }
+})();
+
+function _validateAndNormalizeArgs({ count, concurrency }) {
+  const finalCount = _validateAndNormalizeCount(count);
+  const finalConcurrency = _validateAndNormalizeConcurrency(concurrency);
+
+  return {
+    count: finalCount,
+    concurrency: finalConcurrency,
+  };
+}
+
+function _validateAndNormalizeCount(count) {
+  if (isNaN(count)) {
+    count = DEFAULT_COUNT;
+  }
+  if (count <= 0 || count > 50000) {
+    throw new Error(`Nombre de certifications à traiter ${count} ne peut pas être inférieur à 1 ni supérieur à 50000.`);
+  }
+
+  return count;
+}
+
+function _validateAndNormalizeConcurrency(concurrency) {
+  if (isNaN(concurrency)) {
+    concurrency = DEFAULT_CONCURRENCY;
+  }
+  if (concurrency <= 0 || concurrency > 5) {
+    throw new Error(`La concurrence ${concurrency} ne peut pas être inférieure à 1 ni supérieure à 5.`);
+  }
+
+  return concurrency;
+}
+
+function _findEligibleCertifications(count) {
+  return knex
+    .pluck('id')
+    .from('certification-courses')
+    .whereNull('pixCertificationStatus')
+    .where({ isPublished: true })
+    .limit(count);
+}
+
+async function _updatePixCertificationStatus(certificationId) {
+  const certificationDTO = await knex('certification-courses')
+    .select({ assessmentResultStatus: 'assessment-results.status' })
+    .where({ certificationCourseId: certificationId })
+    .join('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
+    .leftJoin('assessment-results', 'assessment-results.assessmentId', 'assessments.id')
+    .whereNotExists(
+      knex
+        .select(1)
+        .from({ 'last-assessment-results': 'assessment-results' })
+        .whereRaw('"last-assessment-results"."assessmentId" = assessments.id')
+        .whereRaw('"assessment-results"."createdAt" < "last-assessment-results"."createdAt"')
+    )
+    .first();
+  if (!certificationDTO) throw new Error(`Went wrong for certification ${certificationId}`);
+  if (![status.VALIDATED, status.REJECTED].includes(certificationDTO.assessmentResultStatus))
+    throw new Error(`Went wrong for certification ${certificationId}`);
+
+  await knex('certification-courses').where({ id: certificationId }).update({
+    pixCertificationStatus: certificationDTO.assessmentResultStatus,
+    updatedAt: new Date(),
+  });
+}
+
+module.exports = { updatePixCertificationStatus };

--- a/api/tests/integration/infrastructure/repositories/certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-repository_test.js
@@ -1,153 +1,113 @@
 const { expect, databaseBuilder, catchErr, knex } = require('../../../test-helper');
 const certificationRepository = require('../../../../lib/infrastructure/repositories/certification-repository');
 const { CertificationCourseNotPublishableError } = require('../../../../lib/domain/errors');
-const CertificationCourseBookshelf = require('../../../../lib/infrastructure/orm-models/CertificationCourse');
-const PARTNER_CLEA_KEY = 'BANANA';
+const { status } = require('../../../../lib/domain/models/AssessmentResult');
 
-describe('Integration | Repository | Certification ', function () {
-  let sessionLatestAssessmentRejected;
-  let sessionWithPublishedCertificationCourses;
-  let sessionWithStartedAndError;
-  let sessionLatestAssessmentRejectedCertifCourseIds;
-  let sessionWithStartedAndErrorCertifCourseIds;
-  let sessionWithPublishedCertificationCoursesCertifCourseIds;
-
-  let certificationCenterId;
-  let certificationCenter;
-
-  beforeEach(async function () {
-    databaseBuilder.factory.buildBadge({ key: PARTNER_CLEA_KEY });
-    ({ id: certificationCenterId, name: certificationCenter } = databaseBuilder.factory.buildCertificationCenter({
-      name: 'Certif College',
-    }));
-
-    sessionLatestAssessmentRejectedCertifCourseIds = [];
-    sessionWithStartedAndErrorCertifCourseIds = [];
-    sessionWithPublishedCertificationCoursesCertifCourseIds = [];
-
-    sessionLatestAssessmentRejected = databaseBuilder.factory.buildSession();
-    let id = createCertifCourseWithAssessementResults(
-      sessionLatestAssessmentRejected.id,
-      { status: 'started', createdAt: new Date('2018-02-15T15:00:34Z') },
-      { status: 'rejected', createdAt: new Date('2018-02-16T15:00:34Z') }
-    );
-    sessionLatestAssessmentRejectedCertifCourseIds.push(id);
-
-    sessionWithStartedAndError = databaseBuilder.factory.buildSession();
-    id = createCertifCourseWithAssessementResults(sessionWithStartedAndError.id, { status: 'started' });
-    sessionWithStartedAndErrorCertifCourseIds.push(id);
-    id = createCertifCourseWithAssessementResults(sessionWithStartedAndError.id, { status: 'error' });
-    sessionWithStartedAndErrorCertifCourseIds.push(id);
-
-    sessionWithPublishedCertificationCourses = databaseBuilder.factory.buildSession();
-    id = createPublishedCertifCourseWithAssessementResults(
-      sessionWithPublishedCertificationCourses.id,
-      { status: 'started', createdAt: new Date('2018-02-15T15:00:34Z') },
-      { status: 'rejected', createdAt: new Date('2018-02-16T15:00:34Z') }
-    );
-    sessionWithPublishedCertificationCoursesCertifCourseIds.push(id);
-
-    await databaseBuilder.commit();
-  });
-
-  afterEach(async function () {
-    await knex('complementary-certification-course-results').delete();
-    await knex('assessment-results').delete();
-    await knex('assessments').delete();
-    await knex('certification-courses').delete();
-    return knex('sessions').delete();
-  });
-
+describe('Integration | Repository | Certification', function () {
   describe('#publishCertificationCoursesBySessionId', function () {
-    it('should flag the specified certifications as published', async function () {
-      await certificationRepository.publishCertificationCoursesBySessionId(sessionLatestAssessmentRejected.id);
-      await Promise.all(
-        sessionLatestAssessmentRejectedCertifCourseIds.map(async (id) => {
-          const certifCourse = await get(id);
-          expect(certifCourse.isPublished).to.be.true;
-        })
-      );
+    const sessionId = 200;
+    beforeEach(function () {
+      databaseBuilder.factory.buildSession({ id: sessionId });
+      _buildValidatedCertification({ id: 1, sessionId, isPublished: false });
+      _buildRejectedCertification({ id: 2, sessionId, isPublished: false });
+      return databaseBuilder.commit();
     });
 
-    it('should not flag the specified certifications as published and be rejected', async function () {
-      const result = await catchErr(
-        certificationRepository.publishCertificationCoursesBySessionId.bind(certificationRepository)
-      )(sessionWithStartedAndError.id);
-      // then
-      expect(result).to.be.instanceOf(CertificationCourseNotPublishableError);
-
-      await Promise.all(
-        sessionWithStartedAndErrorCertifCourseIds.map(async (id) => expect((await get(id)).isPublished).to.be.false)
-      );
-    });
-
-    it('does nothing when there are no certification courses', async function () {
-      // given
-      const sessionWithNoCertificationCourses = databaseBuilder.factory.buildSession({
-        certificationCenterId,
-        certificationCenter,
-        finalizedAt: new Date('2020-01-01'),
+    context('when some certifications latest assessment result is error', function () {
+      beforeEach(function () {
+        _buildErrorCertification({ id: 3, sessionId, isPublished: false });
+        return databaseBuilder.commit();
       });
-      await databaseBuilder.commit();
 
-      // when
-      const publicationPromise = certificationRepository.publishCertificationCoursesBySessionId(
-        sessionWithNoCertificationCourses.id
-      );
+      it('should throw a CertificationCourseNotPublishableError without publishing any certification', async function () {
+        // when
+        const err = await catchErr(certificationRepository.publishCertificationCoursesBySessionId)(sessionId);
 
-      // then
-      await expect(publicationPromise).not.to.be.rejected;
+        // then
+        const isPublishedStates = await knex('certification-courses').pluck('isPublished').where({ sessionId });
+        expect(err).to.be.instanceOf(CertificationCourseNotPublishableError);
+        expect(isPublishedStates).to.deepEqualArray([false, false, false]);
+      });
+    });
+
+    context('when some certification are still started', function () {
+      beforeEach(function () {
+        _buildStartedCertification({ id: 3, sessionId, isPublished: false });
+        return databaseBuilder.commit();
+      });
+
+      it('should throw a CertificationCourseNotPublishableError without publishing any certification', async function () {
+        // when
+        const err = await catchErr(certificationRepository.publishCertificationCoursesBySessionId)(sessionId);
+
+        // then
+        const isPublishedStates = await knex('certification-courses').pluck('isPublished').where({ sessionId });
+        expect(err).to.be.instanceOf(CertificationCourseNotPublishableError);
+        expect(isPublishedStates).to.deepEqualArray([false, false, false]);
+      });
+    });
+
+    context('when all certification latest assessment result are validated or rejected', function () {
+      it('should set certifications as published within the session', async function () {
+        // when
+        await certificationRepository.publishCertificationCoursesBySessionId(sessionId);
+
+        // then
+        const isPublishedStates = await knex('certification-courses').pluck('isPublished').where({ sessionId });
+        expect(isPublishedStates).to.deepEqualArray([true, true]);
+      });
     });
   });
 
   describe('#unpublishCertificationCoursesBySessionId', function () {
-    it('should update the specified certifications', async function () {
-      await certificationRepository.unpublishCertificationCoursesBySessionId(
-        sessionWithPublishedCertificationCourses.id
-      );
-      await Promise.all(
-        sessionWithPublishedCertificationCoursesCertifCourseIds.map(async (id) => {
-          const certifCourse = await get(id);
-          expect(certifCourse.isPublished).to.be.false;
-        })
-      );
+    const sessionId = 200;
+    beforeEach(function () {
+      databaseBuilder.factory.buildSession({ id: sessionId });
+      _buildValidatedCertification({ id: 1, sessionId, isPublished: true });
+      _buildRejectedCertification({ id: 2, sessionId, isPublished: true });
+      _buildErrorCertification({ id: 3, sessionId, isPublished: true });
+      _buildStartedCertification({ id: 4, sessionId, isPublished: true });
+      return databaseBuilder.commit();
+    });
+
+    it('should unpublish all certifications within a session', async function () {
+      // when
+      await certificationRepository.unpublishCertificationCoursesBySessionId(sessionId);
+
+      // then
+      const isPublishedStates = await knex('certification-courses').pluck('isPublished').where({ sessionId });
+      expect(isPublishedStates).to.deepEqualArray([false, false, false, false]);
     });
   });
-
-  function createPublishedCertifCourseWithAssessementResults(sessionId, ...assessmentResults) {
-    const { id: certifCourseId } = databaseBuilder.factory.buildCertificationCourse({ sessionId, isPublished: true });
-    const { id: assessmentId } = databaseBuilder.factory.buildAssessment({
-      certificationCourseId: certifCourseId,
-    });
-    assessmentResults.forEach(({ status, createdAt }) =>
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId: assessmentId,
-        createdAt,
-        status,
-      })
-    );
-
-    return certifCourseId;
-  }
-
-  function createCertifCourseWithAssessementResults(sessionId, ...assessmentResults) {
-    const { id: certifCourseId } = databaseBuilder.factory.buildCertificationCourse({ sessionId, isPublished: false });
-    const { id: assessmentId } = databaseBuilder.factory.buildAssessment({
-      certificationCourseId: certifCourseId,
-    });
-    assessmentResults.forEach(({ status, createdAt }) =>
-      databaseBuilder.factory.buildAssessmentResult({
-        assessmentId: assessmentId,
-        createdAt,
-        status,
-      })
-    );
-
-    return certifCourseId;
-  }
-
-  async function get(id) {
-    const certification = await CertificationCourseBookshelf.where({ id }).fetch();
-    return certification.attributes;
-  }
 });
+
+function _buildValidatedCertification({ id, sessionId, isPublished }) {
+  _buildCertification({ id, sessionId, isPublished, status: status.VALIDATED });
+}
+
+function _buildRejectedCertification({ id, sessionId, isPublished }) {
+  _buildCertification({ id, sessionId, isPublished, status: status.REJECTED });
+}
+
+function _buildErrorCertification({ id, sessionId, isPublished }) {
+  _buildCertification({ id, sessionId, isPublished, status: status.ERROR });
+}
+
+function _buildStartedCertification({ id, sessionId, isPublished }) {
+  _buildCertification({ id, sessionId, isPublished, status: null });
+}
+
+function _buildCertification({ id, sessionId, status, isPublished }) {
+  databaseBuilder.factory.buildCertificationCourse({ id, sessionId, isPublished });
+  databaseBuilder.factory.buildAssessment({ id, certificationCourseId: id });
+  if (status) {
+    // not the latest
+    databaseBuilder.factory.buildAssessmentResult({
+      assessmentId: id,
+      createdAt: new Date('2020-01-01'),
+      status: status.VALIDATED,
+    });
+    // the latest
+    databaseBuilder.factory.buildAssessmentResult({ assessmentId: id, createdAt: new Date('2021-01-01'), status });
+  }
+}

--- a/api/tests/integration/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table_test.js
+++ b/api/tests/integration/scripts/certification/fill-pix-certification-status-column-in-certification-courses-table_test.js
@@ -1,0 +1,115 @@
+const { expect, databaseBuilder, knex, sinon } = require('../../../test-helper');
+const {
+  updatePixCertificationStatus,
+} = require('../../../../scripts/certification/fill-pix-certification-status-column-in-certification-courses-table');
+const { status } = require('../../../../lib/domain/models/AssessmentResult');
+
+const OLD_UPDATED_AT = new Date('2020-01-01');
+const NEW_UPDATED_AT = new Date('2022-02-02');
+
+describe('Integration | Scripts | Certification | fill-pix-certification-status-column-in-certification', function () {
+  let clock;
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers(NEW_UPDATED_AT);
+  });
+
+  afterEach(function () {
+    clock.restore();
+  });
+
+  describe('#updatePixCertificationStatus', function () {
+    it('do what expected', async function () {
+      // given
+      _buildAlreadyFilledPixCertificationStatus({
+        id: 1,
+        assessmentResultStatus: status.VALIDATED,
+        pixCertificationStatus: status.REJECTED,
+      });
+      _buildNotPublished({
+        id: 2,
+        assessmentResultStatus: status.VALIDATED,
+      });
+      _buildPublishedAndError({ id: 3 });
+      _buildPublishedAndValidated({ id: 4 });
+      _buildPublishedAndRejected({ id: 5 });
+      await databaseBuilder.commit();
+
+      // when
+      await updatePixCertificationStatus({ count: 10, concurrency: 1 });
+
+      // then
+      const certificationDTOs = await knex('certification-courses')
+        .select('pixCertificationStatus', 'updatedAt')
+        .orderBy('id');
+      expect(certificationDTOs[0]).to.deep.equal({
+        pixCertificationStatus: status.REJECTED,
+        updatedAt: OLD_UPDATED_AT,
+      });
+      expect(certificationDTOs[1]).to.deep.equal({ pixCertificationStatus: null, updatedAt: OLD_UPDATED_AT });
+      expect(certificationDTOs[2]).to.deep.equal({ pixCertificationStatus: null, updatedAt: OLD_UPDATED_AT });
+      expect(certificationDTOs[3]).to.deep.equal({
+        pixCertificationStatus: status.VALIDATED,
+        updatedAt: NEW_UPDATED_AT,
+      });
+      expect(certificationDTOs[4]).to.deep.equal({
+        pixCertificationStatus: status.REJECTED,
+        updatedAt: NEW_UPDATED_AT,
+      });
+    });
+  });
+});
+
+function _buildAlreadyFilledPixCertificationStatus({ id, assessmentResultStatus, pixCertificationStatus }) {
+  _buildCertification({
+    id,
+    assessmentResultStatus,
+    pixCertificationStatus,
+    isPublished: true,
+  });
+}
+
+function _buildNotPublished({ id, assessmentResultStatus }) {
+  _buildCertification({ id, assessmentResultStatus, pixCertificationStatus: null, isPublished: false });
+}
+
+function _buildPublishedAndError({ id }) {
+  _buildCertification({ id, assessmentResultStatus: status.ERROR, pixCertificationStatus: null, isPublished: true });
+}
+
+function _buildPublishedAndValidated({ id }) {
+  _buildCertification({
+    id,
+    assessmentResultStatus: status.VALIDATED,
+    pixCertificationStatus: null,
+    isPublished: true,
+  });
+}
+
+function _buildPublishedAndRejected({ id }) {
+  _buildCertification({ id, assessmentResultStatus: status.REJECTED, pixCertificationStatus: null, isPublished: true });
+}
+
+function _buildCertification({ id, assessmentResultStatus, isPublished, pixCertificationStatus }) {
+  databaseBuilder.factory.buildCertificationCourse({
+    id,
+    isPublished,
+    pixCertificationStatus,
+    updatedAt: OLD_UPDATED_AT,
+  });
+  databaseBuilder.factory.buildAssessment({ id, certificationCourseId: id });
+  if (assessmentResultStatus) {
+    // not the latest
+    databaseBuilder.factory.buildAssessmentResult({
+      assessmentId: id,
+      createdAt: new Date('2020-01-01'),
+      status: status.VALIDATED,
+    });
+    // the latest
+    databaseBuilder.factory.buildAssessmentResult({
+      assessmentId: id,
+      createdAt: new Date('2021-01-01'),
+      status: assessmentResultStatus,
+    });
+  }
+}


### PR DESCRIPTION
## :jack_o_lantern: Problème
Marre de faire des jointures des enfers dans le code ou sur Metabase pour récupérer une information simple concernant la certification.
ETQ moi, je souhaite récupérer facilement l'obtention de la certification Pix lorsqu'une certification est publiée.

## :bat: Proposition
- Ajout d'une colonne `pixCertificationStatus` dans la table `certification-courses`, valeur par défaut à null
- A la publication, on remplit la colonne avec la valeur de statut de l'`assessment-result` le plus récent
- A la dépublication, on remet à null
- Ecriture d'un script pour rétrocalculer le statut sur les certifications publiées existantes

## :spider_web: Remarques
Quand ce sera fait, y'a un ménage (petit à petit) sympa à faire sur Metabase, voire dans le code !

## :ghost: Pour tester
Publier / dépublier les certifications et lire la colonne dans la BDD
