### PR TITLE
[BUGFIX] QCM - Recentrer les inputs (PIX-6072)

### DIFF
--- a/mon-pix/app/styles/components/_qcu-proposals.scss
+++ b/mon-pix/app/styles/components/_qcu-proposals.scss
@@ -25,6 +25,7 @@
   }
 
   &__label {
+    width: 100%;
     display: inline-block;
     padding-left: 20px;
     line-height: 21px;

--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -31,7 +31,6 @@
 
   &__row label {
     display: inline;
-    width: 100%;
   }
 }
 

--- a/mon-pix/app/styles/globals/_redesign-inputs.scss
+++ b/mon-pix/app/styles/globals/_redesign-inputs.scss
@@ -27,6 +27,7 @@ fieldset {
 
 .label-checkbox-proposal {
   display: inline-block;
+  width: 100%;
   padding-left: 20px;
   line-height: 21px;
   position: relative;


### PR DESCRIPTION
## :jack_o_lantern: Problème
Suite à la [PR](https://github.com/1024pix/pix/pull/5084), un bug d'affichage pour certains questionnaires était visible.

![image](https://user-images.githubusercontent.com/58207021/196565282-db6f7179-d0b3-433c-bed6-8d02d6ff05a1.png)

## :bat: Proposition
- Cibler les classes Scss nécessitant le `width:100%`

## :spider_web: Remarques


## :ghost: Pour tester
Tester les url suivants sur la review  : 

- https://app-pr5095.review.pix.fr/challenges/challenge1yRdbrGHi3tHns/preview
- https://app-pr5095.review.pix.fr/challenges/challenge1Pbnchn6fPwfkc/preview
- https://app-pr5095.review.pix.fr/challenges/recWY2fgyQuc4QMu/preview