### PR TITLE
[TECH] Supprimer une tâche de lint dupliquée

### DIFF
--- a/api/nodemon.json
+++ b/api/nodemon.json
@@ -1,0 +1,19 @@
+{
+  "signal": "SIGTERM",
+  "watch": [
+    "lib",
+    "index.js",
+    "server.js",
+    "worker.js",
+    "package.json",
+    "db",
+    "translations",
+    ".env"
+  ],
+  "ignore": [
+    "db/seeds",
+    "db/migrations",
+    "db/database-builder"
+  ],
+  "ext": "js"
+}

--- a/api/package.json
+++ b/api/package.json
@@ -163,24 +163,5 @@
     "test:api:watch": "NODE_ENV=test mocha --recursive tests --watch --reporter dot",
     "test:api:bail": "npm run test:api:unit -- --bail && npm run test:api:integration -- --bail && npm run test:api:acceptance -- --bail",
     "test:ci": "npm run test"
-  },
-  "nodemonConfig": {
-    "signal": "SIGTERM",
-    "watch": [
-      "lib",
-      "index.js",
-      "server.js",
-      "worker.js",
-      "package.json",
-      "db",
-      "translations",
-      ".env"
-    ],
-    "ignore": [
-      "db/seeds",
-      "db/migrations",
-      "db/database-builder"
-    ],
-    "ext": "js"
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -162,8 +162,7 @@
     "test:api:debug": "NODE_ENV=test mocha --inspect-brk=9229 --recursive --exit --reporter dot tests",
     "test:api:watch": "NODE_ENV=test mocha --recursive tests --watch --reporter dot",
     "test:api:bail": "npm run test:api:unit -- --bail && npm run test:api:integration -- --bail && npm run test:api:acceptance -- --bail",
-    "test:ci": "npm run test",
-    "test:lint": "npm test && npm run lint"
+    "test:ci": "npm run test"
   },
   "nodemonConfig": {
     "signal": "SIGTERM",


### PR DESCRIPTION
## :jack_o_lantern: Problème
La tâche npm `test:lint` fait la même chose que  `lint` suivie de `test`.

## :bat: Proposition
Supprimer cette tâche. 

Si un développeur a un besoin spécifique, il peut créer un alias bash sur  `npm test && npm run lint`.

## :spider_web: Remarques
Externalisation de la configuration de `node-monitor` dans un fichier, car le `package.json` est bien rempli.

## :ghost: Pour tester
Vérifier que la CI passe.
