### PR TITLE
[TECH] Ne pas attendre la connexion PoleEmploi plus longtemps que ce que Scalingo permet

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -73,6 +73,10 @@ module.exports = (function () {
       pixCertif: process.env.DOMAIN_PIX_CERTIF || 'https://certif.pix',
     },
 
+    partner: {
+      fetchTimeOut: ms(process.env.FETCH_TIMEOUT_MILLISECONDS || '20s'),
+    },
+
     lcms: {
       url: _removeTrailingSlashFromUrl(process.env.CYPRESS_LCMS_API_URL || process.env.LCMS_API_URL || ''),
       apiKey: process.env.CYPRESS_LCMS_API_KEY || process.env.LCMS_API_KEY,
@@ -419,6 +423,8 @@ module.exports = (function () {
       url: process.env.TEST_REDIS_URL,
       database: 1,
     };
+
+    config.partner.fetchTimeOut = '5ms';
   }
 
   return config;

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -74,7 +74,6 @@ class OidcAuthenticationService {
       const message = 'Erreur lors de la récupération des tokens du partenaire.';
       const dataToLog = httpErrorsHelper.serializeHttpErrorResponse(response, message);
       monitoringTools.logErrorWithCorrelationIds({ message: dataToLog });
-
       throw new InvalidExternalAPIResponseError(message);
     }
 

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -45,6 +45,7 @@ module.exports = {
         code = httpErr.response.status;
         data = httpErr.response.data;
       } else {
+        code = httpErr.code;
         data = httpErr.message;
       }
 
@@ -66,7 +67,7 @@ module.exports = {
     const startTime = performance.now();
     let responseTime = null;
     try {
-      const config = { data: payload, headers };
+      const config = { data: payload, headers, timeout: TIMEOUT_MILLISECONDS };
       const httpResponse = await axios.get(url, config);
       responseTime = performance.now() - startTime;
       monitoringTools.logInfoWithCorrelationIds({

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -1,7 +1,12 @@
 // eslint-disable-next-line no-restricted-modules
 const axios = require('axios');
 const { performance } = require('perf_hooks');
+
+const config = require('../../config');
+
 const monitoringTools = require('../monitoring-tools');
+
+const TIMEOUT_MILLISECONDS = config.partner.fetchTimeOut;
 
 class HttpResponse {
   constructor({ code, data, isSuccessful }) {
@@ -18,6 +23,7 @@ module.exports = {
     try {
       const httpResponse = await axios.post(url, payload, {
         headers,
+        timeout: TIMEOUT_MILLISECONDS,
       });
       responseTime = performance.now() - startTime;
       monitoringTools.logInfoWithCorrelationIds({

--- a/api/sample.env
+++ b/api/sample.env
@@ -874,3 +874,15 @@ TEST_REDIS_URL=redis://localhost:6379
 # presence: required for CPF xml file generation, optional otherwise
 # type: string
 # sample:CPF_SEND_EMAIL_JOB_CRON=0 0 1 1 *
+
+# =======
+# HTTP
+# =======
+
+# `timeout` specifies the number of milliseconds before the request times out.
+# If the request takes longer than `timeout`, the request will be aborted.
+#
+# presence: required for fetch http request configuration
+# type: string
+# default: 60s
+# sample:FETCH_TIMEOUT_MILLISECONDS=20s

--- a/api/tests/unit/infrastructure/http/http-agent_test.js
+++ b/api/tests/unit/infrastructure/http/http-agent_test.js
@@ -3,6 +3,9 @@ const axios = require('axios');
 const { post, get } = require('../../../../lib/infrastructure/http/http-agent');
 const monitoringTools = require('../../../../lib/infrastructure/monitoring-tools');
 
+const config = require('../../../../lib/config');
+const TIMEOUT_MILLISECONDS = config.partner.fetchTimeOut;
+
 describe('Unit | Infrastructure | http | http-agent', function () {
   describe('#post', function () {
     afterEach(function () {
@@ -18,7 +21,13 @@ describe('Unit | Infrastructure | http | http-agent', function () {
         data: Symbol('data'),
         status: 'someStatus',
       };
-      sinon.stub(axios, 'post').withArgs(url, payload, { headers }).resolves(axiosResponse);
+      sinon
+        .stub(axios, 'post')
+        .withArgs(url, payload, {
+          headers,
+          timeout: TIMEOUT_MILLISECONDS,
+        })
+        .resolves(axiosResponse);
 
       // when
       const actualResponse = await post({ url, payload, headers });
@@ -46,7 +55,10 @@ describe('Unit | Infrastructure | http | http-agent', function () {
             status: 400,
           },
         };
-        sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
+        sinon
+          .stub(axios, 'post')
+          .withArgs(url, payload, { headers, timeout: TIMEOUT_MILLISECONDS })
+          .rejects(axiosError);
 
         // when
         await post({ url, payload, headers });
@@ -70,7 +82,13 @@ describe('Unit | Infrastructure | http | http-agent', function () {
               status: 'someStatus',
             },
           };
-          sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
+          sinon
+            .stub(axios, 'post')
+            .withArgs(url, payload, {
+              headers,
+              timeout: TIMEOUT_MILLISECONDS,
+            })
+            .rejects(axiosError);
 
           // when
           const actualResponse = await post({ url, payload, headers });
@@ -97,7 +115,13 @@ describe('Unit | Infrastructure | http | http-agent', function () {
               status: 400,
             },
           };
-          sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
+          sinon
+            .stub(axios, 'post')
+            .withArgs(url, payload, {
+              headers,
+              timeout: TIMEOUT_MILLISECONDS,
+            })
+            .rejects(axiosError);
 
           const expectedResponse = {
             isSuccessful: false,

--- a/api/tests/unit/infrastructure/http/http-agent_test.js
+++ b/api/tests/unit/infrastructure/http/http-agent_test.js
@@ -151,7 +151,10 @@ describe('Unit | Infrastructure | http | http-agent', function () {
         data: Symbol('data'),
         status: 'someStatus',
       };
-      sinon.stub(axios, 'get').withArgs(url, { data: payload, headers }).resolves(axiosResponse);
+      sinon
+        .stub(axios, 'get')
+        .withArgs(url, { data: payload, headers, timeout: TIMEOUT_MILLISECONDS })
+        .resolves(axiosResponse);
 
       // when
       const actualResponse = await get({ url, payload, headers });
@@ -179,7 +182,10 @@ describe('Unit | Infrastructure | http | http-agent', function () {
             status: 400,
           },
         };
-        sinon.stub(axios, 'get').withArgs(url, { data: payload, headers }).rejects(axiosError);
+        sinon
+          .stub(axios, 'get')
+          .withArgs(url, { data: payload, headers, timeout: TIMEOUT_MILLISECONDS })
+          .rejects(axiosError);
 
         // when
         await get({ url, payload, headers });
@@ -203,7 +209,10 @@ describe('Unit | Infrastructure | http | http-agent', function () {
               status: 'someStatus',
             },
           };
-          sinon.stub(axios, 'get').withArgs(url, { data: payload, headers }).rejects(axiosError);
+          sinon
+            .stub(axios, 'get')
+            .withArgs(url, { data: payload, headers, timeout: TIMEOUT_MILLISECONDS })
+            .rejects(axiosError);
 
           // when
           const actualResponse = await get({ url, payload, headers });


### PR DESCRIPTION
## :jack_o_lantern: Problème
En regardant la [doc d'axios](https://github.com/axios/axios#request-config), je vois qu'il n'y a pas de timeout par défaut.
> // default is `0` (no timeout)

Lorsque l'API Pix fait un appel à l'API PoleEmploi:
-  si l'API PE n'est pas disponible;
-  l'API Pix attend indéfiniment (enfin, l'OS doit finir par couper la socket).

Il faut attendre un délai raisonnable,  < 1 minute, sinon :
- le routeur Scalingo coupe la connexion;
- le conteneur API, s'il a une réponse ensuite, essaye de réponder au routeur back;
- qui n'écoute plus.

Bref, on continue pour rien..

## :bat: Proposition
Ajouter un timeout à tous les appels partenaire (ici, un POST).
Il peut être configuré via une variable d'environnement `FETCH_TIMEOUT_MILLISECONDS` si on veut ajuster sans prendre de risques.

Le test devrait être effectué uniquement au niveau de `http-client`.
Là, j'ai modifié un test d'acceptance pour montrer les implications.

## :spider_web: Remarques
Ceci est une proposition, il n'y a rien de cassé en production.

## :ghost: Pour tester
Vérifier la CI
