### PR TITLE
[TECH] Renvoyer plus de détails dans les logs lors d'un appel en erreur sur PoleEmploi lors du parcours

### DIFF
--- a/api/lib/infrastructure/http/errors-helper.js
+++ b/api/lib/infrastructure/http/errors-helper.js
@@ -9,6 +9,10 @@ function serializeHttpErrorResponse(response, customMessage) {
     errorDetails = JSON.stringify(response.data);
   }
 
+  if (!customMessage) {
+    return errorDetails;
+  }
+
   const dataToLog = {
     customMessage,
     errorDetails,

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -264,7 +264,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
 
           monitoringTools.logErrorWithCorrelationIds.resolves();
 
-          const expectedLoggerMessage = `${errorData.error} ${errorData.error_description}`;
+          const expectedLoggerMessage = JSON.stringify(tokenResponse.data);
           const expectedResult = {
             code: tokenResponse.code,
             isSuccessful: tokenResponse.isSuccessful,

--- a/api/tests/unit/infrastructure/http/errors-helper_test.js
+++ b/api/tests/unit/infrastructure/http/errors-helper_test.js
@@ -109,4 +109,23 @@ describe('serializeHttpErrorResponse', function () {
       });
     });
   });
+
+  describe('When no custom message is provided', function () {
+    it('should display only formatted error', function () {
+      // given
+      const errorResponse = {
+        code: 400,
+        data: {
+          error: 'invalid_client',
+          custom_error: 'Invalid authentication method for accessing this endpoint.',
+        },
+      };
+
+      // when
+      const formattedResponse = serializeHttpErrorResponse(errorResponse);
+
+      // then
+      expect(formattedResponse).to.deep.equal(JSON.stringify(errorResponse.data));
+    });
+  });
 });


### PR DESCRIPTION
## :jack_o_lantern: Problème
Lorsque le prescrit
- démarre son parcours
- finit son parcours
- partage ses résulats

Alors on notifie PoleEmploi.

Si la notification échoue car l'appel PoleEmploi tombe en erreur, on logge l'erreur.
Or  dans les routes qui sont appelées, on appelle la même route qui est utilisé pour récupérer les access token ce qui est parfois confusant.

## :bat: Proposition
Pour faciliter le monitoring, un message contextualisant a été ajouté.

## :spider_web: Remarques

## :ghost: Pour tester
Vérifier que la CI passe
