### PR TITLE
[TECH] Ne pas tracer les réponses ne pouvant être insérées en BDD à cause d'un encodage incorrect

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -200,7 +200,6 @@ module.exports = (function () {
       isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: isFeatureEnabled(
         process.env.FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS
       ),
-      logAnswers: isFeatureEnabled(process.env.FT_LOG_ANSWERS),
     },
 
     infra: {
@@ -323,7 +322,6 @@ module.exports = (function () {
     config.features.pixCertifScoBlockedAccessDateCollege = null;
 
     config.featureToggles.isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled = false;
-    config.featureToggles.logAnswers = false;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'sendinblue';

--- a/api/lib/infrastructure/repositories/answer-repository.js
+++ b/api/lib/infrastructure/repositories/answer-repository.js
@@ -4,8 +4,6 @@ const { knex } = require('../../../db/knex-database-connection');
 const { ChallengeAlreadyAnsweredError, NotFoundError } = require('../../domain/errors');
 const Answer = require('../../domain/models/Answer');
 const answerStatusDatabaseAdapter = require('../adapters/answer-status-database-adapter');
-const config = require('../../config');
-const monitoringTools = require('../monitoring-tools');
 
 function _adaptAnswerToDb(answer) {
   return {
@@ -117,15 +115,7 @@ module.exports = {
       if (alreadySavedAnswer.length !== 0) {
         throw new ChallengeAlreadyAnsweredError();
       }
-      let result;
-      try {
-        result = await trx('answers').insert(answerForDB).returning(COLUMNS);
-      } catch (error) {
-        const errorMessage = `INSERT INTO answers failed with values ${JSON.stringify(answerForDB)}`;
-        monitoringTools.logErrorWithCorrelationIds({ message: errorMessage });
-        throw error;
-      }
-      const [savedAnswerDTO] = result;
+      const [savedAnswerDTO] = await trx('answers').insert(answerForDB).returning(COLUMNS);
       const savedAnswer = _toDomain(savedAnswerDTO);
       if (!_.isEmpty(knowledgeElements)) {
         for (const knowledgeElement of knowledgeElements) {

--- a/api/lib/infrastructure/repositories/answer-repository.js
+++ b/api/lib/infrastructure/repositories/answer-repository.js
@@ -121,10 +121,8 @@ module.exports = {
       try {
         result = await trx('answers').insert(answerForDB).returning(COLUMNS);
       } catch (error) {
-        if (config.featureToggles.logAnswers) {
-          const errorMessage = `INSERT INTO answers failed with values ${JSON.stringify(answerForDB)}`;
-          monitoringTools.logErrorWithCorrelationIds({ message: errorMessage });
-        }
+        const errorMessage = `INSERT INTO answers failed with values ${JSON.stringify(answerForDB)}`;
+        monitoringTools.logErrorWithCorrelationIds({ message: errorMessage });
         throw error;
       }
       const [savedAnswerDTO] = result;

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -24,7 +24,6 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
           attributes: {
             'is-pix-app-trainings-page-enabled': false,
             'is-clea-results-retrieval-by-habilitated-certification-centers-enabled': false,
-            'log-answers': false,
           },
         },
       };


### PR DESCRIPTION
## :jack_o_lantern: Problème
Le besoin exprimé dans https://github.com/1024pix/pix/pull/5013/ n'est plus présent

## :bat: Proposition
Supprimer la fonctionnalité
Supprimer manuellement le FT en variable d'environnement après merge

## :spider_web: Remarques
Si quelqu'un sait comment revert tous les commit de la PR en une commande, je prends !

## :ghost: Pour tester
Vérifier que la CI passe
