### PR TITLE
[TECH] Supprimer le feature toggle sur les filtres des tutoriels (PIX-5686).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -197,7 +197,6 @@ module.exports = (function () {
 
     featureToggles: {
       isPixAppTrainingsPageEnabled: isFeatureEnabled(process.env.FT_TRAININGS_PAGE),
-      isPixAppTutoFiltersEnabled: isFeatureEnabled(process.env.FT_TUTOS_V2_1_FILTERS),
       isSsoAccountReconciliationEnabled: isFeatureEnabled(process.env.FT_SSO_ACCOUNT_RECONCILIATION),
       isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: isFeatureEnabled(
         process.env.FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS
@@ -324,7 +323,6 @@ module.exports = (function () {
     config.features.pixCertifScoBlockedAccessDateLycee = null;
     config.features.pixCertifScoBlockedAccessDateCollege = null;
 
-    config.featureToggles.isPixAppTutoFiltersEnabled = false;
     config.featureToggles.isSsoAccountReconciliationEnabled = false;
     config.featureToggles.isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled = false;
     config.featureToggles.logAnswers = false;

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -23,7 +23,6 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
           type: 'feature-toggles',
           attributes: {
             'is-pix-app-trainings-page-enabled': false,
-            'is-pix-app-tuto-filters-enabled': false,
             'is-sso-account-reconciliation-enabled': false,
             'is-clea-results-retrieval-by-habilitated-certification-centers-enabled': false,
             'log-answers': false,

--- a/mon-pix/app/components/tutorials/header.hbs
+++ b/mon-pix/app/components/tutorials/header.hbs
@@ -16,7 +16,7 @@
           {{t "pages.user-tutorials.saved"}}
         </ChoiceChip>
       </li>
-      {{#if (and this.featureToggles.featureToggles.isPixAppTutoFiltersEnabled @shouldShowFilterButton)}}
+      {{#if @shouldShowFilterButton}}
         <li class="user-tutorials-banner-v2-filters__filter">
           <PixButton
             @backgroundColor="transparent-light"

--- a/mon-pix/app/models/feature-toggle.js
+++ b/mon-pix/app/models/feature-toggle.js
@@ -1,6 +1,5 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
-  @attr('boolean') isPixAppTutoFiltersEnabled;
   @attr('boolean') isSsoAccountReconciliationEnabled;
 }

--- a/mon-pix/tests/acceptance/user-tutorials/recommended_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials/recommended_test.js
@@ -13,7 +13,6 @@ describe('Acceptance | User-tutorials-v2 | Recommended', function () {
   let user;
 
   beforeEach(async function () {
-    server.create('feature-toggle', { id: 0, isPixAppTutoFiltersEnabled: true });
     user = server.create('user', 'withEmail');
     await authenticateByEmail(user);
     await server.db.tutorials.remove();

--- a/mon-pix/tests/acceptance/user-tutorials/saved_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials/saved_test.js
@@ -12,7 +12,6 @@ describe('Acceptance | User-tutorials-v2 | Saved', function () {
   let user;
 
   beforeEach(async function () {
-    server.create('feature-toggle', { id: 0, isPixAppTutoFiltersEnabled: true });
     const numberOfTutorials = 100;
     user = server.create('user', 'withEmail');
     await authenticateByEmail(user);

--- a/mon-pix/tests/integration/components/tutorials/header_test.js
+++ b/mon-pix/tests/integration/components/tutorials/header_test.js
@@ -28,13 +28,7 @@ describe('Integration | Component | Tutorials | Header', function () {
   });
 
   describe('when shouldShowFilterButton is true', function () {
-    it('should render filter button when tutorial filter feature toggle is activate', async function () {
-      // given
-      class FeatureTogglesStub extends Service {
-        featureToggles = { isPixAppTutoFiltersEnabled: true };
-      }
-      this.owner.register('service:featureToggles', FeatureTogglesStub);
-
+    it('should render filter button', async function () {
       // when
       const screen = await render(hbs`<Tutorials::Header @shouldShowFilterButton={{true}}/>`);
 
@@ -44,13 +38,7 @@ describe('Integration | Component | Tutorials | Header', function () {
   });
 
   describe('when shouldShowFilterButton is false', function () {
-    it('should render filter button when tutorial filter feature toggle is activate', async function () {
-      // given
-      class FeatureTogglesStub extends Service {
-        featureToggles = { isPixAppTutoFiltersEnabled: true };
-      }
-      this.owner.register('service:featureToggles', FeatureTogglesStub);
-
+    it('should render filter button', async function () {
       // when
       const screen = await render(hbs`<Tutorials::Header @shouldShowFilterButton={{false}}/>`);
 


### PR DESCRIPTION
## :jack_o_lantern: Problème
Les filtres sur les tutoriels sont en prod depuis plus d'un mois, mais l'affichage de ceux-ci est toujours conditionné par un FT. Il ajoute de la complexité dans le code, alors que nous souhaitons pas retirer l'affichage des filtres.

## :bat: Proposition
Supprimer le FT `FT_TUTOS_V2_1_FILTERS`

## :spider_web: Remarques
Après la MEP de ce ticket, nous pourrons supprimer la variable en recette, production.

## :ghost: Pour tester
- Se connecter sur Pix App
- Aller sur la page "Mes Tutos" `/mes-tutos`
- Vérifier le bon fonctionnement des filtres