### PR TITLE
[FEATURE] Ajouter le logo de l'éditeur sur les contenus formatifs sur Pix App (PIX-6074)

### DIFF
--- a/mon-pix/app/components/training/card.hbs
+++ b/mon-pix/app/components/training/card.hbs
@@ -11,7 +11,14 @@
         </li>
       </ul>
     </PixTag>
-    {{! template-lint-disable require-valid-alt-text }}
-    <img class="training-card-content__image" src={{this.imageSrc}} alt="" />
+    <div class="training-card-content__illustration">
+      <img
+        class="training-card-content-illustration__logo"
+        src="images/logo/logo-ministere-education-nationale-et-jeunesse.svg"
+        alt="{{t 'common.french-education-ministry'}}"
+      />
+      {{! template-lint-disable require-valid-alt-text }}
+      <img class="training-card-content-illustration__image" src={{this.imageSrc}} alt="" />
+    </div>
   </a>
 </PixBlock>

--- a/mon-pix/app/styles/components/_training-card.scss
+++ b/mon-pix/app/styles/components/_training-card.scss
@@ -36,11 +36,31 @@
   }
 }
 
-.training-card-content__image {
+.training-card-content__illustration {
   position: absolute;
-  bottom: 80px;
-  left: 0;
   height: 155px;
   width: 100%;
-  object-fit: cover;
+  bottom: 80px;
+  left: 0;
+
+  .training-card-content-illustration {
+
+    &__logo {
+      z-index: 1;
+      position: absolute;
+      left: $spacing-s;
+      width: 64px;
+      padding: $spacing-xxs;
+      background-color: $pix-neutral-0;
+      border-radius: 0 0 4px 4px;
+    }
+
+    &__image {
+      height: 155px;
+      width: 100%;
+      z-index: 0;
+      position: absolute;
+      object-fit: cover;
+    }
+  }
 }

--- a/mon-pix/tests/integration/components/training/card_test.js
+++ b/mon-pix/tests/integration/components/training/card_test.js
@@ -27,6 +27,9 @@ describe('Integration | Component | Training | Card', function () {
     expect(find('.training-card-content__infos')).to.exist;
     expect(find('.training-card-content-infos-list__type').textContent.trim()).to.equal('Webinaire');
     expect(find('.training-card-content-infos-list__duration').textContent.trim()).to.equal('6h');
-    expect(find('.training-card-content__image')).to.have.property('alt').to.be.empty;
+    expect(find('.training-card-content-illustration__image')).to.have.property('alt').to.be.empty;
+    expect(find('.training-card-content-illustration__logo'))
+      .to.have.property('alt')
+      .that.equals(this.intl.t('common.french-education-ministry'));
   });
 });


### PR DESCRIPTION
## :jack_o_lantern: Problème
On souhaite connaître l'éditeur du contenus formatifs.

## :bat: Proposition
Ajouter le logo.

## :ghost: Pour tester
- Aller sur Pix App
- Aller sur la campagne `PIXEDUINI`
- En fin de parcours constater le logo de l'éditeur sur les contenus formatifs
