### PR TITLE
[TECH] Isoler la configuration de nodemon

### DIFF
--- a/api/nodemon.json
+++ b/api/nodemon.json
@@ -1,0 +1,19 @@
+{
+  "signal": "SIGTERM",
+  "watch": [
+    "lib",
+    "index.js",
+    "server.js",
+    "worker.js",
+    "package.json",
+    "db",
+    "translations",
+    ".env"
+  ],
+  "ignore": [
+    "db/seeds",
+    "db/migrations",
+    "db/database-builder"
+  ],
+  "ext": "js"
+}

--- a/api/package.json
+++ b/api/package.json
@@ -166,25 +166,6 @@
     "test:ci": "npm run test",
     "test:lint": "npm test && npm run lint"
   },
-  "nodemonConfig": {
-    "signal": "SIGTERM",
-    "watch": [
-      "lib",
-      "index.js",
-      "server.js",
-      "worker.js",
-      "package.json",
-      "db",
-      "translations",
-      ".env"
-    ],
-    "ignore": [
-      "db/seeds",
-      "db/migrations",
-      "db/database-builder"
-    ],
-    "ext": "js"
-  },
   "optionalDependencies": {
     "nyc": "^15.1.0"
   }


### PR DESCRIPTION
## :jack_o_lantern: Problème
La configuration de nodemon est dans le `package.json` et prend de la place.
Or ce fichier est déjà très long.

## :bat: Proposition
L'extraire dans un fichier dédié.

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
Démarrer en mode watch
Modifier le fichier `.env`
Vérifier le message "restarting due to changes"