### PR TITLE
 [BUGFIX] Les badges ne sont plus affichés dans PixOrga (PIX-6050).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-report-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-report-repository.js
@@ -47,6 +47,7 @@ module.exports = {
         targetProfileId: 'target-profiles.id',
         targetProfileDescription: 'target-profiles.description',
         targetProfileName: 'target-profiles.name',
+        multipleSendings: 'campaigns.multipleSendings',
       })
       .select(
         knex.raw('ARRAY_AGG("badges"."id")  AS "badgeIds"'),
@@ -76,7 +77,7 @@ module.exports = {
       id: result.targetProfileId,
       name: result.targetProfileName,
       tubeCount: _.uniqBy(skills, 'tubeId').length,
-      thematicResults: _.uniq(result.badgeIds).filter((id) => id),
+      thematicResultCount: _.uniq(result.badgeIds).filter((id) => id).length,
       hasStage: result.stageIds.some((stage) => stage),
       description: result.targetProfileDescription,
     });

--- a/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -9,161 +9,248 @@ const { STARTED, SHARED } = CampaignParticipationStatuses;
 
 describe('Integration | Repository | Campaign-Report', function () {
   describe('#get', function () {
-    let campaign;
-    let targetProfileId;
+    context('campaign information', function () {
+      it('returns informations about campaign', async function () {
+        const creator = databaseBuilder.factory.buildUser({ firstName: 'Walter', lastName: 'White' });
+        const campaign = databaseBuilder.factory.buildCampaign({
+          archivedAt: new Date(),
+          ownerId: creator.id,
+          multipleSendings: false,
+        });
+        mockLearningContent({ skills: [] });
 
-    beforeEach(function () {
-      targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      campaign = databaseBuilder.factory.buildCampaign({ targetProfileId, archivedAt: new Date() });
+        await databaseBuilder.commit();
+        const result = await campaignReportRepository.get(campaign.id);
 
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'skill2' });
-
-      const learningContent = {
-        skills: [
-          {
-            id: 'skill1',
-          },
-          {
-            id: 'skill2',
-          },
-        ],
-      };
-
-      mockLearningContent(learningContent);
-      return databaseBuilder.commit();
-    });
-
-    it('should return a CampaignReport by its id', async function () {
-      // when
-      const result = await campaignReportRepository.get(campaign.id);
-
-      // then
-      expect(result).to.be.an.instanceof(CampaignReport);
-      expect(result).to.deep.include(
-        _.pick(campaign, [
-          'id',
-          'name',
-          'code',
-          'createdAt',
-          'archivedAt',
-          'targetProfileId',
-          'idPixLabel',
-          'title',
-          'type',
-          'customLandingPageText',
-          'creatorLastName',
-          'creatorFirstName',
-          'targetProfileId',
-          'targetProfileName',
-          'targetProfileTubesCount',
-          'targetProfileDescription',
-          'participationsCount',
-          'sharedParticipationsCount',
-          'averageResult',
-        ])
-      );
-    });
-
-    it('should only count tube in targetProfile', async function () {
-      // given
-      // when
-      const result = await campaignReportRepository.get(campaign.id);
-
-      // then
-      expect(result.targetProfileTubesCount).to.equal(1);
-    });
-
-    it('should only count participations not improved', async function () {
-      // given
-      const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId: campaign.id, isImproved: true });
-      databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId: campaign.id, isImproved: false });
-      await databaseBuilder.commit();
-
-      // when
-      const result = await campaignReportRepository.get(campaign.id);
-
-      // then
-      expect(result.participationsCount).to.equal(1);
-    });
-
-    it('should only count non-deleted participations', async function () {
-      // given
-      const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId: campaign.id, deletedAt: '2022-03-21' });
-      databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId: campaign.id, deletedAt: null });
-      await databaseBuilder.commit();
-
-      // when
-      const result = await campaignReportRepository.get(campaign.id);
-
-      // then
-      expect(result.participationsCount).to.equal(1);
-    });
-
-    it('should only count shared participations not improved', async function () {
-      // given
-      const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildCampaignParticipation({
-        userId,
-        campaignId: campaign.id,
-        sharedAt: new Date(),
-        isImproved: true,
+        expect(result).to.be.an.instanceof(CampaignReport);
+        expect(result).deep.include({
+          id: campaign.id,
+          name: campaign.name,
+          code: campaign.code,
+          title: campaign.title,
+          idPixLabel: campaign.idPixLabel,
+          createdAt: campaign.createdAt,
+          customLandingPageText: campaign.customLandingPageText,
+          archivedAt: campaign.archivedAt,
+          type: campaign.type,
+          ownerId: campaign.ownerId,
+          ownerLastName: 'White',
+          ownerFirstName: 'Walter',
+          multipleSendings: campaign.multipleSendings,
+        });
       });
-      databaseBuilder.factory.buildCampaignParticipation({
-        userId,
-        campaignId: campaign.id,
-        sharedAt: null,
-        status: STARTED,
-        isImproved: false,
-      });
-      await databaseBuilder.commit();
-
-      // when
-      const result = await campaignReportRepository.get(campaign.id);
-
-      // then
-      expect(result.sharedParticipationsCount).to.equal(0);
     });
 
-    it('should only count shared participations not deleted', async function () {
-      // given
-      databaseBuilder.factory.buildCampaignParticipation({
-        campaignId: campaign.id,
-        sharedAt: '2022-03-21',
-        status: SHARED,
-      });
-      databaseBuilder.factory.buildCampaignParticipation({
-        campaignId: campaign.id,
-        sharedAt: '2022-03-10',
-        status: SHARED,
-        deletedAt: '2022-03-21',
-      });
-      await databaseBuilder.commit();
+    context('target profile information', function () {
+      beforeEach(function () {
+        const learningContent = {
+          skills: [
+            { id: 'skill1', tubeId: 1 },
+            { id: 'skill2', tubeId: 1 },
+            { id: 'skill3', tubeId: 2 },
+            { id: 'skill4', tubeId: 3 },
+          ],
+        };
 
-      // when
-      const result = await campaignReportRepository.get(campaign.id);
-
-      // then
-      expect(result.sharedParticipationsCount).to.equal(1);
-    });
-
-    it('should not count any shared participations when participation is deleted', async function () {
-      // given
-      databaseBuilder.factory.buildCampaignParticipation({
-        campaignId: campaign.id,
-        sharedAt: '2022-03-10',
-        status: SHARED,
-        deletedAt: '2022-03-21',
+        mockLearningContent(learningContent);
+        return databaseBuilder.commit();
       });
 
-      await databaseBuilder.commit();
+      it('returns general information about target profile', async function () {
+        const targetProfile = databaseBuilder.factory.buildTargetProfile({
+          name: 'Name',
+          description: 'Description',
+        });
+        const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
 
-      // when
-      const result = await campaignReportRepository.get(campaign.id);
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill1' });
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill2' });
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill3' });
 
-      // then
-      expect(result.sharedParticipationsCount).to.equal(0);
+        await databaseBuilder.commit();
+        const result = await campaignReportRepository.get(campaign.id);
+
+        expect(result).deep.include({
+          targetProfileId: targetProfile.id,
+          targetProfileDescription: targetProfile.description,
+          targetProfileName: targetProfile.name,
+          targetProfileTubesCount: 2,
+        });
+      });
+
+      context('Thematic Result information', function () {
+        it('returns general information about thematic results', async function () {
+          const creator = databaseBuilder.factory.buildUser({ firstName: 'Walter', lastName: 'White' });
+          const targetProfile = databaseBuilder.factory.buildTargetProfile({
+            name: 'Name',
+            description: 'Description',
+          });
+          const campaign = databaseBuilder.factory.buildCampaign({
+            targetProfileId: targetProfile.id,
+            archivedAt: new Date(),
+            ownerId: creator.id,
+            multipleSendings: false,
+          });
+
+          databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill1' });
+          databaseBuilder.factory.buildBadge({ targetProfileId: targetProfile.id, key: 1 });
+          databaseBuilder.factory.buildBadge({ targetProfileId: targetProfile.id, key: 2 });
+          databaseBuilder.factory.buildBadge({ key: 3 });
+
+          await databaseBuilder.commit();
+          const result = await campaignReportRepository.get(campaign.id);
+
+          expect(result.targetProfileThematicResultCount).to.equal(2);
+        });
+      });
+
+      context('Stages information', function () {
+        context('when the target profile has stages', function () {
+          it('returns general information about stages', async function () {
+            const targetProfile = databaseBuilder.factory.buildTargetProfile();
+            const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+
+            databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill1' });
+            databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id });
+
+            await databaseBuilder.commit();
+            const result = await campaignReportRepository.get(campaign.id);
+
+            expect(result.targetProfileHasStage).to.equal(true);
+          });
+        });
+        context('when the target profile has no stages', function () {
+          it('returns general information about stages', async function () {
+            const { id: otherTargetProfilId } = databaseBuilder.factory.buildTargetProfile();
+            const campaign = databaseBuilder.factory.buildCampaign();
+
+            databaseBuilder.factory.buildTargetProfileSkill({
+              targetProfileId: campaign.targetProfileId,
+              skillId: 'skill1',
+            });
+            databaseBuilder.factory.buildStage({ targetProfileId: otherTargetProfilId });
+
+            await databaseBuilder.commit();
+            const result = await campaignReportRepository.get(campaign.id);
+
+            expect(result.targetProfileHasStage).to.equal(false);
+          });
+        });
+      });
+    });
+
+    context('participations', function () {
+      let campaign;
+      beforeEach(function () {
+        campaign = databaseBuilder.factory.buildCampaign();
+
+        databaseBuilder.factory.buildTargetProfileSkill({
+          targetProfileId: campaign.targetProfileId,
+          skillId: 'skill1',
+        });
+
+        const learningContent = { skills: [{ id: 'skill1' }] };
+
+        mockLearningContent(learningContent);
+        return databaseBuilder.commit();
+      });
+
+      it('should only count participations not improved', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId: campaign.id, isImproved: true });
+        databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId: campaign.id, isImproved: false });
+        await databaseBuilder.commit();
+
+        // when
+        const result = await campaignReportRepository.get(campaign.id);
+
+        // then
+        expect(result.participationsCount).to.equal(1);
+      });
+
+      it('should only count non-deleted participations', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCampaignParticipation({
+          userId,
+          campaignId: campaign.id,
+          deletedAt: '2022-03-21',
+        });
+        databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId: campaign.id, deletedAt: null });
+        await databaseBuilder.commit();
+
+        // when
+        const result = await campaignReportRepository.get(campaign.id);
+
+        // then
+        expect(result.participationsCount).to.equal(1);
+      });
+
+      it('should only count shared participations not improved', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCampaignParticipation({
+          userId,
+          campaignId: campaign.id,
+          sharedAt: new Date(),
+          isImproved: true,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          userId,
+          campaignId: campaign.id,
+          sharedAt: null,
+          status: STARTED,
+          isImproved: false,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const result = await campaignReportRepository.get(campaign.id);
+
+        // then
+        expect(result.sharedParticipationsCount).to.equal(0);
+      });
+
+      it('should only count shared participations not deleted', async function () {
+        // given
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          sharedAt: '2022-03-21',
+          status: SHARED,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          sharedAt: '2022-03-10',
+          status: SHARED,
+          deletedAt: '2022-03-21',
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const result = await campaignReportRepository.get(campaign.id);
+
+        // then
+        expect(result.sharedParticipationsCount).to.equal(1);
+      });
+
+      it('should not count any shared participations when participation is deleted', async function () {
+        // given
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          sharedAt: '2022-03-10',
+          status: SHARED,
+          deletedAt: '2022-03-21',
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await campaignReportRepository.get(campaign.id);
+
+        // then
+        expect(result.sharedParticipationsCount).to.equal(0);
+      });
     });
 
     it('should throw a NotFoundError if campaign can not be found', async function () {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Les badges ne sont plus affichés dans PixOrga

## :bat: Proposition
Corriger l'appel au targetProfileForSpecifier pour qu'il compte le nombre de badge du profile cible.

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
Participer à une campagne avec des badges et obtenir des badges.
Dans les résulats du participant sur PixOrga constater la présence des badges.
