### PR TITLE
[BUGFIX] Corrige le passage de parametre de script d'import (PIX-6097)

### DIFF
--- a/api/scripts/certification/import-certification-cpf-cities.js
+++ b/api/scripts/certification/import-certification-cpf-cities.js
@@ -419,7 +419,8 @@ async function main(filePath) {
 (async () => {
   if (isLaunchedFromCommandLine) {
     try {
-      await main();
+      const filePath = process.argv[2];
+      await main(filePath);
     } catch (error) {
       logger.error(error);
       process.exitCode = 1;


### PR DESCRIPTION
## :jack_o_lantern: Problème
Suite à un refacto, la fonction `main` ne prends plus en parametre le nom du fichier à importer

## :bat: Proposition
Le remettre à sa place (the place to be)

## :spider_web: Remarques
/

## :ghost: Pour tester
Lancer le script en ligne de commande 
`node import-certification-cpf-cities ./data.csv`
