### PR TITLE
[TASK] Api : Création d'un script de migration pour l'ajout des informations des DPOs pour des organisations (PIX-4468)

### DIFF
--- a/api/lib/domain/usecases/update-organization-data-protection-officer-information.js
+++ b/api/lib/domain/usecases/update-organization-data-protection-officer-information.js
@@ -1,0 +1,10 @@
+module.exports = async function ({ dataProtectionOfficer, dataProtectionOfficerRepository }) {
+  const { organizationId } = dataProtectionOfficer;
+  const dataProtectionOfficerToUpdate = await dataProtectionOfficerRepository.get({ organizationId });
+
+  if (!dataProtectionOfficerToUpdate) {
+    return dataProtectionOfficerRepository.create(dataProtectionOfficer);
+  }
+
+  return dataProtectionOfficerRepository.update(dataProtectionOfficer);
+};

--- a/api/scripts/add-or-update-organizations-dpo-infos.js
+++ b/api/scripts/add-or-update-organizations-dpo-infos.js
@@ -1,0 +1,93 @@
+require('dotenv').config();
+
+const _ = require('lodash');
+const bluebird = require('bluebird');
+const { checkCsvHeader, parseCsvWithHeader } = require('./helpers/csvHelpers');
+const { disconnect } = require('../db/knex-database-connection');
+const updateOrganizationDataProtectionOfficerInformation = require('../lib/domain/usecases/update-organization-data-protection-officer-information');
+const dataProtectionOfficerRepository = require('../lib/infrastructure/repositories/data-protection-officer-repository');
+
+const IS_LAUNCHED_FROM_CLI = require.main === module;
+const REQUIRED_FIELD_NAMES = ['organizationId', 'firstName', 'lastName', 'email'];
+
+const parsingOptions = {
+  skipEmptyLines: true,
+  header: true,
+  transform: (value, columnName) => {
+    if (typeof value === 'string') {
+      value = value.trim();
+    }
+    if (!_.isEmpty(value)) {
+      if (columnName === 'organizationId') {
+        value = Number(value);
+      }
+      if (columnName === 'email') {
+        value = value.replaceAll(' ', '').toLowerCase();
+      }
+    } else {
+      value = null;
+    }
+
+    return value;
+  },
+};
+
+async function _updateOrganizationsDataProtectionOfficerInformation(filePath) {
+  const errors = [];
+
+  await checkCsvHeader({
+    filePath,
+    requiredFieldNames: REQUIRED_FIELD_NAMES,
+  });
+
+  console.log('Reading and parsing csv data file... ');
+
+  const dataProtectionOfficers = await parseCsvWithHeader(filePath, parsingOptions);
+
+  await bluebird.mapSeries(dataProtectionOfficers, async (dataProtectionOfficer) => {
+    try {
+      await updateOrganizationDataProtectionOfficerInformation({
+        dataProtectionOfficer,
+        dataProtectionOfficerRepository,
+      });
+    } catch (error) {
+      errors.push({ dataProtectionOfficer, error });
+    }
+  });
+
+  if (errors.length === 0) {
+    return;
+  }
+
+  console.log(`Errors occurs on ${errors.length} element!`);
+  errors.forEach((error) => {
+    console.log(JSON.stringify(error.dataProtectionOfficer));
+    console.error(error.error?.message);
+  });
+
+  throw new Error('Process done with errors');
+}
+
+async function main() {
+  console.log('Starting updating organizations data protection officer information.');
+  console.time('Organizations DPO updated');
+
+  const filePath = process.argv[2];
+  await _updateOrganizationsDataProtectionOfficerInformation(filePath);
+
+  console.timeEnd('Organizations DPO updated');
+}
+
+(async function () {
+  if (IS_LAUNCHED_FROM_CLI) {
+    try {
+      await main();
+      console.log('\nOrganizations DPO information updated with success!');
+    } catch (error) {
+      console.error(error?.message);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();

--- a/api/tests/integration/domain/usecases/update-organization-data-protection-officer-information_test.js
+++ b/api/tests/integration/domain/usecases/update-organization-data-protection-officer-information_test.js
@@ -1,0 +1,70 @@
+const { knex, expect, databaseBuilder } = require('../../../test-helper');
+const DataProtectionOfficer = require('../../../../lib/domain/models/DataProtectionOfficer');
+const updateOrganizationDataProtectionOfficerInformation = require('../../../../lib/domain/usecases/update-organization-data-protection-officer-information');
+const dataProtectionOfficerRepository = require('../../../../lib/infrastructure/repositories/data-protection-officer-repository');
+
+describe('Integration | UseCases | update-organization-data-protection-officer-information', function () {
+  afterEach(async function () {
+    await knex('data-protection-officers').delete();
+  });
+
+  it('should add data protection officer information for an organization', async function () {
+    // given
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+    await databaseBuilder.commit();
+
+    const dataProtectionOfficer = {
+      firstName: 'Justin',
+      lastName: 'Ptipeu',
+      email: 'justin.ptipeu@example.net',
+      organizationId,
+    };
+
+    // when
+    const updatedDataProtectionOfficer = await updateOrganizationDataProtectionOfficerInformation({
+      dataProtectionOfficer,
+      dataProtectionOfficerRepository,
+    });
+
+    // then
+    expect(updatedDataProtectionOfficer).to.be.an.instanceOf(DataProtectionOfficer);
+    expect(updatedDataProtectionOfficer.id).to.be.a('number');
+    expect(updatedDataProtectionOfficer.firstName).to.equal('Justin');
+    expect(updatedDataProtectionOfficer.lastName).to.equal('Ptipeu');
+    expect(updatedDataProtectionOfficer.email).to.equal('justin.ptipeu@example.net');
+    expect(updatedDataProtectionOfficer.organizationId).to.equal(organizationId);
+    expect(updatedDataProtectionOfficer.certificationCenterId).to.be.null;
+  });
+
+  it('should update organization data protection officer information', async function () {
+    // given
+    const organizationId = databaseBuilder.factory.buildOrganization().id;
+    const dataProtectionOfficerToUpdate = databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId({
+      email: 'test@example.net',
+      organizationId,
+    });
+    await databaseBuilder.commit();
+
+    const dataProtectionOfficer = {
+      firstName: 'Justin',
+      lastName: 'Ptipeu',
+      email: 'justin.ptipeu@example.net',
+      organizationId,
+    };
+
+    // when
+    const updatedDataProtectionOfficer = await updateOrganizationDataProtectionOfficerInformation({
+      dataProtectionOfficer,
+      dataProtectionOfficerRepository,
+    });
+
+    // then
+    expect(updatedDataProtectionOfficer).to.be.an.instanceOf(DataProtectionOfficer);
+    expect(updatedDataProtectionOfficer.id).to.be.a('number').and.to.equal(dataProtectionOfficerToUpdate.id);
+    expect(updatedDataProtectionOfficer.firstName).to.equal('Justin');
+    expect(updatedDataProtectionOfficer.lastName).to.equal('Ptipeu');
+    expect(updatedDataProtectionOfficer.email).to.equal('justin.ptipeu@example.net');
+    expect(updatedDataProtectionOfficer.organizationId).to.equal(organizationId);
+    expect(updatedDataProtectionOfficer.certificationCenterId).to.be.null;
+  });
+});


### PR DESCRIPTION
## :jack_o_lantern: Problème

Actuellement le seul moyen d'éditer les informations d'un data protection officer (DPO) d'une organisation est de passer par la page de détails de cette organisation sur Pix Admin.

Il existe un grand nombre d'organisations présentes en base de données et faire cette action sur Pix Admin pour chacune des organisations serait coûteux.

## :bat: Proposition

Créer un script pour éditer les informations des Data Protection Officers (DPO - ou Délégué à la protection des données) pour toutes les organisations qui seront présentes dans le fichier CSV.

## :spider_web: Remarques

RAS

## :ghost: Pour tester

- Se créer un fichier CSV avec des données d'exemples
```
organizationId;firstName;lastName;email
1;Justin;Ptipeu;justin.ptipeu@example.net
2;Tudy;Nainportekoi;
3;;Rouana;MAry.ROUana@example.net
4;;;yvan.Dubois@example.net
5;Kline;;
6;;Coptère;
```
- Exécutez le nouveau script `add-or-update-organizations-dpo-infos.js` avec en paramètre le chemin de votre fichier CSV
- Constatez que le script s'exécute sans erreur
- Exécutez plusieurs fois le script avec le même fichier
- Constatez que le script s'exécute sans erreur