### PR TITLE
[TASK] Api : Création d'un script de migration pour l'ajout des informations des DPOs pour des centres de certifications (PIX-5265)

### DIFF
--- a/api/lib/domain/usecases/update-certification-center-data-protection-officer-information.js
+++ b/api/lib/domain/usecases/update-certification-center-data-protection-officer-information.js
@@ -1,0 +1,13 @@
+module.exports = async function updateCertificationCenterDataProtectionOfficerInformation({
+  dataProtectionOfficer,
+  dataProtectionOfficerRepository,
+}) {
+  const { certificationCenterId } = dataProtectionOfficer;
+  const dataProtectionOfficerToUpdate = await dataProtectionOfficerRepository.get({ certificationCenterId });
+
+  if (!dataProtectionOfficerToUpdate) {
+    return dataProtectionOfficerRepository.create(dataProtectionOfficer);
+  }
+
+  return dataProtectionOfficerRepository.update(dataProtectionOfficer);
+};

--- a/api/scripts/add-or-update-certification-centers-dpo-infos.js
+++ b/api/scripts/add-or-update-certification-centers-dpo-infos.js
@@ -1,0 +1,93 @@
+require('dotenv').config();
+
+const _ = require('lodash');
+const bluebird = require('bluebird');
+const { checkCsvHeader, parseCsvWithHeader } = require('./helpers/csvHelpers');
+const { disconnect } = require('../db/knex-database-connection');
+const updateCertificationCenterDataProtectionOfficerInformation = require('../lib/domain/usecases/update-certification-center-data-protection-officer-information');
+const dataProtectionOfficerRepository = require('../lib/infrastructure/repositories/data-protection-officer-repository');
+
+const IS_LAUNCHED_FROM_CLI = require.main === module;
+const REQUIRED_FIELD_NAMES = ['certificationCenterId', 'firstName', 'lastName', 'email'];
+
+const parsingOptions = {
+  skipEmptyLines: true,
+  header: true,
+  transform: (value, columnName) => {
+    if (typeof value === 'string') {
+      value = value.trim();
+    }
+    if (!_.isEmpty(value)) {
+      if (columnName === 'certificationCenterId') {
+        value = Number(value);
+      }
+      if (columnName === 'email') {
+        value = value.replaceAll(' ', '').toLowerCase();
+      }
+    } else {
+      value = null;
+    }
+
+    return value;
+  },
+};
+
+async function _updateCertificationCentersDataProtectionOfficerInformation(filePath) {
+  const errors = [];
+
+  await checkCsvHeader({
+    filePath,
+    requiredFieldNames: REQUIRED_FIELD_NAMES,
+  });
+
+  console.log('Reading and parsing csv data file... ');
+
+  const dataProtectionOfficers = await parseCsvWithHeader(filePath, parsingOptions);
+
+  await bluebird.mapSeries(dataProtectionOfficers, async (dataProtectionOfficer) => {
+    try {
+      await updateCertificationCenterDataProtectionOfficerInformation({
+        dataProtectionOfficer,
+        dataProtectionOfficerRepository,
+      });
+    } catch (error) {
+      errors.push({ dataProtectionOfficer, error });
+    }
+  });
+
+  if (errors.length === 0) {
+    return;
+  }
+
+  console.log(`Errors occurs on ${errors.length} element!`);
+  errors.forEach((error) => {
+    console.log(JSON.stringify(error.dataProtectionOfficer));
+    console.error(error.error?.message);
+  });
+
+  throw new Error('Process done with errors');
+}
+
+async function main() {
+  console.log('Starting updating certification centers data protection officer information.');
+  console.time('Certification centers DPO updated');
+
+  const filePath = process.argv[2];
+  await _updateCertificationCentersDataProtectionOfficerInformation(filePath);
+
+  console.timeEnd('Certification centers DPO updated');
+}
+
+(async function () {
+  if (IS_LAUNCHED_FROM_CLI) {
+    try {
+      await main();
+      console.log('\nCertification centers DPO information updated with success!');
+    } catch (error) {
+      console.error(error?.message);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();

--- a/api/tests/integration/domain/usecases/update-certification-center-data-protection-officer-information_test.js
+++ b/api/tests/integration/domain/usecases/update-certification-center-data-protection-officer-information_test.js
@@ -1,0 +1,70 @@
+const { knex, expect, databaseBuilder } = require('../../../test-helper');
+const DataProtectionOfficer = require('../../../../lib/domain/models/DataProtectionOfficer');
+const updateCertificationCenterDataProtectionOfficerInformation = require('../../../../lib/domain/usecases/update-certification-center-data-protection-officer-information');
+const dataProtectionOfficerRepository = require('../../../../lib/infrastructure/repositories/data-protection-officer-repository');
+
+describe('Integration | UseCases | update-certification-center-data-protection-officer-information', function () {
+  afterEach(async function () {
+    await knex('data-protection-officers').delete();
+  });
+
+  it('should add data protection officer information for a certification center', async function () {
+    // given
+    const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+    await databaseBuilder.commit();
+
+    const dataProtectionOfficer = {
+      firstName: 'Justin',
+      lastName: 'Ptipeu',
+      email: 'justin.ptipeu@example.net',
+      certificationCenterId,
+    };
+
+    // when
+    const updatedDataProtectionOfficer = await updateCertificationCenterDataProtectionOfficerInformation({
+      dataProtectionOfficer,
+      dataProtectionOfficerRepository,
+    });
+
+    // then
+    expect(updatedDataProtectionOfficer).to.be.an.instanceOf(DataProtectionOfficer);
+    expect(updatedDataProtectionOfficer.id).to.be.a('number');
+    expect(updatedDataProtectionOfficer.firstName).to.equal('Justin');
+    expect(updatedDataProtectionOfficer.lastName).to.equal('Ptipeu');
+    expect(updatedDataProtectionOfficer.email).to.equal('justin.ptipeu@example.net');
+    expect(updatedDataProtectionOfficer.certificationCenterId).to.equal(certificationCenterId);
+    expect(updatedDataProtectionOfficer.organizationId).to.be.null;
+  });
+
+  it('should update certification center data protection officer information', async function () {
+    // given
+    const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+    const dataProtectionOfficerToUpdate = databaseBuilder.factory.buildDataProtectionOfficer.withCertificationCenterId({
+      email: 'test@example.net',
+      certificationCenterId,
+    });
+    await databaseBuilder.commit();
+
+    const dataProtectionOfficer = {
+      firstName: 'Justin',
+      lastName: 'Ptipeu',
+      email: 'justin.ptipeu@example.net',
+      certificationCenterId,
+    };
+
+    // when
+    const updatedDataProtectionOfficer = await updateCertificationCenterDataProtectionOfficerInformation({
+      dataProtectionOfficer,
+      dataProtectionOfficerRepository,
+    });
+
+    // then
+    expect(updatedDataProtectionOfficer).to.be.an.instanceOf(DataProtectionOfficer);
+    expect(updatedDataProtectionOfficer.id).to.be.a('number').and.to.equal(dataProtectionOfficerToUpdate.id);
+    expect(updatedDataProtectionOfficer.firstName).to.equal('Justin');
+    expect(updatedDataProtectionOfficer.lastName).to.equal('Ptipeu');
+    expect(updatedDataProtectionOfficer.email).to.equal('justin.ptipeu@example.net');
+    expect(updatedDataProtectionOfficer.certificationCenterId).to.equal(certificationCenterId);
+    expect(updatedDataProtectionOfficer.organizationId).to.be.null;
+  });
+});


### PR DESCRIPTION
## :jack_o_lantern: Problème

Actuellement le seul moyen d'éditer les informations d'un data protection officer (DPO) d'un centre de certification est de passer par la page de détails de ce centre sur Pix Admin.

Il existe un grand nombre de centres de certifications présents en base de données et faire cette action sur Pix Admin pour chacun des centres serait coûteux.

## :bat: Proposition

Créer un script pour éditer les informations des Data Protection Officers (DPO - ou Délégué à la protection des données) pour tous les centres de certifications qui seront présents dans le fichier CSV.

## :spider_web: Remarques

RAS

## :ghost: Pour tester

- Se créer un fichier CSV avec des données d'exemples
```
certificationCenterId;firstName;lastName;email
1;Justin;Ptipeu;justin.ptipeu@example.net
2;Tudy;Nainportekoi;
3;;Rouana;MAry.ROUana@example.net
4;;;yvan.Dubois@example.net
5;Kline;;
6;;Coptère;
```
- Exécutez le nouveau script `add-or-update-certification-centers-dpo-infos.js` avec en paramètre le chemin de votre fichier CSV
- Constatez que le script s'exécute sans erreur
- Exécutez plusieurs fois le script avec le même fichier
- Constatez que le script d'exécute sans erreur