### PR TITLE
[BUGFIX] Le bouton d'affichage de l'alternative textuelle ne garde pas le focus (PIX-2649).

### DIFF
--- a/mon-pix/app/components/challenge-statement.hbs
+++ b/mon-pix/app/components/challenge-statement.hbs
@@ -113,18 +113,18 @@
 
   {{#if @challenge.alternativeInstruction}}
     <div class="challenge-statement__alternative-instruction">
-      {{#if this.displayAlternativeInstruction}}
-        <PixButton @triggerAction={{this.toggleAlternativeInstruction}}>
+      <PixButton @triggerAction={{this.toggleAlternativeInstruction}}>
+        {{#if this.displayAlternativeInstruction}}
           {{t "pages.challenge.statement.alternative-instruction.actions.hide"}}
-        </PixButton>
+        {{else}}
+          {{t "pages.challenge.statement.alternative-instruction.actions.display"}}
+        {{/if}}
+      </PixButton>
+      {{#if this.displayAlternativeInstruction}}
         <MarkdownToHtml
           class="challenge-statement__alternative-instruction-text"
           @markdown={{@challenge.alternativeInstruction}}
         />
-      {{else}}
-        <PixButton @triggerAction={{this.toggleAlternativeInstruction}}>
-          {{t "pages.challenge.statement.alternative-instruction.actions.display"}}
-        </PixButton>
       {{/if}}
     </div>
   {{/if}}


### PR DESCRIPTION
## :jack_o_lantern: Problème
Actuellement, sur Pix App, lorsque l'utilisateur clique sur le bouton "Afficher l'alternative textuelle", ce dernier ne garde pas le focus, pour pouvoir ensuite rapidement cacher l'alternative. Cela perturbe donc la navigation des personnes au clavier.

## :bat: Proposition
Il y a en réalité 2 boutons pour gérer les états : affiché ou non, on ne peut donc pas garder le focus sur l'un comme il est retiré du dom ensuite. 

Nous conservons du coup un unique bouton, mais nous modifions le texte de celui-ci en fonction de l'action qu'il fait, ce qui permet de garder le focus sur ce dernier. 

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
- Passer une épreuve proposant une alternative textuelle comme : [`rec2PY2kIMZxgyyjd`](https://app-pr5108.review.pix.fr/challenges/rec2PY2kIMZxgyyjd/preview)
- Naviguer au clavier jusqu'au bouton "Afficher l'alternative textuelle"
- Appuyer sur la touche "Entrer"
- Constater que le focus est toujours sur le bouton et que le texte a changé