### PR TITLE
[TECH] Supprimer la rétrocompatibilité des tutoriels (PIX-6101).

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/tutorial-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/tutorial-serializer.js
@@ -5,12 +5,6 @@ const userSavedTutorialAttributes = require('./user-saved-tutorial-attributes');
 module.exports = {
   serialize(tutorial = {}, pagination) {
     return new Serializer('tutorials', {
-      transform(tutorial) {
-        return {
-          ...tutorial,
-          userTutorial: tutorial.userSavedTutorial,
-        };
-      },
       attributes: [
         'duration',
         'format',
@@ -22,15 +16,12 @@ module.exports = {
         'tubePracticalDescription',
         'tutorialEvaluation',
         'userSavedTutorial',
-        'userTutorial',
         'skillId',
       ],
       tutorialEvaluation: tutorialEvaluationAttributes,
       userSavedTutorial: userSavedTutorialAttributes,
-      userTutorial: userSavedTutorialAttributes,
       typeForAttribute(attribute) {
         if (attribute === 'userSavedTutorial') return 'user-saved-tutorial';
-        if (attribute === 'userTutorial') return 'user-tutorial';
         return attribute;
       },
       meta: pagination,

--- a/api/tests/acceptance/application/scorecard-controller_test.js
+++ b/api/tests/acceptance/application/scorecard-controller_test.js
@@ -304,12 +304,6 @@ describe('Acceptance | Controller | scorecard-controller', function () {
                     type: 'user-saved-tutorial',
                   },
                 },
-                'user-tutorial': {
-                  data: {
-                    id: '10500',
-                    type: 'user-tutorial',
-                  },
-                },
               },
             },
             {
@@ -333,9 +327,6 @@ describe('Acceptance | Controller | scorecard-controller', function () {
                 'user-saved-tutorial': {
                   data: null,
                 },
-                'user-tutorial': {
-                  data: null,
-                },
               },
             },
           ],
@@ -348,15 +339,6 @@ describe('Acceptance | Controller | scorecard-controller', function () {
               },
               id: '10500',
               type: 'user-saved-tutorial',
-            },
-            {
-              attributes: {
-                id: 10500,
-                'tutorial-id': 'recTutorial1',
-                'user-id': 42,
-              },
-              id: '10500',
-              type: 'user-tutorial',
             },
           ],
         };

--- a/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
+++ b/api/tests/acceptance/application/tutorials/user-tutorials-controller_test.js
@@ -359,12 +359,6 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
                   type: 'user-saved-tutorial',
                 },
               },
-              'user-tutorial': {
-                data: {
-                  id: `${userSavedTutorialId}`,
-                  type: 'user-tutorial',
-                },
-              },
             },
             type: 'tutorials',
           },
@@ -385,9 +379,6 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
               'user-saved-tutorial': {
                 data: null,
               },
-              'user-tutorial': {
-                data: null,
-              },
             },
             type: 'tutorials',
           },
@@ -406,9 +397,6 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
                 data: null,
               },
               'user-saved-tutorial': {
-                data: null,
-              },
-              'user-tutorial': {
                 data: null,
               },
             },
@@ -478,9 +466,6 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
               'user-saved-tutorial': {
                 data: null,
               },
-              'user-tutorial': {
-                data: null,
-              },
             },
             type: 'tutorials',
           },
@@ -499,9 +484,6 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
                 data: null,
               },
               'user-saved-tutorial': {
-                data: null,
-              },
-              'user-tutorial': {
                 data: null,
               },
             },
@@ -695,7 +677,6 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
             },
             relationships: {
               'user-saved-tutorial': { data: { id: '101', type: 'user-saved-tutorial' } },
-              'user-tutorial': { data: { id: '101', type: 'user-tutorial' } },
               'tutorial-evaluation': {
                 data: null,
               },
@@ -770,12 +751,6 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
                   type: 'user-saved-tutorial',
                 },
               },
-              'user-tutorial': {
-                data: {
-                  id: '103',
-                  type: 'user-tutorial',
-                },
-              },
             },
             type: 'tutorials',
           },
@@ -797,12 +772,6 @@ describe('Acceptance | Controller | user-tutorial-controller', function () {
                 data: {
                   id: '102',
                   type: 'user-saved-tutorial',
-                },
-              },
-              'user-tutorial': {
-                data: {
-                  id: '102',
-                  type: 'user-tutorial',
                 },
               },
             },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/tutorial-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/tutorial-serializer_test.js
@@ -34,9 +34,6 @@ describe('Unit | Serializer | JSONAPI | tutorial-serializer', function () {
             'user-saved-tutorial': {
               data: null,
             },
-            'user-tutorial': {
-              data: null,
-            },
           },
         },
       };
@@ -74,11 +71,6 @@ describe('Unit | Serializer | JSONAPI | tutorial-serializer', function () {
             'tube-name': '@web',
             'tube-practical-description': 'Tube Practical Description',
             'tube-practical-title': 'Tube Practical Title',
-          },
-          relationships: {
-            'user-tutorial': {
-              data: null,
-            },
           },
         },
       };
@@ -130,12 +122,6 @@ describe('Unit | Serializer | JSONAPI | tutorial-serializer', function () {
                 type: 'user-saved-tutorial',
               },
             },
-            'user-tutorial': {
-              data: {
-                id: userSavedTutorialId,
-                type: 'user-tutorial',
-              },
-            },
           },
         },
         included: [
@@ -156,15 +142,6 @@ describe('Unit | Serializer | JSONAPI | tutorial-serializer', function () {
             },
             id: userSavedTutorialId,
             type: 'user-saved-tutorial',
-          },
-          {
-            attributes: {
-              id: userSavedTutorialId,
-              'user-id': userId,
-              'tutorial-id': tutorialId,
-            },
-            id: userSavedTutorialId,
-            type: 'user-tutorial',
           },
         ],
       };
@@ -203,11 +180,6 @@ describe('Unit | Serializer | JSONAPI | tutorial-serializer', function () {
               link: 'https://youtube.fr',
               source: 'Youtube',
               title: 'Savoir regarder des vidéos youtube.',
-            },
-            relationships: {
-              'user-tutorial': {
-                data: null,
-              },
             },
           },
         ],


### PR DESCRIPTION
## :jack_o_lantern: Problème
Nous avons renommer les tutoriels enregistrés par un utilisateur de `user-tutorial` à `user-saved-tutorial`.
Pour assurer la rétrocompatibilité, nous avons laissé les 2 champs dans le serializer. Seulement, il n'est plus nécessaire d'assurer l'ancien nommage, car la nouvelle version est en prod depuis quelques mois. 

## :bat: Proposition
Supprimer la rétrocompatibilité du serializer. 

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
- Se connecter sur Pix App
- Aller sur la page `/mes-tutos` constater que les tutos remontent bien
- Aller sur le détail du compétences et constater aussi
- Enregistrer des tutos
- Vérifier qu'ils remontent dans la page `/mes-tutos/enregistres` 