### PR TITLE
[TECH] Corriger le path de l'url du logo des éditeurs du contenu formatifs (PIX-6108).

### DIFF
--- a/mon-pix/app/components/training/card.hbs
+++ b/mon-pix/app/components/training/card.hbs
@@ -14,7 +14,7 @@
     <div class="training-card-content__illustration">
       <img
         class="training-card-content-illustration__logo"
-        src="images/logo/logo-ministere-education-nationale-et-jeunesse.svg"
+        src="/images/logo/logo-ministere-education-nationale-et-jeunesse.svg"
         alt="{{t 'common.french-education-ministry'}}"
       />
       {{! template-lint-disable require-valid-alt-text }}


### PR DESCRIPTION
## :jack_o_lantern: Problème
Actuellement, sur Pix App le logo de l'éditeur des contenus formatifs ne fonctionne pas.

## :bat: Proposition
Corriger le path du logo

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
- Se connecter sur Pix App
- Passer la campagne `PIXEDUINI`
- En fin de campagne constater que le logo est bien affiché