### PR TITLE
[BUGFIX] Réparer l'affichage des QROC (PIX-6113).

### DIFF
--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -18,7 +18,6 @@
   }
 
   label {
-    flex-shrink: 0;
     font-weight: $font-normal;
   }
 
@@ -110,6 +109,7 @@ form .challenge-response {
     display: flex;
     align-items: center;
     gap: $spacing-xs;
+    flex-wrap: wrap;
 
     .qroc_input-label {
       display: inline;


### PR DESCRIPTION
## :jack_o_lantern: Problème
L'affichage des QROC n'est pas optimal : 
![image](https://user-images.githubusercontent.com/26384707/197215895-dbf66f34-a93d-48f3-a0ac-5067d0209589.png)


## :bat: Proposition
- Corriger l'affichage

## :spider_web: Remarques

## :ghost: Pour tester
- Se connecter sur Pix App
- Tester tous les types d'épreuves et les cas à la marge (question longue, réponse longue)  
- [L'épreuve en exemple](https://app-pr5111.review.pix.fr/challenges/challengeRiFx6fh2fFCPa/preview)