### PR TITLE
[FEATURE] Améliorer le reponsive de l'infobulle sur Pix App (PIX-5611)

### DIFF
--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -61,6 +61,18 @@
     display: flex;
     justify-content: space-around;
     align-items: center;
+
+    .pix-tooltip__content {
+      max-width: 19rem;
+
+      @include device-is('tablet') {
+        max-width: 40rem;
+      }
+
+      @include device-is('desktop') {
+        max-width: 19rem;
+      }
+    }
   }
 }
 

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^20.1.0",
+        "@1024pix/pix-ui": "^20.2.1",
         "@ember/jquery": "^2.0.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^2.0.4",
@@ -456,9 +456,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "20.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.1.0.tgz",
-      "integrity": "sha512-aI0yxiGU0gIxZykqcJU5UT3ShFuyJXViaV1RHybmNAjy1vcN4WLUGl7RccTfJESRtUS40SQBobvU3sYcEBdk/g==",
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.2.1.tgz",
+      "integrity": "sha512-esl2SzuAHlPl1rXdjGxdCKVMTTpWdBDntSlsmCyOOiPkrOpvc393cNiEqMWe2JiDYu709OR57AGhuVJ27BA/Cw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -37977,9 +37977,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "20.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.1.0.tgz",
-      "integrity": "sha512-aI0yxiGU0gIxZykqcJU5UT3ShFuyJXViaV1RHybmNAjy1vcN4WLUGl7RccTfJESRtUS40SQBobvU3sYcEBdk/g==",
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.2.1.tgz",
+      "integrity": "sha512-esl2SzuAHlPl1rXdjGxdCKVMTTpWdBDntSlsmCyOOiPkrOpvc393cNiEqMWe2JiDYu709OR57AGhuVJ27BA/Cw==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^20.1.0",
+    "@1024pix/pix-ui": "^20.2.1",
     "@ember/jquery": "^2.0.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.4",


### PR DESCRIPTION
## :jack_o_lantern: Problème
L'infobulle dépassait lors du zoom. 

## :bat: Proposition
Ajouter une `max-width`.

## :spider_web: Remarques
On est passé à la version 20.2.1 de Pix-ui qui permettait de gérer l'échappement de la tooltip.

## :ghost: Pour tester
Tester le responsive avec le zoom et différents viewport.
