### PR TITLE
[FEATURE] Réduire le texte du bouton retour à l'écran précédent sur les pages sessions (PIX-5785)

### DIFF
--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -3,6 +3,11 @@
   flex-direction: column;
   flex-grow: 1;
   width: 100%;
+
+  &__return-to {
+    font-weight: 400;
+    font-size: 0.875rem;
+  }
 }
 
 .session-details__header {

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -1,6 +1,6 @@
 {{page-title this.pageTitle replace=true}}
 <div class="session-details-page">
-  <PixReturnTo @route="authenticated.sessions.list">
+  <PixReturnTo @route="authenticated.sessions.list" class="session-details-page__return-to">
     Retour à la liste des sessions
   </PixReturnTo>
   <div class="page__title session-details__header">


### PR DESCRIPTION
## :jack_o_lantern: Problème
Le texte “Revenir à la liste des sessions” est trop gras et surcharge cognitivement la page et a un impact sur la hiérarchie du contenu.

## :bat: Proposition
Changer la weight de la font pour 400 (regular) et passer le texte en 14px (0.875rem).

## :ghost: Pour tester
- Se connecter à Pix Certif
- Créer une session
- Aller sur le detail de cette session
- Observer la nouvelle taille du texte "Revenir à la liste des sessions"
<img width="312" alt="Capture d’écran 2022-10-21 à 18 05 56" src="https://user-images.githubusercontent.com/103997660/197240310-35b37cb7-f4cc-46e6-ab2d-15857d7dc200.png">
<img width="312" alt="Capture d’écran 2022-10-21 à 18 02 34" src="https://user-images.githubusercontent.com/103997660/197240206-1b441bb3-c3fc-42c8-8da6-32675ad18fa0.png">

*Et voilà*