### PR TITLE
[FEATURE] Améliorer le design de la page double mire SSO (PIX-6075)

### DIFF
--- a/mon-pix/app/components/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.hbs
@@ -2,8 +2,8 @@
 <div class="login-or-register-oidc-form__container">
   <div class="login-or-register-oidc-form__register-container">
     <h2 class="login-or-register-oidc-form__subtitle">{{t "pages.login-or-register-oidc.register-form.title"}}</h2>
-    <div class="login-or-register-oidc-form__description">
-      <p>
+    <div>
+      <p class="login-or-register-oidc-form__description">
         {{! template-lint-disable "no-bare-strings" }}
         {{t "pages.login-or-register-oidc.register-form.description"}}
         <em>{{this.identityProviderOrganizationName}}</em>&nbsp;:

--- a/mon-pix/app/styles/components/authentication/_login-or-register-oidc.scss
+++ b/mon-pix/app/styles/components/authentication/_login-or-register-oidc.scss
@@ -6,7 +6,7 @@
   flex-direction: column;
 
   @include device-is('desktop') {
-    padding: 50px 100px;
+    padding: 50px 50px;
   }
 
   &__logo {
@@ -28,13 +28,13 @@
     @include device-is('desktop') {
       padding: 32px 0 48px 0;
       font-size: 46px;
-      line-height: 60px;
+      line-height: 3.75rem;
     }
   }
 
   &__container {
     display: flex;
-    min-height: 500px;
+    min-height: 450px;
     flex-direction: column;
     align-items: center;
 
@@ -50,7 +50,7 @@
     font-family: $font-open-sans;
     font-weight: 500;
     font-size: 22px;
-    line-height: 40px;
+    line-height: 2.5rem;
     padding-bottom: 24px;
 
     @include device-is('desktop') {
@@ -60,9 +60,10 @@
 
   &__description {
     color: $pix-neutral-60;
-    font-family: $font-open-sans;
-    font-weight: 600;
     font-size: 16px;
+    font-family: $font-roboto;
+    font-weight: 500;
+    line-height: 1.375rem;
     padding-bottom: 24px;
     margin: 0;
   }
@@ -76,13 +77,15 @@
 
   &__information {
     color: $pix-neutral-60;
-    font-family: $font-open-sans;
-    font-weight: 600;
+    font-family: $font-roboto;
+    font-weight: 500;
+    line-height: 1.375rem;
     font-size: 16px;
     margin-bottom: 2rem;
 
     ul {
       padding-left: 1rem;
+      margin: 0;
     }
 
     li {
@@ -99,13 +102,13 @@
 
   &__register-container {
     @include device-is('desktop') {
-      padding-right: 20px;
+      padding-right: 30px;
     }
   }
 
   &__login-container {
     @include device-is('desktop') {
-      padding-left: 20px;
+      padding-left: 30px;
     }
   }
 
@@ -129,7 +132,6 @@
 
   &__cgu-label {
     margin-bottom: 0;
-    padding: 3px 0 0 15px;
     font-size: 14px;
   }
 
@@ -138,7 +140,7 @@
   }
 
   &__mandatory-description {
-    padding: 10px 0 10px 0;
+    padding-bottom: 10px;
     text-align: center;
     font-size: 14px;
     color: $pix-neutral-70;

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -820,8 +820,8 @@
       "title": "Join",
       "button": "Let's go!",
       "rgpd-legal-notice": "To know how your personnal data is processed, and what your rights are, you can read",
-      "rgpd-legal-notice-link": "TODO",
-      "rgpd-legal-notice-url": "TODO",
+      "rgpd-legal-notice-link": "Mentions d'information.",
+      "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
       "fields": {
         "birthdate": {
           "day-error": "Your birth day is in an invalid format.",
@@ -949,8 +949,8 @@
         "legal-text": "The information collected in this form is saved in a computer file by Pix to enable access to the service offered by Pix. They are kept for the duration of use of the service and are intended for Pix. Test results may be communicated to third parties, with your consent, if you have been invited to take a specific customised test. In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), you can exercise the right to access and rectify your data by emailing our Data Protection Officer at dpo@pix.fr.",
         "not-me": "That's not me",
         "rgpd-legal-notice": "To know how your personnal data is processed, and what your rights are, you can read",
-        "rgpd-legal-notice-link": "TODO",
-        "rgpd-legal-notice-url": "TODO",
+        "rgpd-legal-notice-link": "Mentions d'information.",
+        "rgpd-legal-notice-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
         "options": {
           "email": "My email address",
           "text": "Sign up with:",


### PR DESCRIPTION
## :jack_o_lantern: Problème
Design de la double mire SSO à revoir.

## :bat: Proposition

- il faut pas que le “?” soit à la ligne
- retirer des sauts de ligne
- marge de gauche et droite trop grande
- avoir la même font partout

## :spider_web: Remarques
**```Avant :```**
![image](https://user-images.githubusercontent.com/82950611/197509322-0c4a1389-f94f-4dbe-8e26-abce6ac9c131.png)

**```Après :```**

<img width="1017" alt="Capture d’écran 2022-10-24 à 15 17 49" src="https://user-images.githubusercontent.com/82950611/197534938-adee25db-2b36-4fe9-8c57-0e8ded178506.png">


## :ghost: Pour tester

- Se connecter à l'application Pix via Pôle Emploi : http://localhost.fr:4200/connexion/
- Voir la page de la double mire pour se connecter à l'application Pix.
