### PR TITLE
[TECH] Corriger la date dans les tests Pix Admin

### DIFF
--- a/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
@@ -75,7 +75,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
       const screen = await visit(`/sessions/${session.id}`);
 
       // when
-      assert.dom(screen.getByText('01/01/2022')).exists();
+      assert.dom(screen.getByText('01/04/2022')).exists();
     });
 
     test('it renders all the stats of the session', async function (assert) {

--- a/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations_test.js
@@ -180,13 +180,13 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
       test('it renders the publishedAt date', async function (assert) {
         // given
         await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-        const session = _buildSessionWithTwoJuryCertificationSummary({ publishedAt: new Date('2022-10-24') }, server);
+        const session = _buildSessionWithTwoJuryCertificationSummary({ publishedAt: new Date('2022-10-20') }, server);
 
         // when
         const screen = await visit(`/sessions/${session.id}`);
 
         // when
-        assert.dom(screen.getByText('24/10/2022')).exists();
+        assert.dom(screen.getByText('20/10/2022')).exists();
       });
     });
 
@@ -238,8 +238,9 @@ function _buildSessionWithTwoJuryCertificationSummary(sessionData, server) {
   });
 
   return server.create('session', {
+    date: new Date('2022-01-01'),
     status: 'finalized',
-    finalizedAt: new Date('2022-01-01'),
+    finalizedAt: new Date('2022-04-01'),
     examinerGlobalComment: 'ceci est un commentaire sur les sessions de certification',
     juryCertificationSummaries: [juryCertifSummary1, juryCertifSummary2],
     ...sessionData,


### PR DESCRIPTION
## :jack_o_lantern: Problème
Un test sur Pix Admin est flacky car la date fixée est la date d'aujourd'hui, or, il y a d'autres dates affichées dans la même page qui sont par défaut des `new Date()` et donc sont aussi la date du jour. Ce qui ne plaît pas à testing library car il trouve plusieurs fois la même date et plante.

## :bat: Proposition
Fixer les dates (c'est à dire éviter les `new Date()` ). Et fixer les dates dans le passé.

## :spider_web: Remarques
RAS

## :ghost: Pour tester
Vérifier la CI.
