### PR TITLE
[FEATURE] Ajout d'un formulaire pour créer une invitation pour rejoindre un centre de certif depuis Pix Admin (PIX-137)

### DIFF
--- a/admin/app/adapters/certification-center-invitation.js
+++ b/admin/app/adapters/certification-center-invitation.js
@@ -3,10 +3,8 @@ import ApplicationAdapter from './application';
 export default class CertificationCenterInvitationAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
 
-  urlForQuery(query) {
-    const { certificationCenterId } = query.filter;
-    delete query.filter.certificationCenterId;
-
+  urlForFindAll(modelName, { adapterOptions }) {
+    const { certificationCenterId } = adapterOptions;
     return `${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/invitations`;
   }
 

--- a/admin/app/adapters/certification-center-invitation.js
+++ b/admin/app/adapters/certification-center-invitation.js
@@ -9,4 +9,15 @@ export default class CertificationCenterInvitationAdapter extends ApplicationAda
 
     return `${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/invitations`;
   }
+
+  queryRecord(store, type, query) {
+    if (query.certificationCenterId) {
+      const url = `${this.host}/${this.namespace}/certification-centers/${query.certificationCenterId}/invitations`;
+      return this.ajax(url, 'POST', {
+        data: { data: { attributes: { email: query.email, language: query.language } } },
+      });
+    }
+
+    return super.queryRecord(...arguments);
+  }
 }

--- a/admin/app/components/certification-centers/invitations-action.hbs
+++ b/admin/app/components/certification-centers/invitations-action.hbs
@@ -1,0 +1,38 @@
+<section class="page-section certification-center-invitations">
+  <form>
+    <h2 class="certification-center-invitations__heading">Inviter un membre</h2>
+    <div class="certification-center-invitations-form-container">
+      <PixInput
+        @id="userEmailToInvite"
+        value={{@userEmailToInvite}}
+        {{on "change" @onChangeUserEmailToInvite}}
+        @label="Adresse e-mail du membre à inviter"
+        class="certification-center-invitations-form-container__input
+          {{if @userEmailToInviteError "certification-center-invitations-form-container__input--error"}}"
+      />
+
+      <PixSelect
+        @options={{this.languagesOptions}}
+        @selectedOption={{this.invitationLanguage}}
+        @onChange={{this.changeInvitationLanguage}}
+        aria-label="Choisir la langue de l’email d’invitation"
+      />
+
+      <PixButton
+        @size="small"
+        @triggerAction={{fn @createInvitation this.invitationLanguage}}
+        aria-label="Inviter un membre"
+        class="certification-center-invitations-form-container__button"
+        name="Inviter"
+      >
+        Inviter
+      </PixButton>
+    </div>
+    {{#if @userEmailToInviteError}}
+      <label
+        for="userEmailToInvite"
+        class="certification-center-invitations-form-container__error-message"
+      >{{@userEmailToInviteError}}</label>
+    {{/if}}
+  </form>
+</section>

--- a/admin/app/components/certification-centers/invitations-action.js
+++ b/admin/app/components/certification-centers/invitations-action.js
@@ -1,0 +1,29 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class CertificationCenterInvitationsAction extends Component {
+  @tracked invitationLanguage = this.languagesOptions[0].value;
+
+  get languagesOptions() {
+    return [
+      {
+        label: 'Français',
+        value: 'fr-fr',
+      },
+      {
+        label: 'Francophone',
+        value: 'fr',
+      },
+      {
+        label: 'Anglais',
+        value: 'en',
+      },
+    ];
+  }
+
+  @action
+  changeInvitationLanguage(event) {
+    this.invitationLanguage = event.target.value;
+  }
+}

--- a/admin/app/components/certification-centers/invitations.hbs
+++ b/admin/app/components/certification-centers/invitations.hbs
@@ -4,7 +4,7 @@
   </header>
   <div class="content-text content-text--small">
     <div class="table-admin">
-      {{#if @certificationCenterInvitations}}
+      {{#if this.sortedCertificationCenterInvitations}}
         <table>
           <thead>
             <tr>
@@ -13,7 +13,7 @@
             </tr>
           </thead>
           <tbody>
-            {{#each @certificationCenterInvitations as |invitation|}}
+            {{#each this.sortedCertificationCenterInvitations as |invitation|}}
               <tr aria-label="Invitation en attente de {{invitation.email}}">
                 <td>{{invitation.email}}</td>
                 <td>{{dayjs-format invitation.updatedAt "DD/MM/YYYY [-] HH:mm" locale="fr"}}</td>

--- a/admin/app/components/certification-centers/invitations.js
+++ b/admin/app/components/certification-centers/invitations.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export default class CertificationCenterInvitations extends Component {
+  get sortedCertificationCenterInvitations() {
+    return this.args.certificationCenterInvitations.sortBy('updatedAt').reverse();
+  }
+}

--- a/admin/app/controllers/authenticated/certification-centers/get/invitations.js
+++ b/admin/app/controllers/authenticated/certification-centers/get/invitations.js
@@ -1,0 +1,63 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import isEmailValid from '../../../../utils/email-validator';
+
+export default class AuthenticatedCertificationCentersGetInvitationsController extends Controller {
+  @service accessControl;
+  @service notifications;
+  @service errorResponseHandler;
+  @service store;
+
+  @tracked userEmailToInvite = null;
+  @tracked userEmailToInviteError;
+
+  CUSTOM_ERROR_MESSAGES = {
+    DEFAULT: 'Une erreur s’est produite, veuillez réessayer.',
+  };
+
+  @action
+  onChangeUserEmailToInvite(event) {
+    this.userEmailToInvite = event.target.value;
+  }
+
+  @action
+  async createInvitation(language) {
+    this.isLoading = true;
+    const email = this.userEmailToInvite?.trim();
+    if (!this._isEmailToInviteValid(email)) {
+      this.isLoading = false;
+      return;
+    }
+
+    try {
+      await this.store.queryRecord('certification-center-invitation', {
+        email,
+        language,
+        certificationCenterId: this.model.certificationCenterId,
+      });
+
+      this.notifications.success(`Un email a bien a été envoyé à l'adresse ${email}.`);
+      this.userEmailToInvite = null;
+    } catch (err) {
+      this.errorResponseHandler.notify(err, this.CUSTOM_ERROR_MESSAGES);
+    }
+    this.isLoading = false;
+  }
+
+  _isEmailToInviteValid(email) {
+    if (!email) {
+      this.userEmailToInviteError = 'Ce champ est requis.';
+      return false;
+    }
+
+    if (!isEmailValid(email)) {
+      this.userEmailToInviteError = "L'adresse e-mail saisie n'est pas valide.";
+      return false;
+    }
+
+    this.userEmailToInviteError = null;
+    return true;
+  }
+}

--- a/admin/app/routes/authenticated/certification-centers/get/invitations.js
+++ b/admin/app/routes/authenticated/certification-centers/get/invitations.js
@@ -5,10 +5,10 @@ export default class AuthenticatedCertificationCentersGetInvitationsRoute extend
     this.store.unloadAll('certification-center-invitation');
     const { certificationCenter } = this.modelFor('authenticated.certification-centers.get');
     const certificationCenterId = certificationCenter.id;
-    return await this.store.query('certification-center-invitation', {
-      filter: {
-        certificationCenterId,
-      },
+
+    const certificationCenterInvitations = await this.store.findAll('certification-center-invitation', {
+      adapterOptions: { certificationCenterId },
     });
+    return certificationCenterInvitations;
   }
 }

--- a/admin/app/routes/authenticated/certification-centers/get/invitations.js
+++ b/admin/app/routes/authenticated/certification-centers/get/invitations.js
@@ -9,6 +9,6 @@ export default class AuthenticatedCertificationCentersGetInvitationsRoute extend
     const certificationCenterInvitations = await this.store.findAll('certification-center-invitation', {
       adapterOptions: { certificationCenterId },
     });
-    return certificationCenterInvitations;
+    return { certificationCenterId, certificationCenterInvitations };
   }
 }

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -37,6 +37,7 @@
 @import 'components/certification/competence-list';
 @import 'components/certification/certification-status-select';
 @import 'components/certification-centers/information';
+@import 'components/certification-centers/invitations-action';
 @import 'components/certification-center-form';
 @import 'components/certification-details-answer';
 @import 'components/certification-details-competence';

--- a/admin/app/styles/components/certification-centers/invitations-action.scss
+++ b/admin/app/styles/components/certification-centers/invitations-action.scss
@@ -1,0 +1,32 @@
+.certification-center-invitations {
+  display: flex;
+  justify-content: space-around;
+}
+
+.certification-center-invitations__heading {
+  font-size: 1.125rem;
+}
+
+.certification-center-invitations-form-container {
+  display: flex;
+  align-items: flex-end;
+}
+
+.certification-center-invitations-form-container__input {
+  min-width: 18rem;
+  margin-right: 0.4rem;
+
+  &--error {
+    border-right: 1px solid $pix-error-70;
+    border-color: $pix-error-70;
+  }
+}
+
+.certification-center-invitations-form-container__button {
+  margin-left: 6px;
+}
+
+.certification-center-invitations-form-container__error-message {
+  color: $pix-error-70;
+  font-size: 0.85rem;
+}

--- a/admin/app/templates/authenticated/certification-centers/get/invitations.hbs
+++ b/admin/app/templates/authenticated/certification-centers/get/invitations.hbs
@@ -1,3 +1,10 @@
 {{page-title "Invitations"}}
 
+<CertificationCenters::InvitationsAction
+  @userEmailToInvite={{this.userEmailToInvite}}
+  @onChangeUserEmailToInvite={{this.onChangeUserEmailToInvite}}
+  @userEmailToInviteError={{this.userEmailToInviteError}}
+  @createInvitation={{this.createInvitation}}
+/>
+
 <CertificationCenters::Invitations @certificationCenterInvitations={{this.model.certificationCenterInvitations}} />

--- a/admin/app/templates/authenticated/certification-centers/get/invitations.hbs
+++ b/admin/app/templates/authenticated/certification-centers/get/invitations.hbs
@@ -1,3 +1,3 @@
 {{page-title "Invitations"}}
 
-<CertificationCenters::Invitations @certificationCenterInvitations={{this.model}} />
+<CertificationCenters::Invitations @certificationCenterInvitations={{this.model.certificationCenterInvitations}} />

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -130,6 +130,13 @@ export default function () {
     const certificationCenterId = request.params.id;
     return schema.certificationCenterInvitations.where({ certificationCenterId });
   });
+  this.post('/admin/certification-centers/:id/invitations', (schema, request) => {
+    const params = JSON.parse(request.requestBody);
+    const email = params.data.attributes.email;
+    const lang = params.data.attributes.lang;
+    const updatedAt = Date.now();
+    return schema.certificationCenterInvitations.create({ email, lang, updatedAt });
+  });
 
   this.delete('/admin/certification-center-memberships/:id', (schema, request) => {
     const certificationCenterMembershipId = request.params.id;

--- a/admin/tests/acceptance/authenticated/certification-centers/get/invitations_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get/invitations_test.js
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { fillIn, click } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { visit } from '@1024pix/ember-testing-library';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+
+module('Acceptance | Certification-centers | Invitations management', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('should allow to invite a member', async function (assert) {
+    // given
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+    const certificationCenter = this.server.create('certification-center', {
+      name: 'Aude Javel Company',
+    });
+
+    // when
+    const screen = await visit(`/certification-centers/${certificationCenter.id}/invitations`);
+    await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail du membre à inviter' }), 'user@example.com');
+    await click(screen.getByRole('button', { name: 'Inviter un membre' }));
+
+    // then
+    assert.dom(screen.getByText('user@example.com')).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail du membre à inviter' })).hasNoValue();
+  });
+});

--- a/admin/tests/integration/components/certification-centers/get/invitations_test.js
+++ b/admin/tests/integration/components/certification-centers/get/invitations_test.js
@@ -8,8 +8,13 @@ module('Integration | Component | Certification Centers | Invitations', function
 
   module('when there is no certification center invitations', function () {
     test('should show "Aucune invitation en attente"', async function (assert) {
-      // give & when
-      const screen = await render(hbs`<CertificationCenters::Invitations />`);
+      // given
+      this.certificationCenterInvitations = [];
+
+      // when
+      const screen = await render(
+        hbs`<CertificationCenters::Invitations @certificationCenterInvitations={{certificationCenterInvitations}} />`
+      );
 
       // then
       assert.dom(screen.getByText('Aucune invitation en attente')).exists();
@@ -22,9 +27,11 @@ module('Integration | Component | Certification Centers | Invitations', function
       const store = this.owner.lookup('service:store');
       const certificationCenterInvitation1 = store.createRecord('certification-center-invitation', {
         email: 'elo.dela@example.net',
+        updatedAt: new Date('2020-02-02'),
       });
       const certificationCenterInvitation2 = store.createRecord('certification-center-invitation', {
         email: 'alain.finis@example.net',
+        updatedAt: new Date('2022-02-02'),
       });
       this.certificationCenterInvitations = [certificationCenterInvitation1, certificationCenterInvitation2];
 

--- a/admin/tests/integration/components/certification-centers/invitations-action_test.js
+++ b/admin/tests/integration/components/certification-centers/invitations-action_test.js
@@ -1,0 +1,47 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, selectByLabelAndOption } from '@1024pix/ember-testing-library';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+import { clickByText } from '@1024pix/ember-testing-library';
+
+module('Integration | Component | certification-center-invitations-action', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should create certification-center invitation with default language', async function (assert) {
+    // given
+    const createInvitationStub = sinon.stub();
+    this.set('createInvitation', createInvitationStub);
+    this.set('noop', () => {});
+
+    // when
+    await render(
+      hbs`<CertificationCenters::InvitationsAction
+        @createInvitation={{createInvitation}}
+        @onChangeUserEmailToInvite={{noop}}/>`
+    );
+    await clickByText('Inviter');
+
+    // then
+    assert.ok(createInvitationStub.calledWith('fr-fr'));
+  });
+
+  test('it should create certification-center invitation with choosen language', async function (assert) {
+    // given
+    const createInvitationStub = sinon.stub();
+    this.set('createInvitation', createInvitationStub);
+    this.set('noop', () => {});
+
+    // when
+    await render(
+      hbs`<CertificationCenters::InvitationsAction
+        @createInvitation={{createInvitation}}
+        @onChangeUserEmailToInvite={{noop}}/>`
+    );
+    await selectByLabelAndOption('Choisir la langue de l’email d’invitation', 'en');
+    await clickByText('Inviter');
+
+    // then
+    assert.ok(createInvitationStub.calledWith('en'));
+  });
+});

--- a/admin/tests/unit/adapters/certification-center-invitation_test.js
+++ b/admin/tests/unit/adapters/certification-center-invitation_test.js
@@ -6,14 +6,14 @@ import sinon from 'sinon';
 module('Unit | Adapter | certification-center-invitation', function (hooks) {
   setupTest(hooks);
 
-  module('#urlForQuery', function () {
+  module('#urlForFindAll', function () {
     test('should build url with certification center id as dynamic segment', async function (assert) {
       // given
       const adapter = this.owner.lookup('adapter:certification-center-invitation');
-      const query = { filter: { certificationCenterId: 7 } };
+      const snapshot = { adapterOptions: { certificationCenterId: 7 } };
 
       // when
-      const url = adapter.urlForQuery(query);
+      const url = adapter.urlForFindAll('certification-center-invitation', snapshot);
 
       // then
       assert.deepEqual(url, `${ENV.APP.API_HOST}/api/admin/certification-centers/7/invitations`);

--- a/admin/tests/unit/adapters/certification-center-invitation_test.js
+++ b/admin/tests/unit/adapters/certification-center-invitation_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import ENV from 'pix-admin/config/environment';
+import sinon from 'sinon';
 
 module('Unit | Adapter | certification-center-invitation', function (hooks) {
   setupTest(hooks);
@@ -16,6 +17,25 @@ module('Unit | Adapter | certification-center-invitation', function (hooks) {
 
       // then
       assert.deepEqual(url, `${ENV.APP.API_HOST}/api/admin/certification-centers/7/invitations`);
+    });
+  });
+
+  module('#queryRecord', function () {
+    test('should build request with specific payload and url', async function (assert) {
+      // given
+      const adapter = this.owner.lookup('adapter:certification-center-invitation');
+      const store = this.owner.lookup('service:store');
+      sinon.stub(adapter, 'ajax');
+      const query = { certificationCenterId: 666, email: 'super@example.net', language: 'fr-fr' };
+
+      // when
+      adapter.queryRecord(store, 'certification-center-invitation', query);
+
+      // then
+      const expectedUrl = `${ENV.APP.API_HOST}/api/admin/certification-centers/666/invitations`;
+      const expectedPayload = { data: { data: { attributes: { email: 'super@example.net', language: 'fr-fr' } } } };
+      sinon.assert.calledWith(adapter.ajax, expectedUrl, 'POST', expectedPayload);
+      assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
     });
   });
 });

--- a/admin/tests/unit/routes/authenticated/certification-centers/get/invitations_test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/get/invitations_test.js
@@ -42,6 +42,6 @@ module('Unit | Route | authenticated/certification-centers/get/invitations', fun
     const result = await route.model();
 
     // then
-    assert.deepEqual(result, certificationCenterInvitations);
+    assert.deepEqual(result, { certificationCenterId: 777, certificationCenterInvitations });
   });
 });

--- a/admin/tests/unit/routes/authenticated/certification-centers/get/invitations_test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/get/invitations_test.js
@@ -5,12 +5,12 @@ import sinon from 'sinon';
 module('Unit | Route | authenticated/certification-centers/get/invitations', function (hooks) {
   setupTest(hooks);
 
-  test("it should unload certification center invitation because it's maybe other certification center's invitations", async function (assert) {
+  test("it should unload certification center invitations because it's maybe other certification center's invitations", async function (assert) {
     // given
     const route = this.owner.lookup('route:authenticated/certification-centers/get/invitations');
     const store = this.owner.lookup('service:store');
 
-    store.query = sinon.stub();
+    store.findAll = sinon.stub();
     store.unloadAll = sinon.stub();
     route.modelFor = sinon.stub().returns({ certificationCenter: { id: 777 } });
 
@@ -21,27 +21,27 @@ module('Unit | Route | authenticated/certification-centers/get/invitations', fun
     assert.ok(store.unloadAll.calledWith('certification-center-invitation'));
   });
 
-  test('it should return certification center invitations', async function (assert) {
+  test('it should return certification center with its invitations', async function (assert) {
     // given
     const route = this.owner.lookup('route:authenticated/certification-centers/get/invitations');
     const store = this.owner.lookup('service:store');
 
     const certificationCenterInvitations = Symbol('some certification center invitations');
+
     store.unloadAll = sinon.stub();
-    store.query = sinon.stub();
-    store.query
+    route.modelFor = sinon.stub();
+    route.modelFor.withArgs('authenticated.certification-centers.get').returns({ certificationCenter: { id: 777 } });
+    store.findAll = sinon.stub();
+    store.findAll
       .withArgs('certification-center-invitation', {
-        filter: { certificationCenterId: 777 },
+        adapterOptions: { certificationCenterId: 777 },
       })
       .resolves(certificationCenterInvitations);
 
-    route.modelFor = sinon.stub();
-    route.modelFor.withArgs('authenticated.certification-centers.get').returns({ certificationCenter: { id: 777 } });
-
     // when
-    const expectedCertificationCenterInvitations = await route.model();
+    const result = await route.model();
 
     // then
-    assert.strictEqual(expectedCertificationCenterInvitations, certificationCenterInvitations);
+    assert.deepEqual(result, certificationCenterInvitations);
   });
 });

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -139,4 +139,23 @@ module.exports = {
     });
     return h.response().code(204);
   },
+
+  async sendInvitationForAdmin(request, h) {
+    const certificationCenterId = request.params.certificationCenterId;
+    const invitationInformation = await certificationCenterInvitationSerializer.deserializeForAdmin(request.payload);
+
+    const { certificationCenterInvitation, created } =
+      await usecases.createOrUpdateCertificationCenterInvitationForAdmin({
+        email: invitationInformation.email,
+        locale: invitationInformation.language,
+        certificationCenterId,
+      });
+
+    const serializedCertificationCenterInvitation =
+      certificationCenterInvitationSerializer.serializeForAdmin(certificationCenterInvitation);
+    if (created) {
+      return h.response(serializedCertificationCenterInvitation).created();
+    }
+    return h.response(serializedCertificationCenterInvitation);
+  },
 };

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -284,6 +284,48 @@ exports.register = async function (server) {
         tags: ['api', 'certification-center', 'invitations', 'admin'],
       },
     },
+
+    {
+      method: 'POST',
+      path: '/api/admin/certification-centers/{certificationCenterId}/invitations',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: certificationCenterController.sendInvitationForAdmin,
+        validate: {
+          params: Joi.object({
+            certificationCenterId: identifiersType.certificationCenterId,
+          }),
+          options: {
+            allowUnknown: true,
+          },
+          payload: Joi.object({
+            data: {
+              attributes: {
+                email: Joi.string().email().required(),
+                language: Joi.string().valid('fr-fr', 'fr', 'en'),
+              },
+            },
+          }),
+        },
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            "- Elle permet à un administrateur d'inviter des personnes, déjà utilisateurs de Pix ou non, à être membre d'un centre de certification, via leur **email**",
+        ],
+        tags: ['api', 'invitations', 'certification-center'],
+      },
+    },
+
     {
       method: 'POST',
       path: '/api/certif/certification-centers/{certificationCenterId}/update-referer',

--- a/api/lib/domain/models/CertificationCenterInvitation.js
+++ b/api/lib/domain/models/CertificationCenterInvitation.js
@@ -16,16 +16,18 @@ const validationScheme = Joi.object({
     .optional(),
   certificationCenterId: Joi.number().optional(),
   certificationCenterName: Joi.string().optional(),
+  code: Joi.string().optional(),
 });
 
 class CertificationCenterInvitation {
-  constructor({ id, email, updatedAt, status, certificationCenterId, certificationCenterName } = {}) {
+  constructor({ id, email, updatedAt, status, certificationCenterId, certificationCenterName, code } = {}) {
     this.id = id;
     this.email = email;
     this.updatedAt = updatedAt;
     this.status = status;
     this.certificationCenterId = certificationCenterId;
     this.certificationCenterName = certificationCenterName;
+    this.code = code;
 
     validateEntity(validationScheme, this);
   }

--- a/api/lib/domain/models/CertificationCenterInvitation.js
+++ b/api/lib/domain/models/CertificationCenterInvitation.js
@@ -1,5 +1,6 @@
 const Joi = require('joi').extend(require('@joi/date'));
 const { validateEntity } = require('../validators/entity-validator');
+const randomString = require('randomstring');
 
 const statuses = {
   PENDING: 'pending',
@@ -30,6 +31,23 @@ class CertificationCenterInvitation {
     this.code = code;
 
     validateEntity(validationScheme, this);
+  }
+
+  static create({ email, certificationCenterId, updatedAt = new Date(), code = this.generateCode() }) {
+    const certificationCenterToCreate = new CertificationCenterInvitation({
+      email,
+      certificationCenterId,
+      status: CertificationCenterInvitation.StatusType.PENDING,
+      updatedAt,
+      code,
+    });
+    delete certificationCenterToCreate.id;
+    delete certificationCenterToCreate.certificationCenterName;
+    return certificationCenterToCreate;
+  }
+
+  static generateCode() {
+    return randomString.generate({ length: 10, capitalization: 'uppercase' });
   }
 
   get isPending() {

--- a/api/lib/domain/usecases/create-or-update-certification-center-invitation-for-admin.js
+++ b/api/lib/domain/usecases/create-or-update-certification-center-invitation-for-admin.js
@@ -1,0 +1,7 @@
+const CertificationCenterInvitation = require('../models/CertificationCenterInvitation');
+
+module.exports = async function ({ email, certificationCenterId, certificationCenterInvitationRepository }) {
+  const newInvitation = CertificationCenterInvitation.create({ email, certificationCenterId });
+  const certificationCenterInvitationCreated = await certificationCenterInvitationRepository.create(newInvitation);
+  return { created: true, certificationCenterInvitation: certificationCenterInvitationCreated };
+};

--- a/api/lib/domain/usecases/create-or-update-certification-center-invitation-for-admin.js
+++ b/api/lib/domain/usecases/create-or-update-certification-center-invitation-for-admin.js
@@ -1,7 +1,21 @@
 const CertificationCenterInvitation = require('../models/CertificationCenterInvitation');
 
 module.exports = async function ({ email, certificationCenterId, certificationCenterInvitationRepository }) {
-  const newInvitation = CertificationCenterInvitation.create({ email, certificationCenterId });
-  const certificationCenterInvitationCreated = await certificationCenterInvitationRepository.create(newInvitation);
-  return { created: true, certificationCenterInvitation: certificationCenterInvitationCreated };
+  const alreadyExistingPendingInvitationForThisEmail =
+    await certificationCenterInvitationRepository.findOnePendingByEmailAndCertificationCenterId({
+      email,
+      certificationCenterId,
+    });
+
+  const shouldCreateInvitation = !alreadyExistingPendingInvitationForThisEmail;
+  if (shouldCreateInvitation) {
+    const newInvitation = CertificationCenterInvitation.create({ email, certificationCenterId });
+    const certificationCenterInvitationCreated = await certificationCenterInvitationRepository.create(newInvitation);
+    return { created: true, certificationCenterInvitation: certificationCenterInvitationCreated };
+  }
+
+  const updatedCertificationCenterInvitation = await certificationCenterInvitationRepository.update(
+    alreadyExistingPendingInvitationForThisEmail
+  );
+  return { created: false, certificationCenterInvitation: updatedCertificationCenterInvitation };
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -214,6 +214,7 @@ module.exports = injectDependencies(
     createCertificationCenter: require('./create-certification-center'),
     createCertificationCenterMembershipByEmail: require('./create-certification-center-membership-by-email'),
     createCertificationCenterMembershipForScoOrganizationMember: require('./create-certification-center-membership-for-sco-organization-member'),
+    createOrUpdateCertificationCenterInvitationForAdmin: require('./create-or-update-certification-center-invitation-for-admin'),
     createLcmsRelease: require('./create-lcms-release'),
     createMembership: require('./create-membership'),
     createOrUpdateUserOrgaSettings: require('./create-or-update-user-orga-settings'),

--- a/api/lib/infrastructure/repositories/certification-center-invitation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-invitation-repository.js
@@ -49,4 +49,11 @@ module.exports = {
 
     return _toDomain(certificationCenterInvitation);
   },
+
+  async create(invitation) {
+    const [newInvitation] = await knex(CERTIFICATION_CENTER_INVITATIONS)
+      .insert(invitation)
+      .returning(['id', 'email', 'updatedAt']);
+    return _toDomain(newInvitation);
+  },
 };

--- a/api/lib/infrastructure/repositories/certification-center-invitation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-invitation-repository.js
@@ -2,6 +2,8 @@ const CertificationCenterInvitation = require('../../domain/models/Certification
 const { knex } = require('../../../db/knex-database-connection');
 const { NotFoundError } = require('../../domain/errors');
 
+const CERTIFICATION_CENTER_INVITATIONS = 'certification-center-invitations';
+
 function _toDomain(invitationDTO) {
   return new CertificationCenterInvitation({
     id: invitationDTO.id,
@@ -15,9 +17,8 @@ function _toDomain(invitationDTO) {
 
 module.exports = {
   async findPendingByCertificationCenterId({ certificationCenterId }) {
-    const pendingCertificationCenterInvitations = await knex
+    const pendingCertificationCenterInvitations = await knex(CERTIFICATION_CENTER_INVITATIONS)
       .select('id', 'email', 'certificationCenterId', 'updatedAt')
-      .from('certification-center-invitations')
       .where({ certificationCenterId, status: CertificationCenterInvitation.StatusType.PENDING })
       .orderBy('email')
       .orderBy('updatedAt', 'desc');
@@ -25,7 +26,7 @@ module.exports = {
   },
 
   async getByIdAndCode({ id, code }) {
-    const certificationCenterInvitation = await knex('certification-center-invitations')
+    const certificationCenterInvitation = await knex(CERTIFICATION_CENTER_INVITATIONS)
       .select({
         id: 'certification-center-invitations.id',
         status: 'certification-center-invitations.status',

--- a/api/lib/infrastructure/repositories/certification-center-invitation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-invitation-repository.js
@@ -20,7 +20,6 @@ module.exports = {
     const pendingCertificationCenterInvitations = await knex(CERTIFICATION_CENTER_INVITATIONS)
       .select('id', 'email', 'certificationCenterId', 'updatedAt')
       .where({ certificationCenterId, status: CertificationCenterInvitation.StatusType.PENDING })
-      .orderBy('email')
       .orderBy('updatedAt', 'desc');
     return pendingCertificationCenterInvitations.map(_toDomain);
   },

--- a/api/lib/infrastructure/repositories/certification-center-invitation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-invitation-repository.js
@@ -50,10 +50,28 @@ module.exports = {
     return _toDomain(certificationCenterInvitation);
   },
 
+  async findOnePendingByEmailAndCertificationCenterId({ email, certificationCenterId }) {
+    const existingPendingInvitation = await knex(CERTIFICATION_CENTER_INVITATIONS)
+      .select('id')
+      .where({ email, certificationCenterId, status: CertificationCenterInvitation.StatusType.PENDING })
+      .first();
+
+    return existingPendingInvitation ? _toDomain(existingPendingInvitation) : null;
+  },
+
   async create(invitation) {
     const [newInvitation] = await knex(CERTIFICATION_CENTER_INVITATIONS)
       .insert(invitation)
       .returning(['id', 'email', 'updatedAt']);
     return _toDomain(newInvitation);
+  },
+
+  async update(certificationCenterInvitation) {
+    const [updatedCertificationCenterInvitation] = await knex('certification-center-invitations')
+      .update({ updatedAt: new Date() })
+      .where({ id: certificationCenterInvitation.id })
+      .returning(['id', 'email', 'updatedAt']);
+
+    return _toDomain(updatedCertificationCenterInvitation);
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js
@@ -1,4 +1,4 @@
-const { Serializer } = require('jsonapi-serializer');
+const { Serializer, Deserializer } = require('jsonapi-serializer');
 
 module.exports = {
   serialize(invitations) {
@@ -11,5 +11,14 @@ module.exports = {
     return new Serializer('certification-center-invitations', {
       attributes: ['certificationCenterId', 'email', 'updatedAt'],
     }).serialize(invitations);
+  },
+
+  deserializeForAdmin(payload) {
+    return new Deserializer().deserialize(payload).then((record) => {
+      return {
+        email: record.email,
+        language: record.language,
+      };
+    });
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-invitation-serializer.js
@@ -9,7 +9,7 @@ module.exports = {
 
   serializeForAdmin(invitations) {
     return new Serializer('certification-center-invitations', {
-      attributes: ['certificationCenterId', 'email', 'updatedAt'],
+      attributes: ['email', 'updatedAt'],
     }).serialize(invitations);
   },
 

--- a/api/tests/acceptance/application/certification-centers/index_test.js
+++ b/api/tests/acceptance/application/certification-centers/index_test.js
@@ -4,10 +4,11 @@ const {
   generateValidRequestAuthorizationHeader,
   insertUserWithRoleSuperAdmin,
   knex,
+  sinon,
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
 
-describe('Acceptance | API | Certification Centers', function () {
+describe('Acceptance | Route | Certification Centers', function () {
   let server;
 
   beforeEach(async function () {
@@ -17,6 +18,7 @@ describe('Acceptance | API | Certification Centers', function () {
   afterEach(async function () {
     await knex('complementary-certification-habilitations').delete();
     await knex('data-protection-officers').delete();
+    await knex('certification-center-invitations').delete();
   });
 
   describe('PATCH /api/admin/certification-centers/{id}', function () {
@@ -55,6 +57,55 @@ describe('Acceptance | API | Certification Centers', function () {
         expect(result.data.attributes['data-protection-officer-last-name']).to.equal('Ptipeu');
         expect(result.data.attributes['data-protection-officer-email']).to.equal('justin.ptipeu@example.net');
         expect(result.data.attributes.name).to.equal('Justin Ptipeu Orga');
+      });
+    });
+  });
+
+  describe('POST /api/admin/certification-centers/{certificationCenterId}/invitations', function () {
+    let clock;
+    const now = new Date('2021-05-01');
+
+    beforeEach(async function () {
+      clock = sinon.useFakeTimers({
+        now,
+        toFake: ['Date'],
+      });
+    });
+
+    afterEach(async function () {
+      clock.restore();
+    });
+
+    it('should return 201 HTTP status code with created invitation', async function () {
+      // given
+      const adminMember = await insertUserWithRoleSuperAdmin();
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      await databaseBuilder.commit();
+
+      // when
+      const { result, statusCode } = await server.inject({
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(adminMember.id),
+        },
+        method: 'POST',
+        payload: {
+          data: {
+            attributes: {
+              email: 'some.user@example.net',
+              lang: 'fr-fr',
+            },
+          },
+        },
+        url: `/api/admin/certification-centers/${certificationCenterId}/invitations`,
+      });
+
+      // then
+      expect(statusCode).to.equal(201);
+      expect(result.data.type).to.equal('certification-center-invitations');
+      expect(result.data).to.have.property('id');
+      expect(result.data.attributes).to.deep.equal({
+        'updated-at': now,
+        email: 'some.user@example.net',
       });
     });
   });

--- a/api/tests/acceptance/application/certifications/index_test.js
+++ b/api/tests/acceptance/application/certifications/index_test.js
@@ -596,7 +596,6 @@ describe('Acceptance | API | Certifications', function () {
           type: 'certification-center-invitations',
           id: certificationCenterInvitation1.id.toString(),
           attributes: {
-            'certification-center-id': certificationCenterId,
             email: 'alex.terieur@example.net',
             'updated-at': now,
           },
@@ -605,7 +604,6 @@ describe('Acceptance | API | Certifications', function () {
           type: 'certification-center-invitations',
           id: certificationCenterInvitation2.id.toString(),
           attributes: {
-            'certification-center-id': certificationCenterId,
             email: 'sarah.pelle@example.net',
             'updated-at': now,
           },

--- a/api/tests/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
+++ b/api/tests/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
@@ -52,4 +52,37 @@ describe('Integration | UseCase | create-or-update-certification-center-invitati
       .first();
     expect(result.certificationCenterInvitation).to.deep.include({ id: newAddedInvitation.id, email, updatedAt: now });
   });
+
+  it('should update an already existing pending invitation’s', async function () {
+    // given
+    const email = 'some.user@example.net';
+    const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+
+    const someTimeInThePastDate = new Date('2019-03-12T01:02:03Z');
+    const existingPendingInvitationId = databaseBuilder.factory.buildCertificationCenterInvitation({
+      email,
+      certificationCenterId,
+      status: CertificationCenterInvitation.StatusType.PENDING,
+      updatedAt: someTimeInThePastDate,
+    }).id;
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await useCases.createOrUpdateCertificationCenterInvitationForAdmin({
+      email,
+      certificationCenterId,
+    });
+
+    // then
+    const allInvitations = await knex('certification-center-invitations').select('*');
+    expect(allInvitations).to.have.length(1);
+
+    expect(result.certificationCenterInvitation).to.be.instanceOf(CertificationCenterInvitation);
+    expect(result.certificationCenterInvitation).to.deep.include({
+      id: existingPendingInvitationId,
+      email,
+      updatedAt: now,
+    });
+  });
 });

--- a/api/tests/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
+++ b/api/tests/integration/domain/usecases/create-or-update-certification-center-invitation-for-admin_test.js
@@ -1,0 +1,55 @@
+const { expect, databaseBuilder, knex, sinon } = require('../../../test-helper');
+const useCases = require('../../../../lib/domain/usecases');
+const CertificationCenterInvitation = require('../../../../lib/domain/models/CertificationCenterInvitation');
+
+describe('Integration | UseCase | create-or-update-certification-center-invitation-for-admin', function () {
+  let clock;
+  const now = new Date('2022-09-25');
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers(now.getTime());
+  });
+
+  afterEach(async function () {
+    clock.restore();
+  });
+
+  it('should create a new invitation if there isn’t an already pending existing one with given email', async function () {
+    // given
+    const email = 'some.user@example.net';
+    const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+
+    databaseBuilder.factory.buildCertificationCenterInvitation({
+      email: 'another.user@example.net',
+      certificationCenterId,
+      status: CertificationCenterInvitation.StatusType.PENDING,
+      updatedAt: new Date('2022-04-04'),
+    });
+    databaseBuilder.factory.buildCertificationCenterInvitation({
+      email,
+      certificationCenterId,
+      status: CertificationCenterInvitation.StatusType.CANCELLED,
+      updatedAt: new Date('2000-03-03'),
+    }).id;
+
+    await databaseBuilder.commit();
+
+    // when
+    const result = await useCases.createOrUpdateCertificationCenterInvitationForAdmin({
+      email,
+      certificationCenterId,
+    });
+
+    // then
+    const allInvitations = await knex('certification-center-invitations').select('*');
+    expect(allInvitations).to.have.length(3);
+
+    expect(result.created).to.be.true;
+    expect(result.certificationCenterInvitation).to.be.instanceOf(CertificationCenterInvitation);
+    const newAddedInvitation = await knex('certification-center-invitations')
+      .select('*')
+      .where({ email, status: CertificationCenterInvitation.StatusType.PENDING })
+      .first();
+    expect(result.certificationCenterInvitation).to.deep.include({ id: newAddedInvitation.id, email, updatedAt: now });
+  });
+});

--- a/api/tests/integration/domain/usecases/find-pending-certification-center-invitations_test.js
+++ b/api/tests/integration/domain/usecases/find-pending-certification-center-invitations_test.js
@@ -54,11 +54,11 @@ describe('Integration | UseCase | find-pending-certification-center-invitations'
     });
   });
 
-  it('should return pending certification center invitations sorted by email and updatedAt', async function () {
+  it('should return pending certification center invitations sorted by updatedAt', async function () {
     // given
     const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
     const oldestInvitationUpdatedAt = new Date('2022-06-10');
-    const latestInvitationUpdatedAt = new Date('2023-10-15');
+    const latestInvitationUpdatedAt = new Date('2024-10-15');
 
     databaseBuilder.factory.buildCertificationCenterInvitation({
       certificationCenterId,
@@ -93,10 +93,10 @@ describe('Integration | UseCase | find-pending-certification-center-invitations'
     });
 
     // then
-    expect(certificationCenterInvitations[0].email).to.equal('alex.terieur@example.net');
+    expect(certificationCenterInvitations[0].email).to.equal('sarah.pelle@example.net');
+    expect(certificationCenterInvitations[0].updatedAt).to.deep.equal(latestInvitationUpdatedAt);
     expect(certificationCenterInvitations[1].email).to.equal('amede.bu@example.net');
-    expect(certificationCenterInvitations[2].email).to.equal('sarah.pelle@example.net');
-    expect(certificationCenterInvitations[2].updatedAt).to.deep.equal(latestInvitationUpdatedAt);
+    expect(certificationCenterInvitations[2].email).to.equal('alex.terieur@example.net');
     expect(certificationCenterInvitations[3].email).to.equal('sarah.pelle@example.net');
     expect(certificationCenterInvitations[3].updatedAt).to.deep.equal(oldestInvitationUpdatedAt);
   });

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -93,6 +93,7 @@ async function insertOrganizationUserWithRoleAdmin() {
 const hFake = {
   response(source) {
     return {
+      statusCode: 200,
       source,
       code(c) {
         this.statusCode = c;

--- a/api/tests/unit/domain/models/CertificationCenterInvitation_test.js
+++ b/api/tests/unit/domain/models/CertificationCenterInvitation_test.js
@@ -15,6 +15,7 @@ describe('Unit | Domain | Models | CertificationCenterInvitation', function () {
         status: 'pending',
         certificationCenterId: 10,
         certificationCenterName: 'La Raclette des Pixous',
+        code: 'ABCDE',
       };
 
       // when

--- a/api/tests/unit/domain/models/CertificationCenterInvitation_test.js
+++ b/api/tests/unit/domain/models/CertificationCenterInvitation_test.js
@@ -1,6 +1,7 @@
 const CertificationCenterInvitation = require('../../../../lib/domain/models/CertificationCenterInvitation');
-const { expect } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const { EntityValidationError } = require('../../../../lib/domain/errors');
+const randomString = require('randomstring');
 
 describe('Unit | Domain | Models | CertificationCenterInvitation', function () {
   describe('constructor', function () {
@@ -114,6 +115,44 @@ describe('Unit | Domain | Models | CertificationCenterInvitation', function () {
 
       // /then
       expect(result).to.be.false;
+    });
+  });
+
+  describe('#create', function () {
+    it('should create a new certification center invitation', function () {
+      // given
+      const now = new Date('2022-03-02');
+
+      // when
+      const result = CertificationCenterInvitation.create({
+        certificationCenterId: 7,
+        email: 'new@example.net',
+        updatedAt: now,
+        code: '666AAALLL9',
+      });
+
+      // /then
+      expect(result).to.be.instanceOf(CertificationCenterInvitation);
+      expect(result).to.deep.equal({
+        email: 'new@example.net',
+        certificationCenterId: 7,
+        status: CertificationCenterInvitation.StatusType.PENDING,
+        updatedAt: now,
+        code: '666AAALLL9',
+      });
+    });
+  });
+
+  describe('#generateCode', function () {
+    it('should generate a code with 10 characters', function () {
+      // given
+      sinon.stub(randomString, 'generate');
+
+      // when
+      CertificationCenterInvitation.generateCode();
+
+      // /then
+      expect(randomString.generate).to.have.been.calledWithExactly({ length: 10, capitalization: 'uppercase' });
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-invitation-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-invitation-serializer_test.js
@@ -59,4 +59,28 @@ describe('Unit | Serializer | JSONAPI | certification-center-invitation-serializ
       });
     });
   });
+
+  describe('#deserializeForAdmin', function () {
+    it('should convert the JSON payload to Object', async function () {
+      //given
+      const payload = {
+        data: {
+          type: 'certification-center-invitations',
+          attributes: {
+            language: 'fr-fr',
+            email: 'email@example.net',
+          },
+        },
+      };
+
+      // when
+      const json = await serializer.deserializeForAdmin(payload);
+
+      // then
+      expect(json).to.deep.equal({
+        language: 'fr-fr',
+        email: 'email@example.net',
+      });
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-invitation-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-invitation-serializer_test.js
@@ -51,7 +51,6 @@ describe('Unit | Serializer | JSONAPI | certification-center-invitation-serializ
           type: 'certification-center-invitations',
           id: '7',
           attributes: {
-            'certification-center-id': 666,
             email: 'anne.atole@example.net',
             'updated-at': now,
           },


### PR DESCRIPTION
## :jack_o_lantern: Problème

Dans pix-admin il manque une interface utilisateur pour pouvoir inviter un membre à rejoindre un centre de certif.

## :bat: Proposition

Dans pix-admin, dans l'onglet « Invitations » du centre de certification, on ajoute un nouveau formulaire pour envoyer une invitation. Cette PR ne fait qu'ajouter une invitation en BDD, l'envoi effectif du courriel d'invitation se fera dans une autre PR.

Cette fonctionnalité doit être disponible uniquement pour les rôles suivants : 
- SUPER ADMIN
- SUPPORT
- METIER
- CERTIF

Mais comme dans pix-admin il n'y a que ces 4 rôles, cela revient à ne pas mettre de restriction sur les rôles.

### Détails

Au clic du bouton « Inviter » vérifier s’il y a déjà une invitation en ‘pending’ pour cette adresse email et centre de certif, qui soit au statut ‘pending’.

* si NON:, alors: 
   * l’invitation est créée en bdd au statut “pending”
   * l’invitation envoyée doit être visible dans le tableau
* si OUI, alors:
   * ne pas créer de nouvelle invitation en bdd. on va plutôt mettre à jour la ligne existante
   * mettre à jour le ‘UpdatedAt’

Les invitations doivent être listées triées par `updatedAt` décroissant, comme sur l’onglet des invitations des organisations.

## :spider_web: Remarques

❓ Le code de cette PR s'inspire de ce qui était déjà fait pour les `organizations`. Dans ce code la même notion est nommée de 2 manière différente : `lang` dans la partie cliente et `locale` dans la partie serveur. Cette PR garde le même nommage. Mais ne pourrait-on pas uniformiser et donc éviter les erreurs en utilisant `locale` partout dans le code cette PR ? Question subsidiaire est-ce que `fr-fr` est bien une locale ? En effet c'est plutôt `fr_FR` qui est une locale.

## :ghost: Pour tester

1. Aller dans l'onglet « Invitations » d'un centre de certification
2. Inviter un membre à l'aide du formulaire du même nom
3. Vérifier que l'adresse email apparaît bien dans la liste des invitations avec la bonne heure d'envoi
4. Attendre au moins 1 minute et renvoyer une invitation au même membre en utilisant la même adresse email
5. Vérifier que l'adresse email apparaît toujours dans la liste des invitations mais avec son heure d'envoi mise à jour avec une heure correspondant au dernier envoi
6. Inviter un nouveau membre à l'aide du formulaire
7. Vérifier que cette invitation apparaît bien en haut de la liste des invitations, car les invitations doivent être classées par ordre décroissant de leur `updatedAt`
8. Recharger la page dans le navigateur
9. Vérifier que la liste des invitations a toujours le même ordre qu'à l'étape précédente, ceci pour vérifier que le tri côté client et côté serveur ont bien le même comportement