### PR TITLE
[TECH] Ajouter l'id de campagne au token de récupération des résultats de la campagne (PIX-6028)

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -17,6 +17,7 @@ const groupSerializer = require('../../infrastructure/serializers/jsonapi/group-
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 const requestResponseUtils = require('../../infrastructure/utils/request-response-utils');
 const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
+const { ForbiddenAccess } = require('../../domain/errors');
 
 module.exports = {
   async save(request, h) {
@@ -72,8 +73,12 @@ module.exports = {
 
   async getCsvAssessmentResults(request) {
     const token = request.query.accessToken;
-    const { userId } = tokenService.extractCampaignResultsTokenContent(token);
+    const { userId, campaignId: extractedCampaignId } = tokenService.extractCampaignResultsTokenContent(token);
     const campaignId = request.params.id;
+
+    if (extractedCampaignId !== campaignId) {
+      throw new ForbiddenAccess();
+    }
 
     const writableStream = new PassThrough();
 
@@ -99,8 +104,12 @@ module.exports = {
 
   async getCsvProfilesCollectionResults(request) {
     const token = request.query.accessToken;
-    const { userId } = tokenService.extractCampaignResultsTokenContent(token);
+    const { userId, campaignId: extractedCampaignId } = tokenService.extractCampaignResultsTokenContent(token);
     const campaignId = request.params.id;
+
+    if (extractedCampaignId !== campaignId) {
+      throw new ForbiddenAccess();
+    }
 
     const writableStream = new PassThrough();
 

--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -64,7 +64,7 @@ module.exports = {
     const { userId } = request.auth.credentials;
     const campaignId = request.params.id;
 
-    const tokenForCampaignResults = tokenService.createTokenForCampaignResults(userId);
+    const tokenForCampaignResults = tokenService.createTokenForCampaignResults({ userId, campaignId });
 
     const campaign = await usecases.getCampaign({ campaignId, userId });
     return campaignReportSerializer.serialize(campaign, {}, { tokenForCampaignResults });

--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -72,7 +72,7 @@ module.exports = {
 
   async getCsvAssessmentResults(request) {
     const token = request.query.accessToken;
-    const userId = tokenService.extractUserIdForCampaignResults(token);
+    const { userId } = tokenService.extractCampaignResultsTokenContent(token);
     const campaignId = request.params.id;
 
     const writableStream = new PassThrough();
@@ -99,7 +99,7 @@ module.exports = {
 
   async getCsvProfilesCollectionResults(request) {
     const token = request.query.accessToken;
-    const userId = tokenService.extractUserIdForCampaignResults(token);
+    const { userId } = tokenService.extractCampaignResultsTokenContent(token);
     const campaignId = request.params.id;
 
     const writableStream = new PassThrough();

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -110,7 +110,7 @@ module.exports = (function () {
       secret: process.env.AUTH_SECRET,
       accessTokenLifespanMs: ms(process.env.ACCESS_TOKEN_LIFESPAN || '20m'),
       refreshTokenLifespanMs: ms(process.env.REFRESH_TOKEN_LIFESPAN || '7d'),
-      tokenForCampaignResultLifespan: '1h',
+      tokenForCampaignResultLifespan: process.env.CAMPAIGN_RESULT_ACCESS_TOKEN_LIFESPAN || '1h',
       tokenForStudentReconciliationLifespan: '1h',
       passwordResetTokenLifespan: '1h',
     },

--- a/api/lib/domain/services/token-service.js
+++ b/api/lib/domain/services/token-service.js
@@ -47,10 +47,11 @@ function createAccessTokenFromApplication(
   );
 }
 
-function createTokenForCampaignResults(userId) {
+function createTokenForCampaignResults({ userId, campaignId }) {
   return jsonwebtoken.sign(
     {
       access_id: userId,
+      campaign_id: campaignId,
     },
     settings.authentication.secret,
     { expiresIn: settings.authentication.tokenForCampaignResultLifespan }

--- a/api/lib/domain/services/token-service.js
+++ b/api/lib/domain/services/token-service.js
@@ -173,9 +173,10 @@ function extractClientId(token, secret = settings.authentication.secret) {
   return decoded.client_id || null;
 }
 
-function extractUserIdForCampaignResults(token) {
+function extractCampaignResultsTokenContent(token) {
   const decoded = getDecodedToken(token);
-  return decoded.access_id || null;
+  if (decoded === false) return null;
+  return { userId: decoded.access_id, campaignId: decoded.campaign_id };
 }
 
 async function extractExternalUserFromIdToken(token) {
@@ -213,5 +214,5 @@ module.exports = {
   extractTokenFromAuthChain,
   extractUserId,
   extractClientId,
-  extractUserIdForCampaignResults,
+  extractCampaignResultsTokenContent,
 };

--- a/api/sample.env
+++ b/api/sample.env
@@ -671,6 +671,12 @@ POLE_EMPLOI_ACCESS_TOKEN_LIFESPAN=7d
 # default: 7d
 CNAV_ACCESS_TOKEN_LIFESPAN=7d
 
+# Campaign result access token lifespan
+# presence: optional
+# type: string
+# default: 1h
+#CAMPAIGN_RESULT_ACCESS_TOKEN_LIFESPAN=
+
 # ========
 # TESTS
 # ========

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -201,10 +201,11 @@ describe('Acceptance | API | Campaign Controller', function () {
   describe('GET /api/campaigns/{id}/csv-assessment-results', function () {
     let accessToken;
 
-    function _createTokenWithAccessId(userId) {
+    function _createTokenWithAccessId({ userId, campaignId }) {
       return jwt.sign(
         {
           access_id: userId,
+          campaign_id: campaignId,
         },
         settings.authentication.secret,
         { expiresIn: settings.authentication.accessTokenLifespanMs }
@@ -221,7 +222,7 @@ describe('Acceptance | API | Campaign Controller', function () {
         organizationId: organization.id,
         targetProfileId: targetProfile.id,
       });
-      accessToken = _createTokenWithAccessId(userId);
+      accessToken = _createTokenWithAccessId({ userId, campaignId: campaign.id });
 
       databaseBuilder.factory.buildMembership({
         userId,
@@ -263,28 +264,38 @@ describe('Acceptance | API | Campaign Controller', function () {
     });
 
     it('should return csv file with statusCode 200', async function () {
-      // given
-      const url = `/api/campaigns/${campaign.id}/csv-assessment-results?accessToken=${accessToken}`;
-      const request = {
+      // given & when
+      const { statusCode, payload } = await server.inject({
         method: 'GET',
-        url,
-      };
-
-      // when
-      const response = await server.inject(request);
+        url: `/api/campaigns/${campaign.id}/csv-assessment-results?accessToken=${accessToken}`,
+      });
 
       // then
-      expect(response.statusCode).to.equal(200, response.payload);
+      expect(statusCode).to.equal(200, payload);
+    });
+
+    context('when accessing another campaign with the wrong access token', function () {
+      it('should return an error response with an HTTP status code 403', async function () {
+        // given & when
+        const { statusCode } = await server.inject({
+          method: 'GET',
+          url: `/api/campaigns/1234567890/csv-assessment-results?accessToken=${accessToken}`,
+        });
+
+        // then
+        expect(statusCode).to.equal(403);
+      });
     });
   });
 
   describe('GET /api/campaigns/{id}/csv-profiles-collection-results', function () {
     let accessToken;
 
-    function _createTokenWithAccessId(userId) {
+    function _createTokenWithAccessId({ userId, campaignId }) {
       return jwt.sign(
         {
           access_id: userId,
+          campaign_id: campaignId,
         },
         settings.authentication.secret,
         { expiresIn: settings.authentication.accessTokenLifespanMs }
@@ -298,7 +309,7 @@ describe('Acceptance | API | Campaign Controller', function () {
         organizationId: organization.id,
         type: 'PROFILES_COLLECTION',
       });
-      accessToken = _createTokenWithAccessId(userId);
+      accessToken = _createTokenWithAccessId({ userId, campaignId: campaign.id });
 
       databaseBuilder.factory.buildMembership({
         userId,
@@ -340,18 +351,27 @@ describe('Acceptance | API | Campaign Controller', function () {
     });
 
     it('should return csv file with statusCode 200', async function () {
-      // given
-      const url = `/api/campaigns/${campaign.id}/csv-profiles-collection-results?accessToken=${accessToken}`;
-      const request = {
+      // given & when
+      const { statusCode, payload } = await server.inject({
         method: 'GET',
-        url,
-      };
-
-      // when
-      const response = await server.inject(request);
+        url: `/api/campaigns/${campaign.id}/csv-profiles-collection-results?accessToken=${accessToken}`,
+      });
 
       // then
-      expect(response.statusCode).to.equal(200, response.payload);
+      expect(statusCode).to.equal(200, payload);
+    });
+
+    context('when accessing another campaign with the wrong access token', function () {
+      it('should return an error response with an HTTP status code 403', async function () {
+        // given & when
+        const { statusCode } = await server.inject({
+          method: 'GET',
+          url: `/api/campaigns/1234567890/csv-profiles-collection-results?accessToken=${accessToken}`,
+        });
+
+        // then
+        expect(statusCode).to.equal(403);
+      });
     });
   });
 

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -330,7 +330,7 @@ describe('Unit | Application | Controller | Campaign', function () {
       sinon.stub(tokenService, 'createTokenForCampaignResults');
 
       queryParamsUtils.extractParameters.withArgs({}).returns({});
-      tokenService.createTokenForCampaignResults.withArgs(request.auth.credentials.userId).returns('token');
+      tokenService.createTokenForCampaignResults.returns('token');
       usecases.getCampaign.resolves(campaign);
     });
 
@@ -345,6 +345,7 @@ describe('Unit | Application | Controller | Campaign', function () {
 
       // then
       expect(usecases.getCampaign).calledWith({ campaignId, userId });
+      expect(tokenService.createTokenForCampaignResults).to.have.been.calledWith({ userId, campaignId });
       expect(response).to.deep.equal(expectedResult);
     });
   });

--- a/api/tests/unit/domain/services/token-service_test.js
+++ b/api/tests/unit/domain/services/token-service_test.js
@@ -13,6 +13,29 @@ const settings = require('../../../../lib/config');
 const tokenService = require('../../../../lib/domain/services/token-service');
 
 describe('Unit | Domain | Service | Token Service', function () {
+  describe('#createTokenForCampaignResults', function () {
+    it('should create an access token with user id and campaign id', function () {
+      // given
+      const generatedAccessToken = 'Valid-Access-Token';
+      const userId = 123;
+      const campaignId = 456;
+
+      settings.authentication.secret = 'a secret';
+      settings.authentication.tokenForCampaignResultLifespan = 10;
+
+      sinon.stub(jsonwebtoken, 'sign').returns(generatedAccessToken);
+
+      // when
+      const accessTokenForCampaignResults = tokenService.createTokenForCampaignResults({ userId, campaignId });
+
+      // then
+      expect(accessTokenForCampaignResults).to.equal(generatedAccessToken);
+      expect(jsonwebtoken.sign).to.have.been.calledWith({ access_id: userId, campaign_id: campaignId }, 'a secret', {
+        expiresIn: 10,
+      });
+    });
+  });
+
   describe('#createAccessTokenFromUser', function () {
     it('should create access token with user id and source', function () {
       // given

--- a/api/tests/unit/domain/services/token-service_test.js
+++ b/api/tests/unit/domain/services/token-service_test.js
@@ -137,28 +137,32 @@ describe('Unit | Domain | Service | Token Service', function () {
     });
   });
 
-  describe('#extractUserIdForCampaignResults', function () {
-    it('should return userId if the accessToken is valid', function () {
-      // given
-      const userId = 123;
-      const accessToken = tokenService.createTokenForCampaignResults(userId);
+  describe('#extractCampaignResultsTokenContent', function () {
+    context('valid token', function () {
+      it('should return userId and campaignId if the accessToken is valid', function () {
+        // given
+        const accessToken = tokenService.createTokenForCampaignResults({ userId: 123, campaignId: 456 });
 
-      // when
-      const result = tokenService.extractUserIdForCampaignResults(accessToken);
+        // when
+        const { userId, campaignId } = tokenService.extractCampaignResultsTokenContent(accessToken);
 
-      // then
-      expect(result).to.equal(userId);
+        // then
+        expect(userId).to.equal(123);
+        expect(campaignId).to.equal(456);
+      });
     });
 
-    it('should return null if the accessToken is invalid', function () {
-      // given
-      const accessToken = 'WRONG_DATA';
+    context('invalid token', function () {
+      it('should return null', function () {
+        // given
+        const accessToken = 'WRONG_DATA';
 
-      // when
-      const result = tokenService.extractUserIdForCampaignResults(accessToken);
+        // when
+        const result = tokenService.extractCampaignResultsTokenContent(accessToken);
 
-      // then
-      expect(result).to.equal(null);
+        // then
+        expect(result).to.equal(null);
+      });
     });
   });
 


### PR DESCRIPTION
## :jack_o_lantern: Problème

Actuellement, il est possible pour un utilisateur de Pix Orga de télécharger les résultats d'une campagne dont il n'a pas accès dans son organisation. Ce qui pose un souci de sécurité. L'utilisateur ne peut télécharger que les résultats de campagnes qui lui sont accessibles.

## :bat: Proposition

- Ajouter dans le payload de l'access token généré, l'identifiant de la campagne.
- Lors de la tentative de téléchargement, vérifier si l'identifiant de la campagne se trouvant dans l'URL est le même que celui de l'access token. Si c'est le cas alors le téléchargement peut se faire. Dans le cas contraire, retourner un code d'erreur HTTP 403 Forbidden.

## :spider_web: Remarques

- Ajout d'une variable d'environnement pour définir un temps d'expiration pour le token d'accès au téléchargement des résultats.
- Lorsque l'access token permettant de récupérer les résultats aura expiré, une erreur surviendra lors du téléchargement du fichier.
- Sur Safari et Firefox, le bouton lance le téléchargement d'un fichier HTML au lieu du fichier CSV. Le problème est reproductible sur la branche `dev`

## :ghost: Pour tester

- Modifier dans la variable d'environnement `CAMPAIGN_RESULT_ACCESS_TOKEN_LIFESPAN` (par défaut : 1h)
- Relancer l'API pour prendre en compte la modification
- Se connecter à Pix Orga
- Ouvrir la page de détails d'une campagne
- Cliquez sur le bouton pour télécharger le fichier des résultats
- Constatez que le fichier CSV se télécharge
- Attendre que l'access token pour télécharger le fichier des résultats expire
- Cliquez sur le bouton pour télécharger le fichier des résultats
- Constatez qu'il y a une erreur de téléchargement.
