### PR TITLE
[TECH] Tracer le nombre de requêtes SQL associées à une requête http

### DIFF
--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -56,22 +56,18 @@ QueryBuilder.prototype.toSQL = function () {
 };
 
 knex.on('query', function (data) {
-  if (logging.enableLogKnexQueries) {
+  if (logging.enableKnexPerformanceMonitoring) {
     monitoringTools.setInContext(`knexQueryStartTimes.${data.__knexQueryUid}`, performance.now());
   }
 });
 
-knex.on('query-response', function (response, obj) {
+knex.on('query-response', function (response, data) {
   monitoringTools.incrementInContext('metrics.knexQueryCount');
-  if (logging.enableLogKnexQueries) {
-    const queryStartedTime = monitoringTools.getInContext(`knexQueryStartTimes.${obj.__knexQueryUid}`);
+  if (logging.enableKnexPerformanceMonitoring) {
+    const queryStartedTime = monitoringTools.getInContext(`knexQueryStartTimes.${data.__knexQueryUid}`);
     if (queryStartedTime) {
       const duration = performance.now() - queryStartedTime;
-      monitoringTools.pushInContext('metrics.knexQueries', {
-        id: obj.__knexQueryUid,
-        sql: obj.sql,
-        duration,
-      });
+      monitoringTools.incrementInContext('metrics.knexTotalTimeSpent', duration);
     }
   }
 });

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -62,12 +62,11 @@ knex.on('query', function (data) {
 });
 
 knex.on('query-response', function (response, obj) {
+  monitoringTools.incrementInContext('metrics.knexQueryCount');
   if (logging.enableLogKnexQueries) {
     const queryStartedTime = monitoringTools.getInContext(`knexQueryStartTimes.${obj.__knexQueryUid}`);
     if (queryStartedTime) {
       const duration = performance.now() - queryStartedTime;
-
-      monitoringTools.incrementInContext('metrics.knexQueryCount');
       monitoringTools.pushInContext('metrics.knexQueries', {
         id: obj.__knexQueryUid,
         sql: obj.sql,

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -57,7 +57,8 @@ QueryBuilder.prototype.toSQL = function () {
 
 knex.on('query', function (data) {
   if (logging.enableKnexPerformanceMonitoring) {
-    monitoringTools.setInContext(`knexQueryStartTimes.${data.__knexQueryUid}`, performance.now());
+    const queryId = data.__knexQueryUid;
+    monitoringTools.setInContext(`knexQueryStartTimes.${queryId}`, performance.now());
   }
 });
 

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -81,7 +81,7 @@ module.exports = (function () {
       enabled: isFeatureEnabled(process.env.LOG_ENABLED),
       logLevel: process.env.LOG_LEVEL || 'info',
       logForHumans: _getLogForHumans(),
-      enableKnexPerformanceMonitoring: isFeatureEnabled(process.env.LOG_KNEX_PERFORMANCE),
+      enableKnexPerformanceMonitoring: isFeatureEnabled(process.env.ENABLE_KNEX_PERFORMANCE_MONITORING),
       enableLogStartingEventDispatch: isFeatureEnabled(process.env.LOG_STARTING_EVENT_DISPATCH),
       enableLogEndingEventDispatch: isFeatureEnabled(process.env.LOG_ENDING_EVENT_DISPATCH),
       emitOpsEventEachSeconds: isFeatureEnabled(process.env.OPS_EVENT_EACH_SECONDS) || 15,

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -81,7 +81,7 @@ module.exports = (function () {
       enabled: isFeatureEnabled(process.env.LOG_ENABLED),
       logLevel: process.env.LOG_LEVEL || 'info',
       logForHumans: _getLogForHumans(),
-      enableLogKnexQueries: isFeatureEnabled(process.env.LOG_KNEX_QUERIES),
+      enableKnexPerformanceMonitoring: isFeatureEnabled(process.env.LOG_KNEX_PERFORMANCE),
       enableLogStartingEventDispatch: isFeatureEnabled(process.env.LOG_STARTING_EVENT_DISPATCH),
       enableLogEndingEventDispatch: isFeatureEnabled(process.env.LOG_ENDING_EVENT_DISPATCH),
       emitOpsEventEachSeconds: isFeatureEnabled(process.env.OPS_EVENT_EACH_SECONDS) || 15,

--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -58,10 +58,10 @@ function setInContext(path, value) {
   set(store, path, value);
 }
 
-function incrementInContext(path) {
+function incrementInContext(path, increment = 1) {
   const store = asyncLocalStorage.getStore();
   if (!store) return;
-  update(store, path, (v) => (v ?? 0) + 1);
+  update(store, path, (v) => (v ?? 0) + increment);
 }
 
 function getContext() {

--- a/api/lib/infrastructure/monitoring-tools.js
+++ b/api/lib/infrastructure/monitoring-tools.js
@@ -108,4 +108,5 @@ module.exports = {
   logInfoWithCorrelationIds,
   pushInContext,
   setInContext,
+  asyncLocalStorageForTests: asyncLocalStorage,
 };

--- a/api/lib/infrastructure/validate-environment-variables.js
+++ b/api/lib/infrastructure/validate-environment-variables.js
@@ -55,7 +55,7 @@ const schema = Joi.object({
   CPF_PLANNER_JOB_CRON: Joi.string().optional(),
   CPF_SEND_EMAIL_JOB_RECIPIENT: Joi.string().optional(),
   CPF_SEND_EMAIL_JOB_CRON: Joi.string().optional(),
-  LOG_KNEX_PERFORMANCE: Joi.string().optional().valid('true', 'false'),
+  ENABLE_KNEX_PERFORMANCE_MONITORING: Joi.string().optional().valid('true', 'false'),
 }).options({ allowUnknown: true });
 
 const validateEnvironmentVariables = function () {

--- a/api/lib/infrastructure/validate-environment-variables.js
+++ b/api/lib/infrastructure/validate-environment-variables.js
@@ -55,6 +55,7 @@ const schema = Joi.object({
   CPF_PLANNER_JOB_CRON: Joi.string().optional(),
   CPF_SEND_EMAIL_JOB_RECIPIENT: Joi.string().optional(),
   CPF_SEND_EMAIL_JOB_CRON: Joi.string().optional(),
+  LOG_KNEX_PERFORMANCE: Joi.string().optional().valid('true', 'false'),
 }).options({ allowUnknown: true });
 
 const validateEnvironmentVariables = function () {

--- a/api/sample.env
+++ b/api/sample.env
@@ -605,18 +605,14 @@ MAX_REACHABLE_LEVEL=
 ENABLE_REQUEST_MONITORING=true
 
 # ========
-# LOG KNEX QUERIES
+# LOG KNEX PERFORMANCE
 # ========
 
-# Enable knex log queries metrics
-# duration: to calculate the response time of the query
-# sql: sql queries
-# knexQueryCount: le nombre de queries par API
+# Enable knex performance monitoring
 # presence: optional
 # type: boolean
 # default: false
-# note: Enabled in demand in production
-LOG_KNEX_QUERIES=true
+LOG_KNEX_PERFORMANCE=true
 
 # ========
 # FLASH METHOD CHALLENGES

--- a/api/sample.env
+++ b/api/sample.env
@@ -605,14 +605,14 @@ MAX_REACHABLE_LEVEL=
 ENABLE_REQUEST_MONITORING=true
 
 # ========
-# LOG KNEX PERFORMANCE
+# ENABLE KNEX PERFORMANCE MONITORING
 # ========
 
-# Enable knex performance monitoring
+# Enable knex performance monitoring by inserting metrics in context
 # presence: optional
 # type: boolean
 # default: false
-LOG_KNEX_PERFORMANCE=true
+ENABLE_KNEX_PERFORMANCE_MONITORING=false
 
 # ========
 # FLASH METHOD CHALLENGES

--- a/api/tests/integration/infrastructure/knex-database-performance-monitoring_test.js
+++ b/api/tests/integration/infrastructure/knex-database-performance-monitoring_test.js
@@ -1,0 +1,37 @@
+const { expect, sinon } = require('../../test-helper');
+const knexDatabaseConnection = require('../../../db/knex-database-connection');
+const knex = knexDatabaseConnection.knex;
+const { asyncLocalStorageForTests: asyncLocalStorage } = require('../../../lib/infrastructure/monitoring-tools.js');
+const config = require('../../../lib/config');
+
+describe('Integration | Infrastructure | knex-database-performance-monitoring', function () {
+  it('with knex monitoring disabled it should insert knex metrics in context', async function () {
+    // given
+    sinon.stub(config.logging, 'enableKnexPerformanceMonitoring').value(false);
+
+    // when
+    const store = await asyncLocalStorage.run({}, async () => {
+      await knex.raw('SELECT 1 as value');
+      return asyncLocalStorage.getStore();
+    });
+
+    // then
+    expect(store.metrics.knexQueryCount).to.equal(1);
+    expect(store.metrics.knexTotalTimeSpent).to.not.exist;
+  });
+
+  it('with knex monitoring enabled it should insert knex metrics in context', async function () {
+    // given
+    sinon.stub(config.logging, 'enableKnexPerformanceMonitoring').value(true);
+
+    // when
+    const store = await asyncLocalStorage.run({}, async () => {
+      await knex.raw('SELECT 1 as value');
+      return asyncLocalStorage.getStore();
+    });
+
+    // then
+    expect(store.metrics.knexQueryCount).to.equal(1);
+    expect(store.metrics.knexTotalTimeSpent).to.be.above(0);
+  });
+});


### PR DESCRIPTION
## :jack_o_lantern: Problème
Nous n'avons pas de monitoring sur le nombre de requêtes Knex associées à chaque appel http
Il y a bien un toggle pour tracer le texte des requêtes, mais il n'est pas exploitable.

## :bat: Proposition
Supprimer la trace du texte des requêtes.

Ajouter:
-  le nombre de requête knex traitées par appel http;
- la durée totale passée dans des appels knex par appel http.

## :spider_web: Remarques
Des tests ont été rajoutés, mais le nommage n'est peut être pas évident, je suis preneur de retours ou d'idées.

## :ghost: Pour tester

### Local
Activer les FT 
- `ENABLE_REQUEST_MONITORING=true`
- `LOG_KNEX_PERFORMANCE=true`

Démarrer l'API

Appeler le endpoint `db`
```shell
curl http://localhost:3000/api/healthcheck/db
```

Vérifier la présence de `metrics` dans le log http, par exemple
```
[09:19:38] INFO: request completed
    queryParams: {}
    req: {
      "method": "get",
      "url": "/api/healthcheck/db",
	  (..)
      "user_id": "-",
      "metrics": {
        "knexQueryCount": 1,
        "knexTotalTimeSpent": 4.5130390003323555
      },
```

## Review-app
Appeler l'API
``` shell
curl https://api-pr5119.review.pix.fr/api/healthcheck/db
```

Vérifier la présence de `metrics` dans le log http, par exemple
```
2022-10-25 11:33:18.611377299 +0200 CEST[web-1] {"level":30,"time":1666690398609,"pid":21,"hostname":"pix-api-review-pr5119-web-1","queryParams":{},"req":{"id":"1666690398569:pix-api-review-pr5119-web-1:21:l9o0em41:10000","method":"get","url":"/api/healthcheck/db","headers":{"host":"pix-api-review-pr5119.osc-fr1.scalingo.io","x-forwarded-proto":"https","x-real-ip":"171.33.105.206","x-forwarded-port":"443","x-forwarded-for":"88.172.56.105, 88.172.56.105, 171.33.105.206","connection":"close","x-forwarded-host":"api-pr5119.review.pix.fr","pix-application":"api","user-agent":"curl/7.81.0","accept":"*/*","x-request-id":"f1eb354a-4187-4423-a15c-c07a4378a36a"},"remoteAddress":"10.0.0.97","remotePort":36922,"version":"aa814d715be6b87668fb27452c6cdc1a0a44bec9","user_id":"-","metrics":{"knexQueryCount":1,"knexTotalTimeSpent":3.4322270154953003},"route":"/api/healthcheck/db"},"res":{"statusCode":200,"headers":{"content-type":"application/json; charset=utf-8","vary":"origin","access-control-expose-headers":"WWW-Authenticate,Server-Authorization","cache-control":"no-cache","content-length":39,"accept-ranges":"bytes"}},"responseTime":40,"msg":"request completed"} 
```

