### PR TITLE
[FEATURE] ETQ Pix certif user d'un CDC habilité CléA numérique, JV pouvoir modifier le référent Pix dans mon centre (PIX-5798)

### DIFF
--- a/api/lib/domain/usecases/update-certification-center-referer.js
+++ b/api/lib/domain/usecases/update-certification-center-referer.js
@@ -4,6 +4,18 @@ module.exports = async function updateCertificationCenterReferer({
   certificationCenterId,
   certificationCenterMembershipRepository,
 }) {
+  const actualReferer = await certificationCenterMembershipRepository.getRefererByCertificationCenterId({
+    certificationCenterId,
+  });
+
+  if (actualReferer) {
+    await certificationCenterMembershipRepository.updateRefererStatusByUserIdAndCertificationCenterId({
+      userId: actualReferer.user.id,
+      certificationCenterId,
+      isReferer: false,
+    });
+  }
+
   return certificationCenterMembershipRepository.updateRefererStatusByUserIdAndCertificationCenterId({
     userId,
     certificationCenterId,

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -139,4 +139,18 @@ module.exports = {
   async updateRefererStatusByUserIdAndCertificationCenterId({ userId, certificationCenterId, isReferer }) {
     await knex('certification-center-memberships').where({ userId, certificationCenterId }).update({ isReferer });
   },
+
+  async getRefererByCertificationCenterId({ certificationCenterId }) {
+    const refererCertificationCenterMembership = await knex('certification-center-memberships')
+      .select('certification-center-memberships.*', 'users.lastName', 'users.firstName', 'users.email')
+      .join('users', 'users.id', 'certification-center-memberships.userId')
+      .where({ certificationCenterId, isReferer: true })
+      .first();
+
+    if (!refererCertificationCenterMembership) {
+      return null;
+    }
+
+    return _toDomain(refererCertificationCenterMembership);
+  },
 };

--- a/api/tests/unit/domain/usecases/update-certification-center-referer_test.js
+++ b/api/tests/unit/domain/usecases/update-certification-center-referer_test.js
@@ -1,28 +1,81 @@
-const { expect, sinon } = require('../../../test-helper');
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const updateCertificationCenterReferer = require('../../../../lib/domain/usecases/update-certification-center-referer');
 
 describe('Unit | UseCase | update-certification-center-referer', function () {
-  it('should update the certification center membership', async function () {
-    // given
-    const certificationCenterMembershipRepository = {
-      updateRefererStatusByUserIdAndCertificationCenterId: sinon.stub(),
-    };
+  context('when there is already a referer', function () {
+    it('should replace the current referer', async function () {
+      // given
+      const certificationCenterMembershipRepository = {
+        updateRefererStatusByUserIdAndCertificationCenterId: sinon.stub(),
+        getRefererByCertificationCenterId: sinon.stub(),
+      };
 
-    // when
-    await updateCertificationCenterReferer({
-      userId: 1234,
-      certificationCenterId: 456,
-      isReferer: true,
-      certificationCenterMembershipRepository,
+      certificationCenterMembershipRepository.getRefererByCertificationCenterId
+        .withArgs({ certificationCenterId: 456 })
+        .resolves(
+          domainBuilder.buildCertificationCenterMembership({
+            isReferer: true,
+            user: domainBuilder.buildUser({
+              id: 4567,
+            }),
+          })
+        );
+
+      // when
+      await updateCertificationCenterReferer({
+        userId: 1234,
+        certificationCenterId: 456,
+        isReferer: true,
+        certificationCenterMembershipRepository,
+      });
+
+      // then
+      expect(
+        certificationCenterMembershipRepository.updateRefererStatusByUserIdAndCertificationCenterId
+      ).to.have.been.calledTwice;
+
+      expect(
+        certificationCenterMembershipRepository.updateRefererStatusByUserIdAndCertificationCenterId.firstCall
+      ).to.have.been.calledWithExactly({
+        userId: 4567,
+        certificationCenterId: 456,
+        isReferer: false,
+      });
+
+      expect(
+        certificationCenterMembershipRepository.updateRefererStatusByUserIdAndCertificationCenterId.secondCall
+      ).to.have.been.calledWithExactly({
+        userId: 1234,
+        certificationCenterId: 456,
+        isReferer: true,
+      });
     });
+  });
 
-    // then
-    expect(
-      certificationCenterMembershipRepository.updateRefererStatusByUserIdAndCertificationCenterId
-    ).to.have.been.calledWithExactly({
-      userId: 1234,
-      certificationCenterId: 456,
-      isReferer: true,
+  context('when there is no referer yet', function () {
+    it('should select a referer', async function () {
+      // given
+      const certificationCenterMembershipRepository = {
+        updateRefererStatusByUserIdAndCertificationCenterId: sinon.stub(),
+        getRefererByCertificationCenterId: sinon.stub(),
+      };
+
+      // when
+      await updateCertificationCenterReferer({
+        userId: 1234,
+        certificationCenterId: 456,
+        isReferer: true,
+        certificationCenterMembershipRepository,
+      });
+
+      // then
+      expect(
+        certificationCenterMembershipRepository.updateRefererStatusByUserIdAndCertificationCenterId
+      ).to.have.been.calledOnceWithExactly({
+        userId: 1234,
+        certificationCenterId: 456,
+        isReferer: true,
+      });
     });
   });
 });

--- a/certif/app/components/members-list.hbs
+++ b/certif/app/components/members-list.hbs
@@ -13,7 +13,7 @@
         </thead>
 
         <tbody>
-          {{#each @members as |member|}}
+          {{#each this.orderedMemberListWithRefererFirst as |member|}}
             <tr aria-label="Membres du centre de certification">
               <td>{{member.lastName}}</td>
               <td>{{member.firstName}}</td>

--- a/certif/app/components/members-list.js
+++ b/certif/app/components/members-list.js
@@ -4,6 +4,24 @@ import { inject as service } from '@ember/service';
 export default class MembersList extends Component {
   @service featureToggles;
 
+  get orderedMemberListWithRefererFirst() {
+    const membersArray = this.args.members.toArray();
+
+    membersArray.sort((member1, member2) => {
+      if (member1.isReferer) {
+        return -1;
+      }
+
+      if (member2.isReferer) {
+        return 1;
+      }
+
+      return member1.lastName.localeCompare(member2.lastName, 'fr-FR', { sensitivity: 'base' });
+    });
+
+    return membersArray;
+  }
+
   get shouldDisplayRefererColumn() {
     return (
       this.args.hasCleaHabilitation &&

--- a/certif/app/controllers/authenticated/team.js
+++ b/certif/app/controllers/authenticated/team.js
@@ -21,6 +21,7 @@ export default class Team extends Controller {
     return this.model.members
       .toArray()
       .sort((member1, member2) => member1.lastName.localeCompare(member2.lastName, 'fr-FR', { sensitivity: 'base' }))
+      .filter((member) => !member.isReferer)
       .map((member) => ({ value: member.id, label: `${member.firstName} ${member.lastName}` }));
   }
 

--- a/certif/app/controllers/authenticated/team.js
+++ b/certif/app/controllers/authenticated/team.js
@@ -17,6 +17,14 @@ export default class Team extends Controller {
     );
   }
 
+  get shouldDisplayUpdateRefererButton() {
+    return (
+      this.model.hasCleaHabilitation &&
+      _hasAtLeastTwoMembersAndOneReferer(this.model.members) &&
+      this.featureToggles.featureToggles.isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled
+    );
+  }
+
   get membersSelectOptionsSortedByLastName() {
     return this.model.members
       .toArray()
@@ -50,4 +58,8 @@ export default class Team extends Controller {
 
 function _hasAtLeastOneMemberAndNoReferer(members) {
   return members.length > 0 && !members.toArray().some((member) => member.isReferer);
+}
+
+function _hasAtLeastTwoMembersAndOneReferer(members) {
+  return members.length > 1 && members.toArray().some((member) => member.isReferer);
 }

--- a/certif/app/styles/pages/authenticated/team.scss
+++ b/certif/app/styles/pages/authenticated/team.scss
@@ -1,4 +1,18 @@
 .team {
+  &__header {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+    align-items:center;
+  }
+
+  &__update-referer-button {
+    width: 180px;
+    height: 50px;
+    font-weight: 500;
+    border-radius: 6px;
+  }
+
   &__no-referer-container {
     margin-bottom: 24px;
     padding: 6px;

--- a/certif/app/templates/authenticated/team.hbs
+++ b/certif/app/templates/authenticated/team.hbs
@@ -1,6 +1,17 @@
 {{page-title (t "pages.team.title")}}
 
-<h1 class="page__title page-title">{{t "pages.team.title"}}</h1>
+<div class="team__header">
+  <h1 class="page__title page-title">{{t "pages.team.title"}}</h1>
+  {{#if this.shouldDisplayUpdateRefererButton}}
+    <PixButton
+      class="team__update-referer-button"
+      @backgroundColor="transparent-light"
+      @isBorderVisible={{true}}
+      @triggerAction={{this.toggleRefererModal}}
+    >{{t "pages.team.update-referer-button"}}</PixButton>
+  {{/if}}
+</div>
+
 {{#if this.shouldDisplayNoRefererSection}}
   <div class="panel team__no-referer-container">
     <div class="team__no-referer-container-grey">

--- a/certif/tests/unit/components/members-list_test.js
+++ b/certif/tests/unit/components/members-list_test.js
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+
+module('Unit | Component | member-list', (hooks) => {
+  setupTest(hooks);
+
+  module('#orderedMemberListWithRefererFirst', () => {
+    test('should return an array of members ordered by lastName and with referer first', async function (assert) {
+      // given
+      const component = createGlimmerComponent('component:members-list');
+      component.args.members = [
+        { firstName: 'Piegrièche', lastName: 'Ouicestunoiseau', isReferer: false },
+        { firstName: 'Pierre', lastName: 'Quiroule', isReferer: true },
+        { firstName: 'Paul', lastName: 'Ochon', isReferer: false },
+      ];
+
+      // when
+      const result = component.orderedMemberListWithRefererFirst;
+
+      // then
+      assert.deepEqual(result, [
+        { firstName: 'Pierre', lastName: 'Quiroule', isReferer: true },
+        { firstName: 'Paul', lastName: 'Ochon', isReferer: false },
+        { firstName: 'Piegrièche', lastName: 'Ouicestunoiseau', isReferer: false },
+      ]);
+    });
+  });
+});

--- a/certif/tests/unit/controllers/team_test.js
+++ b/certif/tests/unit/controllers/team_test.js
@@ -139,7 +139,7 @@ module('Unit | Controller | authenticated/team', function (hooks) {
   });
 
   module('#membersSelectOptionsSortedByLastName', function () {
-    test('should return an array of members select options ordered by last name', function (assert) {
+    test('should return an array of non referer members select options ordered by last name', function (assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/team');
       const store = this.owner.lookup('service:store');
@@ -147,13 +147,21 @@ module('Unit | Controller | authenticated/team', function (hooks) {
         id: 102,
         firstName: 'Abe',
         lastName: 'Sapiens',
+        isReferer: false,
       });
       const member2 = store.createRecord('member', {
         id: 100,
         firstName: 'Trevor',
         lastName: 'Bruttenholm',
+        isReferer: false,
       });
-      controller.model = { members: [member1, member2], hasCleaHabilitation: true };
+      const member3 = store.createRecord('member', {
+        id: 101,
+        firstName: 'Aby',
+        lastName: 'Gails',
+        isReferer: true,
+      });
+      controller.model = { members: [member1, member2, member3], hasCleaHabilitation: true };
 
       // when then
       assert.deepEqual(controller.membersSelectOptionsSortedByLastName, [

--- a/certif/tests/unit/controllers/team_test.js
+++ b/certif/tests/unit/controllers/team_test.js
@@ -248,4 +248,91 @@ module('Unit | Controller | authenticated/team', function (hooks) {
       });
     });
   });
+
+  module('#shouldDisplayUpdateRefererButton', function () {
+    module('when FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS is enabled', function (hooks) {
+      hooks.beforeEach(function () {
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: true };
+        }
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+      });
+
+      module('when there is only one member', function () {
+        test('should return false', function (assert) {
+          // given
+          const controller = this.owner.lookup('controller:authenticated/team');
+          const store = this.owner.lookup('service:store');
+          const isReferer = store.createRecord('member', {
+            isReferer: true,
+          });
+
+          controller.model = { members: [isReferer], hasCleaHabilitation: true };
+
+          // when then
+          assert.false(controller.shouldDisplayUpdateRefererButton);
+        });
+      });
+      module('when there is at least 2 members', function () {
+        module('when there is a referer', function () {
+          test('should return true', function (assert) {
+            // given
+            const controller = this.owner.lookup('controller:authenticated/team');
+            const store = this.owner.lookup('service:store');
+
+            const notReferer = store.createRecord('member', {
+              isReferer: false,
+            });
+            const isReferer = store.createRecord('member', {
+              isReferer: true,
+            });
+
+            controller.model = { members: [notReferer, isReferer], hasCleaHabilitation: true };
+
+            // when then
+            assert.true(controller.shouldDisplayUpdateRefererButton);
+          });
+        });
+        module('when there is no referer', function () {
+          test('should return false', function (assert) {
+            // given
+            const controller = this.owner.lookup('controller:authenticated/team');
+            const store = this.owner.lookup('service:store');
+
+            const notReferer = store.createRecord('member', {
+              isReferer: false,
+            });
+            const notReferer2 = store.createRecord('member', {
+              isReferer: false,
+            });
+
+            controller.model = { members: [notReferer, notReferer2], hasCleaHabilitation: true };
+
+            // when then
+            assert.false(controller.shouldDisplayUpdateRefererButton);
+          });
+        });
+      });
+    });
+    module('when FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS is not enabled', function (hooks) {
+      hooks.beforeEach(function () {
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: false };
+        }
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+      });
+
+      test('should return false', function (assert) {
+        // given
+        const controller = this.owner.lookup('controller:authenticated/team');
+        const store = this.owner.lookup('service:store');
+
+        const member = store.createRecord('member');
+        controller.model = { members: [member], hasCleaHabilitation: true };
+
+        // when then
+        assert.false(controller.shouldDisplayUpdateRefererButton);
+      });
+    });
+  });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -144,6 +144,7 @@
       "first-name": "Prénom",
       "referer": "Référent",
       "pix-referer": "Référent Pix",
+      "update-referer-button": "Changer de référent",
       "pix-referer-tooltip": "Le référent Pix est le contact privilégié des équipes de Pix. Il est le responsable du bon déroulement des sessions de certification.",
       "no-referer-section": {
         "title": "Aucun référent Pix désigné",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -144,6 +144,7 @@
       "first-name": "Prénom",
       "referer": "Référent",
       "pix-referer": "Référent Pix",
+      "update-referer-button": "Changer de référent",
       "pix-referer-tooltip": "Le référent Pix est le contact privilégié des équipes de Pix. Il est le responsable du bon déroulement des sessions de certification.",
       "no-referer-section": {
         "title": "Aucun référent Pix désigné",


### PR DESCRIPTION
## :jack_o_lantern: Problème
Dans le cadre de l'épix de récupération des résultats Cléa par les CDC habilités, un référent Pix va devoir être désigné dans chaque centre habilité CléA, car il sera le responsable de la mise à dispo des certificats Cléa aux candidats ayant obtenus leur certif CléA numérique by Pix.

Une fois le référent Pix désigné, le CDC habilité peut avoir besoin de le modifier.

## :bat: Proposition
Dans Pix certif > page “Equipe”, uniquement pour les CDC habilités CléA numérique : 

- filtrer les membres de l'équipe afin que le référent actuellement désigné apparaisse toujours en premier dans la liste
- ajouter un bouton “Changer de référent” : visible uniquement si au moins 1 référent a été identifié pour le CDC
- dans la modale de choix du nouveau référent, ne pas faire apparaître le membre déjà désigné comme référent du CDC
- placer sous FT

## :spider_web: Remarques
RAS

## :ghost: Pour tester
- Se connecter à Pix Certif avec le compte certifpro@example.net
- Aller dans l'onglet "Equipe" et constater que les membres sont trié par ordre alphabétique sur le nom
- Ajouter un référent au site
- Voir le bouton "Changer de référent" apparait et cliquer dessus
- Modifier le référent depuis la modale et constater que le référent actuel n'est pas présent dans la liste du menu déroulant
- Voir le changement du tag référent sur le nouveau et son passage au début de la liste