### PR TITLE
[FEATURE] Ajouter la page "/mes-formations" sur Pix App (PIX-5759).

### DIFF
--- a/api/db/seeds/data/trainings-builder.js
+++ b/api/db/seeds/data/trainings-builder.js
@@ -36,6 +36,41 @@ function trainingBuilder({ databaseBuilder }) {
     duration: '06:00:00',
     locale: 'fr-fr',
   });
+  const training6 = databaseBuilder.factory.buildTraining({
+    title: 'Apprendre à jouer à la coinche',
+    link: 'http://www.example6.net',
+    type: 'autoformation',
+    duration: '50:00:50',
+    locale: 'fr-fr',
+  });
+  const training7 = databaseBuilder.factory.buildTraining({
+    title: 'Savoir coudre',
+    link: 'http://www.example7.net',
+    type: 'webinaire',
+    duration: '00:05:00',
+    locale: 'fr-fr',
+  });
+  const training8 = databaseBuilder.factory.buildTraining({
+    title: 'Apprendre à faire du cidre breton',
+    link: 'http://www.example8.net',
+    type: 'autoformation',
+    duration: '01:00:00',
+    locale: 'fr-fr',
+  });
+  const training9 = databaseBuilder.factory.buildTraining({
+    title: 'Apprendre à compter',
+    link: 'http://www.example9.net',
+    type: 'webinaire',
+    duration: '10:00:00',
+    locale: 'fr-fr',
+  });
+  const training10 = databaseBuilder.factory.buildTraining({
+    title: 'Devenir influenceur de bonheur',
+    link: 'http://www.example10.net',
+    type: 'autoformation',
+    duration: '10:00:00',
+    locale: 'fr-fr',
+  });
   databaseBuilder.factory.buildTargetProfileTraining({
     trainingId: training1.id,
     targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,
@@ -54,6 +89,26 @@ function trainingBuilder({ databaseBuilder }) {
   });
   databaseBuilder.factory.buildTargetProfileTraining({
     trainingId: training5.id,
+    targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,
+  });
+  databaseBuilder.factory.buildTargetProfileTraining({
+    trainingId: training6.id,
+    targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,
+  });
+  databaseBuilder.factory.buildTargetProfileTraining({
+    trainingId: training7.id,
+    targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,
+  });
+  databaseBuilder.factory.buildTargetProfileTraining({
+    trainingId: training8.id,
+    targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,
+  });
+  databaseBuilder.factory.buildTargetProfileTraining({
+    trainingId: training9.id,
+    targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,
+  });
+  databaseBuilder.factory.buildTargetProfileTraining({
+    trainingId: training10.id,
     targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,
   });
 }

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -917,6 +917,29 @@ exports.register = async function (server) {
         tags: ['api', 'user', 'authentication-methods'],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/users/{id}/trainings',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
+        pre: [
+          {
+            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
+            assign: 'requestedUserIsAuthenticatedUser',
+          },
+        ],
+        handler: userController.findPaginatedUserRecommendedTrainings,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            "- Elle permet la récupération des contenus formatifs de l'utilisateur courant.",
+        ],
+        tags: ['api', 'user', 'trainings'],
+      },
+    },
   ]);
 };
 

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -17,9 +17,10 @@ const authenticationMethodsSerializer = require('../../infrastructure/serializer
 const campaignParticipationForUserManagementSerializer = require('../../infrastructure/serializers/jsonapi/campaign-participation-for-user-management-serializer');
 const userOrganizationForAdminSerializer = require('../../infrastructure/serializers/jsonapi/user-organization-for-admin-serializer');
 const certificationCenterMembershipSerializer = require('../../infrastructure/serializers/jsonapi/certification-center-membership-serializer');
+const trainingSerializer = require('../../infrastructure/serializers/jsonapi/training-serializer');
 
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
-const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
+const requestResponseUtils = require('../../infrastructure/utils/request-response-utils');
 
 const usecases = require('../../domain/usecases');
 
@@ -27,7 +28,7 @@ module.exports = {
   save(request, h) {
     const campaignCode = request.payload.meta ? request.payload.meta['campaign-code'] : null;
     const user = userSerializer.deserialize(request.payload);
-    const locale = extractLocaleFromRequest(request);
+    const locale = requestResponseUtils.extractLocaleFromRequest(request);
 
     const password = request.payload.data.attributes.password;
 
@@ -163,6 +164,18 @@ module.exports = {
     return userForAdminSerializer.serialize(users, pagination);
   },
 
+  async findPaginatedUserRecommendedTrainings(request) {
+    const locale = requestResponseUtils.extractLocaleFromRequest(request);
+    const { page } = queryParamsUtils.extractParameters(request.query);
+    const { userRecommendedTrainings, meta } = await usecases.findPaginatedUserRecommendedTrainings({
+      userId: request.auth.credentials.userId,
+      locale,
+      page,
+    });
+
+    return trainingSerializer.serialize(userRecommendedTrainings, meta);
+  },
+
   getCampaignParticipations(request) {
     const authenticatedUserId = request.auth.credentials.userId;
 
@@ -193,14 +206,14 @@ module.exports = {
 
   getProfile(request) {
     const authenticatedUserId = request.auth.credentials.userId;
-    const locale = extractLocaleFromRequest(request);
+    const locale = requestResponseUtils.extractLocaleFromRequest(request);
 
     return usecases.getUserProfile({ userId: authenticatedUserId, locale }).then(profileSerializer.serialize);
   },
 
   getProfileForAdmin(request) {
     const userId = request.params.id;
-    const locale = extractLocaleFromRequest(request);
+    const locale = requestResponseUtils.extractLocaleFromRequest(request);
 
     return usecases.getUserProfile({ userId, locale }).then(profileSerializer.serialize);
   },
@@ -208,7 +221,7 @@ module.exports = {
   resetScorecard(request) {
     const authenticatedUserId = request.auth.credentials.userId;
     const competenceId = request.params.competenceId;
-    const locale = extractLocaleFromRequest(request);
+    const locale = requestResponseUtils.extractLocaleFromRequest(request);
 
     return usecases
       .resetScorecard({ userId: authenticatedUserId, competenceId, locale })
@@ -227,7 +240,7 @@ module.exports = {
   async getUserProfileSharedForCampaign(request) {
     const authenticatedUserId = request.auth.credentials.userId;
     const campaignId = request.params.campaignId;
-    const locale = extractLocaleFromRequest(request);
+    const locale = requestResponseUtils.extractLocaleFromRequest(request);
 
     const sharedProfileForCampaign = await usecases.getUserProfileSharedForCampaign({
       userId: authenticatedUserId,
@@ -241,7 +254,7 @@ module.exports = {
   async getUserCampaignAssessmentResult(request) {
     const authenticatedUserId = request.auth.credentials.userId;
     const campaignId = request.params.campaignId;
-    const locale = extractLocaleFromRequest(request);
+    const locale = requestResponseUtils.extractLocaleFromRequest(request);
 
     const campaignAssessmentResult = await usecases.getUserCampaignAssessmentResult({
       userId: authenticatedUserId,
@@ -266,7 +279,7 @@ module.exports = {
   },
 
   async sendVerificationCode(request, h) {
-    const locale = extractLocaleFromRequest(request);
+    const locale = requestResponseUtils.extractLocaleFromRequest(request);
     const i18n = request.i18n;
     const userId = request.params.id;
     const { newEmail, password } = await emailVerificationSerializer.deserialize(request.payload);

--- a/api/lib/domain/usecases/find-paginated-user-recommended-trainings.js
+++ b/api/lib/domain/usecases/find-paginated-user-recommended-trainings.js
@@ -12,6 +12,4 @@ async function findPaginatedUserRecommendedTrainings({ userId, locale, page, tra
   };
 }
 
-module.exports = {
-  findPaginatedUserRecommendedTrainings,
-};
+module.exports = findPaginatedUserRecommendedTrainings;

--- a/api/lib/domain/usecases/find-paginated-user-recommended-trainings.js
+++ b/api/lib/domain/usecases/find-paginated-user-recommended-trainings.js
@@ -1,0 +1,17 @@
+async function findPaginatedUserRecommendedTrainings({ userId, locale, page, trainingRepository }) {
+  const { userRecommendedTrainings, pagination } = await trainingRepository.findPaginatedByUserId({
+    userId,
+    locale,
+    page,
+  });
+  return {
+    userRecommendedTrainings,
+    meta: {
+      pagination,
+    },
+  };
+}
+
+module.exports = {
+  findPaginatedUserRecommendedTrainings,
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -281,6 +281,7 @@ module.exports = injectDependencies(
     findPaginatedFilteredTargetProfileOrganizations: require('./find-paginated-filtered-target-profile-organizations'),
     findPaginatedFilteredUsers: require('./find-paginated-filtered-users'),
     findPaginatedParticipationsForCampaignManagement: require('./find-paginated-participations-for-campaign-management'),
+    findPaginatedUserRecommendedTrainings: require('./find-paginated-user-recommended-trainings'),
     findPendingCertificationCenterInvitations: require('./find-pending-certification-center-invitations'),
     findPendingOrganizationInvitations: require('./find-pending-organization-invitations'),
     findStudentsForEnrollment: require('./find-students-for-enrollment'),

--- a/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
@@ -1,9 +1,10 @@
 const { Serializer, Deserializer } = require('jsonapi-serializer');
 
 module.exports = {
-  serialize(training = {}) {
+  serialize(training = {}, meta) {
     return new Serializer('trainings', {
       attributes: ['duration', 'link', 'locale', 'title', 'type'],
+      meta,
     }).serialize(training);
   },
 

--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -4,10 +4,6 @@ const User = require('../../../domain/models/User');
 module.exports = {
   serialize(users, meta) {
     return new Serializer('user', {
-      transform(record) {
-        record.profile = null;
-        return record;
-      },
       attributes: [
         'firstName',
         'lastName',
@@ -31,6 +27,7 @@ module.exports = {
         'hasSeenNewDashboardInfo',
         'hasSeenFocusedChallengeTooltip',
         'hasSeenOtherChallengesTooltip',
+        'trainings',
       ],
       memberships: {
         ref: 'id',
@@ -71,6 +68,7 @@ module.exports = {
       profile: {
         ref: 'id',
         ignoreRelationshipData: true,
+        nullIfMissing: true,
         relationshipLinks: {
           related: function (record, current, parent) {
             return `/api/users/${parent.id}/profile`;
@@ -93,6 +91,16 @@ module.exports = {
         relationshipLinks: {
           related: function (record, current, parent) {
             return `/api/users/${parent.id}/is-certifiable`;
+          },
+        },
+      },
+      trainings: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        nullIfMissing: true,
+        relationshipLinks: {
+          related: function (record, current, parent) {
+            return `/api/users/${parent.id}/trainings`;
           },
         },
       },

--- a/api/lib/infrastructure/serializers/jsonapi/user-with-activity-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-with-activity-serializer.js
@@ -3,10 +3,6 @@ const { Serializer } = require('jsonapi-serializer');
 module.exports = {
   serialize(users, meta) {
     return new Serializer('user', {
-      transform(record) {
-        record.profile = null;
-        return record;
-      },
       attributes: [
         'firstName',
         'lastName',
@@ -31,6 +27,7 @@ module.exports = {
         'hasSeenOtherChallengesTooltip',
         'hasAssessmentParticipations',
         'codeForLastProfileToShare',
+        'trainings',
       ],
       memberships: {
         ref: 'id',
@@ -71,6 +68,7 @@ module.exports = {
       profile: {
         ref: 'id',
         ignoreRelationshipData: true,
+        nullIfMissing: true,
         relationshipLinks: {
           related: function (record, current, parent) {
             return `/api/users/${parent.id}/profile`;
@@ -84,6 +82,16 @@ module.exports = {
         relationshipLinks: {
           related: function (record, current, parent) {
             return `/api/users/${parent.id}/is-certifiable`;
+          },
+        },
+      },
+      trainings: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        nullIfMissing: true,
+        relationshipLinks: {
+          related: function (record, current, parent) {
+            return `/api/users/${parent.id}/trainings`;
           },
         },
       },

--- a/api/tests/acceptance/application/users/users-controller-find-paginated-user-recommended-trainings_test.js
+++ b/api/tests/acceptance/application/users/users-controller-find-paginated-user-recommended-trainings_test.js
@@ -1,0 +1,55 @@
+const { databaseBuilder, expect, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | users-controller-find-paginated-user-recommended-trainings', function () {
+  let options;
+  let server;
+  let userId;
+
+  beforeEach(async function () {
+    userId = databaseBuilder.factory.buildUser({}).id;
+    const authorization = generateValidRequestAuthorizationHeader(userId);
+
+    await databaseBuilder.commit();
+    options = {
+      method: 'GET',
+      url: `/api/users/${userId}/trainings`,
+      payload: {},
+      headers: { authorization },
+    };
+    server = await createServer();
+  });
+
+  describe('GET /users/:id/trainings', function () {
+    it('should return 200', async function () {
+      //given
+      const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({ userId });
+      const { id: trainingId } = databaseBuilder.factory.buildTraining();
+      databaseBuilder.factory.buildUserRecommendedTraining({ userId, trainingId, campaignParticipationId });
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data).to.deep.equal([
+        {
+          type: 'trainings',
+          id: `${trainingId}`,
+          attributes: {
+            duration: { hours: 6 },
+            link: 'http://mon-link.com',
+            locale: 'fr-fr',
+            title: 'title',
+            type: 'webinaire',
+          },
+        },
+      ]);
+      expect(response.result.meta).to.deep.equal({
+        pagination: { page: 1, pageSize: 10, rowCount: 1, pageCount: 1 },
+      });
+    });
+  });
+});

--- a/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
@@ -92,6 +92,11 @@ describe('Acceptance | Controller | users-controller-get-current-user', function
                 related: `/api/users/${user.id}/is-certifiable`,
               },
             },
+            trainings: {
+              links: {
+                related: `/api/users/${user.id}/trainings`,
+              },
+            },
           },
         },
       };

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -550,6 +550,44 @@ describe('Unit | Router | user-router', function () {
     });
   });
 
+  describe('GET /api/users/{id}/trainings', function () {
+    const method = 'GET';
+
+    it('should return 200', async function () {
+      // given
+      sinon.stub(userController, 'findPaginatedUserRecommendedTrainings').returns('ok');
+      const securityPreHandlersStub = sinon
+        .stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser')
+        .callsFake((request, h) => h.response(true));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const url = '/api/users/1/trainings';
+
+      // when
+      const result = await httpTestServer.request(method, url);
+
+      // then
+      expect(result.statusCode).to.equal(200);
+      expect(securityPreHandlersStub).to.have.been.called;
+    });
+
+    it('should return 400 when userId is not a number', async function () {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const userId = 'wrongId';
+      const url = `/api/users/${userId}/trainings`;
+
+      // when
+      const result = await httpTestServer.request(method, url);
+
+      // then
+      expect(result.statusCode).to.equal(400);
+    });
+  });
+
   context('Routes /admin', function () {
     describe('GET /api/admin/users', function () {
       it('should return an HTTP status code 200', async function () {

--- a/api/tests/unit/domain/usecases/find-paginated-user-recommended-trainings_test.js
+++ b/api/tests/unit/domain/usecases/find-paginated-user-recommended-trainings_test.js
@@ -1,0 +1,49 @@
+const { sinon, expect } = require('../../../test-helper');
+const findPaginatedUserRecommendedTrainings = require('../../../../lib/domain/usecases/find-paginated-user-recommended-trainings');
+
+describe('Unit | UseCase | find-user-recommended-trainings', function () {
+  it('should return paginated recommended trainings', async function () {
+    // given
+    const userId = 123;
+    const locale = 'fr-fr';
+    const expectedUserRecommendedTrainings = Symbol('user-recommended-trainings');
+    const trainingRepository = {
+      findPaginatedByUserId: sinon.stub().resolves({
+        userRecommendedTrainings: expectedUserRecommendedTrainings,
+        pagination: {
+          page: 1,
+          pageSize: 2,
+          rowCount: 1,
+          pageCount: 1,
+        },
+      }),
+    };
+
+    const page = {
+      number: 1,
+      size: 2,
+    };
+
+    const expectedMeta = {
+      pagination: {
+        page: 1,
+        pageSize: 2,
+        rowCount: 1,
+        pageCount: 1,
+      },
+    };
+
+    // when
+    const { userRecommendedTrainings, meta } = await findPaginatedUserRecommendedTrainings({
+      userId,
+      locale,
+      page,
+      trainingRepository,
+    });
+
+    // then
+    expect(trainingRepository.findPaginatedByUserId).to.have.been.calledWithExactly({ userId, locale, page });
+    expect(userRecommendedTrainings).to.equal(expectedUserRecommendedTrainings);
+    expect(meta).to.deep.equal(expectedMeta);
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -29,6 +29,41 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
       // then
       expect(json).to.deep.equal(expectedSerializedTraining);
     });
+
+    it('should serialize trainings with pagination', function () {
+      // given
+      const training = domainBuilder.buildTraining();
+      const meta = {
+        pagination: {
+          page: 1,
+          pageSize: 10,
+          rowCount: 1,
+          pageCount: 1,
+        },
+      };
+      const expectedSerializedTraining = {
+        data: {
+          attributes: {
+            title: 'Training 1',
+            link: 'https://example.net',
+            type: 'webinar',
+            duration: {
+              hours: 5,
+            },
+            locale: 'fr-fr',
+          },
+          id: training.id.toString(),
+          type: 'trainings',
+        },
+        meta,
+      };
+
+      // when
+      const json = serializer.serialize(training, meta);
+
+      // then
+      expect(json).to.deep.equal(expectedSerializedTraining);
+    });
   });
 
   describe('#deserialize', function () {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -87,6 +87,11 @@ describe('Unit | Serializer | JSONAPI | user-serializer', function () {
                   related: `/api/users/${userModelObject.id}/is-certifiable`,
                 },
               },
+              trainings: {
+                links: {
+                  related: `/api/users/${userModelObject.id}/trainings`,
+                },
+              },
             },
           },
         };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-with-activity-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-with-activity-serializer_test.js
@@ -89,6 +89,11 @@ describe('Unit | Serializer | JSONAPI | user-with-activity-serializer', function
                   related: `/api/users/${userModelObject.id}/is-certifiable`,
                 },
               },
+              trainings: {
+                links: {
+                  related: `/api/users/${userModelObject.id}/trainings`,
+                },
+              },
             },
           },
         };

--- a/mon-pix/app/adapters/training.js
+++ b/mon-pix/app/adapters/training.js
@@ -1,0 +1,12 @@
+import ApplicationAdapter from './application';
+
+export default class Training extends ApplicationAdapter {
+  urlForQuery(query, ...args) {
+    if (query.userId) {
+      const { userId } = query;
+      delete query.userId;
+      return `${this.host}/${this.namespace}/users/${userId}/trainings`;
+    }
+    return super.urlForQuery(query, ...args);
+  }
+}

--- a/mon-pix/app/components/training/cards.hbs
+++ b/mon-pix/app/components/training/cards.hbs
@@ -1,7 +1,0 @@
-<ul class="skill-review-trainings__list">
-  {{#each @trainings as |training|}}
-    <li class="skill-review-trainings-list__item">
-      <Training::Card @training={{training}} />
-    </li>
-  {{/each}}
-</ul>

--- a/mon-pix/app/components/training/cards.hbs
+++ b/mon-pix/app/components/training/cards.hbs
@@ -1,0 +1,7 @@
+<ul class="skill-review-trainings__list">
+  {{#each @trainings as |training|}}
+    <li class="skill-review-trainings-list__item">
+      <Training::Card @training={{training}} />
+    </li>
+  {{/each}}
+</ul>

--- a/mon-pix/app/components/training/header.hbs
+++ b/mon-pix/app/components/training/header.hbs
@@ -1,0 +1,8 @@
+<div class="background-banner-v2">
+  <div class="user-trainings-banner">
+    <h1 class="user-trainings-banner__title">{{t "pages.user-trainings.title"}}</h1>
+    <p class="user-trainings-banner__description">
+      {{t "pages.user-trainings.description"}}
+    </p>
+  </div>
+</div>

--- a/mon-pix/app/controllers/authenticated/user-trainings.js
+++ b/mon-pix/app/controllers/authenticated/user-trainings.js
@@ -1,0 +1,11 @@
+import Controller from '@ember/controller';
+
+export default class UserTrainingsController extends Controller {
+  pageOptions = [
+    { label: '8', value: 8 },
+    { label: '16', value: 16 },
+    { label: '24', value: 24 },
+    { label: '32', value: 32 },
+    { label: '80', value: 80 },
+  ];
+}

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -22,6 +22,7 @@ export default class User extends Model {
   @belongsTo('profile', { async: false }) profile;
   @hasMany('certification') certifications;
   @hasMany('scorecard') scorecards;
+  @hasMany('trainings') trainings;
 
   // methods
   get fullName() {

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -26,6 +26,8 @@ Router.map(function () {
     this.route('user-tests', { path: '/mes-parcours' });
     this.route('sitemap', { path: '/plan-du-site' });
 
+    this.route('user-trainings', { path: '/mes-formations' });
+
     this.route('user-tutorials', { path: '/mes-tutos' }, function () {
       this.route('recommended', { path: '/recommandes' });
       this.route('saved', { path: '/enregistres' });

--- a/mon-pix/app/routes/authenticated/user-trainings.js
+++ b/mon-pix/app/routes/authenticated/user-trainings.js
@@ -1,0 +1,28 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class UserTrainingsRoute extends Route {
+  @service currentUser;
+  @service store;
+  queryParams = {
+    pageNumber: { refreshModel: true },
+    pageSize: { refreshModel: true },
+  };
+
+  async model(params) {
+    const user = this.currentUser.user;
+    const trainings = await this.store.query(
+      `training`,
+      {
+        page: {
+          number: params.pageNumber,
+          size: params.pageSize || 8,
+        },
+        userId: user.id,
+      },
+      { reload: true }
+    );
+
+    return { trainings };
+  }
+}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -141,6 +141,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'pages/update-expired-password-form';
 @import 'pages/user-certifications';
 @import 'pages/user-certifications-get';
+@import 'pages/user-trainings';
 @import 'pages/user-tutorials';
 @import 'pages/user-tests';
 @import 'pages/personal-information';

--- a/mon-pix/app/styles/components/_training-card.scss
+++ b/mon-pix/app/styles/components/_training-card.scss
@@ -1,6 +1,7 @@
 .training-card {
   position: relative;
   height: 390px;
+  min-width: 240px;
 }
 
 .training-card__content {

--- a/mon-pix/app/styles/pages/_user-trainings.scss
+++ b/mon-pix/app/styles/pages/_user-trainings.scss
@@ -1,0 +1,87 @@
+.user-trainings-banner {
+  margin: 0 24px;
+  font-family: $font-roboto;
+  font-weight: $font-light;
+  padding-bottom: 16px;
+
+  @include device-is('desktop') {
+    max-width: 1280px;
+    padding: 0 20px 16px 20px;
+    margin: 0 auto;
+  }
+
+  &__title {
+    color: $pix-neutral-90;
+    font-size: 2rem;
+    font-family: $font-open-sans;
+    font-weight: $font-normal;
+    letter-spacing: 0.0093rem;
+    line-height: 2.6875rem;
+  }
+
+  &__description {
+    margin: 0;
+    padding: 8px 0 32px 0;
+    color: $pix-neutral-60;
+    font-family: $font-roboto;
+    font-weight: $font-normal;
+    font-size: 1rem;
+    letter-spacing: 0.0093rem;
+    line-height: 1.375rem;
+  }
+}
+
+.user-trainings-content {
+  padding: 20px 32px;
+  width: 100%;
+  min-height: inherit;
+  display: flex;
+  flex-direction: column;
+  margin: 24px auto;
+  color: $pix-neutral-90;
+
+  @include device-is('tablet') {
+    padding: 40px 0;
+  }
+
+  &__title {
+    margin: 0 0 32px;
+  }
+
+  &__container {
+    width: 100%;
+    margin: 0 auto;
+    padding: 0 20px;
+
+    @include device-is('desktop') {
+      max-width: 1280px;
+    }
+  }
+
+  &__list {
+    display: grid;
+    padding: 0;
+    grid-template-columns: 1fr;
+    column-gap: 24px;
+    row-gap: 24px;
+    list-style: none;
+
+    @include device-is('tablet') {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    @include device-is('desktop') {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+  }
+}
+
+.user-trainings-content-list {
+
+  &__item {
+
+    &:hover {
+      box-shadow: $box-shadow-competence-cards-hover;
+    }
+  }
+}

--- a/mon-pix/app/templates/authenticated/user-trainings.hbs
+++ b/mon-pix/app/templates/authenticated/user-trainings.hbs
@@ -1,0 +1,26 @@
+{{page-title (t "pages.user-trainings.title")}}
+<header role="banner">
+  <NavbarHeader />
+  <Training::Header />
+</header>
+
+<main id="main" class="main" role="main">
+  <div class="user-trainings-content">
+    {{#if @model.trainings.meta.pagination.rowCount}}
+      <div class="user-trainings-content__container">
+        <ul class="user-trainings-content__list">
+          {{#each @model.trainings as |training|}}
+            <li class="user-trainings-content-list__item">
+              <Training::Card @training={{training}} />
+            </li>
+          {{/each}}
+        </ul>
+        <PixPagination
+          @pagination={{@model.trainings.meta.pagination}}
+          @pageOptions={{this.pageOptions}}
+          @isCondensed="true"
+        />
+      </div>
+    {{/if}}
+  </div>
+</main>

--- a/mon-pix/mirage/factories/user.js
+++ b/mon-pix/mirage/factories/user.js
@@ -243,6 +243,26 @@ export default Factory.extend({
       user.update({ certifications: certificates });
     },
   }),
+  withSomeTrainings: trait({
+    afterCreate(user, server) {
+      const training = server.create('training', {
+        title: 'Devenir tailleur de citrouille',
+        link: 'http://www.example2.net',
+        type: 'autoformation',
+        duration: '10:00:00',
+        locale: 'fr-fr',
+      });
+      const anotherTraining = server.create('training', {
+        title: 'Apprendre à piloter des chauves-souris',
+        link: 'http://www.example2.net',
+        type: 'webinaire',
+        duration: '10:00:00',
+        locale: 'fr-fr',
+      });
+      const trainings = [training, anotherTraining];
+      user.update({ trainings });
+    },
+  }),
   afterCreate(user, server) {
     _addDefaultIsCertifiable(user, server);
     _addDefaultScorecards(user, server);

--- a/mon-pix/mirage/routes/users/find-paginated-user-trainings.js
+++ b/mon-pix/mirage/routes/users/find-paginated-user-trainings.js
@@ -1,0 +1,24 @@
+import { getPaginationFromQueryParams, applyPagination } from '../../handlers/pagination-utils';
+
+export default function (schema, request) {
+  const queryParams = request.queryParams;
+  const userId = request.params.id;
+
+  const trainings = schema.users.find(userId).trainings.models;
+
+  const rowCount = trainings.length;
+  const pagination = getPaginationFromQueryParams(queryParams);
+
+  const paginatedTrainings = applyPagination(trainings, pagination);
+
+  const json = this.serialize({ modelName: 'training', models: paginatedTrainings }, 'training');
+
+  json.meta = {
+    pagination: {
+      ...pagination,
+      rowCount,
+      pageCount: Math.ceil(rowCount / pagination.pageSize),
+    },
+  };
+  return json;
+}

--- a/mon-pix/mirage/routes/users/index.js
+++ b/mon-pix/mirage/routes/users/index.js
@@ -12,6 +12,7 @@ import resetScorecard from './reset-scorecard';
 import patchTermsOfServiceAcceptance from './patch-terms-of-service-acceptance';
 import putVerificationCode from './put-verification-code';
 import putUpdateEmail from './put-update-email';
+import findPaginatedUserTrainings from './find-paginated-user-trainings';
 
 export default function index(config) {
   config.get('/users/me', getAuthenticatedUser);
@@ -32,6 +33,7 @@ export default function index(config) {
   config.get('/users/:id/profile', getProfile);
   config.get('/users/:id/campaign-participations', getUserCampaignParticipations);
   config.get('/users/:id/campaign-participation-overviews', getUserCampaignParticipationOverviews);
+  config.get('/users/:id/trainings', findPaginatedUserTrainings);
 
   config.get('/users/:id/authentication-methods', (schema, request) => {
     return schema.authenticationMethods.where({ userId: request.params.id });

--- a/mon-pix/mirage/serializers/training.js
+++ b/mon-pix/mirage/serializers/training.js
@@ -1,0 +1,3 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({});

--- a/mon-pix/mirage/serializers/user.js
+++ b/mon-pix/mirage/serializers/user.js
@@ -42,6 +42,9 @@ export default ApplicationSerializer.extend({
       memberships: {
         related: `${userBaseUrl}/memberships`,
       },
+      trainings: {
+        related: `${userBaseUrl}/trainings`,
+      },
     };
   },
 });

--- a/mon-pix/tests/acceptance/user-trainings_test.js
+++ b/mon-pix/tests/acceptance/user-trainings_test.js
@@ -1,0 +1,36 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { setupApplicationTest } from 'ember-mocha';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { visit, currentURL, find, findAll } from '@ember/test-helpers';
+import { authenticateByEmail } from '../helpers/authentication';
+
+describe('Acceptance | mes-formations', function () {
+  setupApplicationTest();
+  setupMirage();
+  let user;
+
+  describe('When the user tries to reach /mes-formations', function () {
+    it('the user-trainings page is displayed to the user', async function () {
+      // given
+      user = server.create('user', 'withEmail', 'withSomeTrainings');
+
+      // when
+      await authenticateByEmail(user);
+      await visit('/mes-formations');
+
+      // then
+      expect(currentURL()).to.equal('/mes-formations');
+      expect(find('.user-trainings-banner__title')).to.exist;
+      expect(find('.user-trainings-banner__title').textContent).to.contain('Mes formations');
+      expect(find('.user-trainings-banner__description')).to.exist;
+      expect(find('.user-trainings-banner__description').textContent).to.contain(
+        'Continuez à progresser grâce aux formations recommandées à l’issue de vos parcours d’évaluation.'
+      );
+      expect(find('.user-trainings-content__container')).to.exist;
+      expect(find('.user-trainings-content-list__item')).to.exist;
+      expect(findAll('.user-trainings-content-list__item')).to.be.lengthOf(2);
+      expect(find('.pix-pagination__navigation')).to.exist;
+    });
+  });
+});

--- a/mon-pix/tests/acceptance/user-tutorials_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials_test.js
@@ -10,7 +10,7 @@ describe('Acceptance | mes-tutos', function () {
   setupMirage();
   let user;
 
-  describe('When the the new tutorials page is disabled', function () {
+  describe('When the new tutorials page is disabled', function () {
     beforeEach(async function () {
       user = server.create('user', 'withEmail');
       await authenticateByEmail(user);

--- a/mon-pix/tests/unit/adapters/training_test.js
+++ b/mon-pix/tests/unit/adapters/training_test.js
@@ -1,0 +1,41 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Adapters | Training', function () {
+  setupTest();
+
+  describe('#urlForQuery', () => {
+    let adapter;
+
+    beforeEach(function () {
+      adapter = this.owner.lookup('adapter:training');
+      adapter.ajax = sinon.stub().resolves();
+    });
+
+    it('should build the training url if userId is passed in query', async function () {
+      // given
+      const query = {
+        userId: 1,
+      };
+
+      // when
+      const url = await adapter.urlForQuery(query, 'training');
+
+      // then
+      expect(url.endsWith('/api/users/1/trainings')).to.be.true;
+    });
+
+    it('should build the training url if userId is not in the query', async function () {
+      // given
+      const query = {};
+
+      // when
+      const url = await adapter.urlForQuery(query, 'training');
+
+      // then
+      expect(url.endsWith('/api/trainings')).to.be.true;
+    });
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1550,6 +1550,10 @@
     "user-tests": {
       "title": "My customised tests"
     },
+    "user-trainings": {
+      "title": "My trainings",
+      "description": "Keep improving thanks to the recommended training courses at the end of your test."
+    },
     "user-tutorials": {
       "title": "My tutorials",
       "description": "Improve with the help of tutorials suggested by the Pix users' community.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1550,6 +1550,10 @@
     "user-tests": {
       "title": "Mes parcours"
     },
+    "user-trainings": {
+      "title": "Mes formations",
+      "description": "Continuez à progresser grâce aux formations recommandées à l’issue de vos parcours d’évaluation."
+    },
     "user-tutorials": {
       "title": "Mes tutos",
       "description": "Progresser grâce aux tutos suggérés par la communauté des utilisateurs de Pix.",


### PR DESCRIPTION
## :jack_o_lantern: Problème
Actuellement, il n'y a aucun moyen de visualiser les fomations recommandées sur pix app.

## :bat: Proposition
Accéder à une nouvelle page /mes-formations depuis pix app.
1. créer une nouvelle page /mes-formations
2. afficher les formations paginées recommandées pour le user connecté.

## :spider_web: Remarques
- N/A

## :ghost: Pour tester
- Se connecter sur la RA de pix app.
- Passer un parcours avec le code PIXEDUINI cliquant sur `Passer` à chaque épreuve.
- Constater qu'on a des formations qui sont proposées.
- Atteindre l'URL RA/mes-formations.
- Constater que l'on récupère la même liste de formations qu'en fin de parcours.
- Constater qu'il y a une pagination en bas de page.
- Se rendre sur la deuxième page et constater qu'il y a deux formations.