### PR TITLE
[FEATURE] Afficher le statut “Autorisé à reprendre” dans l'espace surveillant (PIX-6019)

### DIFF
--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -31,11 +31,19 @@
       {{/if}}
     </div>
     {{#if @candidate.hasStarted}}
-      <span
-        class="session-supervising-candidate-in-list__status session-supervising-candidate-in-list__status--started"
-      >
-        {{t "pages.session-supervising.candidate-in-list.ongoing"}}
-      </span>
+      {{#if @candidate.isAuthorizedToResume}}
+        <span
+          class="session-supervising-candidate-in-list__status session-supervising-candidate-in-list__status--authorized-to-resume"
+        >
+          {{t "pages.session-supervising.candidate-in-list.authorized-to-resume"}}
+        </span>
+      {{else}}
+        <span
+          class="session-supervising-candidate-in-list__status session-supervising-candidate-in-list__status--started"
+        >
+          {{t "pages.session-supervising.candidate-in-list.ongoing"}}
+        </span>
+      {{/if}}
       <span class="session-supervising-candidate-in-list__start-time">{{t
           "pages.session-supervising.candidate-in-list.start"
         }}

--- a/certif/app/models/certification-candidate-for-supervising.js
+++ b/certif/app/models/certification-candidate-for-supervising.js
@@ -21,6 +21,10 @@ export default class CertificationCandidateForSupervising extends Model {
     return this.assessmentStatus === 'started';
   }
 
+  get isAuthorizedToResume() {
+    return this.hasStarted && this.authorizedToStart;
+  }
+
   get hasCompleted() {
     return [assessmentStates.COMPLETED, assessmentStates.ENDED_BY_SUPERVISOR].includes(this.assessmentStatus);
   }

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -39,6 +39,11 @@
       color: $pix-success-80;
     }
 
+    &--authorized-to-resume {
+      background-color: $pix-tertiary-5;
+      color: $pix-tertiary-80;
+    }
+
     &--completed {
       background-color: $pix-primary-10;
       color: $pix-primary-70;

--- a/certif/app/styles/components/session-supervising/candidate-in-list.scss
+++ b/certif/app/styles/components/session-supervising/candidate-in-list.scss
@@ -18,6 +18,7 @@
   &__full-name {
     color: $pix-warning-40;
     margin-bottom: 4px;
+    text-transform: capitalize;
   }
 
   &__checkbox[type="checkbox"] {

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -95,7 +95,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
           lastName: 'Racoon',
           birthdate: '1982-07-28',
           extraTimePercentage: null,
-          authorizedToStart: true,
+          authorizedToStart: false,
           assessmentStatus: 'started',
           // eslint-disable-next-line no-restricted-syntax
           startDateTime: new Date('2022-10-19T14:30:15'),

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -86,32 +86,67 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
   });
 
   module('when the candidate has started the test', function () {
-    test('it displays the "en cours" label, the start time and the options menu button', async function (assert) {
-      // given
-      this.candidate = store.createRecord('certification-candidate-for-supervising', {
-        id: 789,
-        firstName: 'Rocket',
-        lastName: 'Racoon',
-        birthdate: '1982-07-28',
-        extraTimePercentage: null,
-        authorizedToStart: true,
-        assessmentStatus: 'started',
-        // eslint-disable-next-line no-restricted-syntax
-        startDateTime: new Date('2022-10-19T14:30:15'),
+    module('when the candidate has not left the session', function () {
+      test('it displays the "en cours" label, the start time and the options menu button', async function (assert) {
+        // given
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: 789,
+          firstName: 'Rocket',
+          lastName: 'Racoon',
+          birthdate: '1982-07-28',
+          extraTimePercentage: null,
+          authorizedToStart: true,
+          assessmentStatus: 'started',
+          // eslint-disable-next-line no-restricted-syntax
+          startDateTime: new Date('2022-10-19T14:30:15'),
+        });
+
+        // when
+        const screen = await renderScreen(hbs`
+          <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+        `);
+
+        // then
+        assert.dom(screen.getByText('Racoon Rocket')).exists();
+        assert.dom(screen.getByText('28/07/1982')).exists();
+        assert.dom(screen.getByText('En cours')).exists();
+        assert.dom(screen.queryByText('Autorisé à reprendre')).doesNotExist();
+        assert.dom(screen.getByText('14:30')).exists();
+        assert.dom(screen.queryByRole('checkbox', { name: 'Racoon Rocket' })).doesNotExist();
+        assert
+          .dom(
+            screen.queryByRole('button', {
+              name: 'Afficher les options du candidat',
+            })
+          )
+          .exists();
       });
+    });
 
-      // when
-      const screen = await renderScreen(hbs`
-        <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
-      `);
+    module('when the candidate has left the session and has been authorized to resume', function () {
+      test('it displays the "Autorisé à reprendre" label, the start time and the options menu button', async function (assert) {
+        // given
+        this.candidate = store.createRecord('certification-candidate-for-supervising', {
+          id: 789,
+          firstName: 'Rocket',
+          lastName: 'Racoon',
+          birthdate: '1982-07-28',
+          extraTimePercentage: null,
+          authorizedToStart: true,
+          assessmentStatus: 'started',
+          // eslint-disable-next-line no-restricted-syntax
+          startDateTime: new Date('2022-10-19T14:30:15'),
+        });
 
-      // then
-      assert.dom(screen.getByText('Racoon Rocket')).exists();
-      assert.dom(screen.getByText('28/07/1982')).exists();
-      assert.dom(screen.getByText('En cours')).exists();
-      assert.dom(screen.getByText('14:30')).exists();
-      assert.dom(screen.queryByRole('checkbox', { name: 'Racoon Rocket' })).doesNotExist();
-      assert.dom(screen.queryByRole('button', { name: 'Afficher les options du candidat' })).exists();
+        // when
+        const screen = await renderScreen(hbs`
+          <SessionSupervising::CandidateInList @candidate={{this.candidate}} />
+        `);
+
+        // then
+        assert.dom(screen.getByText('Autorisé à reprendre')).exists();
+        assert.dom(screen.queryByText('En cours')).doesNotExist();
+      });
     });
 
     module('when the candidate options button is clicked', function () {

--- a/certif/tests/unit/models/certification-candidate-for-supervising_test.js
+++ b/certif/tests/unit/models/certification-candidate-for-supervising_test.js
@@ -51,6 +51,56 @@ module('Unit | Model | certification-candidate-for-supervising', function (hooks
     });
   });
 
+  module('#get isAuthorizedToResume', function () {
+    test('it returns true if candidate is authorized to start and has already started', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const data = { assessmentStatus: 'started', authorizedToStart: true };
+
+      // when
+      const model = store.createRecord('certification-candidate-for-supervising', data);
+
+      // then
+      assert.true(model.isAuthorizedToResume);
+    });
+
+    test('it returns false if candidate is not authorized to start and has already started', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const data = { assessmentStatus: 'started', authorizedToStart: false };
+
+      // when
+      const model = store.createRecord('certification-candidate-for-supervising', data);
+
+      // then
+      assert.false(model.isAuthorizedToResume);
+    });
+
+    test('it returns false if candidate is authorized to start and has not already started', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const data = { assessmentStatus: null, authorizedToStart: true };
+
+      // when
+      const model = store.createRecord('certification-candidate-for-supervising', data);
+
+      // then
+      assert.false(model.isAuthorizedToResume);
+    });
+
+    test('it returns false if candidate is not authorized to start and has not already started', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const data = { assessmentStatus: null, authorizedToStart: false };
+
+      // when
+      const model = store.createRecord('certification-candidate-for-supervising', data);
+
+      // then
+      assert.false(model.isAuthorizedToResume);
+    });
+  });
+
   module('#get hasCompleted', () => {
     test('returns false if assessmentStatus is started', function (assert) {
       // given

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -117,6 +117,7 @@
         "extra-time": "Extra time",
         "ongoing": "In progress",
         "finished": "Finished",
+        "authorized-to-resume": "Allowed to resume",
         "display-candidate-options": "Display the candidate's options",
         "candidate-options": "Candidate's options",
         "start": "Start",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -116,6 +116,7 @@
       "candidate-in-list": {
         "extra-time": "Temps majoré",
         "ongoing": "En cours",
+        "authorized-to-resume": "Autorisé à reprendre",
         "finished": "Terminé",
         "display-candidate-options": "Afficher les options du candidat",
         "candidate-options": "Options du candidat",


### PR DESCRIPTION
## :jack_o_lantern: Problème
L’espace surveillant est déjà disponible pour tous les CDC. Suite aux retours utilisateurs obtenus lors des beta tests réalisés par Pix, des axes d’amélioration ont été identifiés afin d’avoir une meilleure expérience utilisateurs.

Les candidats aux certifications Pix n’avancent pas au même rythme et peuvent parfois rencontrer des problèmes qui interrompent leur session.

Le surveillant n’a pas de moyen actuellement d’identifier dans la liste des candidats ceux auxquels il a autorisé la reprise de test par rapport à ceux qui n’ont pas rencontré de problème et dont le test est en cours.

## :bat: Proposition
Afficher le statut “Autorisé à reprendre” (et non pas “Prêt à reprendre” comme dans la maquette - en cours de correction) dès lors que le candidat s’est déconnecté de son test en cours de certification et a été autorisé à reprendre par le surveillant

## :spider_web: Remarques
Maquette : https://www.figma.com/file/IWVcwbasXoFUQPhIG097XT/Pix-Certif?node-id=1047%3A23301

## :ghost: Pour tester
- Se connecter à Pix Certif (avec [certifpro@example.net](mailto:certifpro@example.net), par exemple)
- Créer une session de certification et y inscrire un candidat
- Se connecter à Pix App avec ce candidat et démarrer un test de certification
- Se connecter à l'espace surveillant et constater que le statut de candidat est à "En cours"
- Dans Pix App, quitter la certification 
- Dans l'ES, Autoriser le candidat ayant quitté sa certification à reprendre le test
- Constater que son statut est à "Autorisé à reprendre le test"
- Dans Pix App, se reconnecter à sa certification
- Dans l'ES, le statut est repassé à "En cours"
