### PR TITLE
[BUGFIX] Evite les conflicts lors de la création d'un `user-recommended-training` (PIX-6144)

### DIFF
--- a/api/lib/infrastructure/repositories/user-recommended-training-repository.js
+++ b/api/lib/infrastructure/repositories/user-recommended-training-repository.js
@@ -7,7 +7,10 @@ const TABLE_NAME = 'user-recommended-trainings';
 module.exports = {
   save({ userId, trainingId, campaignParticipationId, domainTransaction = DomainTransaction.emptyTransaction() }) {
     const knexConn = domainTransaction?.knexTransaction || knex;
-    return knexConn(TABLE_NAME).insert({ userId, trainingId, campaignParticipationId });
+    return knexConn(TABLE_NAME)
+      .insert({ userId, trainingId, campaignParticipationId })
+      .onConflict(['userId', 'trainingId', 'campaignParticipationId'])
+      .merge({ updatedAt: knexConn.fn.now() });
   },
 
   async findByCampaignParticipationId({

--- a/api/tests/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -33,6 +33,31 @@ describe('Integration | Repository | user-recommended-training-repository', func
         userRecommendedTraining
       );
     });
+
+    it('should not throw an error on userRecommendedTraing conflict', async function () {
+      // given
+      const userRecommendedTraining = databaseBuilder.factory.buildUserRecommendedTraining({
+        userId: databaseBuilder.factory.buildUser().id,
+        trainingId: databaseBuilder.factory.buildTraining().id,
+        campaignParticipationId: databaseBuilder.factory.buildCampaignParticipation().id,
+        updatedAt: new Date('2022-01-01'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const saveSameUserRecommendedTraining = async () => {
+        return userRecommendedTrainingRepository.save(userRecommendedTraining);
+      };
+
+      // then
+      expect(saveSameUserRecommendedTraining).not.to.throw();
+      const updatedUserRecommendedTraining = await knex('user-recommended-trainings')
+        .where({
+          id: userRecommendedTraining.id,
+        })
+        .first();
+      expect(updatedUserRecommendedTraining.updatedAt).to.be.above(userRecommendedTraining.updatedAt);
+    });
   });
 
   describe('#findByCampaignParticipationId', function () {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Des erreurs 500 arrivent lors de l'enregistrement d'un training recommandé à l'utilisateur (`user-recommended-trainings`). Elles proviennent d'une violation de clé `userId`-`trainingId`-`campaignParticipationId`.

```
duplicate key value violates unique constraint "user_recommended_trainings_userid_trainingid_campaignparticipat"
```

## :bat: Proposition
Ajouter une gestion de conflit pour éviter ces erreurs.

## :spider_web: Remarques
RAS

## :ghost: Pour tester
1. Lancer la campagne `PIXEDUINI`
2. La terminer
3. Relancer la requête `PATCH /api/assessments/<assessmentId>/complete-assessment`
4. Constater qu'il n'y a pas d'erreur 500
