### PR TITLE
[TECH] Tracer les requêtes HTTP en cours

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -53,6 +53,7 @@
         "node-cache": "^5.1.2",
         "node-redis-scan": "^1.3.5",
         "node-stream-zip": "^1.15.0",
+        "oppsy": "https://github.com/1024pix/oppsy#main",
         "papaparse": "^5.3.2",
         "pdf-lib": "^1.17.1",
         "pg": "^8.7.3",
@@ -10889,6 +10890,17 @@
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
       "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw==",
       "peer": true
+    },
+    "node_modules/oppsy": {
+      "version": "3.0.0",
+      "resolved": "git+ssh://git@github.com/1024pix/oppsy.git#179016714e55eeb9f13e5bdb8820fbd3076ced08",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      },
+      "engines": {
+        "node": "16.14.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.1",
@@ -23120,6 +23132,13 @@
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
       "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw==",
       "peer": true
+    },
+    "oppsy": {
+      "version": "git+ssh://git@github.com/1024pix/oppsy.git#179016714e55eeb9f13e5bdb8820fbd3076ced08",
+      "from": "oppsy@https://github.com/1024pix/oppsy#main",
+      "requires": {
+        "@hapi/hoek": "9.x.x"
+      }
     },
     "optionator": {
       "version": "0.9.1",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -16,7 +16,6 @@
         "@hapi/accept": "^6.0.0",
         "@hapi/hapi": "^20.2.2",
         "@hapi/inert": "^6.0.5",
-        "@hapi/oppsy": "^3.0.0",
         "@hapi/vision": "^6.1.0",
         "@joi/date": "^2.1.0",
         "@pdf-lib/fontkit": "^1.1.1",
@@ -2759,14 +2758,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@hapi/oppsy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/oppsy/-/oppsy-3.0.0.tgz",
-      "integrity": "sha512-0kfUEAqIi21GzFVK2snMO07znMEBiXb+/pOx1dmgOO9TuvFstcfmHU5i56aDfiFP2DM5WzQCU2UWc2gK1lMDhQ==",
-      "dependencies": {
-        "@hapi/hoek": "9.x.x"
       }
     },
     "node_modules/@hapi/pez": {
@@ -16971,14 +16962,6 @@
       "requires": {
         "@hapi/hoek": "^9.0.4",
         "@hapi/vise": "^4.0.0"
-      }
-    },
-    "@hapi/oppsy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/oppsy/-/oppsy-3.0.0.tgz",
-      "integrity": "sha512-0kfUEAqIi21GzFVK2snMO07znMEBiXb+/pOx1dmgOO9TuvFstcfmHU5i56aDfiFP2DM5WzQCU2UWc2gK1lMDhQ==",
-      "requires": {
-        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/pez": {

--- a/api/package.json
+++ b/api/package.json
@@ -59,6 +59,7 @@
     "node-cache": "^5.1.2",
     "node-redis-scan": "^1.3.5",
     "node-stream-zip": "^1.15.0",
+    "oppsy": "https://github.com/1024pix/oppsy#main",
     "papaparse": "^5.3.2",
     "pdf-lib": "^1.17.1",
     "pg": "^8.7.3",

--- a/api/package.json
+++ b/api/package.json
@@ -22,7 +22,6 @@
     "@hapi/accept": "^6.0.0",
     "@hapi/hapi": "^20.2.2",
     "@hapi/inert": "^6.0.5",
-    "@hapi/oppsy": "^3.0.0",
     "@hapi/vision": "^6.1.0",
     "@joi/date": "^2.1.0",
     "@pdf-lib/fontkit": "^1.1.1",

--- a/api/sample.env
+++ b/api/sample.env
@@ -327,6 +327,15 @@ LOG_ENDING_EVENT_DISPATCH=true
 # type: String
 # LOG_OPS_METRICS=true
 
+
+# Log operations metrics sampling rate
+#
+# presence: optional
+# type: integer
+# default: 15
+# OPS_EVENT_EACH_SECONDS=1
+
+
 # Log for humans
 #
 # Make log human-friendly:

--- a/api/server.js
+++ b/api/server.js
@@ -1,6 +1,6 @@
 require('dotenv').config();
 const Hapi = require('@hapi/hapi');
-const Oppsy = require('@hapi/oppsy');
+const Oppsy = require('oppsy');
 
 const settings = require('./lib/config');
 const preResponseUtils = require('./lib/application/pre-response-utils');


### PR DESCRIPTION
## :jack_o_lantern: Problème
Le nombre de requêtes http en cours n'est pas tracée

## :bat: Proposition
Utiliser le fork de oppsy qui le fait une fois la PR mergée
https://github.com/1024pix/oppsy/pull/1

## :spider_web: Remarques
Documenter l'usage de `OPS_EVENT_EACH_SECONDS` déjà implémenté

## :ghost: Pour tester
Activer les logs ops 
```
LOG_OPS_METRICS=true
OPS_EVENT_EACH_SECONDS=1
```
Effectuer des appels en masse
`siege -c 50 https://api-pr5126.review.pix.fr/api/healthcheck/db`

Regarder les logs ops et localiser `activeRequests`.
Vérifier qu'elle n'est pas vide.

```shell
2022-10-26 17:07:44.491376465 +0200 CEST[web-1] {"level":30,"time":1666796864491,"pid":21,"hostname":"pix-api-review-pr5126-web-1","tags":["ops"],"data":{"host":"pix-api-review-pr5126-web-1","osload":[4.66,4.67,4.56],"osmem":{"total":42077519872,"free":1047932928},"osup":15126047.79,"psup":21153.824691028,"psmem":{"rss":145502208,"heapTotal":106655744,"heapUsed":95674912,"external":5615381,"arrayBuffers":4334454},"pscpu":{"user":84503271,"system":12822639},"psdelay":0.08557701110839844,"requests":{"total":0,"disconnects":0,"statusCodes":{},"activeRequests":0},"responseTimes":{"avg":null,"max":null},"sockets":{"http":{"total":0},"https":{"total":0}},"knexPool":{"used":0,"free":0,"pendingAcquires":0,"pendingCreates":0}}} 
```
