### PR TITLE
[TECH] Supprimer la route inutilisée : /api/certification-center-memberships (PIX-6154).

### DIFF
--- a/api/lib/application/certification-center-memberships/certification-center-membership-controller.js
+++ b/api/lib/application/certification-center-memberships/certification-center-membership-controller.js
@@ -1,14 +1,6 @@
 const usecases = require('../../domain/usecases');
 
 module.exports = {
-  create(request, h) {
-    const userId = request.payload.data.attributes['user-id'];
-    const certificationCenterId = request.payload.data.attributes['certification-center-id'];
-    return usecases
-      .createCertificationCenterMembership({ userId, certificationCenterId })
-      .then((membership) => h.response(membership).created());
-  },
-
   async disable(request, h) {
     const certificationCenterMembershipId = request.params.id;
     await usecases.disableCertificationCenterMembership({

--- a/api/lib/application/certification-center-memberships/index.js
+++ b/api/lib/application/certification-center-memberships/index.js
@@ -29,33 +29,7 @@ exports.register = async function (server) {
     },
   ];
 
-  server.route([
-    ...adminRoutes,
-    {
-      method: 'POST',
-      path: '/api/certification-center-memberships',
-      config: {
-        handler: certificationCenterMembershipController.create,
-        pre: [
-          {
-            method: (request, h) =>
-              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
-                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
-                securityPreHandlers.checkAdminMemberHasRoleCertif,
-                securityPreHandlers.checkAdminMemberHasRoleSupport,
-                securityPreHandlers.checkAdminMemberHasRoleMetier,
-              ])(request, h),
-            assign: 'hasAuthorizationToAccessAdminScope',
-          },
-        ],
-        notes: [
-          "- **Cette route est restreinte aux utilisateurs ayant les droits d'accès**\n" +
-            '- Création d‘un lien entre un utilisateur et un centre de certification\n',
-        ],
-        tags: ['api', 'certification-center-membership'],
-      },
-    },
-  ]);
+  server.route([...adminRoutes]);
 };
 
 exports.name = 'certification-center-memberships-api';

--- a/api/lib/domain/usecases/create-certification-center-membership.js
+++ b/api/lib/domain/usecases/create-certification-center-membership.js
@@ -1,7 +1,0 @@
-module.exports = function createCertificationCenterMembership({
-  userId,
-  certificationCenterId,
-  certificationCenterMembershipRepository,
-}) {
-  return certificationCenterMembershipRepository.save({ userId, certificationCenterId });
-};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -210,7 +210,6 @@ module.exports = injectDependencies(
     createBadge: require('./create-badge'),
     createCampaign: require('./create-campaign'),
     createCertificationCenter: require('./create-certification-center'),
-    createCertificationCenterMembership: require('./create-certification-center-membership'),
     createCertificationCenterMembershipByEmail: require('./create-certification-center-membership-by-email'),
     createCertificationCenterMembershipForScoOrganizationMember: require('./create-certification-center-membership-for-sco-organization-member'),
     createLcmsRelease: require('./create-lcms-release'),

--- a/api/tests/acceptance/application/certification-center-membership-route_test.js
+++ b/api/tests/acceptance/application/certification-center-membership-route_test.js
@@ -3,7 +3,6 @@ const {
   generateValidRequestAuthorizationHeader,
   insertUserWithRoleSuperAdmin,
   databaseBuilder,
-  knex,
   sinon,
 } = require('../../test-helper');
 const createServer = require('../../../server');
@@ -14,101 +13,6 @@ describe('Acceptance | API | Certification Center Membership', function () {
   beforeEach(async function () {
     server = await createServer();
     await insertUserWithRoleSuperAdmin();
-  });
-
-  describe('POST /api/certification-center-memberships', function () {
-    afterEach(async function () {
-      await knex('certification-center-memberships').delete();
-    });
-
-    context('when user is Super Admin', function () {
-      it('should return 201 HTTP status', async function () {
-        // given
-        const user = databaseBuilder.factory.buildUser();
-        const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
-        await databaseBuilder.commit();
-
-        const options = {
-          method: 'POST',
-          url: '/api/certification-center-memberships',
-          headers: { authorization: generateValidRequestAuthorizationHeader() },
-          payload: {
-            data: {
-              type: 'certification-center-membership',
-              attributes: {
-                'user-id': user.id,
-                'certification-center-id': certificationCenter.id,
-              },
-            },
-          },
-        };
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(201);
-      });
-    });
-
-    context('when user is not SuperAdmin', function () {
-      it('should return 403 HTTP status code ', async function () {
-        // given
-        const user = databaseBuilder.factory.buildUser();
-        const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
-        await databaseBuilder.commit();
-
-        const options = {
-          method: 'POST',
-          url: '/api/certification-center-memberships',
-          headers: { authorization: generateValidRequestAuthorizationHeader(1111) },
-          payload: {
-            data: {
-              type: 'certification-center-membership',
-              attributes: {
-                'user-id': user.id,
-                'certification-center-id': certificationCenter.id,
-              },
-            },
-          },
-        };
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(403);
-      });
-    });
-
-    context('when user is not connected', function () {
-      it('should return 401 HTTP status code if user is not authenticated', async function () {
-        // given
-        const user = databaseBuilder.factory.buildUser();
-        const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
-        await databaseBuilder.commit();
-
-        const options = {
-          method: 'POST',
-          url: '/api/certification-center-memberships',
-          payload: {
-            data: {
-              type: 'certification-center-membership',
-              attributes: {
-                'user-id': user.id,
-                'certification-center-id': certificationCenter.id,
-              },
-            },
-          },
-        };
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(401);
-      });
-    });
   });
 
   describe('DELETE /api/admin/certification-center-memberships/{id}', function () {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Cette [route API, créé dans cette PR de 2019](https://github.com/1024pix/pix/commit/5c9d758b5b302aa1e27a91f3ae4ca729ae2b0c56) ne semble plus utilisé ( n'a pas été appelé depuis 1 mois sur Datadog. )

<img width="561" alt="Capture d’écran 2022-10-26 à 15 26 14" src="https://user-images.githubusercontent.com/58915422/198038045-f8696e0b-303c-42c6-a574-f7b23db23b37.png">

## :bat: Proposition
Supprimer la route.

## :spider_web: Remarques
La PR qui l'introduit ne comporte aucune information pour permettre d'avoir l'app qui fait appel à elle, quel scénario il convient de faire pour reproduire. Elle ne contient que du code API également.

Mais la route possédait un pré handler `hasRolePixMaster` qui laisse alors à penser qu'elle est lié à Pix Admin. Sauf que je n'ai rien trouvé sur l'app. Le modèle `certification-center-membership` n'est introduit qu'en 2021 sur l'app.

L'audit des endpoints de l'API ne signale aucun problème 🤔 mais je ne sais pas si elle a été traîté (me contacter sur slack pour le lien de l'audit)

## :ghost: Pour tester
Les tests API passent

Faire une passe sur des scénarios Pix Admin concernant les centre de certification et leurs memberships ?