### PR TITLE
[TECH] Résoudre un test flaky sur `user-recommended-trainings` repository.

### DIFF
--- a/api/tests/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -34,7 +34,7 @@ describe('Integration | Repository | user-recommended-training-repository', func
       );
     });
 
-    it('should not throw an error on userRecommendedTraing conflict', async function () {
+    it('should not throw an error on userRecommendedTraining conflict', async function () {
       // given
       const userRecommendedTraining = databaseBuilder.factory.buildUserRecommendedTraining({
         userId: databaseBuilder.factory.buildUser().id,
@@ -50,7 +50,7 @@ describe('Integration | Repository | user-recommended-training-repository', func
       };
 
       // then
-      expect(saveSameUserRecommendedTraining).not.to.throw();
+      expect(await saveSameUserRecommendedTraining()).not.to.throw;
       const updatedUserRecommendedTraining = await knex('user-recommended-trainings')
         .where({
           id: userRecommendedTraining.id,


### PR DESCRIPTION
## :jack_o_lantern: Problème
Nous avons actuellement un test flaky. 

## :bat: Proposition
Ce dernier était due à un mauvais usage de : `expect().not.to.throw` qui doit recevoir une promesse qu'il résoud.  

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
### CI 
- Vérifier le bon fonctionnement de la CI 

### En local 
- Remplacer les lignes 48 à 50 par : 
```js
   const saveSameUserRecommendedTraining = async () => {
        await userRecommendedTrainingRepository.save(userRecommendedTraining);
        return new Promise((resolve) => setTimeout(resolve, 1000));
      };
```
- Placer un only sur le test 
- Et lancer : `while :; do; npm run test:api:integration; done`
- Constater que ça fonctionne avec la nouvelle implémentation et que ça ne fonctionnait pas avec l'ancienne. 