### PR TITLE
[TECH] Ajouter de l'outillage pour créer facilement à la volée des profil-cibles pour les seeds (PIX-6168)

### DIFF
--- a/api/db/seeds/data/learning-content/target-profiles-builder.js
+++ b/api/db/seeds/data/learning-content/target-profiles-builder.js
@@ -1,8 +1,8 @@
-const { createTargetProfile } = require('./tooling');
+const { createTargetProfile, createBadge } = require('./tooling');
 const { PRO_COMPANY_ID } = require('../organizations-pro-builder');
 
 async function richTargetProfilesBuilder({ databaseBuilder }) {
-  let config = {
+  let configTargetProfile = {
     frameworks: [{
       chooseCoreFramework: true,
       countTubes: 30,
@@ -10,17 +10,43 @@ async function richTargetProfilesBuilder({ databaseBuilder }) {
       maxLevel: 5,
     }],
   };
-  await createTargetProfile({
+  const configBadge = {
+    criteria: [
+      {
+        scope: 'CappedTubes',
+        threshold: 60,
+      },
+      {
+        scope: 'CampaignParticipation',
+        threshold: 50,
+      },
+    ],
+  };
+  const { targetProfileId, cappedTubesDTO } = await createTargetProfile({
     databaseBuilder,
     targetProfileId: 500,
     name: 'Profil cible Pur Pix (Niv3 ~ 5)',
     isPublic: true,
     ownerOrganizationId: PRO_COMPANY_ID,
     isSimplifiedAccess: false,
-    description: 'Profil cible pur pix (Niv3 ~ 5)',
-    config,
+    description: 'Profil cible pur pix (Niv3 ~ 5) avec 1 RT double critère (tube et participation)',
+    configTargetProfile,
   });
-  config = {
+  createBadge({
+    databaseBuilder,
+    targetProfileId,
+    cappedTubesDTO,
+    badgeId: 600,
+    altMessage: '1 RT double critère Campaign & Tubes',
+    imageUrl: 'some_image.svg',
+    message: '1 RT double critère Campaign & Tubes',
+    title: '1 RT double critère Campaign & Tubes',
+    key: 'SOME_KEY_FOR_RT_600',
+    isCertifiable: false,
+    isAlwaysVisible: false,
+    configBadge,
+  });
+  configTargetProfile = {
     frameworks: [{
       chooseCoreFramework: true,
       countTubes: 5,
@@ -41,7 +67,7 @@ async function richTargetProfilesBuilder({ databaseBuilder }) {
     ownerOrganizationId: PRO_COMPANY_ID,
     isSimplifiedAccess: false,
     description: 'Profil cible pur pix et un autre réf (Niv1 ~ 8)',
-    config,
+    configTargetProfile,
   });
 }
 

--- a/api/db/seeds/data/learning-content/target-profiles-builder.js
+++ b/api/db/seeds/data/learning-content/target-profiles-builder.js
@@ -1,0 +1,50 @@
+const { createTargetProfile } = require('./tooling');
+const { PRO_COMPANY_ID } = require('../organizations-pro-builder');
+
+async function richTargetProfilesBuilder({ databaseBuilder }) {
+  let config = {
+    frameworks: [{
+      chooseCoreFramework: true,
+      countTubes: 30,
+      minLevel: 3,
+      maxLevel: 5,
+    }],
+  };
+  await createTargetProfile({
+    databaseBuilder,
+    targetProfileId: 500,
+    name: 'Profil cible Pur Pix (Niv3 ~ 5)',
+    isPublic: true,
+    ownerOrganizationId: PRO_COMPANY_ID,
+    isSimplifiedAccess: false,
+    description: 'Profil cible pur pix (Niv3 ~ 5)',
+    config,
+  });
+  config = {
+    frameworks: [{
+      chooseCoreFramework: true,
+      countTubes: 5,
+      minLevel: 1,
+      maxLevel: 8,
+    }, {
+      chooseCoreFramework: false,
+      countTubes: 3,
+      minLevel: 1,
+      maxLevel: 8,
+    }],
+  };
+  await createTargetProfile({
+    databaseBuilder,
+    targetProfileId: 501,
+    name: 'Profil cible Pix et un autre réf (Niv1 ~ 8)',
+    isPublic: true,
+    ownerOrganizationId: PRO_COMPANY_ID,
+    isSimplifiedAccess: false,
+    description: 'Profil cible pur pix et un autre réf (Niv1 ~ 8)',
+    config,
+  });
+}
+
+module.exports = {
+  richTargetProfilesBuilder,
+};

--- a/api/db/seeds/data/learning-content/target-profiles-builder.js
+++ b/api/db/seeds/data/learning-content/target-profiles-builder.js
@@ -1,4 +1,4 @@
-const { createTargetProfile, createBadge } = require('./tooling');
+const { createTargetProfile, createBadge, createStages } = require('./tooling');
 const { PRO_COMPANY_ID } = require('../organizations-pro-builder');
 
 async function richTargetProfilesBuilder({ databaseBuilder }) {
@@ -45,6 +45,13 @@ async function richTargetProfilesBuilder({ databaseBuilder }) {
     isCertifiable: false,
     isAlwaysVisible: false,
     configBadge,
+  });
+  createStages({
+    databaseBuilder,
+    targetProfileId,
+    cappedTubesDTO,
+    type: 'LEVEL',
+    countStages: 3,
   });
   configTargetProfile = {
     frameworks: [{

--- a/api/db/seeds/data/learning-content/target-profiles-builder.js
+++ b/api/db/seeds/data/learning-content/target-profiles-builder.js
@@ -2,7 +2,16 @@ const { createTargetProfile, createBadge, createStages } = require('./tooling');
 const { PRO_COMPANY_ID } = require('../organizations-pro-builder');
 
 async function richTargetProfilesBuilder({ databaseBuilder }) {
-  let configTargetProfile = {
+  await _createTargetProfile500(databaseBuilder);
+  await _createTargetProfile501(databaseBuilder);
+}
+
+module.exports = {
+  richTargetProfilesBuilder,
+};
+
+async function _createTargetProfile500(databaseBuilder) {
+  const configTargetProfile = {
     frameworks: [{
       chooseCoreFramework: true,
       countTubes: 30,
@@ -29,7 +38,7 @@ async function richTargetProfilesBuilder({ databaseBuilder }) {
     isPublic: true,
     ownerOrganizationId: PRO_COMPANY_ID,
     isSimplifiedAccess: false,
-    description: 'Profil cible pur pix (Niv3 ~ 5) avec 1 RT double critère (tube et participation)',
+    description: 'Profil cible pur pix (Niv3 ~ 5) avec 1 RT double critère (tube et participation) et des paliers NIVEAUX',
     configTargetProfile,
   });
   createBadge({
@@ -53,7 +62,10 @@ async function richTargetProfilesBuilder({ databaseBuilder }) {
     type: 'LEVEL',
     countStages: 3,
   });
-  configTargetProfile = {
+}
+
+async function _createTargetProfile501(databaseBuilder) {
+  const configTargetProfile = {
     frameworks: [{
       chooseCoreFramework: true,
       countTubes: 5,
@@ -66,18 +78,21 @@ async function richTargetProfilesBuilder({ databaseBuilder }) {
       maxLevel: 8,
     }],
   };
-  await createTargetProfile({
+  const { targetProfileId, cappedTubesDTO } = await createTargetProfile({
     databaseBuilder,
     targetProfileId: 501,
     name: 'Profil cible Pix et un autre réf (Niv1 ~ 8)',
     isPublic: true,
     ownerOrganizationId: PRO_COMPANY_ID,
     isSimplifiedAccess: false,
-    description: 'Profil cible pur pix et un autre réf (Niv1 ~ 8)',
+    description: 'Profil cible pur pix et un autre réf (Niv1 ~ 8) et des paliers SEUILS',
     configTargetProfile,
   });
+  createStages({
+    databaseBuilder,
+    targetProfileId,
+    cappedTubesDTO,
+    type: 'THRESHOLD',
+    countStages: 4,
+  });
 }
-
-module.exports = {
-  richTargetProfilesBuilder,
-};

--- a/api/db/seeds/data/learning-content/tooling.js
+++ b/api/db/seeds/data/learning-content/tooling.js
@@ -1,0 +1,93 @@
+const _ = require('lodash');
+const bluebird = require('bluebird');
+const skillRepository = require('../../../../lib/infrastructure/repositories/skill-repository');
+const competenceRepository = require('../../../../lib/infrastructure/repositories/competence-repository');
+
+const tubeIdsByFramework = {};
+let frameworkNames;
+let learningContentCached = false;
+
+async function createTargetProfile({
+  databaseBuilder,
+  targetProfileId,
+  name,
+  isPublic,
+  ownerOrganizationId,
+  isSimplifiedAccess,
+  description,
+  config, // { framework[{ chooseCoreFramework: true/false, countTubes: 10, minLevel: 1, maxLevel: 5 }]
+}) {
+  await _cacheLearningContent();
+  _createTargetProfile({ databaseBuilder, targetProfileId, name, isPublic, ownerOrganizationId, isSimplifiedAccess, description });
+  _createTargetProfileTubes({ databaseBuilder, targetProfileId, config });
+  return targetProfileId;
+}
+
+async function _cacheLearningContent() {
+  if (!learningContentCached) {
+    learningContentCached = true;
+    const allCompetences = await competenceRepository.list();
+    await bluebird.mapSeries(allCompetences, async (competence) => {
+      if (!tubeIdsByFramework[competence.origin]) tubeIdsByFramework[competence.origin] = [];
+      const skillsForCompetence = await skillRepository.findActiveByCompetenceId(competence.id);
+      tubeIdsByFramework[competence.origin] = _(skillsForCompetence)
+        .flatMap('tubeId')
+        .concat(tubeIdsByFramework[competence.origin])
+        .uniq()
+        .value();
+    });
+    frameworkNames = Object.keys(tubeIdsByFramework);
+  }
+}
+
+function _createTargetProfile({ databaseBuilder, targetProfileId, name, isPublic, ownerOrganizationId, isSimplifiedAccess, description }) {
+  databaseBuilder.factory.buildTargetProfile({ id: targetProfileId, name, isPublic, ownerOrganizationId, isSimplifiedAccess, description });
+}
+
+function _createTargetProfileTubes({ databaseBuilder, targetProfileId, config }) {
+  const cappedTubesDTO = [];
+  for (const framework of config.frameworks) {
+    const frameworkName = _getFrameworkName(framework);
+    for (let i = 0; i < framework.countTubes; ++i) {
+      const tubeId = _pickRandomTube(frameworkName, cappedTubesDTO.map(({ id }) => id));
+      if (tubeId) {
+        const level = _.random(framework.minLevel, framework.maxLevel);
+        cappedTubesDTO.push({
+          id: tubeId,
+          level,
+        });
+        databaseBuilder.factory.buildTargetProfileTube({
+          targetProfileId,
+          tubeId,
+          level,
+        });
+      }
+    }
+  }
+  return cappedTubesDTO;
+}
+
+function _getFrameworkName({ chooseCoreFramework }) {
+  if (chooseCoreFramework) return 'Pix';
+  return _pickRandomAmong(frameworkNames, 1);
+}
+
+function _pickRandomTube(frameworkName, alreadyPickedTubeIds) {
+  let attempt = 0;
+  while (attempt < 10) {
+    const tubeId = _pickRandomAmong(tubeIdsByFramework[frameworkName], 1);
+    if (!alreadyPickedTubeIds.includes(tubeId)) return tubeId;
+    ++attempt;
+  }
+  return null;
+}
+
+function _pickRandomAmong(collection, howMuch) {
+  const shuffledCollection = _.sortBy(collection, () => _.random(0, 100));
+  if (howMuch === 1) return shuffledCollection[0];
+  return _.slice(shuffledCollection, 0, howMuch);
+}
+
+module.exports = {
+  createTargetProfile,
+};

--- a/api/db/seeds/data/learning-content/tooling.js
+++ b/api/db/seeds/data/learning-content/tooling.js
@@ -44,6 +44,28 @@ function createBadge({
   _createBadgeCriteria({ databaseBuilder, badgeId, configBadge, cappedTubesDTO });
 }
 
+function createStages({
+  databaseBuilder,
+  targetProfileId,
+  cappedTubesDTO,
+  type, // 'LEVEL' or 'THRESHOLD'
+  countStages,
+}) {
+  const values = [0];
+  if (type === 'LEVEL') {
+    const maxLevel = _.maxBy(cappedTubesDTO, 'level').level;
+    const possibleLevels = Array.from({ length: maxLevel }, (_, i) => i + 1);
+    const pickedLevels = _pickRandomAmong(possibleLevels, countStages - 1);
+    values.push(...pickedLevels);
+  }
+  if (type === 'THRESHOLD') {
+    console.log('coucou');
+  }
+  for (const value of values) {
+    _createStage({ databaseBuilder, targetProfileId, type, value });
+  }
+}
+
 async function _cacheLearningContent() {
   if (!learningContentCached) {
     learningContentCached = true;
@@ -67,6 +89,16 @@ function _createTargetProfile({ databaseBuilder, targetProfileId, name, isPublic
 
 function _createBadge({ databaseBuilder, badgeId, targetProfileId, altMessage, imageUrl, message, title, key, isCertifiable, isAlwaysVisible }) {
   databaseBuilder.factory.buildBadge({ id: badgeId, targetProfileId, altMessage, imageUrl, message, title, key, isCertifiable, isAlwaysVisible });
+}
+
+function _createStage({ databaseBuilder, targetProfileId, type, value }) {
+  databaseBuilder.factory.buildStage({
+    targetProfileId,
+    message: `Palier "${value}" pour ${targetProfileId}`,
+    title: `Palier "${value}" pour ${targetProfileId}`,
+    level: type === 'LEVEL' ? value : null,
+    threshold: type === 'LEVEL' ? null : value,
+  });
 }
 
 function _createTargetProfileTubes({ databaseBuilder, targetProfileId, configTargetProfile }) {
@@ -143,4 +175,5 @@ function _pickRandomAmong(collection, howMuch) {
 module.exports = {
   createTargetProfile,
   createBadge,
+  createStages,
 };

--- a/api/db/seeds/data/learning-content/tooling.js
+++ b/api/db/seeds/data/learning-content/tooling.js
@@ -59,7 +59,9 @@ function createStages({
     values.push(...pickedLevels);
   }
   if (type === 'THRESHOLD') {
-    console.log('coucou');
+    const possibleThresholds = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+    const pickedThresholds = _pickRandomAmong(possibleThresholds, countStages - 1);
+    values.push(...pickedThresholds);
   }
   for (const value of values) {
     _createStage({ databaseBuilder, targetProfileId, type, value });

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -42,6 +42,7 @@ const computeParticipationsResults = require('../../scripts/prod/compute-partici
 
 const poleEmploiSendingsBuilder = require('./data/pole-emploi-sendings-builder');
 const { trainingBuilder } = require('./data/trainings-builder');
+const { richTargetProfilesBuilder } = require('./data/learning-content/target-profiles-builder');
 
 exports.seed = async (knex) => {
   const databaseBuilder = new DatabaseBuilder({ knex });
@@ -95,6 +96,8 @@ exports.seed = async (knex) => {
 
   // Création d'envois pole emploi
   poleEmploiSendingsBuilder({ databaseBuilder });
+
+  await richTargetProfilesBuilder({ databaseBuilder });
 
   await databaseBuilder.commit();
   await databaseBuilder.fixSequences();


### PR DESCRIPTION
## :jack_o_lantern: Problème
Les seeds sont pas très complètes pour tester les profil-cibles sur pixadmin (et clés de lecture)

## :bat: Proposition
ajout d'un tooling pour créer dynamiquement des profil-cibles et des clés de lecture sans écrire des ids d'élements de référentiel en dur

## :spider_web: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :ghost: Pour tester
Les profil-cibles 500 et 501 ont été créés dynamiquement, allez les voir sur Pix Admin !
