### PR TITLE
[FEATURE] Deplacer la navbar certif (PIX-5744)

### DIFF
--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -1,5 +1,7 @@
 @charset "utf-8";
 
+$navbar-height: 60px;
+
 @import "pix-design-tokens";
 @import "globals/errors";
 @import "globals/forms";

--- a/certif/app/styles/components/user-logged-menu.scss
+++ b/certif/app/styles/components/user-logged-menu.scss
@@ -39,8 +39,9 @@
 
 .logged-user-menu {
   right: 0;
+  margin-right: 10px;
   top: $navbar-height;
-  width: 400px;
+  min-width: 400px;
 
   &-item {
     color: $pix-neutral-60;

--- a/certif/app/styles/components/user-logged-menu.scss
+++ b/certif/app/styles/components/user-logged-menu.scss
@@ -39,7 +39,7 @@
 
 .logged-user-menu {
   right: 0;
-  top: 49px;
+  top: $navbar-height;
   width: 400px;
 
   &-item {

--- a/certif/app/styles/globals/panels.scss
+++ b/certif/app/styles/globals/panels.scss
@@ -5,7 +5,7 @@
 }
 
 .navbar {
-  height: 60px;
+  height: $navbar-height;
   border: none;
   padding: 0 10px;
 

--- a/certif/app/styles/pages/authenticated.scss
+++ b/certif/app/styles/pages/authenticated.scss
@@ -73,7 +73,7 @@
 
   &__topbar {
     background-color: $pix-neutral-0;
-    min-height: 60px;
+    min-height: $navbar-height;
   }
 }
 


### PR DESCRIPTION
## :jack_o_lantern: Problème
Dans le cadre de l’audit design Pix Certif, il a été remonté un problème de positionnement du menu de la top nav.
Le menu est positionné à droite de son parent et hors de la grille du contenu de la page.

## :bat: Proposition
Replacer le menu en suivant [la charte ](https://www.figma.com/file/IWVcwbasXoFUQPhIG097XT/Pix-Certif?node-id=307%3A6217)

## :spider_web: Remarques
la hauteur de la navbar est utilisée à plusieurs endroits. On ajoute une variable css navbar-height pour ne pas avoir de soucis de synchro si la taille viens à changer

## :ghost: Pour tester
Avant:
![image](https://user-images.githubusercontent.com/3769147/198074329-18a4ba66-3a9e-4c2a-8d12-a9caecb95c22.png)
Apres:
![image](https://user-images.githubusercontent.com/3769147/198083228-49f9aded-2c67-4e06-8ad9-0e2e73f89da4.png)



