### PR TITLE
[TECH] Supprimer le builder superAdmin en doublon

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -218,7 +218,7 @@ buildUser.withRole = function buildUserWithRole({
   id = databaseBuffer.getNextId(),
   firstName = 'Billy',
   lastName = 'TheKid',
-  role = ROLES.SUPER_ADMIN,
+  role = ROLES.METIER,
   email,
   cgu = true,
   lang = 'fr',
@@ -269,6 +269,49 @@ buildUser.withRole = function buildUserWithRole({
   buildPixAdminRole({ userId: user.id, role, disabledAt, createdAt, updatedAt });
 
   return user;
+};
+
+buildUser.withRoleSuperAdmin = function buildUserWithRoleSuperAdmin({
+  id = databaseBuffer.getNextId(),
+  firstName = 'Billy',
+  lastName = 'TheKid',
+  email,
+  cgu = true,
+  lang = 'fr',
+  lastTermsOfServiceValidatedAt,
+  lastPixOrgaTermsOfServiceValidatedAt = null,
+  lastPixCertifTermsOfServiceValidatedAt = null,
+  mustValidateTermsOfService = false,
+  pixOrgaTermsOfServiceAccepted = false,
+  pixCertifTermsOfServiceAccepted = false,
+  hasSeenAssessmentInstructions = false,
+  createdAt = new Date(),
+  updatedAt = new Date(),
+  disabledAt,
+  rawPassword = DEFAULT_PASSWORD,
+  shouldChangePassword = false,
+} = {}) {
+  return buildUser.withRole({
+    role: ROLES.SUPER_ADMIN,
+    id,
+    firstName,
+    lastName,
+    email,
+    cgu,
+    lang,
+    lastTermsOfServiceValidatedAt,
+    lastPixOrgaTermsOfServiceValidatedAt,
+    lastPixCertifTermsOfServiceValidatedAt,
+    mustValidateTermsOfService,
+    pixOrgaTermsOfServiceAccepted,
+    pixCertifTermsOfServiceAccepted,
+    hasSeenAssessmentInstructions,
+    createdAt,
+    updatedAt,
+    disabledAt,
+    rawPassword,
+    shouldChangePassword,
+  });
 };
 
 buildUser.withMembership = function buildUserWithMemberships({

--- a/api/tests/acceptance/application/admin-members/admin-members-routes_test.js
+++ b/api/tests/acceptance/application/admin-members/admin-members-routes_test.js
@@ -1,9 +1,4 @@
-const {
-  expect,
-  databaseBuilder,
-  generateValidRequestAuthorizationHeader,
-  insertUserWithRoleSuperAdmin,
-} = require('../../../test-helper');
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 const createServer = require('../../../../server');
 const { ROLES } = require('../../../../lib/domain/constants').PIX_ADMIN;
 
@@ -11,7 +6,7 @@ describe('Acceptance | Application | Admin-members | Routes', function () {
   describe('GET /api/admin/admin-members/me', function () {
     it('should return 200 http status code', async function () {
       // given
-      const admin = databaseBuilder.factory.buildUser.withRole(ROLES.SUPER_ADMIN);
+      const admin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       await databaseBuilder.commit();
       const server = await createServer();
 
@@ -51,14 +46,7 @@ describe('Acceptance | Application | Admin-members | Routes', function () {
   describe('GET /api/admin/admin-members', function () {
     it('should return 200 http status code when admin member has role "SUPER_ADMIN"', async function () {
       // given
-      const admin = databaseBuilder.factory.buildUser.withRole({
-        id: 1234,
-        firstName: 'Super',
-        lastName: 'Papa',
-        email: 'super.papa@example.net',
-        password: 'Password123',
-        role: ROLES.SUPER_ADMIN,
-      });
+      const admin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
 
       await databaseBuilder.commit();
       const server = await createServer();
@@ -80,7 +68,7 @@ describe('Acceptance | Application | Admin-members | Routes', function () {
   describe('PATCH /api/admin/admin-members/{id}', function () {
     it('should return 200 http status code if admin member has role "SUPER_ADMIN"', async function () {
       // given
-      const superAdmin = databaseBuilder.factory.buildUser.withRole();
+      const superAdmin = databaseBuilder.factory.buildUser.withRoleSuperAdmin();
       const pixAdminUserToUpdate = databaseBuilder.factory.buildUser.withRole();
       const pixAdminRole = databaseBuilder.factory.buildPixAdminRole({
         userId: pixAdminUserToUpdate.id,

--- a/api/tests/acceptance/application/admin-members/admin-members-routes_test.js
+++ b/api/tests/acceptance/application/admin-members/admin-members-routes_test.js
@@ -11,8 +11,7 @@ describe('Acceptance | Application | Admin-members | Routes', function () {
   describe('GET /api/admin/admin-members/me', function () {
     it('should return 200 http status code', async function () {
       // given
-      databaseBuilder.factory.buildUser.withRole();
-      const admin = await insertUserWithRoleSuperAdmin();
+      const admin = databaseBuilder.factory.buildUser.withRole(ROLES.SUPER_ADMIN);
       await databaseBuilder.commit();
       const server = await createServer();
 

--- a/api/tests/acceptance/application/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-controller_test.js
@@ -1,12 +1,6 @@
 const _ = require('lodash');
 
-const {
-  databaseBuilder,
-  expect,
-  generateValidRequestAuthorizationHeader,
-  insertUserWithRoleSuperAdmin,
-  knex,
-} = require('../../test-helper');
+const { databaseBuilder, expect, generateValidRequestAuthorizationHeader, knex } = require('../../test-helper');
 
 const createServer = require('../../../server');
 
@@ -366,6 +360,7 @@ describe('Acceptance | API | Certification Center', function () {
         headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
       };
     }
+
     function _buildOrganizationLearnersNotConnectedUserRequest(certificationCenter, session) {
       return {
         method: 'GET',

--- a/api/tests/acceptance/application/certification-issue-report-controller_test.js
+++ b/api/tests/acceptance/application/certification-issue-report-controller_test.js
@@ -1,11 +1,6 @@
-const {
-  expect,
-  databaseBuilder,
-  generateValidRequestAuthorizationHeader,
-  insertUserWithRoleSuperAdmin,
-  knex,
-} = require('../../test-helper');
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, knex } = require('../../test-helper');
 const createServer = require('../../../server');
+const { ROLES } = require('../../../lib/domain/constants').PIX_ADMIN;
 
 describe('Acceptance | Controller | certification-issue-report-controller', function () {
   describe('DELETE /api/certification-issue-reports/{id}', function () {
@@ -41,7 +36,7 @@ describe('Acceptance | Controller | certification-issue-report-controller', func
       // given
       const server = await createServer();
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      const superAdmin = await insertUserWithRoleSuperAdmin();
+      const superAdmin = databaseBuilder.factory.buildUser.withRole(ROLES.SUPER_ADMIN);
       const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
       const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ sessionId }).id;
       const certificationIssueReportId = databaseBuilder.factory.buildCertificationIssueReport({

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -61,20 +61,6 @@ function generateIdTokenForExternalUser(externalUser) {
   return tokenService.createIdTokenForUserReconciliation(externalUser);
 }
 
-async function insertUserWithRoleSuperAdmin() {
-  const user = databaseBuilder.factory.buildUser.withRole({
-    id: 1234,
-    firstName: 'Super',
-    lastName: 'Papa',
-    email: 'super.papa@example.net',
-    password: 'Password123',
-  });
-
-  await databaseBuilder.commit();
-
-  return user;
-}
-
 async function insertOrganizationUserWithRoleAdmin() {
   const adminUser = databaseBuilder.factory.buildUser();
   const organization = databaseBuilder.factory.buildOrganization();
@@ -222,7 +208,6 @@ module.exports = {
   hFake,
   HttpTestServer: require('./tooling/server/http-test-server'),
   insertOrganizationUserWithRoleAdmin,
-  insertUserWithRoleSuperAdmin,
   knex,
   nock,
   sinon,


### PR DESCRIPTION
## :jack_o_lantern: Problème
Un builder d'utilisateur avec le rôle de superadministrateur est présent dans les tests helpers.
Ce n'est l'emplacement normal des builders, et un autre builder existe qui fait la même chose.

## :bat: Proposition
Remplacer l'usage par le builder classique.
Supprimer ce builder.

## :spider_web: Remarques
Création d'un builder dédié pour rendre le code plus expressif.
Passage du rôle par défaut du rôle le plus élevé au rôle le moins élevé pour éviter les failles de sécurité (faus négatifs sur 401).

## :ghost: Pour tester
Vérifier que la CI passe
