### PR TITLE
[BUGFIX] Changement de libellé de réponse incorrect (PIX-6177)

### DIFF
--- a/mon-pix/tests/integration/components/qcu-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qcu-solution-panel_test.js
@@ -163,9 +163,7 @@ describe('Integration | Component | qcu-solution-panel.js', function () {
       // Then
       const correctAnswer = find('.qcu-solution-answer-feedback__expected-answer');
       expect(correctAnswer).to.exist;
-      expect(correctAnswer.innerText).to.equal(
-        'Réponse incorrecte.\nLa bonne réponse est la réponse : ' + solutionAsText
-      );
+      expect(correctAnswer.innerText).to.equal('Réponse incorrecte.\nLa bonne réponse est : ' + solutionAsText);
     });
 
     it('should inform the user of the correct answer with solution to display when it is not null', async function () {
@@ -183,9 +181,7 @@ describe('Integration | Component | qcu-solution-panel.js', function () {
       // Then
       const correctAnswer = find('.qcu-solution-answer-feedback__expected-answer');
       expect(correctAnswer).to.exist;
-      expect(correctAnswer.innerText).to.equal(
-        'Réponse incorrecte.\nLa bonne réponse est la réponse : ' + solutionToDisplay
-      );
+      expect(correctAnswer.innerText).to.equal('Réponse incorrecte.\nLa bonne réponse est : ' + solutionToDisplay);
     });
   });
 

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -627,7 +627,7 @@
         },
         "feedback": {
           "correct": "Réponse correcte",
-          "wrong": "Réponse incorrecte. '<br>'La bonne réponse est la réponse : "
+          "wrong": "Réponse incorrecte. '<br>'La bonne réponse est : "
         },
         "ko": {
           "title": "Vous n’avez pas la bonne réponse",
@@ -1399,7 +1399,7 @@
       "primary": "Vous disposerez de '<span class=\"timed-challenge-instructions__time\">'{time}'</span>' pour réussir la question suivante.",
       "secondary": "Vous pourrez continuer à répondre ensuite, mais la question ne sera pas considérée comme réussie."
     },
-    "training" : {
+    "training": {
       "type": {
         "autoformation": "Parcours d'autoformation",
         "webinaire": "Webinaire"


### PR DESCRIPTION
## :jack_o_lantern: Problème
Il y a un doublon du mot "réponse" lors que l'on donne du feedback sur une réponse incorrecte.

## :bat: Proposition
Simplifier le libellé.

## :spider_web: Remarques
RAS

## :ghost: Pour tester
Faire une réponse incorrecte sur [un QCU](https://app-pr5143.review.pix.fr/assessments/108514/challenges/0?challengeId=recT0Ks2EDgoDgEKc) et vérifier le libellé dans la correction de l'écran checkpoint.

![image](https://user-images.githubusercontent.com/5855339/198293139-513ce970-fa74-47b2-8ced-bd01f5f1e2a8.png)

