### PR TITLE
[FEATURE] Ajouter une route permettant de modifier du contenu formatif (PIX-6121).

### DIFF
--- a/api/db/database-builder/factory/build-training.js
+++ b/api/db/database-builder/factory/build-training.js
@@ -7,6 +7,8 @@ function buildTraining({
   type = 'webinaire',
   duration = '06:00:00',
   locale = 'fr-fr',
+  createdAt = new Date(),
+  updatedAt = new Date(),
 } = {}) {
   const values = {
     id,
@@ -15,6 +17,8 @@ function buildTraining({
     type,
     duration,
     locale,
+    createdAt,
+    updatedAt,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'trainings',

--- a/api/lib/application/trainings/index.js
+++ b/api/lib/application/trainings/index.js
@@ -1,0 +1,52 @@
+const Joi = require('joi');
+
+const trainingsController = require('./training-controller');
+const identifiersType = require('../../domain/types/identifiers-type');
+const securityPreHandlers = require('../security-pre-handlers');
+
+exports.register = async (server) => {
+  server.route([
+    {
+      method: 'PATCH',
+      path: '/api/admin/trainings/{trainingId}',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+          },
+        ],
+        handler: trainingsController.update,
+        validate: {
+          params: Joi.object({
+            trainingId: identifiersType.trainingId,
+          }),
+          payload: Joi.object({
+            data: Joi.object({
+              attributes: Joi.object({
+                link: Joi.string().allow(null),
+                title: Joi.string().allow(null),
+                duration: Joi.string().allow(null),
+                type: Joi.string().valid('autoformation', 'webinaire').allow(null),
+                locale: Joi.string().valid('fr-fr', 'fr', 'en-gb').allow(null),
+              }),
+              type: Joi.string().valid('trainings'),
+            }).required(),
+          }).required(),
+          options: {
+            allowUnknown: true,
+          },
+        },
+        tags: ['api', 'admin', 'trainings'],
+        notes: [
+          "- Permet à un administrateur de mettre à jour les attributs d'un contenu formatif par son identifiant",
+        ],
+      },
+    },
+  ]);
+};
+
+exports.name = 'trainings-api';

--- a/api/lib/application/trainings/training-controller.js
+++ b/api/lib/application/trainings/training-controller.js
@@ -1,0 +1,11 @@
+const trainingSerializer = require('../../infrastructure/serializers/jsonapi/training-serializer');
+const usecases = require('../../domain/usecases');
+
+module.exports = {
+  async update(request) {
+    const { trainingId } = request.params;
+    const training = await trainingSerializer.deserialize(request.payload);
+    const updatedTraining = await usecases.updateTraining({ training: { ...training, id: trainingId } });
+    return trainingSerializer.serialize(updatedTraining);
+  },
+};

--- a/api/lib/domain/types/identifiers-type.js
+++ b/api/lib/domain/types/identifiers-type.js
@@ -50,6 +50,7 @@ const typesPositiveInteger32bits = [
   'supervisorAccessesId',
   'targetProfileId',
   'targetProfileTemplateId',
+  'trainingId',
   'userId',
   'userOrgaSettingsId',
 ];

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -427,6 +427,7 @@ module.exports = injectDependencies(
     updateStage: require('./update-stage'),
     updateStudentNumber: require('./update-student-number'),
     updateTargetProfile: require('./update-target-profile'),
+    updateTraining: require('./update-training'),
     updateCertificationCenterReferer: require('./update-certification-center-referer'),
     updateUserForAccountRecovery: require('./account-recovery/update-user-for-account-recovery'),
     updateUserDetailsForAdministration: require('./update-user-details-for-administration'),

--- a/api/lib/domain/usecases/update-training.js
+++ b/api/lib/domain/usecases/update-training.js
@@ -1,0 +1,9 @@
+module.exports = async function updateTraining({ training, trainingRepository }) {
+  const trainingId = training.id;
+  await trainingRepository.get(trainingId);
+
+  return trainingRepository.update({
+    id: trainingId,
+    attributesToUpdate: training,
+  });
+};

--- a/api/lib/infrastructure/repositories/training-repository.js
+++ b/api/lib/infrastructure/repositories/training-repository.js
@@ -54,6 +54,18 @@ module.exports = {
 
     return trainingsDTO.map((training) => _toDomain(training, targetProfileTrainings));
   },
+
+  async update({ id, attributesToUpdate, domainTransaction = DomainTransaction.emptyTransaction() }) {
+    const knexConn = domainTransaction?.knexTransaction || knex;
+    const [updatedTraining] = await knexConn(TABLE_NAME)
+      .where({ id })
+      .update({ ...attributesToUpdate, updatedAt: new Date() })
+      .returning('*');
+
+    const targetProfileTrainings = await knexConn('target-profile-trainings').where({ trainingId: id });
+
+    return _toDomain(updatedTraining, targetProfileTrainings);
+  },
 };
 
 function _toDomain(training, targetProfileTrainings) {

--- a/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
@@ -1,9 +1,13 @@
-const { Serializer } = require('jsonapi-serializer');
+const { Serializer, Deserializer } = require('jsonapi-serializer');
 
 module.exports = {
   serialize(training = {}) {
     return new Serializer('trainings', {
       attributes: ['duration', 'link', 'locale', 'title', 'type'],
     }).serialize(training);
+  },
+
+  deserialize(payload) {
+    return new Deserializer({ keyForAttribute: 'camelCase' }).deserialize(payload);
   },
 };

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -46,6 +46,7 @@ module.exports = [
   require('./application/stages'),
   require('./application/tags'),
   require('./application/target-profiles'),
+  require('./application/trainings'),
   require('./application/frameworks'),
   require('./application/tutorial-evaluations'),
   require('./application/user-orga-settings'),

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -1,0 +1,67 @@
+const {
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  insertUserWithRoleSuperAdmin,
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | training-controller', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('PATCH /api/admin/trainings/{trainingId}', function () {
+    let options;
+
+    describe('nominal case', function () {
+      it('should update training and response with a 200', async function () {
+        // given
+        const superAdmin = await insertUserWithRoleSuperAdmin();
+        const training = databaseBuilder.factory.buildTraining();
+        await databaseBuilder.commit();
+        const updatedTraining = { title: 'new title' };
+
+        options = {
+          method: 'PATCH',
+          url: `/api/admin/trainings/${training.id}`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(superAdmin.id),
+          },
+          payload: {
+            data: {
+              type: 'trainings',
+              attributes: {
+                title: updatedTraining.title,
+              },
+            },
+          },
+        };
+
+        const expectedResponse = {
+          data: {
+            type: 'trainings',
+            id: '1',
+            attributes: {
+              title: updatedTraining.title,
+              link: training.link,
+              duration: training.duration,
+            },
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data.type).to.deep.equal(expectedResponse.data.type);
+        expect(response.result.data.id).to.exist;
+        expect(response.result.data.attributes.title).to.deep.equal(expectedResponse.data.attributes.title);
+        expect(response.result.data.attributes.link).to.deep.equal(expectedResponse.data.attributes.link);
+      });
+    });
+  });
+});

--- a/api/tests/unit/application/trainings/index_test.js
+++ b/api/tests/unit/application/trainings/index_test.js
@@ -1,0 +1,103 @@
+const { expect, HttpTestServer, sinon } = require('../../../test-helper');
+
+const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+const trainingController = require('../../../../lib/application/trainings/training-controller');
+const moduleUnderTest = require('../../../../lib/application/trainings');
+
+describe('Unit | Router | training-router', function () {
+  describe('PATCH /api/admin/trainings', function () {
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    [
+      {
+        role: 'SUPER_ADMIN',
+        securityPreHandlersResponses: {
+          checkAdminMemberHasRoleSuperAdmin: (request, h) => h.response(true),
+          checkAdminMemberHasRoleMetier: (request, h) => h.response({ errors: new Error('forbidden') }).code(403),
+        },
+      },
+      {
+        role: 'METIER',
+        securityPreHandlersResponses: {
+          checkAdminMemberHasRoleSuperAdmin: (request, h) => h.response({ errors: new Error('forbidden') }).code(403),
+          checkAdminMemberHasRoleMetier: (request, h) => h.response(true),
+        },
+      },
+    ].forEach(({ role, securityPreHandlersResponses }) => {
+      it(`should verify user identity and return success update when user role is "${role}"`, async function () {
+        // given
+        sinon.stub(trainingController, 'update').returns('ok');
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake(securityPreHandlersResponses.checkAdminMemberHasRoleSuperAdmin);
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier')
+          .callsFake(securityPreHandlersResponses.checkAdminMemberHasRoleMetier);
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        const payloadAttributes = { title: 'new title' };
+        const payload = { data: { attributes: payloadAttributes } };
+
+        // when
+        const result = await httpTestServer.request('PATCH', '/api/admin/trainings/12344', payload);
+
+        // then
+        sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
+        sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleMetier);
+        sinon.assert.calledOnce(trainingController.update);
+        expect(result.statusCode).to.equal(200);
+      });
+    });
+
+    it('should return bad request when param id is not numeric', async function () {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const payload = { data: { attributes: { title: 'new title' } } };
+
+      // when
+      const result = await httpTestServer.request('PATCH', '/api/admin/trainings/not_number', payload);
+
+      // then
+      expect(result.statusCode).to.equal(400);
+    });
+
+    it('should return bad request when payload is not provided', async function () {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const result = await httpTestServer.request('PATCH', '/api/admin/trainings/12344');
+
+      // then
+      expect(result.statusCode).to.equal(400);
+    });
+
+    it(`should return 403 when user does not have access METIER`, async function () {
+      // given
+      sinon.stub(trainingController, 'update').returns('ok');
+      sinon
+        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      const payloadAttributes = { title: 'new title' };
+      const payload = { data: { attributes: payloadAttributes } };
+
+      // when
+      const result = await httpTestServer.request('PATCH', '/api/admin/trainings/12344', payload);
+
+      // then
+      sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
+      sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleMetier);
+      sinon.assert.notCalled(trainingController.update);
+      expect(result.statusCode).to.equal(403);
+    });
+  });
+});

--- a/api/tests/unit/application/trainings/training-controller_test.js
+++ b/api/tests/unit/application/trainings/training-controller_test.js
@@ -1,0 +1,79 @@
+const { sinon, expect, hFake } = require('../../../test-helper');
+
+const trainingController = require('../../../../lib/application/trainings/training-controller');
+const usecases = require('../../../../lib/domain/usecases');
+const trainingSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/training-serializer');
+
+describe('Unit | Controller | training-controller', function () {
+  describe('#update', function () {
+    const deserializedTraining = { title: 'new title' };
+    const updatedTraining = { title: 'new title' };
+
+    beforeEach(function () {
+      sinon.stub(trainingSerializer, 'deserialize').returns(deserializedTraining);
+      sinon.stub(trainingSerializer, 'serialize');
+      sinon.stub(usecases, 'updateTraining').resolves(updatedTraining);
+    });
+
+    describe('when request is valid', function () {
+      it('should call the training update use-case', async function () {
+        // given
+        const useCaseParameters = {
+          training: { ...deserializedTraining, id: 134 },
+        };
+        const payload = {
+          data: {
+            attributes: {
+              title: 'New title',
+              link: 'https://example.net/new-link',
+            },
+          },
+        };
+
+        // when
+        await trainingController.update(
+          {
+            params: {
+              trainingId: 134,
+            },
+            payload,
+          },
+          hFake
+        );
+
+        // then
+        expect(trainingSerializer.deserialize).to.have.been.calledWith(payload);
+        expect(usecases.updateTraining).to.have.been.calledWith(useCaseParameters);
+      });
+
+      it('should return a serialized training', async function () {
+        // given
+        const payload = {
+          data: {
+            attributes: {
+              title: 'New title',
+              link: 'https://example.net/new-link',
+            },
+          },
+        };
+        const expectedSerializedUser = { message: 'serialized user' };
+        trainingSerializer.serialize.returns(expectedSerializedUser);
+
+        // when
+        const response = await trainingController.update(
+          {
+            params: {
+              trainingId: 134,
+            },
+            payload,
+          },
+          hFake
+        );
+
+        // then
+        expect(trainingSerializer.serialize).to.have.been.calledWith(updatedTraining);
+        expect(response).to.deep.equal(expectedSerializedUser);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/update-training_test.js
+++ b/api/tests/unit/domain/usecases/update-training_test.js
@@ -1,0 +1,63 @@
+const { catchErr, expect, sinon } = require('../../../test-helper');
+const updateTraining = require('../../../../lib/domain/usecases/update-training');
+const { NotFoundError } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | update-training', function () {
+  let trainingRepository;
+
+  beforeEach(function () {
+    trainingRepository = {
+      get: sinon.stub(),
+      update: sinon.stub(),
+    };
+  });
+
+  it('should get a training by its id', async function () {
+    const training = { id: 1011 };
+
+    // when
+    await updateTraining({
+      training,
+      trainingRepository,
+    });
+
+    // then
+    expect(trainingRepository.get).to.have.been.calledWithExactly(training.id);
+  });
+
+  it('should throw a NotFoundError when the training does not exist', async function () {
+    // given
+    const training = { id: 1011 };
+    trainingRepository.get.throws(new NotFoundError('Not found training'));
+
+    // when
+    const error = await catchErr(updateTraining)({
+      training,
+      trainingRepository,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(NotFoundError);
+  });
+
+  it('should update training and return it', async function () {
+    // given
+    const newTrainingAttributes = { id: 1011, title: 'new title' };
+    trainingRepository.get.resolves(Symbol('current-training'));
+    const expectedUpdatedTraining = Symbol('updated-training');
+    trainingRepository.update.resolves(expectedUpdatedTraining);
+
+    // when
+    const updatedTraining = await updateTraining({
+      training: newTrainingAttributes,
+      trainingRepository,
+    });
+
+    // then
+    expect(trainingRepository.update).to.have.been.calledWithExactly({
+      id: newTrainingAttributes.id,
+      attributesToUpdate: newTrainingAttributes,
+    });
+    expect(updatedTraining).to.equal(expectedUpdatedTraining);
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -30,4 +30,34 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
       expect(json).to.deep.equal(expectedSerializedTraining);
     });
   });
+
+  describe('#deserialize', function () {
+    it('should convert JSON API data to Training object', async function () {
+      // given
+      const jsonTraining = {
+        data: {
+          type: 'training',
+          attributes: {
+            title: 'title',
+            link: 'https://example.net',
+            duration: '6h',
+            type: 'webinaire',
+            locale: 'fr-fr',
+          },
+        },
+      };
+
+      // when
+      const training = await serializer.deserialize(jsonTraining);
+
+      // then
+      expect(training).to.deep.equal({
+        title: 'title',
+        link: 'https://example.net',
+        locale: 'fr-fr',
+        duration: '6h',
+        type: 'webinaire',
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :jack_o_lantern: Problème
Actuellement, nous ne pouvons pas modifier le contenu formatif, alors que des liens peuvent devenir obsolètes ou autres.

## :bat: Proposition
Ajouter une route accessible uniquement pour le rôle `METIER` ou `SUPER_ADMIN` qui permet de modifier un contenu formatif.

## :spider_web: Remarques
Les champs modifiables sont : 
```
 link: Joi.string().allow(null),
 title: Joi.string().allow(null),
 duration: Joi.string().allow(null),
 type: Joi.string().valid('autoformation', 'webinaire').allow(null),
 locale: Joi.string().valid('fr-fr', 'fr', 'en-gb').allow(null),
```

## :ghost: Pour tester
 - Se connecter sur Pix Admin, avec un compte `METIER` ou `SUPER_ADMIN`
 - Récupérer le Bearer dans le local storage
 - Lancer une requête `curl -X PATCH https://api-pr5144.review.pix.fr/api/admin/trainings/101023 -H 'Authorization: Bearer <token>' -H 'Content-Type: application/json' -H 'Accept: application/json' --data-raw '{ "data": { "attributes": { "title": "Mon nouveau titre" }, "type": "trainings" } }'`
 - Passer la campagne `PIXEDUINI` 
 - Constater qu'une formation s'appelle "Mon nouveau titre"