### PR TITLE
[FEATURE] Modifier le texte de l'erreur E11 (PIX-6182)

### DIFF
--- a/admin/app/models/certification-issue-report.js
+++ b/admin/app/models/certification-issue-report.js
@@ -71,7 +71,7 @@ export const subcategoryToLabel = {
   [certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT]:
     'Le candidat a été contraint de cliquer en dehors du cadre autorisé pour une question en mode focus',
   [certificationIssueReportSubcategories.SKIP_ON_OOPS]:
-    'Une page affichant “Oups une erreur est survenue” a contraint le candidat à ne pas répondre à la question',
+    'Une page «Oups une erreur est survenue» ou tout autre problème technique lié à la plateforme a empêché le candidat de répondre à la question',
   [certificationIssueReportSubcategories.ACCESSIBILITY_ISSUE]:
     'Problème avec l’accessibilité de la question (ex : daltonisme)',
 };

--- a/admin/tests/integration/components/certifications/issue-report_test.js
+++ b/admin/tests/integration/components/certifications/issue-report_test.js
@@ -205,7 +205,7 @@ module('Integration | Component | certifications/issue-report', function (hooks)
     {
       subcategory: certificationIssueReportSubcategories.SKIP_ON_OOPS,
       expectedLabel:
-        'Une page affichant “Oups une erreur est survenue” a contraint le candidat à ne pas répondre à la question',
+        'Une page «Oups une erreur est survenue» ou tout autre problème technique lié à la plateforme a empêché le candidat de répondre à la question',
     },
     {
       subcategory: certificationIssueReportSubcategories.ACCESSIBILITY_ISSUE,

--- a/certif/app/models/certification-issue-report.js
+++ b/certif/app/models/certification-issue-report.js
@@ -52,7 +52,7 @@ export const subcategoryToLabel = {
   [certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT]:
     'Le candidat a été contraint de cliquer en dehors du cadre autorisé pour une question en mode focus',
   [certificationIssueReportSubcategories.SKIP_ON_OOPS]:
-    'Une page affichant “Oups une erreur est survenue” a contraint le candidat à ne pas répondre à la question',
+    'Une page «Oups une erreur est survenue» ou tout autre problème technique lié à la plateforme a empêché le candidat de répondre à la question',
   [certificationIssueReportSubcategories.ACCESSIBILITY_ISSUE]:
     'Problème avec l’accessibilité de la question (ex : daltonisme)',
 };


### PR DESCRIPTION
## :jack_o_lantern: Problème
Lors du passage de sa certification, si le candidat n’a pas pu répondre à une question à cause d’un problème technique, alors le surveillant doit faire un signalement lors de la finalisation de la session dans Pix Certif pour que cette question soit neutralisée.

Ainsi, le candidat n’est pas pénalisé par un problème technique Pix pour sa certification Pix.

Actuellement, le texte du signalement indique “E11 Une page affichant « Oups une erreur est survenue» a contraint le candidat à ne pas répondre à la question".

Or, dans le cas où aucune page “Oups une erreur est survenue” n’apparaît mais qu’un problème technique a bien empêché le candidat de répondre à une question, les surveillants n’ont pas de signalement adéquat.

## :bat: Proposition
Remplacer le texte du signalement E11 avec le message suivant : “Une page affichant « Oups une erreur est survenue», ou tout autre problème technique lié à la plateforme a contraint le candidat à ne pas répondre à la question”.

## :spider_web: Remarques
Le texte est trop long pour passer dans le menu déroulant des signalements
<img width="1167" alt="image" src="https://user-images.githubusercontent.com/35962680/198678171-93a57ed8-8683-4b59-865c-120f54d74805.png">


## :ghost: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
