### PR TITLE
[FEATURE] Changement du label du numéro de session sur le dashboard des sessions (PIX-5771)

### DIFF
--- a/certif/app/components/session-summary-list.hbs
+++ b/certif/app/components/session-summary-list.hbs
@@ -5,7 +5,7 @@
         <thead>
           <tr>
             <th class="table__column table__column--small" scope="col">
-              Numéro de session
+              N° de session
             </th>
             <th class="table__column table__column--small" scope="col">
               Nom du site

--- a/certif/app/components/session-summary-list.hbs
+++ b/certif/app/components/session-summary-list.hbs
@@ -5,35 +5,35 @@
         <thead>
           <tr>
             <th class="table__column table__column--small" scope="col">
-              N° de session
+              {{t "pages.sessions.list.session-summary.session-number"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              Nom du site
+              {{t "pages.sessions.list.session-summary.center-name"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              Salle
+              {{t "pages.sessions.list.session-summary.room"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              Date
+              {{t "pages.sessions.list.session-summary.date"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              Heure
+              {{t "pages.sessions.list.session-summary.time"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              Surveillant(s)
+              {{t "pages.sessions.list.session-summary.supervisor"}}
             </th>
             <th class="table__column table__column" scope="col">
-              Candidats inscrits
+              {{t "pages.sessions.list.session-summary.effective-candidates"}}
             </th>
             <th class="table__column table__column" scope="col">
-              Certifications passées
+              {{t "pages.sessions.list.session-summary.enrolled-candidates"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              Statut
+              {{t "pages.sessions.list.session-summary.status"}}
             </th>
             <th class="table__column table__column--small" scope="col">
               <span class="sr-only">
-                Actions
+                {{t "pages.sessions.list.session-summary.actions"}}
               </span>
             </th>
           </tr>
@@ -42,7 +42,7 @@
         <tbody>
           {{#each @sessionSummaries as |sessionSummary|}}
             <tr
-              aria-label="Session de certification"
+              aria-label="{{t 'pages.sessions.list.session-summary.certification-session'}}"
               {{on "click" (fn @goToSessionDetails sessionSummary.id)}}
               class="tr--clickable"
             >
@@ -51,7 +51,7 @@
                   @route="authenticated.sessions.details"
                   @model={{sessionSummary.id}}
                   class="session-summary-list__link"
-                  aria-label="Session {{sessionSummary.id}}"
+                  aria-label="{{t 'pages.sessions.list.session-summary.session-and-id' sessionId=sessionSummary.id}}"
                 >
                   {{sessionSummary.id}}
                 </LinkTo>
@@ -71,19 +71,24 @@
                       <:triggerElement>
                         <PixIconButton
                           @icon="trash-alt"
-                          aria-label="Supprimer la session {{sessionSummary.id}}"
+                          aria-label={{t
+                            "pages.sessions.list.session-summary.delete-session"
+                            sessionSummaryId=sessionSummary.id
+                          }}
                           disabled={{true}}
                           aria-describedby="tooltip-delete-session-button"
                           @withBackground={{true}}
                         />
                       </:triggerElement>
-                      <:tooltip
-                      >{{"Au moins un candidat a rejoint la session, vous ne pouvez pas la supprimer."}}</:tooltip>
+                      <:tooltip>{{t "pages.sessions.list.session-summary.tooltip-label"}}</:tooltip>
                     </PixTooltip>
                   {{else}}
                     <PixIconButton
                       @icon="trash-alt"
-                      aria-label="Supprimer la session {{sessionSummary.id}}"
+                      aria-label={{t
+                        "pages.sessions.list.session-summary.delete-session"
+                        sessionSummaryId=sessionSummary.id
+                      }}
                       disabled={{false}}
                       @withBackground={{true}}
                       @triggerAction={{fn
@@ -101,7 +106,7 @@
       </table>
       {{#if (eq @sessionSummaries.length 0)}}
         <div class="table__empty content-text">
-          Aucune session trouvée
+          {{t "pages.sessions.list.session-summary.empty-table"}}
         </div>
       {{/if}}
     </div>

--- a/certif/tests/integration/components/session-summary-list_test.js
+++ b/certif/tests/integration/components/session-summary-list_test.js
@@ -24,7 +24,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
                   @goToSessionDetails={{this.goToSessionDetailsSpy}} />`);
 
     // then
-    assert.dom(screen.getByRole('columnheader', { name: 'Numéro de session' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'N° de session' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'Nom du site' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'Salle' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'Date' })).exists();

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -90,6 +90,23 @@
           "label": "Souhaitez-vous supprimer la session <span>{sessionId}</span> ?",
           "enrolled-candidates": "<span>{enrolledCandidatesCount} candidats</span> sont inscrits à cette session",
           "disclaimer": "Attention, cette action est irréversible."
+        },
+        "session-summary": {
+          "session-number": "N° de session",
+          "center-name": "Nom du site",
+          "room": "Salle",
+          "date": "Date",
+          "time": "Heure",
+          "supervisor": "Surveillant(s)",
+          "enrolled-candidates": "Candidats inscrits",
+          "effective-candidates": "Certifications passées",
+          "status": "Statut",
+          "actions": "Actions",
+          "certification-session": "Session de certification",
+          "delete-session": "Supprimer la session {sessionSummaryId}",
+          "tooltip-label": "Au moins un candidat a rejoint la session, vous ne pouvez pas la supprimer.",
+          "empty-table": "Aucune session trouvée",
+          "session-and-id": "Session {sessionId}"
         }
       },
       "detail": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -90,6 +90,23 @@
           "label": "Souhaitez-vous supprimer la session <span>{sessionId}</span> ?",
           "enrolled-candidates": "<span>{enrolledCandidatesCount} {enrolledCandidatesCount, plural,one {candidat} other {candidats}}</span> {enrolledCandidatesCount, plural,one {est inscrit} other {sont inscrits}} à cette session",
           "disclaimer": "Attention, cette action est irréversible."
+        },
+        "session-summary": {
+          "session-number": "N° de session",
+          "center-name": "Nom du site",
+          "room": "Salle",
+          "date": "Date",
+          "time": "Heure",
+          "supervisor": "Surveillant(s)",
+          "enrolled-candidates": "Candidats inscrits",
+          "effective-candidates": "Certifications passées",
+          "status": "Statut",
+          "actions": "Actions",
+          "certification-session": "Session de certification",
+          "delete-session": "Supprimer la session {sessionSummaryId}",
+          "tooltip-label": "Au moins un candidat a rejoint la session, vous ne pouvez pas la supprimer.",
+          "empty-table": "Aucune session trouvée",
+          "session-and-id": "Session {sessionId}"
         }
       },
       "detail": {


### PR DESCRIPTION
## :jack_o_lantern: Problème
Dans le cadre de l’audit design Pix Certif, il a été remonté un point de densité informationnelle sur la page des sessions de certification sur Pix Certif.

Le tableau est très chargé, les textes à petite résolution risque de se chevaucher ce qui a un impact sur la lisibilité.

## :bat: Proposition
Remplacer "Numéro" par "N°"

## :spider_web: Remarques
Avant : 
<img width="95" alt="Capture d’écran 2022-07-12 à 10_53_35" src="https://user-images.githubusercontent.com/11388201/198992217-ba5b54c3-7215-40ce-a0c1-fbb03a37abf2.png">

Après : 
<img width="292" alt="Capture d’écran 2022-07-12 à 10_55_07" src="https://user-images.githubusercontent.com/11388201/198992233-14046ccc-e7ec-4071-8f93-149f40e63d5a.png">


## :ghost: Pour tester
Se connecter à Pix Certif et aller sur la liste des sessions, avec au moins une session.
Vérifier que le numéro est affiché "N° de session"
