### PR TITLE
[TASK] Api: Retirer le code obsolète qui scan toute la base de données Redis (PIX-6080)

### DIFF
--- a/api/lib/infrastructure/temporary-storage/InMemoryTemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/InMemoryTemporaryStorage.js
@@ -28,12 +28,6 @@ class InMemoryTemporaryStorage extends TemporaryStorage {
     return this._client.del(key);
   }
 
-  deleteByPrefix(prefix) {
-    const keys = this._client.keys();
-    const matchingKeys = keys.filter((key) => key.startsWith(prefix));
-    return this._client.del(matchingKeys);
-  }
-
   quit() {
     noop;
   }

--- a/api/lib/infrastructure/temporary-storage/RedisTemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/RedisTemporaryStorage.js
@@ -40,10 +40,6 @@ class RedisTemporaryStorage extends TemporaryStorage {
     await this._client.del(key);
   }
 
-  async deleteByPrefix(prefix) {
-    await this._client.deleteByPrefix(prefix);
-  }
-
   async quit() {
     await this._client.quit();
   }

--- a/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/TemporaryStorage.js
@@ -21,10 +21,6 @@ class TemporaryStorage {
     throw new Error('Method #delete(key) must be overridden');
   }
 
-  async deleteByPrefix(/* prefix */) {
-    throw new Error('Method #deleteByPrefix(prefix) must be overridden');
-  }
-
   async expire(/* { key, expirationDelaySeconds } */) {
     throw new Error('Method #expire({ key, expirationDelaySeconds }) must be overridden');
   }
@@ -68,10 +64,6 @@ class TemporaryStorage {
 
       delete(key) {
         return storage.delete(prefix + key);
-      },
-
-      deleteByPrefix(searchedPrefix) {
-        return storage.deleteByPrefix(prefix + searchedPrefix);
       },
 
       expire({ key, expirationDelaySeconds }) {

--- a/api/lib/infrastructure/utils/RedisClient.js
+++ b/api/lib/infrastructure/utils/RedisClient.js
@@ -1,5 +1,4 @@
 const redis = require('redis');
-const redisScan = require('node-redis-scan');
 const Redlock = require('redlock');
 const { promisify } = require('util');
 const logger = require('../logger');
@@ -63,18 +62,5 @@ module.exports = class RedisClient {
 
   async quit() {
     await this._client.quit();
-  }
-
-  async deleteByPrefix(searchedPrefix) {
-    const searchedPrefixWithClientPrefix = `${this._prefix}${searchedPrefix}`;
-    const escapedPrefix = searchedPrefixWithClientPrefix.replace(/[*?[\\\]]/g, '\\$&');
-    const pattern = `${escapedPrefix}*`;
-    const redisWithScan = new redisScan(this._client);
-    const scan = promisify(redisWithScan.scan).bind(redisWithScan);
-    const matchingKeys = await scan(pattern);
-    if (matchingKeys.length > 0) {
-      const del = promisify(this._client.del).bind(this._client);
-      await del(matchingKeys);
-    }
   }
 };

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -51,7 +51,6 @@
         "moment-timezone": "^0.5.34",
         "ms": "^2.1.3",
         "node-cache": "^5.1.2",
-        "node-redis-scan": "^1.3.5",
         "node-stream-zip": "^1.15.0",
         "oppsy": "https://github.com/1024pix/oppsy#main",
         "papaparse": "^5.3.2",
@@ -10219,14 +10218,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/node-redis-scan": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/node-redis-scan/-/node-redis-scan-1.3.5.tgz",
-      "integrity": "sha512-qQ33kqRj56IgaMZK5Hf+8UTdUG7cwxLEgbGBXjeqjI7KdVHN7HokyQzm4JScNMS6VFEufG92JxE2oXAtfJOuag==",
-      "engines": {
-        "node": ">= 10.12.0"
       }
     },
     "node_modules/node-releases": {
@@ -22621,11 +22612,6 @@
       "requires": {
         "process-on-spawn": "^1.0.0"
       }
-    },
-    "node-redis-scan": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/node-redis-scan/-/node-redis-scan-1.3.5.tgz",
-      "integrity": "sha512-qQ33kqRj56IgaMZK5Hf+8UTdUG7cwxLEgbGBXjeqjI7KdVHN7HokyQzm4JScNMS6VFEufG92JxE2oXAtfJOuag=="
     },
     "node-releases": {
       "version": "2.0.5",

--- a/api/package.json
+++ b/api/package.json
@@ -57,7 +57,6 @@
     "moment-timezone": "^0.5.34",
     "ms": "^2.1.3",
     "node-cache": "^5.1.2",
-    "node-redis-scan": "^1.3.5",
     "node-stream-zip": "^1.15.0",
     "oppsy": "https://github.com/1024pix/oppsy#main",
     "papaparse": "^5.3.2",

--- a/api/tests/integration/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
+++ b/api/tests/integration/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
@@ -6,25 +6,6 @@ describe('Integration | Infrastructure | TemporaryStorage | RedisTemporaryStorag
   // this check is used to prevent failure when redis is not setup
   // eslint-disable-next-line mocha/no-setup-in-describe
   if (process.env.REDIS_TEST_URL !== undefined) {
-    describe('#deleteByPrefix', function () {
-      it('should delete all found keys with the given matching prefix', async function () {
-        // given
-        const expirationDelaySeconds = 1000;
-        const storage = new RedisTemporaryStorage(process.env.REDIS_TEST_URL);
-        await storage.save({ key: '456:c', value: 'c', expirationDelaySeconds });
-        await storage.save({ key: '123:a', value: 'a', expirationDelaySeconds });
-        await storage.save({ key: '123:b', value: 'b', expirationDelaySeconds });
-
-        // when
-        await storage.deleteByPrefix('123:');
-
-        // then
-        expect(await storage.get('123:a')).to.not.exist;
-        expect(await storage.get('123:b')).to.not.exist;
-        expect(await storage.get('456:c')).to.exist;
-      });
-    });
-
     describe('#set', function () {
       it('should set new value', async function () {
         // given

--- a/api/tests/integration/infrastructure/utils/RedisClient_test.js
+++ b/api/tests/integration/infrastructure/utils/RedisClient_test.js
@@ -45,56 +45,6 @@ describe('Integration | Infrastructure | Utils | RedisClient', function () {
     await redisClient2.del('key');
   });
 
-  describe('#deleteByPrefix', function () {
-    it('should delete keys with given matching prefix', async function () {
-      // given
-      const value = new Date().toISOString();
-      const redisClient = new RedisClient(config.redis.url, { prefix: 'client-prefix:' });
-      await redisClient.set('123:AVRIL', value);
-      await redisClient.set('123:abcde', value);
-      await redisClient.set('456:abcde', value);
-
-      // when
-      await redisClient.deleteByPrefix('123:');
-
-      // then
-      expect(await redisClient.get('123:AVRIL')).to.not.exist;
-      expect(await redisClient.get('123:abcde')).to.not.exist;
-      expect(await redisClient.get('456:abcde')).to.exist;
-    });
-
-    it('should escape special characters', async function () {
-      // given
-      const value = new Date().toISOString();
-      const redisClient = new RedisClient(config.redis.url, { prefix: 'client-prefix:' });
-      await redisClient.set('123:AVRIL', value);
-      await redisClient.set('123:abcde', value);
-      await redisClient.set('456:abcde', value);
-      await redisClient.set('*:abcde', value);
-      await redisClient.set('**:abcde', value);
-
-      // when
-      await redisClient.deleteByPrefix('**');
-
-      // then
-      expect(await redisClient.get('**:abcde')).to.not.exist;
-      expect(await redisClient.get('*:abcde')).to.exist;
-    });
-
-    it('should do nothing if there is no matching prefix', async function () {
-      // given
-      const value = new Date().toISOString();
-      const redisClient = new RedisClient(config.redis.url, { prefix: 'client-prefix:' });
-      await redisClient.set('789:abcde', value);
-
-      // when
-      await redisClient.deleteByPrefix('333:');
-
-      // then
-      expect(await redisClient.get('789:abcde')).to.exist;
-    });
-  });
-
   it('should allow to handle a list of values for a key', async function () {
     // given
     const keyToAdd = uuidv4();

--- a/api/tests/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
@@ -139,26 +139,6 @@ describe('Unit | Infrastructure | temporary-storage | InMemoryTemporaryStorage',
     });
   });
 
-  describe('#deleteByPrefix', function () {
-    it('should delete all found keys with the given matching prefix', async function () {
-      // given
-      const expirationDelaySeconds = 1000;
-
-      const inMemoryTemporaryStorage = new InMemoryTemporaryStorage();
-      await inMemoryTemporaryStorage.save({ key: '456:c', value: {}, expirationDelaySeconds });
-      await inMemoryTemporaryStorage.save({ key: '123:a', value: {}, expirationDelaySeconds });
-      await inMemoryTemporaryStorage.save({ key: '123:b', value: {}, expirationDelaySeconds });
-
-      // when
-      await inMemoryTemporaryStorage.deleteByPrefix('123:');
-
-      // then
-      expect(await inMemoryTemporaryStorage.get('123:a')).to.be.undefined;
-      expect(await inMemoryTemporaryStorage.get('123:b')).to.be.undefined;
-      expect(await inMemoryTemporaryStorage.get('456:c')).to.exist;
-    });
-  });
-
   describe('#expire', function () {
     it('should add an expiration time to the list', async function () {
       // given

--- a/api/tests/unit/infrastructure/temporary-storage/TemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/TemporaryStorage_test.js
@@ -41,19 +41,6 @@ describe('Unit | Infrastructure | temporary-storage | TemporaryStorage', functio
     });
   });
 
-  describe('#deleteByPrefix', function () {
-    it('should reject an error (because this class actually mocks an interface)', function () {
-      // given
-      const temporaryStorageInstance = new TemporaryStorage();
-
-      // when
-      const result = temporaryStorageInstance.deleteByPrefix('123:');
-
-      // then
-      expect(result).to.be.rejected;
-    });
-  });
-
   describe('#generateKey', function () {
     it('should return a key from static method', function () {
       // when
@@ -81,14 +68,6 @@ describe('Unit | Infrastructure | temporary-storage | TemporaryStorage', functio
         async delete(key) {
           delete store[key];
         }
-
-        async deleteByPrefix(prefix) {
-          for (const key in store) {
-            if (key.startsWith(prefix)) {
-              delete store[key];
-            }
-          }
-        }
       }
 
       const storage = new TestStorage().withPrefix('a-prefix:');
@@ -105,10 +84,6 @@ describe('Unit | Infrastructure | temporary-storage | TemporaryStorage', functio
       expect(randomKey).to.exist;
       expect(store['a-prefix:' + randomKey]).to.exist;
       expect(await storage.get(randomKey)).to.equal('random-key-value');
-
-      await storage.save({ key: '123:a-key', value: 'a-value' });
-      await storage.deleteByPrefix('123:');
-      expect(await storage.get('123:a-key')).to.be.undefined;
     });
   });
 


### PR DESCRIPTION
## :jack_o_lantern: Problème

Le code permettant d’améliorer les performances de l’action d’anonymisation d’un utilisateur (PIX-5951) a été implémenter sur cette pull request : #5091 .

Pour des soucis de compatibilités, le précédent code est toujours actif. Une fois que 7 jours (environ) ce seront écoulés, nous pourrons retirer l’ancien code effectuant un scan de la base de données pour retrouver tous les refresh tokens d’un utilisateur.

## :bat: Proposition

Retirer le code obsolète.

## :spider_web: Remarques

RAS

## :ghost: Pour tester

Testez la non-régression de l'anonymisation d'un utilisateur.

#### Multiples connexions + anonymisation

- Se connecter avec le même compte sur Pix app avec différents navigateurs (Chrome, Safari, Firefox, Opera, Brave, Edge, ...)
- Se connecter sur Redis
- Constatez qu'il existe différentes entrées pour chacune des connexions mais aussi une nouvelle entrée `user-refresh-tokens:<votre-user-id>` étant une liste de tous les refresh tokens de l'utilisateur
- Se connecter sur Pix Admin
- Ouvrir la page de détails de l'utilisateur
- Anonymiser cet utilisateur
- Constatez sur Redis que toutes les entrées lié à l'utilisateur ne sont plus présentes, ainsi que la nouvelle entrée `user-refresh-tokens:<votre-user-id>`

#### Une seule connexion + déconnexion

- Se connecter avec le même compte sur Pix app
- Se connecter sur Redis
- Constatez qu'il existe différentes entrées pour la connexion de l'utilisateur comprenant une nouvelle entrée `user-refresh-tokens:<votre-user-id>` étant une liste de tous les refresh tokens de l'utilisateur
- Se déconnecter
- Constatez sur Redis que toutes les entrées lié à l'utilisateur ne sont plus présentes, ainsi que la nouvelle entrée `user-refresh-tokens:<votre-user-id>`
