### PR TITLE
[BUGFIX] Eviter une erreur lorsque l'on publie une session sans Referer (PIX-6204)

### DIFF
--- a/api/lib/infrastructure/repositories/certification-center-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-repository.js
@@ -164,10 +164,6 @@ module.exports = {
       .where('certification-centers.id', certificationCenterId)
       .where('certification-center-memberships.isReferer', true);
 
-    if (!refererEmails.length) {
-      return null;
-    }
-
     return refererEmails;
   },
 };

--- a/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -781,7 +781,7 @@ describe('Integration | Repository | Certification Center', function () {
 
   describe('#getRefererEmails', function () {
     context('when the certification center has no referer', function () {
-      it('should return null', async function () {
+      it('should return an empty array', async function () {
         // given
         const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
         const userId = databaseBuilder.factory.buildUser().id;
@@ -792,7 +792,7 @@ describe('Integration | Repository | Certification Center', function () {
         const refererEmails = await certificationCenterRepository.getRefererEmails(certificationCenterId);
 
         // then
-        expect(refererEmails).to.be.null;
+        expect(refererEmails).to.be.empty;
       });
     });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsque l’on publie une session sans referer, la session est publiée mais un message d’erreur apparait
![image](https://user-images.githubusercontent.com/3769147/199684002-20fc5820-4f2a-4582-b6aa-4b088ae2d87f.png)


## :gift: Proposition
- Ne pas chercher les referer s’il n’y a pas de certification CléA
- Corriger le bug s’il n’y a pas de referer avec des certifications clea
- Logger un message en warn

## :star2: Remarques
On ne renvoie pas de message d'erreur/warning au front

## :santa: Pour tester
[Session a publier avec CléA](https://admin-pr5151.review.pix.fr/sessions/108540/certifications)

pas de referer:
- S'assurer qu'il n'y a pas de referer sur le centre de certification
- Publier une session, verifier qu'il n'y a pas d'erreur 

avec referer
-Ajouter un referer sur le centre de certification
- Publier la session avec clea
- S'assurer que les mails sont envoyés
