### PR TITLE
[TECH] Supprimer le conditionnement de la page `/mes-formations` (PIX-6205).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -196,7 +196,6 @@ module.exports = (function () {
     },
 
     featureToggles: {
-      isPixAppTrainingsPageEnabled: isFeatureEnabled(process.env.FT_TRAININGS_PAGE),
       isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: isFeatureEnabled(
         process.env.FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS
       ),

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -22,7 +22,6 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
           id: '0',
           type: 'feature-toggles',
           attributes: {
-            'is-pix-app-trainings-page-enabled': false,
             'is-clea-results-retrieval-by-habilitated-certification-centers-enabled': false,
           },
         },


### PR DESCRIPTION
## :christmas_tree: Problème
Nous n'avons plus besoin du FT pour conditionner l'affichage de la page `/mes-formations`.

## :gift: Proposition
Le supprimer 

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Vérifier que la CI fonctionne