### PR TITLE
[BUGFIX] Régler le problème d'interprétation de la valeur de la colonne isManagingStudents du script OGA (PIX-6212)

### DIFF
--- a/api/scripts/create-organizations-with-tags-and-target-profiles.js
+++ b/api/scripts/create-organizations-with-tags-and-target-profiles.js
@@ -47,7 +47,7 @@ const batchOrganizationOptionsWithHeader = {
       value = value.trim();
     }
     if (columnName === 'isManagingStudents') {
-      value = Boolean(value);
+      value = value?.toLowerCase() === 'true';
     }
     if (!isEmpty(value)) {
       if (

--- a/api/tests/unit/scripts/helpers/csvHelpers_test.js
+++ b/api/tests/unit/scripts/helpers/csvHelpers_test.js
@@ -148,6 +148,8 @@ describe('Unit | Scripts | Helpers | csvHelpers.js', function () {
 
         // then
         expect(data[0].isManagingStudents).to.equal(false);
+        expect(data[1].isManagingStudents).to.equal(true);
+        expect(data[2].isManagingStudents).to.equal(false);
       });
 
       it('should convert identityProviderForCampaigns to uppercase', async function () {

--- a/api/tests/unit/scripts/helpers/files/organizations-with-tags-and-target-profiles-test.csv
+++ b/api/tests/unit/scripts/helpers/files/organizations-with-tags-and-target-profiles-test.csv
@@ -1,2 +1,4 @@
 type,externalId,name,provinceCode,credit,emailInvitations,emailForSCOActivation,organizationInvitationRole,locale,tags,createdBy,documentationUrl,targetProfiles,isManagingStudents,identityProviderForCampaigns,DPOFirstName,DPOLastName,DPOEmail
 pro,TUTU001,Team Accès,123,,   team-acces@e  x  ample.net   ,superadmin@example.net,admin,,PUBLIC_AGRICULTURE,100,https://pix.fr/,123456,,pole_emploi,Djamal,Dormi,super admin @ Example.net
+pro,TUTU001,Team Accès,123,,   team-acces@e  x  ample.net   ,superadmin@example.net,admin,,PUBLIC_AGRICULTURE,100,https://pix.fr/,123456,true,pole_emploi,Djamal,Dormi,super admin @ Example.net
+pro,TUTU001,Team Accès,123,,   team-acces@e  x  ample.net   ,superadmin@example.net,admin,,PUBLIC_AGRICULTURE,100,https://pix.fr/,123456,false,pole_emploi,Djamal,Dormi,super admin @ Example.net


### PR DESCRIPTION
## :christmas_tree: Problème

Lors de l’exécution du script OGA (create-organizations-with-tags-and-target-profiles.js), si la valeur de la colonne isManagingStudents est “false” alors le script retournera true comme valeur lors de la lecture du fichier CSV.

Cela est dû à l’expression utilisée pour transformer une chaîne de caractères en boolean.

## :gift: Proposition

Il faut changer cette expression en vérifiant uniquement si la valeur est bien égale à “true“ en terme de valeur et de type.

Si aucune valeur n’est fourni ou “false“ est fourni cela retourna false. Et dans le case de la valeur “true“, on aura en retour true

## :star2: Remarques

RAS

## :santa: Pour tester (en local)

- Se créer un fichier CSV avec des données factices (3 lignes)

```csv
type,externalId,name,provinceCode,credit,createdBy,documentationUrl,identityProviderForCampaigns,isManagingStudents,emailForSCOActivation,DPOFirstName,DPOLastName,DPOEmail,emailInvitations,organizationInvitationRole,locale,tags,targetProfiles
PRO,OGA123,Orga#1,,0,1,,,false,,,,alain.verse@example.net,alain.verse@example.net,MEMBER,fr-fr,POLE PRO,1
PRO,OGA1234,Orga#2,,0,1,,,true,,,,alain.terieur@example.net,alain.terieur@example.net,MEMBER,fr-fr,POLE PRO,1
PRO,OGA12345,Orga#3,,0,1,,,,,,,alex.terieur@example.net,alex.terieur@example.net,MEMBER,fr-fr,POLE PRO,1

```

- Exécutez le script OGA avec votre CSV
- Constatez en base de données que la valeur de chacune des entrées pour la colonne isManagingStudents est bonne
