### PR TITLE
[FEATURE][CERTIF] Permettre l'inscription à Pix Certif depuis une invitation (PIX- 6209)

### DIFF
--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -111,14 +111,14 @@ module.exports = {
     return userSerializer.serialize(updatedUser);
   },
 
-  async acceptPixCertifTermsOfService(request) {
+  async acceptPixCertifTermsOfService(request, h) {
     const authenticatedUserId = request.auth.credentials.userId;
 
-    const updatedUser = await usecases.acceptPixCertifTermsOfService({
+    await usecases.acceptPixCertifTermsOfService({
       userId: authenticatedUserId,
     });
 
-    return userSerializer.serialize(updatedUser);
+    return h.response().code(204);
   },
 
   async rememberUserHasSeenAssessmentInstructions(request) {

--- a/api/tests/acceptance/application/users/accept-pix-certif-terms-of-service_test.js
+++ b/api/tests/acceptance/application/users/accept-pix-certif-terms-of-service_test.js
@@ -46,13 +46,12 @@ describe('Acceptance | Controller | users-controller-accept-pix-certif-terms-of-
   });
 
   describe('Success case', function () {
-    it('should return the user with pixCertifTermsOfServiceAccepted', async function () {
+    it('should return a response with HTTP status code 204', async function () {
       // when
       const response = await server.inject(options);
 
       // then
-      expect(response.statusCode).to.equal(200);
-      expect(response.result.data.attributes['pix-certif-terms-of-service-accepted']).to.be.true;
+      expect(response.statusCode).to.equal(204);
     });
   });
 });

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -283,29 +283,22 @@ describe('Unit | Controller | user-controller', function () {
   });
 
   describe('#acceptPixCertifTermsOfService', function () {
-    let request;
-    const userId = 1;
-
-    beforeEach(function () {
-      request = {
-        auth: { credentials: { userId } },
-        params: { id: userId },
-      };
-
-      sinon.stub(usecases, 'acceptPixCertifTermsOfService');
-      sinon.stub(userSerializer, 'serialize');
-    });
-
     it('should accept pix certif terms of service', async function () {
       // given
-      usecases.acceptPixCertifTermsOfService.withArgs({ userId }).resolves({});
-      userSerializer.serialize.withArgs({}).returns('ok');
+      const userId = 1;
+      sinon.stub(usecases, 'acceptPixCertifTermsOfService');
 
       // when
-      const response = await userController.acceptPixCertifTermsOfService(request);
+      await userController.acceptPixCertifTermsOfService(
+        {
+          auth: { credentials: { userId } },
+          params: { id: userId },
+        },
+        hFake
+      );
 
       // then
-      expect(response).to.be.equal('ok');
+      sinon.assert.calledWith(usecases.acceptPixCertifTermsOfService, { userId: 1 });
     });
   });
 

--- a/certif/app/adapters/certification-center-invitation-response.js
+++ b/certif/app/adapters/certification-center-invitation-response.js
@@ -1,0 +1,9 @@
+import ApplicationAdapter from './application';
+
+export default class CertificationCenterInvitationResponseAdapter extends ApplicationAdapter {
+  urlForCreateRecord(modelName, { adapterOptions }) {
+    const { certificationCenterInvitationId } = adapterOptions;
+
+    return `${this.host}/${this.namespace}/certification-center-invitations/${certificationCenterInvitationId}/accept`;
+  }
+}

--- a/certif/app/components/auth/login-or-register.hbs
+++ b/certif/app/components/auth/login-or-register.hbs
@@ -25,7 +25,10 @@
           }}
         >
           {{#if this.displayRegisterForm}}
-            <Auth::RegisterForm />
+            <Auth::RegisterForm
+              @certificationCenterInvitationId={{@certificationCenterInvitationId}}
+              @certificationCenterInvitationCode={{@certificationCenterInvitationCode}}
+            />
           {{/if}}
         </div>
       </div>

--- a/certif/app/components/auth/register-form.js
+++ b/certif/app/components/auth/register-form.js
@@ -31,8 +31,12 @@ export default class RegisterForm extends Component {
   }
 
   @action
-  async register() {
-    /* TODO */
+  async register(event) {
+    event.preventDefault();
+    if (!this._isFormValid()) {
+      return;
+    }
+    this.isLoading = true;
   }
 
   @action
@@ -87,5 +91,15 @@ export default class RegisterForm extends Component {
     if (!isInputChecked) {
       this.cguValidationMessage = this.intl.t('pages.login-or-register.register-form.fields.cgu.error');
     }
+  }
+
+  _isFormValid() {
+    return (
+      !isEmpty(this.lastName) &&
+      !isEmpty(this.firstName) &&
+      isEmailValid(this.email) &&
+      isPasswordValid(this.password) &&
+      Boolean(this.cgu)
+    );
   }
 }

--- a/certif/app/components/auth/register-form.js
+++ b/certif/app/components/auth/register-form.js
@@ -42,6 +42,7 @@ export default class RegisterForm extends Component {
     }
     this.isLoading = true;
 
+    let certificationCenterInvitationResponseRecord;
     const userRecord = this.store.createRecord('user', {
       lastName: this.lastName,
       firstName: this.firstName,
@@ -52,6 +53,18 @@ export default class RegisterForm extends Component {
 
     try {
       await userRecord.save();
+
+      certificationCenterInvitationResponseRecord = this.store.createRecord(
+        'certification-center-invitation-response',
+        {
+          id: this.args.certificationCenterInvitationId,
+          code: this.args.certificationCenterInvitationCode,
+          email: this.email,
+        }
+      );
+      await certificationCenterInvitationResponseRecord.save({
+        adapterOptions: { certificationCenterInvitationId: this.args.certificationCenterInvitationId },
+      });
     } catch (response) {
       const status = get(response, 'errors[0].status');
 
@@ -62,6 +75,7 @@ export default class RegisterForm extends Component {
       }
 
       await userRecord?.deleteRecord();
+      await certificationCenterInvitationResponseRecord?.deleteRecord();
     } finally {
       this.isLoading = false;
     }

--- a/certif/app/components/auth/register-form.js
+++ b/certif/app/components/auth/register-form.js
@@ -11,6 +11,7 @@ export default class RegisterForm extends Component {
   @service intl;
   @service url;
   @service store;
+  @service session;
 
   @tracked isLoading = false;
   @tracked firstName = null;
@@ -65,6 +66,8 @@ export default class RegisterForm extends Component {
       await certificationCenterInvitationResponseRecord.save({
         adapterOptions: { certificationCenterInvitationId: this.args.certificationCenterInvitationId },
       });
+
+      await this._authenticate(this.email, this.password);
     } catch (response) {
       const status = get(response, 'errors[0].status');
 
@@ -143,5 +146,10 @@ export default class RegisterForm extends Component {
       isPasswordValid(this.password) &&
       Boolean(this.cgu)
     );
+  }
+
+  _authenticate(email, password) {
+    const scope = 'pix-certif';
+    return this.session.authenticate('authenticator:oauth2', email, password, scope);
   }
 }

--- a/certif/app/components/auth/register-form.js
+++ b/certif/app/components/auth/register-form.js
@@ -5,10 +5,12 @@ import { tracked } from '@glimmer/tracking';
 import isEmpty from 'lodash/isEmpty';
 import isEmailValid from '../../utils/email-validator';
 import isPasswordValid from '../../utils/password-validator';
+import get from 'lodash/get';
 
 export default class RegisterForm extends Component {
   @service intl;
   @service url;
+  @service store;
 
   @tracked isLoading = false;
   @tracked firstName = null;
@@ -33,10 +35,36 @@ export default class RegisterForm extends Component {
   @action
   async register(event) {
     event.preventDefault();
+    this.errorMessage = null;
+
     if (!this._isFormValid()) {
       return;
     }
     this.isLoading = true;
+
+    const userRecord = this.store.createRecord('user', {
+      lastName: this.lastName,
+      firstName: this.firstName,
+      email: this.email,
+      password: this.password,
+      cgu: true,
+    });
+
+    try {
+      await userRecord.save();
+    } catch (response) {
+      const status = get(response, 'errors[0].status');
+
+      if (status === '422') {
+        this.errorMessage = this.intl.t('pages.login-or-register.register-form.errors.email-already-exists');
+      } else {
+        this.errorMessage = this.intl.t('pages.login-or-register.register-form.errors.default');
+      }
+
+      await userRecord?.deleteRecord();
+    } finally {
+      this.isLoading = false;
+    }
   }
 
   @action

--- a/certif/app/controllers/join.js
+++ b/certif/app/controllers/join.js
@@ -1,0 +1,7 @@
+import Controller from '@ember/controller';
+
+export default class JoinController extends Controller {
+  queryParams = ['code', 'invitationId'];
+  code = null;
+  invitationId = null;
+}

--- a/certif/app/controllers/terms-of-service.js
+++ b/certif/app/controllers/terms-of-service.js
@@ -4,13 +4,18 @@ import { inject as service } from '@ember/service';
 
 export default class TermsOfServiceController extends Controller {
   @service currentUser;
+  @service notifications;
 
   @action
   async submit() {
-    await this.currentUser.certificationPointOfContact.save({
-      adapterOptions: { acceptPixCertifTermsOfService: true },
-    });
-    this.currentUser.certificationPointOfContact.pixCertifTermsOfServiceAccepted = true;
-    return this.transitionToRoute('authenticated.sessions.list');
+    try {
+      await this.currentUser.certificationPointOfContact.save({
+        adapterOptions: { acceptPixCertifTermsOfService: true },
+      });
+      this.currentUser.certificationPointOfContact.pixCertifTermsOfServiceAccepted = true;
+      return this.transitionToRoute('authenticated.sessions.list');
+    } catch (errorResponse) {
+      this.notifications.error('Une erreur est survenue.');
+    }
   }
 }

--- a/certif/app/models/certification-center-invitation-response.js
+++ b/certif/app/models/certification-center-invitation-response.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class CertificationCenterInvitationResponse extends Model {
+  @attr('string') code;
+  @attr('string') email;
+}

--- a/certif/app/models/user.js
+++ b/certif/app/models/user.js
@@ -1,0 +1,9 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class User extends Model {
+  @attr('string') email;
+  @attr('string') firstName;
+  @attr('string') lastName;
+  @attr('string') password;
+  @attr('boolean') cgu;
+}

--- a/certif/app/styles/components/register-form.scss
+++ b/certif/app/styles/components/register-form.scss
@@ -1,7 +1,7 @@
 .register-form {
   max-width: 360px;
   font-size: 0.875rem;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   &__cgu-label {
     font-family: $font-roboto;

--- a/certif/app/templates/application.hbs
+++ b/certif/app/templates/application.hbs
@@ -1,3 +1,4 @@
 {{page-title "Pix Certif"}}
 <CommunicationBanner />
 {{outlet}}
+<NotificationContainer @position="bottom-right" />

--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -82,6 +82,4 @@
     <Layout::Footer />
   </div>
 
-  <NotificationContainer @position="bottom-right" />
-
 </div>

--- a/certif/app/templates/join.hbs
+++ b/certif/app/templates/join.hbs
@@ -1,5 +1,9 @@
 {{page-title (t "pages.login-or-register.title" certificationCenterName=@model.certificationCenterName)}}
 
 <div class="join-page">
-  <Auth::LoginOrRegister @certificationCenterName={{@model.certificationCenterName}} />
+  <Auth::LoginOrRegister
+    @certificationCenterInvitationId={{this.invitationId}}
+    @certificationCenterInvitationCode={{this.code}}
+    @certificationCenterName={{@model.certificationCenterName}}
+  />
 </div>

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -26,7 +26,7 @@ export default function () {
     const params = parseQueryString(request.requestBody);
     const foundUser = schema.certificationPointOfContacts.findBy({ email: params.username });
 
-    if (foundUser && params.password === 'secret') {
+    if (foundUser && ['secret', 'Pa$$w0rd'].includes(params.password)) {
       return {
         expires_in: 3600,
         token_type: 'Bearer token type',
@@ -205,7 +205,7 @@ export default function () {
     const certificationPointOfContact = schema.certificationPointOfContacts.find(certificationPointOfContactId);
     certificationPointOfContact.update({ pixCertifTermsOfServiceAccepted: true });
 
-    return certificationPointOfContact;
+    return new Response(204);
   });
 
   this.get('feature-toggles', (schema) => {
@@ -257,5 +257,47 @@ export default function () {
     const member = schema.members.find(memberId);
     await member.update({ isReferer: true });
     return new Response(204);
+  });
+
+  this.get('/certification-center-invitations/:id', (schema, request) => {
+    const certificationCenterInvitationId = request.params.id;
+    return schema.certificationCenterInvitations.find(certificationCenterInvitationId);
+  });
+
+  this.post('/certification-center-invitations/:id/accept', (schema) => {
+    const certificationPointOfContact = schema.certificationPointOfContacts.find(12345);
+    const allowedCertificationCenterAccess = schema.allowedCertificationCenterAccesses.create({
+      name: 'Super Centre de Certif',
+      type: 'SCO',
+      externalId: 'ABC123',
+      isRelatedToManagingStudentsOrganization: false,
+      isAccessBlockedCollege: false,
+      isAccessBlockedLycee: false,
+      isAccessBlockedAEFE: false,
+      isAccessBlockedAgri: false,
+    });
+
+    certificationPointOfContact.update({ allowedCertificationCenterAccesses: [allowedCertificationCenterAccess] });
+
+    return new Response(204);
+  });
+
+  this.post('/users', (schema, request) => {
+    const requestBody = JSON.parse(request.requestBody);
+    const attributes = requestBody.data.attributes;
+    const user = {
+      firstName: attributes['first-name'],
+      lastName: attributes['last-name'],
+      email: attributes.email,
+      password: 'secret',
+    };
+
+    schema.certificationPointOfContacts.create({ id: 12345, ...user });
+
+    return schema.users.create({
+      id: 12345,
+      ...user,
+      cgu: attributes.cgu,
+    });
   });
 }

--- a/certif/tests/acceptance/routes/join_test.js
+++ b/certif/tests/acceptance/routes/join_test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { currentURL, fillIn } from '@ember/test-helpers';
+import { visit, clickByName } from '@1024pix/ember-testing-library';
+import setupIntl from '../../helpers/setup-intl';
+
+module('Acceptance | Routes | join', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  module('when a user wants to join a certification center', function () {
+    test('it should allow the user to create his account and display the dashboard page', async function (assert) {
+      // given
+      const certificationCenterInvitation = server.create('certification-center-invitation', {
+        id: 1,
+        certificationCenterName: 'Super Centre de Certif',
+      });
+
+      // when
+      const screen = await visit(`/rejoindre?invitationId=${certificationCenterInvitation.id}&code=ABCDEF123`);
+      await fillIn(screen.getByRole('textbox', { name: 'Prénom' }), 'Prénom');
+      await fillIn(screen.getByRole('textbox', { name: 'Nom' }), 'Nom');
+      await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail' }), 'p.n@email.com');
+      await fillIn('#register-password', 'Pa$$w0rd');
+      await clickByName(`Accepter les conditions d'utilisation de Pix`);
+      await clickByName(`Je m'inscris`);
+      await clickByName(`J’accepte les conditions d’utilisation`);
+
+      // then
+      assert.strictEqual(currentURL(), '/sessions/liste');
+      assert.dom(screen.getByText('Super Centre de Certif', { exact: false })).exists();
+    });
+  });
+});

--- a/certif/tests/unit/adapters/certification-center-invitation-response_test.js
+++ b/certif/tests/unit/adapters/certification-center-invitation-response_test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapters | certification-center-invitation-response', function (hooks) {
+  setupTest(hooks);
+
+  module('#urlForCreateRecord', function () {
+    test('should build create url from certification-center-invitation id', async function (assert) {
+      // given
+      const adapter = this.owner.lookup('adapter:certification-center-invitation-response');
+      const options = { adapterOptions: { certificationCenterInvitationId: 1 } };
+
+      // when
+      const url = await adapter.urlForCreateRecord('certification-center-invitation-response', options);
+
+      // then
+      assert.true(url.endsWith('/certification-center-invitations/1/accept'));
+    });
+  });
+});

--- a/certif/tests/unit/components/auth/register-form_test.js
+++ b/certif/tests/unit/components/auth/register-form_test.js
@@ -42,27 +42,34 @@ module('Unit | Component | register-form', (hooks) => {
     });
 
     module('when form is valid', () => {
-      test('should call the store', async function (assert) {
+      test('should create pix account, membership and validate invitation', async function (assert) {
         // given
-        component.firstName = 'Alain';
-        component.lastName = 'Ternational';
-        component.email = 'alainternational@example.net';
-        component.password = 'Password123';
-        component.cgu = true;
+        const firstName = 'Alain';
+        const lastName = 'Ternational';
+        const email = 'alainternational@example.net';
+        const password = 'Password123';
+        const cgu = true;
+        const certificationCenterInvitationId = 1234;
+        const certificationCenterInvitationCode = 'AZERTY123';
+        component.firstName = firstName;
+        component.lastName = lastName;
+        component.email = email;
+        component.password = password;
+        component.cgu = cgu;
+        component.args.certificationCenterInvitationId = certificationCenterInvitationId;
+        component.args.certificationCenterInvitationCode = certificationCenterInvitationCode;
 
         // when
         await component.register(eventStub);
 
         // then
-        assert.ok(
-          component.store.createRecord.calledWith('user', {
-            lastName: 'Ternational',
-            firstName: 'Alain',
-            email: 'alainternational@example.net',
-            password: 'Password123',
-            cgu: true,
-          })
-        );
+        sinon.assert.calledWith(component.store.createRecord, 'user', { firstName, lastName, password, email, cgu });
+        sinon.assert.calledWith(component.store.createRecord, 'certification-center-invitation-response', {
+          id: certificationCenterInvitationId,
+          code: certificationCenterInvitationCode,
+          email,
+        });
+        assert.ok(true);
       });
     });
 

--- a/certif/tests/unit/components/auth/register-form_test.js
+++ b/certif/tests/unit/components/auth/register-form_test.js
@@ -1,0 +1,122 @@
+import sinon from 'sinon';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+import setupIntl from '../../../helpers/setup-intl';
+
+module('Unit | Component | register-form', (hooks) => {
+  setupTest(hooks);
+  setupIntl(hooks);
+  const eventStub = { preventDefault: sinon.stub().returns() };
+
+  let component;
+
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('component:auth/register-form');
+    component.store = {
+      createRecord: sinon.stub().returns({ save: sinon.stub(), deleteRecord: sinon.stub() }),
+    };
+  });
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('#register', () => {
+    module('when form is invalid', () => {
+      test('should not call the store', async function (assert) {
+        // given
+        const incorrectEmail = 'alainternational';
+        component.firstName = 'Alain';
+        component.lastName = 'Ternational';
+        component.email = incorrectEmail;
+        component.password = 'Password123';
+        component.cgu = true;
+
+        // when
+        await component.register(eventStub);
+
+        // then
+        assert.ok(component.store.createRecord.notCalled);
+      });
+    });
+
+    module('when form is valid', () => {
+      test('should call the store', async function (assert) {
+        // given
+        component.firstName = 'Alain';
+        component.lastName = 'Ternational';
+        component.email = 'alainternational@example.net';
+        component.password = 'Password123';
+        component.cgu = true;
+
+        // when
+        await component.register(eventStub);
+
+        // then
+        assert.ok(
+          component.store.createRecord.calledWith('user', {
+            lastName: 'Ternational',
+            firstName: 'Alain',
+            email: 'alainternational@example.net',
+            password: 'Password123',
+            cgu: true,
+          })
+        );
+      });
+    });
+
+    module('error cases', () => {
+      test('should throw default error', async function (assert) {
+        // given
+        const deleteRecord = sinon.stub();
+        component.store = {
+          createRecord: sinon
+            .stub()
+            .returns({ save: sinon.stub().rejects({ errors: [{ status: '400' }] }), deleteRecord }),
+        };
+
+        component.firstName = 'Alain';
+        component.lastName = 'Ternational';
+        component.email = 'alainternational@example.net';
+        component.password = 'Password123';
+        component.cgu = true;
+
+        // when
+        await component.register(eventStub);
+
+        // then
+        assert.strictEqual(component.errorMessage, this.intl.t('pages.login-or-register.register-form.errors.default'));
+        sinon.assert.calledOnce(deleteRecord);
+      });
+
+      module('when email already exists', () => {
+        test('should throw an error', async function (assert) {
+          // given
+          const deleteRecord = sinon.stub();
+          component.store = {
+            createRecord: sinon
+              .stub()
+              .returns({ save: sinon.stub().rejects({ errors: [{ status: '422' }] }), deleteRecord }),
+          };
+
+          component.firstName = 'Alain';
+          component.lastName = 'Ternational';
+          component.email = 'alainternational@example.net';
+          component.password = 'Password123';
+          component.cgu = true;
+
+          // when
+          await component.register(eventStub);
+
+          // then
+          assert.strictEqual(
+            component.errorMessage,
+            this.intl.t('pages.login-or-register.register-form.errors.email-already-exists')
+          );
+          sinon.assert.calledOnce(deleteRecord);
+        });
+      });
+    });
+  });
+});

--- a/certif/tests/unit/controllers/terms-of-service_test.js
+++ b/certif/tests/unit/controllers/terms-of-service_test.js
@@ -32,5 +32,20 @@ module('Unit | Controller | terms-of-service', function (hooks) {
       sinon.assert.calledWith(controller.transitionToRoute, 'authenticated.sessions.list');
       assert.ok(controller);
     });
+
+    module('when an error occurs', function () {
+      test('it should display a notification error', async function (assert) {
+        // given
+        controller.notifications = { error: sinon.stub() };
+        controller.currentUser = { certificationPointOfContact: { save: sinon.stub().rejects() } };
+
+        // when
+        await controller.send('submit');
+
+        // then
+        sinon.assert.calledOnce(controller.notifications.error);
+        assert.ok(controller);
+      });
+    });
   });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -72,7 +72,11 @@
             "label": "Password"
           }
         },
-        "legal-text": "The information collected in this form is saved in a computer file by Pix to enable access to the service offered by Pix. They are kept for the duration of use of the service and are intended for Pix. Test results may be communicated to third parties, with your consent, if you have been invited to take a specific customised test. In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), you can exercise the right to access and rectify your data by emailing our Data Protection Officer at dpo@pix.fr."
+        "legal-text": "The information collected in this form is saved in a computer file by Pix to enable access to the service offered by Pix. They are kept for the duration of use of the service and are intended for Pix. Test results may be communicated to third parties, with your consent, if you have been invited to take a specific customised test. In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), you can exercise the right to access and rectify your data by emailing our Data Protection Officer at dpo@pix.fr.",
+        "errors": {
+          "default": "The service is temporarily unavailable. Please try again later.",
+          "email-already-exists": "This email address is already registered, please login."
+        }
       }
     },
     "sessions": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -72,7 +72,11 @@
             "label": "Mot de passe"
           }
         },
-        "legal-text": "Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix pour permettre l’accès au service offert. Elles sont conservées pendant la durée d’utilisation du service et sont destinées à Pix. Les résultats des tests pourront être communiqués à des tiers, avec votre consentement, dans le cas où vous avez été invité à suivre un parcours spécifique. Conformément à la loi « Informatique et Libertés », vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en contactant le Délégué à la Protection des Données de Pix à dpo@pix.fr."
+        "legal-text": "Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix pour permettre l’accès au service offert. Elles sont conservées pendant la durée d’utilisation du service et sont destinées à Pix. Les résultats des tests pourront être communiqués à des tiers, avec votre consentement, dans le cas où vous avez été invité à suivre un parcours spécifique. Conformément à la loi « Informatique et Libertés », vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en contactant le Délégué à la Protection des Données de Pix à dpo@pix.fr.",
+        "errors": {
+          "default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
+          "email-already-exists": "Cette adresse e-mail est déjà enregistrée, connectez-vous."
+        }
       }
     },
     "sessions": {


### PR DESCRIPTION
## :jack_o_lantern: Problème

Dans le cadre de l'epix, nous voulons permettre aux agents Pix d'envoyer par e-mail des invitations à rejoindre un centre de certification depuis Pix Admin. Il se peut que le destinataire de l'e-mail n'ait pas déjà un compte Pix, auquel cas il doit pouvoir le créer depuis la double-mire.

## :bat: Proposition

Permettre la création d'un compte depuis la double mire lorsque l'utilisateur suit le lien d'une invitation.

## :spider_web: Remarques
- https://github.com/1024pix/pix/pull/2278
- https://github.com/1024pix/pix/pull/4080
- Ce ticket provient d'un split de la PR https://github.com/1024pix/pix/pull/5129 afin de créer la route api pour permettre de traiter 2 tickets front qui en dépendent en parallèle.

## :ghost: Pour tester

#### Invitation qui n'existe pas

- Allez sur le lien https://certif-pr5157.review.pix.fr/rejoindre?invitationId=111&code=AAA
- Constatez que vous arrivez sur la page de connexion de l'application Pix Certif

#### Invitation existante et en attente

- Allez sur le lien https://certif-pr5157.review.pix.fr/rejoindre?invitationId=101259&code=ABCDEF123
- Constatez que vous arrivez sur la double mire
- Fournir toutes les informations nécessaire à l'inscription (Prénom, Nom, Adresse e-mail, Mot de passe)
- Acceptez les CGU (checkbox)
- Cliquez sur le bouton `Je m'inscris`
- Constatez que vous arrivez sur la page des CGU (`/cgu`)
- Cliquez sur le bouton `J'accepte les conditions d'utilisation`
- Constatez que vous arrivez sur la liste des sessions de certification 🎉

#### Invitation existante, en attente et utilisation d'un e-mail existant

- Allez sur le lien https://certif-pr5157.review.pix.fr/rejoindre?invitationId=101260&code=ABCDEF123
- Constatez que vous arrivez sur la double mire
- Fournir toutes les informations nécessaire à l'inscription (Prénom, Nom, Adresse e-mail, Mot de passe) avec un e-mail existant en base de données
- Acceptez les CGU (checkbox)
- Cliquez sur le bouton `Je m'inscris`
- Constatez que vous êtes toujours sur la double mire
- Constatez qu'un message d'erreur est affiché `Cette adresse e-mail est déjà enregistrée, connectez-vous.`

#### Invitation existante et déjà acceptée

- Allez sur le lien https://certif-pr5157.review.pix.fr/rejoindre?invitationId=101261&code=ABCDEF123
- Constatez que vous arrivez sur la page de connexion de l'application Pix Certif

#### Invitation existante et annulée

- Allez sur le lien https://certif-pr5157.review.pix.fr/rejoindre?invitationId=101262&code=ABCDEF123
- Constatez que vous arrivez sur la page de connexion de l'application Pix Certif