### PR TITLE
[BUGFIX] Double scroll bar sur l'onglet "Candidats" dans Pix Certif (PIX-6039)

### DIFF
--- a/certif/app/styles/pages/authenticated.scss
+++ b/certif/app/styles/pages/authenticated.scss
@@ -1,6 +1,5 @@
 .app {
   display: flex;
-  min-height: 100%;
   min-height: 100vh;
 
   &__sidebar {
@@ -68,7 +67,6 @@
 .main-content {
   display: flex;
   flex-direction: column;
-  height: 100vh;
   overflow: auto;
 
   &__topbar {


### PR DESCRIPTION
## :christmas_tree: Problème
Dans la page Candidats de Pix Certif lorsque l'on scroll tout en bas de la page une 2e barre de scroll apparait.

![image](https://user-images.githubusercontent.com/103997660/199740849-e1179964-3ed8-46de-aaec-dad4ce5dfa18.png)

## :gift: Proposition
Fixer la taille de la page pour retirer cette 2e scroll bar

## :santa: Pour tester
- Se connecter sur Pix Certif avec le compte certifsco@example.net
- Aller sur le détail de la session 3, scroller tout en bas et ne pas voir de seconde bar.