### PR TITLE
[FEATURE] En tant qu'utilisateur Pix Admin, je veux désactiver un membre Pix Certif depuis la page du user (PIX-5712)

### DIFF
--- a/admin/app/components/users/certification-center-memberships.hbs
+++ b/admin/app/components/users/certification-center-memberships.hbs
@@ -11,6 +11,7 @@
           <th>Nom</th>
           <th>Type</th>
           <th>Identifiant externe</th>
+          <th>Actions</th>
         </tr>
       </thead>
 
@@ -30,6 +31,16 @@
               <td>{{certificationCenterMembership.certificationCenter.name}}</td>
               <td>{{certificationCenterMembership.certificationCenter.type}}</td>
               <td>{{certificationCenterMembership.certificationCenter.externalId}}</td>
+              <td>
+                <PixButton
+                  @size="small"
+                  @backgroundColor="red"
+                  @triggerAction={{fn this.disableCertificationCenterMembership certificationCenterMembership}}
+                  class="member-item-actions__button"
+                >
+                  <FaIcon @icon="trash" />Désactiver
+                </PixButton>
+              </td>
             </tr>
           {{/each}}
         </tbody>

--- a/admin/app/components/users/certification-center-memberships.js
+++ b/admin/app/components/users/certification-center-memberships.js
@@ -1,7 +1,21 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class CertificationCenterMemberships extends Component {
+  @service notifications;
+
   get orderedCertificationCenterMemberships() {
     return this.args.certificationCenterMemberships.sortBy('certificationCenter.name');
+  }
+
+  @action
+  async disableCertificationCenterMembership(certificationCenterMembership) {
+    try {
+      await certificationCenterMembership.destroyRecord();
+      this.notifications.success('Le membre a correctement été désactivé.');
+    } catch (e) {
+      this.notifications.error("Une erreur est survenue, le membre n'a pas été désactivé.");
+    }
   }
 }


### PR DESCRIPTION
## :christmas_tree: Problème
On ne peut pas supprimer un utilisateur Pix Certif d'un centre de certification depuis la page 'Informations de l'utilisateur'.

## :gift: Proposition
Depuis Pix Admin, sur la page de détail d’un utilisateur > Centres de Certification > tableau Centres de certification de l’utilisateur :

- ajouter une colonne ‘Actions’ en dernière position à droite
- ajouter le bouton ‘Désactiver’


## :star2: Remarques

- On veut exactement le même comportement que depuis la page Pix Admin > Centres de certifications > Membres.
- Cette action doit être accessible par tous les rôles: SUPER_ADMIN, SUPPORT, CERTIF et METIER..


## :santa: Pour tester

- Se connecter à Pix Admin
- Se rendre sur la page des utilisateurs
- Rechercher 'SCO' dans le champ 'Prénom'
- Sélectionner l'utilisateur suivant :
 _--ID : 100,
 --Prénom: SCO,
 --Nom: Certification
 --Adresse e-mail: certifsco@example.net_
- Arriver sur la page des informations de l'utilisateur, cliquer sur 'Centres de Certification'
- Voir le tableau avec la liste des centres de certification de l’utilisateur avec une colonne nommée Action où se trouve un bouton rouge 'Désactiver'.
