### PR TITLE
[FEATURE] Ajout d'un feature toggle pour la gestion massive des sessions (PIX-6130)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -199,6 +199,7 @@ module.exports = (function () {
       isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: isFeatureEnabled(
         process.env.FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS
       ),
+      isMassiveSessionManagementEnabled: isFeatureEnabled(process.env.FT_MASSIVE_SESSION_MANAGEMENT),
     },
 
     infra: {

--- a/api/sample.env
+++ b/api/sample.env
@@ -737,6 +737,13 @@ RATE_LIMIT_DEFAULT_WINDOW=60
 # default: false
 # FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS=true
 
+# Allow massive management for sessions creations and modifications
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_MASSIVE_SESSION_MANAGEMENT=true
+
 # =====
 # CPF
 # =====

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -23,6 +23,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
           type: 'feature-toggles',
           attributes: {
             'is-clea-results-retrieval-by-habilitated-certification-centers-enabled': false,
+            'is-massive-session-management-enabled': false,
           },
         },
       };

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -2,4 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('boolean') isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled;
+  @attr('boolean') isMassiveSessionManagementEnabled;
 }


### PR DESCRIPTION
## :christmas_tree: Problème
Dans le cadre de l'épix sur la gestion massive des sessions, on souhaite pouvoir ajouter de nouvelles fonctionnalités sans qu'elles soient disponibles à nos utilisateurs dès leur développement.

## :gift: Proposition
Ajouter un feature toggle portant le nom de l'épix. 

## :santa: Pour tester
On peut retrouver l'état du feature toggle via 
https://api-pr5160.review.pix.fr/api/feature-toggles
Activer le feature toggle puis verifier qu'il est bien à `true`
