### PR TITLE
[FEATURE] Ajouter le lien "Politique de protection des données des élèves" dans le footer de Pix App (PIX-6203)

### DIFF
--- a/mon-pix/app/components/footer.hbs
+++ b/mon-pix/app/components/footer.hbs
@@ -49,6 +49,17 @@
               {{t "navigation.footer.data-protection-policy"}}
             </a>
           </li>
+
+          <li>
+            <a
+              href="{{t 'navigation.footer.student-data-protection-policy-url'}}"
+              target="_blank"
+              class="footer-navigation__item"
+              rel="noopener noreferrer"
+            >
+              {{t "navigation.footer.student-data-protection-policy"}}
+            </a>
+          </li>
           <li>
             <LinkTo
               @route="authenticated.sitemap"

--- a/mon-pix/app/styles/components/_footer.scss
+++ b/mon-pix/app/styles/components/_footer.scss
@@ -3,19 +3,18 @@
 }
 
 .footer {
-  padding: 20px 0;
+  padding: 20px 30px;
 
   &__container {
     display: flex;
     flex-direction: column;
-    padding: 24px 20px 0;
     max-width: 1280px;
     width: 100%;
     margin: auto;
 
-    @include device-is('tablet') {
+    @include device-is('desktop') {
       flex-direction: row;
-      padding-top: 18px;
+      align-items: center;
     }
   }
 
@@ -32,10 +31,14 @@
     width: 100%;
 
     @include device-is('tablet') {
-      flex-direction: row;
-      align-items: center;
+      flex-direction: column;
       justify-content: space-between;
       border: none;
+    }
+
+    @include device-is('desktop') {
+      flex-direction: row;
+      align-items: center;
     }
   }
 
@@ -54,21 +57,30 @@
 
   &__navigation {
     @include device-is('tablet') {
-      padding: 0 15px;
       flex-direction: row;
       align-items: center;
+    }
+
+    @include device-is('desktop') {
+      margin-left: 12px;
     }
 
     &-list {
       list-style: none;
       display: flex;
-      flex-direction: column;
+      flex-wrap: wrap;
       padding: 0;
       margin: 0;
+      margin-top: 20px;
 
       @include device-is('tablet') {
         flex-direction: row;
         align-self: center;
+      }
+
+      @include device-is('desktop') {
+        padding-top: 0;
+        margin: 0;
       }
     }
   }
@@ -80,8 +92,9 @@
     font-family: $font-roboto;
     padding-top: 16px;
 
-    @include device-is('tablet') {
-      padding-top: 0;
+    @include device-is('desktop') {
+      padding: 0;
+      white-space: nowrap;
     }
   }
 }
@@ -89,12 +102,13 @@
 .footer-navigation {
 
   &__item {
-    margin: 3px 0;
     color: $pix-neutral-60;
     font-size: 0.8125rem;
     font-family: $font-roboto;
     letter-spacing: 0.009rem;
     line-height: 1.375rem;
+    display: inline-block;
+    padding: 0 12px 6px 0;
 
     &--internal-link {
 
@@ -103,8 +117,9 @@
       }
     }
 
-    @include device-is('tablet') {
-      margin: 0 12px;
+    @include device-is('desktop') {
+      margin: 0 10px;
+      padding: 0;
     }
 
     &.active {

--- a/mon-pix/tests/integration/components/footer_test.js
+++ b/mon-pix/tests/integration/components/footer_test.js
@@ -4,6 +4,7 @@ import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 import { contains } from '../../helpers/contains';
 
@@ -23,12 +24,13 @@ describe('Integration | Component | Footer', function () {
     await render(hbs`<Footer />}`);
 
     // then
-    expect(findAll('.footer-navigation__item')).to.have.lengthOf(5);
+    expect(findAll('.footer-navigation__item')).to.have.lengthOf(6);
     expect(contains(this.intl.t('navigation.footer.a11y'))).to.exist;
     expect(contains(this.intl.t('navigation.footer.data-protection-policy'))).to.exist;
     expect(contains(this.intl.t('navigation.footer.eula'))).to.exist;
     expect(contains(this.intl.t('navigation.footer.help-center'))).to.exist;
     expect(contains(this.intl.t('navigation.footer.sitemap'))).to.exist;
+    expect(contains(this.intl.t('navigation.footer.student-data-protection-policy'))).to.exist;
   });
 
   it('should not display marianne logo when url does not have frenchDomainExtension', async function () {
@@ -61,5 +63,14 @@ describe('Integration | Component | Footer', function () {
 
     // then
     expect(find('.footer-logos__french-government')).to.exist;
+  });
+
+  it('should display the student data policy', async function () {
+    // given & when
+    const screen = await renderScreen(hbs`<Footer />}`);
+
+    // then
+    expect(screen.getByRole('link', { name: this.intl.t('navigation.footer.student-data-protection-policy') })).to
+      .exist;
   });
 });

--- a/mon-pix/tests/integration/components/footer_test.js
+++ b/mon-pix/tests/integration/components/footer_test.js
@@ -2,35 +2,32 @@ import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { render as renderScreen } from '@1024pix/ember-testing-library';
-
-import { contains } from '../../helpers/contains';
+import { render } from '@1024pix/ember-testing-library';
 
 describe('Integration | Component | Footer', function () {
   setupIntlRenderingTest();
 
   it('should display the Pix logo', async function () {
     // when
-    await render(hbs`<Footer />}`);
+    const screen = await render(hbs`<Footer />}`);
 
     // then
-    expect(find('.pix-logo__image')).to.exist;
+    expect(screen.getByAltText(this.intl.t('navigation.homepage'))).to.exist;
   });
 
   it('should display the navigation menu with expected elements', async function () {
     // when
-    await render(hbs`<Footer />}`);
+    const screen = await render(hbs`<Footer />}`);
 
     // then
-    expect(findAll('.footer-navigation__item')).to.have.lengthOf(6);
-    expect(contains(this.intl.t('navigation.footer.a11y'))).to.exist;
-    expect(contains(this.intl.t('navigation.footer.data-protection-policy'))).to.exist;
-    expect(contains(this.intl.t('navigation.footer.eula'))).to.exist;
-    expect(contains(this.intl.t('navigation.footer.help-center'))).to.exist;
-    expect(contains(this.intl.t('navigation.footer.sitemap'))).to.exist;
-    expect(contains(this.intl.t('navigation.footer.student-data-protection-policy'))).to.exist;
+    expect(screen.getByRole('link', { name: this.intl.t('navigation.footer.a11y') })).to.exist;
+    expect(screen.getByRole('link', { name: this.intl.t('navigation.footer.data-protection-policy') })).to.exist;
+    expect(screen.getByRole('link', { name: this.intl.t('navigation.footer.student-data-protection-policy') })).to
+      .exist;
+    expect(screen.getByRole('link', { name: this.intl.t('navigation.footer.eula') })).to.exist;
+    expect(screen.getByRole('link', { name: this.intl.t('navigation.footer.help-center') })).to.exist;
+    expect(screen.getByRole('link', { name: this.intl.t('navigation.footer.sitemap') })).to.exist;
   });
 
   it('should not display marianne logo when url does not have frenchDomainExtension', async function () {
@@ -43,10 +40,10 @@ describe('Integration | Component | Footer', function () {
     this.owner.register('service:url', UrlServiceStub);
 
     // when
-    await render(hbs`<Footer />`);
+    const screen = await render(hbs`<Footer />`);
 
     // then
-    expect(find('.footer-logos__french-government')).to.not.exist;
+    expect(screen.queryByAltText(this.intl.t('common.french-republic'))).to.not.exist;
   });
 
   it('should display marianne logo when url does have frenchDomainExtension', async function () {
@@ -59,15 +56,15 @@ describe('Integration | Component | Footer', function () {
     this.owner.register('service:url', UrlServiceStub);
 
     // when
-    await render(hbs`<Footer />`);
+    const screen = await render(hbs`<Footer />`);
 
     // then
-    expect(find('.footer-logos__french-government')).to.exist;
+    expect(screen.getByAltText(this.intl.t('common.french-republic'))).to.exist;
   });
 
   it('should display the student data policy', async function () {
     // given & when
-    const screen = await renderScreen(hbs`<Footer />}`);
+    const screen = await render(hbs`<Footer />}`);
 
     // then
     expect(screen.getByRole('link', { name: this.intl.t('navigation.footer.student-data-protection-policy') })).to

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -100,6 +100,8 @@
       "label": "Secondary navigation",
       "a11y": "Accessibility",
       "data-protection-policy": "Personal data protection policy",
+      "student-data-protection-policy": "Student data protection policy",
+      "student-data-protection-policy-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
       "eula": "Terms and conditions",
       "help-center": "Help center",
       "sitemap": "Site map"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -100,6 +100,8 @@
       "label": "Menu secondaire",
       "a11y": "Accessibilité : partiellement conforme",
       "data-protection-policy": "Politique de protection des données",
+      "student-data-protection-policy": "Politique de protection des données des élèves",
+      "student-data-protection-policy-url": "https://cloud.pix.fr/s/nqgBodTkbtsGb39",
       "eula": "CGU",
       "help-center": "Centre d'aide",
       "sitemap": "Plan du site"


### PR DESCRIPTION
## :christmas_tree: Problème
Le GAR nous a remonté le fait que la politique de protection des données des élèves soit affichée dans le footer de pix.fr et non sur pix app.

## :gift: Proposition
Ajouter cette mention, ainsi que son lien dans le footer de Pix App (même nom, même pdf).

## :star2: Remarques
A positionner à côté du lien existant ‘[Politique de protection des données](https://pix.fr/politique-protection-donnees-personnelles-app)’.

## :santa: Pour tester

- Se rendre sur Pix App : http://localhost:4200/connexion
- Se connecter avec les identifiants suivants :
 _-- E-mail: certif-success@example.net
 -- Mot de passe: Pix123_
- Scroller tout en bas de la page et voir la mention 'Politique de protection des données des élèves' qui renvoie vers ce document https://cloud.pix.fr/s/nqgBodTkbtsGb39.
