### PR TITLE
[FEATURE] Créer un fichier CSV d'import des sessions en masse (PIX-6132)

### DIFF
--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -798,6 +798,18 @@ exports.register = async (server) => {
         ],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/sessions/import',
+      config: {
+        handler: sessionController.getSessionsCreationFile,
+        tags: ['api', 'sessions'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            '- Elle permet de récupérer le fichier de création de sessions de certification',
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -802,7 +802,7 @@ exports.register = async (server) => {
       method: 'GET',
       path: '/api/sessions/import',
       config: {
-        handler: sessionController.getSessionsCreationFile,
+        handler: sessionController.getSessionsImportTemplate,
         tags: ['api', 'sessions'],
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -348,6 +348,10 @@ module.exports = {
 
     return h.response().code(204);
   },
+
+  getSessionsCreationFile(request, h) {
+    return h.response().header('Content-Type', 'text/csv; charset=utf-8').code(200);
+  },
 };
 
 function _logSessionBatchPublicationErrors(result) {

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -350,7 +350,7 @@ module.exports = {
     return h.response().code(204);
   },
 
-  getSessionsCreationFile(_, h) {
+  getSessionsImportTemplate(_, h) {
     const headers = getHeaders();
     return h.response(headers).header('Content-Type', 'text/csv; charset=utf-8').code(200);
   },

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -17,6 +17,7 @@ const queryParamsUtils = require('../../infrastructure/utils/query-params-utils'
 const requestResponseUtils = require('../../infrastructure/utils/request-response-utils');
 const certificationResultUtils = require('../../infrastructure/utils/csv/certification-results');
 const fillCandidatesImportSheet = require('../../infrastructure/files/candidates-import/fill-candidates-import-sheet');
+const { getHeaders } = require('../../infrastructure/files/sessions-import');
 const supervisorKitPdf = require('../../infrastructure/utils/pdf/supervisor-kit-pdf');
 
 const trim = require('lodash/trim');
@@ -349,8 +350,9 @@ module.exports = {
     return h.response().code(204);
   },
 
-  getSessionsCreationFile(request, h) {
-    return h.response().header('Content-Type', 'text/csv; charset=utf-8').code(200);
+  getSessionsCreationFile(_, h) {
+    const headers = getHeaders();
+    return h.response(headers).header('Content-Type', 'text/csv; charset=utf-8').code(200);
   },
 };
 

--- a/api/lib/infrastructure/files/sessions-import.js
+++ b/api/lib/infrastructure/files/sessions-import.js
@@ -1,0 +1,5 @@
+function getHeaders() {
+  return '"N° de session";"* Nom du site";"* Nom de la salle";"* Date de début";"* Heure de début (heure locale)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: jj/mm/aaaa)";"* Sexe (M ou F)";"Code Insee";"Code postal";"Nom de la commune";"* Pays";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant local";"Temps majoré ?"';
+}
+
+module.exports = { getHeaders };

--- a/api/tests/acceptance/application/session/session-controller-get-import-template_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-import-template_test.js
@@ -1,0 +1,32 @@
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | session-controller-get-import-template', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('GET /api/sessions/import', function () {
+    context('when user requests sessions import template', function () {
+      it('should return a csv file', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        await databaseBuilder.commit();
+
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: '/api/sessions/import',
+          payload: {},
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.headers['content-type']).to.equal('text/csv; charset=utf-8');
+      });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/utils/csv/sessions-import_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/sessions-import_test.js
@@ -1,0 +1,16 @@
+const { expect } = require('../../../../test-helper');
+const { getHeaders } = require('../../../../../lib/infrastructure/files/sessions-import');
+
+describe('Integration | Infrastructure | Utils | csv | sessions-import', function () {
+  context('#getHeaders', function () {
+    it('should return the correct values', function () {
+      // when
+      const result = getHeaders();
+
+      // then
+      const expectedResult =
+        '"N° de session";"* Nom du site";"* Nom de la salle";"* Date de début";"* Heure de début (heure locale)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: jj/mm/aaaa)";"* Sexe (M ou F)";"Code Insee";"Code postal";"Nom de la commune";"* Pays";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant local";"Temps majoré ?"';
+      expect(result).to.equal(expectedResult);
+    });
+  });
+});

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -1042,4 +1042,18 @@ describe('Unit | Application | Sessions | Routes', function () {
       expect(response.statusCode).to.equal(200);
     });
   });
+
+  describe('GET /api/sessions/import', function () {
+    it('should exist', async function () {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/sessions/import');
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Dans le cadre de l'epix de l'import de sessions en masse, les utilisateurs de l'espace certification doivent pouvoir récupérer un fichier template csv afin de pouvoir le remplir par la suite. Ce fichier n'existe pas

## :gift: Proposition
Ajouter une route `[GET] api/sessions/import` qui permet de récupérer ce fichier au format csv

## :star2: Remarques
Pas de gestion des droits, un utilisateur authentifié peut récupérer le fichier
L'interface/bouton pour le récupérer n'est pas couvert par cette story

## :santa: Pour tester
Récupérer un token d'authentification (pix-app, pix-certif etc...) et telecharger le fichier via l'url `api/sessions/import`
Celui ci doit contenir le header suivant: 
`N° de session;* Nom du site;* Nom de la salle;* Date de début;* Heure de début (heure locale);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: jj/mm/aaaa);* Sexe (M ou F);Code Insee;Code postal;Nom de la commune;* Pays;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant local;Temps majoré ?`
