### PR TITLE
[FEATURE] Redesign de la page de certification (PIX-5986).

### DIFF
--- a/api/lib/domain/usecases/get-user-certification-eligibility.js
+++ b/api/lib/domain/usecases/get-user-certification-eligibility.js
@@ -17,9 +17,10 @@ module.exports = async function getUserCertificationEligibility({
     userId,
   });
 
-  const eligibleComplementaryCertifications = stillValidBadgeAcquisitions.map(
-    ({ badge }) => badge.complementaryCertificationBadge.label
-  );
+  const eligibleComplementaryCertifications = stillValidBadgeAcquisitions.map(({ badge }) => ({
+    label: badge.complementaryCertificationBadge.label,
+    imageUrl: badge.complementaryCertificationBadge.imageUrl,
+  }));
 
   return new CertificationEligibility({
     id: userId,

--- a/api/tests/acceptance/application/users/users-controller-is-certifiable_test.js
+++ b/api/tests/acceptance/application/users/users-controller-is-certifiable_test.js
@@ -249,7 +249,12 @@ describe('Acceptance | users-controller-is-certifiable', function () {
             type: 'isCertifiables',
             attributes: {
               'is-certifiable': true,
-              'eligible-complementary-certifications': ['PARTNER_LABEL'],
+              'eligible-complementary-certifications': [
+                {
+                  imageUrl: 'http://badge-image-url.fr',
+                  label: 'PARTNER_LABEL',
+                },
+              ],
             },
           },
         };

--- a/api/tests/unit/domain/usecases/get-user-certification-eligibility_test.js
+++ b/api/tests/unit/domain/usecases/get-user-certification-eligibility_test.js
@@ -48,7 +48,7 @@ describe('Unit | UseCase | get-user-certification-eligibility', function () {
   });
 
   context(`when badge is not acquired`, function () {
-    it(`should return the user certification eligibility with not eligible badge`, async function () {
+    it('should return the user certification eligibility with not eligible badge', async function () {
       // given
       const placementProfile = {
         isCertifiable: () => true,
@@ -66,34 +66,40 @@ describe('Unit | UseCase | get-user-certification-eligibility', function () {
       // then
       expect(certificationEligibility.eligibleComplementaryCertifications).to.be.empty;
     });
+  });
 
-    context(`when badge is acquired`, function () {
-      it(`should return the user certification eligibility with eligible badge`, async function () {
-        // given
-        const placementProfile = {
-          isCertifiable: () => true,
-        };
-        placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
-        const badgeAcquisition = domainBuilder.buildBadgeAcquisition({
-          badge: domainBuilder.buildBadge({
-            key: 'BADGE_KEY',
-            complementaryCertificationBadge: domainBuilder.buildComplementaryCertificationBadge({
-              label: 'BADGE_LABEL',
-            }),
+  context('when badge is acquired', function () {
+    it('should return the user certification eligibility with the eligible badge', async function () {
+      // given
+      const placementProfile = {
+        isCertifiable: () => true,
+      };
+      placementProfileService.getPlacementProfile.withArgs({ userId: 2, limitDate: now }).resolves(placementProfile);
+      const badgeAcquisition = domainBuilder.buildBadgeAcquisition({
+        badge: domainBuilder.buildBadge({
+          key: 'BADGE_KEY',
+          complementaryCertificationBadge: domainBuilder.buildComplementaryCertificationBadge({
+            label: 'BADGE_LABEL',
+            imageUrl: 'http://www.image-url.com',
           }),
-        });
-        certificationBadgesService.findStillValidBadgeAcquisitions.resolves([badgeAcquisition]);
-
-        // when
-        const certificationEligibility = await getUserCertificationEligibility({
-          userId: 2,
-          placementProfileService,
-          certificationBadgesService,
-        });
-
-        // then
-        expect(certificationEligibility.eligibleComplementaryCertifications).contains('BADGE_LABEL');
+        }),
       });
+      certificationBadgesService.findStillValidBadgeAcquisitions.resolves([badgeAcquisition]);
+
+      // when
+      const certificationEligibility = await getUserCertificationEligibility({
+        userId: 2,
+        placementProfileService,
+        certificationBadgesService,
+      });
+
+      // then
+      expect(certificationEligibility.eligibleComplementaryCertifications).to.deep.equal([
+        {
+          label: 'BADGE_LABEL',
+          imageUrl: 'http://www.image-url.com',
+        },
+      ]);
     });
   });
 });

--- a/mon-pix/app/components/congratulations-certification-banner.hbs
+++ b/mon-pix/app/components/congratulations-certification-banner.hbs
@@ -10,14 +10,23 @@
   <p class="congratulations-banner__message">
     {{t "pages.certification-joiner.congratulation-banner.message" fullName=@fullName htmlSafe=true}}
   </p>
-  {{#each @certificationEligibility.eligibleComplementaryCertifications as |eligibleComplementaryCertification|}}
-    <p>
-      {{t
-        "pages.certification-joiner.congratulation-banner.complementary-certification-eligibility"
-        complementaryCertificationName=eligibleComplementaryCertification
-      }}
-    </p>
-  {{/each}}
+  <div class="congratulations-banner__complementary-certifications">
+    <div class="congratulations-banner-complementary-certifications__icons">
+      {{#each @certificationEligibility.eligibleComplementaryCertifications as |eligibleComplementaryCertification|}}
+        <img src={{eligibleComplementaryCertification.imageUrl}} alt={{eligibleComplementaryCertification.label}} />
+      {{/each}}
+    </div>
+    <div class="congratulations-banner-complementary-certifications__labels">
+      {{#each @certificationEligibility.eligibleComplementaryCertifications as |eligibleComplementaryCertification|}}
+        <p>
+          {{t
+            "pages.certification-joiner.congratulation-banner.complementary-certification-eligibility"
+            complementaryCertificationName=eligibleComplementaryCertification.label
+          }}
+        </p>
+      {{/each}}
+    </div>
+  </div>
   <a
     href={{t "pages.certification-joiner.congratulation-banner.link.url"}}
     class="congratulations-banner__link"

--- a/mon-pix/app/components/congratulations-certification-banner.hbs
+++ b/mon-pix/app/components/congratulations-certification-banner.hbs
@@ -27,14 +27,20 @@
       {{/each}}
     </div>
   </div>
-  <a
-    href={{t "pages.certification-joiner.congratulation-banner.link.url"}}
-    class="congratulations-banner__link"
-    target="_blank"
-    rel="noopener noreferrer"
-  >
-    <FaIcon @icon="arrow-right" class="congratulations-banner__link__icon" />
-    {{t "pages.certification-joiner.congratulation-banner.link.text"}}
-    <FaIcon @icon="up-right-from-square" class="congratulations-banner__link__icon" />
-  </a>
+  <div class="congratulations-banner__links">
+    <a
+      href={{t "pages.certification-joiner.congratulation-banner.link.url"}}
+      class="congratulations-banner-links__link"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {{t "pages.certification-joiner.congratulation-banner.link.text"}}
+      <FaIcon @icon="up-right-from-square" class="congratulations-banner-links__link--icon" />
+    </a>
+    <LinkTo @route="authenticated.user-certifications" class="congratulations-banner-links__link">{{t
+        "pages.certification-start.link-to-user-certification"
+      }}
+      <FaIcon @icon="eye" class="congratulations-banner-links__link--icon" />
+    </LinkTo>
+  </div>
 </div>

--- a/mon-pix/app/components/congratulations-certification-banner.hbs
+++ b/mon-pix/app/components/congratulations-certification-banner.hbs
@@ -10,23 +10,31 @@
   <p class="congratulations-banner__message">
     {{t "pages.certification-joiner.congratulation-banner.message" fullName=@fullName htmlSafe=true}}
   </p>
-  <div class="congratulations-banner__complementary-certifications">
-    <div class="congratulations-banner-complementary-certifications__icons">
-      {{#each @certificationEligibility.eligibleComplementaryCertifications as |eligibleComplementaryCertification|}}
-        <img src={{eligibleComplementaryCertification.imageUrl}} alt={{eligibleComplementaryCertification.label}} />
-      {{/each}}
-    </div>
-    <div class="congratulations-banner-complementary-certifications__labels">
-      {{#each @certificationEligibility.eligibleComplementaryCertifications as |eligibleComplementaryCertification|}}
-        <p>
+  {{#if this.isEligible}}
+    <div class="congratulations-banner__complementary-certifications">
+      <div class="congratulations-banner-complementary-certifications__icons">
+        {{#each @certificationEligibility.eligibleComplementaryCertifications as |eligibleComplementaryCertification|}}
+          <img src={{eligibleComplementaryCertification.imageUrl}} alt={{eligibleComplementaryCertification.label}} />
+        {{/each}}
+      </div>
+      <div class="congratulations-banner-complementary-certifications__list">
+        <p class="congratulations-banner-complementary-certifications-list__message">
           {{t
             "pages.certification-joiner.congratulation-banner.complementary-certification-eligibility"
-            complementaryCertificationName=eligibleComplementaryCertification.label
+            count=@certificationEligibility.eligibleComplementaryCertifications.length
           }}
         </p>
-      {{/each}}
+        <ul class="congratulations-banner-complementary-certifications-list__labels">
+          {{#each
+            @certificationEligibility.eligibleComplementaryCertifications
+            as |eligibleComplementaryCertification|
+          }}
+            <li>{{eligibleComplementaryCertification.label}}</li>
+          {{/each}}
+        </ul>
+      </div>
     </div>
-  </div>
+  {{/if}}
   <div class="congratulations-banner__links">
     <a
       href={{t "pages.certification-joiner.congratulation-banner.link.url"}}

--- a/mon-pix/app/components/congratulations-certification-banner.js
+++ b/mon-pix/app/components/congratulations-certification-banner.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export default class CongratulationsCertificationBanner extends Component {
+  get isEligible() {
+    return this.args.certificationEligibility.eligibleComplementaryCertifications?.length > 0;
+  }
+}

--- a/mon-pix/app/styles/components/_congratulations-certification-banner.scss
+++ b/mon-pix/app/styles/components/_congratulations-certification-banner.scss
@@ -5,11 +5,16 @@
   color: $pix-neutral-10;
   border-radius: 6px;
   box-sizing: border-box;
-  height: 194px;
+  height: fit-content;
   display: flex;
   flex-flow: column nowrap;
   align-items: center;
   justify-content: center;
+  padding: 24px 16px;
+
+  @include device-is('tablet') {
+    padding: 24px 32px;
+  }
 }
 
 .congratulations-banner p {
@@ -47,15 +52,89 @@
 
   padding: 0 8px;
   font-size: 1.5rem;
-  margin-bottom: 16px;
+  margin: 0 0 24px 0;
 }
 
-.congratulations-banner__link {
+.congratulations-banner__complementary-certifications {
+  display: flex;
+  flex-direction: column;
+  margin: 0 auto;
+  padding: 16px 32px;
+  border-radius: 16px;
+  background-color: $pix-success-5;
+}
+
+.congratulations-banner-complementary-certifications__icons {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.congratulations-banner-complementary-certifications__icons img {
+  max-height: 64px;
+  margin-right: 16px;
+
+  &:last-of-type {
+    margin-right: 0;
+  }
+}
+
+.congratulations-banner-complementary-certifications__list {
+  display: flex;
+  flex-direction: column;
+  margin-top: 16px;
+  text-align: center;
+  color: $pix-neutral-90;
+}
+
+.congratulations-banner-complementary-certifications-list__message {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 22px;
+}
+
+.congratulations-banner-complementary-certifications-list__labels {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 22px;
+}
+
+.congratulations-banner__links {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-around;
+  width: 80%;
+  margin-top: 24px;
+
+  @include device-is('tablet') {
+    flex-direction: row;
+    width: 55%;
+  }
+}
+
+.congratulations-banner-links__link {
   @include textBannerStyle();
 
+  padding: 4px 16px;
+  width: 100%;
+  border: 1px solid $pix-neutral-10;
+  border-radius: 4px;
+  font-family: $font-roboto;
+  font-weight: 500;
   font-size: 0.875rem;
+  margin-bottom: 12px;
 
-  &__icon {
-    margin: auto 5px;
+  &:last-child {
+    margin-bottom: 0;
   }
+
+  @include device-is('tablet') {
+    width: 45%;
+    margin-bottom: 0;
+  }
+}
+
+.congratulations-banner-links__link--icon {
+  margin: auto 5px;
 }

--- a/mon-pix/app/styles/components/_congratulations-certification-banner.scss
+++ b/mon-pix/app/styles/components/_congratulations-certification-banner.scss
@@ -45,6 +45,7 @@
 .congratulations-banner__message {
   @include textBannerStyle();
 
+  padding: 0 8px;
   font-size: 1.5rem;
   margin-bottom: 16px;
 }
@@ -56,12 +57,5 @@
 
   &__icon {
     margin: auto 5px;
-  }
-}
-
-@include device-is('mobile') {
-
-  .congratulations-banner__message {
-    padding: 0 8px;
   }
 }

--- a/mon-pix/app/templates/authenticated/certifications/join.hbs
+++ b/mon-pix/app/templates/authenticated/certifications/join.hbs
@@ -16,12 +16,6 @@
             @closeBanner={{this.closeBanner}}
           />
         {{/if}}
-        <div class="certification-start-page__link-to-user-certifications">
-          <FaIcon @icon="arrow-right" />
-          <LinkTo @route="authenticated.user-certifications">{{t
-              "pages.certification-start.link-to-user-certification"
-            }}</LinkTo>
-        </div>
         <CertificationJoiner @onStepChange={{this.changeStep}} />
       </PixBlock>
     {{else}}

--- a/mon-pix/tests/integration/components/congratulations-certification-banner_test.js
+++ b/mon-pix/tests/integration/components/congratulations-certification-banner_test.js
@@ -2,8 +2,8 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import sinon from 'sinon';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { click, find, render } from '@ember/test-helpers';
-import { contains } from '../../helpers/contains';
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | Congratulations Certification Banner', function () {
@@ -14,12 +14,10 @@ describe('Integration | Component | Congratulations Certification Banner', funct
     this.set('fullName', 'Fifi Brindacier');
 
     // when
-    await render(hbs`<CongratulationsCertificationBanner @fullName={{this.fullName}}/>`);
+    const screen = await render(hbs`<CongratulationsCertificationBanner @fullName={{this.fullName}}/>`);
 
     // then
-    expect(find('.congratulations-banner__message').textContent).to.contains(
-      'Bravo Fifi Brindacier,votre profil est certifiable.'
-    );
+    expect(screen.getByText('Bravo Fifi Brindacier,votre profil est certifiable.')).to.exist;
   });
 
   it('calls the closeBanner method when closing the banner', async function () {
@@ -27,12 +25,12 @@ describe('Integration | Component | Congratulations Certification Banner', funct
     const closeBannerStub = sinon.stub();
     this.set('closeBanner', closeBannerStub);
     this.set('fullName', 'Fifi Brindacier');
-    await render(
+    const screen = await render(
       hbs`<CongratulationsCertificationBanner @fullName={{this.fullName}} @closeBanner={{this.closeBanner}}/>`
     );
 
     // when
-    await click('[aria-label="Fermer"]');
+    await click(screen.getByLabelText('Fermer'));
 
     // then
     sinon.assert.calledOnce(closeBannerStub);
@@ -49,13 +47,13 @@ describe('Integration | Component | Congratulations Certification Banner', funct
       this.set('fullName', 'Fifi Brindacier');
 
       // when
-      await render(
+      const screen = await render(
         hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}}/>`
       );
 
       // then
-      expect(contains('Vous êtes également éligible à la certification CléA Numérique.')).to.exist;
-      expect(contains('Vous êtes également éligible à la certification Pix+ Édu 1er degré Confirmé.')).to.exist;
+      expect(screen.getByText('Vous êtes également éligible à la certification CléA Numérique.')).to.exist;
+      expect(screen.getByText('Vous êtes également éligible à la certification Pix+ Édu 1er degré Confirmé.')).to.exist;
     });
   });
 });

--- a/mon-pix/tests/integration/components/congratulations-certification-banner_test.js
+++ b/mon-pix/tests/integration/components/congratulations-certification-banner_test.js
@@ -37,11 +37,14 @@ describe('Integration | Component | Congratulations Certification Banner', funct
   });
 
   describe('When there are eligible complementary certifications', function () {
-    it(`renders complementary certification eligibility message`, async function () {
+    it(`renders complementary certification eligibility messages and pictures`, async function () {
       // given
       const store = this.owner.lookup('service:store');
       const certificationEligibility = store.createRecord('is-certifiable', {
-        eligibleComplementaryCertifications: ['CléA Numérique', 'Pix+ Édu 1er degré Confirmé'],
+        eligibleComplementaryCertifications: [
+          { label: 'CléA Numérique', imageUrl: 'http://www.image-clea.com' },
+          { label: 'Pix+ Édu 1er degré Confirmé', imageUrl: 'http://www.image-clea.com' },
+        ],
       });
       this.set('certificationEligibility', certificationEligibility);
       this.set('fullName', 'Fifi Brindacier');
@@ -54,6 +57,8 @@ describe('Integration | Component | Congratulations Certification Banner', funct
       // then
       expect(screen.getByText('Vous êtes également éligible à la certification CléA Numérique.')).to.exist;
       expect(screen.getByText('Vous êtes également éligible à la certification Pix+ Édu 1er degré Confirmé.')).to.exist;
+      expect(screen.getByRole('img', { name: 'CléA Numérique' })).to.exist;
+      expect(screen.getByRole('img', { name: 'Pix+ Édu 1er degré Confirmé' })).to.exist;
     });
   });
 });

--- a/mon-pix/tests/integration/components/congratulations-certification-banner_test.js
+++ b/mon-pix/tests/integration/components/congratulations-certification-banner_test.js
@@ -17,7 +17,7 @@ describe('Integration | Component | Congratulations Certification Banner', funct
     const screen = await render(hbs`<CongratulationsCertificationBanner @fullName={{this.fullName}}/>`);
 
     // then
-    expect(screen.getByText('Bravo Fifi Brindacier,votre profil est certifiable.')).to.exist;
+    expect(screen.getByText('Bravo Fifi Brindacier, votre profil Pix est certifiable.')).to.exist;
   });
 
   it('calls the closeBanner method when closing the banner', async function () {

--- a/mon-pix/tests/integration/components/congratulations-certification-banner_test.js
+++ b/mon-pix/tests/integration/components/congratulations-certification-banner_test.js
@@ -37,28 +37,53 @@ describe('Integration | Component | Congratulations Certification Banner', funct
   });
 
   describe('When there are eligible complementary certifications', function () {
-    it(`renders complementary certification eligibility messages and pictures`, async function () {
-      // given
-      const store = this.owner.lookup('service:store');
-      const certificationEligibility = store.createRecord('is-certifiable', {
-        eligibleComplementaryCertifications: [
-          { label: 'CléA Numérique', imageUrl: 'http://www.image-clea.com' },
-          { label: 'Pix+ Édu 1er degré Confirmé', imageUrl: 'http://www.image-clea.com' },
-        ],
+    describe('When there is only one eligible complementary certification', function () {
+      it(`renders the complementary certification eligibility special message and picture`, async function () {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certificationEligibility = store.createRecord('is-certifiable', {
+          eligibleComplementaryCertifications: [{ label: 'CléA Numérique', imageUrl: 'http://www.image-clea.com' }],
+        });
+        this.set('certificationEligibility', certificationEligibility);
+        this.set('fullName', 'Fifi Brindacier');
+
+        // when
+        const screen = await render(
+          hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}}/>`
+        );
+
+        // then
+        expect(screen.getByText('Vous êtes également éligible à la certification complémentaire :')).to.exist;
+        expect(screen.getByText('CléA Numérique')).to.exist;
+        expect(screen.getByRole('img', { name: 'CléA Numérique' })).to.exist;
       });
-      this.set('certificationEligibility', certificationEligibility);
-      this.set('fullName', 'Fifi Brindacier');
+    });
 
-      // when
-      const screen = await render(
-        hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}}/>`
-      );
+    describe('When there are multiple eligible complementary certifications', function () {
+      it(`renders the multiple complementary certification eligibility pluralized message and pictures`, async function () {
+        // given
+        const store = this.owner.lookup('service:store');
+        const certificationEligibility = store.createRecord('is-certifiable', {
+          eligibleComplementaryCertifications: [
+            { label: 'CléA Numérique', imageUrl: 'http://www.image-clea.com' },
+            { label: 'Pix+ Édu 1er degré Confirmé', imageUrl: 'http://www.image-clea.com' },
+          ],
+        });
+        this.set('certificationEligibility', certificationEligibility);
+        this.set('fullName', 'Fifi Brindacier');
 
-      // then
-      expect(screen.getByText('Vous êtes également éligible à la certification CléA Numérique.')).to.exist;
-      expect(screen.getByText('Vous êtes également éligible à la certification Pix+ Édu 1er degré Confirmé.')).to.exist;
-      expect(screen.getByRole('img', { name: 'CléA Numérique' })).to.exist;
-      expect(screen.getByRole('img', { name: 'Pix+ Édu 1er degré Confirmé' })).to.exist;
+        // when
+        const screen = await render(
+          hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}}/>`
+        );
+
+        // then
+        expect(screen.getByText('Vous êtes également éligible aux certifications complémentaires :')).to.exist;
+        expect(screen.getByText('CléA Numérique')).to.exist;
+        expect(screen.getByText('Pix+ Édu 1er degré Confirmé')).to.exist;
+        expect(screen.getByRole('img', { name: 'CléA Numérique' })).to.exist;
+        expect(screen.getByRole('img', { name: 'Pix+ Édu 1er degré Confirmé' })).to.exist;
+      });
     });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -256,7 +256,7 @@
           "text": "How do I certify my digital skills?",
           "url": "https://support.pix.org/fr/support/solutions/articles/15000039372-la-certification-pix-c-est-quoi-"
         },
-        "message": "Well done, {fullName},'<br>'your profile can now be certified."
+        "message": "Well done, {fullName}, your Pix profile can now be certified."
       },
       "error-messages": {
         "generic": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -251,7 +251,7 @@
     "certification-joiner": {
       "title": "Join a certification session",
       "congratulation-banner": {
-        "complementary-certification-eligibility": "You are also eligible for the {complementaryCertificationName} certification.",
+        "complementary-certification-eligibility": "You are also eligible for the following complementary { count, plural, =1 {certification} other {certifications} } :",
         "link": {
           "text": "How do I certify my digital skills?",
           "url": "https://support.pix.org/fr/support/solutions/articles/15000039372-la-certification-pix-c-est-quoi-"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -251,7 +251,7 @@
     "certification-joiner": {
       "title": "Rejoindre une session de certification",
       "congratulation-banner": {
-        "complementary-certification-eligibility": "Vous êtes également éligible à la certification {complementaryCertificationName}.",
+        "complementary-certification-eligibility": "Vous êtes également éligible { count, plural, =1 {à la certification complémentaire} other {aux certifications complémentaires} } :",
         "link": {
           "text": "Comment se certifier ?",
           "url": "https://pix.fr/se-certifier#slice-2"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -256,7 +256,7 @@
           "text": "Comment se certifier ?",
           "url": "https://pix.fr/se-certifier#slice-2"
         },
-        "message": "Bravo {fullName},'<br>'votre profil est certifiable."
+        "message": "Bravo {fullName}, votre profil Pix est certifiable."
       },
       "error-messages": {
         "generic": {


### PR DESCRIPTION
## :christmas_tree: Problème

Afin d’assumer la différence entre RT "simples" et RT "certifiants" et de mettre en valeur les RT “certifiants”, le design de la page "Certification" doit être revu car il n'est désormais plus harmonisé avec celui de la page de fin de parcours. (#5081)

![image](https://user-images.githubusercontent.com/36371437/199896237-e6f22400-3973-47a9-b1f0-43bbf44b53e9.png)

## :gift: Proposition

• Créer un encadré de couleur différente pour indiquer les certifications complémentaires à laquelle/auxquelles l’utilisateur est éligible.
• Modifier l’affichage de “Comment se certifier ?” et “Voir mes certifications” pour qu’ils apparaissent tous les deux sous forme de boutons dans l’encadré vert

![image](https://user-images.githubusercontent.com/36371437/199896346-589856f9-175c-43cf-a4cd-26d665c8e920.png)

## :star2: Remarques

L'ensemble des maquettes à jour se trouve [ici](https://www.figma.com/file/y6p1FS5HKhJkMLrJN4i90P/Pix-App?node-id=2045%3A37762)

⚠️ 
- Impossibilité de changer la couleur du lien visité sur la RA dans le bouton "Voir mes certifications" malgré que cela fonctionne en développement local. 🤷‍♂️
- Bien qu'il n'y ait pas encore de consensus  (ni d'ADR) à ce sujet au moment où j'écris ces lignes, j'ai gardé l'organisation sans imbrication du fichier de style de la bannière tel qu'il existait avant cette PR, mais cela peut bien sûr être modifié au besoin.
- Les getters du nouveau fichier de composant `congratulations-certification-banner` étant testés au niveau intégration et acceptation, je n'ai pas jugé nécessaire d'en rajouter au niveau unitaire.

## :santa: Pour tester

Dans mon-pix, se connecter avec les comptes ci-dessous pour vérifier les différents scénarios:

- `Email: toto@example.net / MDP: Qsdfghjk1+` : non certifiable
- `Email: userpix1@example.net / MDP: pix123` : certifiable et NON éligible à la certification complémentaire
- `Email: sup108488@example.net / MDP: pix123` : certifiable et éligible à UNE certif complémentaire
- `Email: sup108489@example.net / MDP: pix123` : certifiable et éligible à DEUX certifs complémentaires

Vérifier que le rendu corresponde aux maquettes fournies, dans les différents formats.
