### PR TITLE
[FEATURE][CERTIF] Rejoindre un centre de certification avec un compte existant et une invitation (PIX-5008)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -182,7 +182,7 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.CertificationCandidateForbiddenDeletionError) {
     return new HttpErrors.ForbiddenError(error.message);
   }
-  if (error instanceof DomainErrors.CancelledOrganizationInvitationError) {
+  if (error instanceof DomainErrors.CancelledInvitationError) {
     return new HttpErrors.ForbiddenError(error.message);
   }
   if (error instanceof DomainErrors.SupervisorAccessNotAuthorizedError) {
@@ -221,17 +221,11 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.AlreadyExistingMembershipError) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }
-  if (error instanceof DomainErrors.AlreadyExistingOrganizationInvitationError) {
+  if (error instanceof DomainErrors.AlreadyExistingInvitationError) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }
   if (error instanceof DomainErrors.AlreadyAcceptedOrCancelledInvitationError) {
     return new HttpErrors.ConflictError(error.message);
-  }
-  if (error instanceof DomainErrors.AlreadyExistingCertificationCenterInvitationError) {
-    return new HttpErrors.PreconditionFailedError(error.message);
-  }
-  if (error instanceof DomainErrors.CancelledCertificationCenterInvitationError) {
-    return new HttpErrors.ForbiddenError(error.message);
   }
   if (error instanceof DomainErrors.AlreadyExistingCampaignParticipationError) {
     return new HttpErrors.PreconditionFailedError(error.message);

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -97,7 +97,7 @@ class ManyOrganizationsFoundError extends DomainError {
   }
 }
 
-class AlreadyExistingOrganizationInvitationError extends DomainError {
+class AlreadyExistingInvitationError extends DomainError {
   constructor(message = "L'invitation de l'organisation existe déjà.") {
     super(message);
   }
@@ -151,7 +151,7 @@ class AlreadySharedCampaignParticipationError extends DomainError {
   }
 }
 
-class CancelledOrganizationInvitationError extends DomainError {
+class CancelledInvitationError extends DomainError {
   constructor(
     message = "L'invitation à cette organisation a été annulée.",
     code = 'CANCELLED_ORGANIZATION_INVITATION_CODE'
@@ -573,21 +573,6 @@ class CertificationCenterMembershipCreationError extends DomainError {
 class CertificationCenterMembershipDisableError extends DomainError {
   constructor(message = 'Erreur lors de la mise à jour du membership de centre de certification.') {
     super(message);
-  }
-}
-
-class AlreadyExistingCertificationCenterInvitationError extends DomainError {
-  constructor(message = "L'invitation à un centre de certification existe déjà.") {
-    super(message);
-  }
-}
-
-class CancelledCertificationCenterInvitationError extends DomainError {
-  constructor(
-    message = "L'invitation à ce centre de certification a été annulée.",
-    code = 'CANCELLED_CERTIFICATION_CENTER_INVITATION_CODE'
-  ) {
-    super(message, code);
   }
 }
 
@@ -1223,13 +1208,12 @@ module.exports = {
   AlreadyExistingEntityError,
   AlreadyExistingCampaignParticipationError,
   AlreadyExistingMembershipError,
-  AlreadyExistingOrganizationInvitationError,
+  AlreadyExistingInvitationError,
   AlreadyRatedAssessmentError,
   AlreadyRegisteredEmailAndUsernameError,
   AlreadyRegisteredEmailError,
   AlreadyRegisteredUsernameError,
   AlreadySharedCampaignParticipationError,
-  AlreadyExistingCertificationCenterInvitationError,
   ApplicationWithInvalidClientIdError,
   ApplicationWithInvalidClientSecretError,
   ApplicationScopeNotAllowedError,
@@ -1244,8 +1228,7 @@ module.exports = {
   CampaignCodeError,
   CampaignParticipationDeletedError,
   CampaignTypeError,
-  CancelledOrganizationInvitationError,
-  CancelledCertificationCenterInvitationError,
+  CancelledInvitationError,
   CandidateNotAuthorizedToJoinSessionError,
   CandidateNotAuthorizedToResumeCertificationTestError,
   CertificateVerificationCodeGenerationTooManyTrials,

--- a/api/lib/domain/usecases/get-certification-center-invitation.js
+++ b/api/lib/domain/usecases/get-certification-center-invitation.js
@@ -1,7 +1,4 @@
-const {
-  AlreadyExistingCertificationCenterInvitationError,
-  CancelledCertificationCenterInvitationError,
-} = require('../../domain/errors');
+const { CancelledInvitationError, AlreadyExistingInvitationError } = require('../errors');
 
 module.exports = async function getCertificationCenterInvitation({
   certificationCenterInvitationId,
@@ -14,12 +11,12 @@ module.exports = async function getCertificationCenterInvitation({
   });
 
   if (foundCertificationCenterInvitation.isCancelled) {
-    throw new CancelledCertificationCenterInvitationError("L'invitation à ce centre de certification a été annulée.");
+    throw new CancelledInvitationError(`L'invitation avec l'id ${certificationCenterInvitationId} a été annulée.`);
   }
 
   if (foundCertificationCenterInvitation.isAccepted) {
-    throw new AlreadyExistingCertificationCenterInvitationError(
-      `L'invitation avec l'id ${certificationCenterInvitationId} existe déjà.`
+    throw new AlreadyExistingInvitationError(
+      `L'invitation avec l'id ${certificationCenterInvitationId} a déjà été acceptée.`
     );
   }
 

--- a/api/lib/domain/usecases/get-organization-invitation.js
+++ b/api/lib/domain/usecases/get-organization-invitation.js
@@ -1,7 +1,4 @@
-const {
-  AlreadyExistingOrganizationInvitationError,
-  CancelledOrganizationInvitationError,
-} = require('../../domain/errors');
+const { AlreadyExistingInvitationError, CancelledInvitationError } = require('../../domain/errors');
 
 module.exports = async function getOrganizationInvitation({
   organizationInvitationId,
@@ -15,13 +12,11 @@ module.exports = async function getOrganizationInvitation({
   });
 
   if (foundOrganizationInvitation.isCancelled) {
-    throw new CancelledOrganizationInvitationError(`Invitation was cancelled`);
+    throw new CancelledInvitationError(`Invitation was cancelled`);
   }
 
   if (foundOrganizationInvitation.isAccepted) {
-    throw new AlreadyExistingOrganizationInvitationError(
-      `Invitation already accepted with the id ${organizationInvitationId}`
-    );
+    throw new AlreadyExistingInvitationError(`Invitation already accepted with the id ${organizationInvitationId}`);
   }
 
   const { name: organizationName } = await organizationRepository.get(foundOrganizationInvitation.organizationId);

--- a/api/lib/infrastructure/repositories/certification-center-invitation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-invitation-repository.js
@@ -44,7 +44,7 @@ module.exports = {
       .first();
 
     if (!certificationCenterInvitation) {
-      throw new NotFoundError("L'invitation à ce centre de certfication n'existe pas");
+      throw new NotFoundError("L'invitation à ce centre de certification n'existe pas");
     }
 
     return _toDomain(certificationCenterInvitation);

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -75,26 +75,14 @@ describe('Integration | API | Controller Error', function () {
       expect(responseDetail(response)).to.equal('Le membership existe déjà.');
     });
 
-    it('responds Precondition Failed when a AlreadyExistingOrganizationInvitationError error occurs', async function () {
+    it('responds Precondition Failed when a AlreadyExistingInvitationError error occurs', async function () {
       routeHandler.throws(
-        new DomainErrors.AlreadyExistingOrganizationInvitationError("L'invitation de l'organisation existe déjà.")
+        new DomainErrors.AlreadyExistingInvitationError("L'invitation de l'organisation existe déjà.")
       );
       const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(PRECONDITION_FAILED);
       expect(responseDetail(response)).to.equal("L'invitation de l'organisation existe déjà.");
-    });
-
-    it('responds Precondition Failed when a AlreadyExistingCertificationCenterInvitationError error occurs', async function () {
-      routeHandler.throws(
-        new DomainErrors.AlreadyExistingCertificationCenterInvitationError(
-          "L'invitation à un centre de certification existe déjà."
-        )
-      );
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(PRECONDITION_FAILED);
-      expect(responseDetail(response)).to.equal("L'invitation à un centre de certification existe déjà.");
     });
 
     it('responds Precondition Failed when a AlreadySharedCampaignParticipationError error occurs', async function () {
@@ -478,21 +466,12 @@ describe('Integration | API | Controller Error', function () {
       expect(responseTitle(response)).to.equal('Forbidden');
     });
 
-    it('responds Forbidden when a CancelledOrganizationInvitationError error occurs', async function () {
-      routeHandler.throws(new DomainErrors.CancelledOrganizationInvitationError());
+    it('responds Forbidden when a CancelledInvitationError error occurs', async function () {
+      routeHandler.throws(new DomainErrors.CancelledInvitationError());
       const response = await server.requestObject(request);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
       expect(responseDetail(response)).to.equal("L'invitation à cette organisation a été annulée.");
-      expect(responseTitle(response)).to.equal('Forbidden');
-    });
-
-    it('responds Forbidden when a CancelledCertificationCenterInvitationError error occurs', async function () {
-      routeHandler.throws(new DomainErrors.CancelledCertificationCenterInvitationError());
-      const response = await server.requestObject(request);
-
-      expect(response.statusCode).to.equal(FORBIDDEN_ERROR);
-      expect(responseDetail(response)).to.equal("L'invitation à ce centre de certification a été annulée.");
       expect(responseTitle(response)).to.equal('Forbidden');
     });
   });

--- a/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
@@ -5,7 +5,7 @@ const scoOrganizationInvitationSerializer = require('../../../../lib/infrastruct
 const moduleUnderTest = require('../../../../lib/application/organization-invitations');
 
 const {
-  AlreadyExistingOrganizationInvitationError,
+  AlreadyExistingInvitationError,
   NotFoundError,
   UserNotFoundError,
   OrganizationWithoutEmailError,
@@ -60,9 +60,9 @@ describe('Integration | Application | Organization-invitations | organization-in
     });
 
     context('Error cases', function () {
-      it('should respond an HTTP response with status code 412 when AlreadyExistingOrganizationInvitationError', async function () {
+      it('should respond an HTTP response with status code 412 when AlreadyExistingInvitationError', async function () {
         // given
-        usecases.acceptOrganizationInvitation.rejects(new AlreadyExistingOrganizationInvitationError());
+        usecases.acceptOrganizationInvitation.rejects(new AlreadyExistingInvitationError());
 
         // when
         const response = await httpTestServer.request('POST', '/api/organization-invitations/1/response', payload);

--- a/api/tests/integration/domain/usecases/get-certification-center-invitation_test.js
+++ b/api/tests/integration/domain/usecases/get-certification-center-invitation_test.js
@@ -69,7 +69,7 @@ describe('Integration | API | getCertificationCenterInvitation', function () {
 
       // then
       expect(error).to.be.instanceof(NotFoundError);
-      expect(error.message).to.equal("L'invitation à ce centre de certfication n'existe pas");
+      expect(error.message).to.equal("L'invitation à ce centre de certification n'existe pas");
     });
   });
 

--- a/api/tests/integration/domain/usecases/get-certification-center-invitation_test.js
+++ b/api/tests/integration/domain/usecases/get-certification-center-invitation_test.js
@@ -3,8 +3,8 @@ const useCases = require('../../../../lib/domain/usecases');
 const CertificationCenterInvitation = require('../../../../lib/domain/models/CertificationCenterInvitation');
 const {
   NotFoundError,
-  AlreadyExistingCertificationCenterInvitationError,
-  CancelledCertificationCenterInvitationError,
+  AlreadyExistingInvitationError,
+  CancelledInvitationError,
 } = require('../../../../lib/domain/errors');
 
 describe('Integration | API | getCertificationCenterInvitation', function () {
@@ -94,8 +94,8 @@ describe('Integration | API | getCertificationCenterInvitation', function () {
       });
 
       // then
-      expect(error).to.be.instanceof(AlreadyExistingCertificationCenterInvitationError);
-      expect(error.message).to.equal(`L'invitation avec l'id ${killuaInvitation.id} existe déjà.`);
+      expect(error).to.be.instanceof(AlreadyExistingInvitationError);
+      expect(error.message).to.equal(`L'invitation avec l'id ${killuaInvitation.id} a déjà été acceptée.`);
     });
   });
 
@@ -120,8 +120,8 @@ describe('Integration | API | getCertificationCenterInvitation', function () {
       });
 
       // then
-      expect(error).to.be.instanceof(CancelledCertificationCenterInvitationError);
-      expect(error.message).to.equal("L'invitation à ce centre de certification a été annulée.");
+      expect(error).to.be.instanceof(CancelledInvitationError);
+      expect(error.message).to.equal(`L'invitation avec l'id ${dekuInvitation.id} a été annulée.`);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/get-organization-invitation_test.js
+++ b/api/tests/unit/domain/usecases/get-organization-invitation_test.js
@@ -3,8 +3,8 @@ const getOrganizationInvitation = require('../../../../lib/domain/usecases/get-o
 const OrganizationInvitation = require('../../../../lib/domain/models/OrganizationInvitation');
 const {
   NotFoundError,
-  AlreadyExistingOrganizationInvitationError,
-  CancelledOrganizationInvitationError,
+  AlreadyExistingInvitationError,
+  CancelledInvitationError,
 } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | get-organization-invitation', function () {
@@ -59,7 +59,7 @@ describe('Unit | UseCase | get-organization-invitation', function () {
   });
 
   context('when invitation is already accepted', function () {
-    it('should throw an AlreadyExistingOrganizationInvitationError', async function () {
+    it('should throw an AlreadyExistingInvitationError', async function () {
       // given
       const status = OrganizationInvitation.StatusType.ACCEPTED;
       const organizationInvitation = domainBuilder.buildOrganizationInvitation({ status });
@@ -73,7 +73,7 @@ describe('Unit | UseCase | get-organization-invitation', function () {
       });
 
       // then
-      expect(err).to.be.instanceOf(AlreadyExistingOrganizationInvitationError);
+      expect(err).to.be.instanceOf(AlreadyExistingInvitationError);
     });
   });
 
@@ -105,7 +105,7 @@ describe('Unit | UseCase | get-organization-invitation', function () {
     });
 
     context('when invitation is cancelled', function () {
-      it('should throw an CancelledOrganizationInvitationError', async function () {
+      it('should throw an CancelledInvitationError', async function () {
         // given
         const status = OrganizationInvitation.StatusType.CANCELLED;
         const organization = domainBuilder.buildOrganization();
@@ -125,7 +125,7 @@ describe('Unit | UseCase | get-organization-invitation', function () {
         });
 
         // then
-        expect(error).to.be.instanceOf(CancelledOrganizationInvitationError);
+        expect(error).to.be.instanceOf(CancelledInvitationError);
       });
     });
   });

--- a/certif/app/routes/join.js
+++ b/certif/app/routes/join.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 export default class JoinRoute extends Route {
   @service store;
+  @service router;
 
   queryParams = {
     code: { replace: true },
@@ -9,9 +10,13 @@ export default class JoinRoute extends Route {
   };
 
   model(params) {
-    return this.store.queryRecord('certification-center-invitation', {
-      invitationId: params.invitationId,
-      code: params.code,
-    });
+    return this.store
+      .queryRecord('certification-center-invitation', {
+        invitationId: params.invitationId,
+        code: params.code,
+      })
+      .catch(() => {
+        this.router.replaceWith('login');
+      });
   }
 }

--- a/certif/tests/unit/routes/join_test.js
+++ b/certif/tests/unit/routes/join_test.js
@@ -32,5 +32,29 @@ module('Unit | Route | join', function (hooks) {
       // then
       assert.strictEqual(certificationCenterName, 'Ninja School');
     });
+
+    module('when invitation was cancelled', function () {
+      test('should redirect to login route', async function (assert) {
+        // given
+        const route = this.owner.lookup('route:join');
+        const store = this.owner.lookup('service:store');
+
+        sinon.stub(route.router, 'replaceWith');
+        sinon.stub(store, 'queryRecord');
+        const conflictError = { status: '409' };
+        store.queryRecord.rejects({ errors: [conflictError] });
+
+        const params = {
+          invitationId: 2,
+          code: 'ABCDEF',
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        assert.ok(route.router.replaceWith.calledWith('login'));
+      });
+    });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

Dans le cadre de l'epix, nous voulons permettre aux agents Pix d'envoyer par e-mail des invitations à rejoindre un centre de certification depuis Pix Admin. 
Il se peut que l'invitation ait déjà été accepté, ou annulée ou n'existe pas. Dans ces cas l'utilisateur doit être redirigé vers la page de login.


## :gift: Proposition
En cas d'erreur de la part de l'API au moment de récupérer l'invitation (via le code et l'id), rediriger l'utilisateur vers la page de login.

## :star2: Remarques
La gestion des messages d'erreur se fera dans une autre PR ultérieurement.

## :santa: Pour tester
Aller sur Pix Certif et replacer `/connexion` par ... 

Tester la redirection avec une invitation déjà acceptée :
- `/rejoindre?invitationId=101261&code=ABCDEF123`

Tester la redirection avec une invitation annulée :
- `/rejoindre?invitationId=101262&code=ABCDEF123`

Tester la redirection avec une invitation inexistante :
- `/rejoindre?invitationId=666&code=ABCDEF123`