### PR TITLE
[TECH] Améliorer la lisibilité du composant `scorecard-details` (PIX-5609).

### DIFF
--- a/mon-pix/app/components/scorecard-details.hbs
+++ b/mon-pix/app/components/scorecard-details.hbs
@@ -26,7 +26,7 @@
                 <span class="score-label competence-card__score-label--congrats">{{t "common.level"}}</span>
                 <span
                   class="score-value competence-card__score-value competence-card__score-value--congrats"
-                >{{this.level}}</span>
+                >{{@scorecard.level}}</span>
               </div>
             </div>
           {{else}}
@@ -40,7 +40,7 @@
             >
               <div class="competence-card__level">
                 <span class="score-label">{{t "common.level"}}</span>
-                <span class="score-value">{{replace-zero-by-dash this.level}}</span>
+                <span class="score-value">{{replace-zero-by-dash @scorecard.level}}</span>
               </div>
             </CircleChart>
           {{/if}}

--- a/mon-pix/app/components/scorecard-details.hbs
+++ b/mon-pix/app/components/scorecard-details.hbs
@@ -18,7 +18,7 @@
 
     <div class="scorecard-details-content__right">
 
-      {{#if (or @scorecard.isStarted @scorecard.isFinished)}}
+      {{#if @scorecard.isFinished}}
         <div class="scorecard-details-content-right__score-container">
           {{#if @scorecard.isFinishedWithMaxLevel}}
             <div class="competence-card__congrats">
@@ -50,58 +50,85 @@
             <div class="score-value">{{replace-zero-by-dash @scorecard.earnedPix}}</div>
           </div>
         </div>
-      {{/if}}
 
-      {{#if this.isProgressable}}
-        <div class="scorecard-details-content-right__level-info">
-          {{t
-            "pages.competence-details.next-level-info"
-            remainingPixToNextLevel=@scorecard.remainingPixToNextLevel
-            level=(inc @scorecard.level)
-          }}
-        </div>
-      {{/if}}
-
-      {{#if (and @scorecard.isFinished this.canImprove)}}
-        {{#if this.shouldWaitBeforeImproving}}
-          <div class="scorecard-details__improvement-countdown">
-            <span class="scorecard-details-improvement-countdown__label">{{t
-                "pages.competence-details.actions.improve.description.waiting-text"
+        {{#if this.canImprove}}
+          {{#if this.shouldWaitBeforeImproving}}
+            <div class="scorecard-details__improvement-countdown">
+              <span class="scorecard-details-improvement-countdown__label">{{t
+                  "pages.competence-details.actions.improve.description.waiting-text"
+                }}</span>
+              <span class="scorecard-details-improvement-countdown__count">{{t
+                  "pages.competence-details.actions.improve.description.countdown"
+                  daysBeforeImproving=@scorecard.remainingDaysBeforeImproving
+                }}</span>
+            </div>
+          {{else}}
+            <PixButton
+              class="scorecard-details__improve-button"
+              @shape="rounded"
+              @backgroundColor="green"
+              @triggerAction={{this.improveCompetenceEvaluation}}
+            >
+              {{t "pages.competence-details.actions.improve.label"}}
+              <span class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</span>
+            </PixButton>
+            <span class="scorecard-details__improving-text">{{t
+                "pages.competence-details.actions.improve.improvingText"
               }}</span>
-            <span class="scorecard-details-improvement-countdown__count">{{t
-                "pages.competence-details.actions.improve.description.countdown"
-                daysBeforeImproving=@scorecard.remainingDaysBeforeImproving
-              }}</span>
-          </div>
-        {{else}}
-          <PixButton
-            class="scorecard-details__improve-button"
-            @shape="rounded"
-            @backgroundColor="green"
-            @triggerAction={{this.improveCompetenceEvaluation}}
-          >
-            {{t "pages.competence-details.actions.improve.label"}}
-            <span class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</span>
-          </PixButton>
-          <span class="scorecard-details__improving-text">{{t
-              "pages.competence-details.actions.improve.improvingText"
-            }}</span>
+          {{/if}}
         {{/if}}
       {{/if}}
 
-      {{#if (or @scorecard.isStarted @scorecard.isNotStarted)}}
+      {{#if @scorecard.isStarted}}
+        <div class="scorecard-details-content-right__score-container">
+          <CircleChart
+            @value={{@scorecard.percentageAheadOfNextLevel}}
+            @sliceColor={{@scorecard.area.color}}
+            @chartClass="circle-chart__content--big"
+            @thicknessClass="circle--thick"
+            role="img"
+            aria-label="{{scorecard-aria-label @scorecard}}"
+          >
+            <div class="competence-card__level">
+              <span class="score-label">{{t "common.level"}}</span>
+              <span class="score-value">{{replace-zero-by-dash @scorecard.level}}</span>
+            </div>
+          </CircleChart>
+
+          <div class="scorecard-details-content-right-score-container__pix-earned">
+            <div class="score-label">{{t "common.pix"}}</div>
+            <div class="score-value">{{replace-zero-by-dash @scorecard.earnedPix}}</div>
+          </div>
+        </div>
+
+        {{#if this.isNotMaxLevel}}
+          <div class="scorecard-details-content-right__level-info">
+            {{t
+              "pages.competence-details.next-level-info"
+              remainingPixToNextLevel=@scorecard.remainingPixToNextLevel
+              level=(inc @scorecard.level)
+            }}
+          </div>
+        {{/if}}
+
         <LinkTo
           @route="authenticated.competences.resume"
           @model={{@scorecard.competenceId}}
           class="button button--big button--thin button--round button--link button--green scorecard-details__resume-or-start-button"
         >
-          {{#if @scorecard.isStarted}}
-            {{t "pages.competence-details.actions.continue.label"}}
-            <div class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</div>
-          {{else}}
-            {{t "pages.competence-details.actions.start.label"}}
-            <div class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</div>
-          {{/if}}
+          {{t "pages.competence-details.actions.continue.label"}}
+          <div class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</div>
+        </LinkTo>
+      {{/if}}
+
+      {{#if @scorecard.isNotStarted}}
+        <LinkTo
+          @route="authenticated.competences.resume"
+          @model={{@scorecard.competenceId}}
+          class="button button--big button--thin button--round button--link button--green scorecard-details__resume-or-start-button"
+        >
+          {{t "pages.competence-details.actions.start.label"}}
+          <div class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</div>
         </LinkTo>
       {{/if}}
 
@@ -117,7 +144,9 @@
           {{t "pages.competence-details.actions.reset.label"}}
           <div class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</div>
         </PixButton>
-      {{else if this.displayWaitSentence}}
+      {{/if}}
+
+      {{#if this.displayWaitSentence}}
         <p class="scorecard-details-content-right__reset-message">{{t
             "pages.competence-details.actions.reset.description"
             daysBeforeReset=@scorecard.remainingDaysBeforeReset

--- a/mon-pix/app/components/scorecard-details.hbs
+++ b/mon-pix/app/components/scorecard-details.hbs
@@ -77,6 +77,27 @@
               }}</span>
           {{/if}}
         {{/if}}
+
+        {{#if this.displayResetButton}}
+          <PixButton
+            id="reset-button-finished"
+            class="scorecard-details__reset-button"
+            @backgroundColor="transparent-light"
+            @isBorderVisible={{true}}
+            @shape="rounded"
+            @triggerAction={{this.openModal}}
+          >
+            {{t "pages.competence-details.actions.reset.label"}}
+            <div class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</div>
+          </PixButton>
+        {{/if}}
+
+        {{#if this.displayWaitSentence}}
+          <p class="scorecard-details-content-right__reset-message">{{t
+              "pages.competence-details.actions.reset.description"
+              daysBeforeReset=@scorecard.remainingDaysBeforeReset
+            }}</p>
+        {{/if}}
       {{/if}}
 
       {{#if @scorecard.isStarted}}
@@ -119,6 +140,27 @@
           {{t "pages.competence-details.actions.continue.label"}}
           <div class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</div>
         </LinkTo>
+
+        {{#if this.displayResetButton}}
+          <PixButton
+            id="reset-button-started"
+            class="scorecard-details__reset-button"
+            @backgroundColor="transparent-light"
+            @isBorderVisible={{true}}
+            @shape="rounded"
+            @triggerAction={{this.openModal}}
+          >
+            {{t "pages.competence-details.actions.reset.label"}}
+            <div class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</div>
+          </PixButton>
+        {{/if}}
+
+        {{#if this.displayWaitSentence}}
+          <p class="scorecard-details-content-right__reset-message">{{t
+              "pages.competence-details.actions.reset.description"
+              daysBeforeReset=@scorecard.remainingDaysBeforeReset
+            }}</p>
+        {{/if}}
       {{/if}}
 
       {{#if @scorecard.isNotStarted}}
@@ -130,27 +172,6 @@
           {{t "pages.competence-details.actions.start.label"}}
           <div class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</div>
         </LinkTo>
-      {{/if}}
-
-      {{#if this.displayResetButton}}
-        <PixButton
-          id="reset-button"
-          class="scorecard-details__reset-button"
-          @backgroundColor="transparent-light"
-          @isBorderVisible={{true}}
-          @shape="rounded"
-          @triggerAction={{this.openModal}}
-        >
-          {{t "pages.competence-details.actions.reset.label"}}
-          <div class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</div>
-        </PixButton>
-      {{/if}}
-
-      {{#if this.displayWaitSentence}}
-        <p class="scorecard-details-content-right__reset-message">{{t
-            "pages.competence-details.actions.reset.description"
-            daysBeforeReset=@scorecard.remainingDaysBeforeReset
-          }}</p>
       {{/if}}
     </div>
   </div>

--- a/mon-pix/app/components/scorecard-details.hbs
+++ b/mon-pix/app/components/scorecard-details.hbs
@@ -18,7 +18,7 @@
 
     <div class="scorecard-details-content__right">
 
-      {{#unless @scorecard.isNotStarted}}
+      {{#if (or @scorecard.isStarted @scorecard.isFinished)}}
         <div class="scorecard-details-content-right__score-container">
           {{#if @scorecard.isFinishedWithMaxLevel}}
             <div class="competence-card__congrats">
@@ -50,7 +50,7 @@
             <div class="score-value">{{replace-zero-by-dash @scorecard.earnedPix}}</div>
           </div>
         </div>
-      {{/unless}}
+      {{/if}}
 
       {{#if this.isProgressable}}
         <div class="scorecard-details-content-right__level-info">

--- a/mon-pix/app/components/scorecard-details.hbs
+++ b/mon-pix/app/components/scorecard-details.hbs
@@ -62,34 +62,34 @@
         </div>
       {{/if}}
 
-      {{#if @scorecard.isFinished}}
-        {{#if this.canImprove}}
-          {{#if this.shouldWaitBeforeImproving}}
-            <div class="scorecard-details__improvement-countdown">
-              <span class="scorecard-details-improvement-countdown__label">{{t
-                  "pages.competence-details.actions.improve.description.waiting-text"
-                }}</span>
-              <span class="scorecard-details-improvement-countdown__count">{{t
-                  "pages.competence-details.actions.improve.description.countdown"
-                  daysBeforeImproving=@scorecard.remainingDaysBeforeImproving
-                }}</span>
-            </div>
-          {{else}}
-            <PixButton
-              class="scorecard-details__improve-button"
-              @shape="rounded"
-              @backgroundColor="green"
-              @triggerAction={{this.improveCompetenceEvaluation}}
-            >
-              {{t "pages.competence-details.actions.improve.label"}}
-              <span class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</span>
-            </PixButton>
-            <span class="scorecard-details__improving-text">{{t
-                "pages.competence-details.actions.improve.improvingText"
+      {{#if (and @scorecard.isFinished this.canImprove)}}
+        {{#if this.shouldWaitBeforeImproving}}
+          <div class="scorecard-details__improvement-countdown">
+            <span class="scorecard-details-improvement-countdown__label">{{t
+                "pages.competence-details.actions.improve.description.waiting-text"
               }}</span>
-          {{/if}}
+            <span class="scorecard-details-improvement-countdown__count">{{t
+                "pages.competence-details.actions.improve.description.countdown"
+                daysBeforeImproving=@scorecard.remainingDaysBeforeImproving
+              }}</span>
+          </div>
+        {{else}}
+          <PixButton
+            class="scorecard-details__improve-button"
+            @shape="rounded"
+            @backgroundColor="green"
+            @triggerAction={{this.improveCompetenceEvaluation}}
+          >
+            {{t "pages.competence-details.actions.improve.label"}}
+            <span class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</span>
+          </PixButton>
+          <span class="scorecard-details__improving-text">{{t
+              "pages.competence-details.actions.improve.improvingText"
+            }}</span>
         {{/if}}
-      {{else}}
+      {{/if}}
+
+      {{#if (or @scorecard.isStarted @scorecard.isNotStarted)}}
         <LinkTo
           @route="authenticated.competences.resume"
           @model={{@scorecard.competenceId}}
@@ -104,6 +104,7 @@
           {{/if}}
         </LinkTo>
       {{/if}}
+
       {{#if this.displayResetButton}}
         <PixButton
           id="reset-button"

--- a/mon-pix/app/components/scorecard-details.hbs
+++ b/mon-pix/app/components/scorecard-details.hbs
@@ -20,7 +20,7 @@
 
       {{#if @scorecard.isFinished}}
         <div class="scorecard-details-content-right__score-container">
-          {{#if @scorecard.isFinishedWithMaxLevel}}
+          {{#if this.displayCongrats}}
             <div class="competence-card__congrats">
               <div class="competence-card__level competence-card__level--congrats">
                 <span class="score-label competence-card__score-label--congrats">{{t "common.level"}}</span>
@@ -51,31 +51,31 @@
           </div>
         </div>
 
-        {{#if this.canImprove}}
-          {{#if this.shouldWaitBeforeImproving}}
-            <div class="scorecard-details__improvement-countdown">
-              <span class="scorecard-details-improvement-countdown__label">{{t
-                  "pages.competence-details.actions.improve.description.waiting-text"
-                }}</span>
-              <span class="scorecard-details-improvement-countdown__count">{{t
-                  "pages.competence-details.actions.improve.description.countdown"
-                  daysBeforeImproving=@scorecard.remainingDaysBeforeImproving
-                }}</span>
-            </div>
-          {{else}}
-            <PixButton
-              class="scorecard-details__improve-button"
-              @shape="rounded"
-              @backgroundColor="green"
-              @triggerAction={{this.improveCompetenceEvaluation}}
-            >
-              {{t "pages.competence-details.actions.improve.label"}}
-              <span class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</span>
-            </PixButton>
-            <span class="scorecard-details__improving-text">{{t
-                "pages.competence-details.actions.improve.improvingText"
+        {{#if this.displayImprovingWaitSentence}}
+          <div class="scorecard-details__improvement-countdown">
+            <span class="scorecard-details-improvement-countdown__label">{{t
+                "pages.competence-details.actions.improve.description.waiting-text"
               }}</span>
-          {{/if}}
+            <span class="scorecard-details-improvement-countdown__count">{{t
+                "pages.competence-details.actions.improve.description.countdown"
+                daysBeforeImproving=@scorecard.remainingDaysBeforeImproving
+              }}</span>
+          </div>
+        {{/if}}
+
+        {{#if this.displayImprovingButton}}
+          <PixButton
+            class="scorecard-details__improve-button"
+            @shape="rounded"
+            @backgroundColor="green"
+            @triggerAction={{this.improveCompetenceEvaluation}}
+          >
+            {{t "pages.competence-details.actions.improve.label"}}
+            <span class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</span>
+          </PixButton>
+          <span class="scorecard-details__improving-text">{{t
+              "pages.competence-details.actions.improve.improvingText"
+            }}</span>
         {{/if}}
 
         {{#if this.displayResetButton}}
@@ -92,7 +92,7 @@
           </PixButton>
         {{/if}}
 
-        {{#if this.displayWaitSentence}}
+        {{#if this.displayResetWaitSentence}}
           <p class="scorecard-details-content-right__reset-message">{{t
               "pages.competence-details.actions.reset.description"
               daysBeforeReset=@scorecard.remainingDaysBeforeReset
@@ -122,7 +122,7 @@
           </div>
         </div>
 
-        {{#if this.isNotMaxLevel}}
+        {{#if this.displayRemainingPixToNextLevel}}
           <div class="scorecard-details-content-right__level-info">
             {{t
               "pages.competence-details.next-level-info"
@@ -155,7 +155,7 @@
           </PixButton>
         {{/if}}
 
-        {{#if this.displayWaitSentence}}
+        {{#if this.displayResetWaitSentence}}
           <p class="scorecard-details-content-right__reset-message">{{t
               "pages.competence-details.actions.reset.description"
               daysBeforeReset=@scorecard.remainingDaysBeforeReset

--- a/mon-pix/app/components/scorecard-details.hbs
+++ b/mon-pix/app/components/scorecard-details.hbs
@@ -93,10 +93,7 @@
         <LinkTo
           @route="authenticated.competences.resume"
           @model={{@scorecard.competenceId}}
-          class={{concat
-            "button button--big button--thin button--round button--link button--green "
-            (if @scorecard.isNotStarted "" "scorecard-details__resume-or-start-button")
-          }}
+          class="button button--big button--thin button--round button--link button--green scorecard-details__resume-or-start-button"
         >
           {{#if @scorecard.isStarted}}
             {{t "pages.competence-details.actions.continue.label"}}

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -17,6 +17,10 @@ export default class ScorecardDetails extends Component {
     return this.args.scorecard.isStarted && !this.args.scorecard.isMaxLevel;
   }
 
+  get isNotMaxLevel() {
+    return !this.args.scorecard.isMaxLevel;
+  }
+
   get canImprove() {
     return !this.args.scorecard.isFinishedWithMaxLevel;
   }

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -18,7 +18,7 @@ export default class ScorecardDetails extends Component {
   }
 
   get isProgressable() {
-    return !(this.args.scorecard.isFinished || this.args.scorecard.isMaxLevel || this.args.scorecard.isNotStarted);
+    return this.args.scorecard.isStarted && !this.args.scorecard.isMaxLevel;
   }
 
   get canImprove() {

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -13,28 +13,28 @@ export default class ScorecardDetails extends Component {
 
   @tracked showResetModal = false;
 
-  get isProgressable() {
-    return this.args.scorecard.isStarted && !this.args.scorecard.isMaxLevel;
+  get displayImprovingWaitSentence() {
+    return !this.args.scorecard.isImprovable;
   }
 
-  get isNotMaxLevel() {
-    return !this.args.scorecard.isMaxLevel;
+  get displayImprovingButton() {
+    return this.args.scorecard.isImprovable;
   }
 
-  get canImprove() {
-    return !this.args.scorecard.isFinishedWithMaxLevel;
+  get displayCongrats() {
+    return this.args.scorecard.isFinishedWithMaxLevel;
   }
 
-  get displayWaitSentence() {
-    return this.args.scorecard.remainingDaysBeforeReset > 0;
+  get displayRemainingPixToNextLevel() {
+    return this.args.scorecard.isProgressable;
+  }
+
+  get displayResetWaitSentence() {
+    return !this.args.scorecard.isResettable;
   }
 
   get displayResetButton() {
-    return this.args.scorecard.remainingDaysBeforeReset === 0;
-  }
-
-  get shouldWaitBeforeImproving() {
-    return this.args.scorecard.remainingDaysBeforeImproving > 0;
+    return this.args.scorecard.isResettable;
   }
 
   get tutorialsGroupedByTubeName() {

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -13,10 +13,6 @@ export default class ScorecardDetails extends Component {
 
   @tracked showResetModal = false;
 
-  get level() {
-    return this.args.scorecard.isNotStarted ? null : this.args.scorecard.level;
-  }
-
   get isProgressable() {
     return this.args.scorecard.isStarted && !this.args.scorecard.isMaxLevel;
   }

--- a/mon-pix/app/models/scorecard.js
+++ b/mon-pix/app/models/scorecard.js
@@ -43,8 +43,20 @@ export default class Scorecard extends Model {
     return this.level >= ENV.APP.MAX_REACHABLE_LEVEL;
   }
 
+  get isProgressable() {
+    return this.isStarted && !this.isMaxLevel;
+  }
+
   get isImprovable() {
     return this.isFinished && !this.isFinishedWithMaxLevel && this.remainingDaysBeforeImproving === 0;
+  }
+
+  get shouldWaitBeforeImproving() {
+    return this.isFinished && !this.isFinishedWithMaxLevel && this.remainingDaysBeforeImproving > 0;
+  }
+
+  get isResettable() {
+    return (this.isFinished || this.isStarted) && this.remainingDaysBeforeReset == 0;
   }
 
   get hasNotEarnAnything() {

--- a/mon-pix/tests/integration/components/scorecard-details_test.js
+++ b/mon-pix/tests/integration/components/scorecard-details_test.js
@@ -298,48 +298,6 @@ describe('Integration | Component | scorecard-details', function () {
           expect(findAll('.tube')).to.have.lengthOf(2);
           expect(findAll('.tutorial-card-v2')).to.have.lengthOf(3);
         });
-
-        context('when newTutorials FT is enabled', function () {
-          it('should display the tutorial section and related tutorials', async function () {
-            // given
-            const tuto1 = EmberObject.create({
-              title: 'Tuto 1.1',
-              tubeName: '@first_tube',
-              tubePracticalTitle: 'Practical Title',
-              duration: '00:15:10',
-            });
-            const tuto2 = EmberObject.create({
-              title: 'Tuto 2.1',
-              tubeName: '@second_tube',
-              tubePracticalTitle: 'Practical Title',
-              duration: '00:04:00',
-            });
-            const tuto3 = EmberObject.create({
-              title: 'Tuto 2.2',
-              tubeName: '@second_tube',
-              tubePracticalTitle: 'Practical Title',
-              duration: '00:04:00',
-            });
-
-            const tutorials = A([tuto1, tuto2, tuto3]);
-
-            const scorecard = EmberObject.create({
-              competenceId: 1,
-              isStarted: true,
-              tutorials,
-            });
-
-            this.set('scorecard', scorecard);
-
-            // when
-            await render(hbs`<ScorecardDetails @scorecard={{this.scorecard}} />`);
-
-            // then
-            expect(find('.tutorials')).to.exist;
-            expect(findAll('.tube')).to.have.lengthOf(2);
-            expect(findAll('.tutorial-card-v2')).to.have.lengthOf(3);
-          });
-        });
       });
     });
   });

--- a/mon-pix/tests/integration/components/scorecard-details_test.js
+++ b/mon-pix/tests/integration/components/scorecard-details_test.js
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 import { A } from '@ember/array';
-import { find, findAll, render } from '@ember/test-helpers';
+import { find, findAll } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
@@ -143,10 +144,10 @@ describe('Integration | Component | scorecard-details', function () {
 
         // when
         this.set('scorecard', scorecard);
-        await render(hbs`<ScorecardDetails @scorecard={{this.scorecard}} />`);
+        const screen = await render(hbs`<ScorecardDetails @scorecard={{this.scorecard}} />`);
 
         // then
-        expect(find('.scorecard-details__improve-button')).to.exist;
+        expect(screen.getByRole('button', this.intl.t('pages.competence-details.actions.improve.label'))).to.exist;
       });
 
       it('should show the improving countdown if the remaining days before improving are different than 0', async function () {
@@ -220,6 +221,7 @@ describe('Integration | Component | scorecard-details', function () {
         // given
         const store = this.owner.lookup('service:store');
         const scorecard = store.createRecord('scorecard', {
+          name: 'competence1',
           competenceId: 1,
           status: 'NOT_STARTED',
         });
@@ -227,12 +229,17 @@ describe('Integration | Component | scorecard-details', function () {
         this.set('scorecard', scorecard);
 
         // when
-        await render(hbs`<ScorecardDetails @scorecard={{this.scorecard}} />`);
+        const screen = await render(hbs`<ScorecardDetails @scorecard={{this.scorecard}} />`);
 
         // then
-        const element = find('.scorecard-details__resume-or-start-button');
-        expect(element).to.exist;
-        expect(element.textContent).to.contain('Commencer');
+        expect(
+          screen.getByRole('link', {
+            name: `${this.intl.t('pages.competence-details.actions.start.label')} ${this.intl.t(
+              'pages.competence-details.for-competence',
+              { competence: scorecard.name }
+            )}`,
+          })
+        ).to.exist;
       });
     });
 
@@ -241,6 +248,7 @@ describe('Integration | Component | scorecard-details', function () {
         // given
         const store = this.owner.lookup('service:store');
         const scorecard = store.createRecord('scorecard', {
+          name: 'competence1',
           competenceId: 1,
           status: 'STARTED',
         });
@@ -248,12 +256,17 @@ describe('Integration | Component | scorecard-details', function () {
         this.set('scorecard', scorecard);
 
         // when
-        await render(hbs`<ScorecardDetails @scorecard={{this.scorecard}} />`);
+        const screen = await render(hbs`<ScorecardDetails @scorecard={{this.scorecard}} />`);
 
         // then
-        const element = find('.scorecard-details__resume-or-start-button');
-        expect(element).to.exist;
-        expect(element.textContent).to.contain('Reprendre');
+        expect(
+          screen.getByRole('link', {
+            name: `${this.intl.t('pages.competence-details.actions.continue.label')} ${this.intl.t(
+              'pages.competence-details.for-competence',
+              { competence: scorecard.name }
+            )}`,
+          })
+        ).to.exist;
       });
 
       it('should not display the tutorial section when there is no tutorial to show', async function () {

--- a/mon-pix/tests/unit/components/scorecard-details_test.js
+++ b/mon-pix/tests/unit/components/scorecard-details_test.js
@@ -9,62 +9,6 @@ import createGlimmerComponent from '../../helpers/create-glimmer-component';
 describe('Unit | Component | scorecard-details ', function () {
   setupTest();
 
-  describe('#isProgressable', function () {
-    it('returns false if isMaxLevel', function () {
-      // when
-      const component = createGlimmerComponent('component:scorecard-details', { scorecard: { isMaxLevel: true } });
-
-      // then
-      expect(component.isProgressable).to.equal(false);
-    });
-
-    it('returns false if isNotStarted', function () {
-      // when
-      const component = createGlimmerComponent('component:scorecard-details', { scorecard: { isNotStarted: true } });
-
-      // then
-      expect(component.isProgressable).to.equal(false);
-    });
-
-    it('returns false if isFinished', function () {
-      // when
-      const component = createGlimmerComponent('component:scorecard-details', { scorecard: { isFinished: true } });
-
-      // then
-      expect(component.isProgressable).to.equal(false);
-    });
-
-    it('returns true otherwise', function () {
-      // when
-      const component = createGlimmerComponent('component:scorecard-details', { scorecard: {} });
-
-      // then
-      expect(component.isProgressable).to.equal(true);
-    });
-  });
-
-  describe('#canImprove', function () {
-    it('returns true if maxlevel not reached', function () {
-      // when
-      const component = createGlimmerComponent('component:scorecard-details', {
-        scorecard: { isFinishedWithMaxLevel: false },
-      });
-
-      // then
-      expect(component.canImprove).to.equal(true);
-    });
-
-    it('returns false if maxlevel reached', function () {
-      // when
-      const component = createGlimmerComponent('component:scorecard-details', {
-        scorecard: { isFinishedWithMaxLevel: true },
-      });
-
-      // then
-      expect(component.canImprove).to.equal(false);
-    });
-  });
-
   describe('#tutorialsGroupedByTubeName', function () {
     it('returns an array of tubes with related tutorials', function () {
       // given
@@ -161,38 +105,6 @@ describe('Unit | Component | scorecard-details ', function () {
 
       // then
       sinon.assert.calledWith(competenceEvaluation.improve, { userId, competenceId, scorecardId });
-    });
-  });
-
-  describe('#shouldWaitBeforeImproving', function () {
-    let component, scorecard;
-
-    beforeEach(() => {
-      const competenceId = 'recCompetenceId';
-      scorecard = EmberObject.create({ competenceId });
-      component = createGlimmerComponent('component:competence-card-default', { scorecard });
-    });
-
-    it('should return true when remaining days before improving are different than 0', () => {
-      // given
-      scorecard.remainingDaysBeforeImproving = 3;
-
-      // when
-      const result = component.shouldWaitBeforeImproving;
-
-      // then
-      expect(result).to.be.true;
-    });
-
-    it('should return false when remaining days before improving are equal to 0', () => {
-      // given
-      scorecard.remainingDaysBeforeImproving = 0;
-
-      // when
-      const result = component.shouldWaitBeforeImproving;
-
-      // then
-      expect(result).to.be.false;
     });
   });
 });

--- a/mon-pix/tests/unit/components/scorecard-details_test.js
+++ b/mon-pix/tests/unit/components/scorecard-details_test.js
@@ -9,24 +9,6 @@ import createGlimmerComponent from '../../helpers/create-glimmer-component';
 describe('Unit | Component | scorecard-details ', function () {
   setupTest();
 
-  describe('#level', function () {
-    it('returns null if the scorecard isNotStarted', function () {
-      // when
-      const component = createGlimmerComponent('component:scorecard-details', { scorecard: { isNotStarted: true } });
-
-      // then
-      expect(component.level).to.equal(null);
-    });
-
-    it('returns the level if the scorecard is not isNotStarted', function () {
-      // when
-      const component = createGlimmerComponent('component:scorecard-details', { scorecard: { level: 1 } });
-
-      // then
-      expect(component.level).to.equal(1);
-    });
-  });
-
   describe('#isProgressable', function () {
     it('returns false if isMaxLevel', function () {
       // when

--- a/mon-pix/tests/unit/models/scorecard_test.js
+++ b/mon-pix/tests/unit/models/scorecard_test.js
@@ -125,6 +125,64 @@ describe('Unit | Model | Scorecard model', function () {
     });
   });
 
+  describe('isProgressable', function () {
+    context('when the competence is finished', function () {
+      it('should return false', function () {
+        // given
+        scorecard.status = 'COMPLETED';
+
+        // when
+        const isProgressable = scorecard.isProgressable;
+
+        // then
+        expect(isProgressable).to.be.false;
+      });
+    });
+
+    context('when the competence is not started', function () {
+      it('should return false', function () {
+        // given
+        scorecard.status = 'NOT_STARTED';
+
+        // when
+        const isProgressable = scorecard.isProgressable;
+
+        // then
+        expect(isProgressable).to.be.false;
+      });
+    });
+
+    context('when the competence is started', function () {
+      context('and max level is reached', function () {
+        it('should return false', function () {
+          // given
+          scorecard.level = maxReachableLevel;
+          scorecard.status = 'STARTED';
+
+          // when
+          const isProgressable = scorecard.isProgressable;
+
+          // then
+          expect(isProgressable).to.be.false;
+        });
+      });
+
+      context('when max level is not reached', function () {
+        it('should return true', function () {
+          // given
+          scorecard.level = 1;
+          scorecard.status = 'STARTED';
+
+          // when
+          const isProgressable = scorecard.isProgressable;
+
+          // then
+          expect(isProgressable).to.be.true;
+        });
+      });
+    });
+  });
+
   describe('isImprovable', function () {
     context('when the competence is finished with max level', function () {
       it('should return false', function () {
@@ -188,6 +246,158 @@ describe('Unit | Model | Scorecard model', function () {
         });
       }
     );
+  });
+
+  describe('shouldWaitBeforeImproving', function () {
+    context('when the competence is not started', function () {
+      it('should return false', function () {
+        // given
+        scorecard.status = 'NOT_STARTED';
+
+        // when
+        const shouldWaitBeforeImproving = scorecard.shouldWaitBeforeImproving;
+
+        // then
+        expect(shouldWaitBeforeImproving).to.be.false;
+      });
+    });
+
+    context('when the competence is started', function () {
+      it('should return false', function () {
+        // given
+        scorecard.status = 'STARTED';
+
+        // when
+        const shouldWaitBeforeImproving = scorecard.shouldWaitBeforeImproving;
+
+        // then
+        expect(shouldWaitBeforeImproving).to.be.false;
+      });
+    });
+
+    context('when the competence is finished', function () {
+      beforeEach(function () {
+        scorecard.status = 'COMPLETED';
+      });
+
+      context('when the max level is reached', function () {
+        it('should return false', function () {
+          // given
+          scorecard.level = maxReachableLevel;
+
+          // when
+          const shouldWaitBeforeImproving = scorecard.shouldWaitBeforeImproving;
+
+          // then
+          expect(shouldWaitBeforeImproving).to.be.false;
+        });
+      });
+
+      context('when the max level is not reached', function () {
+        context('when there are remaining days before improving', function () {
+          it('should return true', function () {
+            // given
+            scorecard.level = 2;
+            scorecard.remainingDaysBeforeImproving = 1;
+
+            // when
+            const shouldWaitBeforeImproving = scorecard.shouldWaitBeforeImproving;
+
+            // then
+            expect(shouldWaitBeforeImproving).to.be.true;
+          });
+        });
+
+        context('when there are no remaining days before improving', function () {
+          it('should return false', function () {
+            // given
+            scorecard.level = 2;
+            scorecard.remainingDaysBeforeImproving = 0;
+
+            // when
+            const shouldWaitBeforeImproving = scorecard.shouldWaitBeforeImproving;
+
+            // then
+            expect(shouldWaitBeforeImproving).to.be.false;
+          });
+        });
+      });
+    });
+  });
+
+  describe('isResettable', function () {
+    context('when the competence is not started', function () {
+      it('should return false', function () {
+        // given
+        scorecard.status = 'NOT_STARTED';
+
+        // when
+        const isResettable = scorecard.isResettable;
+
+        // then
+        expect(isResettable).to.be.false;
+      });
+    });
+
+    context('when the competence is started', function () {
+      context('when there are remaining days before reset', function () {
+        it('should return false', function () {
+          // given
+          scorecard.status = 'STARTED';
+          scorecard.remainingDaysBeforeReset = 2;
+
+          // when
+          const isResettable = scorecard.isResettable;
+
+          // then
+          expect(isResettable).to.be.false;
+        });
+      });
+
+      context('when there are no remaining days before reset', function () {
+        it('should return true', function () {
+          // given
+          scorecard.status = 'STARTED';
+          scorecard.remainingDaysBeforeReset = 0;
+
+          // when
+          const isResettable = scorecard.isResettable;
+
+          // then
+          expect(isResettable).to.be.true;
+        });
+      });
+    });
+
+    context('when the competence is finished', function () {
+      context('when there are remaining days before reset', function () {
+        it('should return true', function () {
+          // given
+          scorecard.status = 'COMPLETED';
+          scorecard.remainingDaysBeforeReset = 1;
+
+          // when
+          const isResettable = scorecard.isResettable;
+
+          // then
+          expect(isResettable).to.be.false;
+        });
+      });
+
+      context('when there are no remaining days before reset', function () {
+        it('should return false', function () {
+          // given
+          scorecard.status = 'COMPLETED';
+          scorecard.remainingDaysBeforeReset = 0;
+
+          // when
+          const isResettable = scorecard.isResettable;
+
+          // then
+          expect(isResettable).to.be.true;
+        });
+      });
+    });
   });
 
   describe('hasNotEarnAnything', function () {


### PR DESCRIPTION
## :christmas_tree: Problème
Pour améliorer l'accessibilité du composant `scorecard-details` sur Pix App, nous devons ajouter une liste autour des boutons. Cependant, ces derniers sont conditionnés. 

## :gift: Proposition
Améliorer la lisibilité du composant en duplicant du code quand cela est nécessaire. 

## :star2: Remarques
 Les tests sur un FT plus existant ont été supprimé.
Au préalable, les tests ont été modifié pour désormais  : 
- utiliser des models d'Ember Data afin d'utiliser leurs `getter` 
- utiliser`ember-testing-library`.

La suite pourrait être de supprimer les getter de scorecard et que l'API nous retourne ces champs, car il s'agit du domain. De plus, cela nous éviterait d'avoir des variables d'environnement dans le front. 

## :santa: Pour tester
- Se connecter sur Pix App 

### Compétence non débuté
- Afficher le détail d'une compétence non débuté 
- Constater qu'il y a uniquement le bouton "Commencer" 

![before-after-not-started](https://user-images.githubusercontent.com/26384707/200001426-3b41a48a-f35d-47e5-8889-06c38b3580aa.png)


###  Compétence commencé

##### A passé la compétence depuis plus de 5 jours 
- Cercle de progression 
- Bouton "Reprendre"
- Bouton "Remise à 0"

![before-after-started-w-raz](https://user-images.githubusercontent.com/26384707/200001828-f5eacd25-e472-4f74-9827-1781dc2ed86f.png)

##### A passé la compétence depuis moins de 5 jours 
- Cercle de progression 
- Bouton "Reprendre"
- Phrase : avant de pouvoir remettre à 0

![before-after-started-wo-raz](https://user-images.githubusercontent.com/26384707/200001684-e98b0f40-eb81-4e78-ab76-acaa0b240a0c.png)

### Compétence terminé 

#### Niveau Max obtenu 

##### A passé la compétence depuis plus de 5 jours 
- Les lauriers sont affichés 
- Uniquement le bouton Remettre à 0

![before-after-completed-w-raz](https://user-images.githubusercontent.com/26384707/200003220-67f0bac3-e4ac-47fd-a0ab-b2b9988d87f1.png)

##### A passé la compétence depuis moins de 5 jours 
- Les lauriers sont affichés 
- Pas de bouton MAIS phrase avant de pouvoir remettre à 0

![before-after-completed-wo-raz](https://user-images.githubusercontent.com/26384707/200003615-75a2b62d-3724-4121-a734-5dd5877b2e42.png)

#### PAS niveau Max 

##### A passé la compétence depuis plus de 5 jours 
- Cercle de progression
- Bouton "Retenter"
- Bouton "Remettre à 0"

![before-after-completed-wo-max-w-raz](https://user-images.githubusercontent.com/26384707/200007002-41c79e3b-4bab-4cdd-988f-518c0d66dcdc.png)


##### A passé la compétence depuis moins de 5 jours 
- Cercle de progression
- Pas de bouton "retenter" MAIS phrase avant de pouvoir retenter
- Pas de bouton "Remise à 0" MAIS phrase avant de pouvoir remettre à 0

![before-after-completed-wo-max-wo-raz](https://user-images.githubusercontent.com/26384707/200007008-2d3e2376-61d8-4bce-a88b-e289dfea8b77.png)
