### PR TITLE
[BUGFIX] Chercher l'identifiant sans la casse sur Pix App (PIX-6232)

### DIFF
--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -40,7 +40,9 @@ module.exports = {
   },
 
   getByUsernameOrEmailWithRolesAndPassword(username) {
-    return BookshelfUser.query((qb) => qb.where({ email: username.toLowerCase() }).orWhere({ username: username }))
+    return BookshelfUser.query((qb) =>
+      qb.where({ email: username.toLowerCase() }).orWhere({ username: username.toLowerCase() })
+    )
       .fetch({
         require: false,
         withRelated: [

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -352,21 +352,27 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
         expect(foundUser.email).to.equal(expectedUser.email);
       });
 
-      it('should return user informations for the given username', async function () {
+      it('should return user informations for the given username (case insensitive)', async function () {
         // given
-        const expectedUser = new User(userInDB);
+        const savedUser = databaseBuilder.factory.buildUser({
+          username: 'thomas123',
+          firstName: 'Thomas',
+          lastName: 'Dupont',
+          cgu: true,
+        });
+        await databaseBuilder.commit();
 
         // when
-        const foundUser = await userRepository.getByUsernameOrEmailWithRolesAndPassword(userInDB.username);
+        const foundUser = await userRepository.getByUsernameOrEmailWithRolesAndPassword('thOMas123');
 
         // then
         expect(foundUser).to.be.an.instanceof(User);
-        expect(foundUser.id).to.equal(expectedUser.id);
-        expect(foundUser.firstName).to.equal(expectedUser.firstName);
-        expect(foundUser.lastName).to.equal(expectedUser.lastName);
-        expect(foundUser.username).to.equal(expectedUser.username);
-        expect(foundUser.email).to.equal(expectedUser.email);
-        expect(foundUser.cgu).to.equal(expectedUser.cgu);
+        expect(foundUser.id).to.equal(savedUser.id);
+        expect(foundUser.firstName).to.equal(savedUser.firstName);
+        expect(foundUser.lastName).to.equal(savedUser.lastName);
+        expect(foundUser.username).to.equal(savedUser.username);
+        expect(foundUser.email).to.equal(savedUser.email);
+        expect(foundUser.cgu).to.equal(savedUser.cgu);
       });
 
       it('should return authenticationMethods associated to the user', async function () {


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsqu'un utilisateur se connecte en mettant son usename en majuscule il n'arrive pas à se connecter même si son username correspond à celui en bdd en minscule. 
On ne devrait pas faire de distinction entre les majuscules et minuscules lors de la recherche de cet utilisateur.

## :gift: Proposition
Rendre non sensible à la casse la recherche du username.

## :star2: Remarques
Normalement en BDD tous les usenames sont en minuscule. (voir https://github.com/1024pix/pix/pull/934/files#r362219417) 

## :santa: Pour tester
- Essayer de se connecter à Pix App avec un username existant mais en rajoutant des majuscules (ex: `geoRGe.decambridge2207`)
- Constater qu'il n'y a pas d'erreur et que vous êtes connectés 
