### PR TITLE
[BUGFIX] Correction de l'affichage des RT certifiants de fin de parcours (PIX-6231).

### DIFF
--- a/mon-pix/app/styles/components/_badge-card-certifiable.scss
+++ b/mon-pix/app/styles/components/_badge-card-certifiable.scss
@@ -10,10 +10,10 @@
   background-color: $pix-success-5;
   border-radius: 16px;
   display: flex;
-  flex-basis: 100%;
+  flex-grow: 1;
   flex-direction: column;
   justify-content: center;
-  margin-bottom: 16px;
+  margin-bottom: 20px;
   padding: 20px 35px;
 
   &--not-acquired {
@@ -31,6 +31,16 @@
   }
 
   @include device-is('tablet') {
-    flex-basis: calc(50% - 10px);
+    height: 253px;
+    flex-grow: 0;
+    width: calc(50% - 10px);
+
+    &:nth-child(even) {
+      margin-left: 20px;
+    }
+
+    &:first-child:last-child {
+      width: 100%;
+    }
   }
 }

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -360,7 +360,7 @@
   }
 
   &__share-container {
-    padding: 16px 40px 32px 40px;
+    padding: 16px 40px 0 40px;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -442,6 +442,7 @@
   }
 
   &__legal {
+    margin: 4px 0;
     font-family: $font-roboto;
     font-size: 0.85rem;
     color: $pix-neutral-45;
@@ -577,6 +578,10 @@
     font-weight: $font-normal;
     color: $pix-neutral-45;
     line-height: 1.8rem;
+
+    & p {
+      margin: 0;
+    }
   }
 }
 

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -502,7 +502,7 @@
   border-radius: 16px;
 
   &__image {
-    max-width: 70px;
+    max-width: 50px;
     margin: 8px 0 8px 10px;
 
     &:last-child {


### PR DESCRIPTION
## :christmas_tree: Problème

Sur la page de fin de parcours dans Pix App, le RT certifiant s’affiche dans un encadré vert qui prend la moitié de la largeur de la page. Or celui-ci devrait prendre la largeur entière de la page s'il est seul sur la ligne. 

![index](https://user-images.githubusercontent.com/36371437/200154466-69cdff7a-4487-49d5-b689-da26d5962d4b.png)

## :gift: Proposition

Modification du style.

![index](https://user-images.githubusercontent.com/36371437/200154538-027da7f5-86e5-4df8-81a2-22a4b5acb95b.png)

## :star2: Remarques

D'autres petits correctifs de padding et margin ont également été apportés sur cette page afin de correspondre davantage aux maquettes fournies. (voir [ici](https://www.figma.com/file/y6p1FS5HKhJkMLrJN4i90P/Pix-App?node-id=1983%3A24971))

## :santa: Pour tester

Dans `mon-pix`, se connecter avec le compte : `Email: tata@example.net / MDP: Qsdfghj+1`
Aller sur la page de fin du parcours entamé.
Vérifier que le rendu corresponde aux maquettes fournies dans l'ensemble des formats.

(Pour vérifier que l'affichage soit correct avec plusieurs RT certifiants, dupliquer le noeud dans le DOM)
