### PR TITLE
[TECH] Corriger le nom de la constante de l'url redis dans un test

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -229,9 +229,6 @@ module.exports = (function () {
       logoutUrl: process.env.POLE_EMPLOI_OIDC_LOGOUT_URL,
       afterLogoutUrl: process.env.POLE_EMPLOI_OIDC_AFTER_LOGOUT_URL,
       temporaryStorage: {
-        expirationDelaySeconds:
-          parseInt(process.env.POLE_EMPLOI_TEMPORARY_STORAGE_EXPIRATION_DELAY_SECONDS, 10) || 1140,
-        redisUrl: process.env.REDIS_URL,
         idTokenLifespanMs: ms(process.env.POLE_EMPLOI_ID_TOKEN_LIFESPAN || '7d'),
       },
       poleEmploiSendingsLimit: _getNumber(process.env.POLE_EMPLOI_SENDING_LIMIT, 100),

--- a/api/lib/infrastructure/temporary-storage/index.js
+++ b/api/lib/infrastructure/temporary-storage/index.js
@@ -1,5 +1,5 @@
 const settings = require('../../config');
-const REDIS_URL = settings.poleEmploi.temporaryStorage.redisUrl;
+const REDIS_URL = settings.temporaryStorage.redisUrl;
 
 const InMemoryTemporaryStorage = require('./InMemoryTemporaryStorage');
 const RedisTemporaryStorage = require('./RedisTemporaryStorage');

--- a/api/tests/integration/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
+++ b/api/tests/integration/infrastructure/temporary-storage/RedisTemporaryStorage_test.js
@@ -1,17 +1,19 @@
 const { v4: uuidv4 } = require('uuid');
 const RedisTemporaryStorage = require('../../../../lib/infrastructure/temporary-storage/RedisTemporaryStorage');
 const { expect } = require('../../../test-helper');
+const settings = require('../../../../lib/config');
+const REDIS_URL = settings.redis.url;
 
 describe('Integration | Infrastructure | TemporaryStorage | RedisTemporaryStorage', function () {
   // this check is used to prevent failure when redis is not setup
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  if (process.env.REDIS_TEST_URL !== undefined) {
+
+  if (REDIS_URL !== undefined) {
     describe('#set', function () {
       it('should set new value', async function () {
         // given
         const TWO_MINUTES_IN_SECONDS = 2 * 60;
         const value = { url: 'url' };
-        const storage = new RedisTemporaryStorage(process.env.REDIS_TEST_URL);
+        const storage = new RedisTemporaryStorage(REDIS_URL);
         const key = await storage.save({ value: 'c', expirationDelaySeconds: TWO_MINUTES_IN_SECONDS });
 
         // when
@@ -29,7 +31,7 @@ describe('Integration | Infrastructure | TemporaryStorage | RedisTemporaryStorag
       it('should add an expiration time to the list', async function () {
         // given
         const key = uuidv4();
-        const storage = new RedisTemporaryStorage(process.env.REDIS_TEST_URL);
+        const storage = new RedisTemporaryStorage(REDIS_URL);
 
         // when
         await storage.lpush(key, 'value');
@@ -47,7 +49,7 @@ describe('Integration | Infrastructure | TemporaryStorage | RedisTemporaryStorag
       it('should retrieve the remaining expiration time from a list', async function () {
         // given
         const key = uuidv4();
-        const storage = new RedisTemporaryStorage(process.env.REDIS_TEST_URL);
+        const storage = new RedisTemporaryStorage(REDIS_URL);
 
         // when
         await storage.lpush(key, 'value');
@@ -63,7 +65,7 @@ describe('Integration | Infrastructure | TemporaryStorage | RedisTemporaryStorag
       it('should add a value to a list and return the length of the list', async function () {
         // given
         const key = uuidv4();
-        const storage = new RedisTemporaryStorage(process.env.REDIS_TEST_URL);
+        const storage = new RedisTemporaryStorage(REDIS_URL);
 
         // when
         const length = await storage.lpush(key, 'value');
@@ -78,7 +80,7 @@ describe('Integration | Infrastructure | TemporaryStorage | RedisTemporaryStorag
       it('should remove a value from a list and return the number of removed elements', async function () {
         // given
         const key = uuidv4();
-        const storage = new RedisTemporaryStorage(process.env.REDIS_TEST_URL);
+        const storage = new RedisTemporaryStorage(REDIS_URL);
 
         await storage.lpush(key, 'value1');
         await storage.lpush(key, 'value1');
@@ -97,7 +99,7 @@ describe('Integration | Infrastructure | TemporaryStorage | RedisTemporaryStorag
       it('should return a list of values', async function () {
         // given
         const key = uuidv4();
-        const storage = new RedisTemporaryStorage(process.env.REDIS_TEST_URL);
+        const storage = new RedisTemporaryStorage(REDIS_URL);
 
         // when
         await storage.lpush(key, 'value1');


### PR DESCRIPTION
## :christmas_tree: Problème
Dans le test nous utilisons une constante nommée `REDIS_TEST_URL`. Or, cette dernière n'est déclarée ni utilisée nulle part, la constante qui correspond s'appelle en réalité `TEST_REDIS_URL`.

## :gift: Proposition
Corriger le nommage.

## :star2: Remarques
Un deuxième commit a été rajouté pour récupérer la REDIS_URL depuis la constante temporaryStorage.redisUrl (constante qui existe déjà dans `config.js`). En effet, historiquement le temporaryStorage a été introduit pour l'interconnexion à pole emploi, cependant aujourd'hui il nous sert à une utilisation plus large (notamment pour les tokens des utilisateurs).  

## :santa: Pour tester
Vérifier que la CI passe.
