### PR TITLE
[FEATURE] Permet la configuration du nombre minimum de connexion ouvertes

### DIFF
--- a/api/db/knexfile.js
+++ b/api/db/knexfile.js
@@ -28,7 +28,7 @@ module.exports = {
     client: 'postgresql',
     connection: process.env.DATABASE_URL,
     pool: {
-      min: 1,
+      min: parseInt(process.env.DATABASE_CONNECTION_POOL_MIN_SIZE, 10) || 1,
       max: parseInt(process.env.DATABASE_CONNECTION_POOL_MAX_SIZE, 10) || 4,
     },
     migrations: {

--- a/api/lib/infrastructure/validate-environment-variables.js
+++ b/api/lib/infrastructure/validate-environment-variables.js
@@ -6,6 +6,7 @@ const schema = Joi.object({
   TEST_DATABASE_URL: Joi.string().optional(),
   KNEX_ASYNC_STACKTRACE_ENABLED: Joi.string().optional().valid('true', 'false'),
   DATABASE_CONNECTION_POOL_MAX_SIZE: Joi.number().integer().min(0).optional(),
+  DATABASE_CONNECTION_POOL_MIN_SIZE: Joi.number().integer().min(0).optional(),
   MAILING_ENABLED: Joi.string().optional().valid('true', 'false'),
   MAILING_PROVIDER: Joi.string().optional().valid('sendinblue'),
   SENDINBLUE_API_KEY: Joi.string().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -83,6 +83,16 @@ TEST_DATABASE_URL=postgresql://postgres@localhost/pix_test
 # sample: DATABASE_CONNECTION_POOL_MAX_SIZE=10
 # DATABASE_CONNECTION_POOL_MAX_SIZE=
 
+
+# Minimum connection pool size
+# https://knexjs.org/#Installation-pooling
+#
+# presence: optional
+# type: positive integer
+# default: 1
+# sample: DATABASE_CONNECTION_POOL_MIN_SIZE=2
+# DATABASE_CONNECTION_POOL_MIN_SIZE=
+
 # Capture stack trace for all query builders, raw queries and schema builders
 # This has small performance overhead, so it is advised to use only for development.
 # https://knexjs.org/#Installation-pooling


### PR DESCRIPTION
## :christmas_tree: Problème
Le nombre minimum de connexion ouverte a postgres est de 1. Le nombre max est paramétrable. Avec le nombre de requêtes HTTP qui varie beaucoup, nous pouvons avoir des requêtes SQL en attente d'une manière intempestive parce que le seuil est vraiment trop bas.

## :gift: Proposition
Permettre la configuration du nombre minimal de connexions ouvertes.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
1. Activer les logs ops: `LOG_OPS_METRICS=true`
2. Mettre la variable d'environnement `DATABASE_CONNECTION_POOL_MIN_SIZE=2`
3. Regarder les logs ops et vérifier que knexPool.free est a 2. similaire a `knexPool":{"used":0,"free":2,"pendingAcquires":0,"pendingCreates":0}`