### PR TITLE
[FEATURE] Supprimer la notion de "v2" dans les tutoriels sur Pix-App (PIX-6102)

### DIFF
--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -1,16 +1,16 @@
 <li>
-  <article class="tutorial-card-v2" role="article">
-    <div class="tutorial-card-v2__content">
+  <article class="tutorial-card" role="article">
+    <div class="tutorial-card__content">
       <a
         target="_blank"
         rel="noopener noreferrer"
         href="{{@tutorial.link}}"
-        class="tutorial-card-v2-content__link"
+        class="tutorial-card-content__link"
         title="{{@tutorial.title}}"
       >
         {{@tutorial.title}}
       </a>
-      <p class="tutorial-card-v2-content__details">
+      <p class="tutorial-card-content__details">
         {{@tutorial.source}}
         •
         {{@tutorial.format}}
@@ -18,7 +18,7 @@
         {{moment-duration @tutorial.duration}}
       </p>
       {{#if this.shouldShowActions}}
-        <ul class="tutorial-card-v2-content__actions">
+        <ul class="tutorial-card-content__actions">
           <li>
             <ActionChip
               @title={{this.evaluateInformation}}

--- a/mon-pix/app/components/tutorials/cards.hbs
+++ b/mon-pix/app/components/tutorials/cards.hbs
@@ -1,4 +1,4 @@
-<ul class="user-tutorials-content-v2__cards">
+<ul class="user-tutorials-content__cards">
   {{#each @tutorials as |tutorial|}}
     <Tutorials::Card @tutorial={{tutorial}} @afterRemove={{@afterRemove}} />
   {{/each}}

--- a/mon-pix/app/components/tutorials/header.hbs
+++ b/mon-pix/app/components/tutorials/header.hbs
@@ -1,23 +1,23 @@
 <div class="background-banner-v2">
-  <div class="user-tutorials-banner-v2">
-    <h1 class="user-tutorials-banner-v2__title">{{t "pages.user-tutorials.title"}}</h1>
-    <p class="user-tutorials-banner-v2__description">
+  <div class="user-tutorials-banner">
+    <h1 class="user-tutorials-banner__title">{{t "pages.user-tutorials.title"}}</h1>
+    <p class="user-tutorials-banner__description">
       {{t "pages.user-tutorials.description"}}
     </p>
 
-    <ul class="user-tutorials-banner-v2__filters">
-      <li class="user-tutorials-banner-v2-filters__filter">
+    <ul class="user-tutorials-banner__filters">
+      <li class="user-tutorials-banner-filters__filter">
         <ChoiceChip @route="authenticated.user-tutorials.recommended">
           {{t "pages.user-tutorials.recommended"}}
         </ChoiceChip>
       </li>
-      <li class="user-tutorials-banner-v2-filters__filter">
+      <li class="user-tutorials-banner-filters__filter">
         <ChoiceChip @route="authenticated.user-tutorials.saved">
           {{t "pages.user-tutorials.saved"}}
         </ChoiceChip>
       </li>
       {{#if @shouldShowFilterButton}}
-        <li class="user-tutorials-banner-v2-filters__filter">
+        <li class="user-tutorials-banner-filters__filter">
           <PixButton
             @backgroundColor="transparent-light"
             @isBorderVisible={{false}}

--- a/mon-pix/app/components/tutorials/recommended-empty.hbs
+++ b/mon-pix/app/components/tutorials/recommended-empty.hbs
@@ -1,12 +1,12 @@
-<div class="user-tutorials-content-v2__recommended-empty">
+<div class="user-tutorials-content__recommended-empty">
   <div>
-    <h2 class="user-tutorials-recommended-empty-v2__title">
+    <h2 class="user-tutorials-recommended-empty__title">
       {{t "pages.user-tutorials.recommended-empty.title" firstName=this.currentUser.user.firstName}}
     </h2>
-    <p class="user-tutorials-recommended-empty-v2__description">
+    <p class="user-tutorials-recommended-empty__description">
       {{t "pages.user-tutorials.recommended-empty.description"}}
     </p>
-    <PixButtonLink @route="authenticated.profile" class="user-tutorials-recommended-empty-v2__link">
+    <PixButtonLink @route="authenticated.profile" class="user-tutorials-recommended-empty__link">
       {{t "pages.user-tutorials.recommended-empty.link"}}
     </PixButtonLink>
   </div>

--- a/mon-pix/app/components/tutorials/saved-empty.hbs
+++ b/mon-pix/app/components/tutorials/saved-empty.hbs
@@ -1,9 +1,9 @@
-<div class="user-tutorials-content-v2__saved-empty">
+<div class="user-tutorials-content__saved-empty">
   <div>
-    <h2 class="user-tutorials-saved-empty-v2__title">
+    <h2 class="user-tutorials-saved-empty__title">
       {{t "pages.user-tutorials.saved-empty.title"}}
     </h2>
-    <p class="user-tutorials-saved-empty-v2__description">
+    <p class="user-tutorials-saved-empty__description">
       {{t "pages.user-tutorials.saved-empty.description"}}
     </p>
   </div>

--- a/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
@@ -12,7 +12,7 @@
     margin: 25px 40px;
   }
 
-  & .tutorial-card-v2 {
+  & .tutorial-card {
     margin-bottom: 16px;
   }
 }

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -40,7 +40,7 @@
     margin: 0;
     padding: 0;
 
-    & .tutorial-card-v2 {
+    & .tutorial-card {
       margin-bottom: 16px;
     }
   }

--- a/mon-pix/app/styles/components/_tutorial-card.scss
+++ b/mon-pix/app/styles/components/_tutorial-card.scss
@@ -1,4 +1,4 @@
-.tutorial-card-v2 {
+.tutorial-card {
   display: flex;
   min-height: 170px;
   background: $pix-neutral-0;
@@ -14,7 +14,7 @@
   }
 }
 
-.tutorial-card-v2-content {
+.tutorial-card-content {
 
   &__link {
     display: -webkit-box;

--- a/mon-pix/app/styles/components/_tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_tutorial-panel.scss
@@ -35,7 +35,7 @@
   display: flex;
   flex-direction: column;
 
-  & .tutorial-card-v2 {
+  & .tutorial-card {
     margin-bottom: 16px;
   }
 }

--- a/mon-pix/app/styles/pages/_user-tutorials.scss
+++ b/mon-pix/app/styles/pages/_user-tutorials.scss
@@ -1,57 +1,4 @@
 .user-tutorials-banner {
-  position: relative;
-  max-width: 980px;
-  margin: auto;
-  font-family: $font-roboto;
-  font-weight: $font-light;
-  height: 270px;
-  padding: 0 20px;
-  text-align: center;
-
-  @include device-is('tablet') {
-    text-align: left;
-  }
-
-  @include device-is('desktop') {
-    padding: 0;
-  }
-
-  &__icon {
-    display: none;
-
-    @include device-is('tablet') {
-      position: absolute;
-      display: block;
-      bottom: 0;
-      right: 50px;
-    }
-
-    @include device-is('desktop') {
-      right: 70px;
-    }
-  }
-
-  &__title {
-    margin: 0 0 8px;
-    padding-top: 64px;
-    font-size: 3rem;
-    color: $pix-neutral-0;
-  }
-
-  &__description {
-    font-size: 1rem;
-    margin: auto;
-    line-height: 1.688rem;
-    letter-spacing: 0.15px;
-    max-width: 440px;
-
-    @include device-is('tablet') {
-      margin: 0;
-    }
-  }
-}
-
-.user-tutorials-banner-v2 {
   margin: 0 24px;
   font-family: $font-roboto;
   font-weight: $font-light;
@@ -95,7 +42,7 @@
   }
 }
 
-.user-tutorials-content-v2 {
+.user-tutorials-content {
   padding-top: 20px;
   width: 100%;
   min-height: inherit;
@@ -149,8 +96,8 @@
   }
 }
 
-.user-tutorials-saved-empty-v2,
-.user-tutorials-recommended-empty-v2 {
+.user-tutorials-saved-empty,
+.user-tutorials-recommended-empty {
 
   &__title,
   &__description {
@@ -168,21 +115,6 @@
 
   &__link {
     display: inline-flex;
-  }
-}
-
-.user-tutorials-content {
-  max-width: 980px;
-  margin: 24px auto;
-  padding: 0 32px;
-  color: $pix-neutral-90;
-
-  @include device-is('tablet') {
-    padding: 40px 0;
-  }
-
-  &__title {
-    margin: 0 0 32px;
   }
 }
 

--- a/mon-pix/app/templates/authenticated/user-tutorials/recommended.hbs
+++ b/mon-pix/app/templates/authenticated/user-tutorials/recommended.hbs
@@ -10,9 +10,9 @@
     @areas={{this.model.areas}}
     @onClose={{this.closeSidebar}}
   />
-  <div class="user-tutorials-content-v2">
+  <div class="user-tutorials-content">
     {{#if @model.recommendedTutorials.meta.pagination.rowCount}}
-      <div class="user-tutorials-content-v2__container">
+      <div class="user-tutorials-content__container">
         <Tutorials::Cards @tutorials={{@model.recommendedTutorials}} />
         <PixPagination
           @pagination={{@model.recommendedTutorials.meta.pagination}}

--- a/mon-pix/app/templates/authenticated/user-tutorials/saved.hbs
+++ b/mon-pix/app/templates/authenticated/user-tutorials/saved.hbs
@@ -4,9 +4,9 @@
 </header>
 
 <main id="main" class="main" role="main">
-  <div class="user-tutorials-content-v2">
+  <div class="user-tutorials-content">
     {{#if @model.savedTutorials.meta.pagination.rowCount}}
-      <div class="user-tutorials-content-v2__container">
+      <div class="user-tutorials-content__container">
         <Tutorials::Cards @tutorials={{@model.savedTutorials}} @afterRemove={{this.refresh}} />
         <PixPagination
           @pagination={{@model.savedTutorials.meta.pagination}}

--- a/mon-pix/tests/acceptance/challenge-item-qcm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcm_test.js
@@ -153,8 +153,8 @@ describe('Acceptance | Displaying a QCM challenge', () => {
 
       expect(find('.tutorial-panel__hint-container').textContent).to.contains(correction.hint);
 
-      const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card-v2')[0];
-      const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-card-v2')[0];
+      const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card')[0];
+      const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-card')[0];
 
       expect(tutorialToSuccess.textContent).to.contains(tutorial.title);
       expect(tutorialToLearnMore.textContent).to.contains(learningMoreTutorial.title);

--- a/mon-pix/tests/acceptance/challenge-item-qcu_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcu_test.js
@@ -154,8 +154,8 @@ describe('Acceptance | Displaying a QCU challenge', () => {
 
       expect(find('.tutorial-panel__hint-container').textContent).to.contains(correction.hint);
 
-      const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card-v2')[0];
-      const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-card-v2')[0];
+      const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card')[0];
+      const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-card')[0];
 
       expect(tutorialToSuccess.textContent).to.contains(tutorial.title);
       expect(tutorialToLearnMore.textContent).to.contains(learningMoreTutorial.title);

--- a/mon-pix/tests/acceptance/challenge-item-qroc_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qroc_test.js
@@ -211,8 +211,8 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         expect(find('.tutorial-panel__hint-container').textContent).to.contains(correction.hint);
 
-        const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card-v2')[0];
-        const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-card-v2')[0];
+        const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card')[0];
+        const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-card')[0];
 
         expect(tutorialToSuccess.textContent).to.contains(tutorial.title);
         expect(tutorialToLearnMore.textContent).to.contains(learningMoreTutorial.title);
@@ -364,8 +364,8 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         expect(find('.tutorial-panel__hint-container').textContent).to.contains(correction.hint);
 
-        const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card-v2')[0];
-        const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-card-v2')[0];
+        const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card')[0];
+        const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-card')[0];
 
         expect(tutorialToSuccess.textContent).to.contains(tutorial.title);
         expect(tutorialToLearnMore.textContent).to.contains(learningMoreTutorial.title);
@@ -473,8 +473,8 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         expect(find('.tutorial-panel__hint-container').textContent).to.contains(correction.hint);
 
-        const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card-v2')[0];
-        const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-card-v2')[0];
+        const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card')[0];
+        const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-card')[0];
 
         expect(tutorialToSuccess.textContent).to.contains(tutorial.title);
         expect(tutorialToLearnMore.textContent).to.contains(learningMoreTutorial.title);

--- a/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
@@ -273,8 +273,8 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
 
       expect(find('.tutorial-panel__hint-container').textContent).to.contains(correctionDep.hint);
 
-      const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card-v2')[0];
-      const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-card-v2')[0];
+      const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card')[0];
+      const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-card')[0];
 
       expect(tutorialToSuccess.textContent).to.contains(tutorial.title);
       expect(tutorialToLearnMore.textContent).to.contains(learningMoreTutorial.title);
@@ -300,8 +300,8 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
 
       expect(find('.tutorial-panel__hint-container').textContent).to.contains(correctionDep.hint);
 
-      const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card-v2')[0];
-      const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-card-v2')[0];
+      const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card')[0];
+      const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-card')[0];
 
       expect(tutorialToSuccess.textContent).to.contains(tutorial.title);
       expect(tutorialToLearnMore.textContent).to.contains(learningMoreTutorial.title);
@@ -327,8 +327,8 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
 
       expect(find('.tutorial-panel__hint-container').textContent).to.contains(correctionIndSelect.hint);
 
-      const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card-v2')[0];
-      const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-card-v2')[0];
+      const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card')[0];
+      const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-card')[0];
 
       expect(tutorialToSuccess.textContent).to.contains(tutorial.title);
       expect(tutorialToLearnMore.textContent).to.contains(learningMoreTutorial.title);

--- a/mon-pix/tests/acceptance/competences-details_test.js
+++ b/mon-pix/tests/acceptance/competences-details_test.js
@@ -125,7 +125,7 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
         await visit(`/competences/${scorecardWithPoints.competenceId}/details`);
 
         // then
-        expect(findAll('.tutorial-card-v2')).to.have.lengthOf(nbTutos);
+        expect(findAll('.tutorial-card')).to.have.lengthOf(nbTutos);
       });
 
       context('when it has remaining some days before reset', () => {

--- a/mon-pix/tests/acceptance/tutorial-actions_test.js
+++ b/mon-pix/tests/acceptance/tutorial-actions_test.js
@@ -29,7 +29,7 @@ describe('Acceptance | Tutorial | Actions', function () {
   describe('Authenticated cases as simple user', function () {
     it('should display tutorial item in competence page with actions', async function () {
       // then
-      expect(find('.tutorial-card-v2')).to.exist;
+      expect(find('.tutorial-card')).to.exist;
       expect(find('[aria-label="Marquer ce tuto comme utile"]')).to.exist;
       expect(find('[aria-label="Enregistrer dans ma liste de tutos"]')).to.exist;
     });

--- a/mon-pix/tests/acceptance/user-tutorials/recommended_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials/recommended_test.js
@@ -7,7 +7,7 @@ import { visit } from '@1024pix/ember-testing-library';
 import { authenticateByEmail } from '../../helpers/authentication';
 import { waitForDialog } from '../../helpers/wait-for';
 
-describe('Acceptance | User-tutorials-v2 | Recommended', function () {
+describe('Acceptance | User-tutorials | Recommended', function () {
   setupApplicationTest();
   setupMirage();
   let user;
@@ -27,8 +27,8 @@ describe('Acceptance | User-tutorials-v2 | Recommended', function () {
       await visit('/mes-tutos/recommandes');
 
       //then
-      expect(findAll('.tutorial-card-v2')).to.exist;
-      expect(findAll('.tutorial-card-v2')).to.be.lengthOf(10);
+      expect(findAll('.tutorial-card')).to.exist;
+      expect(findAll('.tutorial-card')).to.be.lengthOf(10);
       expect(find('.pix-pagination__navigation').textContent).to.contain('Page 1 / 10');
     });
 
@@ -42,7 +42,7 @@ describe('Acceptance | User-tutorials-v2 | Recommended', function () {
         await click(screen.getByLabelText('Enregistrer dans ma liste de tutos'));
 
         // then
-        expect(findAll('.tutorial-card-v2')).to.be.lengthOf(1);
+        expect(findAll('.tutorial-card')).to.be.lengthOf(1);
         expect(screen.getByLabelText('Retirer de ma liste de tutos')).to.exist;
       });
     });
@@ -57,7 +57,7 @@ describe('Acceptance | User-tutorials-v2 | Recommended', function () {
         await click(screen.getByLabelText('Retirer de ma liste de tutos'));
 
         // then
-        expect(findAll('.tutorial-card-v2')).to.be.lengthOf(1);
+        expect(findAll('.tutorial-card')).to.be.lengthOf(1);
       });
     });
 
@@ -82,7 +82,7 @@ describe('Acceptance | User-tutorials-v2 | Recommended', function () {
         server.create('area', 'withCompetences');
         server.createList('tutorial', 100);
         const screen = await visit('/mes-tutos/recommandes');
-        expect(findAll('.tutorial-card-v2')).to.be.lengthOf(10);
+        expect(findAll('.tutorial-card')).to.be.lengthOf(10);
         await click(screen.getByRole('button', { name: 'Filtrer' }));
         await waitForDialog();
         await click(screen.getByRole('button', { name: 'Mon super domaine' }));
@@ -93,7 +93,7 @@ describe('Acceptance | User-tutorials-v2 | Recommended', function () {
 
         // then
         expect(currentURL()).to.equal('/mes-tutos/recommandes?competences=1&pageNumber=1');
-        expect(findAll('.tutorial-card-v2')).to.be.lengthOf(1);
+        expect(findAll('.tutorial-card')).to.be.lengthOf(1);
         expect(find('.pix-sidebar--hidden')).to.exist;
       });
 

--- a/mon-pix/tests/acceptance/user-tutorials/saved_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials/saved_test.js
@@ -6,7 +6,7 @@ import { find, findAll, click } from '@ember/test-helpers';
 import { visit } from '@1024pix/ember-testing-library';
 import { authenticateByEmail } from '../../helpers/authentication';
 
-describe('Acceptance | User-tutorials-v2 | Saved', function () {
+describe('Acceptance | User-tutorials | Saved', function () {
   setupApplicationTest();
   setupMirage();
   let user;
@@ -22,8 +22,8 @@ describe('Acceptance | User-tutorials-v2 | Saved', function () {
   describe('When there are tutorials saved', function () {
     it('should display paginated tutorial cards', async function () {
       await visit('/mes-tutos/enregistres');
-      expect(findAll('.tutorial-card-v2')).to.exist;
-      expect(findAll('.tutorial-card-v2')).to.be.lengthOf(10);
+      expect(findAll('.tutorial-card')).to.exist;
+      expect(findAll('.tutorial-card')).to.be.lengthOf(10);
       expect(find('.pix-pagination__navigation').textContent).to.contain('Page 1 / 10');
     });
 
@@ -40,7 +40,7 @@ describe('Acceptance | User-tutorials-v2 | Saved', function () {
         await click('[aria-label="Retirer de ma liste de tutos"]');
 
         // then
-        expect(findAll('.tutorial-card-v2')).to.be.lengthOf(9);
+        expect(findAll('.tutorial-card')).to.be.lengthOf(9);
       });
     });
   });

--- a/mon-pix/tests/integration/components/learning-more-panel_test.js
+++ b/mon-pix/tests/integration/components/learning-more-panel_test.js
@@ -41,7 +41,7 @@ describe('Integration | Component | learning-more-panel', function () {
         await render(hbs`<LearningMorePanel @learningMoreTutorials={{this.learningMoreTutorials}} />`);
 
         // then
-        expect(findAll('.tutorial-card-v2')).to.have.lengthOf(1);
+        expect(findAll('.tutorial-card')).to.have.lengthOf(1);
       });
     });
   });

--- a/mon-pix/tests/integration/components/scorecard-details_test.js
+++ b/mon-pix/tests/integration/components/scorecard-details_test.js
@@ -325,7 +325,7 @@ describe('Integration | Component | scorecard-details', function () {
           // then
           expect(find('.tutorials')).to.exist;
           expect(findAll('.tube')).to.have.lengthOf(2);
-          expect(findAll('.tutorial-card-v2')).to.have.lengthOf(3);
+          expect(findAll('.tutorial-card')).to.have.lengthOf(3);
         });
       });
     });

--- a/mon-pix/tests/integration/components/tutorial-panel_test.js
+++ b/mon-pix/tests/integration/components/tutorial-panel_test.js
@@ -57,10 +57,10 @@ describe('Integration | Component | Tutorial Panel', function () {
           await render(hbs`<TutorialPanel @hint={{this.hint}} @tutorials={{this.tutorials}} />`);
 
           // then
-          expect(find('.tutorial-card-v2')).to.exist;
-          expect(find('.tutorial-card-v2__content')).to.exist;
-          expect(find('.tutorial-card-v2-content__details')).to.exist;
-          expect(find('.tutorial-card-v2-content__actions')).to.exist;
+          expect(find('.tutorial-card')).to.exist;
+          expect(find('.tutorial-card__content')).to.exist;
+          expect(find('.tutorial-card-content__details')).to.exist;
+          expect(find('.tutorial-card-content__actions')).to.exist;
           expect(find('[aria-label="Marquer ce tuto comme utile"]')).to.exist;
           expect(find('[aria-label="Enregistrer dans ma liste de tutos"]')).to.exist;
           expect(find('[title="Marquer ce tuto comme utile"]')).to.exist;
@@ -79,10 +79,10 @@ describe('Integration | Component | Tutorial Panel', function () {
           await render(hbs`<TutorialPanel @hint={{this.hint}} @tutorials={{this.tutorials}} />`);
 
           // then
-          expect(find('.tutorial-card-v2')).to.exist;
-          expect(find('.tutorial-card-v2__content')).to.exist;
-          expect(find('.tutorial-card-v2-content__details')).to.exist;
-          expect(find('.tutorial-card-v2-content__actions')).to.not.exist;
+          expect(find('.tutorial-card')).to.exist;
+          expect(find('.tutorial-card__content')).to.exist;
+          expect(find('.tutorial-card-content__details')).to.exist;
+          expect(find('.tutorial-card-content__actions')).to.not.exist;
         });
       });
     });

--- a/mon-pix/tests/integration/components/tutorials/card_test.js
+++ b/mon-pix/tests/integration/components/tutorials/card_test.js
@@ -29,18 +29,16 @@ describe('Integration | Component | Tutorials | Card', function () {
       await render(hbs`<Tutorials::Card @tutorial={{this.tutorial}} />`);
 
       // then
-      expect(find('.tutorial-card-v2')).to.exist;
-      expect(find('.tutorial-card-v2__content')).to.exist;
-      expect(find('.tutorial-card-v2-content__link'))
-        .to.have.property('textContent')
-        .that.contains('Mon super tutoriel');
-      expect(find('.tutorial-card-v2-content__link')).to.have.property('href').that.equals('https://exemple.net/');
-      expect(find('.tutorial-card-v2-content__details'))
+      expect(find('.tutorial-card')).to.exist;
+      expect(find('.tutorial-card__content')).to.exist;
+      expect(find('.tutorial-card-content__link')).to.have.property('textContent').that.contains('Mon super tutoriel');
+      expect(find('.tutorial-card-content__link')).to.have.property('href').that.equals('https://exemple.net/');
+      expect(find('.tutorial-card-content__details'))
         .to.have.property('textContent')
         .that.contains('mon-tuto')
         .and.contains('vidéo')
         .and.contains('une minute');
-      expect(find('.tutorial-card-v2-content__actions')).to.exist;
+      expect(find('.tutorial-card-content__actions')).to.exist;
       expect(find('[aria-label="Ne plus considérer ce tuto comme utile"]')).to.exist;
       expect(find('[aria-label="Retirer de ma liste de tutos"]')).to.exist;
       expect(find('[title="Ne plus considérer ce tuto comme utile"]')).to.exist;
@@ -68,18 +66,16 @@ describe('Integration | Component | Tutorials | Card', function () {
       await render(hbs`<Tutorials::Card @tutorial={{this.tutorial}} />`);
 
       // then
-      expect(find('.tutorial-card-v2')).to.exist;
-      expect(find('.tutorial-card-v2__content')).to.exist;
-      expect(find('.tutorial-card-v2-content__link'))
-        .to.have.property('textContent')
-        .that.contains('Mon super tutoriel');
-      expect(find('.tutorial-card-v2-content__link')).to.have.property('href').that.equals('https://exemple.net/');
-      expect(find('.tutorial-card-v2-content__details'))
+      expect(find('.tutorial-card')).to.exist;
+      expect(find('.tutorial-card__content')).to.exist;
+      expect(find('.tutorial-card-content__link')).to.have.property('textContent').that.contains('Mon super tutoriel');
+      expect(find('.tutorial-card-content__link')).to.have.property('href').that.equals('https://exemple.net/');
+      expect(find('.tutorial-card-content__details'))
         .to.have.property('textContent')
         .that.contains('mon-tuto')
         .and.contains('vidéo')
         .and.contains('une minute');
-      expect(find('.tutorial-card-v2-content__actions')).to.not.exist;
+      expect(find('.tutorial-card-content__actions')).to.not.exist;
     });
   });
 });

--- a/mon-pix/tests/integration/components/tutorials/cards_test.js
+++ b/mon-pix/tests/integration/components/tutorials/cards_test.js
@@ -16,8 +16,8 @@ describe('Integration | Component | Tutorials | Cards', function () {
     await render(hbs`<Tutorials::Cards @tutorials={{this.tutorials}} />`);
 
     // then
-    expect(find('.user-tutorials-content-v2__cards')).to.exist;
-    expect(findAll('.tutorial-card-v2').length).to.equal(0);
+    expect(find('.user-tutorials-content__cards')).to.exist;
+    expect(findAll('.tutorial-card').length).to.equal(0);
   });
 
   it('renders a list of cards if there are tutorials', async function () {
@@ -48,7 +48,7 @@ describe('Integration | Component | Tutorials | Cards', function () {
     await render(hbs`<Tutorials::Cards @tutorials={{this.tutorials}} />`);
 
     // then
-    expect(find('.user-tutorials-content-v2__cards')).to.exist;
-    expect(findAll('.tutorial-card-v2').length).to.equal(2);
+    expect(find('.user-tutorials-content__cards')).to.exist;
+    expect(findAll('.tutorial-card').length).to.equal(2);
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Les classes `css` des tutos sont suffixées par "v2" ce qui n’est pas nécessaire.

## :gift: Proposition
Supprimer la notion de v2.

## :santa: Pour tester
Vérifier le visuel des tutos.