### PR TITLE
[FEATURE] Ajout du lien vers la page mes formations dans le menu (PIX-5760)

### DIFF
--- a/api/lib/domain/read-models/UserWithActivity.js
+++ b/api/lib/domain/read-models/UserWithActivity.js
@@ -1,7 +1,8 @@
 class UserWithActivity {
-  constructor({ user, hasAssessmentParticipations, codeForLastProfileToShare }) {
+  constructor({ user, hasAssessmentParticipations, codeForLastProfileToShare, hasRecommendedTrainings }) {
     this.hasAssessmentParticipations = hasAssessmentParticipations;
     this.codeForLastProfileToShare = codeForLastProfileToShare;
+    this.hasRecommendedTrainings = hasRecommendedTrainings;
     Object.assign(this, user);
   }
 }

--- a/api/lib/domain/usecases/get-current-user.js
+++ b/api/lib/domain/usecases/get-current-user.js
@@ -4,15 +4,18 @@ module.exports = async function getCurrentUser({
   authenticatedUserId,
   userRepository,
   campaignParticipationRepository,
+  userRecommendedTrainingRepository,
 }) {
-  const [hasAssessmentParticipations, codeForLastProfileToShare] = await Promise.all([
+  const [hasAssessmentParticipations, codeForLastProfileToShare, hasRecommendedTrainings] = await Promise.all([
     campaignParticipationRepository.hasAssessmentParticipations(authenticatedUserId),
     campaignParticipationRepository.getCodeOfLastParticipationToProfilesCollectionCampaignForUser(authenticatedUserId),
+    userRecommendedTrainingRepository.hasRecommendedTrainings(authenticatedUserId),
   ]);
   const user = await userRepository.get(authenticatedUserId);
   return new UserWithActivity({
     user,
     hasAssessmentParticipations,
     codeForLastProfileToShare,
+    hasRecommendedTrainings,
   });
 };

--- a/api/lib/infrastructure/repositories/user-recommended-training-repository.js
+++ b/api/lib/infrastructure/repositories/user-recommended-training-repository.js
@@ -26,6 +26,12 @@ module.exports = {
       .orderBy('id', 'asc');
     return trainings.map(_toDomain);
   },
+
+  async hasRecommendedTrainings(userId, domainTransaction = DomainTransaction.emptyTransaction()) {
+    const knexConn = domainTransaction?.knexTransaction || knex;
+    const result = await knexConn(TABLE_NAME).select(1).where({ userId }).first();
+    return Boolean(result);
+  },
 };
 
 function _toDomain(training) {

--- a/api/lib/infrastructure/serializers/jsonapi/user-with-activity-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-with-activity-serializer.js
@@ -26,6 +26,7 @@ module.exports = {
         'hasSeenFocusedChallengeTooltip',
         'hasSeenOtherChallengesTooltip',
         'hasAssessmentParticipations',
+        'hasRecommendedTrainings',
         'codeForLastProfileToShare',
         'trainings',
       ],

--- a/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
@@ -15,7 +15,7 @@ describe('Acceptance | Controller | users-controller-get-current-user', function
     const campaign = databaseBuilder.factory.buildCampaign({ type: 'PROFILES_COLLECTION', code: 'SOMECODE' });
     const assessmentCampaign = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT' });
     expectedCode = campaign.code;
-    databaseBuilder.factory.buildCampaignParticipation({
+    const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
       campaignId: campaign.id,
       status: 'TO_SHARE',
       userId: user.id,
@@ -24,6 +24,8 @@ describe('Acceptance | Controller | users-controller-get-current-user', function
       campaignId: assessmentCampaign.id,
       userId: user.id,
     });
+    const { id: trainingId } = databaseBuilder.factory.buildTraining();
+    databaseBuilder.factory.buildUserRecommendedTraining({ userId: user.id, trainingId, campaignParticipationId });
 
     options = {
       method: 'GET',
@@ -60,6 +62,7 @@ describe('Acceptance | Controller | users-controller-get-current-user', function
             'has-seen-other-challenges-tooltip': user.hasSeenOtherChallengesTooltip,
             'has-assessment-participations': true,
             'code-for-last-profile-to-share': expectedCode,
+            'has-recommended-trainings': true,
           },
           relationships: {
             memberships: {

--- a/api/tests/integration/infrastructure/repositories/user-recommended-training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-recommended-training-repository_test.js
@@ -126,4 +126,40 @@ describe('Integration | Repository | user-recommended-training-repository', func
       expect(result.length).to.equal(0);
     });
   });
+  describe('#hasRecommendedTrainings', function () {
+    it('should return true if the user has recommended trainings', async function () {
+      // given
+      const { id: campaignParticipationId, userId } = databaseBuilder.factory.buildCampaignParticipation();
+      const training = databaseBuilder.factory.buildTraining();
+      const userRecommendedTraining1 = {
+        userId,
+        trainingId: training.id,
+        campaignParticipationId,
+      };
+
+      databaseBuilder.factory.buildUserRecommendedTraining(userRecommendedTraining1);
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await userRecommendedTrainingRepository.hasRecommendedTrainings(userId);
+
+      // then
+      expect(result).to.equal(true);
+    });
+
+    it('should return false if the user has no recommended trainings', async function () {
+      // given
+      const { userId } = databaseBuilder.factory.buildCampaignParticipation();
+      databaseBuilder.factory.buildTraining();
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await userRecommendedTrainingRepository.hasRecommendedTrainings(userId);
+
+      // then
+      expect(result).to.equal(false);
+    });
+  });
 });

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -439,25 +439,23 @@ describe('Unit | Controller | user-controller', function () {
   });
 
   describe('#getCurrentUser', function () {
-    let request;
-
-    beforeEach(function () {
-      request = { auth: { credentials: { userId: 1 } } };
-
-      sinon.stub(usecases, 'getCurrentUser');
-      sinon.stub(userWithActivitySerializer, 'serialize');
-    });
-
     it('should get the current user', async function () {
       // given
-      usecases.getCurrentUser.withArgs({ authenticatedUserId: 1 }).resolves({});
-      userWithActivitySerializer.serialize.withArgs({}).returns('ok');
+      const request = { auth: { credentials: { userId: 1 } } };
+      const currentUser = Symbol('current-user');
+      const getCurrentUserStub = sinon.stub(usecases, 'getCurrentUser');
+      const userWithActivitySerializerStub = sinon.stub(userWithActivitySerializer, 'serialize');
+
+      usecases.getCurrentUser.withArgs({ authenticatedUserId: 1 }).resolves(currentUser);
+      userWithActivitySerializer.serialize.withArgs(currentUser).returns('ok');
 
       // when
       const response = await userController.getCurrentUser(request);
 
       // then
       expect(response).to.be.equal('ok');
+      expect(getCurrentUserStub).to.have.been.calledWithExactly({ authenticatedUserId: 1 });
+      expect(userWithActivitySerializerStub).to.have.been.calledWithExactly(currentUser);
     });
   });
 

--- a/api/tests/unit/domain/usecases/get-current-user_test.js
+++ b/api/tests/unit/domain/usecases/get-current-user_test.js
@@ -4,12 +4,16 @@ const getCurrentUser = require('../../../../lib/domain/usecases/get-current-user
 describe('Unit | UseCase | get-current-user', function () {
   let userRepository;
   let campaignParticipationRepository;
+  let userRecommendedTrainingRepository;
 
   beforeEach(function () {
     userRepository = { get: sinon.stub() };
     campaignParticipationRepository = {
       hasAssessmentParticipations: sinon.stub(),
       getCodeOfLastParticipationToProfilesCollectionCampaignForUser: sinon.stub(),
+    };
+    userRecommendedTrainingRepository = {
+      hasRecommendedTrainings: sinon.stub(),
     };
   });
 
@@ -20,15 +24,22 @@ describe('Unit | UseCase | get-current-user', function () {
     campaignParticipationRepository.getCodeOfLastParticipationToProfilesCollectionCampaignForUser
       .withArgs(1)
       .resolves('SOMECODE');
+    userRecommendedTrainingRepository.hasRecommendedTrainings.withArgs(1).resolves(false);
 
     // when
     const result = await getCurrentUser({
       authenticatedUserId: 1,
       userRepository,
       campaignParticipationRepository,
+      userRecommendedTrainingRepository,
     });
 
     // then
-    expect(result).to.deep.equal({ id: 1, hasAssessmentParticipations: false, codeForLastProfileToShare: 'SOMECODE' });
+    expect(result).to.deep.equal({
+      id: 1,
+      hasAssessmentParticipations: false,
+      codeForLastProfileToShare: 'SOMECODE',
+      hasRecommendedTrainings: false,
+    });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-with-activity-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-with-activity-serializer_test.js
@@ -29,6 +29,7 @@ describe('Unit | Serializer | JSONAPI | user-with-activity-serializer', function
         }),
         hasAssessmentParticipations: false,
         codeForLastProfileToShare: 'SOMECODE',
+        hasRecommendedTrainings: false,
       });
     });
 
@@ -57,6 +58,7 @@ describe('Unit | Serializer | JSONAPI | user-with-activity-serializer', function
               'has-seen-other-challenges-tooltip': userModelObject.hasSeenOtherChallengesTooltip,
               'has-assessment-participations': userModelObject.hasAssessmentParticipations,
               'code-for-last-profile-to-share': userModelObject.codeForLastProfileToShare,
+              'has-recommended-trainings': userModelObject.hasRecommendedTrainings,
             },
             relationships: {
               memberships: {

--- a/high-level-tests/e2e/cypress/fixtures/target-profile-trainings.json
+++ b/high-level-tests/e2e/cypress/fixtures/target-profile-trainings.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id":1,
+    "targetProfileId":1,
+    "trainingId":1
+  }
+]

--- a/high-level-tests/e2e/cypress/fixtures/trainings.json
+++ b/high-level-tests/e2e/cypress/fixtures/trainings.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id":1,
+    "title":"Comment gagner des pièces d'or",
+    "link":"https://test.fr/",
+    "type":"autoformation",
+    "duration":"0 years 0 mons 0 days 6 hours 0 mins 0.0 secs",
+    "locale":"fr-fr"
+  }
+]

--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y.test.js
@@ -56,6 +56,7 @@ describe('a11y', () => {
       { url: '/competences' },
       { url: '/competences/recH9MjIzN54zXlwr/details', skipFailures: true },
       { url: '/mes-certifications' },
+      { url: '/mes-formations' },
       { url: '/mes-parcours', skipFailures: true },
       { url: '/mes-tutos/enregistres' },
       { url: '/mes-tutos/recommandes' },

--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
@@ -26,8 +26,11 @@ Fonctionnalité: Campagne d'évaluation
     Et je clique sur "Voir mes résultats"
     Alors je vois un résultat global à 50%
     Alors je vois 2 résultats pour la compétence
+    Alors je vois la formation recommandée ayant le titre "Comment gagner des pièces d'or"
     Lorsque je clique sur "J'envoie mes résultats"
     Alors je vois que j'ai envoyé les résultats
+    Lorsque je clique sur "Continuez votre expérience Pix"
+    Alors je vois le lien "Mes formations" dans la navigation
 
   Scénario: Je rejoins un parcours prescrit via l'URL sans être connecté
     Étant donné que je vais sur Pix

--- a/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
@@ -58,6 +58,10 @@ When(`je vois {int} résultats pour la compétence`, (numberOfResultsByCompetenc
   cy.get('[aria-label="Votre résultat pour la compétence"]').should('have.lengthOf', numberOfResultsByCompetence);
 });
 
+When(`je vois la formation recommandée ayant le titre {string}`, (trainingName) => {
+  cy.get('.training-card-content__title').should('contain', trainingName);
+});
+
 Then(`je vois la moyenne des résultats à {int}%`, (averageResult) => {
   cy.contains('Résultat moyen').parents().within(() => cy.contains(`${averageResult} %`));
 });

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -14,6 +14,8 @@ Given('les données de test sont chargées', () => {
   cy.task('db:fixture', 'answers');
   cy.task('db:fixture', 'knowledge-elements');
   cy.task('db:fixture', 'pix-admin-roles');
+  cy.task('db:fixture', 'trainings');
+  cy.task('db:fixture', 'target-profile-trainings');
 });
 
 Given('tous les comptes sont créés', () => {

--- a/high-level-tests/e2e/cypress/support/step_definitions/user-dashboard.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/user-dashboard.js
@@ -13,3 +13,7 @@ Then(`je vois {int} participation\(s\) aux campagnes`, (campaignParticipationOve
 Then(`je vois le bandeau de reprise de la dernière campagne de collecte de profil non partagée`, () => {
   cy.get('.new-information--yellow-gradient-background').should('exist');
 });
+
+Then(`je vois le lien {string} dans la navigation`, (linkName) => {
+  cy.contains("a",linkName);
+});

--- a/mon-pix/app/components/navbar-burger-menu.hbs
+++ b/mon-pix/app/components/navbar-burger-menu.hbs
@@ -28,6 +28,13 @@
               {{t "navigation.main.tutorials"}}
             </LinkTo>
           </li>
+          {{#if this.showMyTrainingsLink}}
+            <li class="navbar-burger-menu-list__item">
+              <LinkTo @route="authenticated.user-trainings" class="navbar-burger-menu-list-item__link">
+                {{t "navigation.main.trainings"}}
+              </LinkTo>
+            </li>
+          {{/if}}
         </ul>
         <div class="navbar-burger-menu__button">
           <LinkTo @route="fill-in-campaign-code" class="button button--thin">

--- a/mon-pix/app/components/navbar-burger-menu.js
+++ b/mon-pix/app/components/navbar-burger-menu.js
@@ -7,4 +7,8 @@ export default class NavbarBurgerMenu extends Component {
   get showMyTestsLink() {
     return this.currentUser.user.hasAssessmentParticipations;
   }
+
+  get showMyTrainingsLink() {
+    return this.currentUser.user.hasRecommendedTrainings;
+  }
 }

--- a/mon-pix/app/components/navbar-desktop-header.hbs
+++ b/mon-pix/app/components/navbar-desktop-header.hbs
@@ -32,6 +32,13 @@
               {{t "navigation.main.tutorials"}}
             </LinkTo>
           </li>
+          {{#if this.showMyTrainingsLink}}
+            <li class="navbar-desktop-header-menu__item">
+              <LinkTo @route="authenticated.user-trainings" class="navbar-desktop-header-menu__link">
+                {{t "navigation.main.trainings"}}
+              </LinkTo>
+            </li>
+          {{/if}}
         </ul>
         <!-- Right -->
         <div class="navbar-desktop-header-right">

--- a/mon-pix/app/components/navbar-desktop-header.js
+++ b/mon-pix/app/components/navbar-desktop-header.js
@@ -33,4 +33,8 @@ export default class NavbarDesktopHeader extends Component {
   get showHeaderMenuItem() {
     return this.isUserLogged && !this.currentUser.user.isAnonymous;
   }
+
+  get showMyTrainingsLink() {
+    return this.currentUser.user.hasRecommendedTrainings;
+  }
 }

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -13,6 +13,7 @@ export default class User extends Model {
   @attr('boolean') hasSeenFocusedChallengeTooltip;
   @attr('boolean') hasSeenOtherChallengesTooltip;
   @attr('boolean') hasAssessmentParticipations;
+  @attr('boolean') hasRecommendedTrainings;
   @attr('string') codeForLastProfileToShare;
   @attr('string') lang;
   @attr('boolean') isAnonymous;

--- a/mon-pix/app/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/routes/campaigns/assessment/skill-review.js
@@ -20,6 +20,12 @@ export default class SkillReviewRoute extends Route {
         userId: user.id,
       });
       const trainings = await campaignParticipation.hasMany('trainings').reload();
+
+      // Reload the user to display my trainings link on the navbar menu
+      if (trainings?.length > 0 && !user.hasRecommendedTrainings) {
+        await this.currentUser.load();
+      }
+
       return { campaign, campaignParticipationResult, trainings };
     } catch (error) {
       if (error.errors?.[0]?.status === '412') {

--- a/mon-pix/mirage/factories/user.js
+++ b/mon-pix/mirage/factories/user.js
@@ -244,6 +244,7 @@ export default Factory.extend({
     },
   }),
   withSomeTrainings: trait({
+    hasRecommendedTrainings: true,
     afterCreate(user, server) {
       const training = server.create('training', {
         title: 'Devenir tailleur de citrouille',

--- a/mon-pix/mirage/serializers/user.js
+++ b/mon-pix/mirage/serializers/user.js
@@ -13,6 +13,7 @@ export default ApplicationSerializer.extend({
     'hasSeenAssessmentInstructions',
     'hasSeenNewDashboardInfo',
     'isAnonymous',
+    'hasRecommendedTrainings',
   ],
   include: ['competences'],
   links(user) {

--- a/mon-pix/tests/acceptance/user-trainings_test.js
+++ b/mon-pix/tests/acceptance/user-trainings_test.js
@@ -10,6 +10,21 @@ describe('Acceptance | mes-formations', function () {
   setupMirage();
   let user;
 
+  describe('When user has recommended trainings', function () {
+    it('should display menu item "Mes formations"', async function () {
+      // given
+      user = server.create('user', 'withEmail', 'withSomeTrainings');
+
+      // when
+      await authenticateByEmail(user);
+      await visit('/');
+
+      // then
+      const menuItem = find('[href="/mes-formations"]');
+      expect(menuItem.textContent).to.contain('Mes formations');
+    });
+  });
+
   describe('When the user tries to reach /mes-formations', function () {
     it('the user-trainings page is displayed to the user', async function () {
       // given

--- a/mon-pix/tests/integration/components/navbar-burger-menu_test.js
+++ b/mon-pix/tests/integration/components/navbar-burger-menu_test.js
@@ -88,4 +88,23 @@ describe('Integration | Component | navbar-burger-menu', function () {
       expect(screen.queryByRole('link', { name: this.intl.t('navigation.user.tests') })).to.not.exist;
     });
   });
+  context('when user has recommended trainings', function () {
+    beforeEach(async function () {
+      class currentUser extends Service {
+        user = {
+          hasRecommendedTrainings: true,
+        };
+      }
+      this.owner.unregister('service:currentUser');
+      this.owner.register('service:currentUser', currentUser);
+    });
+
+    it('should not display "My trainings" link', async function () {
+      // when
+      const screen = await render(hbs`<NavbarBurgerMenu @showSidebar={{true}} />`);
+
+      // then
+      expect(screen.queryByRole('link', { name: this.intl.t('navigation.user.trainings') })).to.not.exist;
+    });
+  });
 });

--- a/mon-pix/tests/integration/components/navbar-desktop-header_test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-header_test.js
@@ -140,14 +140,7 @@ describe('Integration | Component | navbar-desktop-header', function () {
     });
 
     it('should display "My trainings" link', async function () {
-      // then
-      expect(find('.navbar-desktop-header-container__menu')).to.exist;
       expect(findAll('.navbar-desktop-header-menu__item')).to.have.lengthOf(6);
-      expect(contains('Accueil')).to.exist;
-      expect(contains('Compétences')).to.exist;
-      expect(contains('Mes tutos')).to.exist;
-      expect(contains('Certification')).to.exist;
-      expect(contains("J'ai un code")).to.exist;
       expect(contains('Mes formations')).to.exist;
     });
   });

--- a/mon-pix/tests/integration/components/navbar-desktop-header_test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-header_test.js
@@ -111,6 +111,44 @@ describe('Integration | Component | navbar-desktop-header', function () {
       expect(contains('Mes tutos')).to.exist;
       expect(contains('Certification')).to.exist;
       expect(contains("J'ai un code")).to.exist;
+      expect(contains('Mes formations')).not.to.exist;
+    });
+  });
+
+  context('when user has recommended trainings', function () {
+    beforeEach(async function () {
+      class sessionService extends Service {
+        isAuthenticated = true;
+        data = {
+          authenticated: {
+            token: 'access_token',
+            userId: 1,
+            source: 'pix',
+          },
+        };
+      }
+      this.owner.register('service:session', sessionService);
+      class currentUser extends Service {
+        user = {
+          isAnonymous: false,
+          hasRecommendedTrainings: true,
+        };
+      }
+      this.owner.register('service:currentUser', currentUser);
+      setBreakpoint('desktop');
+      await render(hbs`<NavbarDesktopHeader/>}`);
+    });
+
+    it('should display "My trainings" link', async function () {
+      // then
+      expect(find('.navbar-desktop-header-container__menu')).to.exist;
+      expect(findAll('.navbar-desktop-header-menu__item')).to.have.lengthOf(6);
+      expect(contains('Accueil')).to.exist;
+      expect(contains('Compétences')).to.exist;
+      expect(contains('Mes tutos')).to.exist;
+      expect(contains('Certification')).to.exist;
+      expect(contains("J'ai un code")).to.exist;
+      expect(contains('Mes formations')).to.exist;
     });
   });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -115,7 +115,8 @@
       "link-help": "https://support.pix.org/en/support/home",
       "skills": "Competences",
       "start-certification": "Certification",
-      "tutorials": "My tutorials"
+      "tutorials": "My tutorials",
+      "trainings": "My trainings"
     },
     "not-logged": {
       "sign-in": "Log in",
@@ -1401,7 +1402,7 @@
       "primary": "You have '<span class=\"timed-challenge-instructions__time\">'{time}'</span>' to complete the next question.",
       "secondary": "You can continue answering after this, but the question will not be marked as correct."
     },
-    "training" : {
+    "training": {
       "type": {
         "autoformation": "Autoformation course",
         "webinaire": "Webinar"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -115,7 +115,8 @@
       "link-help": "https://support.pix.org/fr/support/home",
       "skills": "Compétences",
       "start-certification": "Certification",
-      "tutorials": "Mes tutos"
+      "tutorials": "Mes tutos",
+      "trainings": "Mes formations"
     },
     "not-logged": {
       "sign-in": "Se connecter",


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, il n'y a pas de lien pour accéder aux formations recommandées.

## :gift: Proposition
Ajouter un bouton dans le menu principal qui ne s'affiche que lorsque l'utilisateur a des formations recommandées.

## :star2: Remarques
Même si le bouton ne s'affiche pas dans la barre de navigation, il est toujours possible d'atteindre la page via l'url. Elle sera alors vide.

## :santa: Pour tester
- Se connecter sur la RA : [https://app-pr5760.review.pix.fr/connexion](https://app-pr5760.review.pix.fr/connexion)
- Aller à la campagne `PIXEDUINI` et tout passer
- Vérifier que le lien "Mes formations" est affiché dans le menu principal, et qu'il redirige bien vers la page "Mes formations".