### PR TITLE
[FEATURE] Fermer le menu utilisateur si on tabule en dehors (PIX-5427)

### DIFF
--- a/mon-pix/app/components/user-logged-menu.hbs
+++ b/mon-pix/app/components/user-logged-menu.hbs
@@ -13,7 +13,12 @@
     </button>
 
     {{#if this.canDisplayMenu}}
-      <div class="logged-user-menu" {{on-key "Escape" this.closeMenu}} {{on-click-outside this.closeMenu}}>
+      <div
+        class="logged-user-menu"
+        {{on-click-outside this.closeMenu}}
+        {{on-key "Escape" this.closeMenu}}
+        {{on-key "Tab" this.handleTab}}
+      >
         <div class="logged-user-menu__details">
           <div class="logged-user-menu-details__fullname">{{this.currentUser.user.fullName}}</div>
         </div>

--- a/mon-pix/app/components/user-logged-menu.js
+++ b/mon-pix/app/components/user-logged-menu.js
@@ -25,4 +25,14 @@ export default class UserLoggedMenu extends Component {
   closeMenu() {
     this.canDisplayMenu = false;
   }
+
+  @action
+  handleTab() {
+    /* `setTimeout(..., 0)` is used to wait the next browser rendering and get the new focused element */
+    setTimeout(() => {
+      if (!document.activeElement.classList.contains('logged-user-menu__link')) {
+        this.closeMenu();
+      }
+    }, 0);
+  }
 }

--- a/mon-pix/tests/integration/components/user-logged-menu_test.js
+++ b/mon-pix/tests/integration/components/user-logged-menu_test.js
@@ -106,6 +106,16 @@ describe('Integration | Component | user logged menu', function () {
       expect(find('.logged-user-menu')).to.not.exist;
     });
 
+    it('should hide user menu, when it was previously open and user press shift-tab key', async function () {
+      // when
+      await render(hbs`<UserLoggedMenu/>`);
+      await click('.logged-user-name');
+      await triggerKeyEvent('.logged-user-name', 'keydown', 9, { shiftKey: true });
+
+      // then
+      expect(find('.logged-user-menu')).to.not.exist;
+    });
+
     it('should hide user menu, when the menu is opened then closed', async function () {
       // when
       await render(hbs`<UserLoggedMenu/>`);


### PR DESCRIPTION
## :christmas_tree: Problème
__Problème d'accessibilité :__
Jusqu'à présent, le sous-menu utilisateur ne se fermait pas lors de la tabulation (au "tab et "maj+tab") sur un élément extérieur.

## :gift: Proposition
Le sous-menu capture l'événement clavier "Tab", et à l'appui sur la touche, si la cible n'est pas un `.logged-user-menu__link`, alors on ferme la dropdown.

## :star2: Remarques
Une réflexion plus poussée pourrait se faire :
- Avoir composant `DropdownMenu` qui gèrerait un focus-trap (suivre ce qui est produit [ici pour le PixSelect](https://github.com/1024pix/pix-ui/pull/266))
- Ouvrir le sous-menu au focus sur le bouton directement ([exemple](https://stripe.com/fr))

## :santa: Pour tester
- Aller sur la RA https://app-pr5179.review.pix.fr/
- Cliquer sur le compte utilisateur puis tabuler jusqu'à sortir du sous-menu
- Vérifier que le sous-menu se ferme bien

➕

- Lancer en local
- Vérifier que les [tests d'intégration du sous-menu](http://localhost:4200/tests?grep=Integration%20%5C%7C%20Component%20%5C%7C%20user%20logged%20menu) passent bien
