### PR TITLE
[TECH] Supprimer le package uuid qui n'est plus utilisé dans mon-pix (PIX-6264)

### DIFF
--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -95,8 +95,7 @@
         "sinon": "^14.0.1",
         "stylelint": "^13.13.1",
         "stylelint-config-standard": "^22.0.0",
-        "uuid": "^9.0.0",
-        "xss": "^1.0.14"
+        "xss": "^1.0.13"
       },
       "engines": {
         "node": "16.14.0",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -124,7 +124,6 @@
     "sinon": "^14.0.1",
     "stylelint": "^13.13.1",
     "stylelint-config-standard": "^22.0.0",
-    "uuid": "^9.0.0",
-    "xss": "^1.0.14"
+    "xss": "^1.0.13"
   }
 }


### PR DESCRIPTION
## :christmas_tree: Problème
Depuis la refonte oidc CNAV/PoleEmploi, ce package n'est plus utilisé dans l'application

## :gift: Proposition
Supprimer ce package

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que les connexions a PE / CNAV sont toujours OK