### PR TITLE
[BUGFIX][MON-PIX] Ne pas rediriger un utilisateur GAR sur la page de connexion (lors de la re-connexion, sur navigateur SAFARI) (PIX-6131)

### DIFF
--- a/api/lib/domain/usecases/get-external-authentication-redirection-url.js
+++ b/api/lib/domain/usecases/get-external-authentication-redirection-url.js
@@ -39,7 +39,7 @@ async function _getUrlWithAccessToken({
   const token = tokenService.createAccessTokenForSaml(user.id);
   await userRepository.updateLastLoggedAt({ userId: user.id });
   await _saveUserFirstAndLastName({ authenticationMethodRepository, user, externalUser });
-  return `/?token=${encodeURIComponent(token)}&user-id=${user.id}`;
+  return `/connexion/gar#${encodeURIComponent(token)}`;
 }
 
 async function _saveUserFirstAndLastName({ authenticationMethodRepository, user, externalUser }) {

--- a/api/tests/acceptance/application/saml-controller_test.js
+++ b/api/tests/acceptance/application/saml-controller_test.js
@@ -237,7 +237,7 @@ describe('Acceptance | Controller | saml-controller', function () {
 
       // then
       expect(response.statusCode).to.equal(302);
-      expect(response.headers.location).to.match(/^\/\?token=[-_a-zA-Z0-9.]+&user-id=[0-9]+$/);
+      expect(response.headers.location).to.match(/^\/connexion\/gar#[-_a-zA-Z0-9.]+$/);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
+++ b/api/tests/unit/domain/usecases/get-external-authentication-redirection-url_test.js
@@ -103,7 +103,7 @@ describe('Unit | UseCase | get-external-authentication-redirection-url', functio
       });
 
       // then
-      const expectedUrl = '/?token=access-token&user-id=1';
+      const expectedUrl = '/connexion/gar#access-token';
       expect(result).to.deep.equal(expectedUrl);
     });
 

--- a/high-level-tests/e2e/cypress/support/commands.js
+++ b/high-level-tests/e2e/cypress/support/commands.js
@@ -95,7 +95,7 @@ Cypress.Commands.add('loginExternalPlatformForTheSecondTime', () => {
     Cypress.env('AUTH_SECRET'),
     { expiresIn: '1h' }
   );
-  cy.visitMonPix(`/?token=${token}`);
+  cy.visitMonPix(`/connexion/gar#${token}`);
   cy.wait(['@getCurrentUser']);
 });
 
@@ -104,7 +104,7 @@ Cypress.Commands.add('loginWithAlmostExpiredToken', () => {
   const token = jsonwebtoken.sign({ user_id: 1 }, Cypress.env('AUTH_SECRET'), {
     expiresIn: '4s',
   });
-  cy.visitMonPix(`/?token=${token}`);
+  cy.visitMonPix(`/connexion/gar#${token}`);
   cy.wait(['@getCurrentUser']);
 });
 

--- a/mon-pix/app/authenticators/gar.js
+++ b/mon-pix/app/authenticators/gar.js
@@ -1,0 +1,18 @@
+import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
+import RSVP from 'rsvp';
+import { decodeToken } from 'mon-pix/helpers/jwt';
+
+export default class GarAuthenticator extends BaseAuthenticator {
+  authenticate(token) {
+    const token_type = 'bearer';
+    const decodedAccessToken = decodeToken(token);
+    const user_id = decodedAccessToken.user_id;
+    const source = decodedAccessToken.source;
+    return RSVP.resolve({
+      token_type,
+      access_token: token,
+      user_id,
+      source,
+    });
+  }
+}

--- a/mon-pix/app/instance-initializers/session.js
+++ b/mon-pix/app/instance-initializers/session.js
@@ -1,0 +1,15 @@
+import PixWindow from 'mon-pix/utils/pix-window';
+
+export function initialize(/* applicationInstance */) {
+  const currentURL = PixWindow.getLocationHref();
+  const isGarAuthenticationURL = currentURL.match(/\/connexion\/gar/i)?.length === 1;
+
+  if (isGarAuthenticationURL) {
+    window.localStorage.removeItem('ember_simple_auth-session');
+  }
+}
+
+export default {
+  before: 'ember-simple-auth',
+  initialize,
+};

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -120,6 +120,7 @@ Router.map(function () {
     this.route('login', { path: '' });
     this.route('login-oidc', { path: '/:identity_provider_slug' });
     this.route('login-or-register-oidc', { path: '/oidc' });
+    this.route('login-gar', { path: '/gar' });
   });
 
   // XXX: this route is used for any request that did not match any of the previous routes. SHOULD ALWAYS BE THE LAST ONE

--- a/mon-pix/app/routes/authentication/login-gar.js
+++ b/mon-pix/app/routes/authentication/login-gar.js
@@ -1,0 +1,12 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import PixWindow from 'mon-pix/utils/pix-window';
+
+export default class LoginGarRoute extends Route {
+  @service session;
+
+  async beforeModel() {
+    const token = decodeURIComponent(PixWindow.getLocationHash().slice(1));
+    await this.session.authenticate('authenticator:gar', token);
+  }
+}

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -88,12 +88,6 @@ export default class CurrentSessionService extends SessionService {
       this.skipRedirectAfterSessionInvalidation = true;
       await this._logoutUser();
     }
-
-    if (transition.to.queryParams && transition.to.queryParams.token) {
-      // Logout user when existing external user is authenticated.
-      await this._logoutUser();
-      return super.authenticate('authenticator:oauth2', { token: transition.to.queryParams.token });
-    }
   }
 
   async _checkAnonymousAccess(transition) {

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -85,8 +85,10 @@ export default class CurrentSessionService extends SessionService {
     if (transition.to.queryParams && transition.to.queryParams.externalUser) {
       // Logout user when a new external user is authenticated
       // without redirecting the user to the login page.
-      this.skipRedirectAfterSessionInvalidation = true;
-      await this._logoutUser();
+      if (this.isAuthenticated) {
+        this.skipRedirectAfterSessionInvalidation = true;
+        await this._logoutUser();
+      }
     }
   }
 

--- a/mon-pix/app/utils/pix-window.js
+++ b/mon-pix/app/utils/pix-window.js
@@ -1,0 +1,9 @@
+function getLocationHref() {
+  return window.location.href;
+}
+
+const PixWindow = {
+  getLocationHref,
+};
+
+export default PixWindow;

--- a/mon-pix/app/utils/pix-window.js
+++ b/mon-pix/app/utils/pix-window.js
@@ -2,8 +2,13 @@ function getLocationHref() {
   return window.location.href;
 }
 
+function getLocationHash() {
+  return window.location.hash;
+}
+
 const PixWindow = {
   getLocationHref,
+  getLocationHash,
 };
 
 export default PixWindow;

--- a/mon-pix/tests/acceptance/user-account/connection-methods_test.js
+++ b/mon-pix/tests/acceptance/user-account/connection-methods_test.js
@@ -1,5 +1,10 @@
 import { describe, it } from 'mocha';
-import { authenticateByEmail, authenticateByGAR, authenticateByUsername } from '../../helpers/authentication';
+import {
+  authenticateByEmail,
+  authenticateByGAR,
+  authenticateByUsername,
+  generateGarAuthenticationURLHash,
+} from '../../helpers/authentication';
 import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -9,6 +14,8 @@ import { contains } from '../../helpers/contains';
 import { clickByLabel } from '../../helpers/click-by-label';
 import { fillInByLabel } from '../../helpers/fill-in-by-label';
 import setupIntl from '../../helpers/setup-intl';
+import PixWindow from 'mon-pix/utils/pix-window';
+import sinon from 'sinon';
 
 describe('Acceptance | user-account | connection-methods', function () {
   setupApplicationTest();
@@ -38,6 +45,7 @@ describe('Acceptance | user-account | connection-methods', function () {
       // given
       const garUser = server.create('user', 'external');
       server.create('authentication-method', 'withGarIdentityProvider', { user: garUser });
+      sinon.stub(PixWindow, 'getLocationHash').returns(generateGarAuthenticationURLHash(garUser));
       await authenticateByGAR(garUser);
 
       // when
@@ -57,11 +65,7 @@ describe('Acceptance | user-account | connection-methods', function () {
       server.create('authentication-method', 'withGenericOidcIdentityProvider', { user });
 
       // when
-      await visit(
-        '/?token=aaa.' +
-          btoa(`{"user_id":${user.id},"source":"oidc-source","iat":1545321469,"exp":4702193958}`) +
-          '.bbb'
-      );
+      await authenticateByEmail(user);
       await visit('/mon-compte/methodes-de-connexion');
 
       // then

--- a/mon-pix/tests/helpers/authentication.js
+++ b/mon-pix/tests/helpers/authentication.js
@@ -15,10 +15,12 @@ export async function authenticateByUsername(user) {
   await clickByLabel('Je me connecte');
 }
 
+export function generateGarAuthenticationURLHash(user) {
+  return '#aaa.' + btoa(`{"user_id":${user.id},"source":"external","iat":1545321469,"exp":4702193958}`) + '.bbb';
+}
+
 export async function authenticateByGAR(user) {
-  await visit(
-    '/?token=aaa.' + btoa(`{"user_id":${user.id},"source":"external","iat":1545321469,"exp":4702193958}`) + '.bbb'
-  );
+  await visit('/connexion/gar' + generateGarAuthenticationURLHash(user));
 }
 
 export async function logout() {

--- a/mon-pix/tests/unit/authenticators/gar_test.js
+++ b/mon-pix/tests/unit/authenticators/gar_test.js
@@ -1,0 +1,35 @@
+import { expect } from 'chai';
+import { setupTest } from 'ember-mocha';
+import { afterEach, describe, it } from 'mocha';
+import * as jwt from 'mon-pix/helpers/jwt';
+import sinon from 'sinon';
+
+describe('Unit | Authenticator | gar', function () {
+  setupTest();
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  describe('#authenticate', function () {
+    it('should authenticate the user', async function () {
+      // given
+      const authenticator = this.owner.lookup('authenticator:gar');
+      const token = Symbol('mon super token');
+
+      sinon.stub(jwt, 'decodeToken').returns({ user_id: 1, source: 'gar' });
+
+      // when
+      const expectedResult = await authenticator.authenticate(token);
+
+      // then
+      sinon.assert.calledWith(jwt.decodeToken, token);
+      expect(expectedResult).to.deep.equal({
+        token_type: 'bearer',
+        access_token: token,
+        user_id: 1,
+        source: 'gar',
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/instance-initializers/session-test.js
+++ b/mon-pix/tests/unit/instance-initializers/session-test.js
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import Application from '@ember/application';
+import { initialize } from 'mon-pix/instance-initializers/session';
+import { run } from '@ember/runloop';
+import Resolver from 'ember-resolver';
+import PixWindow from 'mon-pix/utils/pix-window';
+import sinon from 'sinon';
+
+describe('Unit | Instance Initializer | session', function () {
+  beforeEach(function () {
+    run(() => {
+      // eslint-disable-next-line ember/no-classic-classes
+      this.TestApplication = Application.extend();
+      this.TestApplication.instanceInitializer({
+        name: 'initializer under test',
+        initialize,
+      });
+      this.application = this.TestApplication.create({ autoboot: false, Resolver, modulePrefix: 'mon-pix-test' });
+      this.instance = this.application.buildInstance();
+    });
+  });
+  afterEach(function () {
+    run(this.instance, 'destroy');
+    run(this.application, 'destroy');
+  });
+
+  context('when a session exists', function () {
+    context('when a user finalizes a GAR authentication process', function () {
+      it('should remove the current session before the application loads', async function () {
+        // given
+        const key = 'ember_simple_auth-session';
+        sinon.stub(PixWindow, 'getLocationHref').returns('/connexion/gar#access_token');
+        window.localStorage.setItem(
+          key,
+          JSON.stringify({
+            authenticated: {
+              authenticator: 'authenticator:oauth2',
+              token_type: 'bearer',
+              access_token: 'access_token',
+              user_id: 1,
+              refresh_token: 'refresh_token',
+              expires_in: 45,
+              expires_at: 1667837187635,
+            },
+          })
+        );
+
+        // when
+        await this.instance.boot();
+
+        // then
+        const session = window.localStorage.getItem(key);
+        expect(session).to.be.null;
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/routes/authentication/login-gar_test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-gar_test.js
@@ -1,0 +1,30 @@
+import { setupTest } from 'ember-mocha';
+import { describe, it } from 'mocha';
+import Service from '@ember/service';
+import sinon from 'sinon';
+import PixWindow from 'mon-pix/utils/pix-window';
+
+describe('Unit | Routes | authentication | login-gar', function () {
+  setupTest();
+
+  describe('#beforeModel', function () {
+    context('when a token is set as an hash of an url', function () {
+      it('should authenticate the user', async function () {
+        // given
+        const route = this.owner.lookup('route:authentication/login-gar');
+        const sessionStub = Service.create({
+          authenticate: sinon.stub().resolves(),
+        });
+        route.set('session', sessionStub);
+
+        sinon.stub(PixWindow, 'getLocationHash').returns('#access_token');
+
+        // when
+        await route.beforeModel();
+
+        // then
+        sinon.assert.calledWith(sessionStub.authenticate, 'authenticator:gar', 'access_token');
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/services/session_test.js
+++ b/mon-pix/tests/unit/services/session_test.js
@@ -188,21 +188,6 @@ describe('Unit | Services | session', function () {
       });
     });
 
-    context('when an existing external user is authenticated', function () {
-      it('should invalidate the current session and authenticate the existing external user', async function () {
-        // given
-        const transition = { to: { queryParams: { token: 'token' } } };
-
-        // when
-        await sessionService.handleUserLanguageAndLocale(transition);
-
-        // then
-        sinon.assert.calledOnce(sessionService._logoutUser);
-        sinon.assert.calledOnce(oauthAuthenticator.authenticate);
-        sinon.assert.calledWith(oauthAuthenticator.authenticate, { token: 'token' });
-      });
-    });
-
     context('when an anonymous user is authenticated', function () {
       let transition;
 

--- a/mon-pix/tests/unit/services/session_test.js
+++ b/mon-pix/tests/unit/services/session_test.js
@@ -175,10 +175,15 @@ describe('Unit | Services | session', function () {
       sessionService._loadCurrentUserAndSetLocale = sinon.stub();
     });
 
+    afterEach(function () {
+      sinon.restore();
+    });
+
     context('when a new external user is authenticated', function () {
       it('should invalidate the current session', async function () {
         // given
         const transition = { to: { queryParams: { externalUser: 'user' } } };
+        sinon.stub(sessionService, 'isAuthenticated').value(true);
 
         // when
         await sessionService.handleUserLanguageAndLocale(transition);

--- a/mon-pix/tests/unit/utils/pix-window_test.js
+++ b/mon-pix/tests/unit/utils/pix-window_test.js
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import PixWindow from 'mon-pix/utils/pix-window';
+import sinon from 'sinon';
+
+describe('Unit | Utilities | pix-window', function () {
+  context('GET window.location.href', function () {
+    it('should return an URL', function () {
+      // given
+      sinon.stub(PixWindow, 'getLocationHref').returns('http://domain.com/timely#hash');
+
+      // when
+      const url = PixWindow.getLocationHref();
+
+      // then
+      expect(url).to.equal('http://domain.com/timely#hash');
+    });
+  });
+});

--- a/mon-pix/tests/unit/utils/pix-window_test.js
+++ b/mon-pix/tests/unit/utils/pix-window_test.js
@@ -4,6 +4,10 @@ import PixWindow from 'mon-pix/utils/pix-window';
 import sinon from 'sinon';
 
 describe('Unit | Utilities | pix-window', function () {
+  afterEach(function () {
+    sinon.restore();
+  });
+
   context('GET window.location.href', function () {
     it('should return an URL', function () {
       // given
@@ -14,6 +18,19 @@ describe('Unit | Utilities | pix-window', function () {
 
       // then
       expect(url).to.equal('http://domain.com/timely#hash');
+    });
+  });
+
+  context('GET window.location.hash', function () {
+    it('should return the hash found in the URL', function () {
+      // given
+      sinon.stub(PixWindow, 'getLocationHash').returns('#hash');
+
+      // when
+      const hash = PixWindow.getLocationHash();
+
+      // then
+      expect(hash).to.equal('#hash');
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

Sur le navigateur Safari (MacOS ou iOS), des élèves sont obligés d'effectuer plusieurs tentatives de connexion pour arriver sur la page d'accueil de Pix. Lorsque la connexion à Pix n'a pas abouti, les élèves arrivent sur la page de connexion de Pix, ce qui ne doit jamais arriver pour les élèves.

Après investigation, nous avons remarqué que le processus de connexion, en passant par le GAR, n'était pas adapté ce qui entrainait parfois une boucle de connexion et déconnexion (3 tentatives). Lors de cette boucle, une erreur survient et entraine la redirection de l'utilisateur vers la page de connexion de Pix.

La gestion des paramètres de type `query` par Ember lors d'un rafraichissement de page, ainsi que la gestion des sessions Ember Simple Auth après chargement de l'application sont la cause de cette boucle.

Nous avons également remarqué que le paramètre `user-id` n'était pas utilisé lors du processus de connexion sur Pix.

## :gift: Proposition

- Créer une route dédiée au processus de connexion via le GAR (**/connexion/saml**), ce qui permet de tester plus facilement cette connexion (pour un élève qui a déjà un compte)
- Utiliser un hash (`/connexion/saml#<access_token>`) dans l'URL au lieu du query (`/connexion/saml?token=<access_token>`)
- Retirer le paramètre `user-id` qui n'est pas utile
- Ajout d'un initializer pour supprimer les données d'Ember Simple Auth avant le chargement de l'application, si l'URL correspond à la connexion via le GAR
- Créer un authenticator dédié au GAR (`authenticator:gar`)
- Retirer le code qui gérait la connexion d'un élève ayant un compte Pix du service `session` (car la gestion de la connexion d'un élève se fait désormais par la nouvelle route `/connexion/saml` )

## :star2: Remarques

⚠️ Dû au faite que l'on fourni le token d'accès dans l'URL, nous pouvons retrouver ce token dans les logs. Il faudrait passer par une génération d'un code qui serait échangé par la suite pour récupérer le token.

## :santa: Pour tester

Ces 2 étapes sont a effectuer en priorité sur Safari (MacOS et iOS - tablette et/ou smartphone).

##### 1ère étape

- Se connecter via le GAR avec un élève **n'ayant pas** de compte chez Pix **(Prénom: Prenom, Nom: Nom)**
- Saisir le code `SCOBADGE1` pour accéder au parcours
- Commencer le parcours
- Finaliser la création du compte de l'élève en fournissant sa date de naissance **(Date de naissance: 09/09/2009)**
- Ignorer le didactitiel
- Quitter le parcours
- Constatez que l'utilisateur se retrouve sur la page d'accueil de Pix (`/accueil`)
- Se déconnecter
- Constatez que l'utilisateur se retrouve sur la page `/nonconnecte`

##### 2e étape

- Se connecter via le GAR avec le même élève **(Prénom: Prenom, Nom: Nom)**
- Constatez que l'utilisateur se retrouve sur la page d'accueil de Pix (`/accueil`)
- Se déconnecter
- Constatez que l'utilisateur se retrouve sur la page `/nonconnecte`
