### PR TITLE
[TECH] Corriger un warning jeté par Ember sur Pix App (PIX-6269).

### DIFF
--- a/mon-pix/app/components/dashboard/content.js
+++ b/mon-pix/app/components/dashboard/content.js
@@ -70,7 +70,7 @@ export default class Content extends Component {
   }
 
   get userScore() {
-    return this.currentUser.user.profile.pixScore;
+    return this.currentUser.user.profile.get('pixScore');
   }
 
   @action

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -19,7 +19,7 @@ export default class User extends Model {
 
   // includes
   @belongsTo('is-certifiable') isCertifiable;
-  @belongsTo('profile', { async: false }) profile;
+  @belongsTo('profile') profile;
   @hasMany('certification') certifications;
   @hasMany('scorecard') scorecards;
   @hasMany('trainings') trainings;

--- a/mon-pix/tests/integration/components/dashboard/content_test.js
+++ b/mon-pix/tests/integration/components/dashboard/content_test.js
@@ -16,9 +16,9 @@ describe('Integration | Component | Dashboard | Content', function () {
       firstName: 'Banana',
       email: 'banana.split@example.net',
       fullName: 'Banana Split',
-      profile: {
+      profile: EmberObject.create({
         pixScore,
-      },
+      }),
       hasSeenNewDashboardInfo: false,
     };
   }
@@ -28,9 +28,9 @@ describe('Integration | Component | Dashboard | Content', function () {
       firstName: 'Banana',
       email: 'banana.split@example.net',
       fullName: 'Banana Split',
-      profile: {
+      profile: EmberObject.create({
         pixScore,
-      },
+      }),
       hasSeenNewDashboardInfo: false,
       codeForLastProfileToShare: 'SNAP1234',
     };

--- a/mon-pix/tests/unit/components/dashboard/content_test.js
+++ b/mon-pix/tests/unit/components/dashboard/content_test.js
@@ -336,7 +336,7 @@ describe('Unit | Component | Dashboard | Content', function () {
     it('should return user score', function () {
       // given
       const pixScore = '68';
-      component.currentUser = EmberObject.create({ user: { profile: { pixScore } } });
+      component.currentUser = EmberObject.create({ user: { profile: EmberObject.create({ pixScore }) } });
 
       // when
       const result = component.userScore;


### PR DESCRIPTION
## :christmas_tree: Problème

Ember jette le warning suivant dans Pix App: 
<img width="1546" alt="Capture d’écran 2022-11-07 à 17 59 21" src="https://user-images.githubusercontent.com/58915422/200371345-b0ce73eb-85b5-4aa1-b8cf-0cb321d1a289.png">

Le modèle user coté front comporte une relation avec le modèle profil. Celle-ci possède une option de synchronisation configuré à false.
"But it will error on access when a related resource is known to exist and it has not been loaded"

Relation et synchronisation dans un modèle Ember (bas de page) : https://api.emberjs.com/ember-data/release/functions/@ember-data%2Fmodel/belongsTo

## :gift: Proposition
Retirer l'option async dans le modèle User (implique de récupérer le pixScore du modèle par un get())

## :santa: Pour tester
- Se connecter sur Pix App
- Voir son score Pix
- Ouvrir la console et ne plus voir l'erreur jeté par Ember dans les tests
