### PR TITLE
[BUGFIX] Corriger l'affichage de la page de changement de mot de passe

### DIFF
--- a/mon-pix/app/styles/components/_user-account.scss
+++ b/mon-pix/app/styles/components/_user-account.scss
@@ -36,7 +36,7 @@
   }
 
   &__menu-block {
-    margin: 32px;
+    margin: 32px 26px;
     height: max-content;
 
     .user-account-menu {
@@ -90,6 +90,7 @@
     height: max-content;
     padding: 14px 24px;
     margin: 32px 0;
+    max-width: 600px;
 
     @include device-is('mobile') {
       padding: 16px;


### PR DESCRIPTION
## :christmas_tree: Problème
Quand on change de mot de passe le menu "saute" pour se mettre au-dessus du bloc pour changer de mot de passe (au lieu de rester aligné). 
![image](https://user-images.githubusercontent.com/38167520/200372588-081a2c1c-c9bf-47e4-b625-ba8ee94497a0.png)

![image](https://user-images.githubusercontent.com/38167520/200372571-f15839ef-ac3c-4d46-a305-e9acf94f761a.png)


## :gift: Proposition
Corriger la width max du bloc de droite pour qu'il ne prenne pas trop de place

## :star2: Remarques
RAS

## :santa: Pour tester
- Se connecter sur Pix App (certif-failure@example.net)
- Aller sur `mon-compte/methodes-de-connexion`
- Cliquer sur "changer"
- Constater que le bloc de droite ne saute pas en dessous et reste à sa place 🐶