### PR TITLE
[BUGFIX] Utiliser l'email de destinataire pour l'envoi des resultats CLéA (PIX-6248)

### DIFF
--- a/api/lib/domain/read-models/CleaCertifiedCandidate.js
+++ b/api/lib/domain/read-models/CleaCertifiedCandidate.js
@@ -2,7 +2,7 @@ class CleaCertifiedCandidate {
   constructor({
     firstName,
     lastName,
-    email,
+    resultRecipientEmail,
     birthdate,
     birthplace,
     birthPostalCode,
@@ -13,7 +13,7 @@ class CleaCertifiedCandidate {
   } = {}) {
     this.firstName = firstName;
     this.lastName = lastName;
-    this.email = email;
+    this.resultRecipientEmail = resultRecipientEmail;
     this.birthdate = birthdate;
     this.birthplace = birthplace;
     this.birthPostalCode = birthPostalCode;

--- a/api/lib/infrastructure/repositories/clea-certified-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/clea-certified-candidate-repository.js
@@ -9,7 +9,7 @@ module.exports = {
       .select(
         'certification-courses.firstName',
         'certification-courses.lastName',
-        'users.email',
+        'certification-candidates.resultRecipientEmail',
         'certification-courses.birthdate',
         'certification-courses.birthplace',
         'certification-courses.birthPostalCode',
@@ -18,7 +18,11 @@ module.exports = {
         'certification-courses.sex',
         'certification-courses.createdAt'
       )
-      .innerJoin('users', 'certification-courses.userId', 'users.id')
+      .innerJoin('certification-candidates', function () {
+        this.on({ 'certification-candidates.sessionId': 'certification-courses.sessionId' }).andOn({
+          'certification-candidates.userId': 'certification-courses.userId',
+        });
+      })
       .innerJoin(
         'complementary-certification-courses',
         'complementary-certification-courses.certificationCourseId',

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -121,7 +121,7 @@ function _buildFileDataForCleaCandidates(cleaCertifiedCandidates) {
       [_headers.BIRTHNAME]: candidate.lastName,
       [_headers.USUAL_NAME]: null,
       [_headers.FIRSTNAME]: candidate.firstName,
-      [_headers.EMAIL]: candidate.email,
+      [_headers.EMAIL]: candidate.resultRecipientEmail,
       [_headers.PHONE]: null,
       [_headers.ADDRESS]: null,
       [_headers.ADDITIONAL_ADDRESS]: null,

--- a/api/tests/integration/infrastructure/repositories/clea-certified-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/clea-certified-candidate-repository_test.js
@@ -7,12 +7,20 @@ describe('Integration | Repository | clea-certified-candidate-repository', funct
       it('returns the list of clea certified candidates', async function () {
         // given
         const sessionId = databaseBuilder.factory.buildSession().id;
-        const userId = databaseBuilder.factory.buildUser({
-          email: 'jean-mi@coco.fr',
-        }).id;
-        const userId2 = databaseBuilder.factory.buildUser({
-          email: 'marie-mi@coco.fr',
-        }).id;
+        const userId = databaseBuilder.factory.buildUser({}).id;
+        databaseBuilder.factory.buildCertificationCandidate({
+          userId,
+          sessionId,
+          resultRecipientEmail: 'jean-mi@coco.fr',
+        });
+
+        const userId2 = databaseBuilder.factory.buildUser({}).id;
+        databaseBuilder.factory.buildCertificationCandidate({
+          userId: userId2,
+          sessionId,
+          resultRecipientEmail: 'marie-mi@coco.fr',
+        });
+
         const candidateCleaSuccess = {
           firstName: 'Jean-Mi',
           lastName: 'Mi',
@@ -82,7 +90,7 @@ describe('Integration | Repository | clea-certified-candidate-repository', funct
           domainBuilder.buildCleaCertifiedCandidate({
             firstName: 'Jean-Mi',
             lastName: 'Mi',
-            email: 'jean-mi@coco.fr',
+            resultRecipientEmail: 'jean-mi@coco.fr',
             birthdate: '2001-02-07',
             birthplace: 'Paris',
             birthPostalCode: null,
@@ -94,7 +102,7 @@ describe('Integration | Repository | clea-certified-candidate-repository', funct
           domainBuilder.buildCleaCertifiedCandidate({
             firstName: 'Marie',
             lastName: 'Ri',
-            email: 'marie-mi@coco.fr',
+            resultRecipientEmail: 'marie-mi@coco.fr',
             birthdate: '2001-02-04',
             birthplace: 'Orléans',
             sex: 'F',
@@ -110,9 +118,12 @@ describe('Integration | Repository | clea-certified-candidate-repository', funct
         it('returns the list of clea certified candidates only', async function () {
           // given
           const sessionId = databaseBuilder.factory.buildSession().id;
-          const userId = databaseBuilder.factory.buildUser({
-            email: 'jean-mi@coco.fr',
-          }).id;
+          const userId = databaseBuilder.factory.buildUser().id;
+          databaseBuilder.factory.buildCertificationCandidate({
+            userId,
+            sessionId,
+            resultRecipientEmail: 'jean-mi@coco.fr',
+          });
           const candidateCleaSuccess = {
             firstName: 'Jean-Mi',
             lastName: 'Mi',
@@ -174,7 +185,7 @@ describe('Integration | Repository | clea-certified-candidate-repository', funct
             domainBuilder.buildCleaCertifiedCandidate({
               firstName: 'Jean-Mi',
               lastName: 'Mi',
-              email: 'jean-mi@coco.fr',
+              resultRecipientEmail: 'jean-mi@coco.fr',
               birthdate: '2001-02-07',
               birthplace: 'Paris',
               birthPostalCode: null,

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -407,7 +407,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
         const CleaCertifiedCandidate1 = domainBuilder.buildCleaCertifiedCandidate({
           firstName: 'Léane',
           lastName: 'Bern',
-          email: 'princesse-lele@gg.fr',
+          resultRecipientEmail: 'princesse-lele@gg.fr',
           birthdate: '2001-05-10',
           birthplace: 'Paris',
           birthPostalCode: '75019',
@@ -419,7 +419,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
         const CleaCertifiedCandidate2 = domainBuilder.buildCleaCertifiedCandidate({
           firstName: 'Jean-Mi',
           lastName: 'Mi',
-          email: 'jean-mi@coco.fr',
+          resultRecipientEmail: 'jean-mi@coco.fr',
           birthdate: '2001-02-07',
           birthplace: 'Paris',
           birthPostalCode: '75015',
@@ -450,7 +450,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
           const CleaCertifiedCandidate = domainBuilder.buildCleaCertifiedCandidate({
             firstName: 'Léane',
             lastName: 'Bern',
-            email: 'princesse-lele@gg.fr',
+            resultRecipientEmail: 'princesse-lele@gg.fr',
             birthdate: '2001-05-10',
             birthplace: 'STE MARIE',
             birthPostalCode: '97418',
@@ -480,7 +480,7 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', f
           const CleaCertifiedCandidate = domainBuilder.buildCleaCertifiedCandidate({
             firstName: 'Léane',
             lastName: 'Bern',
-            email: 'princesse-lele@gg.fr',
+            resultRecipientEmail: 'princesse-lele@gg.fr',
             birthdate: '2001-05-10',
             birthplace: 'STE MARIE',
             birthPostalCode: '99416',

--- a/api/tests/tooling/domain-builder/factory/build-clea-certified-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/build-clea-certified-candidate.js
@@ -3,7 +3,7 @@ const CleaCertifiedCandidate = require('../../../../lib/domain/read-models/CleaC
 module.exports = function buildCleaCertifiedCandidate({
   firstName = 'Gandhi',
   lastName = 'Matmatah',
-  email = 'matmatahGdu75@dhi.fr',
+  resultRecipientEmail = 'matmatahGdu75@dhi.fr',
   birthplace = 'Perpignan',
   birthdate = '1985-01-20',
   sex = 'F',
@@ -15,7 +15,7 @@ module.exports = function buildCleaCertifiedCandidate({
   return new CleaCertifiedCandidate({
     firstName,
     lastName,
-    email,
+    resultRecipientEmail,
     birthdate,
     birthplace,
     birthPostalCode,

--- a/api/tests/unit/domain/usecases/get-clea-certified-candidate-by-session_test.js
+++ b/api/tests/unit/domain/usecases/get-clea-certified-candidate-by-session_test.js
@@ -35,7 +35,7 @@ describe('Unit | UseCase | getCleaCertifiedCandidateBySession', function () {
           domainBuilder.buildCleaCertifiedCandidate({
             firstName: 'Jean-Mi',
             lastName: 'Mi',
-            email: 'jean-mi@coco.fr',
+            resultRecipientEmail: 'jean-mi@coco.fr',
             birthdate: '2001-02-07',
             birthplace: 'Paris',
             birthPostalCode: '75015',
@@ -47,7 +47,7 @@ describe('Unit | UseCase | getCleaCertifiedCandidateBySession', function () {
           domainBuilder.buildCleaCertifiedCandidate({
             firstName: 'Léane',
             lastName: 'Bern',
-            email: 'princesse-lele@gg.fr',
+            resultRecipientEmail: 'princesse-lele@gg.fr',
             birthdate: '2001-05-10',
             birthplace: 'Paris',
             birthPostalCode: '75019',
@@ -70,7 +70,7 @@ describe('Unit | UseCase | getCleaCertifiedCandidateBySession', function () {
           domainBuilder.buildCleaCertifiedCandidate({
             firstName: 'Jean-Mi',
             lastName: 'Mi',
-            email: 'jean-mi@coco.fr',
+            resultRecipientEmail: 'jean-mi@coco.fr',
             birthdate: '2001-02-07',
             birthplace: 'Paris',
             birthPostalCode: '75015',
@@ -82,7 +82,7 @@ describe('Unit | UseCase | getCleaCertifiedCandidateBySession', function () {
           domainBuilder.buildCleaCertifiedCandidate({
             firstName: 'Léane',
             lastName: 'Bern',
-            email: 'princesse-lele@gg.fr',
+            resultRecipientEmail: 'princesse-lele@gg.fr',
             birthdate: '2001-05-10',
             birthplace: 'Paris',
             birthPostalCode: '75019',


### PR DESCRIPTION
## :christmas_tree: Problème
Pour l'envoi des certifications cléA, on utilise l'email de l'utilisateur alors que ce devrait etre l'email précisé lors de l'inscription du candidat

## :gift: Proposition
Utiliser le certificationCandidates.resultRecipientEmail plutôt que le user.email

## :star2: Remarques
/

## :santa: Pour tester
https://certif-pr5186.review.pix.fr/sessions/106226

Inscrire un candidat clea en session en specifiant un email
Passer la certif
Verifier le doc pour le clea