### PR TITLE
[FEATURE] Fermer le volet "Signaler un problème" sur Pix App (PIX-6216)

### DIFF
--- a/mon-pix/app/components/comparison-window.hbs
+++ b/mon-pix/app/components/comparison-window.hbs
@@ -120,7 +120,6 @@
             @challenge={{@answer.challenge}}
             @context="comparison-window"
             @answer={{@answer}}
-            @alwaysOpenForm={{true}}
           />
         </div>
       </div>

--- a/mon-pix/tests/acceptance/challenge-feedback_test.js
+++ b/mon-pix/tests/acceptance/challenge-feedback_test.js
@@ -78,13 +78,22 @@ describe('Acceptance | Giving feedback about a challenge', function () {
   });
 
   context('From the comparison modal at the end of the test', function () {
-    it('should be able to give feedback', async () => {
-      // given
+    beforeEach(async function () {
       server.create('answer', 'skipped', { assessment, challenge: firstChallenge });
       await visit(`/assessments/${assessment.id}/checkpoint`);
-
+    });
+    it('should not display the feedback form', async () => {
       // when
       await click('.result-item__correction-button');
+
+      // then
+      assertThatFeedbackFormIsClosed();
+    });
+
+    it('should be able to give feedback', async () => {
+      // when
+      await click('.result-item__correction-button');
+      await click('.feedback-panel__open-button');
 
       // then
       assertThatFeedbackFormIsOpen();

--- a/mon-pix/tests/integration/components/comparison-window_test.js
+++ b/mon-pix/tests/integration/components/comparison-window_test.js
@@ -78,7 +78,7 @@ describe('Integration | Component | comparison-window', function () {
       expect(find('.comparison-window-content-body__instruction')).to.exist;
     });
 
-    it('should render a feedback panel already opened', async function () {
+    it('should render a closed feedback panel', async function () {
       //when
       await render(
         hbs`<ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />`
@@ -86,7 +86,7 @@ describe('Integration | Component | comparison-window', function () {
 
       //then
       expect(find('.comparison-window__feedback-panel')).to.exist;
-      expect(find('.feedback-panel__form')).to.exist;
+      expect(find('.feedback-panel__form')).to.not.exist;
     });
 
     [


### PR DESCRIPTION
## :christmas_tree: Problème
Sur l'écran réponse, le volet "Signaler un problème" est déjà déplié, ce qui incite à signaler.

## :gift: Proposition
Le fermer au départ.

## :santa: Pour tester
Vérifier que le volet est bien fermé et qu'il s'ouvre au clic.
