### PR TITLE
[BUGFIX][ORGA] Retourner une erreur lorsque le token de récupération des résultats d'une campagne n'est plus valide (PIX-6272)

### DIFF
--- a/api/lib/domain/services/token-service.js
+++ b/api/lib/domain/services/token-service.js
@@ -6,6 +6,7 @@ const {
   InvalidSessionResultError,
 } = require('../../domain/errors');
 const settings = require('../../config');
+const { ForbiddenAccess } = require('../errors');
 
 function _createAccessToken({ userId, source, expirationDelaySeconds }) {
   return jsonwebtoken.sign({ user_id: userId, source }, settings.authentication.secret, {
@@ -175,7 +176,9 @@ function extractClientId(token, secret = settings.authentication.secret) {
 
 function extractCampaignResultsTokenContent(token) {
   const decoded = getDecodedToken(token);
-  if (decoded === false) return null;
+  if (decoded === false) {
+    throw new ForbiddenAccess();
+  }
   return { userId: decoded.access_id, campaignId: decoded.campaign_id };
 }
 

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -185,49 +185,53 @@ describe('Unit | Application | Controller | Campaign', function () {
     });
 
     context('when the campaign id is not the same as provided in the access token', function () {
-      it('should thrown an error', async function () {
+      it('should throw an error', async function () {
         // given
         const userId = 1;
         const campaignId = 2;
         const request = _getRequestForCampaignId(campaignId);
 
         sinon.stub(tokenService, 'extractCampaignResultsTokenContent').returns({ userId, campaignId: 19 });
+        sinon.stub(usecases, 'startWritingCampaignAssessmentResultsToStream').resolves();
 
         // when
         const error = await catchErr(campaignController.getCsvAssessmentResults)(request);
 
         // then
         expect(error).to.be.an.instanceOf(ForbiddenAccess);
+        expect(usecases.startWritingCampaignAssessmentResultsToStream).to.not.have.been.called;
+      });
+    });
+
+    context('when the access token is invalid', function () {
+      it('should throw an error', async function () {
+        // given
+        const request = _getRequestForCampaignId(1);
+
+        sinon.stub(tokenService, 'extractCampaignResultsTokenContent').throws(new ForbiddenAccess());
+        sinon.stub(usecases, 'startWritingCampaignAssessmentResultsToStream').resolves();
+
+        // when
+        const error = await catchErr(campaignController.getCsvAssessmentResults)(request);
+
+        // then
+        expect(error).to.be.an.instanceOf(ForbiddenAccess);
+        expect(usecases.startWritingCampaignAssessmentResultsToStream).to.not.have.been.called;
       });
     });
   });
 
   describe('#getCsvProfilesCollectionResult', function () {
-    const userId = 1;
-    const campaignId = 2;
-
-    let request;
-
-    beforeEach(function () {
-      request = {
-        query: {
-          accessToken: 'token',
-        },
-        params: {
-          id: campaignId,
-        },
-        i18n: {
-          __: sinon.stub(),
-        },
-      };
-
-      sinon.stub(usecases, 'startWritingCampaignProfilesCollectionResultsToStream');
-      sinon.stub(tokenService, 'extractCampaignResultsTokenContent').returns({ userId, campaignId });
-    });
-
     it('should call the use case to get result campaign in csv', async function () {
       // given
-      usecases.startWritingCampaignProfilesCollectionResultsToStream.resolves({ fileName: 'any file name' });
+      const userId = 1;
+      const campaignId = 2;
+      const request = _getRequestForCampaignId(campaignId);
+
+      sinon
+        .stub(usecases, 'startWritingCampaignProfilesCollectionResultsToStream')
+        .resolves({ fileName: 'any file name' });
+      sinon.stub(tokenService, 'extractCampaignResultsTokenContent').returns({ userId, campaignId });
 
       // when
       await campaignController.getCsvProfilesCollectionResults(request);
@@ -241,7 +245,14 @@ describe('Unit | Application | Controller | Campaign', function () {
 
     it('should return a response with correct headers', async function () {
       // given
-      usecases.startWritingCampaignProfilesCollectionResultsToStream.resolves({ fileName: 'expected file name' });
+      const userId = 1;
+      const campaignId = 2;
+      const request = _getRequestForCampaignId(campaignId);
+
+      sinon
+        .stub(usecases, 'startWritingCampaignProfilesCollectionResultsToStream')
+        .resolves({ fileName: 'expected file name' });
+      sinon.stub(tokenService, 'extractCampaignResultsTokenContent').returns({ userId, campaignId });
 
       // when
       const response = await campaignController.getCsvProfilesCollectionResults(request);
@@ -254,9 +265,14 @@ describe('Unit | Application | Controller | Campaign', function () {
 
     it('should fix invalid header chars in filename', async function () {
       // given
-      usecases.startWritingCampaignProfilesCollectionResultsToStream.resolves({
+      const userId = 1;
+      const campaignId = 2;
+      const request = _getRequestForCampaignId(campaignId);
+
+      sinon.stub(usecases, 'startWritingCampaignProfilesCollectionResultsToStream').resolves({
         fileName: 'file-name with invalid_chars •’<>:"/\\|?*"\n.csv',
       });
+      sinon.stub(tokenService, 'extractCampaignResultsTokenContent').returns({ userId, campaignId });
 
       // when
       const response = await campaignController.getCsvProfilesCollectionResults(request);
@@ -268,15 +284,38 @@ describe('Unit | Application | Controller | Campaign', function () {
     });
 
     context('when the campaign id is not the same as provided in the access token', function () {
-      it('should thrown an error', async function () {
+      it('should throw an error', async function () {
         // given
-        tokenService.extractCampaignResultsTokenContent.returns({ userId, campaignId: 19 });
+        const userId = 1;
+        const campaignId = 2;
+        const request = _getRequestForCampaignId(campaignId);
+
+        sinon.stub(tokenService, 'extractCampaignResultsTokenContent').returns({ userId, campaignId: 19 });
+        sinon.stub(usecases, 'startWritingCampaignProfilesCollectionResultsToStream');
 
         // when
         const error = await catchErr(campaignController.getCsvProfilesCollectionResults)(request);
 
         // then
         expect(error).to.be.an.instanceOf(ForbiddenAccess);
+        expect(usecases.startWritingCampaignProfilesCollectionResultsToStream).to.not.have.been.called;
+      });
+    });
+
+    context('when the access token is invalid', function () {
+      it('should throw an error', async function () {
+        // given
+        const request = _getRequestForCampaignId(1);
+
+        sinon.stub(tokenService, 'extractCampaignResultsTokenContent').throws(new ForbiddenAccess());
+        sinon.stub(usecases, 'startWritingCampaignProfilesCollectionResultsToStream').resolves();
+
+        // when
+        const error = await catchErr(campaignController.getCsvProfilesCollectionResults)(request);
+
+        // then
+        expect(error).to.be.an.instanceOf(ForbiddenAccess);
+        expect(usecases.startWritingCampaignProfilesCollectionResultsToStream).to.not.have.been.called;
       });
     });
   });

--- a/api/tests/unit/domain/services/token-service_test.js
+++ b/api/tests/unit/domain/services/token-service_test.js
@@ -8,6 +8,7 @@ const {
   InvalidExternalUserTokenError,
   InvalidResultRecipientTokenError,
   InvalidSessionResultError,
+  ForbiddenAccess,
 } = require('../../../../lib/domain/errors');
 const settings = require('../../../../lib/config');
 const tokenService = require('../../../../lib/domain/services/token-service');
@@ -153,15 +154,15 @@ describe('Unit | Domain | Service | Token Service', function () {
     });
 
     context('invalid token', function () {
-      it('should return null', function () {
+      it('should return null', async function () {
         // given
         const accessToken = 'WRONG_DATA';
 
         // when
-        const result = tokenService.extractCampaignResultsTokenContent(accessToken);
+        const error = await catchErr(tokenService.extractCampaignResultsTokenContent)(accessToken);
 
         // then
-        expect(result).to.equal(null);
+        expect(error).to.be.an.instanceof(ForbiddenAccess);
       });
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement lorsque l’on tente de récupérer des résultats d’une campagne avec un token invalide, une erreur 500 est retournée. Ce ne doit pas être le cas. Une erreur 403 devrait plutôt être retournée.

## :gift: Proposition

Comme dans le cas où le token est valide mais n’a pas les bonnes informations dans le contenu (ex: l'identifiant de campagne est différent de celui fourni dans l'URL), il faudrait retourner la même erreur **ForbiddenAccessError**.

## :star2: Remarques

RAS

## :santa: Pour tester

- Se connecter sur Pix Orga avec un compte ayant des campagnes _(ex: pro.admin)_
- Ouvrir la page de détails d'une campagne _(ex: 18 du compte pro.admin)_
- Téléchargez les résultats
- Constatez que le CSV se télécharge
- Ouvrir la console développeur du navigateur
- Ouvrir l'onglet de l'extension|add-on Ember
- Modifiez la valeur de la propriété `tokenForCampaignResults ` de la campagne
- Téléchargez les résultats
- Constatez qu'une erreur est survenue lors du téléchargement
- Constatez au niveau des logs de l'API qu'un code HTTP 403 a été retourné
