### PR TITLE
[TECH] Retirer les arguments obsolètes des composant natifs Ember (PIX-6271)

### DIFF
--- a/mon-pix/app/components/feedback-panel.hbs
+++ b/mon-pix/app/components/feedback-panel.hbs
@@ -72,8 +72,8 @@
                     class="feedback-panel__field feedback-panel__field--content"
                     @value={{this.content}}
                     placeholder={{t "pages.challenge.feedback-panel.form.fields.detail-selection.label"}}
-                    @maxlength="10000"
-                    @rows={{5}}
+                    maxlength="10000"
+                    rows="5"
                     aria-label={{t
                       "pages.challenge.feedback-panel.form.fields.detail-selection.problem-suggestion-description"
                     }}

--- a/mon-pix/app/components/form-textfield-date.hbs
+++ b/mon-pix/app/components/form-textfield-date.hbs
@@ -14,8 +14,8 @@
       <Input
         min="1"
         max="31"
+        id={{@dayTextfieldName}}
         @type="number"
-        @id={{@dayTextfieldName}}
         @value={{@dayInputBindingValue}}
         name={{@dayTextfieldName}}
         {{on "focusout" (fn @onValidateDay @dayTextfieldName @dayInputBindingValue)}}
@@ -52,8 +52,8 @@
       <Input
         min="1"
         max="12"
+        id={{@monthTextfieldName}}
         @type="number"
-        @id={{@monthTextfieldName}}
         @value={{@monthInputBindingValue}}
         name={{@monthTextfieldName}}
         {{on "focusout" (fn @onValidateMonth @monthTextfieldName @monthInputBindingValue)}}
@@ -89,8 +89,8 @@
     >
       <Input
         min="1900"
+        id={{@yearTextfieldName}}
         @type="number"
-        @id={{@yearTextfieldName}}
         @value={{@yearInputBindingValue}}
         name={{@yearTextfieldName}}
         {{on "focusout" (fn @onValidateYear @yearTextfieldName @yearInputBindingValue)}}

--- a/mon-pix/app/components/form-textfield.hbs
+++ b/mon-pix/app/components/form-textfield.hbs
@@ -13,8 +13,8 @@
       {{if this.isPassword 'form-textfield__input-container--password'}}"
   >
     <Input
+      id={{@textfieldName}}
       @type={{this.textfieldType}}
-      @id={{@textfieldName}}
       @value={{@inputBindingValue}}
       name={{@textfieldName}}
       {{on "focusout" (fn this.onValidate @textfieldName @inputBindingValue)}}

--- a/mon-pix/app/components/qcu-proposals.hbs
+++ b/mon-pix/app/components/qcu-proposals.hbs
@@ -2,7 +2,7 @@
 {{#each this.labeledRadios as |labeledRadio index|}}
   <p class="proposal-paragraph qcu-proposals">
     <Input
-      type="radio"
+      @type="radio"
       name="radio"
       class="qcu-proposals__radio"
       value="{{inc index}}"

--- a/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.hbs
+++ b/mon-pix/app/components/routes/campaigns/invited/fill-in-participant-external-id.hbs
@@ -14,7 +14,7 @@
     <div class="fill-in-participant-external-id-form__section">
       <div class="fill-in-participant-external-id__form-field">
         <label for="id-pix-label">{{@campaign.idPixLabel}}</label>
-        <Input required @id="id-pix-label" @value={{this.participantExternalId}} />
+        <Input required id="id-pix-label" @value={{this.participantExternalId}} />
       </div>
 
       <PixButton @type="submit" class="fill-in-participant-external-id__button">

--- a/mon-pix/app/components/routes/login-form.hbs
+++ b/mon-pix/app/components/routes/login-form.hbs
@@ -55,7 +55,7 @@
     <ul>
       <li>{{t "pages.login-or-register.login-form.forgotten-password.email"}}
         <LinkTo
-          @id="link_password-reset-demand"
+          id="link_password-reset-demand"
           @route="password-reset-demand"
           target="_blank"
           rel="noopener noreferrer"

--- a/mon-pix/app/templates/assessments/results.hbs
+++ b/mon-pix/app/templates/assessments/results.hbs
@@ -29,7 +29,7 @@
             }}</span>
         </PixButtonLink>
       {{else}}
-        <LinkTo @route="authenticated" class="assessment-results__index-link__element" @tagName="button">
+        <LinkTo @route="authenticated" class="assessment-results__index-link__element">
           <span class="assessment-results__link-back">{{t "pages.assessment-results.actions.return-to-homepage"}}</span>
         </LinkTo>
       {{/if}}

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -92,12 +92,7 @@
 
   <:footer>
     <div class="mediacentre-start-campaign-modal__action-buttons">
-      <LinkTo
-        class="pix-text--link pix-text--small"
-        @route="campaigns.entry-point"
-        @model={{this.campaign.code}}
-        @backgroundColor="transparent-light"
-      >
+      <LinkTo class="pix-text--link pix-text--small" @route="campaigns.entry-point" @model={{this.campaign.code}}>
         {{t "pages.fill-in-campaign-code.mediacentre-start-campaign-modal.actions.continue"}}
       </LinkTo>
       <PixButton @triggerAction={{this.closeModal}}>

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -24,8 +24,8 @@
             class="input-code"
             @type="text"
             @value={{this.campaignCode}}
-            @maxlength="9"
-            @key-down={{this.clearErrorMessage}}
+            maxlength="9"
+            {{on "keyup" this.clearErrorMessage}}
           />
         </div>
 

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -26,10 +26,10 @@
             required
             class="input-code"
             @type="text"
-            @id="certificate-verification-code"
+            id="certificate-verification-code"
             @value={{this.certificateVerificationCode}}
-            @maxlength="10"
-            @key-down={{this.clearErrorMessage}}
+            maxlength="10"
+            {{on "keyup" this.clearErrors}}
           />
         </div>
 


### PR DESCRIPTION
## :christmas_tree: Problème
A partir de la 3.27, retiré en 4.0, certains attribut des composant natif Ember disparaisse

## :gift: Proposition
Afin de prévenir ce problème, nous faisons les modifications en amont

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier les pages impactés que tout soit correct