### PR TITLE
[BUGFIX] Correction du double log du monitoring pg-boss

### DIFF
--- a/api/lib/infrastructure/jobs/monitoring/MonitoredJobQueue.js
+++ b/api/lib/infrastructure/jobs/monitoring/MonitoredJobQueue.js
@@ -1,6 +1,5 @@
 const MonitoringJobHandler = require('./MonitoringJobExecutionTimeHandler');
 const logger = require('../../logger');
-const _ = require('lodash');
 const { teamSize, teamConcurrency } = require('../../../config').pgBoss;
 
 class MonitoredJobQueue {
@@ -14,16 +13,6 @@ class MonitoredJobQueue {
     const monitoringJobHandler = new MonitoringJobHandler({ logger });
     this.jobQueue.pgBoss.onComplete(name, { teamSize, teamConcurrency }, (job) => {
       monitoringJobHandler.handle(job);
-    });
-
-    this.jobQueue.pgBoss.on('monitor-states', (state) => {
-      logger.info({ event: 'pg-boss-state', name: 'global' }, { ...state, queues: undefined });
-      _.each(state.queues, (queueState, queueName) => {
-        logger.info({ event: 'pg-boss-state', name: queueName }, queueState);
-      });
-    });
-    this.jobQueue.pgBoss.on('error', (err) => {
-      logger.error({ event: 'pg-boss-error' }, err);
     });
   }
 


### PR DESCRIPTION
## :christmas_tree: Problème
Le monitoring des queues pg-boss est en doublon en production, parce que l'event handler a été déplacé dans `MonitoredJobQueue` qui est appelé 2 fois. Avec plusieurs events listener sur le `monitor-states`, nous dupliquons les messages.

## :gift: Proposition
Remettre le code dans worker.js car c'est du code global a pg-boss, pas spécifique a un job.

## :santa: Pour tester
1. Mettre la variable d'environnement `PGBOSS_MONITOR_STATE_INTERVAL_SECONDS=5`
2. Voir que les logs `pg-boss-state` ne sont pas en doublon
