### PR TITLE
[BUGFIX] On affiche les formations recommandées sans doublon (PIX-6277)

### DIFF
--- a/api/db/seeds/data/campaigns-sco-builder.js
+++ b/api/db/seeds/data/campaigns-sco-builder.js
@@ -113,6 +113,21 @@ function _buildCampaigns({ databaseBuilder }) {
     idPixLabel: null,
     createdAt: new Date('2020-01-07'),
   });
+
+  databaseBuilder.factory.buildCampaign({
+    name: 'Sco - AEFE - Campagne d’évaluation Pix+ Édu avec formations recommandées',
+    code: 'PIXEDUTRA',
+    type: 'ASSESSMENT',
+    organizationId: SCO_AEFE_ID,
+    creatorId: 4,
+    ownerId: 5,
+    targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,
+    assessmentMethod: 'SMART_RANDOM',
+    title: null,
+    customLandingPageText: null,
+    idPixLabel: null,
+    createdAt: new Date('2020-01-07'),
+  });
 }
 
 function _buildScoAssessmentParticipations({ databaseBuilder }) {

--- a/api/lib/infrastructure/repositories/training-repository.js
+++ b/api/lib/infrastructure/repositories/training-repository.js
@@ -73,6 +73,7 @@ module.exports = {
     const knexConn = domainTransaction?.knexTransaction || knex;
     const query = knexConn(TABLE_NAME)
       .select('trainings.*')
+      .distinct('trainings.id')
       .join('user-recommended-trainings', 'trainings.id', 'trainingId')
       .where({ userId, locale })
       .orderBy('id', 'asc');

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -307,6 +307,7 @@ describe('Integration | Repository | training-repository', function () {
     it('should return paginated trainings related to given userId', async function () {
       // given
       const { userId, id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation();
+      const { id: campaignParticipationId2 } = databaseBuilder.factory.buildCampaignParticipation({ userId });
       const { userId: anotherUserId, id: anotherCampaignParticipationId } =
         databaseBuilder.factory.buildCampaignParticipation();
       const training1 = databaseBuilder.factory.buildTraining();
@@ -318,6 +319,11 @@ describe('Integration | Repository | training-repository', function () {
         userId,
         trainingId: training1.id,
         campaignParticipationId,
+      });
+      databaseBuilder.factory.buildUserRecommendedTraining({
+        userId,
+        trainingId: training1.id,
+        campaignParticipationId: campaignParticipationId2,
       });
       databaseBuilder.factory.buildUserRecommendedTraining({
         userId,


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, si une formation est recommandée par plusieurs parcours, alors elle est affichée plusieurs fois dans la page "Mes formations".

![image](https://user-images.githubusercontent.com/7335131/200583187-ed9400c1-5468-469d-9767-d433a1b54d6f.png)

## :gift: Proposition
Utiliser un `distinct` sur la colonne `trainings.id` dans la méthode `findPaginatedByUserId` du repository.

## :santa: Pour tester

- Se connecter sur la RA : [https://app-pr5192.review.pix.fr/connexion](https://app-pr5192.review.pix.fr/connexion)
- Aller à la campagne `PIXEDUINI` et tout passer
- Aller à la campagne `PIXEDUTRA` et tout passer
- Vérifier que la page ["/mes-formations"](https://app-pr5192.review.pix.fr/mes-formations) ne contient pas de doublons de formations
