### PR TITLE
[FEATURE] Améliorer le design du bloc contenant le score (PIX-6260)

### DIFF
--- a/mon-pix/app/components/hexagon-score.hbs
+++ b/mon-pix/app/components/hexagon-score.hbs
@@ -7,7 +7,7 @@
       <PixTooltip @isLight={{true}} @isWide={{true}} @position="bottom" @id="hexagon-score-tooltip">
         <:triggerElement>
           <button
-            aria-label={{t "score-tooltip-button-label"}}
+            aria-label={{t "pages.profile.total-score-helper.label"}}
             type="button"
             class="hexagon-score-content-pix-total__icon"
             aria-describedby="hexagon-score-tooltip"

--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -118,4 +118,10 @@
   background: none;
   color: inherit;
   border: none;
+  cursor: pointer;
+
+  &:hover,
+  &:focus {
+    color: $pix-neutral-80;
+  }
 }

--- a/mon-pix/app/styles/components/dashboard/_content.scss
+++ b/mon-pix/app/styles/components/dashboard/_content.scss
@@ -143,6 +143,17 @@
 
   &__button {
     padding-top: 10px;
+    color: $pix-primary;
+
+    &:hover,
+    &:focus {
+      color: $pix-primary-70;
+      text-decoration: underline;
+    }
+
+    &:visited {
+      color: $pix-tertiary-70;
+    }
   }
 }
 


### PR DESCRIPTION
## :christmas_tree: Problème
Plusieurs soucis étaient présents sur le wrapper contenant le score Pix : 
- Le bouton de la tooltip n'avait pas de `aria-label`
- Il manquait un design au hover et focus sur ce bouton
- Le lien "Voir mes compétences" manquait également de style.

## :gift: Proposition
Rendre plus explicite ces éléments tant textuellement que visuellement.

## :santa: Pour tester
- Lancer VoiceOver/NVDA et vérifier que le `aria-label` est bien lu.
- Tester les comportements du bouton et du lien au focus et hover. 