### PR TITLE
[TECH] Mettre à jour `ember-source` en 3.26.2 (PIX-6251).

### DIFF
--- a/mon-pix/app/components/campaign-start-block.hbs
+++ b/mon-pix/app/components/campaign-start-block.hbs
@@ -2,7 +2,7 @@
 <div class="rounded-panel campaign-landing-page__container__start">
   <div class="campaign-landing-page__start__image__container">
     <div class="campaign-landing-page__pix-logo">
-      <img class="campaign-landing-page__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix" />
+      <img class="campaign-landing-page__image" src="/images/pix-logo.svg" alt="Pix" />
     </div>
     {{#if @campaign.organizationLogoUrl}}
       <div data-test-id="campaign-landing-page__logo">

--- a/mon-pix/app/components/certification-results-page.hbs
+++ b/mon-pix/app/components/certification-results-page.hbs
@@ -4,7 +4,7 @@
 <div class="certification-results__content rounded-panel result-content">
   {{#if this.notFinishedYet}}
 
-    <img src="{{@rootURL}}/images/illustrations/flag.svg" alt={{t "pages.certification-results.flag-alt"}} />
+    <img src="/images/illustrations/flag.svg" alt={{t "pages.certification-results.flag-alt"}} />
     <div class="result-content__panel-title">
       {{t "pages.certification-results.not-finished.title"}}
     </div>

--- a/mon-pix/app/components/footer.hbs
+++ b/mon-pix/app/components/footer.hbs
@@ -3,10 +3,7 @@
     <div class="footer-container__logos">
       {{#if this.shouldShowTheMarianneLogo}}
         <div class="footer-logos__french-government">
-          <img
-            src="{{this.rootURL}}/images/logo/logo-de-la-republique-francaise.svg"
-            alt="{{t 'common.french-republic'}}"
-          />
+          <img src="/images/logo/logo-de-la-republique-francaise.svg" alt="{{t 'common.french-republic'}}" />
         </div>
       {{/if}}
 

--- a/mon-pix/app/components/inaccessible-campaign.hbs
+++ b/mon-pix/app/components/inaccessible-campaign.hbs
@@ -4,13 +4,13 @@
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner">
     <div class="campaign-landing-page__start__image__container">
       <div class="campaign-landing-page__pix-logo">
-        <img class="campaign-landing-page__image" src="{{rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.pix'}}" />
+        <img class="campaign-landing-page__image" src="/images/pix-logo.svg" alt="{{t 'navigation.pix'}}" />
       </div>
       {{#if this.shouldShowTheMarianneLogo}}
         <div class="campaign-landing-page__marianne-logo">
           <img
             class="campaign-landing-page__image"
-            src="{{rootURL}}/images/logo/logo-de-la-republique-francaise.svg"
+            src="/images/logo/logo-de-la-republique-francaise.svg"
             alt="{{t 'common.french-republic'}}"
           />
         </div>

--- a/mon-pix/app/components/levelup-notif.hbs
+++ b/mon-pix/app/components/levelup-notif.hbs
@@ -2,7 +2,7 @@
 <div {{did-update this.resetLevelUp}}>
   {{#unless this.closeLevelup}}
     <div class="levelup">
-      <img src="{{rootURL}}/images/levelup.svg" alt="" role="none" />
+      <img src="/images/levelup.svg" alt="" role="none" />
       <div class="levelup__icon-card-level">{{@level}}</div>
       <div class="levelup__competence">
         <div class="levelup-competence__level">{{t "pages.levelup-notif.obtained-level" level=@level}}</div>

--- a/mon-pix/app/components/navbar-desktop-header.hbs
+++ b/mon-pix/app/components/navbar-desktop-header.hbs
@@ -3,10 +3,7 @@
     <div class="navbar-desktop-header-logo">
       {{#if @shouldShowTheMarianneLogo}}
         <div class="navbar-desktop-header-logo__marianne">
-          <img
-            src="{{this.rootURL}}/images/logo/logo-de-la-republique-francaise.svg"
-            alt="{{t 'common.french-republic'}}"
-          />
+          <img src="/images/logo/logo-de-la-republique-francaise.svg" alt="{{t 'common.french-republic'}}" />
         </div>
       {{/if}}
       <PixLogo />

--- a/mon-pix/app/components/navbar-mobile-header.hbs
+++ b/mon-pix/app/components/navbar-mobile-header.hbs
@@ -24,7 +24,7 @@
       </div>
       {{#if @shouldShowTheMarianneLogo}}
         <div class="navbar-mobile-header-logo__marianne">
-          <img src="{{rootURL}}/images/logo/logo-de-la-republique-francaise.svg" alt={{t "common.french-republic"}} />
+          <img src="/images/logo/logo-de-la-republique-francaise.svg" alt={{t "common.french-republic"}} />
         </div>
       {{/if}}
     </div>

--- a/mon-pix/app/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/components/password-reset-demand-form.hbs
@@ -1,7 +1,7 @@
 <main class="sign-form__container" role="main">
 
   <a href={{this.showcaseUrl}} class="pix-logo__link">
-    <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
+    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
   </a>
 
   <div class="sign-form__header">

--- a/mon-pix/app/components/pix-logo.hbs
+++ b/mon-pix/app/components/pix-logo.hbs
@@ -1,5 +1,5 @@
 <div class="pix-logo">
   <LinkTo @route="authenticated" class="pix-logo__link">
-    <img class="pix-logo__image" src="{{this.rootURL}}/images/pix-logo.svg" alt={{t "navigation.homepage"}} />
+    <img class="pix-logo__image" src="/images/pix-logo.svg" alt={{t "navigation.homepage"}} />
   </LinkTo>
 </div>

--- a/mon-pix/app/components/pix-toggle.hbs
+++ b/mon-pix/app/components/pix-toggle.hbs
@@ -1,12 +1,12 @@
 {{! template-lint-disable no-implicit-this no-action no-curly-component-invocation no-invalid-interactive }}
 <div class="pix-toggle">
   <span
-    class="{{firstButtonClass}}"
+    class="{{this.firstButtonClass}}"
     onToggle={{action "onToggle" "firstButtonClass" on="click"}}
-  >{{valueFirstLabel}}</span>
+  >{{this.valueFirstLabel}}</span>
   <span
-    class="{{secondButtonClass}}"
+    class="{{this.secondButtonClass}}"
     onToggle={{action "onToggle" "secondButtonClass" on="click"}}
-  >{{valueSecondLabel}}</span>
+  >{{this.valueSecondLabel}}</span>
 </div>
 {{yield}}

--- a/mon-pix/app/components/reached-stage.hbs
+++ b/mon-pix/app/components/reached-stage.hbs
@@ -4,7 +4,7 @@
       {{#if this.firstStar}}
         <img
           data-test-status="{{this.firstStar.status}}"
-          src="{{this.rootURL}}/images/{{this.firstStar.imageSrc}}"
+          src="/images/{{this.firstStar.imageSrc}}"
           alt="{{t
             'pages.skill-review.stage.starsAcquired'
             acquired=this.acquiredStarsCount
@@ -12,7 +12,7 @@
           }}"
         />
         {{#each this.otherStars as |star|}}
-          <img data-test-status="{{star.status}}" src="{{this.rootURL}}/images/{{star.imageSrc}}" alt="" role="none" />
+          <img data-test-status="{{star.status}}" src="/images/{{star.imageSrc}}" alt="" role="none" />
         {{/each}}
       {{/if}}
     </div>

--- a/mon-pix/app/components/reset-password-form.hbs
+++ b/mon-pix/app/components/reset-password-form.hbs
@@ -1,7 +1,7 @@
 <div class="sign-form__container">
 
   <a href={{this.showcaseUrl}} class="pix-logo__link">
-    <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
+    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
   </a>
 
   <div class="sign-form__header">

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -6,12 +6,7 @@
   {{#if this.showDisabledBlock}}
     <PixBlock class="skill-review__result-abstract-container">
       <div class="skill-review__disabled-share">
-        <img
-          class="skill-review-disabled-share__image"
-          src="{{this.rootURL}}/images/illustrations/fat-bee.svg"
-          alt=""
-          role="none"
-        />
+        <img class="skill-review-disabled-share__image" src="/images/illustrations/fat-bee.svg" alt="" role="none" />
         <p class="skill-review-disabled-share__text">
           {{t "pages.skill-review.disabled-share" htmlSafe=true}}
         </p>
@@ -207,7 +202,9 @@
             target="_blank"
             rel="noopener noreferrer"
             href={{this.customButtonUrl}}
-          >{{this.customButtonText}}<FaIcon @icon="up-right-from-square" aria-hidden="true" /></a>
+          >{{this.customButtonText}}
+            <FaIcon @icon="up-right-from-square" aria-hidden="true" />
+          </a>
         {{/if}}
       </div>
     </PixBlock>

--- a/mon-pix/app/components/routes/campaigns/profiles-collection/send-profile.hbs
+++ b/mon-pix/app/components/routes/campaigns/profiles-collection/send-profile.hbs
@@ -2,7 +2,7 @@
   <div class="send-profile-header__announcement">
     <img
       class="send-profile-header__image"
-      src="{{rootURL}}/images/illustrations/fat-bee.svg"
+      src="/images/illustrations/fat-bee.svg"
       alt={{t "pages.profile-already-shared.first-title"}}
     />
     <p class="send-profile-disabled-share__text">

--- a/mon-pix/app/components/signin-form.hbs
+++ b/mon-pix/app/components/signin-form.hbs
@@ -1,7 +1,7 @@
 <main class="sign-form__container" role="main">
 
   <a href={{this.showcaseUrl}} class="pix-logo__link">
-    <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
+    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
   </a>
 
   <div class="sign-form__header">
@@ -72,7 +72,7 @@
       </div>
 
       <LinkTo @route="authentication.login-oidc" @model="pole-emploi" class="sign-form-body__pole-emploi-connect-link">
-        <img src="{{this.rootURL}}/images/logo/pe-connect-logo.svg" alt="{{t 'pages.sign-in.pole-emploi.link.img'}}" />
+        <img src="/images/logo/pe-connect-logo.svg" alt="{{t 'pages.sign-in.pole-emploi.link.img'}}" />
         <span>{{t "pages.sign-in.pole-emploi.title"}}</span>
       </LinkTo>
     {{/if}}

--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -1,6 +1,6 @@
 <main class="sign-form__container" role="main">
   <a href={{this.showcaseUrl}} class="pix-logo__link">
-    <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
+    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
   </a>
 
   <div class="sign-form__header">

--- a/mon-pix/app/components/tutorial-panel.hbs
+++ b/mon-pix/app/components/tutorial-panel.hbs
@@ -8,7 +8,7 @@
         <div class="tutorial-panel__hint-container-body">
           <div class="tutorial-panel__hint-picto-container">
             <img
-              src="{{this.rootURL}}/images/icons/comparison-window/icon-lampe.svg"
+              src="/images/icons/comparison-window/icon-lampe.svg"
               alt=""
               role="presentation"
               class="tutorial-panel__hint-picto"

--- a/mon-pix/app/components/update-expired-password-form.hbs
+++ b/mon-pix/app/components/update-expired-password-form.hbs
@@ -1,7 +1,7 @@
 <div class="update-expired-password-form__container">
 
   <a href={{this.showcaseUrl}} class="pix-logo__link">
-    <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
+    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
   </a>
 
   <div class="update-expired-password-form__header">

--- a/mon-pix/app/components/user-certifications-detail-competence.hbs
+++ b/mon-pix/app/components/user-certifications-detail-competence.hbs
@@ -5,7 +5,7 @@
     <span class="user-certifications-detail-competence__title--level">{{t "common.level"}}</span>
   </h3>
 
-  {{#each sortedCompetences as |competence|}}
+  {{#each this.sortedCompetences as |competence|}}
     <div>
       <p
         class="user-certifications-detail-competence__competence

--- a/mon-pix/app/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/components/user-certifications-detail-header.hbs
@@ -19,7 +19,10 @@
             birthplace=@certification.birthplace
           }}
         {{else}}
-          {{t "pages.certificate.candidate-birth" birthdate=(moment-format birthdateMidnightLocalTime "D MMMM YYYY")}}
+          {{t
+            "pages.certificate.candidate-birth"
+            birthdate=(moment-format birthdateMidnightLocalTime "D MMMM YYYY")
+          }}
         {{/if}}
       </p>
 

--- a/mon-pix/app/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/components/user-certifications-detail-header.hbs
@@ -15,13 +15,13 @@
         {{#if @certification.birthplace}}
           {{t
             "pages.certificate.candidate-birth-complete"
-            birthdate=(moment-format birthdateMidnightLocalTime "D MMMM YYYY")
+            birthdate=(moment-format this.birthdateMidnightLocalTime "D MMMM YYYY")
             birthplace=@certification.birthplace
           }}
         {{else}}
           {{t
             "pages.certificate.candidate-birth"
-            birthdate=(moment-format birthdateMidnightLocalTime "D MMMM YYYY")
+            birthdate=(moment-format this.birthdateMidnightLocalTime "D MMMM YYYY")
           }}
         {{/if}}
       </p>

--- a/mon-pix/app/controllers/account-recovery/find-sco-record.js
+++ b/mon-pix/app/controllers/account-recovery/find-sco-record.js
@@ -15,6 +15,7 @@ class StudentInformationForAccountRecovery {
 
 export default class FindScoRecordController extends Controller {
   @service intl;
+  @service store;
 
   @tracked accountRecoveryError = {
     message: '',

--- a/mon-pix/app/controllers/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/controllers/authentication/login-or-register-oidc.js
@@ -8,6 +8,7 @@ export default class LoginOrRegisterOidcController extends Controller {
 
   @service url;
   @service oidcIdentityProviders;
+  @service store;
 
   @tracked showOidcReconciliation = false;
   @tracked authenticationKey = null;

--- a/mon-pix/app/controllers/fill-in-certificate-verification-code.js
+++ b/mon-pix/app/controllers/fill-in-certificate-verification-code.js
@@ -6,6 +6,7 @@ import Controller from '@ember/controller';
 export default class FillInCertificateVerificationCode extends Controller {
   @service store;
   @service intl;
+  @service router;
 
   certificateVerificationCode = null;
 
@@ -36,7 +37,7 @@ export default class FillInCertificateVerificationCode extends Controller {
       const certification = await this.store.queryRecord('certification', {
         verificationCode: this.certificateVerificationCode.toUpperCase(),
       });
-      this.transitionToRoute('shared-certification', certification);
+      this.router.transitionTo('shared-certification', certification);
       return;
     } catch (error) {
       this.onVerificateCertificationCodeError(error);

--- a/mon-pix/app/controllers/terms-of-service.js
+++ b/mon-pix/app/controllers/terms-of-service.js
@@ -7,6 +7,7 @@ export default class TermsOfServiceController extends Controller {
   @service session;
   @service currentUser;
   @service url;
+  @service router;
 
   @tracked isTermsOfServiceValidated = false;
   @tracked showErrorTermsOfServiceNotSelected = false;
@@ -24,7 +25,7 @@ export default class TermsOfServiceController extends Controller {
       if (this.session.attemptedTransition) {
         this.session.attemptedTransition.retry();
       } else {
-        this.transitionToRoute('');
+        this.router.transitionTo('');
       }
     } else {
       this.showErrorTermsOfServiceNotSelected = true;

--- a/mon-pix/app/templates/account-recovery/find-sco-record.hbs
+++ b/mon-pix/app/templates/account-recovery/find-sco-record.hbs
@@ -4,7 +4,7 @@
   <div class="account-recovery__content">
     <PixLogo />
     <div class="account-recovery__content--image">
-      <img alt="" role="none" src="{{rootURL}}/images/illustrations/account-recovery/{{this.templateImg}}.svg" />
+      <img alt="" role="none" src="/images/illustrations/account-recovery/{{this.templateImg}}.svg" />
     </div>
 
     <div class="account-recovery__content--step">

--- a/mon-pix/app/templates/account-recovery/update-sco-record.hbs
+++ b/mon-pix/app/templates/account-recovery/update-sco-record.hbs
@@ -4,7 +4,7 @@
   <div class="account-recovery__content">
     <PixLogo />
     <div class="account-recovery__content--image">
-      <img alt="" role="none" src="{{rootURL}}/images/illustrations/account-recovery/illustration.svg" />
+      <img alt="" role="none" src="/images/illustrations/account-recovery/illustration.svg" />
     </div>
 
     <div class="account-recovery__content--step">

--- a/mon-pix/app/templates/application.hbs
+++ b/mon-pix/app/templates/application.hbs
@@ -7,5 +7,5 @@
   {{outlet}}
 
   <!-- Preloading images -->
-  <img src="{{rootURL}}/images/loader-white.svg" alt="{{t 'common.loading.default'}}" style="display: none" />
+  <img src="/images/loader-white.svg" alt="{{t 'common.loading.default'}}" style="display: none" />
 </div>

--- a/mon-pix/app/templates/assessments.hbs
+++ b/mon-pix/app/templates/assessments.hbs
@@ -1,4 +1,4 @@
 {{! template-lint-disable no-implicit-this  }}
-{{page-title model.title}}
+{{page-title @model.title}}
 
 {{outlet}}

--- a/mon-pix/app/templates/authenticated/competences/results.hbs
+++ b/mon-pix/app/templates/authenticated/competences/results.hbs
@@ -10,7 +10,7 @@
 
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner">
     <div class="competence-results-panel__header">
-      {{#if model.scorecard.hasNotEarnAnything}}
+      {{#if @model.scorecard.hasNotEarnAnything}}
         <div class="competence-results-panel-header__banner competence-results-panel-header__banner--too-bad">
           <p class="competence-results-panel-header__banner-result-comment">{{t
               "pages.competence-result.header.too-bad"
@@ -19,7 +19,7 @@
             {{t "pages.competence-result.header.too-bad-subtitle"}}
           </div>
         </div>
-      {{else if model.scorecard.hasNotReachLevelOne}}
+      {{else if @model.scorecard.hasNotReachLevelOne}}
         <div class="competence-results-panel-header__banner competence-results-panel-header__banner--not-bad">
           <p class="competence-results-panel-header__banner-result-comment">{{t
               "pages.competence-result.header.not-bad"
@@ -37,7 +37,7 @@
             </div>
           </div>
         </div>
-      {{else if model.scorecard.hasReachAtLeastLevelOne}}
+      {{else if @model.scorecard.hasReachAtLeastLevelOne}}
         <div class="competence-results-panel-header__banner competence-results-panel-header__banner--congrats">
           <p class="competence-results-panel-header__banner-result-comment">{{t
               "pages.competence-result.header.congratulations"
@@ -61,7 +61,7 @@
         </div>
       {{/if}}
     </div>
-    {{#if model.scorecard}}
+    {{#if @model.scorecard}}
       <ScorecardDetails @scorecard={{@model.scorecard}} />
     {{/if}}
   </div>

--- a/mon-pix/app/templates/authenticated/user-tests.hbs
+++ b/mon-pix/app/templates/authenticated/user-tests.hbs
@@ -7,12 +7,7 @@
 <main id="main" role="main">
   <PixBackgroundHeader>
     <div class="user-tests-banner">
-      <img
-        src="{{this.rootURL}}/images/background/user-test-banner.svg"
-        class="user-tests-banner__icon"
-        role="none"
-        alt=""
-      />
+      <img src="/images/background/user-test-banner.svg" class="user-tests-banner__icon" role="none" alt="" />
       <h3 class="user-tests-banner__title">{{t "pages.user-tests.title"}}</h3>
     </div>
   </PixBackgroundHeader>

--- a/mon-pix/app/templates/campaigns/assessment/tutorial.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/tutorial.hbs
@@ -17,13 +17,13 @@
     <div class="campaign-tutorial__explanation-text"><p>{{@model.explanation}}</p></div>
 
     <div class="campaign-tutorial__paging">
-      {{#each model.paging as |page-class|}}
-        <div class="dot {{page-class}}"> </div>
+      {{#each @model.paging as |page-class|}}
+        <div class="dot {{page-class}}"></div>
       {{/each}}
 
     </div>
     <div class="campaign-tutorial__next-button">
-      {{#if model.showNextButton}}
+      {{#if @model.showNextButton}}
         <PixButton @type="submit" @triggerAction={{this.nextStep}} class="campaign-tutorial__buttons">{{t
             "pages.tutorial.next"
           }}</PixButton>

--- a/mon-pix/app/templates/campaigns/assessment/tutorial.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/tutorial.hbs
@@ -11,7 +11,7 @@
     </div>
 
     <div class="campaign-tutorial__explanation-icon">
-      <img alt="" role="none" src="{{rootURL}}/images/illustrations/tutorial-campaign/{{@model.icon}}" />
+      <img alt="" role="none" src="/images/illustrations/tutorial-campaign/{{@model.icon}}" />
     </div>
 
     <div class="campaign-tutorial__explanation-text"><p>{{@model.explanation}}</p></div>

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -15,7 +15,7 @@
           <div class="campaign-landing-page__details__measure__container">
             <img
               class="campaign-landing-page__details__article-image measure"
-              src="{{this.rootURL}}/images/illustrations/landing-page/icon-mesurer.svg"
+              src="/images/illustrations/landing-page/icon-mesurer.svg"
               role="none"
               alt=""
             />
@@ -36,7 +36,7 @@
           <div
             class="campaign-landing-page__details__measure__container campaign-landing-page__details__measure__container--dashline"
           >
-            <img src="{{this.rootURL}}/images/illustrations/landing-page/icon-conseil.svg" role="none" alt="" />
+            <img src="/images/illustrations/landing-page/icon-conseil.svg" role="none" alt="" />
             <div class="campaign-landing-page__details__article-side">
               <p class="campaign-landing-page__details__text article-title">
                 {{t "pages.campaign-landing.assessment.develop.title"}}
@@ -51,7 +51,7 @@
           <div
             class="campaign-landing-page__details__measure__container campaign-landing-page__details__measure__container--dashline"
           >
-            <img src="{{this.rootURL}}/images/illustrations/landing-page/icon-certif.svg" role="none" alt="" />
+            <img src="/images/illustrations/landing-page/icon-certif.svg" role="none" alt="" />
             <div class="campaign-landing-page__details__article-side">
               <p class="campaign-landing-page__details__text article-title">
                 {{t "pages.campaign-landing.assessment.certify.title"}}

--- a/mon-pix/app/templates/campaigns/profiles-collection/profile-already-shared.hbs
+++ b/mon-pix/app/templates/campaigns/profiles-collection/profile-already-shared.hbs
@@ -8,7 +8,7 @@
       {{#unless this.model.sharedProfile.canRetry}}
         <img
           class="send-profile-header__image"
-          src="{{rootURL}}/images/illustrations/fat-bee.svg"
+          src="/images/illustrations/fat-bee.svg"
           alt={{t "pages.profile-already-shared.first-title"}}
         />
       {{/unless}}

--- a/mon-pix/app/templates/head.hbs
+++ b/mon-pix/app/templates/head.hbs
@@ -4,5 +4,5 @@
   here. The 'model' available in this template can be populated by
   setting values on the 'head-data' service.
 }}
-<title>{{model.title}}</title>
-<meta name="description" content={{model.description}} />
+<title>{{this.model.title}}</title>
+<meta name="description" content={{this.model.description}} />

--- a/mon-pix/app/templates/terms-of-service.hbs
+++ b/mon-pix/app/templates/terms-of-service.hbs
@@ -5,7 +5,7 @@
 
     <div class="terms-of-service-form__logo">
       <a href={{this.showcaseUrl}}>
-        <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
+        <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
       </a>
     </div>
 

--- a/mon-pix/mirage/routes/authentication/oidc/index.js
+++ b/mon-pix/mirage/routes/authentication/oidc/index.js
@@ -79,10 +79,14 @@ export default function (config) {
 
   config.post('/oidc/user/check-reconciliation', () => {
     return {
-      'full-name-from-pix': 'LLoyd Cé',
-      'full-name-from-external-identity-provider': 'LLoyd Idp',
-      email: 'lloyd.ce@example.net',
-      'authentication-methods': [{ identityProvider: 'PIX' }],
+      data: {
+        attributes: {
+          'full-name-from-pix': 'LLoyd Cé',
+          'full-name-from-external-identity-provider': 'LLoyd Idp',
+          email: 'lloyd.ce@example.net',
+          'authentication-methods': [{ identityProvider: 'PIX' }],
+        },
+      },
     };
   });
 }

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -67,7 +67,7 @@
         "ember-resolver": "^8.0.3",
         "ember-responsive": "^5.0.0",
         "ember-simple-auth": "^4.0.2",
-        "ember-source": "^3.25.4",
+        "ember-source": "^3.26.2",
         "ember-template-lint": "^3.16.0",
         "ember-template-lint-plugin-prettier": "^3.0.1",
         "ember-test-selectors": "^6.0.0",
@@ -23976,9 +23976,9 @@
       }
     },
     "node_modules/ember-source": {
-      "version": "3.25.4",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.25.4.tgz",
-      "integrity": "sha512-XqymJJwmY2hFOYg+CX9Rd9hSB0aHwzkCAW2XokFYRQ9zRFe/l5xaTSyP5FOsvt92Mv1sgxBzcAJCE6d74+FsZg==",
+      "version": "3.26.2",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.26.2.tgz",
+      "integrity": "sha512-s7S+6xVwYYmNCK0rGTAimPw1ahiuOXsFgs0jFMVqwMEndvo+GQvk4rEYDHs0JgN+o5UhQjVpoPqXxkgfPTL38A==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.8.3",
@@ -24002,9 +24002,9 @@
         "ember-cli-version-checker": "^5.1.1",
         "ember-router-generator": "^2.0.0",
         "inflection": "^1.12.0",
-        "jquery": "^3.5.0",
+        "jquery": "^3.5.1",
         "resolve": "^1.17.0",
-        "semver": "^6.1.1",
+        "semver": "^7.3.4",
         "silent-error": "^1.1.1"
       },
       "engines": {
@@ -24134,21 +24134,6 @@
         "node": "10.* || >= 12.*"
       }
     },
-    "node_modules/ember-source/node_modules/ember-cli-version-checker/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ember-source/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -24196,12 +24181,18 @@
       }
     },
     "node_modules/ember-source/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ember-source/node_modules/supports-color": {
@@ -56704,9 +56695,9 @@
       }
     },
     "ember-source": {
-      "version": "3.25.4",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.25.4.tgz",
-      "integrity": "sha512-XqymJJwmY2hFOYg+CX9Rd9hSB0aHwzkCAW2XokFYRQ9zRFe/l5xaTSyP5FOsvt92Mv1sgxBzcAJCE6d74+FsZg==",
+      "version": "3.26.2",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.26.2.tgz",
+      "integrity": "sha512-s7S+6xVwYYmNCK0rGTAimPw1ahiuOXsFgs0jFMVqwMEndvo+GQvk4rEYDHs0JgN+o5UhQjVpoPqXxkgfPTL38A==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.8.3",
@@ -56730,9 +56721,9 @@
         "ember-cli-version-checker": "^5.1.1",
         "ember-router-generator": "^2.0.0",
         "inflection": "^1.12.0",
-        "jquery": "^3.5.0",
+        "jquery": "^3.5.1",
         "resolve": "^1.17.0",
-        "semver": "^6.1.1",
+        "semver": "^7.3.4",
         "silent-error": "^1.1.1"
       },
       "dependencies": {
@@ -56815,17 +56806,6 @@
             "resolve-package-path": "^3.1.0",
             "semver": "^7.3.4",
             "silent-error": "^1.1.1"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "7.3.5",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-              "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-              "dev": true,
-              "requires": {
-                "lru-cache": "^6.0.0"
-              }
-            }
           }
         },
         "has-flag": {
@@ -56860,10 +56840,13 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         },
         "supports-color": {
           "version": "7.2.0",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -96,7 +96,7 @@
     "ember-resolver": "^8.0.3",
     "ember-responsive": "^5.0.0",
     "ember-simple-auth": "^4.0.2",
-    "ember-source": "^3.25.4",
+    "ember-source": "^3.26.2",
     "ember-template-lint": "^3.16.0",
     "ember-template-lint-plugin-prettier": "^3.0.1",
     "ember-test-selectors": "^6.0.0",

--- a/mon-pix/tests/integration/components/assessment-banner_test.js
+++ b/mon-pix/tests/integration/components/assessment-banner_test.js
@@ -14,20 +14,20 @@ describe('Integration | Component | assessment-banner', function () {
 
   it('should not display home link button if not requested', async function () {
     this.set('assessmentTitle', 'My assessment');
-    await render(hbs`{{assessment-banner title=assessmentTitle}}`);
+    await render(hbs`{{assessment-banner title=this.assessmentTitle}}`);
     expect(find('.assessment-banner__home-link')).to.not.exist;
   });
 
   it('should display home link button if requested', async function () {
     this.set('assessmentTitle', 'My assessment');
-    await render(hbs`{{assessment-banner title=assessmentTitle displayHomeLink=true}}`);
+    await render(hbs`{{assessment-banner title=this.assessmentTitle displayHomeLink=true}}`);
     expect(find('.assessment-banner__home-link')).to.exist;
   });
 
   context('When assessment has a title', function () {
     beforeEach(async function () {
       this.set('assessmentTitle', 'My assessment');
-      await render(hbs`{{assessment-banner title=assessmentTitle}}`);
+      await render(hbs`{{assessment-banner title=this.assessmentTitle}}`);
     });
 
     it('should render the banner with accessible title information', function () {
@@ -54,7 +54,7 @@ describe('Integration | Component | assessment-banner', function () {
   context("When assessment doesn't have a title", function () {
     beforeEach(async function () {
       this.set('assessmentTitle', null);
-      await render(hbs`{{assessment-banner title=assessmentTitle}}`);
+      await render(hbs`{{assessment-banner title=this.assessmentTitle}}`);
     });
 
     it('should not render the banner with a title', function () {

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/disabled_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/disabled_test.js
@@ -158,7 +158,7 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Archi
 
           // when
           const screen = await renderScreen(
-            hbs`<CampaignParticipationOverview::Card::Disabled @model={{campaignParticipationOverview}} />`
+            hbs`<CampaignParticipationOverview::Card::Disabled @model={{this.campaignParticipationOverview}} />`
           );
 
           // then

--- a/mon-pix/tests/integration/components/certification-results-page_test.js
+++ b/mon-pix/tests/integration/components/certification-results-page_test.js
@@ -18,7 +18,7 @@ describe('Integration | Component | certification results template', function ()
 
     it('should not be able to click on validation button when the verification is unchecked ', async function () {
       // when
-      await render(hbs`{{certification-results-page certificationNumber=certificationNumber}}`);
+      await render(hbs`{{certification-results-page certificationNumber=this.certificationNumber}}`);
 
       // then
       expect(find('.result-content__validation-button')).to.not.exist;
@@ -27,7 +27,7 @@ describe('Integration | Component | certification results template', function ()
 
     it('should be able to click on validation when we check to show the last message', async function () {
       // when
-      const screen = await render(hbs`{{certification-results-page certificationNumber=certificationNumber}}`);
+      const screen = await render(hbs`{{certification-results-page certificationNumber=this.certificationNumber}}`);
       await click(
         screen.getByRole('checkbox', { name: this.intl.t('pages.certification-results.not-finished.checkbox-label') })
       );
@@ -41,7 +41,7 @@ describe('Integration | Component | certification results template', function ()
 
     it('should have a button to logout at the end of certification', async function () {
       // when
-      const screen = await render(hbs`{{certification-results-page certificationNumber=certificationNumber}}`);
+      const screen = await render(hbs`{{certification-results-page certificationNumber=this.certificationNumber}}`);
       await click(
         screen.getByRole('checkbox', { name: this.intl.t('pages.certification-results.not-finished.checkbox-label') })
       );

--- a/mon-pix/tests/integration/components/certifications/certification-ender_test.js
+++ b/mon-pix/tests/integration/components/certifications/certification-ender_test.js
@@ -24,7 +24,7 @@ describe('Integration | Component | Certifications | CertificationEnder', functi
 
     // when
     const screen = await renderScreen(hbs`
-      <Certifications::CertificationEnder @certificationNumber={{certificationNumber}} />
+      <Certifications::CertificationEnder @certificationNumber={{this.certificationNumber}} />
     `);
 
     // then
@@ -38,11 +38,12 @@ describe('Integration | Component | Certifications | CertificationEnder', functi
         fullName: 'Jim Halpert',
       };
     }
+
     this.owner.register('service:currentUser', currentUser);
 
     // when
     const screen = await renderScreen(hbs`
-      <Certifications::CertificationEnder @certificationNumber={{certificationNumber}} />
+      <Certifications::CertificationEnder @certificationNumber={{this.certificationNumber}} />
     `);
 
     // then
@@ -52,7 +53,7 @@ describe('Integration | Component | Certifications | CertificationEnder', functi
   it('should display the remote certification logout message', async function () {
     // when
     const screen = await renderScreen(hbs`
-      <Certifications::CertificationEnder @certificationNumber={{certificationNumber}} />
+      <Certifications::CertificationEnder @certificationNumber={{this.certificationNumber}} />
     `);
 
     // then
@@ -67,11 +68,12 @@ describe('Integration | Component | Certifications | CertificationEnder', functi
           fullName: 'Jim Halpert',
         };
       }
+
       this.owner.register('service:currentUser', currentUser);
 
       // when
       const screen = await renderScreen(hbs`
-      <Certifications::CertificationEnder @certificationNumber={{certificationNumber}} @isEndedBySupervisor={{false}} />
+      <Certifications::CertificationEnder @certificationNumber={{this.certificationNumber}} @isEndedBySupervisor={{false}} />
     `);
 
       // then
@@ -87,11 +89,12 @@ describe('Integration | Component | Certifications | CertificationEnder', functi
           fullName: 'Jim Halpert',
         };
       }
+
       this.owner.register('service:currentUser', currentUser);
 
       // when
       const screen = await renderScreen(hbs`
-      <Certifications::CertificationEnder @certificationNumber={{certificationNumber}} @isEndedBySupervisor={{true}} />
+      <Certifications::CertificationEnder @certificationNumber={{this.certificationNumber}} @isEndedBySupervisor={{true}} />
     `);
 
       // then
@@ -107,11 +110,12 @@ describe('Integration | Component | Certifications | CertificationEnder', functi
           fullName: 'Jim Halpert',
         };
       }
+
       this.owner.register('service:currentUser', currentUser);
 
       // when
       const screen = await renderScreen(hbs`
-      <Certifications::CertificationEnder @certificationNumber={{certificationNumber}} @hasBeenEndedDueToFinalization={{true}} />
+      <Certifications::CertificationEnder @certificationNumber={{this.certificationNumber}} @hasBeenEndedDueToFinalization={{true}} />
     `);
 
       // then

--- a/mon-pix/tests/integration/components/competence-card-mobile_test.js
+++ b/mon-pix/tests/integration/components/competence-card-mobile_test.js
@@ -24,7 +24,7 @@ describe('Integration | Component | competence-card-mobile', function () {
       this.set('scorecard', scorecard);
 
       // when
-      await render(hbs`{{competence-card-mobile scorecard=scorecard}}`);
+      await render(hbs`{{competence-card-mobile scorecard=this.scorecard}}`);
 
       // then
       expect(find('.competence-card')).to.exist;
@@ -36,7 +36,7 @@ describe('Integration | Component | competence-card-mobile', function () {
       this.set('scorecard', scorecard);
 
       // when
-      await render(hbs`{{competence-card-mobile scorecard=scorecard}}`);
+      await render(hbs`{{competence-card-mobile scorecard=this.scorecard}}`);
 
       // then
       expect(find('.competence-card__wrapper').getAttribute('class')).to.contains('competence-card__wrapper--jaffa');
@@ -48,7 +48,7 @@ describe('Integration | Component | competence-card-mobile', function () {
       this.set('scorecard', scorecard);
 
       // when
-      await render(hbs`{{competence-card-mobile scorecard=scorecard}}`);
+      await render(hbs`{{competence-card-mobile scorecard=this.scorecard}}`);
 
       // then
       expect(find('.competence-card__area-name').textContent).to.equal(scorecard.area.title);
@@ -60,7 +60,7 @@ describe('Integration | Component | competence-card-mobile', function () {
       this.set('scorecard', scorecard);
 
       // when
-      await render(hbs`{{competence-card-mobile scorecard=scorecard}}`);
+      await render(hbs`{{competence-card-mobile scorecard=this.scorecard}}`);
 
       // then
       expect(find('.competence-card__competence-name').textContent).to.equal(scorecard.name);
@@ -72,7 +72,7 @@ describe('Integration | Component | competence-card-mobile', function () {
       this.set('scorecard', scorecard);
 
       // when
-      await render(hbs`{{competence-card-mobile scorecard=scorecard}}`);
+      await render(hbs`{{competence-card-mobile scorecard=this.scorecard}}`);
 
       // then
       expect(find('.score-value').textContent).to.equal(scorecard.level.toString());
@@ -86,7 +86,7 @@ describe('Integration | Component | competence-card-mobile', function () {
           this.set('scorecard', scorecard);
 
           // when
-          await render(hbs`{{competence-card-mobile scorecard=scorecard}}`);
+          await render(hbs`{{competence-card-mobile scorecard=this.scorecard}}`);
         });
 
         it('should not show congrats design', function () {
@@ -104,7 +104,7 @@ describe('Integration | Component | competence-card-mobile', function () {
           this.set('scorecard', scorecard);
 
           // when
-          await render(hbs`{{competence-card-mobile scorecard=scorecard}}`);
+          await render(hbs`{{competence-card-mobile scorecard=this.scorecard}}`);
         });
 
         it('should show congrats design', function () {

--- a/mon-pix/tests/integration/components/levelup-notif_test.js
+++ b/mon-pix/tests/integration/components/levelup-notif_test.js
@@ -21,7 +21,7 @@ describe('Integration | Component | levelup-notif', function () {
       title: "Mener une recherche et une veille d'information",
     });
     // when
-    await render(hbs`<LevelupNotif @level={{this.newLevel}} @competenceName={{model.title}}/>`);
+    await render(hbs`<LevelupNotif @level={{this.newLevel}} @competenceName={{this.model.title}}/>`);
     // then
     expect(find('.levelup-competence__level').innerHTML).to.equal(
       this.intl.t('pages.levelup-notif.obtained-level', { level: this.newLevel })

--- a/mon-pix/tests/integration/components/pix-toggle_test.js
+++ b/mon-pix/tests/integration/components/pix-toggle_test.js
@@ -16,7 +16,7 @@ describe('Integration | Component | pix-toggle', function () {
     this.set('isFirstOn', 'true');
 
     await render(
-      hbs`{{pix-toggle onToggle=onToggle valueFirstLabel=valueFirstLabel valueSecondLabel=valueSecondLabel}}`
+      hbs`{{pix-toggle onToggle=this.onToggle valueFirstLabel=this.valueFirstLabel valueSecondLabel=this.valueSecondLabel}}`
     );
   });
 

--- a/mon-pix/tests/integration/components/profile-content_test.js
+++ b/mon-pix/tests/integration/components/profile-content_test.js
@@ -65,7 +65,7 @@ describe('Integration | Component | Profile-content', function () {
         setBreakpoint('tablet');
         this.set('model', model);
         this.owner.register('service:session', Service.extend({ isAuthenticated: true }));
-        await render(hbs`{{profile-content model=model media=media}}`);
+        await render(hbs`{{profile-content model=this.model media=this.media}}`);
 
         // then
         expect(find('.competence-card')).to.exist;
@@ -80,7 +80,7 @@ describe('Integration | Component | Profile-content', function () {
         setBreakpoint('mobile');
         this.set('model', model);
         this.owner.register('service:session', Service.extend({ isAuthenticated: true }));
-        await render(hbs`{{profile-content model=model media=media}}`);
+        await render(hbs`{{profile-content model=this.model media=this.media}}`);
 
         // then
         expect(find('.competence-card')).to.exist;

--- a/mon-pix/tests/integration/components/qcu-proposals_test.js
+++ b/mon-pix/tests/integration/components/qcu-proposals_test.js
@@ -32,7 +32,7 @@ describe('Integration | Component | QCU proposals', function () {
       this.set('answerChanged', answerChangedHandler);
 
       // when
-      await render(hbs`{{qcu-proposals answers=answers proposals=proposals answerChanged='answerChanged'}}`);
+      await render(hbs`{{qcu-proposals answers=this.answers proposals=this.proposals answerChanged='answerChanged'}}`);
 
       // then
       expect(findAll('.proposal-text')).to.have.lengthOf(3);

--- a/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
@@ -210,7 +210,9 @@ describe('Integration | Component | QROCm dep solution panel', function () {
 
     it('should display a disabled textarea', async function () {
       // when
-      await render(hbs`{{qrocm-dep-solution-panel answer=answer solution=solution challenge=challenge}}`);
+      await render(
+        hbs`{{qrocm-dep-solution-panel answer=this.answer solution=this.solution challenge=this.challenge}}`
+      );
 
       // then
       expect(find(INPUT)).to.not.exist;
@@ -237,7 +239,9 @@ describe('Integration | Component | QROCm dep solution panel', function () {
 
     it('should display a disabled input', async function () {
       // when
-      await render(hbs`{{qrocm-dep-solution-panel answer=answer solution=solution challenge=challenge}}`);
+      await render(
+        hbs`{{qrocm-dep-solution-panel answer=this.answer solution=this.solution challenge=this.challenge}}`
+      );
 
       // then
       expect(find(INPUT)).to.not.exist;

--- a/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
@@ -141,7 +141,9 @@ describe('Integration | Component | QROCm ind solution panel', function () {
       //given
       const EMPTY_DEFAULT_MESSAGE = 'Pas de réponse';
       //when
-      await render(hbs`{{qrocm-ind-solution-panel challenge=challenge answer=answer solution=solution}}`);
+      await render(
+        hbs`{{qrocm-ind-solution-panel challenge=this.challenge answer=this.answer solution=this.solution}}`
+      );
       //then
 
       expect(find(PARAGRAPH)).to.not.exist;
@@ -162,7 +164,9 @@ describe('Integration | Component | QROCm ind solution panel', function () {
 
     it('should display a disabled textarea', async function () {
       // when
-      await render(hbs`{{qrocm-ind-solution-panel answer=answer solution=solution challenge=challenge}}`);
+      await render(
+        hbs`{{qrocm-ind-solution-panel answer=this.answer solution=this.solution challenge=this.challenge}}`
+      );
 
       // then
       expect(find(INPUT)).to.not.exist;
@@ -182,7 +186,9 @@ describe('Integration | Component | QROCm ind solution panel', function () {
 
     it('should display a disabled input', async function () {
       // when
-      await render(hbs`{{qrocm-ind-solution-panel answer=answer solution=solution challenge=challenge}}`);
+      await render(
+        hbs`{{qrocm-ind-solution-panel answer=this.answer solution=this.solution challenge=this.challenge}}`
+      );
 
       // then
       expect(find(INPUT)).to.not.exist;

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -267,7 +267,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
 
     context('When they have trainings', function () {
       it('should display the block', async function () {
-        const trainings = [{ title: 'Training 1' }];
+        const trainings = [{ title: 'Training 1', duration: { hours: 4 } }];
         const campaign = {
           customResultPageText: 'Bravo !',
           organizationLogoUrl: 'www.logo-example.com',

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -108,7 +108,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
     it('should congratulate the user', async function () {
       // Given
       campaign = { isFlash: true };
-      const campaignParticipationResult = { estimatedFlashLevel, isDisabled: false };
+      const campaignParticipationResult = { estimatedFlashLevel, isDisabled: false, campaignParticipationBadges: [] };
       this.set('model', { campaign, campaignParticipationResult });
 
       // When
@@ -121,7 +121,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
     it("should display the user's flash estimated level", async function () {
       // Given
       campaign = { isFlash: true };
-      const campaignParticipationResult = { estimatedFlashLevel, isDisabled: false };
+      const campaignParticipationResult = { estimatedFlashLevel, isDisabled: false, campaignParticipationBadges: [] };
       const expectedPixCount = 257;
       this.set('model', { campaign, campaignParticipationResult });
 

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -25,7 +25,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       this.set('model', { campaign, campaignParticipationResult });
 
       // When
-      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
       // Then
       expect(screen.getByText(this.intl.t('pages.skill-review.actions.send'))).to.exist;
@@ -42,7 +42,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         adapter.share = sinon.stub().rejects({ errors: [{ status: '409' }] });
 
         // When
-        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
         await clickByLabel(this.intl.t('pages.skill-review.actions.send'));
 
         // Then
@@ -63,7 +63,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         adapter.share = sinon.stub().rejects({ errors: [{ status: '412' }] });
 
         // When
-        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
         await clickByLabel(this.intl.t('pages.skill-review.actions.send'));
 
         // Then
@@ -81,7 +81,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       this.set('model', { campaign, campaignParticipationResult });
 
       // When
-      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
       // Then
       expect(screen.queryByText(this.intl.t('pages.skill-review.actions.send'))).to.not.exist;
@@ -95,7 +95,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       this.set('model', { campaign, campaignParticipationResult });
 
       // When
-      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
       // Then
       expect(screen.queryByText(this.intl.t('pages.skill-review.details.title'))).to.not.exist;
@@ -112,7 +112,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       this.set('model', { campaign, campaignParticipationResult });
 
       // When
-      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
       // Then
       expect(screen.getByText(this.intl.t('pages.skill-review.flash.abstract'))).to.exist;
@@ -126,7 +126,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       this.set('model', { campaign, campaignParticipationResult });
 
       // When
-      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
       // Then
       expect(screen.getByText(this.intl.t('pages.skill-review.flash.pixCount', { count: expectedPixCount }))).to.exist;
@@ -157,7 +157,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       this.set('model', { campaign, campaignParticipationResult });
 
       // When
-      await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+      await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
       // Then
       expect(contains('Bravo !')).to.exist;
@@ -203,7 +203,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       this.set('model', { campaign, campaignParticipationResult });
 
       // When
-      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
       // Then
       expect(screen.getByRole('img', { name: 'Badge 1' })).to.exist;
@@ -236,7 +236,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       this.set('model', { campaign, campaignParticipationResult });
 
       // When
-      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
       // Then
       expect(screen.getByRole('link', { name: 'Badge 1' }))
@@ -258,7 +258,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult, trainings });
 
         // when
-        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
         // then
         expect(screen.queryByText(this.intl.t('pages.skill-review.trainings.title'))).to.not.exist;
@@ -277,7 +277,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult, trainings });
 
         // when
-        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
         // then
         expect(screen.getByText(this.intl.t('pages.skill-review.trainings.title'))).to.exist;
@@ -310,7 +310,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult, trainings });
 
         // when
-        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
         // then
         expect(findAll('.training-card')).to.have.lengthOf(2);
@@ -334,7 +334,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
             this.set('model', { campaign, campaignParticipationResult });
 
             // When
-            const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+            const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
             // Then
             expect(screen.getByText(this.intl.t('pages.skill-review.organization-message'))).to.exist;
@@ -353,7 +353,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
             this.set('model', { campaign, campaignParticipationResult });
 
             // When
-            const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+            const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
             // Then
             expect(screen.getByRole('img', { name: 'Dragon & Co' })).to.exist;
@@ -373,7 +373,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
             this.set('model', { campaign, campaignParticipationResult });
 
             // When
-            const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+            const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
             // Then
             expect(screen.getByText('Dragon & Co')).to.exist;
@@ -392,7 +392,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
             this.set('model', { campaign, campaignParticipationResult });
 
             // When
-            const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+            const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
             // Then
             expect(screen.queryByRole('img', { name: 'Dragon & Co' })).to.not.exist;
@@ -412,7 +412,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
           this.set('model', { campaign, campaignParticipationResult });
 
           // When
-          const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+          const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
           // Then
           expect(screen.getByText('some message')).to.exist;
@@ -445,7 +445,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
               this.set('model', { campaign, campaignParticipationResult });
 
               // When
-              const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+              const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
               // Then
               expect(screen.getByRole('link', { name: 'Next step' })).to.exist;
@@ -478,7 +478,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
               this.set('model', { campaign, campaignParticipationResult });
 
               // When
-              const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+              const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
               // Then
               expect(screen.getByRole('link', { name: 'Next step' })).to.exist;
@@ -507,7 +507,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
           this.set('model', { campaign, campaignParticipationResult });
 
           // When
-          const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+          const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
           // Then
           expect(screen.queryByText('link', { name: 'Next step' })).to.not.exist;
@@ -532,7 +532,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
           this.set('model', { campaign, campaignParticipationResult });
 
           // When
-          const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+          const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
           // Then
           expect(screen.queryByText(this.intl.t('pages.skill-review.organization-message'))).to.not.exist;
@@ -554,7 +554,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
         // Then
         expect(screen.getByText(this.intl.t('pages.skill-review.actions.send'))).to.exist;
@@ -574,7 +574,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
         // Then
         expect(screen.getByText(this.intl.t('pages.skill-review.retry.button'))).to.exist;
@@ -591,7 +591,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
         // Then
         expect(screen.queryByText(this.intl.t('pages.skill-review.retry.button'))).to.not.exist;
@@ -610,7 +610,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
         // Then
         expect(screen.getByText(this.intl.t('pages.skill-review.improve.title'))).to.exist;
@@ -627,7 +627,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
         // Then
         expect(screen.queryByText(this.intl.t('pages.skill-review.improve.title'))).to.not.exist;
@@ -648,7 +648,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         adapter.share = sinon.stub().rejects({ errors: [{ status: '409' }] });
 
         // When
-        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
         await clickByLabel(this.intl.t('pages.skill-review.actions.send'));
 
         // Then
@@ -670,7 +670,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         adapter.share = sinon.stub().rejects({ errors: [{ status: '412' }] });
 
         // When
-        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
         await clickByLabel(this.intl.t('pages.skill-review.actions.send'));
 
         // Then
@@ -694,7 +694,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
         // Then
         expect(screen.getByText(this.intl.t('pages.skill-review.net-promoter-score.title'))).to.exist;
@@ -713,7 +713,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
         // Then
         expect(screen.getByText(this.intl.t('pages.skill-review.net-promoter-score.link.label'))).to.exist;
@@ -733,7 +733,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
         // Then
         expect(screen.queryByText(this.intl.t('pages.skill-review.net-promoter-score.title'))).to.not.exist;
@@ -753,7 +753,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
         // Then
         expect(contains("Ce parcours a été désactivé par l'organisateur.")).to.exist;
@@ -771,7 +771,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
         // Then
         expect(screen.getByText('Merci, vos résultats ont bien été envoyés !')).to.exist;
@@ -789,7 +789,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         this.set('model', { campaign, campaignParticipationResult });
 
         // When
-        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+        const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
         // Then
         expect(screen.getByText("J'envoie mes résultats")).to.exist;

--- a/mon-pix/tests/integration/components/routes/campaigns/invited/fill-in-participant-external-id_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/invited/fill-in-participant-external-id_test.js
@@ -26,7 +26,7 @@ describe('Integration | Component | routes/campaigns/invited/fill-in-participant
 
       // given
       await render(
-        hbs`<Routes::Campaigns::Invited::FillInParticipantExternalId @campaign={{campaign}} @onSubmit={{this.onSubmitStub}} @onCancel={{this.onCancelStub}}/>`
+        hbs`<Routes::Campaigns::Invited::FillInParticipantExternalId @campaign={{this.campaign}} @onSubmit={{this.onSubmitStub}} @onCancel={{this.onCancelStub}}/>`
       );
 
       // then
@@ -45,7 +45,7 @@ describe('Integration | Component | routes/campaigns/invited/fill-in-participant
 
       // given
       await render(
-        hbs`<Routes::Campaigns::Invited::FillInParticipantExternalId @campaign={{campaign}} @onSubmit={{this.onSubmitStub}} @onCancel={{this.onCancelStub}}/>`
+        hbs`<Routes::Campaigns::Invited::FillInParticipantExternalId @campaign={{this.campaign}} @onSubmit={{this.onSubmitStub}} @onCancel={{this.onCancelStub}}/>`
       );
 
       // then

--- a/mon-pix/tests/integration/components/routes/campaigns/profiles_collection/send-profile_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/profiles_collection/send-profile_test.js
@@ -18,7 +18,7 @@ describe('Integration | Component | routes/campaigns/profiles_collection/send-pr
 
       // when
       await render(
-        hbs`<Routes::Campaigns::ProfilesCollection::SendProfile @isDisabled={{isDisabled}} @campaignParticipation={{campaignParticipation}} />`
+        hbs`<Routes::Campaigns::ProfilesCollection::SendProfile @isDisabled={{this.isDisabled}} @campaignParticipation={{this.campaignParticipation}} />`
       );
 
       expect(contains(this.intl.t('pages.send-profile.form.send'))).to.not.exist;
@@ -35,7 +35,7 @@ describe('Integration | Component | routes/campaigns/profiles_collection/send-pr
 
       // when
       await render(
-        hbs`<Routes::Campaigns::ProfilesCollection::SendProfile @isDisabled={{isDisabled}} @campaignParticipation={{campaignParticipation}} @sendProfile={{sendProfile}} />`
+        hbs`<Routes::Campaigns::ProfilesCollection::SendProfile @isDisabled={{this.isDisabled}} @campaignParticipation={{this.campaignParticipation}} @sendProfile={{this.sendProfile}} />`
       );
       await clickByLabel(this.intl.t('pages.send-profile.form.send'));
 

--- a/mon-pix/tests/integration/components/user-certifications-detail-header_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-header_test.js
@@ -35,7 +35,7 @@ describe('Integration | Component | user certifications detail header', function
       this.set('certification', certification);
 
       // when
-      screen = await renderScreen(hbs`{{user-certifications-detail-header certification=certification}}`);
+      screen = await renderScreen(hbs`{{user-certifications-detail-header certification=this.certification}}`);
     });
 
     it('should show the certification published date', function () {
@@ -83,7 +83,7 @@ describe('Integration | Component | user certifications detail header', function
       this.set('certification', certification);
 
       // when
-      const screen = await renderScreen(hbs`{{user-certifications-detail-header certification=certification}}`);
+      const screen = await renderScreen(hbs`{{user-certifications-detail-header certification=this.certification}}`);
 
       // then
       expect(screen.queryByText('Né(e) le 22 janvier 2000 à Paris')).to.not.exist;
@@ -97,6 +97,7 @@ describe('Integration | Component | user certifications detail header', function
           return true;
         }
       }
+
       this.owner.register('service:url', UrlServiceStub);
     });
 
@@ -122,7 +123,7 @@ describe('Integration | Component | user certifications detail header', function
         this.set('certification', certification);
 
         // when
-        const screen = await renderScreen(hbs`{{user-certifications-detail-header certification=certification}}`);
+        const screen = await renderScreen(hbs`{{user-certifications-detail-header certification=this.certification}}`);
 
         // then
         expect(
@@ -155,7 +156,7 @@ describe('Integration | Component | user certifications detail header', function
         this.set('certification', certification);
 
         // when
-        const screen = await renderScreen(hbs`{{user-certifications-detail-header certification=certification}}`);
+        const screen = await renderScreen(hbs`{{user-certifications-detail-header certification=this.certification}}`);
 
         // then
         expect(
@@ -169,9 +170,11 @@ describe('Integration | Component | user certifications detail header', function
     it('should call file saver with isFrenchDomainExtension set to true in url', async function () {
       // given
       const fileSaverSaveStub = sinon.stub();
+
       class FileSaverStub extends Service {
         save = fileSaverSaveStub;
       }
+
       this.owner.register('service:fileSaver', FileSaverStub);
 
       const store = this.owner.lookup('service:store');
@@ -193,7 +196,7 @@ describe('Integration | Component | user certifications detail header', function
       });
       this.set('certification', certification);
 
-      const screen = await renderScreen(hbs`{{user-certifications-detail-header certification=certification}}`);
+      const screen = await renderScreen(hbs`{{user-certifications-detail-header certification=this.certification}}`);
 
       // when
       await click(screen.getByRole('button', { name: 'Télécharger mon attestation' }));
@@ -215,6 +218,7 @@ describe('Integration | Component | user certifications detail header', function
           return false;
         }
       }
+
       this.owner.register('service:url', UrlServiceStub);
       const store = this.owner.lookup('service:store');
       const certification = store.createRecord('certification', {
@@ -235,7 +239,7 @@ describe('Integration | Component | user certifications detail header', function
       this.set('certification', certification);
 
       // when
-      const screen = await renderScreen(hbs`{{user-certifications-detail-header certification=certification}}`);
+      const screen = await renderScreen(hbs`{{user-certifications-detail-header certification=this.certification}}`);
 
       // then
       expect(
@@ -248,9 +252,11 @@ describe('Integration | Component | user certifications detail header', function
     it('should call file saver with isFrenchDomainExtension set to false in url', async function () {
       // given
       const fileSaverSaveStub = sinon.stub();
+
       class FileSaverStub extends Service {
         save = fileSaverSaveStub;
       }
+
       this.owner.register('service:fileSaver', FileSaverStub);
 
       const store = this.owner.lookup('service:store');
@@ -272,7 +278,7 @@ describe('Integration | Component | user certifications detail header', function
       });
       this.set('certification', certification);
 
-      const screen = await renderScreen(hbs`{{user-certifications-detail-header certification=certification}}`);
+      const screen = await renderScreen(hbs`{{user-certifications-detail-header certification=this.certification}}`);
 
       // when
       await click(screen.getByRole('button', { name: 'Télécharger mon attestation' }));
@@ -290,9 +296,11 @@ describe('Integration | Component | user certifications detail header', function
     it('should show the error message', async function () {
       // given
       const fileSaverSaveStub = sinon.stub();
+
       class FileSaverStub extends Service {
         save = fileSaverSaveStub;
       }
+
       this.owner.register('service:fileSaver', FileSaverStub);
 
       fileSaverSaveStub.rejects(new Error('an error message'));
@@ -316,7 +324,7 @@ describe('Integration | Component | user certifications detail header', function
       });
       this.set('certification', certification);
 
-      const screen = await renderScreen(hbs`{{user-certifications-detail-header certification=certification}}`);
+      const screen = await renderScreen(hbs`{{user-certifications-detail-header certification=this.certification}}`);
 
       // when
       await click(screen.getByRole('button', { name: 'Télécharger mon attestation' }));

--- a/mon-pix/tests/integration/components/user-tutorials/filters/item-checkbox_test.js
+++ b/mon-pix/tests/integration/components/user-tutorials/filters/item-checkbox_test.js
@@ -18,9 +18,9 @@ describe('Integration | Component | User-Tutorials | Filters | ItemCheckbox', fu
       await render(
         hbs`<UserTutorials::Filters::ItemCheckbox
               @type="competences"
-              @item={{item}}
-              @currentFilters={{currentFilters}}
-              @handleFilterChange={{handleFilterChange}}
+              @item={{this.item}}
+              @currentFilters={{this.currentFilters}}
+              @handleFilterChange={{this.handleFilterChange}}
             />`
       );
 
@@ -40,9 +40,9 @@ describe('Integration | Component | User-Tutorials | Filters | ItemCheckbox', fu
       await render(
         hbs`<UserTutorials::Filters::ItemCheckbox
               @type="competences"
-              @item={{item}}
-              @currentFilters={{currentFilters}}
-              @handleFilterChange={{handleFilterChange}}
+              @item={{this.item}}
+              @currentFilters={{this.currentFilters}}
+              @handleFilterChange={{this.handleFilterChange}}
             />`
       );
 

--- a/mon-pix/tests/integration/components/user-tutorials/filters/sidebar_test.js
+++ b/mon-pix/tests/integration/components/user-tutorials/filters/sidebar_test.js
@@ -19,7 +19,7 @@ describe('Integration | Component | User-Tutorials | Filters | Sidebar', functio
       ]);
 
       // when
-      await render(hbs`<UserTutorials::Filters::Sidebar @isVisible={{isVisible}} @areas={{areas}} />`);
+      await render(hbs`<UserTutorials::Filters::Sidebar @isVisible={{this.isVisible}} @areas={{this.areas}} />`);
 
       // then
       expect(find('.tutorials-filters')).to.exist;
@@ -35,7 +35,7 @@ describe('Integration | Component | User-Tutorials | Filters | Sidebar', functio
         ]);
         this.set('onSubmit', () => {});
         const screen = await renderScreen(
-          hbs`<UserTutorials::Filters::Sidebar @isVisible={{isVisible}} @areas={{areas}} @onSubmit={{onSubmit}} />`
+          hbs`<UserTutorials::Filters::Sidebar @isVisible={{this.isVisible}} @areas={{this.areas}} @onSubmit={{this.onSubmit}} />`
         );
         await click(screen.getByRole('button', { name: 'Area 1' }));
         const checkbox = screen.getByRole('checkbox', { name: 'Ma superbe compétence' });
@@ -58,7 +58,7 @@ describe('Integration | Component | User-Tutorials | Filters | Sidebar', functio
           ]);
           this.set('onSubmit', () => {});
           const screen = await renderScreen(
-            hbs`<UserTutorials::Filters::Sidebar @isVisible={{isVisible}} @areas={{areas}} @onSubmit={{onSubmit}} />`
+            hbs`<UserTutorials::Filters::Sidebar @isVisible={{this.isVisible}} @areas={{this.areas}} @onSubmit={{this.onSubmit}} />`
           );
           await click(screen.getByRole('button', { name: 'Area 1' }));
           const checkbox = screen.getByRole('checkbox', { name: 'Ma superbe compétence' });
@@ -80,7 +80,7 @@ describe('Integration | Component | User-Tutorials | Filters | Sidebar', functio
       this.set('isVisible', false);
 
       // when
-      await render(hbs`<UserTutorials::Filters::Sidebar @isVisible={{isVisible}} />`);
+      await render(hbs`<UserTutorials::Filters::Sidebar @isVisible={{this.isVisible}} />`);
 
       // then
       expect(find('.pix-sidebar--hidden')).to.exist;

--- a/mon-pix/tests/unit/components/routes/campaigns/invited/associate-sup-student-form_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/invited/associate-sup-student-form_test.js
@@ -35,7 +35,7 @@ describe('Unit | Component | routes/campaigns/invited/associate-sup-student-form
 
       it('call reconciliation for the sup organization learner', async function () {
         // given
-        const supOrganizationLearner = { save: sinon.stub() };
+        const supOrganizationLearner = { save: sinon.stub(), unloadRecord: sinon.stub() };
         storeStub.createRecord
           .withArgs('sup-organization-learner', {
             id: `${component.args.campaignCode}_${component.lastName}`,

--- a/mon-pix/tests/unit/controllers/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/unit/controllers/authentication/login-or-register-oidc_test.js
@@ -16,10 +16,12 @@ describe('Unit | Controller | authentication | login-or-register-oidc', function
         id: 'oidc-partner',
         code: 'OIDC_PARTNER',
       };
+
       class OidcIdentityProvidersStub extends Service {
         'oidc-partner' = oidcPartner;
         list = [oidcPartner];
       }
+
       this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
 
       const email = 'glace.alo@example.net';
@@ -34,10 +36,9 @@ describe('Unit | Controller | authentication | login-or-register-oidc', function
         fullNameFromPix: 'Glace Alo',
         authenticationMethods: [{ identityProvider: 'OIDC_PARTNER' }],
       });
-      controller.store = { createRecord: () => ({ login }) };
       controller.authenticationKey = authenticationKey;
       controller.identityProviderSlug = 'oidc-partner';
-      sinon.spy(controller.store, 'createRecord');
+      sinon.stub(controller.store, 'createRecord').returns({ login });
 
       // when
       await controller.onLogin({ enteredEmail: email, enteredPassword: password });
@@ -63,10 +64,12 @@ describe('Unit | Controller | authentication | login-or-register-oidc', function
         id: 'oidc-partner',
         code: 'OIDC_PARTNER',
       };
+
       class OidcIdentityProvidersStub extends Service {
         'oidc-partner' = oidcPartner;
         list = [oidcPartner];
       }
+
       this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
 
       const email = 'glace.alo@example.net';

--- a/mon-pix/tests/unit/controllers/fill-in-certificate-verification-code_test.js
+++ b/mon-pix/tests/unit/controllers/fill-in-certificate-verification-code_test.js
@@ -12,7 +12,7 @@ describe('Unit | Controller | Fill in certificate verification Code', function (
   beforeEach(function () {
     controller = this.owner.lookup('controller:fill-in-certificate-verification-code');
     storeStub = { queryRecord: sinon.stub() };
-    controller.transitionToRoute = sinon.stub();
+    controller.router.transitionTo = sinon.stub();
     controller.set('store', storeStub);
     controller.set('errorMessage', null);
     controller.set('certificateVerificationCode', null);

--- a/mon-pix/tests/unit/controllers/terms-of-service_test.js
+++ b/mon-pix/tests/unit/controllers/terms-of-service_test.js
@@ -10,7 +10,7 @@ describe('Unit | Controller | terms-of-service', function () {
   describe('#action submit', function () {
     beforeEach(function () {
       controller = this.owner.lookup('controller:terms-of-service');
-      controller.transitionToRoute = sinon.stub();
+      controller.router.transitionTo = sinon.stub();
       controller.currentUser = { user: { save: sinon.stub().resolves() } };
     });
 
@@ -23,7 +23,7 @@ describe('Unit | Controller | terms-of-service', function () {
 
       // then
       sinon.assert.calledWith(controller.currentUser.user.save, { adapterOptions: { acceptPixTermsOfService: true } });
-      sinon.assert.calledWith(controller.transitionToRoute, '');
+      sinon.assert.calledWith(controller.router.transitionTo, '');
       expect(controller.showErrorTermsOfServiceNotSelected).to.be.false;
     });
 

--- a/mon-pix/tests/unit/routes/authentication/login-oidc_test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-oidc_test.js
@@ -44,10 +44,12 @@ describe('Unit | Route | login-oidc', function () {
           id: 'oidc-partner',
           code: 'OIDC_PARTNER',
         };
+
         class OidcIdentityProvidersStub extends Service {
           'oidc-partner' = oidcPartner;
           list = [oidcPartner];
         }
+
         this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersStub);
       });
 
@@ -99,12 +101,13 @@ describe('Unit | Route | login-oidc', function () {
           const route = this.owner.lookup('route:authentication/login-oidc');
           route.set('session', sessionStub);
           route.location.replace = sinon.stub();
+          route.router.urlFor = sinon.stub();
 
           // when
           await route.beforeModel({ to: { queryParams: {}, params: { identity_provider_slug: 'oidc-partner' } } });
 
           // then
-          expect(sessionStub.data.nextURL).to.equal('/campagnes/PIXOIDC01/acces');
+          sinon.assert.calledWith(route.router.urlFor, 'campaigns.access', 'PIXOIDC01');
         });
       });
 

--- a/mon-pix/tests/unit/routes/campaigns/entrance_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entrance_test.js
@@ -13,6 +13,7 @@ describe('Unit | Route | Entrance', function () {
     route.campaignStorage = { get: sinon.stub(), set: sinon.stub() };
     route.modelFor = sinon.stub();
     route.router = { replaceWith: sinon.stub(), transitionTo: sinon.stub() };
+    route.session.requireAuthenticationAndApprovedTermsOfService = sinon.stub();
   });
 
   describe('#beforeModel', function () {

--- a/mon-pix/tests/unit/routes/campaigns/invited_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/invited_test.js
@@ -13,6 +13,7 @@ describe('Unit | Route | Invited', function () {
     route.modelFor = sinon.stub();
     route.router = { replaceWith: sinon.stub(), transitionTo: sinon.stub() };
     route.campaignStorage = { get: sinon.stub() };
+    route.session.requireAuthenticationAndApprovedTermsOfService = sinon.stub();
   });
 
   describe('#beforeModel', function () {


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, Ember n'est pas à jour sur toutes nos apps. 
Sur Pix App, nous sommes actuellement, en `3.25.4` alors que la dernière version LTS d'Ember est la `4.4.0`

## :gift: Proposition
Nous souhaitons tout d'abord avoir Ember `3.26.2`, qui constitue un premier frein aux montées de version. 
Pour cela, nous nous sommes confronter à plusieurs problématiques. 

- Le manque de `this` avant `rootUrl`, cependant utiliser `rootUrl` n'est pas utile, donc nous les avons supprimer
- Le manque de `this` ou de `@` en utilisant une variable dans un composant ou un template
- Le manque de `this` lorsqu'on instancie un composant dans les tests

## :star2: Remarques
Les tests dans le navigateur permettent de remontés les tests où il manque les `this`.
Nous avons aussi utilisée plus globalement une regex `.*=\{\{(?!this|@|true|false|t )` 

## :santa: Pour tester
- Se balader sur Pix App
