### PR TITLE
[TECH] Logger les tentative de rafraichir le token (PIX-6283).

### DIFF
--- a/api/lib/domain/events/handle-pole-emploi-participation-finished.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-finished.js
@@ -38,8 +38,7 @@ async function handlePoleEmploiParticipationFinished({
       participation,
       assessment,
     });
-
-    const response = await poleEmploiNotifier.notify(user.id, payload.toString());
+    const response = await poleEmploiNotifier.notify(user.id, payload);
 
     const poleEmploiSending = PoleEmploiSending.buildForParticipationFinished({
       campaignParticipationId,

--- a/api/lib/domain/events/handle-pole-emploi-participation-started.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-started.js
@@ -34,7 +34,7 @@ async function handlePoleEmploiParticipationStarted({
       participation,
     });
 
-    const response = await poleEmploiNotifier.notify(user.id, payload.toString());
+    const response = await poleEmploiNotifier.notify(user.id, payload);
 
     const poleEmploiSending = PoleEmploiSending.buildForParticipationStarted({
       campaignParticipationId,

--- a/api/lib/domain/usecases/send-shared-participation-results-to-pole-emploi.js
+++ b/api/lib/domain/usecases/send-shared-participation-results-to-pole-emploi.js
@@ -31,7 +31,7 @@ module.exports = async function sendSharedParticipationResultsToPoleEmploi({
       participationResult,
     });
 
-    const response = await poleEmploiNotifier.notify(user.id, payload.toString());
+    const response = await poleEmploiNotifier.notify(user.id, payload);
 
     const poleEmploiSending = PoleEmploiSending.buildForParticipationShared({
       campaignParticipationId,

--- a/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
+++ b/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
@@ -110,10 +110,10 @@ function _getErrorMessage(data) {
   return message.trim();
 }
 
-function participationState(payload) {
-  if (payload.dateValidation) {
+function participationState({ test }) {
+  if (test.dateValidation) {
     return 'PARTICIPATION_SHARED';
-  } else if (payload.progression === 100) {
+  } else if (test.progression === 100) {
     return 'PARTICIPATION_COMPLETED';
   } else {
     return 'PARTICIPATION_STARTED';

--- a/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
+++ b/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
@@ -30,6 +30,12 @@ module.exports = {
     const expiredDate = get(authenticationMethod, 'authenticationComplement.expiredDate');
     const refreshToken = get(authenticationMethod, 'authenticationComplement.refreshToken');
     if (!refreshToken || new Date(expiredDate) <= new Date()) {
+      monitoringTools.logInfoWithCorrelationIds({
+        event: 'participation-send-pole-emploi',
+        'pole-emploi-action': 'refresh-token',
+        'participation-state': participationState(payload),
+        'expired-date': expiredDate,
+      });
       const data = {
         grant_type: 'refresh_token',
         refresh_token: refreshToken,

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-finished_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-finished_test.js
@@ -1,6 +1,7 @@
 const { catchErr, expect, sinon, domainBuilder } = require('../../../test-helper');
 const AssessmentCompleted = require('../../../../lib/domain/events/AssessmentCompleted');
 const PoleEmploiSending = require('../../../../lib/domain/models/PoleEmploiSending');
+const PoleEmploiPayload = require('../../../../lib/infrastructure/externals/pole-emploi/PoleEmploiPayload');
 const { handlePoleEmploiParticipationFinished } = require('../../../../lib/domain/events')._forTestOnly.handlers;
 
 describe('Unit | Domain | Events | handle-pole-emploi-participation-finished', function () {
@@ -35,11 +36,11 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-finished', f
       poleEmploiSendingRepository,
     };
 
-    expectedResults = JSON.stringify({
+    expectedResults = new PoleEmploiPayload({
       campagne: {
         nom: 'Campagne Pôle Emploi',
-        dateDebut: '2020-01-01T00:00:00.000Z',
-        dateFin: '2020-02-01T00:00:00.000Z',
+        dateDebut: new Date('2020-01-01'),
+        dateFin: new Date('2020-02-01'),
         type: 'EVALUATION',
         codeCampagne: 'CODEPE123',
         urlCampagne: 'https://app.pix.fr/campagnes/CODEPE123',
@@ -55,8 +56,8 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-finished', f
         progression: 100,
         typeTest: 'DI',
         referenceExterne: 55667788,
-        dateDebut: '2020-01-02T00:00:00.000Z',
-        dateProgression: '2020-01-03T00:00:00.000Z',
+        dateDebut: new Date('2020-01-02'),
+        dateProgression: new Date('2020-01-03'),
         dateValidation: null,
         evaluation: null,
         uniteEvaluation: 'A',
@@ -134,7 +135,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-finished', f
           .stub(PoleEmploiSending, 'buildForParticipationFinished')
           .withArgs({
             campaignParticipationId: 55667788,
-            payload: expectedResults,
+            payload: expectedResults.toString(),
             isSuccessful: expectedResponse.isSuccessful,
             responseCode: expectedResponse.code,
           })

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-started_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-started_test.js
@@ -1,6 +1,7 @@
 const { catchErr, expect, sinon, domainBuilder } = require('../../../test-helper');
 const CampaignParticipationStarted = require('../../../../lib/domain/events/CampaignParticipationStarted');
 const PoleEmploiSending = require('../../../../lib/domain/models/PoleEmploiSending');
+const PoleEmploiPayload = require('../../../../lib/infrastructure/externals/pole-emploi/PoleEmploiPayload');
 const { handlePoleEmploiParticipationStarted } = require('../../../../lib/domain/events')._forTestOnly.handlers;
 
 describe('Unit | Domain | Events | handle-pole-emploi-participation-started', function () {
@@ -32,11 +33,11 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-started', fu
       poleEmploiNotifier,
     };
 
-    expectedResults = JSON.stringify({
+    expectedResults = new PoleEmploiPayload({
       campagne: {
         nom: 'Campagne Pôle Emploi',
-        dateDebut: '2020-01-01T00:00:00.000Z',
-        dateFin: '2020-02-01T00:00:00.000Z',
+        dateDebut: new Date('2020-01-01'),
+        dateFin: new Date('2020-02-01'),
         type: 'EVALUATION',
         codeCampagne: 'CODEPE123',
         urlCampagne: 'https://app.pix.fr/campagnes/CODEPE123',
@@ -52,7 +53,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-started', fu
         progression: 0,
         typeTest: 'DI',
         referenceExterne: 55667788,
-        dateDebut: '2020-01-02T00:00:00.000Z',
+        dateDebut: new Date('2020-01-02'),
         dateProgression: null,
         dateValidation: null,
         evaluation: null,
@@ -121,7 +122,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-started', fu
           .stub(PoleEmploiSending, 'buildForParticipationStarted')
           .withArgs({
             campaignParticipationId,
-            payload: expectedResults,
+            payload: expectedResults.toString(),
             isSuccessful: expectedResponse.isSuccessful,
             responseCode: expectedResponse.code,
           })

--- a/api/tests/unit/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
+++ b/api/tests/unit/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
@@ -1,5 +1,6 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const PoleEmploiSending = require('../../../../lib/domain/models/PoleEmploiSending');
+const PoleEmploiPayload = require('../../../../lib/infrastructure/externals/pole-emploi/PoleEmploiPayload');
 const sendSharedParticipationResultsToPoleEmploi = require('../../../../lib/domain/usecases/send-shared-participation-results-to-pole-emploi');
 
 describe('Unit | Domain | UseCase | send-shared-participation-results-to-pole-emploi', function () {
@@ -35,11 +36,11 @@ describe('Unit | Domain | UseCase | send-shared-participation-results-to-pole-em
       poleEmploiNotifier,
     };
 
-    expectedResults = JSON.stringify({
+    expectedResults = new PoleEmploiPayload({
       campagne: {
         nom: 'Campagne Pôle Emploi',
-        dateDebut: '2020-01-01T00:00:00.000Z',
-        dateFin: '2020-02-01T00:00:00.000Z',
+        dateDebut: new Date('2020-01-01'),
+        dateFin: new Date('2020-02-01'),
         type: 'EVALUATION',
         codeCampagne: 'CODEPE123',
         urlCampagne: 'https://app.pix.fr/campagnes/CODEPE123',
@@ -55,9 +56,9 @@ describe('Unit | Domain | UseCase | send-shared-participation-results-to-pole-em
         progression: 100,
         typeTest: 'DI',
         referenceExterne: 55667788,
-        dateDebut: '2020-01-02T00:00:00.000Z',
-        dateProgression: '2020-01-03T00:00:00.000Z',
-        dateValidation: '2020-01-03T00:00:00.000Z',
+        dateDebut: new Date('2020-01-02'),
+        dateProgression: new Date('2020-01-03'),
+        dateValidation: new Date('2020-01-03'),
         evaluation: 70,
         uniteEvaluation: 'A',
         elementsEvalues: [
@@ -158,7 +159,7 @@ describe('Unit | Domain | UseCase | send-shared-participation-results-to-pole-em
         .stub(PoleEmploiSending, 'buildForParticipationShared')
         .withArgs({
           campaignParticipationId,
-          payload: expectedResults,
+          payload: expectedResults.toString(),
           isSuccessful: expectedResponse.isSuccessful,
           responseCode: expectedResponse.code,
         })

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -49,7 +49,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
 
       settings.poleEmploi.tokenUrl = 'someTokenUrlToPoleEmploi';
       settings.poleEmploi.sendingUrl = 'someSendingUrlToPoleEmploi';
-      payload = { progression: 0 };
+      payload = { test: { progression: 0 } };
     });
 
     afterEach(function () {
@@ -107,7 +107,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
 
       it('should log the notification to Pole Emploi', async function () {
         // given
-        payload = { progression: 100 };
+        payload = { test: { progression: 100 } };
         const expiredDate = moment().add(10, 'm').toDate();
         const authenticationMethod = { authenticationComplement: { accessToken, expiredDate, refreshToken } };
 
@@ -266,7 +266,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
 
         it('should log error and return httpResponse with error if sending to PE fails', async function () {
           // given
-          payload = { dateValidation: new Date() };
+          payload = { test: { dateValidation: new Date() } };
 
           const tokenResponse = {
             isSuccessful: true,

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -153,6 +153,25 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
         });
       });
 
+      it('logs the attempt to refresh the access token', async function () {
+        // given
+        authenticationMethodRepository.findOneByUserIdAndIdentityProvider
+          .withArgs({ userId, identityProvider: OidcIdentityProviders.POLE_EMPLOI.code })
+          .resolves(authenticationMethod);
+        httpAgent.post.resolves({ isSuccessful: true, code, data });
+
+        // when
+        await notify(userId, payload, poleEmploiSending);
+
+        // then
+        expect(monitoringTools.logInfoWithCorrelationIds).to.have.been.calledWith({
+          event: 'participation-send-pole-emploi',
+          'pole-emploi-action': 'refresh-token',
+          'participation-state': 'PARTICIPATION_STARTED',
+          'expired-date': expiredDate,
+        });
+      });
+
       context('when it succeeds', function () {
         it('should update the authentication method', async function () {
           // given


### PR DESCRIPTION
## :christmas_tree: Problème
La majorité des erreurs lors de l'envoi de données à PE est lié au rafraichisseent du token
On ne sait pas combien de fois le rafraichissement du token est fait.

L'objectif est de savoir combien de fois le refresh token et de mesurer combien de fois il ne marche pas.
On log aussi la date d'expiration pour savoir quels sont les envois qui plantent.
Avec ces informations on pourra prendre des décision sur  ce qu'on fait du refresh token

## :gift: Proposition
Logger les tentatives re rafraichissement de token

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
