### PR TITLE
[FEATURE] Permettre à un administrateur d'annuler une invitation à rejoindre un centre de certification (PIX-5003)

### DIFF
--- a/admin/app/components/certification-centers/invitations.hbs
+++ b/admin/app/components/certification-centers/invitations.hbs
@@ -10,6 +10,7 @@
             <tr>
               <th>Adresse e-mail</th>
               <th>Date de dernier envoi</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -17,12 +18,23 @@
               <tr aria-label="Invitation en attente de {{invitation.email}}">
                 <td>{{invitation.email}}</td>
                 <td>{{dayjs-format invitation.updatedAt "DD/MM/YYYY [-] HH:mm" locale="fr"}}</td>
+                <td>
+                  <PixButton
+                    @size="small"
+                    @backgroundColor="red"
+                    class="certification-center-invitations-actions__button"
+                    aria-label="Annuler l’invitation de {{invitation.email}}"
+                    @triggerAction={{fn @onCancelCertificationCenterInvitation invitation}}
+                  >
+                    <FaIcon @icon="trash" />Annuler l’invitation
+                  </PixButton>
+                </td>
               </tr>
             {{/each}}
           </tbody>
         </table>
       {{else}}
-        <p class="organization-invitations__message">Aucune invitation en attente</p>
+        <p class="certification-center-invitations__message">Aucune invitation en attente</p>
       {{/if}}
     </div>
   </div>

--- a/admin/app/controllers/authenticated/certification-centers/get/invitations.js
+++ b/admin/app/controllers/authenticated/certification-centers/get/invitations.js
@@ -61,4 +61,18 @@ export default class AuthenticatedCertificationCentersGetInvitationsController e
     this.userEmailToInviteError = null;
     return true;
   }
+
+  @action
+  async cancelCertificationCenterInvitation(certificationCenterInvitation) {
+    try {
+      await certificationCenterInvitation.destroyRecord({
+        adapterOptions: {
+          certificationCenterInvitationId: certificationCenterInvitation.id,
+        },
+      });
+      this.notifications.success('Cette invitation a bien été annulée.');
+    } catch (error) {
+      this.notifications.error('Une erreur s’est produite, veuillez réessayer.');
+    }
+  }
 }

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -44,6 +44,7 @@
 @import 'components/certification-info-field';
 @import 'components/certification-issue-report';
 @import 'components/certification-issue-reports';
+@import 'components/certification-center-invitations.scss';
 @import 'components/profile';
 @import 'components/certified-profile';
 @import 'components/confirm-popup';

--- a/admin/app/styles/components/certification-center-invitations.scss
+++ b/admin/app/styles/components/certification-center-invitations.scss
@@ -1,0 +1,13 @@
+.certification-center-invitations {
+
+  &__message {
+    text-align: center;
+  }
+
+  &-actions__button {
+
+    svg {
+      margin-right: 6px;
+    }
+  }
+}

--- a/admin/app/templates/authenticated/certification-centers/get/invitations.hbs
+++ b/admin/app/templates/authenticated/certification-centers/get/invitations.hbs
@@ -7,4 +7,7 @@
   @createInvitation={{this.createInvitation}}
 />
 
-<CertificationCenters::Invitations @certificationCenterInvitations={{this.model.certificationCenterInvitations}} />
+<CertificationCenters::Invitations
+  @certificationCenterInvitations={{this.model.certificationCenterInvitations}}
+  @onCancelCertificationCenterInvitation={{this.cancelCertificationCenterInvitation}}
+/>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -137,6 +137,11 @@ export default function () {
     const updatedAt = Date.now();
     return schema.certificationCenterInvitations.create({ email, lang, updatedAt });
   });
+  this.delete('/admin/certification-center-invitations/:id', (schema, request) => {
+    const certificationCenterInvitationId = request.params.id;
+    schema.db.certificationCenterInvitations.remove(certificationCenterInvitationId);
+    return new Response(204);
+  });
 
   this.delete('/admin/certification-center-memberships/:id', (schema, request) => {
     const certificationCenterMembershipId = request.params.id;

--- a/admin/tests/acceptance/authenticated/certification-centers/get/invitations_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get/invitations_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { fillIn, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { visit } from '@1024pix/ember-testing-library';
+import { visit, clickByName } from '@1024pix/ember-testing-library';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 
 module('Acceptance | Certification-centers | Invitations management', function (hooks) {
@@ -24,5 +24,26 @@ module('Acceptance | Certification-centers | Invitations management', function (
     // then
     assert.dom(screen.getByText('user@example.com')).exists();
     assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail du membre à inviter' })).hasNoValue();
+  });
+
+  test('should be possible to cancel a certification center invitation', async function (assert) {
+    // given
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+    const certificationCenter = this.server.create('certification-center', {
+      id: 123,
+      name: 'My Hero Academia',
+    });
+    this.server.create('certification-center-invitation', {
+      certificationCenterId: 123,
+      email: 'bakugo@mha.com',
+    });
+
+    // when
+    const screen = await visit(`/certification-centers/${certificationCenter.id}/invitations`);
+    await clickByName('Annuler l’invitation de bakugo@mha.com');
+
+    // then
+    assert.dom(screen.queryByText('bakugo@mha.com')).doesNotExist();
+    assert.dom(screen.getByText('Cette invitation a bien été annulée.'));
   });
 });

--- a/admin/tests/integration/components/certification-centers/invitations_test.js
+++ b/admin/tests/integration/components/certification-centers/invitations_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { render } from '@1024pix/ember-testing-library';
+import sinon from 'sinon';
 
 module('Integration | Component | Certification Centers | Invitations', function (hooks) {
   setupRenderingTest(hooks);
@@ -34,10 +35,14 @@ module('Integration | Component | Certification Centers | Invitations', function
         updatedAt: new Date('2022-02-02'),
       });
       this.certificationCenterInvitations = [certificationCenterInvitation1, certificationCenterInvitation2];
+      this.cancelCertificationCenterInvitation = sinon.stub();
 
       // when
       const screen = await render(
-        hbs`<CertificationCenters::Invitations @certificationCenterInvitations={{this.certificationCenterInvitations}} />`
+        hbs`<CertificationCenters::Invitations 
+          @certificationCenterInvitations={{this.certificationCenterInvitations}} 
+          @onCancelCertificationCenterInvitation={{this.cancelCertificationCenterInvitation}}
+        />`
       );
 
       // then

--- a/admin/tests/unit/controllers/authenticated/certification-centers/get/invitations_test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-centers/get/invitations_test.js
@@ -31,4 +31,29 @@ module('Unit | Controller | authenticated/certification-centers/get/invitations'
       assert.ok(notifyStub.calledWithExactly(anError, customErrors));
     });
   });
+
+  module('When there are pending Pix Certif invitations', function () {
+    test('it should display an error message when it is not possible to cancel a certification center invitation', async function (assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/certification-centers/get/invitations');
+
+      const store = this.owner.lookup('service:store');
+      store.createRecord('certificationCenterInvitation', {
+        destroyRecord: sinon.stub().rejects('an error'),
+      });
+
+      const notificationErrorStub = sinon.stub();
+      class NotificationsStub extends Service {
+        error = notificationErrorStub;
+      }
+      this.owner.register('service:notifications', NotificationsStub);
+
+      // when
+      await controller.cancelCertificationCenterInvitation();
+
+      // then
+      sinon.assert.calledWith(notificationErrorStub, 'Une erreur s’est produite, veuillez réessayer.');
+      assert.ok(true);
+    });
+  });
 });

--- a/api/lib/application/certification-center-invitations/certification-center-invitation-controller.js
+++ b/api/lib/application/certification-center-invitations/certification-center-invitation-controller.js
@@ -25,4 +25,10 @@ module.exports = {
     });
     return certificationCenterInvitationSerializer.serialize(certificationCenterInvitation);
   },
+
+  async cancelCertificationCenterInvitation(request, h) {
+    const certificationCenterInvitationId = request.params.certificationCenterInvitationId;
+    await usecases.cancelCertificationCenterInvitation({ certificationCenterInvitationId });
+    return h.response().code(204);
+  },
 };

--- a/api/lib/application/certification-center-invitations/index.js
+++ b/api/lib/application/certification-center-invitations/index.js
@@ -2,6 +2,7 @@ const Joi = require('joi');
 
 const certificationCenterInvitationController = require('./certification-center-invitation-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
+const securityPreHandlers = require('../security-pre-handlers');
 
 exports.register = async function (server) {
   server.route([
@@ -46,6 +47,35 @@ exports.register = async function (server) {
           "- Cette route permet de récupérer les détails d'une invitation selon un **id d'invitation** et un **code**\n",
         ],
         tags: ['api', 'invitations'],
+      },
+    },
+    {
+      method: 'DELETE',
+      path: '/api/admin/certification-center-invitations/{certificationCenterInvitationId}',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            certificationCenterInvitationId: identifiersType.certificationCenterInvitationId,
+          }),
+        },
+        handler: certificationCenterInvitationController.cancelCertificationCenterInvitation,
+        tags: ['api', 'admin', 'invitations', 'cancel'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            "- Elle permet d'annuler une invitation envoyée mais non acceptée encore.",
+        ],
       },
     },
   ]);

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -169,6 +169,15 @@ class UncancellableOrganizationInvitationError extends DomainError {
   }
 }
 
+class UncancellableCertificationCenterInvitationError extends DomainError {
+  constructor(
+    message = "L'invitation à ce centre de certification ne peut pas être annulée.",
+    code = 'UNCANCELLABLE_CERTIFICATION_CENTER_INVITATION_CODE'
+  ) {
+    super(message, code);
+  }
+}
+
 class CantImproveCampaignParticipationError extends DomainError {
   constructor(message = 'Une campagne de collecte de profils ne peut pas être retentée.') {
     super(message);
@@ -1231,6 +1240,7 @@ module.exports = {
   AuthenticationMethodAlreadyExistsError,
   AuthenticationKeyExpired,
   UncancellableOrganizationInvitationError,
+  UncancellableCertificationCenterInvitationError,
   CampaignCodeError,
   CampaignParticipationDeletedError,
   CampaignTypeError,

--- a/api/lib/domain/usecases/cancel-certification-center-invitation.js
+++ b/api/lib/domain/usecases/cancel-certification-center-invitation.js
@@ -1,0 +1,14 @@
+const { UncancellableCertificationCenterInvitationError } = require('../../domain/errors');
+
+module.exports = async function cancelCertificationCenterInvitation({
+  certificationCenterInvitationId,
+  certificationCenterInvitationRepository,
+}) {
+  const foundCertificationCenterInvitation = await certificationCenterInvitationRepository.get(
+    certificationCenterInvitationId
+  );
+  if (!foundCertificationCenterInvitation.isPending) {
+    throw new UncancellableCertificationCenterInvitationError();
+  }
+  return await certificationCenterInvitationRepository.markAsCancelled({ id: foundCertificationCenterInvitation.id });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -196,6 +196,7 @@ module.exports = injectDependencies(
     authorizeCertificationCandidateToResume: require('./authorize-certification-candidate-to-resume'),
     beginCampaignParticipationImprovement: require('./begin-campaign-participation-improvement'),
     cancelOrganizationInvitation: require('./cancel-organization-invitation'),
+    cancelCertificationCenterInvitation: require('./cancel-certification-center-invitation'),
     cancelCertificationCourse: require('./cancel-certification-course'),
     changeUserLang: require('./change-user-lang'),
     checkScoAccountRecovery: require('./check-sco-account-recovery'),

--- a/api/lib/infrastructure/repositories/certification-center-invitation-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-invitation-repository.js
@@ -51,6 +51,17 @@ module.exports = {
     return _toDomain(certificationCenterInvitation);
   },
 
+  async get(id) {
+    const certificationCenterInvitation = await knex(CERTIFICATION_CENTER_INVITATIONS)
+      .select('*')
+      .where({ id })
+      .first();
+    if (!certificationCenterInvitation) {
+      throw new NotFoundError("L'invitation à ce centre de certification n'existe pas");
+    }
+    return _toDomain(certificationCenterInvitation);
+  },
+
   async findOnePendingByEmailAndCertificationCenterId({ email, certificationCenterId }) {
     const existingPendingInvitation = await knex(CERTIFICATION_CENTER_INVITATIONS)
       .select('id')
@@ -85,5 +96,19 @@ module.exports = {
       .first();
 
     return _toDomain({ ...updatedCertificationCenterInvitation, certificationCenterName });
+  },
+
+  async markAsCancelled({ id }) {
+    const [certificationCenterInvitation] = await knex('certification-center-invitations')
+      .where({ id })
+      .update({
+        status: CertificationCenterInvitation.StatusType.CANCELLED,
+        updatedAt: new Date(),
+      })
+      .returning('*');
+    if (!certificationCenterInvitation) {
+      throw new NotFoundError(`Certification center invitation of id ${id} is not found.`);
+    }
+    return _toDomain(certificationCenterInvitation);
   },
 };

--- a/api/tests/acceptance/application/certification-center-invitations/index_test.js
+++ b/api/tests/acceptance/application/certification-center-invitations/index_test.js
@@ -1,4 +1,10 @@
-const { databaseBuilder, expect, knex } = require('../../../test-helper');
+const {
+  databaseBuilder,
+  expect,
+  knex,
+  generateValidRequestAuthorizationHeader,
+  insertUserWithRoleSuperAdmin,
+} = require('../../../test-helper');
 const CertificationCenterInvitation = require('../../../../lib/domain/models/CertificationCenterInvitation');
 const createServer = require('../../../../server');
 
@@ -55,6 +61,33 @@ describe('Acceptance | API | Certification center invitations', function () {
 
       expect(membership.userId).to.equal(293);
       expect(invitation.status).to.equal(CertificationCenterInvitation.StatusType.ACCEPTED);
+    });
+  });
+
+  describe('DELETE /api/admin/certification-centers/{id}/invitations/{certificationCenterInvitationId}', function () {
+    it('should return 204 HTTP status code', async function () {
+      // given
+      const server = await createServer();
+
+      const adminMember = await insertUserWithRoleSuperAdmin();
+      const certificationCenterInvitation = databaseBuilder.factory.buildCertificationCenterInvitation({
+        certificationCenterId: databaseBuilder.factory.buildCertificationCenter().id,
+        status: CertificationCenterInvitation.StatusType.PENDING,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'DELETE',
+        url: `/api/admin/certification-center-invitations/${certificationCenterInvitation.id}`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(adminMember.id),
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(204);
     });
   });
 });

--- a/api/tests/integration/domain/usecases/cancel-certification-center-invitation_test.js
+++ b/api/tests/integration/domain/usecases/cancel-certification-center-invitation_test.js
@@ -1,0 +1,102 @@
+const { catchErr, databaseBuilder, expect } = require('../../../test-helper');
+const sinon = require('sinon');
+
+const useCases = require('../../../../lib/domain/usecases');
+
+const CertificationCenterInvitation = require('../../../../lib/domain/models/CertificationCenterInvitation');
+
+const { NotFoundError, UncancellableCertificationCenterInvitationError } = require('../../../../lib/domain/errors');
+
+describe('Integration | UseCases | cancel-certification-center-invitation', function () {
+  describe('when the invitation exists', function () {
+    let clock;
+    const now = new Date('2022-09-25');
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers(now.getTime());
+    });
+
+    afterEach(async function () {
+      clock.restore();
+    });
+
+    describe('when the invitation is pending', function () {
+      it('should be possible to cancel a certification center invitation', async function () {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+
+        databaseBuilder.factory.buildCertificationCenterInvitation({
+          id: 123,
+          certificationCenterId,
+          updatedAt: new Date('2022-08-09'),
+        });
+
+        const certificationCenterInvitation = databaseBuilder.factory.buildCertificationCenterInvitation({
+          id: 456,
+          email: 'ploup.user@example.net',
+          certificationCenterId,
+          status: CertificationCenterInvitation.StatusType.PENDING,
+          updatedAt: new Date('2022-08-08'),
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await useCases.cancelCertificationCenterInvitation({
+          certificationCenterInvitationId: certificationCenterInvitation.id,
+        });
+
+        // then
+        expect(result).to.be.instanceOf(CertificationCenterInvitation);
+        expect(result).to.deep.include({
+          id: certificationCenterInvitation.id,
+          email: 'ploup.user@example.net',
+          status: CertificationCenterInvitation.StatusType.CANCELLED,
+          certificationCenterId,
+          updatedAt: now,
+        });
+      });
+    });
+
+    describe('when the invitation is already accepted or cancelled', function () {
+      it('should throw an error', async function () {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+
+        const acceptedInvitation = databaseBuilder.factory.buildCertificationCenterInvitation({
+          email: 'ploup.user@example.net',
+          certificationCenterId,
+          status: CertificationCenterInvitation.StatusType.ACCEPTED,
+          updatedAt: new Date('2022-08-08'),
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(useCases.cancelCertificationCenterInvitation)({
+          certificationCenterInvitationId: acceptedInvitation.id,
+        });
+
+        // then
+        expect(error).to.be.instanceof(UncancellableCertificationCenterInvitationError);
+        expect(error.message).to.equal("L'invitation à ce centre de certification ne peut pas être annulée.");
+      });
+    });
+  });
+
+  describe('when the invitation does not exist', function () {
+    it('should throw an error', async function () {
+      // given
+      const certificationCenterInvitationId = 123;
+
+      // when
+      const error = await catchErr(useCases.cancelCertificationCenterInvitation)({
+        certificationCenterInvitationId,
+      });
+
+      // then
+      expect(error).to.be.instanceof(NotFoundError);
+      expect(error.message).to.equal("L'invitation à ce centre de certification n'existe pas");
+    });
+  });
+});

--- a/api/tests/unit/application/certification-center-invitations/certification-center-invitation-controller_test.js
+++ b/api/tests/unit/application/certification-center-invitations/certification-center-invitation-controller_test.js
@@ -1,6 +1,8 @@
-const { expect, sinon, hFake } = require('../../../test-helper');
+const { expect, sinon, hFake, domainBuilder } = require('../../../test-helper');
 const certificationCenterInvitationController = require('../../../../lib/application/certification-center-invitations/certification-center-invitation-controller');
 const usecases = require('../../../../lib/domain/usecases');
+const CertificationCenterInvitation = require('../../../../lib/domain/models/CertificationCenterInvitation');
+const certificationCenterInvitationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/certification-center-invitation-serializer');
 
 describe('Unit | Application | Certification-center-Invitations | Certification-center-invitation-controller', function () {
   describe('#acceptCertificationCenterInvitation', function () {
@@ -31,6 +33,43 @@ describe('Unit | Application | Certification-center-Invitations | Certification-
         code,
         email: notValidEmail.trim().toLowerCase(),
       });
+      expect(response.statusCode).to.equal(204);
+    });
+  });
+
+  describe('#cancelCertificationCenterInvitation', function () {
+    it('should call the use case to cancel invitation with certificationCenterInvitationId', async function () {
+      //given
+      const certificationCenterInvitationId = 123;
+
+      const cancelledCertificationCenterInvitation = domainBuilder.buildCertificationCenterInvitation({
+        id: certificationCenterInvitationId,
+        status: CertificationCenterInvitation.StatusType.CANCELLED,
+      });
+
+      sinon
+        .stub(usecases, 'cancelCertificationCenterInvitation')
+        .withArgs({
+          certificationCenterInvitationId: cancelledCertificationCenterInvitation.id,
+        })
+        .resolves(cancelledCertificationCenterInvitation);
+      const serializedResponse = Symbol('serializedCancelledCertificationCenterInvitation');
+
+      sinon
+        .stub(certificationCenterInvitationSerializer, 'serialize')
+        .withArgs(cancelledCertificationCenterInvitation)
+        .returns(serializedResponse);
+
+      // when
+      const response = await certificationCenterInvitationController.cancelCertificationCenterInvitation(
+        {
+          auth: { credentials: { userId: 1 } },
+          params: { certificationCenterInvitationId },
+        },
+        hFake
+      );
+
+      // then
       expect(response.statusCode).to.equal(204);
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème
Il manque la possibilité, pour un utilisateur de Pix Admin, d'annuler une invitation à un centre de certification depuis la page du Centre de Certif.

## :gift: Proposition
Dans Pix Admin > centre de certification, sur chaque invitation en attente, afficher bouton un bouton “Annuler l'invitation” dans une nouvelle colonne "Action".

Au clic sur le bouton:

- le statut de l’invitation devient “cancelled” (backend)
- updatedAt = NOW (backend)
- l’invitation disparait de la liste (frontend)
- un message vert de confirmation apparait pour confirmer l’action (frontend)

## :star2: Remarques
RAS.

## :santa: Pour tester

- Se connecter à **Pix Admin**.
- Se rendre sur la page des Centres de certifications.
- Sélectionner le `Centre SUP des Anne-Étoiles`.
- Cliquer sur `Invitations` et voir la liste des invitations en attente.
- Cliquer sur le bouton `Annuler l'invitation` de l'une des invitations.
- L'invitation disparait de la liste et un message vert apparait, indiquant la bonne suppression de cette invitation.
- Vérifier en BDD que le statut de l'invitation supprimer est bien `cancelled` et que le updatedAt a été mis à jour.
