### PR TITLE
[FEATURE] Refonte des RT non obtenus en fin de parcours (PIX-6246).

### DIFF
--- a/api/lib/domain/read-models/participant-results/BadgeResult.js
+++ b/api/lib/domain/read-models/participant-results/BadgeResult.js
@@ -12,6 +12,7 @@ class BadgeResult {
     this.isAcquired = acquiredBadgeIds.includes(badge.id);
     this.isAlwaysVisible = badge.isAlwaysVisible;
     this.isCertifiable = badge.isCertifiable;
+    this.isValid = badge.isValid;
 
     this.skillSetResults = badge.badgeCompetences.map((competence) =>
       _buildCompetenceResults(competence, knowledgeElements)

--- a/api/lib/domain/usecases/get-user-campaign-assessment-result.js
+++ b/api/lib/domain/usecases/get-user-campaign-assessment-result.js
@@ -17,12 +17,14 @@ module.exports = async function getUserCampaignAssessmentResult({
       knowledgeElementRepository,
       badgeForCalculationRepository
     );
-    const stillValidBadges = badges.filter((badge) => stillValidBadgeIds.includes(badge.id));
+
+    const badgesWithValidity = badges.map((badge) => ({ ...badge, isValid: stillValidBadgeIds.includes(badge.id) }));
+
     const assessmentResult = await participantResultRepository.getByUserIdAndCampaignId({
       userId,
       campaignId,
       locale,
-      badges: stillValidBadges,
+      badges: badgesWithValidity,
     });
 
     return assessmentResult;

--- a/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
@@ -34,6 +34,7 @@ module.exports = {
           'partnerCompetenceResults',
           'isAlwaysVisible',
           'isCertifiable',
+          'isValid',
         ],
         skillSetResults: {
           ref: 'id',

--- a/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
+++ b/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
@@ -272,6 +272,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
               'is-acquired': false,
               'is-always-visible': false,
               'is-certifiable': false,
+              'is-valid': true,
               key: 'PIX_BANANA',
               title: 'Banana',
               message: 'You won a Banana Badge',

--- a/api/tests/unit/domain/read-models/participant-results/BadgeResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/BadgeResult_test.js
@@ -21,6 +21,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | BadgeResult', functi
       imageUrl: 'yellow.svg',
       isCertifiable: false,
       isAlwaysVisible: false,
+      isValid: true,
       badgeCompetences: [],
     };
 
@@ -36,6 +37,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | BadgeResult', functi
       imageUrl: 'yellow.svg',
       isCertifiable: false,
       isAlwaysVisible: false,
+      isValid: true,
       skillSetResults: [],
     });
   });

--- a/api/tests/unit/domain/usecases/get-user-campaign-assessment-result_test.js
+++ b/api/tests/unit/domain/usecases/get-user-campaign-assessment-result_test.js
@@ -43,7 +43,7 @@ describe('Unit | UseCase | get-user-campaign-assessment-result', function () {
   });
 
   context('when no error to catch is thrown during process', function () {
-    it('should return assessment result based on still valid badges', async function () {
+    it('should return the assessment result with badges validity', async function () {
       // given
       const expectedCampaignAssessmentResult = Symbol('campaign assessment result');
       const badge1 = domainBuilder.buildBadge({ id: 1 });
@@ -66,7 +66,11 @@ describe('Unit | UseCase | get-user-campaign-assessment-result', function () {
           userId,
           campaignId,
           locale,
-          badges: [badge1, badge3],
+          badges: [
+            { ...badge1, isValid: true },
+            { ...badge2, isValid: false },
+            { ...badge3, isValid: true },
+          ],
         })
         .resolves(expectedCampaignAssessmentResult);
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -63,6 +63,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
           badgeCompetences: [{ id: 31, name: 'BadgeC1', color: 'BadgeColor', skillIds: ['skill1'] }],
           isAlwaysVisible: true,
           isCertifiable: false,
+          isValid: true,
         },
       ];
 
@@ -156,6 +157,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
               'is-acquired': true,
               'is-always-visible': true,
               'is-certifiable': false,
+              'is-valid': true,
             },
             id: '3',
             type: 'campaignParticipationBadges',

--- a/mon-pix/app/components/badge-card-certifiable.hbs
+++ b/mon-pix/app/components/badge-card-certifiable.hbs
@@ -1,12 +1,13 @@
 <div
   id="{{@title}}"
-  class="badge-card-certifiable {{unless @isAcquired 'badge-card-certifiable badge-card-certifiable--not-acquired'}}"
+  class="badge-card-certifiable
+    {{unless this.isStillValid 'badge-card-certifiable badge-card-certifiable--not-acquired'}}"
 >
   <div class="badge-card-certifiable__header">
     <div class="badge-card__status">
       <h3>
         <span>
-          {{#if @isAcquired}}
+          {{#if this.isStillValid}}
             <FaIcon @icon="circle-check" class="badge-card-status__acquired-icon" />
           {{else}}
             <FaIcon @icon="times-circle" class="badge-card-status__not-acquired-icon" />

--- a/mon-pix/app/components/badge-card-certifiable.js
+++ b/mon-pix/app/components/badge-card-certifiable.js
@@ -1,0 +1,7 @@
+import Component from '@glimmer/component';
+
+export default class BadgeCardCertifiable extends Component {
+  get isStillValid() {
+    return this.args.isValid && this.args.isAcquired;
+  }
+}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -107,9 +107,9 @@
                   @isFlashCampaign={{this.isFlashCampaign}}
                 />
                 <div class="skill-review-share__badge-icons">
-                  {{#if this.showCertifiableBadges}}
+                  {{#if this.showValidBadges}}
                     <div class="skill-review-share-badge-icons skill-review-share-badge-icons--certifiable">
-                      {{#each this.acquiredCertifiableBadges as |badge|}}
+                      {{#each this.validBadges as |badge|}}
                         <PixTooltip @position="top" @isInline={{true}} @id="tooltip-certifiable-{{badge.key}}">
                           <:triggerElement>
                             <a href="#{{badge.title}}">
@@ -230,13 +230,14 @@
 
       {{#if this.showCertifiableBadges}}
         <div class="badge-certifiable-container">
-          {{#each this.acquiredCertifiableBadges as |badge|}}
+          {{#each this.certifiableBadgesOrderedByValidity as |badge|}}
             <BadgeCardCertifiable
               @title={{badge.title}}
               @message={{badge.message}}
               @imageUrl={{badge.imageUrl}}
               @altMessage={{badge.altMessage}}
               @isAcquired={{badge.isAcquired}}
+              @isValid={{badge.isValid}}
               @isCertifiable={{badge.isCertifiable}}
             />
           {{/each}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -34,7 +34,7 @@ export default class SkillReview extends Component {
 
   get _isCleaBadgeAcquired() {
     const pixEmploiClea = 'PIX_EMPLOI_CLEA';
-    return this.acquiredCertifiableBadges.some((badge) => badge.key === pixEmploiClea);
+    return this.validBadges.some((badge) => badge.key === pixEmploiClea);
   }
 
   get showDisabledBlock() {
@@ -46,7 +46,7 @@ export default class SkillReview extends Component {
   }
 
   get showCertifiableBadges() {
-    return this.acquiredCertifiableBadges.length > 0;
+    return this.certifiableBadgesOrderedByValidity.length > 0;
   }
 
   get acquiredNotCertifiableBadges() {
@@ -54,9 +54,26 @@ export default class SkillReview extends Component {
     return badges.filter((badge) => badge.isAcquired && !badge.isCertifiable);
   }
 
-  get acquiredCertifiableBadges() {
+  get certifiableBadgesOrderedByValidity() {
+    return [...this.validBadges, ...this.invalidBadges];
+  }
+
+  get showValidBadges() {
+    return this.validBadges.length > 0;
+  }
+
+  get validBadges() {
     const badges = this.args.model.campaignParticipationResult.campaignParticipationBadges;
-    return badges.filter((badge) => badge.isAcquired && badge.isCertifiable);
+    return badges.filter((badge) => badge.isAcquired && badge.isCertifiable && badge.isValid);
+  }
+
+  get invalidBadges() {
+    const badges = this.args.model.campaignParticipationResult.campaignParticipationBadges;
+    return badges.filter(
+      (badge) =>
+        (badge.isCertifiable && badge.isAcquired && !badge.isValid) ||
+        (badge.isCertifiable && !badge.isAcquired && badge.isAlwaysVisible)
+    );
   }
 
   get showStages() {

--- a/mon-pix/app/models/campaign-participation-badge.js
+++ b/mon-pix/app/models/campaign-participation-badge.js
@@ -9,6 +9,7 @@ export default class CampaignParticipationBadge extends Badge {
   @attr('boolean') isAcquired;
   @attr('boolean') isAlwaysVisible;
   @attr('boolean') isCertifiable;
+  @attr('boolean') isValid;
 
   // includes
   @hasMany('skillSetResult') skillSetResults;

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -165,7 +165,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
   });
 
   context('when the the campaign has badges', function () {
-    it('should display acquired badges in both the header and main section whether certifiable or not', async function () {
+    it('should display both valid and invalid acquired certifiable badges in both the header and main section', async function () {
       campaign = {
         customResultPageButtonUrl: 'http://www.my-url.net/resultats',
         customResultPageButtonText: 'Next step',
@@ -177,21 +177,27 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
           altMessage: 'Vous avez validé le badge 1.',
           isAcquired: true,
           isCertifiable: true,
+          isValid: true,
+          isAlwaysVisible: true,
           message: 'Bravo ! Vous maîtrisez les compétences du badge 1',
           title: 'Badge 1',
         },
         {
-          altMessage: 'Vous avez validé le badge 2.',
-          isAcquired: true,
-          isCertifiable: false,
-          message: 'Bravo ! Vous maîtrisez les compétences du badge 2',
+          altMessage: "Vous n'avez pas validé le badge 2.",
+          isAcquired: false,
+          isCertifiable: true,
+          isValid: false,
+          isAlwaysVisible: false,
+          message: 'Dommage ! Essaie encore.',
           title: 'Badge 2',
         },
         {
-          altMessage: "Vous n'avez pas validé le badge 3",
-          isAcquired: false,
-          isCertifiable: false,
-          message: 'Dommage ! Essaie encore.',
+          altMessage: 'Vous avez validé le badge 3.',
+          isAcquired: true,
+          isCertifiable: true,
+          isValid: false,
+          isAlwaysVisible: true,
+          message: 'Bravo ! Vous maîtrisez les compétences du badge 3',
           title: 'Badge 3',
         },
       ];
@@ -208,9 +214,97 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       // Then
       expect(screen.getByRole('img', { name: 'Badge 1' })).to.exist;
       expect(screen.getByRole('img', { name: 'Vous avez validé le badge 1.' })).to.exist;
-      expect(screen.getByRole('img', { name: 'Badge 2' })).to.exist;
-      expect(screen.getByRole('img', { name: 'Vous avez validé le badge 2.' })).to.exist;
-      expect(screen.queryByRole('img', { name: "Vous n'avez pas validé le badge 3" })).to.not.exist;
+      expect(screen.queryByRole('img', { name: 'Badge 2' })).not.to.exist;
+      expect(screen.queryByRole('img', { name: 'Vous avez validé le badge 2.' })).not.to.exist;
+      expect(screen.queryByRole('img', { name: 'Badge 3' })).not.to.exist;
+      expect(screen.getByRole('img', { name: 'Vous avez validé le badge 3.' })).to.exist;
+    });
+
+    it('should display once acquired but then lost certifiable badges only in the page main section', async function () {
+      campaign = {
+        customResultPageButtonUrl: 'http://www.my-url.net/resultats',
+        customResultPageButtonText: 'Next step',
+        organizationName: 'Dragon & Co',
+        organizationShowNPS: false,
+      };
+      const campaignParticipationBadges = [
+        {
+          altMessage: 'Vous avez validé le badge 1.',
+          isAcquired: true,
+          isCertifiable: true,
+          isValid: false,
+          message: 'Bravo ! Vous maîtrisez les compétences du badge 1',
+          title: 'Badge 1',
+        },
+      ];
+      const campaignParticipationResult = {
+        isShared: true,
+        participantExternalId: '1234G56',
+        campaignParticipationBadges,
+      };
+      this.set('model', { campaign, campaignParticipationResult });
+
+      // When
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+
+      // Then
+      expect(screen.queryByRole('img', { name: 'Badge 1' })).not.to.exist;
+      expect(screen.getByRole('img', { name: 'Vous avez validé le badge 1.' })).to.exist;
+    });
+
+    it('should display acquired non certifiable badges in both the header and main section', async function () {
+      campaign = {
+        customResultPageButtonUrl: 'http://www.my-url.net/resultats',
+        customResultPageButtonText: 'Next step',
+        organizationName: 'Dragon & Co',
+        organizationShowNPS: false,
+      };
+      const campaignParticipationBadges = [
+        {
+          altMessage: 'Vous avez validé le badge 1.',
+          isAcquired: true,
+          isCertifiable: false,
+          isValid: true,
+          key: 'Badge_1',
+          message: 'Bravo ! Vous maîtrisez les compétences du badge 1',
+          title: 'Badge 1',
+        },
+        {
+          altMessage: "Vous n'avez pas validé le badge 2.",
+          isAcquired: false,
+          isCertifiable: false,
+          isValid: false,
+          key: 'Badge_2',
+          message: 'Dommage ! Essaie encore.',
+          title: 'Badge 2',
+        },
+        {
+          altMessage: 'Vous avez validé le badge 3.',
+          isAcquired: true,
+          isCertifiable: false,
+          isValid: false,
+          key: 'Badge_3',
+          message: 'Bravo ! Vous maîtrisez les compétences du badge 3',
+          title: 'Badge 3',
+        },
+      ];
+      const campaignParticipationResult = {
+        isShared: false,
+        participantExternalId: '1234G56',
+        campaignParticipationBadges,
+      };
+      this.set('model', { campaign, campaignParticipationResult });
+
+      // When
+      const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}} />`);
+
+      // Then
+      expect(screen.getByRole('img', { name: 'Badge 1' })).to.exist;
+      expect(screen.getByRole('img', { name: 'Vous avez validé le badge 1.' })).to.exist;
+      expect(screen.queryByRole('img', { name: 'Badge 2' })).not.to.exist;
+      expect(screen.queryByRole('img', { name: 'Dommage ! Essaie encore.' })).not.to.exist;
+      expect(screen.getByRole('img', { name: 'Badge 3' })).to.exist;
+      expect(screen.getByRole('img', { name: 'Vous avez validé le badge 3.' })).to.exist;
     });
 
     it('should add an anchor in the header badge icon linked to the badge card', async function () {
@@ -225,6 +319,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
           altMessage: 'Vous avez validé le badge 1.',
           isAcquired: true,
           isCertifiable: true,
+          isValid: true,
           message: 'Bravo ! Vous maîtrisez les compétences du badge 1',
           title: 'Badge 1',
         },

--- a/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
@@ -9,9 +9,28 @@ import Service from '@ember/service';
 describe('Unit | component | Campaigns | Evaluation | Skill Review', function () {
   setupTest();
 
-  let component, adapter;
+  let component, adapter, possibleBadgesCombinations;
 
   beforeEach(function () {
+    possibleBadgesCombinations = [
+      { id: 30, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: true },
+      { id: 31, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: false },
+      { id: 32, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: true },
+      { id: 33, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: false },
+      { id: 34, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: true },
+      { id: 35, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: false },
+      { id: 36, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: true },
+      { id: 37, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: false },
+      { id: 38, isAcquired: false, isCertifiable: true, isValid: true, isAlwaysVisible: true },
+      { id: 39, isAcquired: false, isCertifiable: true, isValid: true, isAlwaysVisible: false },
+      { id: 40, isAcquired: false, isCertifiable: true, isValid: false, isAlwaysVisible: true },
+      { id: 41, isAcquired: false, isCertifiable: true, isValid: false, isAlwaysVisible: false },
+      { id: 42, isAcquired: false, isCertifiable: false, isValid: true, isAlwaysVisible: true },
+      { id: 43, isAcquired: false, isCertifiable: false, isValid: true, isAlwaysVisible: false },
+      { id: 44, isAcquired: false, isCertifiable: false, isValid: false, isAlwaysVisible: true },
+      { id: 45, isAcquired: false, isCertifiable: false, isValid: false, isAlwaysVisible: false },
+    ];
+
     const model = {
       campaign: EmberObject.create(),
       campaignParticipationResult: EmberObject.create({ id: 12345 }),
@@ -247,39 +266,113 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function ()
     });
   });
 
+  describe('#showValidBadges', function () {
+    it('should show badges when valid', function () {
+      // given
+      const badges = [{ id: 33, isAcquired: true, isCertifiable: true, isValid: true }];
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
+
+      // when
+      const shouldShowBadges = component.showValidBadges;
+
+      // then
+      expect(shouldShowBadges).to.equal(true);
+    });
+
+    it('should not show not badges when not valid', function () {
+      // given
+      const badges = [{ id: 33, isAcquired: true, isCertifiable: true, isValid: false }];
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
+
+      // when
+      const shouldShowBadges = component.showValidBadges;
+
+      // then
+      expect(shouldShowBadges).to.equal(false);
+    });
+
+    it('should not show badges when none', function () {
+      // given
+      const badges = [];
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
+
+      // when
+      const shouldShowBadges = component.showValidBadges;
+
+      // then
+      expect(shouldShowBadges).to.equal(false);
+    });
+  });
+
   describe('#acquiredNotCertifiableBadges', function () {
     it('should only return acquired and not certifiable badges', function () {
       // given
-      const badges = [
-        { id: 33, isAcquired: true, isCertifiable: false },
-        { id: 34, isAcquired: false, isCertifiable: true },
-        { id: 35, isAcquired: true, isCertifiable: true },
-        { id: 36, isAcquired: false, isCertifiable: false },
-      ];
-      component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = possibleBadgesCombinations;
 
       // when
       const acquiredBadges = component.acquiredNotCertifiableBadges;
 
       // then
-      expect(acquiredBadges).to.deep.equal([{ id: 33, isAcquired: true, isCertifiable: false }]);
+      expect(acquiredBadges).to.deep.equal([
+        { id: 34, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: true },
+        { id: 35, isAcquired: true, isCertifiable: false, isValid: true, isAlwaysVisible: false },
+        { id: 36, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: true },
+        { id: 37, isAcquired: true, isCertifiable: false, isValid: false, isAlwaysVisible: false },
+      ]);
     });
   });
 
-  describe('#acquiredCertifiableBadges', function () {
-    it('should only return certifiable acquired badges', function () {
+  describe('#validBadges', function () {
+    it('should only return valid badges', function () {
       // given
-      const badges = [
-        { id: 33, isAcquired: true, isCertifiable: true },
-        { id: 34, isAcquired: false, isCertifiable: false },
-      ];
-      component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = possibleBadgesCombinations;
 
       // when
-      const acquiredBadges = component.acquiredCertifiableBadges;
+      const acquiredBadges = component.validBadges;
 
       // then
-      expect(acquiredBadges).to.deep.equal([{ id: 33, isAcquired: true, isCertifiable: true }]);
+      expect(acquiredBadges).to.deep.equal([
+        { id: 30, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: true },
+        { id: 31, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: false },
+      ]);
+    });
+  });
+
+  describe('#invalidBadges', function () {
+    it('should only return invalid badges', function () {
+      // given
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = possibleBadgesCombinations;
+
+      // when
+      const acquiredBadges = component.invalidBadges;
+
+      // then
+      expect(acquiredBadges).to.deep.equal([
+        { id: 32, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: true },
+        { id: 33, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: false },
+        { id: 38, isAcquired: false, isCertifiable: true, isValid: true, isAlwaysVisible: true },
+        { id: 40, isAcquired: false, isCertifiable: true, isValid: false, isAlwaysVisible: true },
+      ]);
+    });
+  });
+
+  describe('#certifiableBadgesOrderedByValidity', function () {
+    it('should return certifiable badges ordered by validity status', function () {
+      // given
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = possibleBadgesCombinations;
+
+      // when
+      const acquiredBadges = component.certifiableBadgesOrderedByValidity;
+
+      // then
+      expect(acquiredBadges).to.deep.equal([
+        { id: 30, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: true },
+        { id: 31, isAcquired: true, isCertifiable: true, isValid: true, isAlwaysVisible: false },
+        { id: 32, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: true },
+        { id: 33, isAcquired: true, isCertifiable: true, isValid: false, isAlwaysVisible: false },
+        { id: 38, isAcquired: false, isCertifiable: true, isValid: true, isAlwaysVisible: true },
+        { id: 40, isAcquired: false, isCertifiable: true, isValid: false, isAlwaysVisible: true },
+      ]);
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème

Nous rencontrons deux problèmes :

- Le candidat ne voit pas les RT non obtenus sur sa page de fin de parcours alors qu’il aurait besoin de connaître les RT qu’il doit repasser.

- Si un candidat obtuient un RT à la fin d'un parcours, remet à jour les compétences ayant mené à l'acquisition de ce RT et retourne sur la page de fin du dit parcours, le RT est toujours considéré comme acquis alors que cela n'est plus le cas. 

## :gift: Proposition

- Faire remonter les lacunes sur la page de fin de parcours
- Afficher les RT non obtenus sur la page de fin de parcours selon le nouveau design

## :star2: Remarques

Pour réaliser cette opération, nous passons par l'ajout d'une propriété `isValid` au read-model `badge-result.js`. Cette solution peut bien sûr être rediscutée au besoin.

## :santa: Pour tester

Sur pix-app, se connecter avec le compte `userpix1@example.net` et aller sur la page `https://app-pr5204.review.pix.fr/mes-parcours` via l'URL ou le menu déroulant de l'utilisateur.

Vous pourrez trouver deux parcours : 

Le parcours `test-alex-rt` contient 3 RT certifiants, dont deux qui ont été obtenus et un non obtenu.
Vérifier que ces RT soient respectivement en vert et grisés.
Dans le cas présent, il n'est pas possible de vérifier que les RT passent en gris pour des RT certifiants acquis qui viendrait à être perdus en cas de réinitialisation des compétences puisque ce profil cible ne contient pas de questions liées au référentiel coeur.

Le parcours `test-clea` contient un RT certifiant CléA qui a été obtenu et qui n'est désormais plus valide suite à la remise à zéro de la compétence `Mener une recherche et une veille d'information` (preuve en images ci-dessous)

<img width="1027" alt="Capture d’écran 2022-11-10 à 09 36 54" src="https://user-images.githubusercontent.com/36371437/201048026-f616230a-6e58-436f-95cd-f908cc31ecc6.png">

<img width="1012" alt="Capture d’écran 2022-11-10 à 09 37 45" src="https://user-images.githubusercontent.com/36371437/201048040-304ac93a-c3c7-4fcd-a279-4ea328721031.png">
