### PR TITLE
[TECH] Déplacer la gestion de l'authentification anonyme dans un service (PIX-6029)

### DIFF
--- a/mon-pix/app/instance-initializers/session.js
+++ b/mon-pix/app/instance-initializers/session.js
@@ -1,11 +1,21 @@
 import PixWindow from 'mon-pix/utils/pix-window';
 
+function _removeCurrentSessionFromLocalStorage() {
+  window.localStorage.removeItem('ember_simple_auth-session');
+}
+
 export function initialize(/* applicationInstance */) {
   const currentURL = PixWindow.getLocationHref();
-  const isGarAuthenticationURL = currentURL.match(/\/connexion\/gar/i)?.length === 1;
 
+  const isGarAuthenticationURL = currentURL.match(/\/connexion\/gar/i)?.length === 1;
   if (isGarAuthenticationURL) {
-    window.localStorage.removeItem('ember_simple_auth-session');
+    _removeCurrentSessionFromLocalStorage();
+    return;
+  }
+
+  const isAuthenticatedExternalUser = currentURL.match(/externalUser=/i)?.length === 1;
+  if (isAuthenticatedExternalUser) {
+    _removeCurrentSessionFromLocalStorage();
   }
 }
 

--- a/mon-pix/app/instance-initializers/session.js
+++ b/mon-pix/app/instance-initializers/session.js
@@ -1,22 +1,18 @@
 import PixWindow from 'mon-pix/utils/pix-window';
 
-function _removeCurrentSessionFromLocalStorage() {
-  window.localStorage.removeItem('ember_simple_auth-session');
-}
-
 export function initialize(/* applicationInstance */) {
   const currentURL = PixWindow.getLocationHref();
 
-  const isGarAuthenticationURL = currentURL.match(/\/connexion\/gar/i)?.length === 1;
-  if (isGarAuthenticationURL) {
-    _removeCurrentSessionFromLocalStorage();
-    return;
-  }
+  const isGarAuthenticationURL = currentURL.includes('/connexion/gar');
+  const isAuthenticatedExternalUser = currentURL.includes('externalUser=');
 
-  const isAuthenticatedExternalUser = currentURL.match(/externalUser=/i)?.length === 1;
-  if (isAuthenticatedExternalUser) {
+  if (isGarAuthenticationURL || isAuthenticatedExternalUser) {
     _removeCurrentSessionFromLocalStorage();
   }
+}
+
+function _removeCurrentSessionFromLocalStorage() {
+  window.localStorage.removeItem('ember_simple_auth-session');
 }
 
 export default {

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -3,12 +3,13 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class ApplicationRoute extends Route {
-  @service splash;
-  @service session;
-  @service intl;
-  @service headData;
+  @service authentication;
   @service featureToggles;
+  @service headData;
+  @service intl;
   @service oidcIdentityProviders;
+  @service session;
+  @service splash;
 
   activate() {
     this.splash.hide();
@@ -32,6 +33,8 @@ export default class ApplicationRoute extends Route {
     await this.featureToggles.load().catch();
 
     await this.oidcIdentityProviders.load().catch();
+
+    await this.authentication.handleAnonymousAuthentication(transition);
 
     await this.session.handleUserLanguageAndLocale(transition);
   }

--- a/mon-pix/app/services/authentication.js
+++ b/mon-pix/app/services/authentication.js
@@ -1,0 +1,35 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+import get from 'lodash/get';
+
+const ALLOWED_ROUTES_FOR_ANONYMOUS_ACCESS = [
+  'fill-in-campaign-code',
+  'campaigns.assessment.tutorial',
+  'campaigns.assessment.start-or-resume',
+  'campaigns.campaign-landing-page',
+  'campaigns.assessment.skill-review',
+  'assessments.challenge',
+  'assessments.checkpoint',
+];
+
+export default class Authentication extends Service {
+  @service router;
+  @service session;
+
+  async handleAnonymousAuthentication(transition) {
+    const isUserAnonymous = get(this.session, 'data.authenticated.authenticator') === 'authenticator:anonymous';
+
+    if (!isUserAnonymous) {
+      return;
+    }
+
+    const isRouteAccessNotAllowedForAnonymousUser = !ALLOWED_ROUTES_FOR_ANONYMOUS_ACCESS.includes(
+      get(transition, 'to.name')
+    );
+
+    if (isRouteAccessNotAllowedForAnonymousUser) {
+      await this.session.invalidate();
+      this.router.replaceWith('/campagnes');
+    }
+  }
+}

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -61,10 +61,7 @@ export default class CurrentSessionService extends SessionService {
   }
 
   async handleUserLanguageAndLocale(transition = null) {
-    await this._checkForURLAuthentication(transition);
-
-    const locale = transition.to.queryParams.lang;
-    await this._loadCurrentUserAndSetLocale(locale);
+    await this._loadCurrentUserAndSetLocale(transition?.to?.queryParams?.lang);
   }
 
   requireAuthenticationAndApprovedTermsOfService(transition, authenticationRoute) {
@@ -78,17 +75,6 @@ export default class CurrentSessionService extends SessionService {
 
   setAttemptedTransition(transition) {
     this.attemptedTransition = transition;
-  }
-
-  async _checkForURLAuthentication(transition) {
-    if (transition.to.queryParams && transition.to.queryParams.externalUser) {
-      // Logout user when a new external user is authenticated
-      // without redirecting the user to the login page.
-      if (this.isAuthenticated) {
-        this.skipRedirectAfterSessionInvalidation = true;
-        await this._logoutUser();
-      }
-    }
   }
 
   async _loadCurrentUserAndSetLocale(locale = null) {

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -62,7 +62,6 @@ export default class CurrentSessionService extends SessionService {
 
   async handleUserLanguageAndLocale(transition = null) {
     await this._checkForURLAuthentication(transition);
-    await this._checkAnonymousAccess(transition);
 
     const locale = transition.to.queryParams.lang;
     await this._loadCurrentUserAndSetLocale(locale);
@@ -89,27 +88,6 @@ export default class CurrentSessionService extends SessionService {
         this.skipRedirectAfterSessionInvalidation = true;
         await this._logoutUser();
       }
-    }
-  }
-
-  async _checkAnonymousAccess(transition) {
-    const allowedRoutesForAnonymousAccess = [
-      'fill-in-campaign-code',
-      'campaigns.assessment.tutorial',
-      'campaigns.start-or-resume',
-      'campaigns.campaign-landing-page',
-      'assessments.challenge',
-      'campaigns.assessment.skill-review',
-      'assessments.checkpoint',
-    ];
-    const isUserAnonymous = get(this, 'data.authenticated.authenticator') === 'authenticator:anonymous';
-    const isRouteAccessNotAllowedForAnonymousUser = !allowedRoutesForAnonymousAccess.includes(
-      get(transition, 'to.name')
-    );
-
-    if (isUserAnonymous && isRouteAccessNotAllowedForAnonymousUser) {
-      await this._logoutUser();
-      this.router.replaceWith('/campagnes');
     }
   }
 

--- a/mon-pix/tests/unit/instance-initializers/session-test.js
+++ b/mon-pix/tests/unit/instance-initializers/session-test.js
@@ -23,6 +23,8 @@ describe('Unit | Instance Initializer | session', function () {
   afterEach(function () {
     run(this.instance, 'destroy');
     run(this.application, 'destroy');
+
+    sinon.restore();
   });
 
   context('when a session exists', function () {
@@ -31,6 +33,35 @@ describe('Unit | Instance Initializer | session', function () {
         // given
         const key = 'ember_simple_auth-session';
         sinon.stub(PixWindow, 'getLocationHref').returns('/connexion/gar#access_token');
+        window.localStorage.setItem(
+          key,
+          JSON.stringify({
+            authenticated: {
+              authenticator: 'authenticator:oauth2',
+              token_type: 'bearer',
+              access_token: 'access_token',
+              user_id: 1,
+              refresh_token: 'refresh_token',
+              expires_in: 45,
+              expires_at: 1667837187635,
+            },
+          })
+        );
+
+        // when
+        await this.instance.boot();
+
+        // then
+        const session = window.localStorage.getItem(key);
+        expect(session).to.be.null;
+      });
+    });
+
+    context('when current URL contains externalUser as query parameter', function () {
+      it('should remove the current session before the application loads', async function () {
+        // given
+        const key = 'ember_simple_auth-session';
+        sinon.stub(PixWindow, 'getLocationHref').returns('/campagnes?externalUser=EXTERNAL_USER_TOKEN');
         window.localStorage.setItem(
           key,
           JSON.stringify({

--- a/mon-pix/tests/unit/services/authentication_test.js
+++ b/mon-pix/tests/unit/services/authentication_test.js
@@ -1,0 +1,121 @@
+import { setupTest } from 'ember-mocha';
+import sinon from 'sinon';
+import { it } from 'mocha';
+
+describe('Unit | Services | authentication', function () {
+  setupTest();
+
+  let authenticationService;
+
+  beforeEach(function () {
+    authenticationService = this.owner.lookup('service:authentication');
+
+    sinon.stub(authenticationService.session, 'invalidate').resolves();
+    sinon.stub(authenticationService.router, 'replaceWith');
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  describe('#handleAnonymousAuthentication', function () {
+    context('when there is no session', function () {
+      context('when the route is available for an anonymous user', function () {
+        it('should do nothing', async function () {
+          // given
+          const transition = { to: { name: 'fill-in-campaign-code' } };
+
+          // when
+          await authenticationService.handleAnonymousAuthentication(transition);
+
+          // then
+          sinon.assert.notCalled(authenticationService.session.invalidate);
+        });
+      });
+
+      context('when the route is not available for an anonymous user', function () {
+        it('should do nothing', async function () {
+          // given
+          const transition = { to: { name: 'not-available-route' } };
+
+          // when
+          await authenticationService.handleAnonymousAuthentication(transition);
+
+          // then
+          sinon.assert.notCalled(authenticationService.session.invalidate);
+        });
+      });
+    });
+
+    context('when there is a session', function () {
+      context('created with the anonymous authenticator', function () {
+        beforeEach(function () {
+          sinon
+            .stub(authenticationService.session, 'data')
+            .value({ authenticated: { authenticator: 'authenticator:anonymous' } });
+        });
+
+        context('when the route is available for an anonymous user', function () {
+          it('should do nothing', async function () {
+            // given
+            const transition = { to: { name: 'fill-in-campaign-code' } };
+
+            // when
+            await authenticationService.handleAnonymousAuthentication(transition);
+
+            // then
+            sinon.assert.notCalled(authenticationService.session.invalidate);
+          });
+        });
+
+        context('when the route is not available for an anonymous user', function () {
+          it('should invalidate the current session and redirect the user to /campagnes', async function () {
+            // given
+            const transition = { to: { name: 'not-available-route' } };
+
+            // when
+            await authenticationService.handleAnonymousAuthentication(transition);
+
+            // then
+            sinon.assert.calledOnce(authenticationService.session.invalidate);
+            sinon.assert.calledWith(authenticationService.router.replaceWith, '/campagnes');
+          });
+        });
+      });
+
+      context('created with another authenticator', function () {
+        beforeEach(function () {
+          sinon
+            .stub(authenticationService.session, 'data')
+            .value({ authenticated: { authenticator: 'authenticator:oauth2' } });
+        });
+
+        context('when the route is available for an anonymous user', function () {
+          it('should do nothing', async function () {
+            // given
+            const transition = { to: { name: 'fill-in-campaign-code' } };
+
+            // when
+            await authenticationService.handleAnonymousAuthentication(transition);
+
+            // then
+            sinon.assert.notCalled(authenticationService.session.invalidate);
+          });
+        });
+
+        context('when the route is not available for an anonymous user', function () {
+          it('should do nothing', async function () {
+            // given
+            const transition = { to: { name: 'not-available-route' } };
+
+            // when
+            await authenticationService.handleAnonymousAuthentication(transition);
+
+            // then
+            sinon.assert.notCalled(authenticationService.session.invalidate);
+          });
+        });
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/services/session_test.js
+++ b/mon-pix/tests/unit/services/session_test.js
@@ -175,57 +175,18 @@ describe('Unit | Services | session', function () {
       sessionService._loadCurrentUserAndSetLocale = sinon.stub();
     });
 
-    afterEach(function () {
-      sinon.restore();
-    });
-
-    context('when a new external user is authenticated', function () {
-      it('should invalidate the current session', async function () {
+    context('when an existing external user is authenticated', function () {
+      it('should invalidate the current session and authenticate the existing external user', async function () {
         // given
-        const transition = { to: { queryParams: { externalUser: 'user' } } };
-        sinon.stub(sessionService, 'isAuthenticated').value(true);
+        const transition = { to: { queryParams: { token: 'token' } } };
 
         // when
         await sessionService.handleUserLanguageAndLocale(transition);
 
         // then
         sinon.assert.calledOnce(sessionService._logoutUser);
-      });
-    });
-
-    context('when an anonymous user is authenticated', function () {
-      let transition;
-
-      beforeEach(function () {
-        transition = { to: { queryParams: {} } };
-        sessionService.data = { authenticated: { authenticator: 'authenticator:anonymous' } };
-      });
-
-      context('and access an unauthorized route', function () {
-        it('should be redirect to campagnes page', async function () {
-          // given
-          transition.to.name = 'unknown.route';
-
-          // when
-          await sessionService.handleUserLanguageAndLocale(transition);
-
-          // then
-          sinon.assert.calledOnce(sessionService._logoutUser);
-          sinon.assert.calledWith(routerService.replaceWith, '/campagnes');
-        });
-      });
-
-      context('and access an authorized route', function () {
-        it('should not be redirect to campagnes page', async function () {
-          // given
-          transition.to.name = 'assessments.checkpoint';
-
-          // when
-          await sessionService.handleUserLanguageAndLocale(transition);
-
-          // then
-          sinon.assert.notCalled(routerService.replaceWith);
-        });
+        sinon.assert.calledOnce(oauthAuthenticator.authenticate);
+        sinon.assert.calledWith(oauthAuthenticator.authenticate, { token: 'token' });
       });
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement la méthode `handleUserLanguageAndLocale` qui se trouve dans le service `session` a des responsabilités en plus qui ne sont pas liées à la gestion de la langue de l'application. Cette méthode gère la connexion via le GAR, ainsi que la connexion d'un utilisateur anonyme.

## :gift: Proposition

- Créer un service pour gérer la vérification d'une authentification par le GAR, et par un utilisateur anonyme.
- Transférer le code nécessaire depuis le service `session` vers le nouveau service

## :star2: Remarques

Grâce au fix effectué sur cette PR https://github.com/1024pix/pix/pull/5182, la gestion de l'`externalUser` se trouve maintenant dans l'`instance-initializer` session.

## :santa: Pour tester

### GAR

##### 1ère connexion (utilisateur n'ayant pas de compte sur Pix : **First;Last;10-10-2010** ou **Prenom;Nom;09-09-2009**)

- Se connecter via le GAR
- Fournir le code de la campagne `SCOBADGE1`
- Commencer le parcours et créer le compte de l'utilisateur
- Finaliser ou ignorer le parcours
  - Finaliser : validez l'envoi des résultats et cliquez sur le lien pour aller sur la page d'accueil
  - Ignorer : cliquez sur le lien `Quitter`
- Constatez que vous arrivez sur la page d'accueil
- Se déconnecter
- Constatez que vous arrivez sur la page `/nonconnecté`

##### 2e connexion (utilisateur ayant un compte sur Pix - celui précédemment utilisé)

- Se connecter via le GAR
- Constatez que vous arrivez sur la page d'accueil
- Se déconnecter
- Constatez que vous arrivez sur la page `/nonconnecté`

### Anonyme

- Ouvrir la console développeur de votre navigateur sur l'onglet `Network|Réseau`
- Allez sur la page `/campagnes`
- Fournir le code `SIMPLIFIE`
- Commencer le parcours
- Constatez dans l'onglet `Network|Réseau` que la requête `/api/token/anonymous` est bien passée
- Constatez que vous avez accès au parcours simplifié