### PR TITLE
[TECH] Utiliser `htmlSafe` importé depuis `ember/template` (PIX-6287).

### DIFF
--- a/mon-pix/app/components/challenge-embed-simulator.js
+++ b/mon-pix/app/components/challenge-embed-simulator.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 export default class ChallengeEmbedSimulator extends Component {
   @tracked

--- a/mon-pix/app/components/communication-banner.js
+++ b/mon-pix/app/components/communication-banner.js
@@ -1,4 +1,4 @@
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import isEmpty from 'lodash/isEmpty';
 import ENV from 'mon-pix/config/environment';

--- a/mon-pix/app/components/markdown-to-html-unsafe.js
+++ b/mon-pix/app/components/markdown-to-html-unsafe.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import showdown from 'showdown';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import ENV from 'mon-pix/config/environment';
 
 export default class MarkdownToHtmlUnsafe extends Component {

--- a/mon-pix/app/components/markdown-to-html.js
+++ b/mon-pix/app/components/markdown-to-html.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import showdown from 'showdown';
 import xss from 'xss';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import ENV from 'mon-pix/config/environment';
 
 function modifyWhiteList() {

--- a/mon-pix/app/components/progress-bar.js
+++ b/mon-pix/app/components/progress-bar.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import colorGradient from 'mon-pix/utils/color-gradient';
 import progressInAssessment from 'mon-pix/utils/progress-in-assessment';
 

--- a/mon-pix/app/components/timeout-gauge.js
+++ b/mon-pix/app/components/timeout-gauge.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import ENV from 'mon-pix/config/environment';
 
 const BLACK_GAUGE_ICON_PATH = '/images/icons/icon-timeout-black.svg';

--- a/mon-pix/app/helpers/text-with-multiple-lang.js
+++ b/mon-pix/app/helpers/text-with-multiple-lang.js
@@ -1,6 +1,6 @@
 import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
-import { htmlSafe, isHTMLSafe } from '@ember/string';
+import { htmlSafe, isHTMLSafe } from '@ember/template';
 
 export default class textWithMultipleLang extends Helper {
   @service intl;

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -20,7 +20,7 @@
         <div class="fill-in-campaign-code__form-field">
           <Input
             required
-            @id="campaign-code"
+            id="campaign-code"
             class="input-code"
             @type="text"
             @value={{this.campaignCode}}

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^20.2.1",
+        "@1024pix/pix-ui": "^20.2.2",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^2.0.4",
         "@formatjs/intl": "^2.5.1",
@@ -452,9 +452,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "20.2.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.2.1.tgz",
-      "integrity": "sha512-esl2SzuAHlPl1rXdjGxdCKVMTTpWdBDntSlsmCyOOiPkrOpvc393cNiEqMWe2JiDYu709OR57AGhuVJ27BA/Cw==",
+      "version": "20.2.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.2.2.tgz",
+      "integrity": "sha512-BlbdrpEYGh8MlpJRyz9D6z5GeOg0KLEoP0Lu05xC+3I3FmJGA8GMxWsrQEYWWWVCTMMaXMh1VQsvVvoXDvMN4g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -36506,15 +36506,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -37724,9 +37715,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "20.2.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.2.1.tgz",
-      "integrity": "sha512-esl2SzuAHlPl1rXdjGxdCKVMTTpWdBDntSlsmCyOOiPkrOpvc393cNiEqMWe2JiDYu709OR57AGhuVJ27BA/Cw==",
+      "version": "20.2.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.2.2.tgz",
+      "integrity": "sha512-BlbdrpEYGh8MlpJRyz9D6z5GeOg0KLEoP0Lu05xC+3I3FmJGA8GMxWsrQEYWWWVCTMMaXMh1VQsvVvoXDvMN4g==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",
@@ -66335,12 +66326,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-      "dev": true
-    },
-    "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "dev": true
     },
     "v8-compile-cache": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^20.2.1",
+    "@1024pix/pix-ui": "^20.2.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.4",
     "@formatjs/intl": "^2.5.1",

--- a/mon-pix/tests/unit/components/progress-bar_test.js
+++ b/mon-pix/tests/unit/components/progress-bar_test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { beforeEach, afterEach, describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import sinon from 'sinon';
 import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
 import progressInAssessment from 'mon-pix/utils/progress-in-assessment';

--- a/mon-pix/tests/unit/helpers/text-with-multiple-lang_test.js
+++ b/mon-pix/tests/unit/helpers/text-with-multiple-lang_test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import textWithMultipleLang from 'mon-pix/helpers/text-with-multiple-lang';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 describe('Unit | Helper | text with multiple lang', function () {
   let textWithMultipleLangHelper;

--- a/mon-pix/tests/unit/routes/assessments/checkpoint_test.js
+++ b/mon-pix/tests/unit/routes/assessments/checkpoint_test.js
@@ -26,10 +26,7 @@ describe('Unit | Route | Assessments | Checkpoint', function () {
     it('should force the progression reload when assessment is for campaign', async function () {
       // given
       const route = this.owner.lookup('route:assessments/checkpoint');
-      const storeStub = {
-        queryRecord: sinon.stub(),
-      };
-      route.set('store', storeStub);
+      route.store.queryRecord = sinon.stub();
       const reloadStub = sinon.stub();
       const assessment = {
         isForCampaign: true,

--- a/mon-pix/tests/unit/routes/assessments/resume_test.js
+++ b/mon-pix/tests/unit/routes/assessments/resume_test.js
@@ -22,7 +22,7 @@ describe('Unit | Route | Assessments | Resume', function () {
     });
 
     route = this.owner.lookup('route:assessments.resume');
-    route.set('store', storeStub);
+    this.owner.register('service:store', storeStub);
     route.router = { replaceWith: sinon.stub() };
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Il était possible d'importer `htmlSafe` depuis `ember/string` et `ember/template`, cependant dans les nouvelles versions d'Ember, [il devient impossible de l'importer depuis `ember/string`.](https://deprecations.emberjs.com/v3.x/#toc_ember-string-htmlsafe-ishtmlsafe) 
Comme nous avons des imports d'`htmlSafe` qui proviennent `ember/string` cela pose problème pour le bon fonctionnement de l'application dans les versions suivantes.

## :gift: Proposition
- Remplacer les `ember/string` par `ember/template`.
- Utiliser [la version de Pix-Ui qui a fait le même changement](https://github.com/1024pix/pix-ui/blob/dev/CHANGELOG.md#v2022-09112022) 

## :star2: Remarques
- Un oubli d'`@id` qui devient déprécié a été ajouté dans cette PR, les autres ont été fait dans celle-ci : #5189  

## :santa: Pour tester
- Se balader sur Pix App et constater que les pages chargent bien (particulière un passage de compétence) 
