### PR TITLE
[BUGFIX] Position du menu de la top nav (PIX-6273)

### DIFF
--- a/certif/app/styles/components/user-logged-menu.scss
+++ b/certif/app/styles/components/user-logged-menu.scss
@@ -40,7 +40,7 @@
 .logged-user-menu {
   right: 0;
   margin-right: 10px;
-  top: $navbar-height;
+  top: 50px;
   min-width: 400px;
 
   &-item {

--- a/certif/app/styles/pages/authenticated.scss
+++ b/certif/app/styles/pages/authenticated.scss
@@ -81,6 +81,7 @@
   align-items: center;
 
   &__user-logged-menu {
+    position: relative;
     padding: 0 30px;
     border-left: 1px solid $pix-neutral-20;
   }


### PR DESCRIPTION
## :christmas_tree: Problème
Quand il y a un bandeau d'info, le menu de la top nav se déplie au dessus du nom de l’utilisateur connecté à Pix Certif et du nom du CDC qu’il est actuellement en train de consulter.

<img width="1440" alt="Capture d’écran 2022-11-03 à 14 39 18" src="https://user-images.githubusercontent.com/11388201/201063844-b37ad1d6-e343-4c0c-80b6-5a936da667c0.png">

## :gift: Proposition
Le menu de la top nav doit se déplier en dessous du nom de l’utilisateur connecté à Pix Certif et du nom du CDC qu’il est actuellement en train de consulter afin de ne pas cacher ces éléments.

<img width="812" alt="Capture d’écran 2022-11-08 à 10 54 48" src="https://user-images.githubusercontent.com/11388201/201063888-8d83216c-8aa4-4f91-bd2c-72342e4232c0.png">

## :star2: Remarques
Le menu doit s'afficher correctement, qu'il y ait un bandeau ou non

## :santa: Pour tester
A tester en recette pour avoir un bandeau ?
