### PR TITLE
[BUGFIX] Corriger le design du bouton de fin de preview (PIX-6298).

### DIFF
--- a/mon-pix/app/styles/pages/_assessment-results.scss
+++ b/mon-pix/app/styles/pages/_assessment-results.scss
@@ -20,7 +20,7 @@
 }
 
 /* XXX : See https://github.com/sgmap/pix/issues/211 */
-.assessment-results [data-lines="2"] + div .tooltip-inner {
+.assessment-results [data-lines='2'] + div .tooltip-inner {
   padding-top: 3px;
 }
 
@@ -51,22 +51,6 @@
 .assessment-results__index-link-container {
   display: flex;
   flex-direction: row-reverse;
-}
-
-.assessment-results__index-link__element {
-  width: 275px;
-  height: 46px;
-  border-radius: 23px;
-  background-color: $pix-primary;
-  border: none;
-}
-
-.assessment-results__index-a-link {
-  width: 355px;
-}
-
-.assessment-results__index-link__element:hover {
-  background-color: $pix-primary-60;
 }
 
 .assessment-results__link-back {

--- a/mon-pix/app/templates/assessments/results.hbs
+++ b/mon-pix/app/templates/assessments/results.hbs
@@ -29,9 +29,9 @@
             }}</span>
         </PixButtonLink>
       {{else}}
-        <LinkTo @route="authenticated" class="assessment-results__index-link__element">
+        <PixButtonLink @route="authenticated" @shape="rounded">
           <span class="assessment-results__link-back">{{t "pages.assessment-results.actions.return-to-homepage"}}</span>
-        </LinkTo>
+        </PixButtonLink>
       {{/if}}
     </div>
   </div>


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, depuis la PR #5189  le design du bouton de fin de preview est cassé. 

<img width="953" alt="image" src="https://user-images.githubusercontent.com/26384707/201075442-ddeee58a-eeee-4884-82e3-e80cc7c2c446.png">


## :gift: Proposition
Remplacer le LinkTo par un `PixButtonLink` pour bénéficier du DS.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Faire une preview sur Pix App et constater en fin de preview que le bouton est nickel : `/challenges/rec6ZOkRMNlJNAKgl/preview`