### PR TITLE
[TECH] Remplacer le composant Ember `<Input>` de type radio en `<PixRadioButton>` dans les QCU (PIX-6299) 

### DIFF
--- a/mon-pix/app/components/qcu-proposals.hbs
+++ b/mon-pix/app/components/qcu-proposals.hbs
@@ -1,17 +1,17 @@
 {{! template-lint-disable builtin-component-arguments }}
 {{#each this.labeledRadios as |labeledRadio index|}}
   <p class="proposal-paragraph qcu-proposals">
-    <Input
-      @type="radio"
-      name="radio"
-      class="qcu-proposals__radio"
-      value="{{inc index}}"
-      data-value="{{inc index}}"
+    <PixRadioButton
       id="radio_{{inc index}}"
+      name="radio"
+      @label={{this.label}}
+      @value={{inc index}}
+      @isDisabled={{@isAnswerFieldDisabled}}
       checked={{get labeledRadio 1}}
       {{on "click" (fn this.radioClicked index)}}
+      data-value="{{inc index}}"
+      class="qcu-proposals__radio"
       data-test="challenge-response-proposal-selector"
-      disabled={{@isAnswerFieldDisabled}}
     />
 
     <label for="radio_{{inc index}}" class="qcu-proposals__label">

--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -1,4 +1,4 @@
-@import "challenge-embed-simulator";
+@import 'challenge-embed-simulator';
 
 .challenge-statement {
   /* XXX required to let "help tooltip" displaying well even if instruction section is short (1 line) */
@@ -151,16 +151,6 @@
   display: inline-block;
   padding: 0 15px;
   margin: 5px;
-
-  input[type=radio]::before {
-    top: -4px;
-    left: -4px;
-  }
-
-  input[type=radio]:checked::after {
-    top: -19px;
-    left: 2px;
-  }
 }
 
 .challenge-statement__file-option-label {

--- a/mon-pix/app/styles/components/_qcu-panel.scss
+++ b/mon-pix/app/styles/components/_qcu-panel.scss
@@ -19,11 +19,6 @@
     }
   }
 
-  & > input[type=radio] {
-    flex-shrink: 0;
-    margin: auto 0;
-  }
-
   &__label {
     display: inline-block;
     padding-left: 20px;

--- a/mon-pix/app/styles/components/_qcu-proposals.scss
+++ b/mon-pix/app/styles/components/_qcu-proposals.scss
@@ -19,11 +19,6 @@
     }
   }
 
-  & > input[type=radio] {
-    flex-shrink: 0;
-    margin: auto 0;
-  }
-
   &__label {
     width: 100%;
     display: inline-block;

--- a/mon-pix/app/styles/components/_qcu-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qcu-solution-panel.scss
@@ -23,11 +23,6 @@
     }
   }
 
-  & > input[type=radio] {
-    flex-shrink: 0;
-    margin: auto 0;
-  }
-
   &__proposal-item {
     line-height: 1.2rem;
     font-weight: $font-normal;

--- a/mon-pix/app/styles/globals/_redesign-inputs.scss
+++ b/mon-pix/app/styles/globals/_redesign-inputs.scss
@@ -46,46 +46,6 @@ fieldset {
   top: 3px;
 }
 
-input[type=radio]::before,
-input[type=radio]:checked::after {
-  display: block;
-  position: relative;
-  content: '';
-  border-radius: 100%;
-}
-
-input[type=radio]::before {
-  height: 17px;
-  width: 17px;
-  top: -3px;
-  left: -5px;
-  border: solid 2px $pix-neutral-30;
-  border-radius: 10px;
-  background-color: $pix-neutral-0;
-}
-
-input[type=radio]:checked::after {
-  height: 9px;
-  width: 9px;
-  top: -18px;
-  left: 1px;
-  background-color: $pix-primary;
-}
-
-input[type=radio]:checked::before {
-  border-color: $pix-primary;
-}
-
-input[type=radio]:focus::before,
-input[type=radio]:hover::before {
-  box-shadow: 0 0 0 8px rgba($pix-primary, 0.1);
-  border-color: $pix-primary;
-}
-
-input[type=radio]:active::before {
-  box-shadow: 0 0 0 8px rgba($pix-primary, 0.3);
-}
-
 /**
  *
  * Configure Radios of input files

--- a/mon-pix/app/styles/globals/_redesign-inputs.scss
+++ b/mon-pix/app/styles/globals/_redesign-inputs.scss
@@ -37,17 +37,6 @@ fieldset {
 
 /**
  *
- * Configure Radios of proposals
- *
- **/
-.picture-checkbox-proposal--qcu {
-  position: absolute;
-  left: -11px;
-  top: 3px;
-}
-
-/**
- *
  * Configure Radios of input files
  *
  **/
@@ -56,23 +45,6 @@ fieldset {
   padding-left: 6px;
   position: relative;
   cursor: pointer;
-}
-
-/**
- *
- * Configure Checkboxes that MUST be disabled
- *
- **/
-.picture-checkbox-proposal--comparison {
-  position: absolute;
-  left: -11px;
-  top: 3px;
-}
-
-.picture-checkbox-proposal--qcm {
-  position: absolute;
-  left: -11px;
-  top: 3px;
 }
 
 .qcm-panel__proposal-label {


### PR DESCRIPTION
## :christmas_tree: Problème
Le composant fourni <Input> par Ember ne permets plus d'avoir le type `radio`. 

## :gift: Proposition
Ne nous souhaitons pas garder les composants fournient par Ember car [en v4 il faut ajouter une lib](https://deprecations.emberjs.com/v3.x/#toc_ember-built-in-components-import) pour avoir ces derniers. 
Seulement, ce qui bloque actuellement la 3.28 est uniquement le `<Input>` de type radio des QCU. 

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Passer une épreuve QCU et constater le bon fonctionnement, ainsi que la solution à la fin : `/challenges/rec6ZOkRMNlJNAKgl/preview`. 