### PR TITLE
[FEATURE] Espace autour des boutons du bloc détail de session (PIX-5780)

### DIFF
--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -137,11 +137,8 @@
 
 .session-details-buttons {
   display: flex;
-  padding: 22px 30px;
-
-  &--push-right {
-    margin-left: auto;
-  }
+  justify-content: space-between;
+  padding: 16px;
 }
 
 .session-details {

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -107,34 +107,28 @@
     </div>
   </div>
 
-  <div class="session-details-row">
+  <div class="session-details-buttons">
     {{#if this.sessionHasStarted}}
-      <div class="session-details-buttons">
-        <PixButtonLink @route="authenticated.sessions.update" @model={{this.session.id}} @backgroundColor="grey">
-          Modifier
+      <PixButtonLink @route="authenticated.sessions.update" @model={{this.session.id}} @backgroundColor="grey">
+        Modifier
+      </PixButtonLink>
+      {{#if this.session.isFinalized}}
+        <p class="session-details-row__session-finalized-warning">
+          Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix
+        </p>
+      {{else}}
+        <PixButtonLink @route="authenticated.sessions.finalize" @model={{this.session.id}} class="push-right">
+          Finaliser la session
         </PixButtonLink>
-      </div>
-      <div class="session-details-buttons session-details-buttons--push-right">
-        {{#if this.session.isFinalized}}
-          <p class="session-details-row__session-finalized-warning">
-            Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix
-          </p>
-        {{else}}
-          <PixButtonLink @route="authenticated.sessions.finalize" @model={{this.session.id}} class="push-right">
-            Finaliser la session
-          </PixButtonLink>
-        {{/if}}
-      </div>
+      {{/if}}
     {{else}}
-      <div class="session-details-buttons">
-        <PixButtonLink
-          @route="authenticated.sessions.update"
-          @model={{this.session.id}}
-          aria-label="Modifier les informations de la session {{this.session.id}}"
-        >
-          Modifier
-        </PixButtonLink>
-      </div>
+      <PixButtonLink
+        @route="authenticated.sessions.update"
+        @model={{this.session.id}}
+        aria-label="Modifier les informations de la session {{this.session.id}}"
+      >
+        Modifier
+      </PixButtonLink>
     {{/if}}
   </div>
 

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -11,7 +11,7 @@
                 @clipboardText={{this.session.id}}
                 @success={{this.showSessionIdTooltip}}
                 @classNames="icon-button session-details-content__clipboard-button"
-                aria-label="Copier le code du numéro de session"
+                aria-label={{t "copy-session-number"}}
               >
                 <FaIcon @icon="copy" prefix="fas" />
               </CopyButton>
@@ -23,8 +23,8 @@
     </div>
 
     <div class="session-details-content session-details-content--multiple session-details-content--copyable">
-      <h3 class="label-text session-details-content__label">Code d'accès
-        <div class="session-details-content__sub-label">Candidat</div>
+      <h3 class="label-text session-details-content__label">{{t "pages.sessions.detail.parameters.session-access-code"}}
+        <div class="session-details-content__sub-label">{{t "pages.sessions.detail.parameters.session-candidate"}}</div>
       </h3>
       <div class="session-details-content__clipboard" {{on "mouseout" this.removeAccessCodeTooltip}}>
         <span class="content-text content-text--bold session-details-content__text">{{this.session.accessCode}}</span>
@@ -36,7 +36,7 @@
                 @clipboardText={{this.session.accessCode}}
                 @success={{this.showAccessCodeTooltip}}
                 @classNames="icon-button session-details-content__clipboard-button"
-                aria-label="Copier le code d'accès pour le candidat"
+                aria-label={{t "pages.sessions.detail.parameters.copy-access-code-number"}}
               >
                 <FaIcon @icon="copy" prefix="fas" />
               </CopyButton>
@@ -50,8 +50,8 @@
     {{#if this.supervisorPasswordShouldBeDisplayed}}
       <div class="session-details-content session-details-content--multiple session-details-content--copyable">
         <h3 class="label-text session-details-content__label">
-          Mot de passe de session
-          <div class="session-details-content__sub-label">Surveillant</div>
+          {{t "pages.sessions.detail.parameters.session-password"}}
+          <div class="session-details-content__sub-label">{{t "pages.session-supervising.header.supervisor"}}</div>
         </h3>
         <div class="session-details-content__clipboard" {{on "mouseout" this.removeSupervisorPasswordTooltip}}>
           <span class="content-text content-text--bold session-details-content__text">
@@ -69,7 +69,7 @@
                   @clipboardText={{this.session.supervisorPassword}}
                   @success={{this.showSupervisorPasswordTooltip}}
                   @classNames="icon-button session-details-content__clipboard-button"
-                  aria-label="Copier le mot de passe de session pour le surveillant"
+                  aria-label={{t "pages.sessions.detail.parameters.copy-session-password-supervisor"}}
                 >
                   <FaIcon @icon="copy" prefix="fas" />
                 </CopyButton>
@@ -82,17 +82,21 @@
     {{/if}}
 
     <div class="session-details-content session-details-content--multiple">
-      <h3 class="label-text session-details-content__label">Nom du site</h3>
+      <h3 class="label-text session-details-content__label">
+        {{t "pages.session-supervising.header.center-name-full"}}
+      </h3>
       <span class="content-text session-details-content__text">{{this.session.address}}</span>
     </div>
 
     <div class="session-details-content session-details-content--multiple">
-      <h3 class="label-text session-details-content__label">Salle</h3>
+      <h3 class="label-text session-details-content__label">{{t "pages.session-supervising.header.room"}}</h3>
       <span class="content-text session-details-content__text">{{this.session.room}}</span>
     </div>
 
     <div class="session-details-content session-details-content--multiple">
-      <h3 class="label-text session-details-content__label">Surveillant(s)</h3>
+      <h3 class="label-text session-details-content__label">
+        {{t "pages.session-supervising.header.multiple-supervisor"}}
+      </h3>
       <span class="content-text session-details-content__text">{{this.session.examiner}}</span>
     </div>
 
@@ -100,7 +104,7 @@
 
   <div class="session-details-row">
     <div class="session-details-content session-details-content--single">
-      <h3 class="label-text session-details-content__label">Observations</h3>
+      <h3 class="label-text session-details-content__label">{{t "pages.sessions.detail.parameters.observations"}}</h3>
       <p class="content-text session-details-content__text">
         {{this.session.description}}
       </p>
@@ -110,24 +114,24 @@
   <div class="session-details-buttons">
     {{#if this.sessionHasStarted}}
       <PixButtonLink @route="authenticated.sessions.update" @model={{this.session.id}} @backgroundColor="grey">
-        Modifier
+        {{t "common.actions.update"}}
       </PixButtonLink>
       {{#if this.session.isFinalized}}
         <p class="session-details-row__session-finalized-warning">
-          Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix
+          {{t "pages.sessions.detail.parameters.finalization-info"}}
         </p>
       {{else}}
         <PixButtonLink @route="authenticated.sessions.finalize" @model={{this.session.id}} class="push-right">
-          Finaliser la session
+          {{t "pages.sessions.detail.parameters.finalizing"}}
         </PixButtonLink>
       {{/if}}
     {{else}}
       <PixButtonLink
         @route="authenticated.sessions.update"
         @model={{this.session.id}}
-        aria-label="Modifier les informations de la session {{this.session.id}}"
+        aria-label={{t "pages.sessions.detail.parameters.session-update" sessionId=this.session.id}}
       >
-        Modifier
+        {{t "common.actions.update"}}
       </PixButtonLink>
     {{/if}}
   </div>

--- a/certif/tests/acceptance/session-details-parameters_test.js
+++ b/certif/tests/acceptance/session-details-parameters_test.js
@@ -3,6 +3,7 @@ import { click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from '../helpers/test-init';
 import { visit } from '@1024pix/ember-testing-library';
+import { setupIntl, t } from 'ember-intl/test-support';
 
 import { CREATED, FINALIZED } from 'pix-certif/models/session';
 
@@ -11,6 +12,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 module('Acceptance | Session Details Parameters', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   hooks.afterEach(function () {
     const notificationMessagesService = this.owner.lookup('service:notifications');
@@ -64,8 +66,20 @@ module('Acceptance | Session Details Parameters', function (hooks) {
             const screen = await visit(`/sessions/${sessionCreated.id}`);
 
             // then
-            assert.dom(screen.getByRole('link', { name: 'Modifier les informations de la session 123' })).exists();
-            assert.dom(screen.queryByRole('button', { name: 'Finaliser la session' })).doesNotExist();
+            assert
+              .dom(
+                screen.getByRole('link', {
+                  name: t('pages.sessions.detail.parameters.session-update', { sessionId: 123 }),
+                })
+              )
+              .exists();
+            assert
+              .dom(
+                screen.queryByRole('button', {
+                  name: t('pages.sessions.detail.parameters.finalize'),
+                })
+              )
+              .doesNotExist();
           });
 
           test('it should redirect to finalize page on click on finalize button', async function (assert) {
@@ -75,7 +89,7 @@ module('Acceptance | Session Details Parameters', function (hooks) {
 
             // when
             const screen = await visit(`/sessions/${sessionCreatedAndStarted.id}`);
-            await click(screen.getByRole('link', { name: 'Finaliser la session' }));
+            await click(screen.getByRole('link', { name: t('pages.sessions.detail.parameters.finalizing') }));
 
             // then
             assert.strictEqual(currentURL(), `/sessions/${sessionCreatedAndStarted.id}/finalisation`);
@@ -93,7 +107,9 @@ module('Acceptance | Session Details Parameters', function (hooks) {
               const screen = await visit(`/sessions/${sessionWithSupervisorPassword.id}`);
 
               // then
-              const supervisorPasswordElement = screen.queryByText('Mot de passe de session');
+              const supervisorPasswordElement = screen.queryByText(
+                t('pages.sessions.detail.parameters.session-password')
+              );
               assert.dom(supervisorPasswordElement).doesNotExist();
             });
           });
@@ -131,14 +147,8 @@ module('Acceptance | Session Details Parameters', function (hooks) {
           const screen = await visit(`/sessions/${sessionFinalized.id}`);
 
           // then
-          assert
-            .dom(
-              screen.getByText(
-                'Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix'
-              )
-            )
-            .exists();
-          assert.dom(screen.queryByRole('button', { name: 'Finaliser la session' })).doesNotExist();
+          assert.dom(screen.getByText(t('pages.sessions.detail.parameters.finalization-info'))).exists();
+          assert.dom(screen.queryByRole('button', { name: t('finalizing') })).doesNotExist();
         });
 
         test('it should throw an error on visiting /finalisation url', async function (assert) {

--- a/certif/tests/acceptance/session-details-parameters_test.js
+++ b/certif/tests/acceptance/session-details-parameters_test.js
@@ -64,22 +64,16 @@ module('Acceptance | Session Details Parameters', function (hooks) {
 
             // when
             const screen = await visit(`/sessions/${sessionCreated.id}`);
+            const updateButton = screen.getByRole('link', {
+              name: t('pages.sessions.detail.parameters.session-update', { sessionId: 123 }),
+            });
+            const finalizeButton = screen.queryByRole('button', {
+              name: t('pages.sessions.detail.parameters.finalize'),
+            });
 
             // then
-            assert
-              .dom(
-                screen.getByRole('link', {
-                  name: t('pages.sessions.detail.parameters.session-update', { sessionId: 123 }),
-                })
-              )
-              .exists();
-            assert
-              .dom(
-                screen.queryByRole('button', {
-                  name: t('pages.sessions.detail.parameters.finalize'),
-                })
-              )
-              .doesNotExist();
+            assert.dom(updateButton).exists();
+            assert.dom(finalizeButton).doesNotExist();
           });
 
           test('it should redirect to finalize page on click on finalize button', async function (assert) {
@@ -89,7 +83,9 @@ module('Acceptance | Session Details Parameters', function (hooks) {
 
             // when
             const screen = await visit(`/sessions/${sessionCreatedAndStarted.id}`);
-            await click(screen.getByRole('link', { name: t('pages.sessions.detail.parameters.finalizing') }));
+            const finalizeButton = screen.getByRole('link', { name: t('pages.sessions.detail.parameters.finalizing') });
+
+            await click(finalizeButton);
 
             // then
             assert.strictEqual(currentURL(), `/sessions/${sessionCreatedAndStarted.id}/finalisation`);
@@ -147,8 +143,11 @@ module('Acceptance | Session Details Parameters', function (hooks) {
           const screen = await visit(`/sessions/${sessionFinalized.id}`);
 
           // then
-          assert.dom(screen.getByText(t('pages.sessions.detail.parameters.finalization-info'))).exists();
-          assert.dom(screen.queryByRole('button', { name: t('finalizing') })).doesNotExist();
+          const finalizeText = screen.getByText(t('pages.sessions.detail.parameters.finalization-info'));
+          const finalizeButton = screen.queryByRole('button', { name: t('finalizing') });
+
+          assert.dom(finalizeText).exists();
+          assert.dom(finalizeButton).doesNotExist();
         });
 
         test('it should throw an error on visiting /finalisation url', async function (assert) {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -2,9 +2,10 @@
   "common": {
     "actions": {
       "cancel": "Annuler",
+      "close": "Fermer",
       "delete": "Supprimer",
       "quit": "Quitter",
-      "close": "Fermer"
+      "update": "Modifier"
     },
     "form": {
       "mandatory-all-fields": "All fields are required."
@@ -120,6 +121,18 @@
           "link-text": "plateforme du CléA numérique.",
           "download-button": "Télécharger la liste des candidats",
           "error-message": "Une erreur est survenue lors du téléchargement du fichier. Veuillez réessayer ou contacter certif@pix.fr en indiquant le numéro de la session concernée."
+        },
+        "parameters": {
+          "copy-access-code-number": "Copier le code du numéro de session",
+          "copy-session-number": "Copier le code du numéro de session",
+          "copy-session-password-supervisor": "Copier le mot de passe de session pour le surveillant",
+          "finalization-info": "Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix",
+          "finalizing": "Finaliser la session",
+          "observations": "Observations",
+          "session-access-code": "Code d'accès",
+          "session-candidate": "Candidat",
+          "session-password": "Mot de passe de session",
+          "session-update": "Modifier les informations de la session {sessionId}"
         }
       }
     },
@@ -127,8 +140,10 @@
       "header": {
         "session-id": "Session {sessionId}",
         "center-name": "Center name",
+        "center-name-full": "Center name",
         "room": "Room",
         "supervisor": "Supervisor",
+        "multiple-supervisor": "Supervisor(s)",
         "access-code": "Access code (candidates)"
       },
       "candidate-list": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -2,9 +2,10 @@
   "common": {
     "actions": {
       "cancel": "Annuler",
+      "close": "Fermer",
       "delete": "Supprimer",
       "quit": "Quitter",
-      "close": "Fermer"
+      "update": "Modifier"
     },
     "form": {
       "mandatory-all-fields": "Tous les champs sont obligatoires."
@@ -120,6 +121,18 @@
           "link-text": "plateforme du CléA numérique.",
           "download-button": "Télécharger la liste des candidats",
           "error-message": "Une erreur est survenue lors du téléchargement du fichier. Veuillez réessayer ou contacter certif@pix.fr en indiquant le numéro de la session concernée."
+        },
+        "parameters": {
+          "copy-access-code-number": "Copier le code du numéro de session",
+          "copy-session-number": "Copier le code du numéro de session",
+          "copy-session-password-supervisor": "Copier le mot de passe de session pour le surveillant",
+          "finalization-info": "Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix",
+          "finalizing": "Finaliser la session",
+          "observations": "Observations",
+          "session-access-code": "Code d'accès",
+          "session-candidate": "Candidat",
+          "session-password": "Mot de passe de session",
+          "session-update": "Modifier les informations de la session {sessionId}"
         }
       }
     },
@@ -127,8 +140,10 @@
       "header": {
         "session-id": "Session {sessionId}",
         "center-name": "Site",
+        "center-name-full": "Nom du site",
         "room": "Salle",
         "supervisor": "Surveillant",
+        "multiple-supervisor": "Surveillant(s)",
         "access-code": "Code d'accès (candidats)"
       },
       "candidate-list": {


### PR DESCRIPTION
## :christmas_tree: Problème
Dans le cadre de l’audit design Pix Certif, une anomalie pourtant sur groupement / distinctions entre items a été remontée sur la page détail d’une session.

Chaque étage de ce tableau (ligne détail, ligne observation, ligne CTA) ont des margin extérieures différentes.

<img width="1039" alt="Capture d’écran 2022-07-12 à 11_03_56" src="https://user-images.githubusercontent.com/11388201/201146976-5e40eab9-da5c-4a6f-b353-2b0e3a9ce522.png">

## :gift: Proposition
Les boutons ont actuellement un margin de 38 px (padding+margin), aligner avec les autres éléments du tableau de détail avec un margin de 16px.

<img width="507" alt="Capture d’écran 2022-07-12 à 11_08_59" src="https://user-images.githubusercontent.com/11388201/201147001-74d54562-c7ab-485c-b438-acf4b78e20cc.png">

## :star2: Remarques
Au passage, remplacement des traductions manquantes
