### PR TITLE
[BUGFIX] Alignement de la liste de RT certifiables (PIX-6302).

### DIFF
--- a/mon-pix/app/styles/components/_congratulations-certification-banner.scss
+++ b/mon-pix/app/styles/components/_congratulations-certification-banner.scss
@@ -82,9 +82,14 @@
 .congratulations-banner-complementary-certifications__list {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   margin-top: 16px;
   text-align: center;
   color: $pix-neutral-90;
+
+  @include device-is('tablet') {
+    align-items: center;
+  }
 }
 
 .congratulations-banner-complementary-certifications-list__message {
@@ -97,6 +102,8 @@
   margin: 0;
   font-size: 1rem;
   line-height: 22px;
+  width: fit-content;
+  text-align: left;
 }
 
 .congratulations-banner__links {


### PR DESCRIPTION
## :christmas_tree: Problème

![index](https://user-images.githubusercontent.com/36371437/201273149-01e405b0-edc3-4c7e-aec1-0e4e9362ed13.png)

Suivant le navigateur utilisé par l'utilisateur, pour un profil éligible à deux certifications complémentaires, les bullets points apparaissent tout à gauche alors que le texte est centré.

## :gift: Proposition

Modification de l'alignement de la liste : 

- A gauche pour le format mobile
- Centré pour les formats d'affichages plus élevés

## :star2: Remarques

Nous alignons également le texte du listing à gauche afin d'aligner verticalement les bullet points.

## :santa: Pour tester

Aller sur la page `/certifications` avec les comptes `sup108507@example.net` et `sup108508@example.net` (respectivement dotés d'un et deux RT certifiables), et vérifier du bon fonctionnement du nouvel affichage avec différents navigateurs et formats.
