### PR TITLE
[TECH] Supprimer l'intégration de JQuery sur Pix App (PIX-6306).

### DIFF
--- a/mon-pix/config/optional-features.json
+++ b/mon-pix/config/optional-features.json
@@ -1,6 +1,6 @@
 {
   "application-template-wrapper": false,
   "default-async-observers": true,
-  "jquery-integration": true,
+  "jquery-integration": false,
   "template-only-glimmer-components": true
 }


### PR DESCRIPTION
## :christmas_tree: Problème
Nous intégrons JQuery sur Pix App, alors que nous l'utilisons plus. 

## :gift: Proposition
Supprimer son intégration 

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Vérifier le bon fonctionnement de Pix App 
- Ouvrir l'extension Ember et dans l'onglet info constater qu'il n'y a plus JQuery