### PR TITLE
[FEATURE] Changer les dates de certification affichées dans le bandeau des centres SCO (PIX-6308)

### DIFF
--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -69,8 +69,8 @@
       <PixBanner
         @actionLabel="documentation pour voir les nouveautés."
         @actionUrl="https://cloud.pix.fr/s/GqwW6dFDDrHezfS"
-      >La certification Pix se déroulera du 29/11/21 au 07/04/22 pour les lycées et du 07/03/22 au 27/05/22 pour les
-        collèges. Pensez à consulter la
+      >La certification Pix se déroulera du 14 novembre 2022 au 31 mars 2023 pour les lycées et du 6 mars au 16 juin
+        2023 pour les collèges. Pensez à consulter la
       </PixBanner>
 
     {{/if}}

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -134,7 +134,7 @@ module('Acceptance | authenticated', function (hooks) {
       assert
         .dom(
           screen.getByText(
-            'La certification Pix se déroulera du 29/11/21 au 07/04/22 pour les lycées et du 07/03/22 au 27/05/22 pour les collèges. Pensez à consulter la'
+            'La certification Pix se déroulera du 14 novembre 2022 au 31 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges. Pensez à consulter la'
           )
         )
         .exists();
@@ -151,7 +151,7 @@ module('Acceptance | authenticated', function (hooks) {
 
       // then
       const certificationBannerMessage = screen.queryByText(
-        'La certification Pix se déroulera du 29/11/21 au 07/04/22 pour les lycées et du 07/03/22 au 27/05/22 pour les collèges. Pensez à consulter la'
+        'La certification Pix se déroulera du 14 novembre 2022 au 31 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges. Pensez à consulter la'
       );
       assert.dom(certificationBannerMessage).doesNotExist();
     });


### PR DESCRIPTION
## :christmas_tree: Problème
Un bandeau s’affiche sur Pix Certif pour les centres de certification rattachés au SCO sur lequel sont rappelées les dates de passage pour la certification Pix. Il est venu le temps de les changer, le monde est entré dans un nouveau cycle scolaire.  

## :gift: Proposition
- Remplacer le texte actuel de la première phrase du bandeau par : "La certification Pix se déroulera du 14 novembre 2022 au 31 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges."
- Gardrer la 2e phrase identique.

## :santa: Pour tester
- Se connecter à Pix Certif avec un compte SCO (certifsco@example.net par exemple)
- Constater la présence du bandeau et l'exactitude du message délivré.