### PR TITLE
[BUFGIX] Corriger le style du bouton pour commencer une compétence sur Pix-App

### DIFF
--- a/mon-pix/app/styles/components/_competence-card-default.scss
+++ b/mon-pix/app/styles/components/_competence-card-default.scss
@@ -109,7 +109,7 @@
 
   .competence-card__button:hover .competence-card-button__arrow {
     opacity: 1;
-    right: 24px;
+    right: 20px;
     top: -2px;
   }
 


### PR DESCRIPTION
## :christmas_tree: Problème
Le label du bouton pour commencer une compétence et l'icône se chevauchait.

## :gift: Proposition
Adapter le css. 

Avant 
<img width="177" alt="Capture d’écran 2022-11-14 à 11 47 42" src="https://user-images.githubusercontent.com/49011144/201641359-41aed6af-0b3c-4a35-ae50-e9a296ecc6c0.png">

Après 
<img width="188" alt="Capture d’écran 2022-11-14 à 11 47 31" src="https://user-images.githubusercontent.com/49011144/201641308-8828431d-642b-4cc2-9f38-c58881063600.png">

## :santa: Pour tester
Vérifier la non-régression des boutons des compétences.