### PR TITLE
[FEATURE] Ajouter la page "Mes formations" au plan du site (PIX-6281).

### DIFF
--- a/mon-pix/app/components/sitemap/content.hbs
+++ b/mon-pix/app/components/sitemap/content.hbs
@@ -35,6 +35,12 @@
       </li>
 
       <li class="sitemap-content-items__link">
+        <LinkTo @route="authenticated.user-trainings">
+          {{t "navigation.main.trainings"}}
+        </LinkTo>
+      </li>
+
+      <li class="sitemap-content-items__link">
         <LinkTo @route="fill-in-campaign-code">
           {{t "navigation.main.code"}}
         </LinkTo>

--- a/mon-pix/tests/acceptance/sitemap_test.js
+++ b/mon-pix/tests/acceptance/sitemap_test.js
@@ -1,4 +1,5 @@
-import { findAll, visit } from '@ember/test-helpers';
+import { findAll } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { beforeEach, describe, it } from 'mocha';
 import { expect } from 'chai';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -42,6 +43,11 @@ describe('Acceptance | Sitemap', function () {
       // then
       const cguPolicyLink = findAll('a[data-test-resource-link]')[1];
       expect(cguPolicyLink.getAttribute('href')).to.contains('/politique-protection-donnees-personnelles-app');
+    });
+
+    it('should contain a link to pix.fr/mes-formations', async function () {
+      // then
+      expect(find('a[href="/mes-formations"]')).to.exist;
     });
   });
 });

--- a/mon-pix/tests/integration/components/Sitemap/content_test.js
+++ b/mon-pix/tests/integration/components/Sitemap/content_test.js
@@ -30,7 +30,7 @@ describe('Integration | Component | Content', function () {
     await render(hbs`<Sitemap::Content />`);
 
     // then
-    expect(findAll('.sitemap-content-items__link')).to.have.lengthOf(10);
+    expect(findAll('.sitemap-content-items__link')).to.have.lengthOf(11);
     expect(contains(this.intl.t('pages.sitemap.title'))).to.exist;
     expect(contains(this.intl.t('navigation.main.dashboard'))).to.exist;
     expect(contains(this.intl.t('navigation.main.skills'))).to.exist;


### PR DESCRIPTION
## :christmas_tree: Problème
Suite à la création de la nouvelle page "Mes formations" sur Pix App, le plan du site ne contient pas le lien "Mes formations".

## :gift: Proposition
L'ajouter dans le plan du site.

## :star2: Remarques
Cette PR doit être mergée après la #5178  

## :santa: Pour tester
- Se rendre sur la RA
- Aller à la page "plan du site"
- Constater la présence du nouveau lien