### PR TITLE
[BUGFIX] Afficher correctement les tutoriels dans la page de résultats d'une compétence (PIX-6110)

### DIFF
--- a/mon-pix/app/routes/authenticated/competences/results.js
+++ b/mon-pix/app/routes/authenticated/competences/results.js
@@ -6,17 +6,24 @@ export default class ResultsRoute extends Route {
 
   async model(params) {
     const assessmentId = params.assessment_id;
+
     const competenceEvaluations = await this.store.findAll('competenceEvaluation', {
       reload: true,
       adapterOptions: { assessmentId },
     });
-    return competenceEvaluations
+
+    const competenceEvaluation = competenceEvaluations
       .sortBy('createdAt')
       .reverse()
       .find((competenceEvaluation) => competenceEvaluation.assessment.get('id') === assessmentId);
-  }
 
-  afterModel(competenceEvaluation) {
-    return competenceEvaluation.belongsTo('scorecard').reload();
+    const scorecard = await competenceEvaluation.belongsTo('scorecard').reload();
+
+    await scorecard.hasMany('tutorials').reload();
+
+    return {
+      competenceEvaluation,
+      scorecard,
+    };
   }
 }

--- a/mon-pix/tests/unit/routes/authenticated/competences/results_test.js
+++ b/mon-pix/tests/unit/routes/authenticated/competences/results_test.js
@@ -15,6 +15,7 @@ describe('Unit | Route | Competences | Results', function () {
     let storeStub;
     let sessionStub;
     let findAllStub;
+    let belongsToStub;
 
     beforeEach(function () {
       findAllStub = sinon.stub();
@@ -33,11 +34,22 @@ describe('Unit | Route | Competences | Results', function () {
 
     it('should return the most recent competence-evaluation for a given assessment', async function () {
       // Given
+      const tutorial = {
+        id: 1,
+      };
+      const scorecard = {
+        id: 1,
+        hasMany: sinon.stub(),
+      };
+      scorecard.hasMany.returns({ reload: sinon.stub().resolves([tutorial]) });
+      belongsToStub = sinon.stub().returns({ reload: sinon.stub().resolves(scorecard) });
+
       const competenceEvaluationsInStore = A([
-        { id: 1, createdAt: new Date('2020-01-01'), assessment: { get: () => assessmentId } },
-        { id: 2, createdAt: new Date('2020-02-01'), assessment: { get: () => assessmentId } },
-        { id: 3, createdAt: new Date('2020-03-01'), assessment: { get: () => 456 } },
+        { id: 1, createdAt: new Date('2020-01-01'), assessment: { get: () => assessmentId }, belongsTo: belongsToStub },
+        { id: 2, createdAt: new Date('2020-02-01'), assessment: { get: () => assessmentId }, belongsTo: belongsToStub },
+        { id: 3, createdAt: new Date('2020-03-01'), assessment: { get: () => 456 }, belongsTo: belongsToStub },
       ]);
+
       findAllStub
         .withArgs('competenceEvaluation', { reload: true, adapterOptions: { assessmentId } })
         .resolves(competenceEvaluationsInStore);
@@ -48,7 +60,8 @@ describe('Unit | Route | Competences | Results', function () {
       });
 
       // Then
-      expect(model.id).to.equal(2);
+      expect(model.competenceEvaluation.id).to.equal(2);
+      expect(model.scorecard.id).to.equal(1);
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
On s’est rendu compte, que les trainings n'étaient pas tout le temps affichés lorsqu’on cliquait sur “Voir les résultats”, à la fin d’une évaluation.
Pour les voir, il faut reload la page : “tutorials” est bien fetch à ce moment là, mais pas avant.

## :gift: Proposition
Reload les tutoriels dans la route `competences/results`.

## :star2: Remarques
On a essayé (avec @matthiasferraina et @squirrel4k) de faire un test d'acceptance pour vérifier que tout fonctionne bien, à la navigation via l'UI : sans réussite.
On pense que ce serait plus un test E2E qui serait viable.

## :santa: Pour tester
- Lancer PixApp en local avec une BDD reset
- Passer toutes les questions de la compétence "Mathématiques"
- Voir les tutoriels sur l'écran de résultats finaux
