### PR TITLE
[TECH] Retirer le "helper" hash pour migrer vers Ember 4.x (PIX-6253)

### DIFF
--- a/mon-pix/app/components/checkpoint-continue.hbs
+++ b/mon-pix/app/components/checkpoint-continue.hbs
@@ -2,7 +2,7 @@
   <PixButtonLink
     @route="assessments.resume"
     @model={{@assessmentId}}
-    @query={{hash hasSeenCheckpoint=true assessmentHasNoMoreQuestions=@finalCheckpoint}}
+    @query={{this.query}}
     @backgroundColor="yellow"
     class="checkpoint__continue-button"
   >

--- a/mon-pix/app/components/checkpoint-continue.js
+++ b/mon-pix/app/components/checkpoint-continue.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+
+export default class CheckpointContinue extends Component {
+  get query() {
+    return {
+      assessmentHasNoMoreQuestions: this.args.finalCheckpoint,
+      hasSeenCheckpoint: true,
+    };
+  }
+}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -160,7 +160,7 @@
           <LinkTo
             @route="campaigns.entry-point"
             @model={{@model.campaign.code}}
-            @query={{hash retry=true}}
+            @query={{this.query}}
             class="skill-review-retry__button button button--big button--link"
           >{{t "pages.skill-review.retry.button"}}</LinkTo>
         </div>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -17,6 +17,12 @@ export default class SkillReview extends Component {
   @tracked showGlobalErrorMessage = false;
   @tracked isShareButtonClicked = false;
 
+  get query() {
+    return {
+      retry: true,
+    };
+  }
+
   get title() {
     return this.args.model.campaign.title || this.intl.t('pages.skill-review.title');
   }

--- a/mon-pix/app/controllers/campaigns/profiles-collection/profile-already-shared.js
+++ b/mon-pix/app/controllers/campaigns/profiles-collection/profile-already-shared.js
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+
+export default class AlreadyProfileSharedController extends Controller {
+  get query() {
+    return {
+      retry: true,
+    };
+  }
+}

--- a/mon-pix/app/templates/campaigns/profiles-collection/profile-already-shared.hbs
+++ b/mon-pix/app/templates/campaigns/profiles-collection/profile-already-shared.hbs
@@ -33,7 +33,7 @@
         <LinkTo
           @route="campaigns.entry-point"
           @model={{@model.campaign.code}}
-          @query={{hash retry=true}}
+          @query={{this.query}}
           class="button button--link profile-already-shared-retry__button"
         >{{t "pages.profile-already-shared.retry.button"}}</LinkTo>
       </div>


### PR DESCRIPTION
## :christmas_tree: Problème
Afin de pouvoir passer à la version 4.4 d’Ember, nous devons suivre la liste de dépréciations d’Ember.
Le helper `hash` ne sera plus supporté.

## :gift: Proposition

Retirer ces hash par des getter 

> You can get the same functionality by using an object created with a tracked property or **getter**, or with a custom helper

## :star2: Remarques
[Lien hash déprécié](https://deprecations.emberjs.com/v3.x/#toc_setting-on-hash)

## :santa: Pour tester
Se connecter sur mon pix

Vérifier les scénarios suivants : 
- checkpoint-continue 
- skill-review : ???
- profile-already-shared : entrer la campagne PROCOLMUL et envoyer son profil puis tenter de le refaire (/deja-envoye)