### PR TITLE
[BUGFIX] Le focus-trap ne fonctionnait plus sur la modale de comparaison des réponses sur Pix-App (PIX-6317)

### DIFF
--- a/mon-pix/app/components/comparison-window.hbs
+++ b/mon-pix/app/components/comparison-window.hbs
@@ -1,4 +1,4 @@
-<PixModal @title={{t this.resultItem.title}} @onCloseButtonClick={{@closeComparisonWindow}} @showModal={{true}}>
+<PixModal @title={{t this.resultItem.title}} @onCloseButtonClick={{@closeComparisonWindow}} @showModal={{@showModal}}>
   <:content>
     <div class="comparison-window-content__body">
 

--- a/mon-pix/app/components/comparison-window.js
+++ b/mon-pix/app/components/comparison-window.js
@@ -24,27 +24,27 @@ function _getTextForResult(result) {
 
 export default class ComparisonWindow extends Component {
   get isAssessmentChallengeTypeQroc() {
-    return this.args.answer.challenge.get('type') === 'QROC';
+    return this.args.answer.challenge?.get('type') === 'QROC';
   }
 
   get isAssessmentChallengeTypeQcm() {
-    return this.args.answer.challenge.get('type') === 'QCM';
+    return this.args.answer.challenge?.get('type') === 'QCM';
   }
 
   get isAssessmentChallengeTypeQcu() {
-    return this.args.answer.challenge.get('type') === 'QCU';
+    return this.args.answer.challenge?.get('type') === 'QCU';
   }
 
   get isAssessmentChallengeTypeQrocm() {
-    return this.args.answer.challenge.get('type') === 'QROCM';
+    return this.args.answer.challenge?.get('type') === 'QROCM';
   }
 
   get isAssessmentChallengeTypeQrocmInd() {
-    return this.args.answer.challenge.get('type') === 'QROCM-ind';
+    return this.args.answer.challenge?.get('type') === 'QROCM-ind';
   }
 
   get isAssessmentChallengeTypeQrocmDep() {
-    return this.args.answer.challenge.get('type') === 'QROCM-dep';
+    return this.args.answer.challenge?.get('type') === 'QROCM-dep';
   }
 
   get answerSuffix() {
@@ -52,13 +52,17 @@ export default class ComparisonWindow extends Component {
   }
 
   get resultItem() {
-    let resultItem = _getTextForResult('default');
+    if (!this.args.answer) {
+      return '';
+    }
+
     const answerStatus = `${this.args.answer.result}${this.answerSuffix}`;
 
     if (answerStatus && answerStatus in TEXT_FOR_RESULT) {
-      resultItem = _getTextForResult(answerStatus);
+      return _getTextForResult(answerStatus);
     }
-    return resultItem;
+
+    return _getTextForResult('default');
   }
 
   get solution() {
@@ -70,6 +74,6 @@ export default class ComparisonWindow extends Component {
   }
 
   get _isAutoReply() {
-    return this.args.answer.challenge.get('autoReply');
+    return Boolean(this.args.answer.challenge?.get('autoReply'));
   }
 }

--- a/mon-pix/app/components/qcu-solution-panel.js
+++ b/mon-pix/app/components/qcu-solution-panel.js
@@ -11,9 +11,13 @@ export default class QcuSolutionPanel extends Component {
   }
 
   get solutionAsText() {
+    if (!this.args.solution) {
+      return '';
+    }
     if (this.args.solutionToDisplay) {
       return this.args.solutionToDisplay;
     }
+
     const answersProposedByUser = this.labeledRadios;
     const correctAnswerIndex = this.solutionArray.indexOf(true);
     const solutionAndStatus = answersProposedByUser[correctAnswerIndex];

--- a/mon-pix/app/controllers/assessments/checkpoint.js
+++ b/mon-pix/app/controllers/assessments/checkpoint.js
@@ -9,7 +9,7 @@ export default class CheckpointController extends Controller {
   @service intl;
   @service currentUser;
 
-  @tracked answer = null;
+  @tracked answer = {};
   @tracked challenge = null;
   @tracked finalCheckpoint = false;
   @tracked isShowingModal = false;

--- a/mon-pix/app/controllers/assessments/results.js
+++ b/mon-pix/app/controllers/assessments/results.js
@@ -4,7 +4,7 @@ import Controller from '@ember/controller';
 
 export default class ResultsController extends Controller {
   @tracked isShowingModal = false;
-  @tracked answer = null;
+  @tracked answer = {};
 
   @action
   async openComparisonWindow(answer) {

--- a/mon-pix/app/templates/assessments/checkpoint.hbs
+++ b/mon-pix/app/templates/assessments/checkpoint.hbs
@@ -69,10 +69,11 @@
     </main>
   </div>
 
-  {{#if this.isShowingModal}}
-    <ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />
-  {{/if}}
-
+  <ComparisonWindow
+    @showModal={{this.isShowingModal}}
+    @answer={{this.answer}}
+    @closeComparisonWindow={{this.closeComparisonWindow}}
+  />
 </div>
 
 {{#if this.showLevelup}}

--- a/mon-pix/app/templates/assessments/results.hbs
+++ b/mon-pix/app/templates/assessments/results.hbs
@@ -35,8 +35,10 @@
     </div>
   </div>
 
-  {{#if this.isShowingModal}}
-    <ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />
-  {{/if}}
+  <ComparisonWindow
+    @answer={{this.answer}}
+    @closeComparisonWindow={{this.closeComparisonWindow}}
+    @showModal={{this.isShowingModal}}
+  />
 
 </div>

--- a/mon-pix/tests/acceptance/compare-answer-solution-qroc_test.js
+++ b/mon-pix/tests/acceptance/compare-answer-solution-qroc_test.js
@@ -50,7 +50,8 @@ describe('Acceptance | Compare answers and solutions for QROC questions', functi
       await click(screen.getByRole('button', { name: 'Réponses et tutos' }));
 
       // then
-      expect(screen.getByRole('dialog', { name: 'Vous n’avez pas la bonne réponse' })).to.exist;
+      expect(find('.pix-modal__overlay--hidden')).to.not.exist;
+      expect(find('.pix-modal__overlay')).to.exist;
     });
 
     it('should contain an instruction', async function () {
@@ -83,7 +84,7 @@ describe('Acceptance | Compare answers and solutions for QROC questions', functi
       await click(screen.getByRole('button', { name: 'Réponses et tutos' }));
 
       // then
-      expect(screen.getByRole('heading', { name: 'Signaler un problème' })).to.exist;
+      expect(find('.feedback-panel__open-button')).to.exist;
     });
   });
 });

--- a/mon-pix/tests/acceptance/compare-answer-solution_test.js
+++ b/mon-pix/tests/acceptance/compare-answer-solution_test.js
@@ -69,7 +69,9 @@ describe('Compare answers and solutions for QCM questions', function () {
       expect(screen.queryByRole('dialog', { name: 'Vous n’avez pas la bonne réponse' })).to.not.exist;
 
       await click('.result-item__correction-button');
-      expect(screen.getByRole('dialog', { name: 'Vous n’avez pas la bonne réponse' })).to.exist;
+
+      expect(find('.pix-modal__overlay--hidden')).to.not.exist;
+      expect(find('.pix-modal__overlay')).to.exist;
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Le focus-trap ne fonctionnait plus sur la modale de comparaison des réponses.

## :gift: Proposition
Intégrer la modale directement dans le dom au lieu de le créer avec un conditionnement.
Gérer les cas `undefined`.


## :santa: Pour tester
Vérifier la non-régression de la modale.
