### PR TITLE
[BUGFIX] Correction d'une regression d'affichage des Tooltips sur PixOrga (PIX-6326)

### DIFF
--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^20.2.2",
+        "@1024pix/pix-ui": "^20.2.3",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
         "@ember/optional-features": "^2.0.0",
@@ -421,9 +421,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "20.2.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.2.2.tgz",
-      "integrity": "sha512-BlbdrpEYGh8MlpJRyz9D6z5GeOg0KLEoP0Lu05xC+3I3FmJGA8GMxWsrQEYWWWVCTMMaXMh1VQsvVvoXDvMN4g==",
+      "version": "20.2.3",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.2.3.tgz",
+      "integrity": "sha512-DOMKXaSE5vaUlNZeEqD8e27hKBSgmVtzVnWZsI/Gx66W7Z8WILqxbjxrmnASKUaNd6CwVIjF7cWxrBc8dbeX0g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -34139,9 +34139,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "20.2.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.2.2.tgz",
-      "integrity": "sha512-BlbdrpEYGh8MlpJRyz9D6z5GeOg0KLEoP0Lu05xC+3I3FmJGA8GMxWsrQEYWWWVCTMMaXMh1VQsvVvoXDvMN4g==",
+      "version": "20.2.3",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.2.3.tgz",
+      "integrity": "sha512-DOMKXaSE5vaUlNZeEqD8e27hKBSgmVtzVnWZsI/Gx66W7Z8WILqxbjxrmnASKUaNd6CwVIjF7cWxrBc8dbeX0g==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/orga/package.json
+++ b/orga/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^20.2.2",
+    "@1024pix/pix-ui": "^20.2.3",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
## :christmas_tree: Problème
La montée de version Pix-UI a introduit une regression

## :gift: Proposition
Mettre à jour PixUI sur sa dernière version

## :star2: Remarques

## :santa: Pour tester
Allez sur Pix Orga, se connecter sur sco.admin@example.net , et voir que le grah des étoiles est à jour