### PR TITLE
[TECH] Déplacement de tests d'acceptance des controllers dans des sous dossiers.

### DIFF
--- a/api/tests/acceptance/application/cache/cache-controller_test.js
+++ b/api/tests/acceptance/application/cache/cache-controller_test.js
@@ -1,5 +1,5 @@
-const { expect, generateValidRequestAuthorizationHeader } = require('../../test-helper');
-const createServer = require('../../../server');
+const { expect, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | cache-controller', function () {
   let server;

--- a/api/tests/acceptance/application/courses/course-controller_test.js
+++ b/api/tests/acceptance/application/courses/course-controller_test.js
@@ -4,8 +4,8 @@ const {
   generateValidRequestAuthorizationHeader,
   mockLearningContent,
   learningContentBuilder,
-} = require('../../test-helper');
-const createServer = require('../../../server');
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
 
 describe('Acceptance | API | Courses', function () {
   let server;

--- a/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_tests.js
@@ -1,6 +1,6 @@
-const { expect } = require('../../test-helper');
+const { expect } = require('../../../test-helper');
 
-const createServer = require('../../../server');
+const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | feature-toggle-controller', function () {
   let server;

--- a/api/tests/acceptance/application/feedbacks/feedback-controller_test.js
+++ b/api/tests/acceptance/application/feedbacks/feedback-controller_test.js
@@ -1,6 +1,6 @@
-const { expect, knex, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../test-helper');
-const createServer = require('../../../server');
-const Feedback = require('../../../lib/infrastructure/orm-models/Feedback');
+const { expect, knex, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+const createServer = require('../../../../server');
+const Feedback = require('../../../../lib/infrastructure/orm-models/Feedback');
 
 describe('Acceptance | Controller | feedback-controller', function () {
   let server;

--- a/api/tests/acceptance/application/saml/saml-controller_test.js
+++ b/api/tests/acceptance/application/saml/saml-controller_test.js
@@ -1,10 +1,10 @@
 const _ = require('lodash');
 
-const { databaseBuilder, expect, sinon } = require('../../test-helper');
+const { databaseBuilder, expect, sinon } = require('../../../test-helper');
 
 const samlify = require('samlify');
-const createServer = require('../../../server');
-const settings = require('../../../lib/config');
+const createServer = require('../../../../server');
+const settings = require('../../../../lib/config');
 
 const testCertificate = `MIICCzCCAXQCCQD2MlHh/QmGmjANBgkqhkiG9w0BAQsFADBKMQswCQYDVQQGEwJG
 UjEPMA0GA1UECAwGRlJBTkNFMQ4wDAYDVQQHDAVQQVJJUzEMMAoGA1UECgwDUElY


### PR DESCRIPTION
## :christmas_tree: Problème
Les tests d'acceptances sont plutôt mis dans une arborescence similaire a celle dans lib/application, mais des fois non, ils sont juste dans tests/acceptance/application, mal aimé, mal rangé.

## :gift: Proposition
Pour tenter d'y voir plus clair et m'assurer que tout le monde est d'accord sur Le Bon Rangement ©, j'ai déplacé quelques tests d'acceptances dans leurs sous dossiers.

## :santa: Pour tester
:green_circle: CI
