### PR TITLE
[TECH] Utiliser les nouveaux attributs thematicId et skillIds du modèle Tube (PIX-6460)

### DIFF
--- a/api/lib/domain/models/Tube.js
+++ b/api/lib/domain/models/Tube.js
@@ -12,7 +12,9 @@ class Tube {
     isTabletCompliant,
     skills = [],
     competenceId,
-  } = {}) {
+    thematicId,
+    skillIds,
+  }) {
     this.id = id;
     this.title = title;
     this.description = description;
@@ -22,6 +24,8 @@ class Tube {
     this.isTabletCompliant = isTabletCompliant;
     this.skills = skills;
     this.competenceId = competenceId;
+    this.thematicId = thematicId;
+    this.skillIds = skillIds;
 
     if (name) {
       this.name = name;

--- a/api/lib/infrastructure/repositories/learning-content-repository.js
+++ b/api/lib/infrastructure/repositories/learning-content-repository.js
@@ -77,10 +77,9 @@ async function _getLearningContentByCappedTubes(cappedTubesDTO, locale) {
 }
 
 async function _getLearningContentByTubes(tubes, locale) {
-  const tubeIds = _.uniq(tubes.map((tube) => tube.id));
-  const thematics = await thematicRepository.list({ locale });
-  const goodThematics = thematics.filter((thematic) => tubeIds.some((tubeId) => thematic.tubeIds.includes(tubeId)));
-  goodThematics.forEach((thematic) => (thematic.tubes = tubes.filter((tube) => thematic.tubeIds.includes(tube.id))));
+  const thematicIds = _.uniq(tubes.map((tube) => tube.thematicId));
+  const thematics = await thematicRepository.findByRecordIds(thematicIds, locale);
+  thematics.forEach((thematic) => (thematic.tubes = tubes.filter((tube) => tube.thematicId === thematic.id)));
 
   const competenceIds = _.uniq(tubes.map((tube) => tube.competenceId));
   const competences = await competenceRepository.findByRecordIds({ competenceIds, locale });
@@ -89,7 +88,7 @@ async function _getLearningContentByTubes(tubes, locale) {
     competence.tubes = tubes.filter((tube) => {
       return tube.competenceId === competence.id;
     });
-    competence.thematics = goodThematics.filter((thematic) => {
+    competence.thematics = thematics.filter((thematic) => {
       return thematic.competenceId === competence.id;
     });
   });

--- a/api/lib/infrastructure/repositories/learning-content-repository.js
+++ b/api/lib/infrastructure/repositories/learning-content-repository.js
@@ -79,7 +79,9 @@ async function _getLearningContentByCappedTubes(cappedTubesDTO, locale) {
 async function _getLearningContentByTubes(tubes, locale) {
   const thematicIds = _.uniq(tubes.map((tube) => tube.thematicId));
   const thematics = await thematicRepository.findByRecordIds(thematicIds, locale);
-  thematics.forEach((thematic) => (thematic.tubes = tubes.filter((tube) => tube.thematicId === thematic.id)));
+  thematics.forEach((thematic) => {
+    thematic.tubes = tubes.filter((tube) => tube.thematicId === thematic.id);
+  });
 
   const competenceIds = _.uniq(tubes.map((tube) => tube.competenceId));
   const competences = await competenceRepository.findByRecordIds({ competenceIds, locale });

--- a/api/lib/infrastructure/repositories/target-profile-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-for-admin-repository.js
@@ -112,25 +112,18 @@ async function _getLearningContent_new(targetProfileId, tubesData, locale) {
     );
   }
 
-  const competenceIds = _.keys(_.groupBy(tubes, 'competenceId'));
+  const thematicIds = _.keys(_.groupBy(tubes, 'thematicId'));
+  const thematics = await thematicRepository.findByRecordIds(thematicIds, locale);
+
+  const competenceIds = _.keys(_.groupBy(thematics, 'competenceId'));
   const competences = await competenceRepository.findByRecordIds({ competenceIds, locale });
 
-  const thematicIds = competences.flatMap((competence) => competence.thematicIds);
-  const uniqThematicIds = _.uniq(thematicIds);
-  const allCompetenceThematics = await thematicRepository.findByRecordIds(uniqThematicIds, locale);
-  const thematics = allCompetenceThematics.filter((thematic) =>
-    thematic.tubeIds.some((tubeId) => tubeIds.includes(tubeId))
-  );
-
-  const areaIds = _.map(competences, (competence) => competence.areaId);
-  const uniqAreaIds = _.uniq(areaIds);
-  const areas = await areaRepository.findByRecordIds({ areaIds: uniqAreaIds, locale });
+  const areaIds = _.keys(_.groupBy(competences, 'areaId'));
+  const areas = await areaRepository.findByRecordIds({ areaIds, locale });
 
   for (const tube of tubes) {
     const tubeData = tubesData.find((data) => tube.id === data.tubeId);
     tube.level = tubeData.level;
-    const correspondingThematic = thematics.find((thematic) => thematic.tubeIds.includes(tube.id));
-    tube.thematicId = correspondingThematic.id;
   }
 
   return {

--- a/api/lib/infrastructure/repositories/tube-repository.js
+++ b/api/lib/infrastructure/repositories/tube-repository.js
@@ -20,6 +20,8 @@ function _toDomain({ tubeData, locale }) {
     isMobileCompliant: tubeData.isMobileCompliant,
     isTabletCompliant: tubeData.isTabletCompliant,
     competenceId: tubeData.competenceId,
+    thematicId: tubeData.thematicId,
+    skillIds: tubeData.skillIds,
   });
 }
 

--- a/api/tests/acceptance/application/target-profiles/index_test.js
+++ b/api/tests/acceptance/application/target-profiles/index_test.js
@@ -821,7 +821,7 @@ describe('Acceptance | Route | target-profiles', function () {
         thematics: [
           { id: 'recThematic', name_i18n: { fr: 'somename' }, tubeIds: ['recTube'], competenceId: 'recCompetence' },
         ],
-        tubes: [{ id: 'recTube', competenceId: 'recCompetence' }],
+        tubes: [{ id: 'recTube', thematicId: 'recThematic' }],
         skills: [{ id: 'recSkill', tubeId: 'recTube', status: 'actif', level: 5, name: 'skill5' }],
         challenges: [],
       };

--- a/api/tests/integration/infrastructure/repositories/target-profile-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-for-admin-repository_test.js
@@ -463,6 +463,7 @@ describe('Integration | Repository | target-profile-for-admin', function () {
               practicalTitle_i18n: {
                 fr: 'practicalTitleFR2',
               },
+              thematicId: 'recThemA',
             },
           ],
         };
@@ -634,6 +635,7 @@ describe('Integration | Repository | target-profile-for-admin', function () {
             {
               id: 'recTube1',
               competenceId: 'recCompA',
+              thematicId: 'recThemA',
               name: 'tubeName1',
               practicalTitle_i18n: {
                 fr: 'practicalTitleFR1',
@@ -644,6 +646,7 @@ describe('Integration | Repository | target-profile-for-admin', function () {
             {
               id: 'recTube2',
               competenceId: 'recCompA',
+              thematicId: 'recThemB',
               name: 'tubeName2',
               practicalTitle_i18n: {
                 fr: 'practicalTitleFR2',
@@ -654,6 +657,7 @@ describe('Integration | Repository | target-profile-for-admin', function () {
             {
               id: 'recTube3',
               competenceId: 'recCompB',
+              thematicId: 'recThemC',
               name: 'tubeName3',
               practicalTitle_i18n: {
                 fr: 'practicalTitleFR3',
@@ -664,6 +668,7 @@ describe('Integration | Repository | target-profile-for-admin', function () {
             {
               id: 'recTube4',
               competenceId: 'recCompB',
+              thematicId: 'recThemD',
               name: 'tubeName4',
               practicalTitle_i18n: {
                 fr: 'practicalTitleFR4',
@@ -872,6 +877,7 @@ describe('Integration | Repository | target-profile-for-admin', function () {
             {
               id: 'recTube1',
               competenceId: 'recCompA',
+              thematicId: 'recThemA',
               name: 'tubeName1',
               practicalTitle_i18n: {
                 fr: 'practicalTitleFR1',

--- a/api/tests/integration/infrastructure/repositories/tube-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tube-repository_test.js
@@ -1,19 +1,23 @@
-const { expect, mockLearningContent } = require('../../../test-helper');
-const Tube = require('../../../../lib/domain/models/Tube');
+const { expect, mockLearningContent, domainBuilder } = require('../../../test-helper');
 const tubeRepository = require('../../../../lib/infrastructure/repositories/tube-repository');
 
 describe('Integration | Repository | tube-repository', function () {
   describe('#get', function () {
     it('should return the tube', async function () {
       // given
-      const expectedTube = new Tube({
+      const expectedTube = domainBuilder.buildTube({
         id: 'recTube0',
         name: 'tubeName',
         title: 'tubeTitle',
         description: 'tubeDescription',
         practicalTitle: 'translatedPracticalTitle',
         practicalDescription: 'translatedPracticalDescription',
+        isMobileCompliant: true,
+        isTabletCompliant: true,
         competenceId: 'recCompetence0',
+        thematicId: 'thematicCoucou',
+        skillIds: ['skillSuper', 'skillGenial'],
+        skills: [],
       });
       const learningContent = {
         tubes: [
@@ -28,7 +32,11 @@ describe('Integration | Repository | tube-repository', function () {
             practicalDescription_i18n: {
               fr: 'translatedPracticalDescription',
             },
+            isMobileCompliant: true,
+            isTabletCompliant: true,
             competenceId: 'recCompetence0',
+            thematicId: 'thematicCoucou',
+            skillIds: ['skillSuper', 'skillGenial'],
           },
         ],
       };
@@ -38,31 +46,40 @@ describe('Integration | Repository | tube-repository', function () {
       const tube = await tubeRepository.get(expectedTube.id);
 
       // then
-      expect(tube).to.be.instanceof(Tube);
-      expect(tube).to.deep.equal(expectedTube);
+      expect(tube).to.deepEqualInstance(expectedTube);
     });
   });
 
   describe('#list', function () {
     it('should return the tubes', async function () {
       // given
-      const tube0 = new Tube({
+      const tube0 = domainBuilder.buildTube({
         id: 'recTube0',
         name: 'tubeName0',
         title: 'tubeTitle0',
         description: 'tubeDescription0',
         practicalTitle: 'translatedPracticalTitle0',
         practicalDescription: 'translatedPracticalDescription0',
+        isMobileCompliant: true,
+        isTabletCompliant: true,
         competenceId: 'recCompetence0',
+        thematicId: 'thematicCoucou',
+        skillIds: ['skillSuper', 'skillGenial'],
+        skills: [],
       });
-      const tube1 = new Tube({
+      const tube1 = domainBuilder.buildTube({
         id: 'recTube1',
         name: 'tubeName1',
         title: 'tubeTitle1',
         description: 'tubeDescription1',
         practicalTitle: 'translatedPracticalTitle1',
         practicalDescription: 'translatedPracticalDescription1',
+        isMobileCompliant: false,
+        isTabletCompliant: false,
         competenceId: 'recCompetence1',
+        thematicId: 'thematicCava',
+        skillIds: ['skillPoire', 'skillPeche'],
+        skills: [],
       });
       const learningContentTube0 = {
         id: 'recTube0',
@@ -75,7 +92,11 @@ describe('Integration | Repository | tube-repository', function () {
         practicalDescription_i18n: {
           fr: 'translatedPracticalDescription0',
         },
+        isMobileCompliant: true,
+        isTabletCompliant: true,
         competenceId: 'recCompetence0',
+        thematicId: 'thematicCoucou',
+        skillIds: ['skillSuper', 'skillGenial'],
       };
 
       const learningContentTube1 = {
@@ -89,7 +110,11 @@ describe('Integration | Repository | tube-repository', function () {
         practicalDescription_i18n: {
           fr: 'translatedPracticalDescription1',
         },
+        isMobileCompliant: false,
+        isTabletCompliant: false,
         competenceId: 'recCompetence1',
+        thematicId: 'thematicCava',
+        skillIds: ['skillPoire', 'skillPeche'],
       };
       mockLearningContent({ tubes: [learningContentTube0, learningContentTube1] });
 
@@ -106,24 +131,34 @@ describe('Integration | Repository | tube-repository', function () {
   describe('#findByNames', function () {
     it('should return the tubes ordered by name', async function () {
       // given
-      const tube0 = new Tube({
+      const tube0 = domainBuilder.buildTube({
         id: 'recTube0',
         name: 'tubeName0',
         title: 'tubeTitle0',
         description: 'tubeDescription0',
         practicalTitle: 'translatedPracticalTitle0',
         practicalDescription: 'translatedPracticalDescription0',
+        isMobileCompliant: true,
+        isTabletCompliant: true,
         competenceId: 'recCompetence0',
+        thematicId: 'thematicCoucou',
+        skillIds: ['skillSuper', 'skillGenial'],
+        skills: [],
       });
 
-      const tube1 = new Tube({
+      const tube1 = domainBuilder.buildTube({
         id: 'recTube1',
         name: 'tubeName1',
         title: 'tubeTitle1',
         description: 'tubeDescription1',
         practicalTitle: 'translatedPracticalTitle1',
         practicalDescription: 'translatedPracticalDescription1',
+        isMobileCompliant: false,
+        isTabletCompliant: false,
         competenceId: 'recCompetence1',
+        thematicId: 'thematicCava',
+        skillIds: ['skillPoire', 'skillPeche'],
+        skills: [],
       });
 
       const learningContentTube0 = {
@@ -137,7 +172,11 @@ describe('Integration | Repository | tube-repository', function () {
         practicalDescription_i18n: {
           fr: 'translatedPracticalDescription0',
         },
+        isMobileCompliant: true,
+        isTabletCompliant: true,
         competenceId: 'recCompetence0',
+        thematicId: 'thematicCoucou',
+        skillIds: ['skillSuper', 'skillGenial'],
       };
 
       const learningContentTube1 = {
@@ -151,7 +190,11 @@ describe('Integration | Repository | tube-repository', function () {
         practicalDescription_i18n: {
           fr: 'translatedPracticalDescription1',
         },
+        isMobileCompliant: false,
+        isTabletCompliant: false,
         competenceId: 'recCompetence1',
+        thematicId: 'thematicCava',
+        skillIds: ['skillPoire', 'skillPeche'],
       };
       mockLearningContent({ tubes: [learningContentTube1, learningContentTube0] });
 
@@ -166,14 +209,19 @@ describe('Integration | Repository | tube-repository', function () {
     context('when no locale is provided (using default locale)', function () {
       it('should return the tubes with default locale translation', async function () {
         // given
-        const expectedTube = new Tube({
+        const expectedTube = domainBuilder.buildTube({
           id: 'recTube0',
           name: 'tubeName',
           title: 'tubeTitle',
           description: 'tubeDescription',
           practicalTitle: 'translatedPracticalTitle',
           practicalDescription: 'translatedPracticalDescription',
+          isMobileCompliant: true,
+          isTabletCompliant: true,
           competenceId: 'recCompetence0',
+          thematicId: 'thematicCoucou',
+          skillIds: ['skillSuper', 'skillGenial'],
+          skills: [],
         });
         const learningContent = {
           tubes: [
@@ -188,7 +236,11 @@ describe('Integration | Repository | tube-repository', function () {
               practicalDescription_i18n: {
                 fr: 'translatedPracticalDescription',
               },
+              isMobileCompliant: true,
+              isTabletCompliant: true,
               competenceId: 'recCompetence0',
+              thematicId: 'thematicCoucou',
+              skillIds: ['skillSuper', 'skillGenial'],
             },
           ],
         };
@@ -206,14 +258,19 @@ describe('Integration | Repository | tube-repository', function () {
     context('when specifying a locale', function () {
       it('should return the tubes with appropriate translation', async function () {
         // given
-        const expectedTube = new Tube({
+        const expectedTube = domainBuilder.buildTube({
           id: 'recTube0',
           name: 'tubeName',
           title: 'tubeTitle',
           description: 'tubeDescription',
           practicalTitle: 'translatedPracticalTitleEnUs',
           practicalDescription: 'translatedPracticalDescriptionEnUs',
+          isMobileCompliant: true,
+          isTabletCompliant: true,
           competenceId: 'recCompetence0',
+          thematicId: 'thematicCoucou',
+          skillIds: ['skillSuper', 'skillGenial'],
+          skills: [],
         });
         const learningContent = {
           tubes: [
@@ -230,7 +287,11 @@ describe('Integration | Repository | tube-repository', function () {
                 fr: 'translatedPracticalDescription',
                 en: 'translatedPracticalDescriptionEnUs',
               },
+              isMobileCompliant: true,
+              isTabletCompliant: true,
               competenceId: 'recCompetence0',
+              thematicId: 'thematicCoucou',
+              skillIds: ['skillSuper', 'skillGenial'],
             },
           ],
         };
@@ -262,7 +323,11 @@ describe('Integration | Repository | tube-repository', function () {
           fr: 'practicalDescriptionFR0',
           en: 'practicalDescriptionEN0',
         },
+        isMobileCompliant: true,
+        isTabletCompliant: true,
         competenceId: 'recCompetence0',
+        thematicId: 'thematicCoucou',
+        skillIds: ['skillSuper', 'skillGenial'],
       };
       const learningContentTube1 = {
         id: 'recTube1',
@@ -277,7 +342,11 @@ describe('Integration | Repository | tube-repository', function () {
           fr: 'practicalDescriptionFR1',
           en: 'practicalDescriptionEN1',
         },
+        isMobileCompliant: false,
+        isTabletCompliant: false,
         competenceId: 'recCompetence1',
+        thematicId: 'thematicCava',
+        skillIds: ['skillBien'],
       };
       const learningContentTube2 = {
         id: 'recTube2',
@@ -292,7 +361,11 @@ describe('Integration | Repository | tube-repository', function () {
           fr: 'practicalDescriptionFR2',
           en: 'practicalDescriptionEN2',
         },
+        isMobileCompliant: true,
+        isTabletCompliant: false,
         competenceId: 'recCompetence1',
+        thematicId: 'thematicCuisse',
+        skillIds: ['skillPoulet'],
       };
       const skills = [
         {
@@ -313,23 +386,33 @@ describe('Integration | Repository | tube-repository', function () {
 
     it('should return a list of tubes (locale FR - default)', async function () {
       // given
-      const tube1 = new Tube({
+      const tube1 = domainBuilder.buildTube({
         id: 'recTube1',
         name: 'tubeName1',
         title: 'tubeTitle1',
         description: 'tubeDescription1',
         practicalTitle: 'practicalTitreFR1',
         practicalDescription: 'practicalDescriptionFR1',
+        isMobileCompliant: false,
+        isTabletCompliant: false,
         competenceId: 'recCompetence1',
+        thematicId: 'thematicCava',
+        skillIds: ['skillBien'],
+        skills: [],
       });
-      const tube2 = new Tube({
+      const tube2 = domainBuilder.buildTube({
         id: 'recTube2',
         name: 'tubeName2',
         title: 'tubeTitle2',
         description: 'tubeDescription2',
         practicalTitle: 'practicalTitreFR2',
         practicalDescription: 'practicalDescriptionFR2',
+        isMobileCompliant: true,
+        isTabletCompliant: false,
         competenceId: 'recCompetence1',
+        thematicId: 'thematicCuisse',
+        skillIds: ['skillPoulet'],
+        skills: [],
       });
 
       // when
@@ -341,23 +424,33 @@ describe('Integration | Repository | tube-repository', function () {
 
     it('should return a list of tubes (locale EN)', async function () {
       // given
-      const tube1 = new Tube({
+      const tube1 = domainBuilder.buildTube({
         id: 'recTube1',
         name: 'tubeName1',
         title: 'tubeTitle1',
         description: 'tubeDescription1',
         practicalTitle: 'practicalTitreEN1',
         practicalDescription: 'practicalDescriptionEN1',
+        isMobileCompliant: false,
+        isTabletCompliant: false,
         competenceId: 'recCompetence1',
+        thematicId: 'thematicCava',
+        skillIds: ['skillBien'],
+        skills: [],
       });
-      const tube2 = new Tube({
+      const tube2 = domainBuilder.buildTube({
         id: 'recTube2',
         name: 'tubeName2',
         title: 'tubeTitle2',
         description: 'tubeDescription2',
         practicalTitle: 'practicalTitreEN2',
         practicalDescription: 'practicalDescriptionEN2',
+        isMobileCompliant: true,
+        isTabletCompliant: false,
         competenceId: 'recCompetence1',
+        thematicId: 'thematicCuisse',
+        skillIds: ['skillPoulet'],
+        skills: [],
       });
 
       // when
@@ -371,14 +464,19 @@ describe('Integration | Repository | tube-repository', function () {
   describe('#findActiveByRecordIds', function () {
     it('should return a list of active tubes', async function () {
       // given
-      const tube1 = new Tube({
+      const tube1 = domainBuilder.buildTube({
         id: 'recTube1',
         name: 'tubeName1',
         title: 'tubeTitle1',
         description: 'tubeDescription1',
         practicalTitle: 'translatedPracticalTitle1',
         practicalDescription: 'translatedPracticalDescription1',
+        isMobileCompliant: true,
+        isTabletCompliant: true,
         competenceId: 'recCompetence1',
+        thematicId: 'thematicCava',
+        skillIds: ['skillCool'],
+        skills: [],
       });
 
       const learningContentTube0 = {
@@ -392,7 +490,11 @@ describe('Integration | Repository | tube-repository', function () {
         practicalDescription_i18n: {
           fr: 'translatedPracticalDescription0',
         },
+        isMobileCompliant: false,
+        isTabletCompliant: false,
         competenceId: 'recCompetence0',
+        thematicId: 'thematicCoucou',
+        skillIds: ['skillSuper', 'skillGenial'],
       };
 
       const learningContentTube1 = {
@@ -406,7 +508,11 @@ describe('Integration | Repository | tube-repository', function () {
         practicalDescription_i18n: {
           fr: 'translatedPracticalDescription1',
         },
+        isMobileCompliant: true,
+        isTabletCompliant: true,
         competenceId: 'recCompetence1',
+        thematicId: 'thematicCava',
+        skillIds: ['skillCool'],
       };
 
       const learningContentTube2 = {
@@ -420,7 +526,11 @@ describe('Integration | Repository | tube-repository', function () {
         practicalDescription_i18n: {
           fr: 'translatedPracticalDescription2',
         },
+        isMobileCompliant: true,
+        isTabletCompliant: false,
         competenceId: 'recCompetence2',
+        thematicId: 'thematicFruit',
+        skillIds: [],
       };
 
       const skills = [
@@ -452,14 +562,19 @@ describe('Integration | Repository | tube-repository', function () {
 
     it('should return a list of english active tubes', async function () {
       // given
-      const tube1 = new Tube({
+      const tube1 = domainBuilder.buildTube({
         id: 'recTube1',
         name: 'tubeName1',
         title: 'tubeTitle1',
         description: 'tubeDescription1',
         practicalTitle: 'translatedPracticalTitle1EnUs',
         practicalDescription: 'translatedPracticalDescription1EnUs',
+        isMobileCompliant: true,
+        isTabletCompliant: true,
         competenceId: 'recCompetence1',
+        thematicId: 'thematicCava',
+        skillIds: ['skillCool'],
+        skills: [],
       });
 
       const learningContentTube0 = {
@@ -475,7 +590,11 @@ describe('Integration | Repository | tube-repository', function () {
           fr: 'translatedPracticalDescription0',
           en: 'translatedPracticalDescription0EnUs',
         },
+        isMobileCompliant: false,
+        isTabletCompliant: false,
         competenceId: 'recCompetence0',
+        thematicId: 'thematicCoucou',
+        skillIds: ['skillSuper', 'skillGenial'],
       };
 
       const learningContentTube1 = {
@@ -491,7 +610,11 @@ describe('Integration | Repository | tube-repository', function () {
           fr: 'translatedPracticalDescription1',
           en: 'translatedPracticalDescription1EnUs',
         },
+        isMobileCompliant: true,
+        isTabletCompliant: true,
         competenceId: 'recCompetence1',
+        thematicId: 'thematicCava',
+        skillIds: ['skillCool'],
       };
 
       const learningContentTube2 = {
@@ -507,7 +630,11 @@ describe('Integration | Repository | tube-repository', function () {
           fr: 'translatedPracticalDescription2',
           en: 'translatedPracticalDescription2EnUs',
         },
+        isMobileCompliant: true,
+        isTabletCompliant: false,
         competenceId: 'recCompetence2',
+        thematicId: 'thematicFruit',
+        skillIds: [],
       };
 
       const skills = [

--- a/api/tests/tooling/domain-builder/factory/build-tube.js
+++ b/api/tests/tooling/domain-builder/factory/build-tube.js
@@ -12,6 +12,8 @@ module.exports = function buildTube({
   isTabletCompliant = false,
   skills = buildSkillCollection(),
   competenceId = 'recCOMP123',
+  thematicId = 'thematic123',
+  skillIds = ['skillABC', 'skillDEF'],
 } = {}) {
   return new Tube({
     id,
@@ -24,5 +26,7 @@ module.exports = function buildTube({
     isTabletCompliant,
     skills,
     competenceId,
+    thematicId,
+    skillIds,
   });
 };

--- a/api/tests/tooling/learning-content-builder/build-learning-content.js
+++ b/api/tests/tooling/learning-content-builder/build-learning-content.js
@@ -16,7 +16,7 @@ const buildLearningContent = function (learningContent) {
     const areas = framework.areas.map((area) => {
       const competences = area.competences.map((competence) => {
         const competenceSkills = [];
-        function mapTubes(pTubes) {
+        function mapTubes(pTubes, thematicId) {
           if (!pTubes) return [];
           return pTubes.map((tube) => {
             const skills = tube.skills.map((skill) => {
@@ -84,6 +84,8 @@ const buildLearningContent = function (learningContent) {
               isMobileCompliant: tube.isMobileCompliant,
               isTabletCompliant: tube.isTabletCompliant,
               competenceId: competence.id,
+              thematicId,
+              skillIds: skills.map((skill) => skill.id),
             };
           });
         }
@@ -91,7 +93,7 @@ const buildLearningContent = function (learningContent) {
         allTubes.push(tubes);
         const thematics =
           competence.thematics?.map((thematic) => {
-            const tubes = mapTubes(thematic.tubes);
+            const tubes = mapTubes(thematic.tubes, thematic.id);
             allTubes.push(tubes);
             return {
               id: thematic.id,

--- a/api/tests/unit/domain/models/Tube_test.js
+++ b/api/tests/unit/domain/models/Tube_test.js
@@ -1,23 +1,11 @@
 const Tube = require('../../../../lib/domain/models/Tube');
-const Skill = require('../../../../lib/domain/models/Skill');
-const { expect } = require('../../../test-helper');
+const { expect, domainBuilder } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | Tube', function () {
   describe('#constructor', function () {
-    it('should accept a list of skills as parameter', function () {
-      // given
-      const skills = [new Skill({ name: '@web', difficulty: 3 }), new Skill({ name: '@web', difficulty: 2 })];
-
-      // when
-      const tube = new Tube({ skills });
-
-      // then
-      expect(tube.skills).to.equal(skills);
-    });
-
     it('should have a name from skills', function () {
       // given
-      const skills = [new Skill({ name: '@web3' }), new Skill({ name: '@web2' })];
+      const skills = [domainBuilder.buildSkill({ name: '@web3' }), domainBuilder.buildSkill({ name: '@web2' })];
 
       // when
       const tube = new Tube({ skills });
@@ -28,7 +16,7 @@ describe('Unit | Domain | Models | Tube', function () {
 
     it('should have a name from constructor', function () {
       // given
-      const skills = [new Skill({ name: '@web3' })];
+      const skills = [domainBuilder.buildSkill({ name: '@web3' })];
 
       // when
       const tube = new Tube({ skills, name: 'tubeName' });
@@ -38,14 +26,6 @@ describe('Unit | Domain | Models | Tube', function () {
     });
 
     it('should not have a name when skills list is empty and name is not provided', function () {
-      // when
-      const tube = new Tube();
-
-      // then
-      expect(tube.name).to.equal('');
-    });
-
-    it('should create the tube without skills', function () {
       // when
       const tube = new Tube({});
 
@@ -57,9 +37,9 @@ describe('Unit | Domain | Models | Tube', function () {
   describe('#getEasierThan()', function () {
     it('should return the skill itself if it is alone within its tube', function () {
       // given
-      const skill = new Skill({ name: '@url', difficulty: 1 });
+      const skill = domainBuilder.buildSkill({ name: '@url', difficulty: 1 });
       const skills = [skill];
-      const tube = new Tube({ skills });
+      const tube = domainBuilder.buildTube({ skills });
 
       // when
       const easierSkills = tube.getEasierThan(skill);
@@ -70,11 +50,11 @@ describe('Unit | Domain | Models | Tube', function () {
 
     it('should return url1 and url3 when requesting skills easier than url3 within url1-3-5', function () {
       // given
-      const url1 = new Skill({ name: '@url1', difficulty: 1 });
-      const url3 = new Skill({ name: '@url3', difficulty: 3 });
-      const url5 = new Skill({ name: '@url5', difficulty: 5 });
+      const url1 = domainBuilder.buildSkill({ name: '@url1', difficulty: 1 });
+      const url3 = domainBuilder.buildSkill({ name: '@url3', difficulty: 3 });
+      const url5 = domainBuilder.buildSkill({ name: '@url5', difficulty: 5 });
       const skills = [url1, url3, url5];
-      const tube = new Tube({ skills });
+      const tube = domainBuilder.buildTube({ skills });
 
       // when
       const easierSkills = tube.getEasierThan(url3);
@@ -87,9 +67,9 @@ describe('Unit | Domain | Models | Tube', function () {
   describe('#getHarderThan()', function () {
     it('should return the skill itself if it is alone within its tube', function () {
       // given
-      const skill = new Skill({ name: '@url', difficulty: 1 });
+      const skill = domainBuilder.buildSkill({ name: '@url', difficulty: 1 });
       const skills = [skill];
-      const tube = new Tube({ skills });
+      const tube = domainBuilder.buildTube({ skills });
 
       // when
       const easierSkills = tube.getHarderThan(skill);
@@ -100,11 +80,11 @@ describe('Unit | Domain | Models | Tube', function () {
 
     it('should return url3 and url5 when requesting skills harder than url3 within url1-3-5', function () {
       // given
-      const url1 = new Skill({ name: '@url1', difficulty: 1 });
-      const url3 = new Skill({ name: '@url3', difficulty: 3 });
-      const url5 = new Skill({ name: '@url5', difficulty: 5 });
+      const url1 = domainBuilder.buildSkill({ name: '@url1', difficulty: 1 });
+      const url3 = domainBuilder.buildSkill({ name: '@url3', difficulty: 3 });
+      const url5 = domainBuilder.buildSkill({ name: '@url5', difficulty: 5 });
       const skills = [url1, url3, url5];
-      const tube = new Tube({ skills });
+      const tube = domainBuilder.buildTube({ skills });
 
       // when
       const easierSkills = tube.getHarderThan(url3);
@@ -117,9 +97,9 @@ describe('Unit | Domain | Models | Tube', function () {
   describe('#addSkill()', function () {
     it('should add skill to the list of skills', function () {
       // given
-      const skillWeb1 = new Skill({ name: '@web1' });
-      const skillWeb2 = new Skill({ name: '@web2' });
-      const tube = new Tube({ skills: [skillWeb1] });
+      const skillWeb1 = domainBuilder.buildSkill({ name: '@web1' });
+      const skillWeb2 = domainBuilder.buildSkill({ name: '@web2' });
+      const tube = domainBuilder.buildTube({ skills: [skillWeb1] });
 
       // when
       tube.addSkill(skillWeb2);
@@ -130,8 +110,8 @@ describe('Unit | Domain | Models | Tube', function () {
 
     it('should not add skill if skill is already present to the list of skills', function () {
       // given
-      const skillWeb1 = new Skill({ name: '@web1' });
-      const tube = new Tube({ skills: [skillWeb1] });
+      const skillWeb1 = domainBuilder.buildSkill({ name: '@web1' });
+      const tube = domainBuilder.buildTube({ skills: [skillWeb1] });
 
       // when
       tube.addSkill(skillWeb1);


### PR DESCRIPTION
## :christmas_tree: Problème
Ajouts récents dans API LCMS, modèle Tube de la release : ajout de thematicId et skillIds.

## :gift: Proposition
Utilisation de ces attributs dans le `targetProfileForAdminRepository` et `learningContentRepository`

## :star2: Remarques
Il y a besoin de merger ça d'abord https://github.com/1024pix/pix-editor/pull/73 et de faire une mise en prod LCMS

## :santa: Pour tester
Non régression sur affichage des profil-cibles dans PixAdmin.
Non régression sur du parcours de campagne.
