### PR TITLE
[TECH]  Corriger les éléments du SaasCompiler apparaissant dans la console lors du build de Pix App (PIX-6284).

### DIFF
--- a/mon-pix/app/styles/components/_tutorial-card.scss
+++ b/mon-pix/app/styles/components/_tutorial-card.scss
@@ -50,7 +50,7 @@
     margin: 0;
     padding: 0;
     justify-content: space-between;
-    align-items: end;
+    align-items: flex-end;
     display: flex;
     flex: 1;
     gap: 13px;

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -120,7 +120,7 @@
   }
 
   &-net-promoter-score__content {
-    align-items: start;
+    align-items: flex-start;
     display: flex;
     flex-direction: column;
 

--- a/mon-pix/app/styles/pages/_user-certifications-get.scss
+++ b/mon-pix/app/styles/pages/_user-certifications-get.scss
@@ -5,7 +5,7 @@
     top: calc(-0.813rem - 20px);
     position: absolute;
     margin-left: -30px;
-    align-self: start;
+    align-self: flex-start;
   }
 
   &__details-body {

--- a/mon-pix/ember-cli-build.js
+++ b/mon-pix/ember-cli-build.js
@@ -18,9 +18,6 @@ module.exports = function (defaults) {
       exclude: ['png', 'svg'],
       extensions: ['js', 'css', 'jpg', 'gif', 'map'],
     },
-    autoprefixer: {
-      grid: 'autoplace',
-    },
   });
 
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
## :christmas_tree: Problème
Lors du build de Pix App, plusieurs messages sur des propriétés css apparaissent : 

```
- autoprefixer: end value has mixed support, consider using flex-end instead
- autoprefixer: start value has mixed support, consider using flex-start instead
- autoprefixer: grid-auto-rows is not supported by IE
- autoprefixer: Autoplacement does not work without grid-template-rows property (affiché 8 fois)
```

## :gift: Proposition
 - Corriger les propriétés css causant ces messages
 - Supprimer l'option d'autoprefixer `grid:'autoplace'`

## :star2: Remarques
La propriété CSS `align-items` possède deux valeurs, `end` et `start` qui ne sont pas supportés partout. 
Il faut donc privilégier les valeur `flex-end` et `flex-start`

Les messages d'auto-placement et du `grid-auto-rows` s’affichent suite à la [PR introduisant une option d’autoprefixer](https://github.com/1024pix/pix/pull/2498) ajouté dans le ember-build-cli. Il a été ajouté pour corriger les affichage pour IE. Comme on ne supporte plus ce navigateur, on peut supprimer cette option.

**D'autres messages apparaissent lors du build et seront traités ultérieurement.**

## :santa: Pour tester
- Ne plus voir de message concernant le SassCompiler lorsqu'on build l'application
- Aller sur Pix App et vérifier que le changement de valeur ne casse pas le design
