### PR TITLE
[BUGFIX] Inversion des colonnes "certifications passées" et "candidats inscrits" (PIX-6333).

### DIFF
--- a/certif/app/components/session-summary-list.hbs
+++ b/certif/app/components/session-summary-list.hbs
@@ -23,10 +23,10 @@
               {{t "pages.sessions.list.session-summary.supervisor"}}
             </th>
             <th class="table__column table__column" scope="col">
-              {{t "pages.sessions.list.session-summary.effective-candidates"}}
+              {{t "pages.sessions.list.session-summary.enrolled-candidates"}}
             </th>
             <th class="table__column table__column" scope="col">
-              {{t "pages.sessions.list.session-summary.enrolled-candidates"}}
+              {{t "pages.sessions.list.session-summary.effective-candidates"}}
             </th>
             <th class="table__column table__column--small" scope="col">
               {{t "pages.sessions.list.session-summary.status"}}


### PR DESCRIPTION
## :christmas_tree: Problème

Dans Pix Certif, sur la page des sessions de certification, un tableau affiche les informations de toutes les sessions du centre de certification concerné.

Parmi ces informations, deux colonnes reprennent le nombre de candidats inscrits par session et le nombre de certifications passées par les candidats de la session.

Le nombre de candidats inscrits s’affiche dans la colonne “Certifications passées” tandis que le nombre de certifications passées se retrouve dans la colonne “Candidats inscrits”.

![index](https://user-images.githubusercontent.com/36371437/202143800-010b8abe-e263-42b2-8c7b-5133dbef7133.png)

## :gift: Proposition

Inversion des colonnes.

## :star2: Remarques
N/A

## :santa: Pour tester

Vérifier que les colonnes soient dans le bon ordre.
