### PR TITLE
[TECH] Ajouter la règle lint no-mocha-arrows sur Pix App (PIX-6335).

### DIFF
--- a/mon-pix/.eslintrc.js
+++ b/mon-pix/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
     'mocha/no-exclusive-tests': 'error',
     'mocha/no-identical-title': 'error',
     'mocha/no-skipped-tests': 'warn',
+    'mocha/no-mocha-arrows': 'error',
     /* Recommended rules */
     'ember/no-mixins': 'off',
     'i18n-json/sorted-keys': [

--- a/mon-pix/tests/acceptance/account-recovery/find-sco-record_test.js
+++ b/mon-pix/tests/acceptance/account-recovery/find-sco-record_test.js
@@ -72,7 +72,7 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
     ).to.exist;
   });
 
-  context('when submitting information form with valid data', () => {
+  context('when submitting information form with valid data', function () {
     it('should hide student information form and show recover account confirmation step', async function () {
       // given
       server.create('user', { id: 1, firstName, lastName, username });
@@ -84,8 +84,9 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
 
       // then
       expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.not.exist;
-      expect(contains(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.good-news', { firstName })))
-        .to.exist;
+      expect(
+        contains(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.good-news', { firstName }))
+      ).to.exist;
     });
 
     it('should redirect to error page when user has already left SCO', async function () {
@@ -113,7 +114,7 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
       expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
     });
 
-    context('click on "Cancel" button', () => {
+    context('click on "Cancel" button', function () {
       it('should return to student information form', async function () {
         // given
         server.create('user', { id: 1, firstName, lastName, username });
@@ -134,7 +135,7 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
     });
   });
 
-  context('when submitting information form with invalid data', () => {
+  context('when submitting information form with invalid data', function () {
     it('should show a not found error', async function () {
       // given & when
       await visit('/recuperer-mon-compte');
@@ -142,8 +143,9 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
 
       // then
       expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.exist;
-      expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.errors.not-found'))).to
-        .exist;
+      expect(
+        contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.errors.not-found'))
+      ).to.exist;
     });
   });
 
@@ -176,8 +178,8 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
     });
   });
 
-  context('when confirming student information', () => {
-    context('click on "Confirm" button', () => {
+  context('when confirming student information', function () {
+    context('click on "Confirm" button', function () {
       it('should hide recover account confirmation step and show recover account backup email confirmation', async function () {
         // given
         server.create('user', { id: 1, firstName, lastName, username });
@@ -350,7 +352,7 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
       });
     });
 
-    context('click on "Cancel" button', () => {
+    context('click on "Cancel" button', function () {
       it('should return to student information form', async function () {
         // given
 

--- a/mon-pix/tests/acceptance/challenge-commons_test.js
+++ b/mon-pix/tests/acceptance/challenge-commons_test.js
@@ -94,8 +94,8 @@ describe('Acceptance | Common behavior to all challenges', function () {
     });
   });
 
-  describe('When user is anonymous', () => {
-    it('should not display home link', async () => {
+  describe('When user is anonymous', function () {
+    it('should not display home link', async function () {
       //given
       const assessment = server.create('assessment', 'ofCompetenceEvaluationType');
       server.create('challenge', 'forCompetenceEvaluation', 'QROCM', {

--- a/mon-pix/tests/acceptance/challenge-feedback_test.js
+++ b/mon-pix/tests/acceptance/challenge-feedback_test.js
@@ -37,7 +37,7 @@ describe('Acceptance | Giving feedback about a challenge', function () {
       await visit(`/assessments/${assessment.id}/challenges/0`);
     });
 
-    it('should be able to directly send a feedback', async () => {
+    it('should be able to directly send a feedback', async function () {
       assertThatFeedbackPanelExist();
     });
 
@@ -82,7 +82,7 @@ describe('Acceptance | Giving feedback about a challenge', function () {
       server.create('answer', 'skipped', { assessment, challenge: firstChallenge });
       await visit(`/assessments/${assessment.id}/checkpoint`);
     });
-    it('should not display the feedback form', async () => {
+    it('should not display the feedback form', async function () {
       // when
       await click('.result-item__correction-button');
 
@@ -90,7 +90,7 @@ describe('Acceptance | Giving feedback about a challenge', function () {
       assertThatFeedbackFormIsClosed();
     });
 
-    it('should be able to give feedback', async () => {
+    it('should be able to give feedback', async function () {
       // when
       await click('.result-item__correction-button');
       await click('.feedback-panel__open-button');

--- a/mon-pix/tests/acceptance/challenge-flash-in-campaign_test.js
+++ b/mon-pix/tests/acceptance/challenge-flash-in-campaign_test.js
@@ -6,7 +6,7 @@ import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import environment from '../../config/environment';
 
-describe('Acceptance | Flash', () => {
+describe('Acceptance | Flash', function () {
   setupApplicationTest();
   setupMirage();
   let assessment;
@@ -15,13 +15,13 @@ describe('Acceptance | Flash', () => {
     assessment = server.create('assessment', 'ofFlashCampaignType');
   });
 
-  describe('Campaign', () => {
+  describe('Campaign', function () {
     beforeEach(function () {
       // In reality we should have 48 challenges but we just use one in this test.
       server.create('challenge', 'forCampaign');
     });
 
-    it('should display 1/48 counter on first challenge', async () => {
+    it('should display 1/48 counter on first challenge', async function () {
       // when
       await visit(`/assessments/${assessment.id}/challenges/0`);
 

--- a/mon-pix/tests/acceptance/challenge-item-qcm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcm_test.js
@@ -4,24 +4,24 @@ import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
-describe('Acceptance | Displaying a QCM challenge', () => {
+describe('Acceptance | Displaying a QCM challenge', function () {
   setupApplicationTest();
   setupMirage();
   let assessment;
   let qcmChallenge;
 
-  beforeEach(async () => {
+  beforeEach(async function () {
     assessment = server.create('assessment', 'ofCompetenceEvaluationType');
     qcmChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QCM');
   });
 
-  describe('When challenge is not already answered', () => {
-    beforeEach(async () => {
+  describe('When challenge is not already answered', function () {
+    beforeEach(async function () {
       // when
       await visit(`/assessments/${assessment.id}/challenges/0`);
     });
 
-    it('should render challenge information and question', () => {
+    it('should render challenge information and question', function () {
       // then
       expect(find('.challenge-statement-instruction__text').textContent.trim()).to.equal(qcmChallenge.instruction);
 
@@ -42,7 +42,7 @@ describe('Acceptance | Displaying a QCM challenge', () => {
       expect(find('.challenge-response__alert')).to.not.exist;
     });
 
-    it('should display the alert box if user validates without checking a checkbox', async () => {
+    it('should display the alert box if user validates without checking a checkbox', async function () {
       // when
       await click('.challenge-actions__action-validate');
 
@@ -53,7 +53,7 @@ describe('Acceptance | Displaying a QCM challenge', () => {
       );
     });
 
-    it('should hide the alert error after the user interact with checkboxes', async () => {
+    it('should hide the alert error after the user interact with checkboxes', async function () {
       // given
       await click('.challenge-actions__action-validate');
 
@@ -64,7 +64,7 @@ describe('Acceptance | Displaying a QCM challenge', () => {
       expect(find('.challenge-response__alert')).to.not.exist;
     });
 
-    it('should go to checkpoint when user validated', async () => {
+    it('should go to checkpoint when user validated', async function () {
       // given
       await click(findAll('.proposal-text')[1]);
 
@@ -76,8 +76,8 @@ describe('Acceptance | Displaying a QCM challenge', () => {
     });
   });
 
-  describe('When challenge is already answered', () => {
-    beforeEach(async () => {
+  describe('When challenge is already answered', function () {
+    beforeEach(async function () {
       // given
       server.create('answer', {
         value: '2, 4',
@@ -90,7 +90,7 @@ describe('Acceptance | Displaying a QCM challenge', () => {
       await visit(`/assessments/${assessment.id}/challenges/0`);
     });
 
-    it('should mark checkboxes corresponding to the answer and propose to continue', async () => {
+    it('should mark checkboxes corresponding to the answer and propose to continue', async function () {
       // then
       expect(findAll('input[type="checkbox"]')[0].checked).to.be.false;
       expect(findAll('input[type="checkbox"]')[1].checked).to.be.true;
@@ -105,9 +105,9 @@ describe('Acceptance | Displaying a QCM challenge', () => {
     });
   });
 
-  describe('When challenge is already answered and user wants to see answers', () => {
+  describe('When challenge is already answered and user wants to see answers', function () {
     let correction, tutorial, learningMoreTutorial;
-    beforeEach(async () => {
+    beforeEach(async function () {
       // given
       tutorial = server.create('tutorial');
       learningMoreTutorial = server.create('tutorial');
@@ -129,14 +129,14 @@ describe('Acceptance | Displaying a QCM challenge', () => {
       await visit(`/assessments/${assessment.id}/checkpoint`);
     });
 
-    it('should show the result of previous challenge in checkpoint', async () => {
+    it('should show the result of previous challenge in checkpoint', async function () {
       // then
       expect(find('.result-item__icon').title).to.equal('Réponse incorrecte');
       expect(find('.result-item__instruction').textContent.trim()).to.equal(qcmChallenge.instruction);
       expect(find('.result-item__correction-button').textContent.trim()).to.equal('Réponses et tutos');
     });
 
-    it('should show details of challenge result in pop-in, with tutorials and feedbacks', async () => {
+    it('should show details of challenge result in pop-in, with tutorials and feedbacks', async function () {
       // when
       await click('.result-item__correction-button');
 

--- a/mon-pix/tests/acceptance/challenge-item-qcu_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcu_test.js
@@ -4,24 +4,24 @@ import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
-describe('Acceptance | Displaying a QCU challenge', () => {
+describe('Acceptance | Displaying a QCU challenge', function () {
   setupApplicationTest();
   setupMirage();
   let assessment;
   let qcuChallenge;
 
-  beforeEach(async () => {
+  beforeEach(async function () {
     assessment = server.create('assessment', 'ofCompetenceEvaluationType');
     qcuChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QCU');
   });
 
-  describe('When challenge is not already answered', () => {
-    beforeEach(async () => {
+  describe('When challenge is not already answered', function () {
+    beforeEach(async function () {
       // when
       await visit(`/assessments/${assessment.id}/challenges/0`);
     });
 
-    it('should render challenge information and question', () => {
+    it('should render challenge information and question', function () {
       // then
       expect(find('.challenge-statement-instruction__text').textContent.trim()).to.equal(qcuChallenge.instruction);
 
@@ -41,7 +41,7 @@ describe('Acceptance | Displaying a QCU challenge', () => {
       expect(find('.challenge-reponse__alert')).to.not.exist;
     });
 
-    it('should display the alert box if user validates without checking a radio button', async () => {
+    it('should display the alert box if user validates without checking a radio button', async function () {
       // when
       await click('.challenge-actions__action-validate');
 
@@ -52,7 +52,7 @@ describe('Acceptance | Displaying a QCU challenge', () => {
       );
     });
 
-    it('should hide the alert error after the user interact with radio button', async () => {
+    it('should hide the alert error after the user interact with radio button', async function () {
       // given
       await click('.challenge-actions__action-validate');
 
@@ -63,7 +63,7 @@ describe('Acceptance | Displaying a QCU challenge', () => {
       expect(find('.challenge-response__alert')).to.not.exist;
     });
 
-    it('should go to checkpoint when user selects an answer and validates', async () => {
+    it('should go to checkpoint when user selects an answer and validates', async function () {
       // when
       await click(findAll('.proposal-text')[1]);
       await click('.challenge-actions__action-validate');
@@ -73,8 +73,8 @@ describe('Acceptance | Displaying a QCU challenge', () => {
     });
   });
 
-  describe('When challenge is already answered', () => {
-    beforeEach(async () => {
+  describe('When challenge is already answered', function () {
+    beforeEach(async function () {
       // given
       server.create('answer', {
         value: '2',
@@ -87,7 +87,7 @@ describe('Acceptance | Displaying a QCU challenge', () => {
       await visit(`/assessments/${assessment.id}/challenges/0`);
     });
 
-    it('should mark radio button corresponding to the answer and propose to continue', async () => {
+    it('should mark radio button corresponding to the answer and propose to continue', async function () {
       // then
       const radioButtons = findAll('input[type=radio][name="radio"]');
       expect(radioButtons[0].checked).to.be.false;
@@ -103,9 +103,9 @@ describe('Acceptance | Displaying a QCU challenge', () => {
     });
   });
 
-  describe('When challenge is already answered and user wants to see answers', () => {
+  describe('When challenge is already answered and user wants to see answers', function () {
     let correction, tutorial, learningMoreTutorial;
-    beforeEach(async () => {
+    beforeEach(async function () {
       // given
       tutorial = server.create('tutorial');
       learningMoreTutorial = server.create('tutorial');
@@ -127,14 +127,14 @@ describe('Acceptance | Displaying a QCU challenge', () => {
       await visit(`/assessments/${assessment.id}/checkpoint`);
     });
 
-    it('should show the result of previous challenge in checkpoint', async () => {
+    it('should show the result of previous challenge in checkpoint', async function () {
       // then
       expect(find('.result-item__icon').title).to.equal('Réponse incorrecte');
       expect(find('.result-item__instruction').textContent.trim()).to.equal(qcuChallenge.instruction);
       expect(find('.result-item__correction-button').textContent.trim()).to.equal('Réponses et tutos');
     });
 
-    it('should show details of challenge result in pop-in, with tutorials and feedbacks', async () => {
+    it('should show details of challenge result in pop-in, with tutorials and feedbacks', async function () {
       // when
       await click('.result-item__correction-button');
 

--- a/mon-pix/tests/acceptance/challenge-item-qroc_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qroc_test.js
@@ -4,20 +4,20 @@ import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
-describe('Acceptance | Displaying a QROC challenge', () => {
+describe('Acceptance | Displaying a QROC challenge', function () {
   setupApplicationTest();
   setupMirage();
   let assessment;
   let qrocChallenge;
 
-  describe('with input format', () => {
-    beforeEach(async () => {
+  describe('with input format', function () {
+    beforeEach(async function () {
       assessment = server.create('assessment', 'ofCompetenceEvaluationType');
       qrocChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROC');
     });
 
-    describe('When challenge is an auto validated embed (autoReply=true)', () => {
-      beforeEach(async () => {
+    describe('When challenge is an auto validated embed (autoReply=true)', function () {
+      beforeEach(async function () {
         // given
         server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withAutoReply', 'withEmbed');
         server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withAutoReply', 'withEmbed');
@@ -27,12 +27,12 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         await click('.challenge-actions__action-skip-text');
       });
 
-      it('should render challenge information and question', () => {
+      it('should render challenge information and question', function () {
         // then
         expect(find('.challenge-response__proposal')).to.not.exist;
       });
 
-      it('should display the alert box when user validates without successfully finishing the embed', async () => {
+      it('should display the alert box when user validates without successfully finishing the embed', async function () {
         // when
         expect(find('.challenge-response__alert')).to.not.exist;
         await click(find('.challenge-actions__action-validate'));
@@ -44,7 +44,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         );
       });
 
-      it('should go to the next challenge when user validates after finishing successfully the embed', async () => {
+      it('should go to the next challenge when user validates after finishing successfully the embed', async function () {
         // when
         const event = document.createEvent('Event');
         event.initEvent('message', true, true);
@@ -58,8 +58,8 @@ describe('Acceptance | Displaying a QROC challenge', () => {
       });
     });
 
-    describe('When challenge is an embed (without autoreply)', () => {
-      beforeEach(async () => {
+    describe('When challenge is an embed (without autoreply)', function () {
+      beforeEach(async function () {
         // given
         server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withEmbed');
 
@@ -68,7 +68,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         await click('.challenge-actions__action-skip-text');
       });
 
-      it('should display the alert box when user validates without successfully answering', async () => {
+      it('should display the alert box when user validates without successfully answering', async function () {
         // when
         const event = document.createEvent('Event');
         event.initEvent('message', true, true);
@@ -84,13 +84,13 @@ describe('Acceptance | Displaying a QROC challenge', () => {
       });
     });
 
-    describe('When challenge is not already answered', () => {
-      beforeEach(async () => {
+    describe('When challenge is not already answered', function () {
+      beforeEach(async function () {
         // when
         await visit(`/assessments/${assessment.id}/challenges/0`);
       });
 
-      it('should render challenge information and question', () => {
+      it('should render challenge information and question', function () {
         // then
         expect(find('.challenge-statement-instruction__text').textContent.trim()).to.equal(qrocChallenge.instruction);
 
@@ -102,7 +102,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         expect(find('.challenge-response__alert')).to.not.exist;
       });
 
-      it('should display the alert box if user validates without write an answer in input', async () => {
+      it('should display the alert box if user validates without write an answer in input', async function () {
         // when
         await fillIn('input[data-uid="qroc-proposal-uid"]', '');
         expect(find('.challenge-response__alert')).to.not.exist;
@@ -115,7 +115,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         );
       });
 
-      it('should hide the alert error after the user interact with input text', async () => {
+      it('should hide the alert error after the user interact with input text', async function () {
         // given
         await click('.challenge-actions__action-validate');
 
@@ -127,7 +127,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         expect(find('.challenge-response__alert')).to.not.exist;
       });
 
-      it('should go to checkpoint when user validated', async () => {
+      it('should go to checkpoint when user validated', async function () {
         // when
         await fillIn('input[data-uid="qroc-proposal-uid"]', 'Test');
         await click('.challenge-actions__action-validate');
@@ -137,8 +137,8 @@ describe('Acceptance | Displaying a QROC challenge', () => {
       });
     });
 
-    describe('When challenge is already answered', () => {
-      beforeEach(async () => {
+    describe('When challenge is already answered', function () {
+      beforeEach(async function () {
         // given
         server.create('answer', {
           value: 'Reponse',
@@ -151,7 +151,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         await visit(`/assessments/${assessment.id}/challenges/0`);
       });
 
-      it('should set the input value with the current answer and propose to continue', async () => {
+      it('should set the input value with the current answer and propose to continue', async function () {
         // then
         expect(find('.challenge-response__proposal').value).to.equal('Reponse');
         expect(find('.challenge-response__proposal').disabled).to.be.true;
@@ -162,9 +162,9 @@ describe('Acceptance | Displaying a QROC challenge', () => {
       });
     });
 
-    describe('When challenge is already answered and user wants to see answers', () => {
+    describe('When challenge is already answered and user wants to see answers', function () {
       let correction, tutorial, learningMoreTutorial;
-      beforeEach(async () => {
+      beforeEach(async function () {
         // given
         tutorial = server.create('tutorial');
         learningMoreTutorial = server.create('tutorial');
@@ -186,14 +186,14 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         await visit(`/assessments/${assessment.id}/checkpoint`);
       });
 
-      it('should show the result of previous challenge in checkpoint', async () => {
+      it('should show the result of previous challenge in checkpoint', async function () {
         // then
         expect(find('.result-item__icon').title).to.equal('Réponse incorrecte');
         expect(find('.result-item__instruction').textContent.trim()).to.equal(qrocChallenge.instruction);
         expect(find('.result-item__correction-button').textContent.trim()).to.equal('Réponses et tutos');
       });
 
-      it('should show details of challenge result in pop-in, with tutorials and feedbacks', async () => {
+      it('should show details of challenge result in pop-in, with tutorials and feedbacks', async function () {
         // when
         await click('.result-item__correction-button');
 
@@ -218,7 +218,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
       });
     });
 
-    describe('When there is two challenges with download file', () => {
+    describe('When there is two challenges with download file', function () {
       let qrocWithFile1Challenge, qrocWithFile2Challenge;
 
       beforeEach(async function () {
@@ -254,19 +254,19 @@ describe('Acceptance | Displaying a QROC challenge', () => {
     });
   });
 
-  describe('with text-area format', () => {
-    beforeEach(async () => {
+  describe('with text-area format', function () {
+    beforeEach(async function () {
       assessment = server.create('assessment', 'ofCompetenceEvaluationType');
       qrocChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROC', 'withTextArea');
     });
 
-    describe('When challenge is not already answered', () => {
-      beforeEach(async () => {
+    describe('When challenge is not already answered', function () {
+      beforeEach(async function () {
         // when
         await visit(`/assessments/${assessment.id}/challenges/0`);
       });
 
-      it('should render challenge information and question', () => {
+      it('should render challenge information and question', function () {
         // then
         expect(find('.challenge-statement-instruction__text').textContent.trim()).to.equal(qrocChallenge.instruction);
 
@@ -277,7 +277,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         expect(find('.challenge-response__alert')).to.not.exist;
       });
 
-      it('should display the alert box if user validates without write an answer in input', async () => {
+      it('should display the alert box if user validates without write an answer in input', async function () {
         // when
         await fillIn('textarea[data-uid="qroc-proposal-uid"]', '');
         expect(find('.challenge-response__alert')).to.not.exist;
@@ -290,7 +290,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         );
       });
 
-      it('should hide the alert error after the user interact with input text', async () => {
+      it('should hide the alert error after the user interact with input text', async function () {
         // given
         await click('.challenge-actions__action-validate');
 
@@ -302,7 +302,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         expect(find('.challenge-response__alert')).to.not.exist;
       });
 
-      it('should go to checkpoint when user validated', async () => {
+      it('should go to checkpoint when user validated', async function () {
         // when
         await fillIn('textarea[data-uid="qroc-proposal-uid"]', 'Test');
         await click('.challenge-actions__action-validate');
@@ -312,9 +312,9 @@ describe('Acceptance | Displaying a QROC challenge', () => {
       });
     });
 
-    describe('When challenge is already answered and user wants to see answers', () => {
+    describe('When challenge is already answered and user wants to see answers', function () {
       let correction, tutorial, learningMoreTutorial;
-      beforeEach(async () => {
+      beforeEach(async function () {
         // given
         tutorial = server.create('tutorial');
         learningMoreTutorial = server.create('tutorial');
@@ -336,14 +336,14 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         await visit(`/assessments/${assessment.id}/checkpoint`);
       });
 
-      it('should show the result of previous challenge in checkpoint', async () => {
+      it('should show the result of previous challenge in checkpoint', async function () {
         // then
         expect(find('.result-item__icon').title).to.equal('Réponse incorrecte');
         expect(find('.result-item__instruction').textContent.trim()).to.equal(qrocChallenge.instruction);
         expect(find('.result-item__correction-button').textContent.trim()).to.equal('Réponses et tutos');
       });
 
-      it('should show details of challenge result in pop-in, with tutorials and feedbacks', async () => {
+      it('should show details of challenge result in pop-in, with tutorials and feedbacks', async function () {
         // when
         await click('.result-item__correction-button');
 
@@ -369,19 +369,19 @@ describe('Acceptance | Displaying a QROC challenge', () => {
     });
   });
 
-  describe('with select format', () => {
-    beforeEach(async () => {
+  describe('with select format', function () {
+    beforeEach(async function () {
       assessment = server.create('assessment', 'ofCompetenceEvaluationType');
       qrocChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCWithSelect');
     });
 
-    describe('When challenge is not already answered', () => {
-      beforeEach(async () => {
+    describe('When challenge is not already answered', function () {
+      beforeEach(async function () {
         // when
         await visit(`/assessments/${assessment.id}/challenges/0`);
       });
 
-      it('should render challenge information and question', () => {
+      it('should render challenge information and question', function () {
         // then
         expect(find('.challenge-statement-instruction__text').textContent.trim()).to.equal(qrocChallenge.instruction);
         expect(findAll('.challenge-response__proposal')).to.have.lengthOf(1);
@@ -391,7 +391,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         expect(find('.challenge-response__alert')).to.not.exist;
       });
 
-      it('should hide the alert error after the user interact with input text', async () => {
+      it('should hide the alert error after the user interact with input text', async function () {
         // given
         await click('.challenge-actions__action-validate');
         expect(find('.challenge-response__alert')).to.exist;
@@ -405,7 +405,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         expect(find('.challenge-response__alert')).to.not.exist;
       });
 
-      it('should go to checkpoint when user validated', async () => {
+      it('should go to checkpoint when user validated', async function () {
         // when
         const selectOptions = findAll('select[data-test="challenge-response-proposal-selector"] option');
         const optionToFillIn = selectOptions[1];
@@ -418,9 +418,9 @@ describe('Acceptance | Displaying a QROC challenge', () => {
       });
     });
 
-    describe('When challenge is already answered and user wants to see answers', () => {
+    describe('When challenge is already answered and user wants to see answers', function () {
       let correction, tutorial, learningMoreTutorial;
-      beforeEach(async () => {
+      beforeEach(async function () {
         // given
         tutorial = server.create('tutorial');
         learningMoreTutorial = server.create('tutorial');
@@ -442,14 +442,14 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         await visit(`/assessments/${assessment.id}/checkpoint`);
       });
 
-      it('should show the result of previous challenge in checkpoint', async () => {
+      it('should show the result of previous challenge in checkpoint', async function () {
         // then
         expect(find('.result-item__icon').title).to.equal('Réponse incorrecte');
         expect(find('.result-item__instruction').textContent.trim()).to.equal(qrocChallenge.instruction);
         expect(find('.result-item__correction-button').textContent.trim()).to.equal('Réponses et tutos');
       });
 
-      it('should show details of challenge result in pop-in, with tutorials and feedbacks', async () => {
+      it('should show details of challenge result in pop-in, with tutorials and feedbacks', async function () {
         // when
         await click('.result-item__correction-button');
 

--- a/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
@@ -4,25 +4,25 @@ import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
-describe('Acceptance | Displaying a QROCM challenge', () => {
+describe('Acceptance | Displaying a QROCM challenge', function () {
   setupApplicationTest();
   setupMirage();
   let assessment;
   let qrocmDepChallenge;
 
-  beforeEach(async () => {
+  beforeEach(async function () {
     assessment = server.create('assessment', 'ofCompetenceEvaluationType');
   });
 
-  describe('When challenge is not already answered', () => {
-    context('and challenge only has input fields', () => {
-      beforeEach(async () => {
+  describe('When challenge is not already answered', function () {
+    context('and challenge only has input fields', function () {
+      beforeEach(async function () {
         // when
         qrocmDepChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCMDep');
         await visit(`/assessments/${assessment.id}/challenges/0`);
       });
 
-      it('should render challenge information and question', () => {
+      it('should render challenge information and question', function () {
         // then
         expect(find('.challenge-statement-instruction__text').textContent.trim()).to.equal(
           qrocmDepChallenge.instruction
@@ -37,7 +37,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
         expect(find('.challenge-response__alert')).to.not.exist;
       });
 
-      it('should display the alert box if user validates without write an answer for each input', async () => {
+      it('should display the alert box if user validates without write an answer for each input', async function () {
         // when
         await fillIn(findAll('input')[0], 'ANSWER');
         await fillIn(findAll('input')[1], '');
@@ -50,7 +50,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
         );
       });
 
-      it('should hide the alert error after the user interact with input text', async () => {
+      it('should hide the alert error after the user interact with input text', async function () {
         // given
         await click('.challenge-actions__action-validate');
 
@@ -63,7 +63,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
         expect(find('.challenge-response__alert')).to.not.exist;
       });
 
-      it('should go to checkpoint when user validated', async () => {
+      it('should go to checkpoint when user validated', async function () {
         // when
         await fillIn(findAll('input')[0], 'ANSWER');
         await fillIn(findAll('input')[1], 'ANSWER');
@@ -74,14 +74,14 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
       });
     });
 
-    context('and challenge contains select field', () => {
-      beforeEach(async () => {
+    context('and challenge contains select field', function () {
+      beforeEach(async function () {
         // when
         server.create('challenge', 'forCompetenceEvaluation', 'QROCMWithSelect');
         await visit(`/assessments/${assessment.id}/challenges/0`);
       });
 
-      it('should not be able to validate with the initial option', async () => {
+      it('should not be able to validate with the initial option', async function () {
         // when
         await click(find('.challenge-actions__action-validate'));
 
@@ -90,7 +90,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
         expect(currentURL()).to.contains(`/assessments/${assessment.id}/challenges/0`);
       });
 
-      it('should not be able to validate the empty option', async () => {
+      it('should not be able to validate the empty option', async function () {
         // given
         const selectOptions = findAll('select[data-test="challenge-response-proposal-selector"] option');
         const optionToFillIn = selectOptions[0];
@@ -104,7 +104,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
         expect(currentURL()).to.contains(`/assessments/${assessment.id}/challenges/0`);
       });
 
-      it('should validate an option and redirect to next page', async () => {
+      it('should validate an option and redirect to next page', async function () {
         // given
         const selectOptions = findAll('select[data-test="challenge-response-proposal-selector"] option');
         const optionToFillIn = selectOptions[1];
@@ -119,9 +119,9 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
     });
   });
 
-  describe('When challenge is already answered', () => {
-    context('and challenge is only made of input fields', () => {
-      beforeEach(async () => {
+  describe('When challenge is already answered', function () {
+    context('and challenge is only made of input fields', function () {
+      beforeEach(async function () {
         // given
         qrocmDepChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCMDep');
         server.create('answer', {
@@ -135,7 +135,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
         await visit(`/assessments/${assessment.id}/challenges/0`);
       });
 
-      it('should set the input text with previous answers and propose to continue', async () => {
+      it('should set the input text with previous answers and propose to continue', async function () {
         // then
         expect(find('div[data-test="qrocm-label-0"]').innerHTML).to.contains('Station <strong>1</strong> :');
         expect(find('div[data-test="qrocm-label-1"]').innerHTML).to.contains('Station <em>2</em> :');
@@ -150,8 +150,8 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
       });
     });
 
-    context('and challenge contains select field', () => {
-      beforeEach(async () => {
+    context('and challenge contains select field', function () {
+      beforeEach(async function () {
         // given
         const qrocmWithSelectChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCMWithSelect');
         server.create('answer', {
@@ -165,7 +165,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
         await visit(`/assessments/${assessment.id}/challenges/0`);
       });
 
-      it('should set the select with previous answer and propose to continue', async () => {
+      it('should set the select with previous answer and propose to continue', async function () {
         // then
         expect(findAll('select[data-test="challenge-response-proposal-selector"] option')[1].hasAttribute('selected'));
 
@@ -176,7 +176,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
     });
   });
 
-  describe('When challenge is already answered and user wants to see answers', () => {
+  describe('When challenge is already answered and user wants to see answers', function () {
     let correctionDep,
       correctionInd,
       tutorial,
@@ -185,7 +185,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
       qrocmIndSelectChallenge,
       correctionIndSelect;
 
-    beforeEach(async () => {
+    beforeEach(async function () {
       // given
       qrocmDepChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCMDep');
       qrocmIndChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCMind');
@@ -238,7 +238,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
       await visit(`/assessments/${assessment.id}/checkpoint`);
     });
 
-    it('should show the result of previous challenges in checkpoint', async () => {
+    it('should show the result of previous challenges in checkpoint', async function () {
       // then
       expect(findAll('.result-item__icon')[0].title).to.equal('Réponse incorrecte');
       const instructionStripped = qrocmDepChallenge.instruction.slice(0, 102);
@@ -256,7 +256,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
       expect(findAll('.result-item__correction-button')[2].textContent.trim()).to.equal('Réponses et tutos');
     });
 
-    it('should show details of QROCM-dep challenge result in pop-in, with tutorials and feedbacks', async () => {
+    it('should show details of QROCM-dep challenge result in pop-in, with tutorials and feedbacks', async function () {
       // when
       await click(findAll('.result-item__correction-button')[0]);
 
@@ -281,7 +281,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
       expect(find('.feedback-panel')).to.exist;
     });
 
-    it('should show details of QROCM-ind challenge result in pop-in, with tutorials and feedbacks', async () => {
+    it('should show details of QROCM-ind challenge result in pop-in, with tutorials and feedbacks', async function () {
       // when
       await click(findAll('.result-item__correction-button')[1]);
 
@@ -307,7 +307,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
       expect(find('.feedback-panel')).to.exist;
     });
 
-    it('should show details of QROCM-ind challenge (with select) result in pop-in, with tutorials and feedbacks', async () => {
+    it('should show details of QROCM-ind challenge (with select) result in pop-in, with tutorials and feedbacks', async function () {
       // when
       await click(findAll('.result-item__correction-button')[2]);
 

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -6,7 +6,7 @@ import { authenticateByEmail } from '../helpers/authentication';
 import { expect } from 'chai';
 import { click, find, triggerEvent, visit } from '@ember/test-helpers';
 
-describe('Acceptance | Displaying a challenge of any type', () => {
+describe('Acceptance | Displaying a challenge of any type', function () {
   setupApplicationTest();
   setupMirage();
 
@@ -29,7 +29,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
 
         describe('when user has not answered the question', function () {
           describe('when user has not seen the challenge tooltip yet', function () {
-            beforeEach(async () => {
+            beforeEach(async function () {
               // given
               const user = server.create('user', 'withEmail', {
                 hasSeenFocusedChallengeTooltip: false,
@@ -43,7 +43,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
               await visit(`/assessments/${assessment.id}/challenges/0`);
             });
 
-            it('should display a tooltip', async () => {
+            it('should display a tooltip', async function () {
               // then
               expect(find('.tooltip-tag__information')).to.exist;
             });
@@ -59,7 +59,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
               expect(find('.challenge__focused-out-overlay')).to.exist;
             });
 
-            describe('when user closes tooltip', () => {
+            describe('when user closes tooltip', function () {
               beforeEach(async function () {
                 // given
                 assessment = server.create('assessment', 'ofCompetenceEvaluationType');
@@ -70,12 +70,12 @@ describe('Acceptance | Displaying a challenge of any type', () => {
                 await click('.tooltip-tag-information__button');
               });
 
-              it('should hide a tooltip', async () => {
+              it('should hide a tooltip', async function () {
                 // then
                 expect(find('#challenge-statement-tag--tooltip')).to.not.exist;
               });
 
-              it('should enable input and buttons', async () => {
+              it('should enable input and buttons', async function () {
                 // then
                 expect(find('.challenge-actions__action-skip').getAttribute('disabled')).to.not.exist;
                 expect(find('.challenge-actions__action-validate').getAttribute('disabled')).to.not.exist;
@@ -124,7 +124,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
           });
 
           describe('when user has already seen challenge tooltip', function () {
-            beforeEach(async () => {
+            beforeEach(async function () {
               const user = server.create('user', 'withEmail', {
                 hasSeenFocusedChallengeTooltip: true,
               });
@@ -240,7 +240,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
         });
 
         describe('when user has already focusedout the challenge', function () {
-          beforeEach(async () => {
+          beforeEach(async function () {
             // given
             const user = server.create('user', 'withEmail', {
               hasSeenFocusedChallengeTooltip: true,
@@ -253,7 +253,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
             await visit(`/assessments/${assessment.id}/challenges/0`);
           });
 
-          it('should enable input and buttons', async () => {
+          it('should enable input and buttons', async function () {
             // then
             expect(find('.challenge-actions__action-skip').getAttribute('disabled')).to.not.exist;
             expect(find('.challenge-actions__action-validate').getAttribute('disabled')).to.not.exist;
@@ -274,7 +274,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
             await authenticateByEmail(user);
           });
 
-          describe('when user goes to another assessment', () => {
+          describe('when user goes to another assessment', function () {
             it('should not display a warning alert saying it has been focused out', async function () {
               // given
               const assessment1 = server.create(
@@ -296,7 +296,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
             });
           });
 
-          describe('when user returns to the same assessment', () => {
+          describe('when user returns to the same assessment', function () {
             it('should display a warning alert saying it has been focused out', async function () {
               // given
               const assessment = server.create('assessment', 'ofCompetenceEvaluationType');
@@ -324,7 +324,7 @@ describe('Acceptance | Displaying a challenge of any type', () => {
         describe(`when ${data.challengeType} challenge is not focused`, function () {
           describe('when user has not answered the question', function () {
             describe('when user has not seen the challenge tooltip yet', function () {
-              beforeEach(async () => {
+              beforeEach(async function () {
                 // given
                 const user = server.create('user', 'withEmail', {
                   hasSeenOtherChallengesTooltip: false,
@@ -338,12 +338,12 @@ describe('Acceptance | Displaying a challenge of any type', () => {
                 await visit(`/assessments/${assessment.id}/challenges/0`);
               });
 
-              it('should display a tooltip', async () => {
+              it('should display a tooltip', async function () {
                 // then
                 expect(find('.tooltip-tag__information')).to.exist;
               });
 
-              describe('when user closes tooltip', () => {
+              describe('when user closes tooltip', function () {
                 beforeEach(async function () {
                   // given
                   assessment = server.create('assessment', 'ofCompetenceEvaluationType');
@@ -354,23 +354,24 @@ describe('Acceptance | Displaying a challenge of any type', () => {
                   await click('.tooltip-tag-information__button');
                 });
 
-                it('should hide a tooltip', async () => {
+                it('should hide a tooltip', async function () {
                   // then
                   expect(find('#challenge-statement-tag--tooltip')).to.not.exist;
                 });
 
-                it('should enable input and buttons', async () => {
+                it('should enable input and buttons', async function () {
                   // then
                   expect(find('.challenge-actions__action-skip').getAttribute('disabled')).to.not.exist;
                   expect(find('.challenge-actions__action-validate').getAttribute('disabled')).to.not.exist;
-                  expect(find('[data-test="challenge-response-proposal-selector"]').getAttribute('disabled')).to.not
-                    .exist;
+                  expect(
+                    find('[data-test="challenge-response-proposal-selector"]').getAttribute('disabled')
+                  ).to.not.exist;
                 });
               });
             });
 
             describe('when user has already seen challenge tooltip', function () {
-              beforeEach(async () => {
+              beforeEach(async function () {
                 const user = server.create('user', 'withEmail', {
                   hasSeenOtherChallengesTooltip: true,
                 });

--- a/mon-pix/tests/acceptance/challenge-timed_test.js
+++ b/mon-pix/tests/acceptance/challenge-timed_test.js
@@ -4,15 +4,15 @@ import { expect } from 'chai';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-mocha';
 
-describe('Acceptance | Timed challenge', () => {
+describe('Acceptance | Timed challenge', function () {
   setupApplicationTest();
   setupMirage();
   let assessment;
   let timedChallenge;
 
-  context('Timed Challenge', () => {
+  context('Timed Challenge', function () {
     context('when asking for confirmation', function () {
-      beforeEach(async () => {
+      beforeEach(async function () {
         // given
         assessment = server.create('assessment', 'ofCompetenceEvaluationType');
         timedChallenge = server.create('challenge', 'forCompetenceEvaluation', 'timed');
@@ -21,18 +21,18 @@ describe('Acceptance | Timed challenge', () => {
         await visit(`/assessments/${assessment.id}/challenges/0`);
       });
 
-      it('should hide the challenge statement', async () => {
+      it('should hide the challenge statement', async function () {
         expect(find('.challenge-statement')).to.not.exist;
       });
 
-      it('should ensure the challenge does not automatically start', async () => {
+      it('should ensure the challenge does not automatically start', async function () {
         expect(find('.timeout-gauge')).to.not.exist;
       });
     });
 
-    context('when the confirmation button is clicked', () => {
+    context('when the confirmation button is clicked', function () {
       context('and the challenge has not been already answered', function () {
-        beforeEach(async () => {
+        beforeEach(async function () {
           // given
           assessment = server.create('assessment', 'ofCompetenceEvaluationType');
           timedChallenge = server.create('challenge', 'forCompetenceEvaluation', 'timed');
@@ -42,22 +42,22 @@ describe('Acceptance | Timed challenge', () => {
           await click('.timed-challenge-instructions button');
         });
 
-        it('should hide the warning button', () => {
+        it('should hide the warning button', function () {
           expect(find('.timed-challenge-instructions button')).to.not.exist;
         });
 
-        it('should display the challenge statement and the feedback form', () => {
+        it('should display the challenge statement and the feedback form', function () {
           expect(find('.challenge-statement')).to.exist;
           expect(find('.feedback-panel')).to.exist;
         });
 
-        it('should start the timer', () => {
+        it('should start the timer', function () {
           expect(find('.timeout-gauge')).to.exist;
         });
       });
 
       context('and the challenge has already been skipped before', function () {
-        beforeEach(async () => {
+        beforeEach(async function () {
           // given
           assessment = server.create('assessment', 'ofCompetenceEvaluationType');
           timedChallenge = server.create('challenge', 'forCompetenceEvaluation', 'timed');
@@ -70,23 +70,23 @@ describe('Acceptance | Timed challenge', () => {
           await visit(`/assessments/${assessment.id}/challenges/0`);
         });
 
-        it('should hide the warning button', () => {
+        it('should hide the warning button', function () {
           expect(find('.timed-challenge-instructions button')).to.not.exist;
         });
 
-        it('should display the challenge statement and the feedback form', () => {
+        it('should display the challenge statement and the feedback form', function () {
           expect(find('.challenge-statement')).to.exist;
           expect(find('.feedback-panel')).to.exist;
         });
 
-        it('should not display the timer', () => {
+        it('should not display the timer', function () {
           expect(find('.timeout-gauge')).to.not.exist;
         });
       });
     });
 
-    context('when the challenge is already timeout', () => {
-      beforeEach(async () => {
+    context('when the challenge is already timeout', function () {
+      beforeEach(async function () {
         // given
         assessment = server.create('assessment', 'ofCompetenceEvaluationType', 'withCurrentChallengeTimeout');
         timedChallenge = server.create('challenge', 'forCompetenceEvaluation', 'timed');
@@ -95,20 +95,20 @@ describe('Acceptance | Timed challenge', () => {
         await visit(`/assessments/${assessment.id}/challenges/0`);
       });
 
-      it('should hide the warning button', () => {
+      it('should hide the warning button', function () {
         expect(find('.timed-challenge-instructions button')).to.not.exist;
       });
 
-      it('should display the challenge statement and the feedback form', () => {
+      it('should display the challenge statement and the feedback form', function () {
         expect(find('.challenge-statement')).to.exist;
         expect(find('.feedback-panel')).to.exist;
       });
 
-      it('should display the timer without time remains', () => {
+      it('should display the timer without time remains', function () {
         expect(find('[data-test="timeout-gauge-remaining"]').textContent).to.contains('0:00');
       });
 
-      it('should only display continue button', () => {
+      it('should only display continue button', function () {
         expect(find('.challenge-actions__action-skip')).to.not.exist;
         expect(find('.challenge-actions__action-validate')).to.not.exist;
         expect(find('.challenge-actions__action-continue')).to.exist;
@@ -116,7 +116,7 @@ describe('Acceptance | Timed challenge', () => {
     });
   });
   context('when user seen two timed challenge', function () {
-    beforeEach(async () => {
+    beforeEach(async function () {
       // given
       assessment = server.create('assessment', 'ofCompetenceEvaluationType');
       timedChallenge = server.create('challenge', 'forCompetenceEvaluation', 'timed');
@@ -128,22 +128,22 @@ describe('Acceptance | Timed challenge', () => {
       await click('.challenge-actions__action-skip');
     });
 
-    it('should hide the challenge statement of the second challenge', async () => {
+    it('should hide the challenge statement of the second challenge', async function () {
       expect(find('.challenge-statement')).to.not.exist;
     });
 
-    it('should ensure the challenge does not automatically start of the second challenge', async () => {
+    it('should ensure the challenge does not automatically start of the second challenge', async function () {
       expect(find('.timeout-gauge')).to.not.exist;
     });
   });
 
-  context('Not Timed Challenge', () => {
-    beforeEach(() => {
+  context('Not Timed Challenge', function () {
+    beforeEach(function () {
       assessment = server.create('assessment', 'ofCompetenceEvaluationType');
       server.create('challenge', 'forCompetenceEvaluation');
     });
 
-    it('should display the challenge statement', async () => {
+    it('should display the challenge statement', async function () {
       // when
       await visit(`/assessments/${assessment.id}/challenges/0`);
 

--- a/mon-pix/tests/acceptance/checkpoint_test.js
+++ b/mon-pix/tests/acceptance/checkpoint_test.js
@@ -5,7 +5,7 @@ import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { authenticateByEmail } from '../helpers/authentication';
 
-describe('Acceptance | Checkpoint', () => {
+describe('Acceptance | Checkpoint', function () {
   setupApplicationTest();
   setupMirage();
   let assessment;
@@ -14,7 +14,7 @@ describe('Acceptance | Checkpoint', () => {
     assessment = server.create('assessment', 'ofCompetenceEvaluationType');
   });
 
-  describe('With answers', () => {
+  describe('With answers', function () {
     const NB_ANSWERS = 3;
 
     beforeEach(function () {
@@ -29,7 +29,7 @@ describe('Acceptance | Checkpoint', () => {
       }
     });
 
-    it('should display questions and links to solutions', async () => {
+    it('should display questions and links to solutions', async function () {
       // when
       await visit(`/assessments/${assessment.id}/checkpoint`);
 
@@ -42,8 +42,8 @@ describe('Acceptance | Checkpoint', () => {
     });
   });
 
-  describe('Without answers', () => {
-    it('should display a message indicating that there is no answers to provide', async () => {
+  describe('Without answers', function () {
+    it('should display a message indicating that there is no answers to provide', async function () {
       // when
       await visit(`/assessments/${assessment.id}/checkpoint?finalCheckpoint=true`);
 
@@ -60,8 +60,8 @@ describe('Acceptance | Checkpoint', () => {
     });
   });
 
-  describe('When user is anonymous', () => {
-    it('should not display home link', async () => {
+  describe('When user is anonymous', function () {
+    it('should not display home link', async function () {
       //given
       const user = server.create('user', 'withEmail', {
         isAnonymous: true,

--- a/mon-pix/tests/acceptance/competences-details_test.js
+++ b/mon-pix/tests/acceptance/competences-details_test.js
@@ -6,7 +6,7 @@ import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import setupIntl from '../helpers/setup-intl';
 
-describe("Acceptance | Competence details | Afficher la page de détails d'une compétence", () => {
+describe("Acceptance | Competence details | Afficher la page de détails d'une compétence", function () {
   setupApplicationTest();
   setupMirage();
   setupIntl();
@@ -18,7 +18,7 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
     user = server.create('user', 'withEmail');
   });
 
-  describe('Authenticated cases as simple user', () => {
+  describe('Authenticated cases as simple user', function () {
     let scorecardWithPoints;
     let scorecardWithRemainingDaysBeforeReset;
     let scorecardWithoutPoints;
@@ -26,7 +26,7 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
     let scorecardWithRemainingDaysBeforeImproving;
     let scorecardWithoutRemainingDaysBeforeImproving;
 
-    beforeEach(async () => {
+    beforeEach(async function () {
       await authenticateByEmail(user);
       scorecardWithPoints = user.scorecards.models[0];
       scorecardWithRemainingDaysBeforeReset = user.scorecards.models[1];
@@ -36,7 +36,7 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
       scorecardWithoutRemainingDaysBeforeImproving = user.scorecards.models[5];
     });
 
-    it('should be able to visit URL of competence details page', async () => {
+    it('should be able to visit URL of competence details page', async function () {
       // when
       await visit(`/competences/${scorecardWithPoints.competenceId}/details`);
 
@@ -44,7 +44,7 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
       expect(currentURL()).to.equal(`/competences/${scorecardWithPoints.competenceId}/details`);
     });
 
-    it('should display the competence details', async () => {
+    it('should display the competence details', async function () {
       // when
       await visit(`/competences/${scorecardWithPoints.competenceId}/details`);
 
@@ -59,7 +59,7 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
       );
     });
 
-    it('should transition to /competences when the user clicks on return', async () => {
+    it('should transition to /competences when the user clicks on return', async function () {
       // given
       await visit(`/competences/${scorecardWithPoints.description}/details`);
 
@@ -70,8 +70,8 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
       expect(currentURL()).to.equal('/competences');
     });
 
-    context('when the scorecard has 0 points because it was not started yet', () => {
-      it('should not display level or score', async () => {
+    context('when the scorecard has 0 points because it was not started yet', function () {
+      it('should not display level or score', async function () {
         // given
         // when
         await visit(`/competences/${scorecardWithoutPoints.competenceId}/details`);
@@ -84,7 +84,7 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
         expect(findAll('.scorecard-details-content-right__level-info')).to.have.lengthOf(0);
       });
 
-      it('should not display reset button nor reset sentence', async () => {
+      it('should not display reset button nor reset sentence', async function () {
         // when
         await visit(`/competences/${scorecardWithoutPoints.competenceId}/details`);
 
@@ -94,8 +94,8 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
       });
     });
 
-    context('when the scorecard has points', () => {
-      it('should display level and score', async () => {
+    context('when the scorecard has points', function () {
+      it('should display level and score', async function () {
         // when
         await visit(`/competences/${scorecardWithPoints.competenceId}/details`);
 
@@ -109,7 +109,7 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
         );
       });
 
-      it('should not display pixScoreAheadOfNextLevel when next level is over the max level', async () => {
+      it('should not display pixScoreAheadOfNextLevel when next level is over the max level', async function () {
         // when
         await visit(`/competences/${scorecardWithMaxLevel.competenceId}/details`);
 
@@ -117,7 +117,7 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
         expect(findAll('.scorecard-details-content-right__level-info')).to.have.lengthOf(0);
       });
 
-      it('should display tutorials if any', async () => {
+      it('should display tutorials if any', async function () {
         // given
         const nbTutos = scorecardWithPoints.tutorials.models.length;
 
@@ -128,8 +128,8 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
         expect(findAll('.tutorial-card')).to.have.lengthOf(nbTutos);
       });
 
-      context('when it has remaining some days before reset', () => {
-        it('should display remaining days before reset', async () => {
+      context('when it has remaining some days before reset', function () {
+        it('should display remaining days before reset', async function () {
           // when
           await visit(`/competences/${scorecardWithRemainingDaysBeforeReset.competenceId}/details`);
 
@@ -141,8 +141,8 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
         });
       });
 
-      context('when it has no remaining days before reset', () => {
-        it('should display reset button', async () => {
+      context('when it has no remaining days before reset', function () {
+        it('should display reset button', async function () {
           // when
           await visit(`/competences/${scorecardWithPoints.competenceId}/details`);
 
@@ -151,7 +151,7 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
           expect(findAll('.scorecard-details-content-right__reset-message')).to.have.lengthOf(0);
         });
 
-        it('should display popup to validate reset', async () => {
+        it('should display popup to validate reset', async function () {
           // given
           await visit(`/competences/${scorecardWithPoints.competenceId}/details`);
 
@@ -197,8 +197,8 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
         });
       });
 
-      context('when it has remaining some days before improving', () => {
-        it('should display remaining days before improving', async () => {
+      context('when it has remaining some days before improving', function () {
+        it('should display remaining days before improving', async function () {
           // when
           await visit(`/competences/${scorecardWithRemainingDaysBeforeImproving.competenceId}/details`);
 
@@ -210,8 +210,8 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
         });
       });
 
-      context('when it has no remaining days before improving', () => {
-        it('should display improving button', async () => {
+      context('when it has no remaining days before improving', function () {
+        it('should display improving button', async function () {
           // when
           await visit(`/competences/${scorecardWithoutRemainingDaysBeforeImproving.competenceId}/details`);
 
@@ -222,8 +222,8 @@ describe("Acceptance | Competence details | Afficher la page de détails d'une 
     });
   });
 
-  describe('Not authenticated cases', () => {
-    it('should redirect to home, when user is not authenticated', async () => {
+  describe('Not authenticated cases', function () {
+    it('should redirect to home, when user is not authenticated', async function () {
       // when
       await visit('/competences/1/details');
 

--- a/mon-pix/tests/acceptance/logout-anonymous-user-when-access-to-not-allowed-pages_test.js
+++ b/mon-pix/tests/acceptance/logout-anonymous-user-when-access-to-not-allowed-pages_test.js
@@ -14,8 +14,8 @@ describe('Acceptance | Campaigns | Simplified access | Anonymous user access to 
   setupMirage();
   let campaign;
 
-  context('When user logged as anonymous, and the access to campaign is simplified', () => {
-    beforeEach(async () => {
+  context('When user logged as anonymous, and the access to campaign is simplified', function () {
+    beforeEach(async function () {
       campaign = server.create('campaign', { isSimplifiedAccess: true, idPixLabel: 'Les anonymes' });
       await currentSession().authenticate('authenticator:anonymous', { campaignCode: campaign.code });
     });

--- a/mon-pix/tests/acceptance/not-found-redirect-to-index_test.js
+++ b/mon-pix/tests/acceptance/not-found-redirect-to-index_test.js
@@ -4,11 +4,11 @@ import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
-describe('Acceptance | Page | Not Found Redirection', () => {
+describe('Acceptance | Page | Not Found Redirection', function () {
   setupApplicationTest();
   setupMirage();
 
-  it('should redirect to home page when URL is a nonexistant page', async () => {
+  it('should redirect to home page when URL is a nonexistant page', async function () {
     await visit('/plop');
 
     expect(currentURL()).to.eq('/connexion');

--- a/mon-pix/tests/acceptance/reset-password_test.js
+++ b/mon-pix/tests/acceptance/reset-password_test.js
@@ -60,7 +60,7 @@ describe('Acceptance | Reset Password Form', function () {
     expect(find('.sign-form__body').textContent).to.contain('Votre mot de passe a été modifié avec succès');
   });
 
-  it('should allow connected user to visit reset-password page', async () => {
+  it('should allow connected user to visit reset-password page', async function () {
     // given
     const user = server.create('user', {
       id: 1000,

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
@@ -319,7 +319,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', functi
         });
       });
 
-      context('When the participation is shared', () => {
+      context('When the participation is shared', function () {
         context('when the campaign allows multiple participations', function () {
           beforeEach(async function () {
             campaign = server.create('campaign', { type: ASSESSMENT, multipleSendings: true });
@@ -346,7 +346,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', functi
           });
         });
 
-        context('when the campaign does not allow multiple participations', () => {
+        context('when the campaign does not allow multiple participations', function () {
           beforeEach(async function () {
             campaign = server.create('campaign', { type: ASSESSMENT, multipleSendings: false });
             const assessment = server.create('assessment', {

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -738,8 +738,8 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
       });
     });
 
-    context('When user is logged as anonymous and campaign is simplified access', () => {
-      beforeEach(async () => {
+    context('When user is logged as anonymous and campaign is simplified access', function () {
+      beforeEach(async function () {
         campaign = server.create('campaign', { isSimplifiedAccess: true, idPixLabel: 'Les anonymes' });
         await currentSession().authenticate('authenticator:anonymous', { campaignCode: campaign.code });
       });
@@ -867,7 +867,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
           });
         });
 
-        context('When user is already reconciled and has no GAR authentication method yet', () => {
+        context('When user is already reconciled and has no GAR authentication method yet', function () {
           const externalUserToken =
             'aaa.' +
             btoa(
@@ -1028,7 +1028,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
             expect(find('#update-form-error-message').textContent).to.equal(expectedErrorMessage);
           });
 
-          context('When user should change password', () => {
+          context('When user should change password', function () {
             it('should begin campaign participation after updating password expired', async function () {
               // given
               const userShouldChangePassword = server.create('user', 'withUsername', 'shouldChangePassword');

--- a/mon-pix/tests/acceptance/user-dashboard_test.js
+++ b/mon-pix/tests/acceptance/user-dashboard_test.js
@@ -64,7 +64,7 @@ describe('Acceptance | User dashboard page', function () {
     });
 
     describe('when user is doing a campaign of type assessment', function () {
-      context('when user has not completed the campaign', () => {
+      context('when user has not completed the campaign', function () {
         beforeEach(async function () {
           const uncompletedCampaign = server.create(
             'campaign',
@@ -102,7 +102,7 @@ describe('Acceptance | User dashboard page', function () {
         });
       });
 
-      context('when user has completed the campaign but not shared his/her results', () => {
+      context('when user has completed the campaign but not shared his/her results', function () {
         beforeEach(async function () {
           const unsharedCampaign = server.create(
             'campaign',
@@ -238,7 +238,7 @@ describe('Acceptance | User dashboard page', function () {
           await authenticateByEmail(user);
         });
 
-        describe('when user has not shared his results', () => {
+        describe('when user has not shared his results', function () {
           it('should display a resume campaign banner for the campaign', async function () {
             // when
             await visit('/accueil');

--- a/mon-pix/tests/acceptance/user-tutorials/recommended_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials/recommended_test.js
@@ -18,7 +18,7 @@ describe('Acceptance | User-tutorials | Recommended', function () {
     await server.db.tutorials.remove();
   });
 
-  describe('When there are recommended tutorials', () => {
+  describe('When there are recommended tutorials', function () {
     it('should display paginated tutorial cards', async function () {
       // given
       server.createList('tutorial', 100);

--- a/mon-pix/tests/integration/components/Sitemap/content_test.js
+++ b/mon-pix/tests/integration/components/Sitemap/content_test.js
@@ -10,7 +10,7 @@ describe('Integration | Component | Content', function () {
 
   let model;
 
-  beforeEach(() => {
+  beforeEach(function () {
     model = {
       scorecards: [
         {

--- a/mon-pix/tests/integration/components/account-recovery/backup-email-confirmation-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/backup-email-confirmation-form-test.js
@@ -163,7 +163,7 @@ describe('Integration | Component | account-recovery::backup-email-confirmation-
     });
   });
 
-  context('form validation', () => {
+  context('form validation', function () {
     it('should show an error when email is empty', async function () {
       // given
       const resetErrors = sinon.stub();

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/disabled_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/disabled_test.js
@@ -15,7 +15,7 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Archi
   });
 
   describe('when card has "ARCHIVED" status', function () {
-    context('when the participation is not completed', () => {
+    context('when the participation is not completed', function () {
       it('should render explanatory text given started status', async function () {
         // given
         const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
@@ -36,11 +36,13 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Archi
         // then
         expect(contains('My organization')).to.exist;
         expect(contains('My campaign')).to.exist;
-        expect(contains('Parcours désactivé par votre organisation.\nVous ne pouvez plus envoyer vos résultats.')).to
-          .exist;
+        expect(
+          contains('Parcours désactivé par votre organisation.\nVous ne pouvez plus envoyer vos résultats.')
+        ).to.exist;
         expect(contains(this.intl.t('pages.campaign-participation-overview.card.tag.disabled').toUpperCase())).to.exist;
-        expect(contains(this.intl.t('pages.campaign-participation-overview.card.started-at', { date: '01/01/2020' })))
-          .to.exist;
+        expect(
+          contains(this.intl.t('pages.campaign-participation-overview.card.started-at', { date: '01/01/2020' }))
+        ).to.exist;
       });
 
       it('should render explanatory text given to_share status', async function () {
@@ -63,11 +65,13 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Archi
         // then
         expect(contains('My organization')).to.exist;
         expect(contains('My campaign')).to.exist;
-        expect(contains('Parcours désactivé par votre organisation.\nVous ne pouvez plus envoyer vos résultats.')).to
-          .exist;
+        expect(
+          contains('Parcours désactivé par votre organisation.\nVous ne pouvez plus envoyer vos résultats.')
+        ).to.exist;
         expect(contains(this.intl.t('pages.campaign-participation-overview.card.tag.disabled').toUpperCase())).to.exist;
-        expect(contains(this.intl.t('pages.campaign-participation-overview.card.started-at', { date: '01/01/2020' })))
-          .to.exist;
+        expect(
+          contains(this.intl.t('pages.campaign-participation-overview.card.started-at', { date: '01/01/2020' }))
+        ).to.exist;
       });
 
       it('should not display go to details link', async function () {
@@ -115,7 +119,7 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Archi
         expect(contains('Voir le détail')).to.exist;
       });
 
-      context('when the participation has a mastery percentage', () => {
+      context('when the participation has a mastery percentage', function () {
         it('should render the result with percentage', async function () {
           // given
           const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
@@ -139,7 +143,7 @@ describe('Integration | Component | CampaignParticipationOverview | Card | Archi
         });
       });
 
-      context('when the campaign has stages', () => {
+      context('when the campaign has stages', function () {
         it('should render the result with stars', async function () {
           // given
           const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {

--- a/mon-pix/tests/integration/components/comparison-window_test.js
+++ b/mon-pix/tests/integration/components/comparison-window_test.js
@@ -96,7 +96,7 @@ describe('Integration | Component | comparison-window', function () {
       expect(find('.learning-more-panel__container')).to.exist;
     });
 
-    context('when the answer is OK', () => {
+    context('when the answer is OK', function () {
       it('should neither display “Bientot ici des tutos“ nor hints nor any tutorials', async function () {
         // given
         answer.setProperties({

--- a/mon-pix/tests/integration/components/routes/campaigns/invited/associate-sup-student-form_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/invited/associate-sup-student-form_test.js
@@ -36,7 +36,7 @@ describe('Integration | Component | routes/campaigns/invited/associate-sup-stude
     this.owner.register('service:store', storeStub);
   });
 
-  context('when user fill the form correctly', () => {
+  context('when user fill the form correctly', function () {
     it('should save form', async function () {
       // when
       await render(hbs`<Routes::Campaigns::Invited::AssociateSupStudentForm @campaignCode={{123}}/>`);
@@ -70,7 +70,7 @@ describe('Integration | Component | routes/campaigns/invited/associate-sup-stude
     });
   });
 
-  context('when the server responds an error', () => {
+  context('when the server responds an error', function () {
     it('should display server error', async function () {
       // given
       saveStub.rejects();

--- a/mon-pix/tests/integration/components/routes/campaigns/invited/fill-in-participant-external-id_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/invited/fill-in-participant-external-id_test.js
@@ -15,7 +15,7 @@ describe('Integration | Component | routes/campaigns/invited/fill-in-participant
     this.set('onCancelStub', onCancelStub);
   });
 
-  context('when externalIdHelpImageUrl exists', () => {
+  context('when externalIdHelpImageUrl exists', function () {
     it('should display image help', async function () {
       // when
       const campaign = {
@@ -35,7 +35,7 @@ describe('Integration | Component | routes/campaigns/invited/fill-in-participant
     });
   });
 
-  context('when externalIdHelpImageUrl does not exist', () => {
+  context('when externalIdHelpImageUrl does not exist', function () {
     it('should not display image help', async function () {
       // when
       const campaign = {

--- a/mon-pix/tests/integration/components/routes/campaigns/profiles_collection/send-profile_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/profiles_collection/send-profile_test.js
@@ -10,7 +10,7 @@ import hbs from 'htmlbars-inline-precompile';
 describe('Integration | Component | routes/campaigns/profiles_collection/send-profile', function () {
   setupIntlRenderingTest();
 
-  context('when isDisabled is true', () => {
+  context('when isDisabled is true', function () {
     it('should not display the share results button', async function () {
       // given
       this.set('isDisabled', true);
@@ -25,7 +25,7 @@ describe('Integration | Component | routes/campaigns/profiles_collection/send-pr
     });
   });
 
-  context('when isDisabled is false', () => {
+  context('when isDisabled is false', function () {
     it('should call sendProfile property', async function () {
       // given
       const sendProfile = sinon.stub();

--- a/mon-pix/tests/test-helper.js
+++ b/mon-pix/tests/test-helper.js
@@ -27,7 +27,7 @@ chai.use(chaiDom);
 setApplication(Application.create(config.APP));
 start();
 
-afterEach(() => {
+afterEach(function () {
   sessionStorage.clear();
   window.localStorage.removeItem('hasConfirmedFocusChallengeScreen');
 });

--- a/mon-pix/tests/unit/adapters/assessment_test.js
+++ b/mon-pix/tests/unit/adapters/assessment_test.js
@@ -11,7 +11,7 @@ describe('Unit | Adapters | assessment', function () {
     adapter = this.owner.lookup('adapter:assessment');
   });
 
-  describe('#urlForUpdateRecord', () => {
+  describe('#urlForUpdateRecord', function () {
     it('should build update url from assessment id', async function () {
       // given
       const options = { adapterOptions: {} };

--- a/mon-pix/tests/unit/adapters/campaign-participation-overview_test.js
+++ b/mon-pix/tests/unit/adapters/campaign-participation-overview_test.js
@@ -13,7 +13,7 @@ describe('Unit | Adapters | campaign-participation-overviews', function () {
     adapter.ajax = sinon.stub().resolves();
   });
 
-  describe('#urlForQueryRecord', () => {
+  describe('#urlForQueryRecord', function () {
     it('should query campaign-participation-overviews with adapterOptions', async function () {
       // given
       const params = {

--- a/mon-pix/tests/unit/adapters/certification-candidate_test.js
+++ b/mon-pix/tests/unit/adapters/certification-candidate_test.js
@@ -13,7 +13,7 @@ describe('Unit | Adapters | certification-candidate', function () {
     adapter.ajax = sinon.stub().resolves();
   });
 
-  describe('#urlForCreateRecord', () => {
+  describe('#urlForCreateRecord', function () {
     it('should build create url from certification-candidate id', async function () {
       // when
       const options = { adapterOptions: {} };

--- a/mon-pix/tests/unit/adapters/challenge_test.js
+++ b/mon-pix/tests/unit/adapters/challenge_test.js
@@ -6,7 +6,7 @@ import { setupTest } from 'ember-mocha';
 describe('Unit | Adapters | challenge', function () {
   setupTest();
 
-  describe('#urlForQueryRecord', () => {
+  describe('#urlForQueryRecord', function () {
     let adapter;
 
     beforeEach(function () {

--- a/mon-pix/tests/unit/adapters/competence-evaluation_test.js
+++ b/mon-pix/tests/unit/adapters/competence-evaluation_test.js
@@ -6,7 +6,7 @@ import { setupTest } from 'ember-mocha';
 describe('Unit | Adapters | competence-evaluation', function () {
   setupTest();
 
-  describe('#urlForFindAll', () => {
+  describe('#urlForFindAll', function () {
     let adapter;
 
     beforeEach(function () {
@@ -23,7 +23,7 @@ describe('Unit | Adapters | competence-evaluation', function () {
     });
   });
 
-  describe('#urlQueryForRecord', () => {
+  describe('#urlQueryForRecord', function () {
     let adapter;
 
     beforeEach(function () {

--- a/mon-pix/tests/unit/adapters/dependent-user_test.js
+++ b/mon-pix/tests/unit/adapters/dependent-user_test.js
@@ -11,7 +11,7 @@ describe('Unit | Adapters | dependent-user', function () {
     adapter = this.owner.lookup('adapter:dependent-user');
   });
 
-  describe('#urlForCreateRecord', () => {
+  describe('#urlForCreateRecord', function () {
     it('should redirect to /api/sco-organization-learners/dependent', async function () {
       // when
       const url = await adapter.urlForCreateRecord();

--- a/mon-pix/tests/unit/adapters/email-verification-code-test.js
+++ b/mon-pix/tests/unit/adapters/email-verification-code-test.js
@@ -7,7 +7,7 @@ import sinon from 'sinon';
 describe('Unit | Adapter | Email-Verification-Code', function () {
   setupTest();
 
-  describe('#buildURL', () => {
+  describe('#buildURL', function () {
     it('should call API to send email verification code', async function () {
       // given
       const adapter = this.owner.lookup('adapter:email-verification-code');

--- a/mon-pix/tests/unit/adapters/external-user_test.js
+++ b/mon-pix/tests/unit/adapters/external-user_test.js
@@ -11,7 +11,7 @@ describe('Unit | Adapters | external-user', function () {
     adapter = this.owner.lookup('adapter:external-user');
   });
 
-  describe('#urlForCreateRecord', () => {
+  describe('#urlForCreateRecord', function () {
     it('should redirect to /api/sco-organization-learners/external', async function () {
       // when
       const url = await adapter.urlForCreateRecord();

--- a/mon-pix/tests/unit/adapters/organization-learner-identity_test.js
+++ b/mon-pix/tests/unit/adapters/organization-learner-identity_test.js
@@ -11,7 +11,7 @@ describe('Unit | Adapters | organization-learner-identity', function () {
     adapter = this.owner.lookup('adapter:organization-learner-identity');
   });
 
-  describe('#urlForQueryRecord', () => {
+  describe('#urlForQueryRecord', function () {
     it('should redirect to /api/organization-learners', async function () {
       // when
       const url = await adapter.urlForQueryRecord();

--- a/mon-pix/tests/unit/adapters/sco-organization-learner_test.js
+++ b/mon-pix/tests/unit/adapters/sco-organization-learner_test.js
@@ -13,7 +13,7 @@ describe('Unit | Adapters | sco-organization-learner', function () {
     adapter.ajax = sinon.stub().resolves();
   });
 
-  describe('#urlForCreateRecord', () => {
+  describe('#urlForCreateRecord', function () {
     context('when is for searchMatchingStudent', function () {
       it('should redirect to /sco-organization-learners/possibilities ', async function () {
         // when
@@ -44,11 +44,11 @@ describe('Unit | Adapters | sco-organization-learner', function () {
     });
   });
 
-  describe('#createRecord', () => {
-    context('when is for searchMatchingStudent', () => {
+  describe('#createRecord', function () {
+    context('when is for searchMatchingStudent', function () {
       let expectedUrl, expectedMethod, expectedData, snapshot;
 
-      beforeEach(() => {
+      beforeEach(function () {
         expectedUrl = 'http://localhost:3000/api/sco-organization-learners/possibilities';
         expectedMethod = 'PUT';
         expectedData = {
@@ -81,7 +81,7 @@ describe('Unit | Adapters | sco-organization-learner', function () {
         };
       });
 
-      it('should change method to PUT', async () => {
+      it('should change method to PUT', async function () {
         // when
         await adapter.createRecord(null, { modelName: 'sco-organization-learner' }, snapshot);
 
@@ -90,10 +90,10 @@ describe('Unit | Adapters | sco-organization-learner', function () {
       });
     });
 
-    context('when tryReconciliation is true', () => {
+    context('when tryReconciliation is true', function () {
       let expectedUrl, expectedMethod, expectedData, snapshot;
 
-      beforeEach(() => {
+      beforeEach(function () {
         expectedUrl = 'http://localhost:3000/api/sco-organization-learners/association/auto';
         expectedMethod = 'POST';
         expectedData = {

--- a/mon-pix/tests/unit/adapters/shared-profile-for-campaign_test.js
+++ b/mon-pix/tests/unit/adapters/shared-profile-for-campaign_test.js
@@ -13,7 +13,7 @@ describe('Unit | Adapters | shared-profile-for-campaign', function () {
     adapter.ajax = sinon.stub().resolves();
   });
 
-  describe('#urlForQueryRecord', () => {
+  describe('#urlForQueryRecord', function () {
     it('should build query url from campaign and user ids', async function () {
       const query = { campaignId: 'campaignId1', userId: 'userId1' };
       const url = await adapter.urlForQueryRecord(query);

--- a/mon-pix/tests/unit/adapters/training_test.js
+++ b/mon-pix/tests/unit/adapters/training_test.js
@@ -6,7 +6,7 @@ import { setupTest } from 'ember-mocha';
 describe('Unit | Adapters | Training', function () {
   setupTest();
 
-  describe('#urlForQuery', () => {
+  describe('#urlForQuery', function () {
     let adapter;
 
     beforeEach(function () {

--- a/mon-pix/tests/unit/adapters/tutorial-evaluation_test.js
+++ b/mon-pix/tests/unit/adapters/tutorial-evaluation_test.js
@@ -13,7 +13,7 @@ describe('Unit | Adapters | tutorial-evaluation', function () {
     adapter.ajax = sinon.stub().resolves();
   });
 
-  describe('#urlForCreateRecord', () => {
+  describe('#urlForCreateRecord', function () {
     it('should redirect to /api/users/tutorials/${tutorialId}/evaluate', async function () {
       // given
       const tutorialId = 'tutorialId';
@@ -27,7 +27,7 @@ describe('Unit | Adapters | tutorial-evaluation', function () {
     });
   });
 
-  describe('#urlForUpdateRecord', () => {
+  describe('#urlForUpdateRecord', function () {
     it('should redirect to /api/users/tutorials/${tutorialId}/evaluate', async function () {
       // given
       const tutorialId = 'tutorialId';
@@ -41,7 +41,7 @@ describe('Unit | Adapters | tutorial-evaluation', function () {
     });
   });
 
-  describe('#createRecord', () => {
+  describe('#createRecord', function () {
     it('should call API to create a tutorial-evaluation', async function () {
       // given
       const tutorialId = 'tutorialId';
@@ -63,7 +63,7 @@ describe('Unit | Adapters | tutorial-evaluation', function () {
     });
   });
 
-  describe('#updateRecord', () => {
+  describe('#updateRecord', function () {
     it('should call API to create a tutorial-evaluation', async function () {
       // given
       const tutorialId = 'tutorialId';

--- a/mon-pix/tests/unit/adapters/tutorial_test.js
+++ b/mon-pix/tests/unit/adapters/tutorial_test.js
@@ -6,7 +6,7 @@ import { setupTest } from 'ember-mocha';
 describe('Unit | Adapters | Tutorial', function () {
   setupTest();
 
-  describe('#urlForQuery', () => {
+  describe('#urlForQuery', function () {
     let adapter;
 
     beforeEach(function () {

--- a/mon-pix/tests/unit/adapters/user-tutorial_test.js
+++ b/mon-pix/tests/unit/adapters/user-tutorial_test.js
@@ -13,7 +13,7 @@ describe('Unit | Adapters | user-saved-tutorial', function () {
     adapter.ajax = sinon.stub().resolves();
   });
 
-  describe('#createRecord', () => {
+  describe('#createRecord', function () {
     it('should call API to create a user-tutorial with skill-id from tutorial', async function () {
       // given
       const tutorialId = 'tutorialId';
@@ -47,7 +47,7 @@ describe('Unit | Adapters | user-saved-tutorial', function () {
     });
   });
 
-  describe('#urlForDeleteRecord', () => {
+  describe('#urlForDeleteRecord', function () {
     it('should return API to delete a user-tutorial', async function () {
       // given
       const tutorialId = 'tutorialId';

--- a/mon-pix/tests/unit/adapters/user_test.js
+++ b/mon-pix/tests/unit/adapters/user_test.js
@@ -13,7 +13,7 @@ describe('Unit | Adapters | user', function () {
     adapter.ajax = sinon.stub().resolves();
   });
 
-  describe('#queryRecord', () => {
+  describe('#queryRecord', function () {
     it('should build /me url', async function () {
       // when
       const url = await adapter.urlForQueryRecord({ me: true }, 'user');
@@ -31,7 +31,7 @@ describe('Unit | Adapters | user', function () {
     });
   });
 
-  describe('#urlForUpdateRecord', () => {
+  describe('#urlForUpdateRecord', function () {
     it('should redirect to /api/users/{id}/pix-terms-of-service-acceptance', async function () {
       // when
       const snapshot = { adapterOptions: { acceptPixTermsOfService: true } };
@@ -87,8 +87,8 @@ describe('Unit | Adapters | user', function () {
     });
   });
 
-  describe('#createRecord', () => {
-    context('when campaignCode adapterOption is defined', () => {
+  describe('#createRecord', function () {
+    context('when campaignCode adapterOption is defined', function () {
       it('should add campaign-code meta', async () => {
         // given
         const campaignCode = 'AZERTY123';

--- a/mon-pix/tests/unit/components/challenge-item-qroc_test.js
+++ b/mon-pix/tests/unit/components/challenge-item-qroc_test.js
@@ -9,7 +9,7 @@ describe('Unit | Component | Challenge item QROC', function () {
 
   let component;
   describe('#_receiveEmbedMessage', function () {
-    beforeEach(() => {
+    beforeEach(function () {
       const challenge = EmberObject.create({
         autoReply: true,
         id: 'rec_123',

--- a/mon-pix/tests/unit/components/competence-card-default_test.js
+++ b/mon-pix/tests/unit/components/competence-card-default_test.js
@@ -34,7 +34,7 @@ describe('Unit | Component | competence-card-default ', function () {
   describe('#shouldWaitBeforeImproving', function () {
     let component, scorecard;
 
-    beforeEach(() => {
+    beforeEach(function () {
       const competenceId = 'recCompetenceId';
       scorecard = EmberObject.create({ competenceId });
       component = createGlimmerComponent('component:competence-card-default', { scorecard, interactive: true });

--- a/mon-pix/tests/unit/components/feedback-panel_test.js
+++ b/mon-pix/tests/unit/components/feedback-panel_test.js
@@ -78,7 +78,7 @@ describe('Unit | Component | feedback-panel', function () {
     let feedback;
     let store;
 
-    beforeEach(() => {
+    beforeEach(function () {
       feedback = {
         save: sinon.stub().resolves(null),
       };

--- a/mon-pix/tests/unit/components/form-textfield-date_test.js
+++ b/mon-pix/tests/unit/components/form-textfield-date_test.js
@@ -8,7 +8,7 @@ describe('Unit | Component | form-textfield-date', function () {
 
   let component;
 
-  beforeEach(() => {
+  beforeEach(function () {
     component = createGlimmerComponent('component:form-textfield-date');
   });
 

--- a/mon-pix/tests/unit/components/navbar-desktop-header_test.js
+++ b/mon-pix/tests/unit/components/navbar-desktop-header_test.js
@@ -36,7 +36,7 @@ describe('Unit | Component | Navbar Desktop Header Component', function () {
       });
     });
 
-    context('#showHeaderMenuItem', () => {
+    context('#showHeaderMenuItem', function () {
       it('should return true, when logged user is not anonymous', () => {
         // given
         currentUserStub.user.isAnonymous = false;
@@ -80,7 +80,7 @@ describe('Unit | Component | Navbar Desktop Header Component', function () {
       });
     });
 
-    context('#showHeaderMenuItem', () => {
+    context('#showHeaderMenuItem', function () {
       it('should return false', () => {
         // then
         expect(component.showHeaderMenuItem).to.be.false;

--- a/mon-pix/tests/unit/components/reached-stage_test.js
+++ b/mon-pix/tests/unit/components/reached-stage_test.js
@@ -16,7 +16,7 @@ describe('Unit | Component | reached-stage', function () {
     { starCount: 5, stageCount: 6, expectedAcquiredStarsCount: 4, expectedUnacquiredStarsCount: 1 },
     { starCount: 2, stageCount: 10, expectedAcquiredStarsCount: 1, expectedUnacquiredStarsCount: 8 },
   ].map(({ starCount, stageCount, expectedAcquiredStarsCount, expectedUnacquiredStarsCount }) => {
-    context(`starCount=${starCount} and stageCount=${stageCount}`, () => {
+    context(`starCount=${starCount} and stageCount=${stageCount}`, function () {
       beforeEach(function () {
         component = createGlimmerComponent('component:reached-stage', { starCount, stageCount });
       });
@@ -42,10 +42,10 @@ describe('Unit | Component | reached-stage', function () {
     });
   });
 
-  context('has no acquired star', () => {
+  context('has no acquired star', function () {
     [{ starCount: 1, stageCount: 3, expectedAcquiredStarsCount: 0, expectedUnacquiredStarsCount: 2 }].map(
       ({ starCount, stageCount, expectedAcquiredStarsCount, expectedUnacquiredStarsCount }) => {
-        context(`starCount=${starCount} and stageCount=${stageCount}`, () => {
+        context(`starCount=${starCount} and stageCount=${stageCount}`, function () {
           beforeEach(function () {
             component = createGlimmerComponent('component:reached-stage', { starCount, stageCount });
           });
@@ -85,7 +85,7 @@ describe('Unit | Component | reached-stage', function () {
     );
   });
 
-  context('has acquired at least one star', () => {
+  context('has acquired at least one star', function () {
     [
       { starCount: 5, stageCount: 5, expectedAcquiredStarsCount: 4, expectedUnacquiredStarsCount: 0 },
       { starCount: 5, stageCount: 6, expectedAcquiredStarsCount: 4, expectedUnacquiredStarsCount: 1 },
@@ -93,7 +93,7 @@ describe('Unit | Component | reached-stage', function () {
       { starCount: 2, stageCount: 3, expectedAcquiredStarsCount: 1, expectedUnacquiredStarsCount: 1 },
       { starCount: 4, stageCount: 5, expectedAcquiredStarsCount: 3, expectedUnacquiredStarsCount: 1 },
     ].map(({ starCount, stageCount, expectedAcquiredStarsCount, expectedUnacquiredStarsCount }) => {
-      context(`starCount=${starCount} and stageCount=${stageCount}`, () => {
+      context(`starCount=${starCount} and stageCount=${stageCount}`, function () {
         beforeEach(function () {
           component = createGlimmerComponent('component:reached-stage', { starCount, stageCount });
         });

--- a/mon-pix/tests/unit/components/routes/campaigns/invited/associate-sup-student-form_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/invited/associate-sup-student-form_test.js
@@ -23,7 +23,7 @@ describe('Unit | Component | routes/campaigns/invited/associate-sup-student-form
   });
 
   describe('#submit', function () {
-    context('when form data are correct', () => {
+    context('when form data are correct', function () {
       beforeEach(function () {
         component.studentNumber = 'F001';
         component.firstName = 'firstName';
@@ -55,7 +55,7 @@ describe('Unit | Component | routes/campaigns/invited/associate-sup-student-form
       });
     });
 
-    context('when form data have errors', () => {
+    context('when form data have errors', function () {
       it('should display an error when student number is not correct', async function () {
         // given
         component.studentNumber = '';

--- a/mon-pix/tests/unit/components/routes/login-form_test.js
+++ b/mon-pix/tests/unit/components/routes/login-form_test.js
@@ -41,8 +41,8 @@ describe('Unit | Component | routes/login-form', function () {
   });
 
   describe('#authenticate', () => {
-    context('when user is a Pix user', () => {
-      it('should not notify error when authentication succeeds', async () => {
+    context('when user is a Pix user', function () {
+      it('should not notify error when authentication succeeds', async function () {
         // when
         await component.authenticate(eventStub);
 
@@ -51,7 +51,7 @@ describe('Unit | Component | routes/login-form', function () {
         expect(component.hasUpdateUserError).to.be.false;
       });
 
-      it('should notify error when authentication fails', async () => {
+      it('should notify error when authentication fails', async function () {
         // given
         sessionStub.authenticate.rejects(new Error());
 
@@ -63,8 +63,8 @@ describe('Unit | Component | routes/login-form', function () {
         expect(component.hasUpdateUserError).to.be.false;
       });
 
-      context('when user should change password', () => {
-        it('should save reset password token and redirect to update-expired-password', async () => {
+      context('when user should change password', function () {
+        it('should save reset password token and redirect to update-expired-password', async function () {
           // given
           const expectedRouteName = 'update-expired-password';
           sessionStub.authenticate.rejects({
@@ -90,7 +90,7 @@ describe('Unit | Component | routes/login-form', function () {
       });
     });
 
-    context('when user is external with an existing token id', () => {
+    context('when user is external with an existing token id', function () {
       const externalUserToken = 'ABCD';
       const expectedUserId = 1;
 
@@ -99,7 +99,7 @@ describe('Unit | Component | routes/login-form', function () {
         sessionStub.get.withArgs('data.expectedUserId').returns(expectedUserId);
       });
 
-      it('should display an error message when update user authentication method fails', async () => {
+      it('should display an error message when update user authentication method fails', async function () {
         // given
         addGarAuthenticationMethodToUserStub.rejects(new Error());
 
@@ -111,8 +111,8 @@ describe('Unit | Component | routes/login-form', function () {
         expect(component.hasUpdateUserError).to.be.true;
       });
 
-      context('when user should change password', () => {
-        it('should save reset password token and redirect to update-expired-password', async () => {
+      context('when user should change password', function () {
+        it('should save reset password token and redirect to update-expired-password', async function () {
           // given
           const response = {
             errors: [

--- a/mon-pix/tests/unit/components/signin-form_test.js
+++ b/mon-pix/tests/unit/components/signin-form_test.js
@@ -9,7 +9,7 @@ describe('Unit | Component | signin-form', function () {
   setupTest();
 
   describe('#signin', () => {
-    context('when user should change password', () => {
+    context('when user should change password', function () {
       it('should save reset password token and redirect to update-expired-password', async () => {
         // given
         const eventStub = { preventDefault: sinon.stub() };
@@ -43,7 +43,7 @@ describe('Unit | Component | signin-form', function () {
       });
     });
 
-    context('when user sign in', () => {
+    context('when user sign in', function () {
       it('should authenticate the user even if email contains spaces', async () => {
         // given
         const foundUser = EmberObject.create({ id: 12 });

--- a/mon-pix/tests/unit/controllers/account-recovery/find-sco-record-test.js
+++ b/mon-pix/tests/unit/controllers/account-recovery/find-sco-record-test.js
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 describe('Unit | Controller | account-recovery | find-sco-record', function () {
   setupTest();
 
-  context('#submitStudentInformation', () => {
+  context('#submitStudentInformation', function () {
     context('when submitting recover account student information form', function () {
       it('should submit student information', async function () {
         // given
@@ -71,7 +71,7 @@ describe('Unit | Controller | account-recovery | find-sco-record', function () {
     });
   });
 
-  context('#sendEmail', () => {
+  context('#sendEmail', function () {
     context('when user clicks on "C\'est parti!" button', function () {
       it('should send account recovery email', async function () {
         // given
@@ -104,7 +104,7 @@ describe('Unit | Controller | account-recovery | find-sco-record', function () {
     });
   });
 
-  context('#continueAccountRecoveryBackupEmailConfirmation', () => {
+  context('#continueAccountRecoveryBackupEmailConfirmation', function () {
     context('when confirm recover account student information form', function () {
       it('should show recovery account backup email confirmation', async function () {
         // given

--- a/mon-pix/tests/unit/controllers/fill-in-campaign-code_test.js
+++ b/mon-pix/tests/unit/controllers/fill-in-campaign-code_test.js
@@ -27,7 +27,7 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
     controller.set('campaignCode', null);
   });
 
-  describe('#startCampaign', () => {
+  describe('#startCampaign', function () {
     context('campaign does not have GAR as identity provider', function () {
       it('should not show GAR modal', async function () {
         // given
@@ -177,7 +177,7 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
   });
 
   describe('get firstTitle', () => {
-    context('When user is not authenticated', () => {
+    context('When user is not authenticated', function () {
       it('should return the not connected first title', () => {
         // given
         sessionStub.isAuthenticated = false;
@@ -191,7 +191,7 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
       });
     });
 
-    context('When user is authenticated', () => {
+    context('When user is authenticated', function () {
       it('should return the connected first title with user firstName', () => {
         // given
         sessionStub.isAuthenticated = true;
@@ -207,7 +207,7 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
       });
     });
 
-    context('When user is anonymous', () => {
+    context('When user is anonymous', function () {
       it('should return the not connected first title', () => {
         // given
         sessionStub.isAuthenticated = true;

--- a/mon-pix/tests/unit/models/campaign-participation-overview_test.js
+++ b/mon-pix/tests/unit/models/campaign-participation-overview_test.js
@@ -11,9 +11,9 @@ describe('Unit | Model | Campaign-Participation-Overview', function () {
     store = this.owner.lookup('service:store');
   });
 
-  describe('#status', () => {
+  describe('#status', function () {
     context('when the campaign is not archived', function () {
-      context('when the participation status is "started"', () => {
+      context('when the participation status is "started"', function () {
         it('should return the status "ONGOING"', function () {
           // given
           const model = store.createRecord('campaign-participation-overview', {
@@ -24,7 +24,7 @@ describe('Unit | Model | Campaign-Participation-Overview', function () {
         });
       });
 
-      context('when the particiaption status is "TO_SHARE" and the participation is not shared"', () => {
+      context('when the particiaption status is "TO_SHARE" and the participation is not shared"', function () {
         it('should return the status "TO_SHARE"', function () {
           // given
           const model = store.createRecord('campaign-participation-overview', {
@@ -37,7 +37,7 @@ describe('Unit | Model | Campaign-Participation-Overview', function () {
         });
       });
 
-      context('when the participation status is "SHARED" and the participation is shared"', () => {
+      context('when the participation status is "SHARED" and the participation is shared"', function () {
         it('should return the status "ENDED"', function () {
           // given
           const model = store.createRecord('campaign-participation-overview', {
@@ -51,7 +51,7 @@ describe('Unit | Model | Campaign-Participation-Overview', function () {
       });
     });
 
-    context('when the participation is disabled"', () => {
+    context('when the participation is disabled"', function () {
       it('should return the status "disabled"', function () {
         // given
         const model = store.createRecord('campaign-participation-overview', {

--- a/mon-pix/tests/unit/models/challenge_test.js
+++ b/mon-pix/tests/unit/models/challenge_test.js
@@ -117,7 +117,7 @@ describe('Unit | Model | Challenge', function () {
   describe('Computed property #hasValidEmbedDocument', function () {
     let embedOptions;
 
-    beforeEach(() => {
+    beforeEach(function () {
       embedOptions = {
         embedUrl: 'https://embed.url',
         embedTitle: 'Embed title',

--- a/mon-pix/tests/unit/models/profile_test.js
+++ b/mon-pix/tests/unit/models/profile_test.js
@@ -17,7 +17,7 @@ describe('Unit | Model | Profile model', function () {
     expect(model).to.be.ok;
   });
 
-  describe('@areas', () => {
+  describe('@areas', function () {
     it('should return an array of unique areas code', function () {
       return run(() => {
         // given

--- a/mon-pix/tests/unit/models/result-competence_test.js
+++ b/mon-pix/tests/unit/models/result-competence_test.js
@@ -16,7 +16,7 @@ describe('Unit | Model | result-competence model', function () {
     expect(model).to.be.ok;
   });
 
-  describe('#area relationship', () => {
+  describe('#area relationship', function () {
     it('should exist', function () {
       // given
       const competence = store.modelFor('result-competence');

--- a/mon-pix/tests/unit/models/tutorial-evaluation_test.js
+++ b/mon-pix/tests/unit/models/tutorial-evaluation_test.js
@@ -11,7 +11,7 @@ describe('Unit | Model | tutorial-evaluation model', function () {
     store = this.owner.lookup('service:store');
   });
 
-  describe('#nextStatus', () => {
+  describe('#nextStatus', function () {
     it('should return "NEUTRAL" when current status is "LIKED"', function () {
       // given
       const model = store.createRecord('tutorial-evaluation');
@@ -31,7 +31,7 @@ describe('Unit | Model | tutorial-evaluation model', function () {
     });
   });
 
-  describe('#isLiked', () => {
+  describe('#isLiked', function () {
     it('should return true if status is "LIKED"', function () {
       // given
       const model = store.createRecord('tutorial-evaluation');

--- a/mon-pix/tests/unit/models/user_test.js
+++ b/mon-pix/tests/unit/models/user_test.js
@@ -16,7 +16,7 @@ describe('Unit | Model | user model', function () {
     expect(model).to.be.ok;
   });
 
-  describe('#fullName', () => {
+  describe('#fullName', function () {
     it('should concatenate user first and last name', function () {
       // given
       const model = store.createRecord('user');

--- a/mon-pix/tests/unit/routes/assessments/resume_test.js
+++ b/mon-pix/tests/unit/routes/assessments/resume_test.js
@@ -108,7 +108,7 @@ describe('Unit | Route | Assessments | Resume', function () {
       });
 
       context('when assessment is a DEMO, PLACEMENT, CERTIFICATION or PREVIEW', function () {
-        beforeEach(() => {
+        beforeEach(function () {
           assessment.isPlacement = true;
         });
         it('should redirect to the challenge view', function () {
@@ -197,7 +197,7 @@ describe('Unit | Route | Assessments | Resume', function () {
       });
 
       context('when assessment is a CERTIFICATION', function () {
-        beforeEach(() => {
+        beforeEach(function () {
           assessment.isCertification = true;
           assessment.certificationNumber = 666;
         });
@@ -214,7 +214,7 @@ describe('Unit | Route | Assessments | Resume', function () {
       });
 
       context('when assessment is a COMPETENCE_EVALUATION', function () {
-        beforeEach(() => {
+        beforeEach(function () {
           assessment.isCompetenceEvaluation = true;
         });
 

--- a/mon-pix/tests/unit/routes/fill-in-campaign-code_test.js
+++ b/mon-pix/tests/unit/routes/fill-in-campaign-code_test.js
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 describe('Unit | Route | fill-in-campaign-code', function () {
   setupTest();
 
-  context('#beforeModel', () => {
+  context('#beforeModel', function () {
     it('should store externalUser queryParam in session', function () {
       // given
       const externalUser = 'external-user-token';

--- a/mon-pix/tests/unit/routes/logout_test.js
+++ b/mon-pix/tests/unit/routes/logout_test.js
@@ -7,7 +7,7 @@ import { expect } from 'chai';
 
 const AUTHENTICATED_SOURCE_FROM_GAR = ENV.APP.AUTHENTICATED_SOURCE_FROM_GAR;
 
-describe('Unit | Route | logout', () => {
+describe('Unit | Route | logout', function () {
   setupTest();
 
   let sessionStub;
@@ -41,7 +41,7 @@ describe('Unit | Route | logout', () => {
     sinon.assert.calledOnce(campaignStorageStub.clearAll);
   });
 
-  describe('when user is authenticated', () => {
+  describe('when user is authenticated', function () {
     it('should disconnect the authenticated user no matter the connexion source', function () {
       // given
       const invalidateStub = sinon.stub();
@@ -119,7 +119,7 @@ describe('Unit | Route | logout', () => {
     });
   });
 
-  describe('when user is not authenticated', () => {
+  describe('when user is not authenticated', function () {
     it('should redirect to home', function () {
       // given
       const route = this.owner.lookup('route:logout');

--- a/mon-pix/tests/unit/services/errors_test.js
+++ b/mon-pix/tests/unit/services/errors_test.js
@@ -5,7 +5,7 @@ import { setupTest } from 'ember-mocha';
 describe('Unit | Service | errors', function () {
   setupTest();
 
-  describe('#push', () => {
+  describe('#push', function () {
     it('should add error in errors array', function () {
       // given
       const service = this.owner.lookup('service:errors');
@@ -19,7 +19,7 @@ describe('Unit | Service | errors', function () {
     });
   });
 
-  describe('#shift', () => {
+  describe('#shift', function () {
     it('should return first error and remove it', function () {
       // given
       const service = this.owner.lookup('service:errors');
@@ -37,7 +37,7 @@ describe('Unit | Service | errors', function () {
     });
   });
 
-  describe('#hasErrors', () => {
+  describe('#hasErrors', function () {
     it('should return true if there is errors', function () {
       // given
       const service = this.owner.lookup('service:errors');

--- a/mon-pix/tests/unit/utils/errors-messages_test.js
+++ b/mon-pix/tests/unit/utils/errors-messages_test.js
@@ -7,8 +7,8 @@ describe('Unit | Utility | errors-messages', function () {
   const JOIN_SHORT_CODES_ERRORS = ['R11', 'R12', 'R13', 'R31', 'R32', 'R33', 'R70'];
   const REGISTER_SHORT_CODES_ERRORS = ['S51', 'S52', 'S53', 'S61', 'S62', 'S63'];
 
-  describe('#getJoinErrorsMessageByShortCode', () => {
-    it('should retrieve all messages by shortCode with value', () => {
+  describe('#getJoinErrorsMessageByShortCode', function () {
+    it('should retrieve all messages by shortCode with value', function () {
       // given
       const expectedMessages = JOIN_SHORT_CODES_ERRORS.map(
         (shortCode) => 'api-error-messages.join-error.' + shortCode.toLowerCase()
@@ -22,8 +22,8 @@ describe('Unit | Utility | errors-messages', function () {
     });
   });
 
-  describe('#getRegisteErrorsMessageByShortCode', () => {
-    it('should retrieve all messages by shortCode with values', () => {
+  describe('#getRegisteErrorsMessageByShortCode', function () {
+    it('should retrieve all messages by shortCode with values', function () {
       // given
       const expectedMessages = REGISTER_SHORT_CODES_ERRORS.map(
         (shortCode) => 'api-error-messages.register-error.' + shortCode.toLowerCase()


### PR DESCRIPTION
## :christmas_tree: Problème
Mocha recommande de ne pas avoir de fonction fléchée dans nos tests
Nous avons également un besoin de les supprimer pour que le codemod de migration de mocha vers QUnit fonctionne au mieux.

## :gift: Proposition
Ajout de la règle `no-mocha-arrows` en mode 'error' 
Fixer les tests avec npm run lint:js --fix

## :star2: Remarques
RAS

## :santa: Pour tester
Les tests passent
