### PR TITLE
[FEATURE] Reformulation des messages d'erreur sur la création de campagne dans orga (PIX-6056)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -7,7 +7,7 @@
       "name-required": "Please name your campaign.",
       "owner_not_in_organization": "Please select a member of your organization.",
       "purpose-required": "Please select the purpose of your campaign: assess participants or collect their profiles.",
-      "target-profile-required": "Please select a target profile for your campaign.",
+      "target-profile-required": "Please select a customised test for your campaign.",
       "title_too_long": "Please choose a shorter title.",
       "custom-landing-page_too_long": "Please choose a shorter text to display on the starting page."
     },
@@ -939,7 +939,7 @@
         },
         "aria-label":"Filters on students",
         "certificability": {
-          "aria-label": "Enter a status for certificability",          
+          "aria-label": "Enter a status for certificability",
           "label": "Search by certificability"
         },
         "group": {
@@ -954,7 +954,7 @@
         "student-number": {
           "aria-label": "Enter a student number",
           "label": "Search by student number"
-        }, 
+        },
         "students-count": "{count, plural, =0 {0 students} =1 {1 student} other {{count} students}}",
         "title": "Filters"
       }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -7,7 +7,7 @@
       "name-required": "Veuillez donner un nom à votre campagne.",
       "owner_not_in_organization": "Le propriétaire ne fait pas parti de l'organisation.",
       "purpose-required": "Veuillez choisir l’objectif de votre campagne : Évaluation ou Collecte de profils.",
-      "target-profile-required": "Veuillez sélectionner un profil cible pour votre campagne.",
+      "target-profile-required": "Veuillez sélectionner un parcours pour votre campagne.",
       "title_too_long": "Le titre de la campagne est trop long.",
       "custom-landing-page_too_long": "Le texte de présentation de la campagne est trop long."
     },


### PR DESCRIPTION
## :christmas_tree: Problème
Le choix du profil cible lors de la création d’une campagne dans Pix Orga pose des problèmes de compréhension.

## :gift: Proposition
Dans les messages d’erreur, changer “profil cible” pour "parcours" (le nouveau wording retenu)

## :santa: Pour tester
Depuis Orga, aller sur la création d'une campagne. 
↪️ Positionner un nom et sélectionner "Evaluer les participants" comme objectif. 
↪️ Sous la question "Que souhaitez-vous tester ?", positionner un nom de parcours inconnu dans le champ.
↪️ Cliquer sur  Créer la campagne. 
👉 Le message d'erreur parle de "parcours" en français et "customised test" en anglais.
