### PR TITLE
[FEATURE][CERTIF] Déconnecter l'utilisateur quand il arrive sur le lien pour rejoindre un centre de certification via invitation (PIX-6324)

### DIFF
--- a/certif/app/instance-initializers/session.js
+++ b/certif/app/instance-initializers/session.js
@@ -1,0 +1,15 @@
+import PixWindow from 'pix-certif/utils/pix-window';
+
+export function initialize(/* applicationInstance */) {
+  const location = PixWindow.getLocation();
+  const isJoinRoute = !!location.pathname.match(/^\/rejoindre/);
+
+  if (isJoinRoute) {
+    window.localStorage.removeItem('ember_simple_auth-session');
+  }
+}
+
+export default {
+  before: 'ember-simple-auth',
+  initialize,
+};

--- a/certif/app/utils/pix-window.js
+++ b/certif/app/utils/pix-window.js
@@ -1,0 +1,9 @@
+function getLocation() {
+  return window.location;
+}
+
+const PixWindow = {
+  getLocation,
+};
+
+export default PixWindow;

--- a/certif/tests/unit/instance-initializers/session_test.js
+++ b/certif/tests/unit/instance-initializers/session_test.js
@@ -1,0 +1,60 @@
+import Application from '@ember/application';
+import config from 'pix-certif/config/environment';
+import { initialize } from 'pix-certif/instance-initializers/session';
+import { module, test } from 'qunit';
+import Resolver from 'ember-resolver';
+import { run } from '@ember/runloop';
+import sinon from 'sinon';
+import PixWindow from 'pix-certif/utils/pix-window';
+
+module('Unit | Instance Initializer | session', function (hooks) {
+  hooks.beforeEach(function () {
+    this.TestApplication = class TestApplication extends Application {
+      modulePrefix = config.modulePrefix;
+      podModulePrefix = config.podModulePrefix;
+      Resolver = Resolver;
+    };
+    this.TestApplication.instanceInitializer({
+      name: 'initializer under test',
+      initialize,
+    });
+    this.application = this.TestApplication.create({ autoboot: false });
+    this.instance = this.application.buildInstance();
+  });
+  hooks.afterEach(function () {
+    run(this.instance, 'destroy');
+    run(this.application, 'destroy');
+    sinon.restore();
+  });
+
+  module('when a session exists', function () {
+    module('when a user tries to join a certification center through an invitation', function () {
+      test('it should remove the current session before the application loads', async function (assert) {
+        // given
+        const key = 'ember_simple_auth-session';
+        sinon.stub(PixWindow, 'getLocation').returns({ pathname: '/rejoindre?invitationId=1&code=ABCDEF123' });
+        window.localStorage.setItem(
+          key,
+          JSON.stringify({
+            authenticated: {
+              authenticator: 'authenticator:oauth2',
+              token_type: 'bearer',
+              access_token: 'access_token',
+              user_id: 1,
+              refresh_token: 'refresh_token',
+              expires_in: 45,
+              expires_at: 1667837187635,
+            },
+          })
+        );
+
+        // when
+        await this.instance.boot();
+
+        // then
+        const session = window.localStorage.getItem(key);
+        assert.strictEqual(session, null);
+      });
+    });
+  });
+});

--- a/certif/tests/unit/utils/pix-window_test.js
+++ b/certif/tests/unit/utils/pix-window_test.js
@@ -22,4 +22,17 @@ module('Unit | Utilities | pix-window', function (hooks) {
       assert.deepEqual(location, {});
     });
   });
+
+  module('GET window.location.pathname', function () {
+    test('should return the path of the URL', function (assert) {
+      // given
+      sinon.stub(PixWindow, 'getLocation').returns({ pathname: '/path/name' });
+
+      // when
+      const location = PixWindow.getLocation();
+
+      // then
+      assert.strictEqual(location.pathname, '/path/name');
+    });
+  });
 });

--- a/certif/tests/unit/utils/pix-window_test.js
+++ b/certif/tests/unit/utils/pix-window_test.js
@@ -1,0 +1,25 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import PixWindow from 'pix-certif/utils/pix-window';
+import sinon from 'sinon';
+
+module('Unit | Utilities | pix-window', function (hooks) {
+  setupTest(hooks);
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('GET window.location', function () {
+    test('should return an object', function (assert) {
+      // given
+      sinon.stub(PixWindow, 'getLocation').returns({});
+
+      // when
+      const location = PixWindow.getLocation();
+
+      // then
+      assert.deepEqual(location, {});
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement, si une session est ouverte sur l'application Pix Certif et que l'on ouvre un lien pour rejoindre un centre de certification, l'utilisateur actuellement connecté n'est pas déconnecté.

Il faudrait déconnecter l'utilisateur courant avant d'afficher la page permettant de rejoindre un centre de certification avec une invitation encore valide.

## :gift: Proposition

Utiliser un initializer Ember `instance-initializer`. Cet initializer permet d'exécuter un bout de code avant que l'application ne soit chargé, et il peut également être éxecuté avant d'autres initializers.

Dans notre cas, nous allons exécuter cet initializer avant celui d'EmberSimpleAuth. Si l'url contient le terme `/rejoindre`, nous allons supprimer dans le `LocalStorage` la clé associée à EmberSimpleAuth étant `ember_simple_auth-session`

## :star2: Remarques

RAS

## :santa: Pour tester

- Ouvrir la console développeur de votre navigateur sur l'onglet permettant de voir le contenu du `LocalStorage`
- Se connecter sur Pix Certif avec `certifsco@example.net`
- Constatez que l'on est connecté et que le `LocalStorage` contient bien des données de la session en cours
- Modifier l'url en `/rejoindre?invitationId=101259&code=ABCDEF123`
- Constatez que l'on arrive bien sur la double mire avec la partie inscription ouverte (partie gauche)
- Constatez dans le `LocalStorage` que le contenu de la session précédente n'est plus disponible