### PR TITLE
[BUGFIX] Corriger la redirection vers la double mire pour un élève ayant déjà un compte Pix (PIX-6343)

### DIFF
--- a/mon-pix/app/components/routes/campaigns/join-sco-information-modal.js
+++ b/mon-pix/app/components/routes/campaigns/join-sco-information-modal.js
@@ -52,6 +52,7 @@ export default class JoinScoInformationModal extends Component {
 
   @action
   async goToCampaignConnectionForm() {
+    this.session.set('skipRedirectAfterSessionInvalidation', true);
     await this.session.invalidate();
     this.campaignStorage.set(this.args.campaignCode, 'hasUserSeenJoinPage', true);
     this.router.replaceWith('campaigns.access', this.args.campaignCode);

--- a/mon-pix/tests/unit/components/routes/campaigns/join-sco-information-modal_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/join-sco-information-modal_test.js
@@ -9,90 +9,14 @@ describe('Unit | Component | routes/campaigns/join-sco-information-modal', funct
   setupTest();
   setupIntl();
 
-  describe('When reconciliation error is provided', function () {
-    describe('When error is a 422 status', function () {
-      it('should set isAccountBelongingToAnotherUser to true', function () {
-        // given
-        const reconciliationError = {
-          status: '422',
-        };
-
-        // when
-        const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
-          reconciliationError,
-        });
-
-        // then
-        expect(component.isAccountBelongingToAnotherUser).to.be.true;
-      });
-
-      it('should not display continue button', function () {
-        // given
-        const reconciliationError = {
-          status: '422',
-        };
-
-        // when
-        const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
-          reconciliationError,
-        });
-
-        // then
-        expect(component.displayContinueButton).to.be.false;
-      });
-
-      it('should set is isInformationMode to false', function () {
-        // given
-        const reconciliationError = {
-          status: '422',
-        };
-
-        // when
-        const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
-          reconciliationError,
-        });
-
-        // then
-        expect(component.isInformationMode).to.be.false;
-      });
-    });
-
-    describe('When error is a 409 status', function () {
-      const reconciliationError = {
-        status: '409',
-        meta: { shortCode: 'R11', value: 'j***@example.net', userId: 1 },
-      };
-
-      it('should set is isInformationMode to false', function () {
-        // when
-        const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
-          reconciliationError,
-        });
-
-        // then
-        expect(component.isInformationMode).to.be.false;
-      });
-
-      it('should display error message', function () {
-        // given
-        const expectedErrorMessage = this.intl.t('api-error-messages.join-error.r11', {
-          value: reconciliationError.meta.value,
-          htmlSafe: true,
-        });
-
-        // when
-        const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
-          reconciliationError,
-        });
-
-        // then
-        expect(component.message).to.deep.equal(expectedErrorMessage);
-      });
-
-      describe('When error is not related to samlId', function () {
-        it('should display continue button', function () {
+  describe('#constructor', function () {
+    describe('When reconciliation error is provided', function () {
+      describe('When error is a 422 status', function () {
+        it('should set isAccountBelongingToAnotherUser to true', function () {
           // given
-          reconciliationError.meta.shortCode = 'R12';
+          const reconciliationError = {
+            status: '422',
+          };
 
           // when
           const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
@@ -100,14 +24,14 @@ describe('Unit | Component | routes/campaigns/join-sco-information-modal', funct
           });
 
           // then
-          expect(component.displayContinueButton).to.be.true;
+          expect(component.isAccountBelongingToAnotherUser).to.be.true;
         });
-      });
 
-      describe('When error is related to samlId', function () {
         it('should not display continue button', function () {
           // given
-          reconciliationError.meta.shortCode = 'R13';
+          const reconciliationError = {
+            status: '422',
+          };
 
           // when
           const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
@@ -117,41 +41,119 @@ describe('Unit | Component | routes/campaigns/join-sco-information-modal', funct
           // then
           expect(component.displayContinueButton).to.be.false;
         });
+
+        it('should set is isInformationMode to false', function () {
+          // given
+          const reconciliationError = {
+            status: '422',
+          };
+
+          // when
+          const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
+            reconciliationError,
+          });
+
+          // then
+          expect(component.isInformationMode).to.be.false;
+        });
+      });
+
+      describe('When error is a 409 status', function () {
+        const reconciliationError = {
+          status: '409',
+          meta: { shortCode: 'R11', value: 'j***@example.net', userId: 1 },
+        };
+
+        it('should set is isInformationMode to false', function () {
+          // when
+          const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
+            reconciliationError,
+          });
+
+          // then
+          expect(component.isInformationMode).to.be.false;
+        });
+
+        it('should display error message', function () {
+          // given
+          const expectedErrorMessage = this.intl.t('api-error-messages.join-error.r11', {
+            value: reconciliationError.meta.value,
+            htmlSafe: true,
+          });
+
+          // when
+          const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
+            reconciliationError,
+          });
+
+          // then
+          expect(component.message).to.deep.equal(expectedErrorMessage);
+        });
+
+        describe('When error is not related to samlId', function () {
+          it('should display continue button', function () {
+            // given
+            reconciliationError.meta.shortCode = 'R12';
+
+            // when
+            const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
+              reconciliationError,
+            });
+
+            // then
+            expect(component.displayContinueButton).to.be.true;
+          });
+        });
+
+        describe('When error is related to samlId', function () {
+          it('should not display continue button', function () {
+            // given
+            reconciliationError.meta.shortCode = 'R13';
+
+            // when
+            const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
+              reconciliationError,
+            });
+
+            // then
+            expect(component.displayContinueButton).to.be.false;
+          });
+        });
       });
     });
-  });
 
-  describe('When reconciliation warning is provided', function () {
-    const reconciliationWarning = {
-      connectionMethod: 'test@example.net',
-      firstName: 'John',
-      lastName: 'Doe',
-    };
+    describe('When reconciliation warning is provided', function () {
+      const reconciliationWarning = {
+        connectionMethod: 'test@example.net',
+        firstName: 'John',
+        lastName: 'Doe',
+      };
 
-    it('should set is isInformationMode to true', function () {
-      // when
-      const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
-        reconciliationWarning,
+      it('should set is isInformationMode to true', function () {
+        // when
+        const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
+          reconciliationWarning,
+        });
+
+        // then
+        expect(component.isInformationMode).to.be.true;
       });
 
-      // then
-      expect(component.isInformationMode).to.be.true;
-    });
+      it('should display an information message', function () {
+        // given
+        const expectedWarningMessage = this.intl.t('pages.join.sco.login-information-message', {
+          ...reconciliationWarning,
+          htmlSafe: true,
+        });
 
-    it('should display an information message', function () {
-      // given
-      const expectedWarningMessage = this.intl.t('pages.join.sco.login-information-message', {
-        ...reconciliationWarning,
-        htmlSafe: true,
+        // when
+        const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
+          reconciliationWarning,
+        });
+
+        // then
+        expect(component.message).to.deep.equal(expectedWarningMessage);
       });
-
-      // when
-      const component = createComponent('component:routes/campaigns/join-sco-information-modal', {
-        reconciliationWarning,
-      });
-
-      // then
-      expect(component.message).to.deep.equal(expectedWarningMessage);
     });
   });
 });

--- a/mon-pix/tests/unit/components/routes/campaigns/join-sco-information-modal_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/join-sco-information-modal_test.js
@@ -1,9 +1,10 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
-
+import sinon from 'sinon';
 import createComponent from '../../../../helpers/create-glimmer-component';
 import setupIntl from '../../../../helpers/setup-intl';
+import Service from '@ember/service';
 
 describe('Unit | Component | routes/campaigns/join-sco-information-modal', function () {
   setupTest();
@@ -154,6 +155,36 @@ describe('Unit | Component | routes/campaigns/join-sco-information-modal', funct
         // then
         expect(component.message).to.deep.equal(expectedWarningMessage);
       });
+    });
+  });
+
+  describe('#goToCampaignConnectionForm', function () {
+    it('should not redirect user to login page when session is invalidated', function () {
+      // given
+      const component = createComponent('component:routes/campaigns/join-sco-information-modal');
+      const invalidateStub = sinon.stub().resolves();
+      const setStub = sinon.stub();
+      class SessionStub extends Service {
+        invalidate = invalidateStub;
+        set = setStub;
+      }
+      this.owner.register('service:session', SessionStub);
+
+      class CampaignStorageStub extends Service {
+        set = sinon.stub();
+      }
+      this.owner.register('service:campaignStorage', CampaignStorageStub);
+      class RouterStub extends Service {
+        replaceWith = sinon.stub();
+      }
+      this.owner.register('service:router', RouterStub);
+
+      // when
+      component.goToCampaignConnectionForm();
+
+      // then
+      sinon.assert.calledOnce(invalidateStub);
+      sinon.assert.calledWith(setStub, 'skipRedirectAfterSessionInvalidation', true);
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsqu'un élève essaie de rejoindre une campagne SCO à accès restreint sur un compte déjà connecté qui n'est pas le sien, s'il a déjà un compte Pix et doit donc se réconcilier, il ne peut pas aller au bout du process car il est renvoyé sur la page de connexion au lieu d'arriver sur la double mire.

Conditions de reproduction du bug : 
- Etre connecté sur un compte d'un user random.
- Essayer de passer une campagne SCO à accès restreint.
- Essayer de rejoindre l'organisation avec un élève inscrit dans cette organisation. Cet élève doit de plus, n'avoir jamais été rattaché à cette organisation mais posséder un compte Pix.
- Confirmer le fait qu'on veut rejoindre l'organisation de la campagne avec le compte existant.
- Tomber sur la page de connexion au lieu de la page double mire.

## :gift: Proposition
Le soucis vient de l'invalidation de la session. En fait comme on détecte qu'une personne est déjà connectée, avant que l'élève essaie de réconcilier son compte et de se connecter, on déconnecte la personne d'avant.
Sauf que l'invalidation de la session entraine une transition automatique vers la page de login. Transition qui est résolue après la transition vers la page de la double mire. 

Un quick fix un peu moche est donc d'empêcher cette transition vers la page de login via le `skipRedirectAfterSessionInvalidation` que nous avions introduit pour des problématiques de transitions avec le SSO Pôle Emploi. 

## :star2: Remarques
Tout ce parcours utilisateur (réconciliation / connexion / inscription des élèves) mérite un gros refacto et nettoyage. Autant d'un point de vue UX que code. C'est un sujet qui sera traité plus tard.

## :santa: Pour tester
- Lancer Pix APp
- Se connecter avec n'importe quel compte (un user classique)
- Cliquer sur "j'ai un code" + rentrer le code SCOBADGE1 (une campagne sco, SSO GAR)
- Renseigner infos de Georges de Cambridge (22/07/2013)
- Une modale informe que George à déjà un compte qui existe
- Cliquer sur continuer
- Vérifiez que vous arrivez bien sur la double-mire avec la partie "J’ai déjà un compte Pix" déjà préouverte (vous n'êtes pas redirigé vers la page de connexion)

