### PR TITLE
[FEATURE] Renommer le terme "profil cible" par "parcours" dans Pix Orga (PIX-6057)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -400,8 +400,8 @@
       },
       "personalised-test-title": "Title of the customised test",
       "target-profile": {
-        "title": "Target profile",
-        "tooltip": "Target profile's description"
+        "title": "Customised test",
+        "tooltip": "Customised test's description"
       }
     },
     "campaign-individual-results": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -400,8 +400,8 @@
       },
       "personalised-test-title": "Titre du parcours",
       "target-profile": {
-        "title": "Profil cible",
-        "tooltip": "Description du profil cible"
+        "title": "Parcours",
+        "tooltip": "Description du parcours"
       }
     },
     "campaign-individual-results": {


### PR DESCRIPTION
## :christmas_tree: Problème
Le nommage du profil cible dans une campagne dans Pix Orga pose des problèmes de compréhension.

## :gift: Proposition
Dans la page des paramètres d’une campagne, remplacer “profil cible” par “parcours" (le nouveau wording retenu)

## :santa: Pour tester
Depuis Orga, créer d'une campagne.
↪️ Positionner un nom et sélectionner "Evaluer les participants" comme objectif.
↪️ Sélectionner un parcours dans la liste.
↪️ Cliquer sur Créer la campagne.
👉 Le titre de la 2ème ligne des paramètres est maintenant "Parcours" en français et "Customised test" en anglais.
👉 Ce même wording est présent dans le champ aria-tooltip du picto ℹ️ juste au dessous.
La version anglaise est visible en ajoutant "?lang=en" en fin d'url.

