### PR TITLE
[FEATURE] Ajout du bouton de téléchargement de template d'import de session en masse (PIX-6173).

### DIFF
--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -352,7 +352,11 @@ module.exports = {
 
   getSessionsImportTemplate(_, h) {
     const headers = getHeaders();
-    return h.response(headers).header('Content-Type', 'text/csv; charset=utf-8').code(200);
+    return h
+      .response(headers)
+      .header('Content-Type', 'text/csv; charset=utf-8')
+      .header('content-disposition', 'filename=import-sessions')
+      .code(200);
   },
 };
 

--- a/api/tests/acceptance/application/session/session-controller-get-import-template_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-import-template_test.js
@@ -26,6 +26,7 @@ describe('Acceptance | Controller | session-controller-get-import-template', fun
         // then
         expect(response.statusCode).to.equal(200);
         expect(response.headers['content-type']).to.equal('text/csv; charset=utf-8');
+        expect(response.headers['content-disposition']).to.include('filename=import-sessions');
       });
     });
   });

--- a/certif/app/components/sessions/panel-header.hbs
+++ b/certif/app/components/sessions/panel-header.hbs
@@ -1,7 +1,10 @@
 <div class="session-list__header">
   <h1 class="page-title">Sessions de certification</h1>
   {{#if this.shouldRenderImportTemplateButton}}
-    <PixButton aria-label="Télécharger le template d'import en masse">
+    <PixButton
+      aria-label="Télécharger le template d'import en masse"
+      @triggerAction={{this.downloadSessionImportTemplate}}
+    >
       Template import en masse
     </PixButton>
   {{/if}}

--- a/certif/app/components/sessions/panel-header.hbs
+++ b/certif/app/components/sessions/panel-header.hbs
@@ -1,5 +1,10 @@
 <div class="session-list__header">
   <h1 class="page-title">Sessions de certification</h1>
+  {{#if this.shouldRenderImportTemplateButton}}
+    <PixButton aria-label="Télécharger le template d'import en masse">
+      Template import en masse
+    </PixButton>
+  {{/if}}
   <PixButtonLink @route="authenticated.sessions.new">
     Créer une session
     <FaIcon @icon="plus" class="new-session-icon" />

--- a/certif/app/components/sessions/panel-header.hbs
+++ b/certif/app/components/sessions/panel-header.hbs
@@ -1,15 +1,17 @@
 <div class="session-list__header">
-  <h1 class="page-title">{{t 'pages.sessions.list.header.title'}}</h1>
-  {{#if this.shouldRenderImportTemplateButton}}
-    <PixButton
-      aria-label={{t "pages.sessions.list.header.template-import-label"}}
-      @triggerAction={{this.downloadSessionImportTemplate}}
-    >
-      {{t 'pages.sessions.list.header.template-import'}}
-    </PixButton>
-  {{/if}}
-  <PixButtonLink @route="authenticated.sessions.new">
-    {{t 'pages.sessions.list.header.session-creation'}}
-    <FaIcon @icon="plus" class="new-session-icon" />
-  </PixButtonLink>
+  <h1 class="page-title">{{t "pages.sessions.list.header.title"}}</h1>
+  <div class="session-list-header__actions">
+    {{#if this.shouldRenderImportTemplateButton}}
+      <PixButton
+        aria-label={{t "pages.sessions.list.header.template-import-label"}}
+        @triggerAction={{this.downloadSessionImportTemplate}}
+      >
+        {{t "pages.sessions.list.header.template-import"}}
+      </PixButton>
+    {{/if}}
+    <PixButtonLink @route="authenticated.sessions.new">
+      {{t "pages.sessions.list.header.session-creation"}}
+      <FaIcon @icon="plus" class="new-session-icon" />
+    </PixButtonLink>
+  </div>
 </div>

--- a/certif/app/components/sessions/panel-header.hbs
+++ b/certif/app/components/sessions/panel-header.hbs
@@ -1,0 +1,7 @@
+<div class="session-list__header">
+  <h1 class="page-title">Sessions de certification</h1>
+  <PixButtonLink @route="authenticated.sessions.new">
+    Créer une session
+    <FaIcon @icon="plus" class="new-session-icon" />
+  </PixButtonLink>
+</div>

--- a/certif/app/components/sessions/panel-header.hbs
+++ b/certif/app/components/sessions/panel-header.hbs
@@ -1,15 +1,15 @@
 <div class="session-list__header">
-  <h1 class="page-title">Sessions de certification</h1>
+  <h1 class="page-title">{{t 'pages.sessions.list.header.title'}}</h1>
   {{#if this.shouldRenderImportTemplateButton}}
     <PixButton
-      aria-label="Télécharger le template d'import en masse"
+      aria-label={{t "pages.sessions.list.header.template-import-label"}}
       @triggerAction={{this.downloadSessionImportTemplate}}
     >
-      Template import en masse
+      {{t 'pages.sessions.list.header.template-import'}}
     </PixButton>
   {{/if}}
   <PixButtonLink @route="authenticated.sessions.new">
-    Créer une session
+    {{t 'pages.sessions.list.header.session-creation'}}
     <FaIcon @icon="plus" class="new-session-icon" />
   </PixButtonLink>
 </div>

--- a/certif/app/components/sessions/panel-header.js
+++ b/certif/app/components/sessions/panel-header.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class PanelHeader extends Component {
+  @service featureToggles;
+
+  get shouldRenderImportTemplateButton() {
+    return this.featureToggles.featureToggles.isMassiveSessionManagementEnabled;
+  }
+}

--- a/certif/app/components/sessions/panel-header.js
+++ b/certif/app/components/sessions/panel-header.js
@@ -1,10 +1,20 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 
 export default class PanelHeader extends Component {
+  @service fileSaver;
+  @service session;
   @service featureToggles;
 
   get shouldRenderImportTemplateButton() {
     return this.featureToggles.featureToggles.isMassiveSessionManagementEnabled;
+  }
+
+  @action
+  async downloadSessionImportTemplate() {
+    const url = '/api/sessions/import';
+    const token = this.session.data.authenticated.access_token;
+    await this.fileSaver.save({ url, token });
   }
 }

--- a/certif/app/components/sessions/panel-header.js
+++ b/certif/app/components/sessions/panel-header.js
@@ -6,6 +6,7 @@ export default class PanelHeader extends Component {
   @service fileSaver;
   @service session;
   @service featureToggles;
+  @service notifications;
 
   get shouldRenderImportTemplateButton() {
     return this.featureToggles.featureToggles.isMassiveSessionManagementEnabled;
@@ -15,6 +16,10 @@ export default class PanelHeader extends Component {
   async downloadSessionImportTemplate() {
     const url = '/api/sessions/import';
     const token = this.session.data.authenticated.access_token;
-    await this.fileSaver.save({ url, token });
+    try {
+      await this.fileSaver.save({ url, token });
+    } catch (e) {
+      this.notifications.error("Une erreur s'est produite pendant le téléchargement");
+    }
   }
 }

--- a/certif/app/styles/pages/authenticated/sessions/list-items.scss
+++ b/certif/app/styles/pages/authenticated/sessions/list-items.scss
@@ -23,6 +23,14 @@
   }
 }
 
+.session-list-header__actions {
+  display: flex;
+
+  & button {
+    margin-right: 12px;
+  }
+}
+
 .new-session-icon {
   font-weight: 900;
   margin-left: 4px;

--- a/certif/app/templates/authenticated/sessions/list.hbs
+++ b/certif/app/templates/authenticated/sessions/list.hbs
@@ -2,13 +2,7 @@
   {{#if this.displayNoSessionPanel}}
     <NoSessionPanel />
   {{else}}
-    <div class="session-list__header">
-      <h1 class="page-title">Sessions de certification</h1>
-      <PixButtonLink @route="authenticated.sessions.new">
-        Créer une session
-        <FaIcon @icon="plus" class="new-session-icon" />
-      </PixButtonLink>
-    </div>
+    <Sessions::PanelHeader />
 
     <SessionSummaryList @sessionSummaries={{@model}} @goToSessionDetails={{this.goToSessionDetails}} />
   {{/if}}

--- a/certif/tests/integration/components/sessions/panel-header_test.js
+++ b/certif/tests/integration/components/sessions/panel-header_test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { hbs } from 'ember-cli-htmlbars';
+import { render } from '@1024pix/ember-testing-library';
+
+module('Integration | Component | panel-header', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders a link to the new session creation page', async function (assert) {
+    // when
+    const { getByRole } = await render(hbs`<Sessions::PanelHeader />`);
+
+    // then
+    assert.dom(getByRole('link', { name: 'Créer une session' })).exists();
+  });
+});

--- a/certif/tests/integration/components/sessions/panel-header_test.js
+++ b/certif/tests/integration/components/sessions/panel-header_test.js
@@ -1,16 +1,53 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
 import { render } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | panel-header', function (hooks) {
   setupRenderingTest(hooks);
 
   test('it renders a link to the new session creation page', async function (assert) {
+    // given
+    class FeatureTogglesStub extends Service {
+      featureToggles = { isMassiveSessionManagementEnabled: false };
+    }
+    this.owner.register('service:featureToggles', FeatureTogglesStub);
+
     // when
     const { getByRole } = await render(hbs`<Sessions::PanelHeader />`);
 
     // then
     assert.dom(getByRole('link', { name: 'Créer une session' })).exists();
+  });
+
+  module('isMassiveSessionManagementEnabled feature toggle', function () {
+    test('it does not render a download button for the mass import template when toggle is set to false', async function (assert) {
+      // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = { isMassiveSessionManagementEnabled: false };
+      }
+      this.owner.register('service:featureToggles', FeatureTogglesStub);
+
+      // when
+      const { queryByLabelText } = await render(hbs`<Sessions::PanelHeader />`);
+
+      // then
+      assert.dom(queryByLabelText("Télécharger le template d'import en masse")).doesNotExist();
+    });
+
+    test('it renders a download button for the mass import template when toggle is set to true', async function (assert) {
+      // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = { isMassiveSessionManagementEnabled: true };
+      }
+      this.owner.register('service:featureToggles', FeatureTogglesStub);
+
+      // when
+      const { getByLabelText } = await render(hbs`<Sessions::PanelHeader />`);
+
+      // then
+      assert.dom(getByLabelText("Télécharger le template d'import en masse")).exists();
+    });
   });
 });

--- a/certif/tests/integration/components/sessions/panel-header_test.js
+++ b/certif/tests/integration/components/sessions/panel-header_test.js
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import { render } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | panel-header', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it renders a link to the new session creation page', async function (assert) {
     // given

--- a/certif/tests/unit/components/sessions/panel-header_test.js
+++ b/certif/tests/unit/components/sessions/panel-header_test.js
@@ -40,5 +40,26 @@ module('Unit | Component | panel-header', function (hooks) {
         })
       );
     });
+
+    test('should call the notifications service in case of an error', async function (assert) {
+      // given
+      component.session = {
+        isAuthenticated: true,
+        data: {
+          authenticated: {
+            access_token: 'wrong token',
+          },
+        },
+      };
+      component.fileSaver = { save: sinon.stub().rejects() };
+      component.notifications = { error: sinon.spy() };
+
+      // when
+      await component.downloadSessionImportTemplate(event);
+
+      // then
+      sinon.assert.calledOnce(component.notifications.error);
+      assert.ok(component);
+    });
   });
 });

--- a/certif/tests/unit/components/sessions/panel-header_test.js
+++ b/certif/tests/unit/components/sessions/panel-header_test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+import sinon from 'sinon';
+
+module('Unit | Component | panel-header', function (hooks) {
+  setupTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('component:sessions/panel-header');
+  });
+
+  module('#downloadSessionImportTemplate', function () {
+    test('should call the file-saver service for downloadSessionImportTemplate with the right parameters', async function (assert) {
+      // given
+      const token = 'a token';
+
+      component.session = {
+        isAuthenticated: true,
+        data: {
+          authenticated: {
+            access_token: token,
+          },
+        },
+      };
+      component.fileSaver = {
+        save: sinon.stub(),
+      };
+
+      // when
+      await component.downloadSessionImportTemplate(event);
+
+      // then
+      assert.ok(
+        component.fileSaver.save.calledWith({
+          token,
+          url: `/api/sessions/import`,
+        })
+      );
+    });
+  });
+});

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -89,6 +89,12 @@
         "unfinished-test-list-description": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon."
       },
       "list": {
+        "header": {
+          "title": "Sessions de certification",
+          "template-import": "Template import en masse",
+          "template-import-label": "Télécharger le template d'import en masse",
+          "session-creation": "Créer une session"
+        },
         "delete-modal": {
           "title": "Supprimer la session",
           "label": "Souhaitez-vous supprimer la session <span>{sessionId}</span> ?",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -89,6 +89,12 @@
         "unfinished-test-list-description": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon."
       },
       "list": {
+        "header": {
+          "title": "Sessions de certification",
+          "template-import": "Template import en masse",
+          "template-import-label": "Télécharger le template d'import en masse",
+          "session-creation": "Créer une session"
+        },
         "delete-modal": {
           "title": "Supprimer la session",
           "label": "Souhaitez-vous supprimer la session <span>{sessionId}</span> ?",


### PR DESCRIPTION
## :christmas_tree: Problème

A l'heure actuelle, le téléchargement du fichier CSV d'import en masse de sessions ne peut se faire qu'au travers d'un appel réseau.
Nous souhaitons donc ajouter un bon à l'interface de l'application `certif`.

## :gift: Proposition

Ajout d'un bouton de téléchargement du fichier CSV d'import en masse des sessions.

<img width="1519" alt="Capture d’écran 2022-11-18 à 17 38 20" src="https://user-images.githubusercontent.com/36371437/202755970-0007899d-f17e-4754-894c-b05e6cd5892e.png">

## :star2: Remarques

- Nous ajoutons un commit côté back (pour compléter la PR ) afin d'ajouter un nom au fichier téléchargé.
- Le style du bouton n'est pas totalement défini à l'heure actuelle, le CSS sera donc amené à évoluer.
- Ce bouton n'est visible que via l'activation du feature toggle `FT_MASSIVE_SESSION_MANAGEMENT`

## :santa: Pour tester

Une fois le FT activé.

Sur certif : 
- Aller sur la page de sessions
- Vérifier que le téléchargement d'import de sessions fonctionne correctement
