### PR TITLE
[TECH] Déplacer les expect dans les tests de Pix App (PIX-6344).

### DIFF
--- a/mon-pix/tests/acceptance/challenge-feedback_test.js
+++ b/mon-pix/tests/acceptance/challenge-feedback_test.js
@@ -20,35 +20,25 @@ describe('Acceptance | Giving feedback about a challenge', function () {
     server.create('challenge', 'forCompetenceEvaluation');
   });
 
-  function assertThatFeedbackPanelExist() {
-    expect(find('.feedback-panel')).to.exist;
-  }
-
-  function assertThatFeedbackFormIsClosed() {
-    expect(find('.feedback-panel__form')).to.not.exist;
-  }
-
-  function assertThatFeedbackFormIsOpen() {
-    expect(find('.feedback-panel__form')).to.exist;
-  }
-
   context('From a challenge', function () {
     beforeEach(async function () {
+      // when
       await visit(`/assessments/${assessment.id}/challenges/0`);
     });
 
     it('should be able to directly send a feedback', async function () {
-      assertThatFeedbackPanelExist();
+      // then
+      expect(find('.feedback-panel')).to.exist;
     });
 
     context('when the feedback-panel button is clicked', function () {
       beforeEach(async function () {
-        assertThatFeedbackFormIsClosed();
         await click('.feedback-panel__open-button');
       });
 
       it('should open the feedback form', function () {
-        assertThatFeedbackFormIsOpen();
+        // then
+        expect(find('.feedback-panel__form')).to.exist;
       });
 
       context('and the form is filled but not sent', function () {
@@ -64,7 +54,8 @@ describe('Acceptance | Giving feedback about a challenge', function () {
           });
 
           it('should not display the feedback form', function () {
-            assertThatFeedbackFormIsClosed();
+            // then
+            expect(find('.feedback-panel__form')).to.not.exist;
           });
 
           it('should always reset the feedback form between two consecutive challenges', async function () {
@@ -87,7 +78,7 @@ describe('Acceptance | Giving feedback about a challenge', function () {
       await click('.result-item__correction-button');
 
       // then
-      assertThatFeedbackFormIsClosed();
+      expect(find('.feedback-panel__form')).to.not.exist;
     });
 
     it('should be able to give feedback', async function () {
@@ -96,7 +87,7 @@ describe('Acceptance | Giving feedback about a challenge', function () {
       await click('.feedback-panel__open-button');
 
       // then
-      assertThatFeedbackFormIsOpen();
+      expect(find('.feedback-panel__form')).to.exist;
     });
   });
 });

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -758,7 +758,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
         const currentUserId = session.data.authenticated['user_id'];
 
         // then
-        expect(currentUserId).to.be.finite;
+        expect(Number.isFinite(currentUserId)).to.be.true;
         expect(previousUserId).not.to.equal(currentUserId);
       });
     });

--- a/mon-pix/tests/integration/components/feedback-panel_test.js
+++ b/mon-pix/tests/integration/components/feedback-panel_test.js
@@ -54,12 +54,16 @@ describe('Integration | Component | feedback-panel', function () {
       this.owner.register('service:store', StoreStub);
 
       await render(hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`);
+    });
+
+    it('should not display the feedback form', async function () {
+      // then
       expect(find('.feedback-panel__form')).not.to.exist;
-      await click(OPEN_FEEDBACK_BUTTON);
     });
 
     it('should display the "mercix" view when clicking on send button', async function () {
       // given
+      await click(OPEN_FEEDBACK_BUTTON);
       const CONTENT_VALUE = 'Prêtes-moi ta plume, pour écrire un mot';
       await setContent(CONTENT_VALUE);
 
@@ -74,6 +78,7 @@ describe('Integration | Component | feedback-panel', function () {
     context('when selecting a category', function () {
       it('should display a second dropdown with the list of questions when category have a nested level', async function () {
         // when
+        await click(OPEN_FEEDBACK_BUTTON);
         await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_NESTED_LEVEL);
 
         // then
@@ -84,6 +89,7 @@ describe('Integration | Component | feedback-panel', function () {
 
       it('should directly display the message box and the submit button when category has a textarea', async function () {
         // when
+        await click(OPEN_FEEDBACK_BUTTON);
         await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA);
 
         // then
@@ -94,6 +100,7 @@ describe('Integration | Component | feedback-panel', function () {
 
       it('should directly display the tuto without the textbox or the send button when category has a tutorial', async function () {
         // when
+        await click(OPEN_FEEDBACK_BUTTON);
         await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TUTORIAL);
 
         // then
@@ -104,6 +111,7 @@ describe('Integration | Component | feedback-panel', function () {
 
       it('should show the correct feedback action when selecting two different categories', async function () {
         // when
+        await click(OPEN_FEEDBACK_BUTTON);
         await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TUTORIAL);
         await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA);
 
@@ -116,6 +124,7 @@ describe('Integration | Component | feedback-panel', function () {
 
       it('should hide the second dropdown when category has fewer levels after a deeper category', async function () {
         // when
+        await click(OPEN_FEEDBACK_BUTTON);
         await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_NESTED_LEVEL);
         await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA);
 
@@ -128,8 +137,8 @@ describe('Integration | Component | feedback-panel', function () {
 
       it('should display tutorial with textarea with selecting related category and subcategory', async function () {
         // when
+        await click(OPEN_FEEDBACK_BUTTON);
         await fillIn(CATEGORY_DROPDOWN, PICK_ANOTHER_SELECT_OPTION_WITH_NESTED_LEVEL);
-
         await fillIn(SUBCATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA_AND_TUTORIAL);
 
         // then

--- a/mon-pix/tests/integration/components/reset-password-form_test.js
+++ b/mon-pix/tests/integration/components/reset-password-form_test.js
@@ -49,7 +49,7 @@ describe('Integration | Component | reset password form', function () {
       });
     });
 
-    describe('A submit button', () => {
+    describe('A submit button', function () {
       let isSaveMethodCalled, saveMethodOptions;
 
       const save = (options) => {

--- a/mon-pix/tests/integration/components/user-logged-menu_test.js
+++ b/mon-pix/tests/integration/components/user-logged-menu_test.js
@@ -126,8 +126,8 @@ describe('Integration | Component | user logged menu', function () {
       expect(find('.logged-user-menu')).to.not.exist;
     });
 
-    describe('Link to "My tests"', () => {
-      describe('when user has at least one participation', () => {
+    describe('Link to "My tests"', function () {
+      describe('when user has at least one participation', function () {
         beforeEach(function () {
           class currentUserService extends Service {
             user = {
@@ -148,7 +148,7 @@ describe('Integration | Component | user logged menu', function () {
         });
       });
 
-      describe('when user has no participation', () => {
+      describe('when user has no participation', function () {
         it('should not display link to user tests', async function () {
           // when
           await render(hbs`<UserLoggedMenu/>`);

--- a/mon-pix/tests/unit/adapters/sco-organization-learner_test.js
+++ b/mon-pix/tests/unit/adapters/sco-organization-learner_test.js
@@ -127,7 +127,7 @@ describe('Unit | Adapters | sco-organization-learner', function () {
         };
       });
 
-      it('should remove user details', async () => {
+      it('should remove user details', async function () {
         // when
         await adapter.createRecord(null, { modelName: 'sco-organization-learner' }, snapshot);
 

--- a/mon-pix/tests/unit/adapters/user_test.js
+++ b/mon-pix/tests/unit/adapters/user_test.js
@@ -89,7 +89,7 @@ describe('Unit | Adapters | user', function () {
 
   describe('#createRecord', function () {
     context('when campaignCode adapterOption is defined', function () {
-      it('should add campaign-code meta', async () => {
+      it('should add campaign-code meta', async function () {
         // given
         const campaignCode = 'AZERTY123';
         const expectedUrl = 'http://localhost:3000/api/users';

--- a/mon-pix/tests/unit/components/action-chip_test.js
+++ b/mon-pix/tests/unit/components/action-chip_test.js
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 describe('Unit | Component | action-chip', function () {
   setupTest();
 
-  describe('triggerAction', () => {
+  describe('triggerAction', function () {
     it('should trigger the triggerAction when triggerAction is called and isTriggering is false', async function () {
       // given
       const triggerAction = sinon.spy();

--- a/mon-pix/tests/unit/components/challenge-statement_test.js
+++ b/mon-pix/tests/unit/components/challenge-statement_test.js
@@ -47,8 +47,8 @@ describe('Unit | Component | challenge statement', function () {
     });
   });
 
-  describe('#orderedAttachments', () => {
-    it('should return empty array if no attachments', () => {
+  describe('#orderedAttachments', function () {
+    it('should return empty array if no attachments', function () {
       // given
       const challenge = EmberObject.create({});
       const component = createGlimmerComponent('component:challenge-statement', { challenge });
@@ -60,7 +60,7 @@ describe('Unit | Component | challenge statement', function () {
       expect(orderedAttachments.length).to.equal(0);
     });
 
-    it('should return files using the preferred formats first, then the others', () => {
+    it('should return files using the preferred formats first, then the others', function () {
       // given
       const attachments = ['https://dl.airtable.com/test.odp', 'https://dl.airtable.com/test.docx'];
       const challenge = EmberObject.create({ attachments });
@@ -75,7 +75,7 @@ describe('Unit | Component | challenge statement', function () {
       expect(orderedAttachments[1]).to.contains('odp');
     });
 
-    it('should return the attachments ordered alphabetically in each group', () => {
+    it('should return the attachments ordered alphabetically in each group', function () {
       // given
       const attachments = [
         'https://dl.airtable.com/test1.ods',

--- a/mon-pix/tests/unit/components/competence-card-default_test.js
+++ b/mon-pix/tests/unit/components/competence-card-default_test.js
@@ -40,7 +40,7 @@ describe('Unit | Component | competence-card-default ', function () {
       component = createGlimmerComponent('component:competence-card-default', { scorecard, interactive: true });
     });
 
-    it('should return true when remaining days before improving are different than 0', () => {
+    it('should return true when remaining days before improving are different than 0', function () {
       // given
       scorecard.remainingDaysBeforeImproving = 3;
 
@@ -51,7 +51,7 @@ describe('Unit | Component | competence-card-default ', function () {
       expect(result).to.be.true;
     });
 
-    it('should return false when remaining days before improving are equal to 0', () => {
+    it('should return false when remaining days before improving are equal to 0', function () {
       // given
       scorecard.remainingDaysBeforeImproving = 0;
 

--- a/mon-pix/tests/unit/components/markdown-to-html-unsafe_test.js
+++ b/mon-pix/tests/unit/components/markdown-to-html-unsafe_test.js
@@ -46,7 +46,7 @@ describe('Unit | Component | markdown-to-html-unsafe', function () {
     });
   });
 
-  it('should keep rel attribute in tag a when they are present', () => {
+  it('should keep rel attribute in tag a when they are present', function () {
     // given
     const html = '<a href="/test" rel="noopener noreferrer" target="_blank">Lien vers un site</a>';
 
@@ -58,8 +58,8 @@ describe('Unit | Component | markdown-to-html-unsafe', function () {
     expect(component.html.string).to.equal(expectedHtml);
   });
 
-  describe('when extensions are passed in arguments', () => {
-    it('should use this', () => {
+  describe('when extensions are passed in arguments', function () {
+    it('should use this', function () {
       // given
       const markdown = '# Title 1\nCeci est un paragraphe.\n![img](/images.png)';
       const extensions = 'remove-paragraph-tags';

--- a/mon-pix/tests/unit/components/markdown-to-html_test.js
+++ b/mon-pix/tests/unit/components/markdown-to-html_test.js
@@ -47,7 +47,7 @@ describe('Unit | Component | markdown-to-html', function () {
     });
   });
 
-  it('should keep rel attribute in tag a when they are present', () => {
+  it('should keep rel attribute in tag a when they are present', function () {
     // given
     const html = '<a href="/test" rel="noopener noreferrer" target="_blank">Lien vers un site</a>';
 
@@ -59,8 +59,8 @@ describe('Unit | Component | markdown-to-html', function () {
     expect(component.html.string).to.equal(expectedHtml);
   });
 
-  describe('when extensions are passed in arguments', () => {
-    it('should use this', () => {
+  describe('when extensions are passed in arguments', function () {
+    it('should use this', function () {
       // given
       const markdown = '# Title 1\nCeci est un paragraphe.\n![img](/images.png)';
       const extensions = 'remove-paragraph-tags';
@@ -74,8 +74,8 @@ describe('Unit | Component | markdown-to-html', function () {
     });
   });
 
-  describe('when class is provided', () => {
-    it('should remove it', () => {
+  describe('when class is provided', function () {
+    it('should remove it', function () {
       // given
       const markdown = '<h1 class="foo">Test</h1>';
 
@@ -88,8 +88,8 @@ describe('Unit | Component | markdown-to-html', function () {
     });
   });
 
-  describe('when accessibility class is provided', () => {
-    it('should keep it', () => {
+  describe('when accessibility class is provided', function () {
+    it('should keep it', function () {
       // given
       const markdown = '<h1 class="sr-only">Test</h1>';
 

--- a/mon-pix/tests/unit/components/navbar-desktop-header_test.js
+++ b/mon-pix/tests/unit/components/navbar-desktop-header_test.js
@@ -37,7 +37,7 @@ describe('Unit | Component | Navbar Desktop Header Component', function () {
     });
 
     context('#showHeaderMenuItem', function () {
-      it('should return true, when logged user is not anonymous', () => {
+      it('should return true, when logged user is not anonymous', function () {
         // given
         currentUserStub.user.isAnonymous = false;
 
@@ -45,7 +45,7 @@ describe('Unit | Component | Navbar Desktop Header Component', function () {
         expect(component.showHeaderMenuItem).to.be.true;
       });
 
-      it('should return false, when logged user is anonymous', () => {
+      it('should return false, when logged user is anonymous', function () {
         // given
         currentUserStub.user.isAnonymous = true;
 
@@ -81,7 +81,7 @@ describe('Unit | Component | Navbar Desktop Header Component', function () {
     });
 
     context('#showHeaderMenuItem', function () {
-      it('should return false', () => {
+      it('should return false', function () {
         // then
         expect(component.showHeaderMenuItem).to.be.false;
       });

--- a/mon-pix/tests/unit/components/password-reset-demand-form_test.js
+++ b/mon-pix/tests/unit/components/password-reset-demand-form_test.js
@@ -6,14 +6,14 @@ import Service from '@ember/service';
 import { setupTest } from 'ember-mocha';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
-describe('Unit | Component | password-reset-demand-form', () => {
+describe('Unit | Component | password-reset-demand-form', function () {
   setupTest();
 
   let component;
   const sentEmail = 'dumb@people.com';
   let createRecordStub, saveStub;
 
-  describe('#savePasswordResetDemand', () => {
+  describe('#savePasswordResetDemand', function () {
     beforeEach(function () {
       saveStub = sinon.stub().resolves();
       createRecordStub = sinon.stub().resolves({
@@ -27,7 +27,7 @@ describe('Unit | Component | password-reset-demand-form', () => {
       component.email = sentEmail;
     });
 
-    it('should not call api if the user did not enter any email', async () => {
+    it('should not call api if the user did not enter any email', async function () {
       // when
       component.email = undefined;
       await component.savePasswordResetDemand();
@@ -36,7 +36,7 @@ describe('Unit | Component | password-reset-demand-form', () => {
       sinon.assert.notCalled(createRecordStub);
     });
 
-    it('should create a passwordResetDemand Record', async () => {
+    it('should create a passwordResetDemand Record', async function () {
       // when
       await component.savePasswordResetDemand();
 
@@ -45,7 +45,7 @@ describe('Unit | Component | password-reset-demand-form', () => {
       sinon.assert.calledWith(createRecordStub, 'password-reset-demand', { email: sentEmail });
     });
 
-    it('should save email without spaces', async () => {
+    it('should save email without spaces', async function () {
       // given
       const emailWithSpaces = '    user@example.net   ';
       component.email = emailWithSpaces;
@@ -58,7 +58,7 @@ describe('Unit | Component | password-reset-demand-form', () => {
       sinon.assert.calledWith(createRecordStub, 'password-reset-demand', { email: expectedEmail });
     });
 
-    it('should save the password reset demand', async () => {
+    it('should save the password reset demand', async function () {
       // when
       await component.savePasswordResetDemand();
 
@@ -66,7 +66,7 @@ describe('Unit | Component | password-reset-demand-form', () => {
       sinon.assert.called(saveStub);
     });
 
-    it('should display success message when save resolves', async () => {
+    it('should display success message when save resolves', async function () {
       // when
       await component.savePasswordResetDemand();
 

--- a/mon-pix/tests/unit/components/reset-password-form_test.js
+++ b/mon-pix/tests/unit/components/reset-password-form_test.js
@@ -10,7 +10,7 @@ describe('Unit | Component | reset password form', function () {
   setupTest();
   setupIntl();
 
-  describe('#validatePassword', () => {
+  describe('#validatePassword', function () {
     it('should set validation status to default, when component is rendered', function () {
       const component = createGlimmerComponent('component:reset-password-form');
       expect(component.validation.status).to.equal('default');
@@ -41,7 +41,7 @@ describe('Unit | Component | reset password form', function () {
     });
   });
 
-  describe('#handleResetPassword', () => {
+  describe('#handleResetPassword', function () {
     const userWithGoodPassword = EmberObject.create({
       firstName: 'toto',
       lastName: 'riri',
@@ -49,7 +49,7 @@ describe('Unit | Component | reset password form', function () {
       save: () => resolve(),
     });
 
-    describe('When user password is saved', () => {
+    describe('When user password is saved', function () {
       it('should update validation with success data', async function () {
         // given
         const component = createGlimmerComponent('component:reset-password-form', { user: userWithGoodPassword });
@@ -85,7 +85,7 @@ describe('Unit | Component | reset password form', function () {
       });
     });
 
-    describe('When user password saving fails', () => {
+    describe('When user password saving fails', function () {
       [
         {
           status: '400',
@@ -104,7 +104,7 @@ describe('Unit | Component | reset password form', function () {
           message: 'api-error-messages.internal-server-error',
         },
       ].forEach((testCase) => {
-        it(`it should display ${testCase.message} when http status is ${testCase.status}`, async () => {
+        it(`it should display ${testCase.message} when http status is ${testCase.status}`, async function () {
           // given
           const userWithBadPassword = EmberObject.create({
             firstName: 'toto',

--- a/mon-pix/tests/unit/components/routes/campaigns/join/associate-sco-student-with-mediacentre-form_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/join/associate-sco-student-with-mediacentre-form_test.js
@@ -69,7 +69,7 @@ describe('Unit | Component | routes/campaigns/join/associate-sco-student-with-me
       sinon.assert.calledWith(onSubmitStub, externalUser);
     });
 
-    it('should reset error message when submit', async () => {
+    it('should reset error message when submit', async function () {
       // given
       component.errorMessage =
         'Vous êtes un élève ? Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.';
@@ -103,7 +103,7 @@ describe('Unit | Component | routes/campaigns/join/associate-sco-student-with-me
         expect(component.errorMessage.string).to.equal(expectedErrorMessage);
       });
 
-      describe('When student is already reconciled', () => {
+      describe('When student is already reconciled', function () {
         it('should open information modal and set reconciliationError', async function () {
           // given
           const error = { status: '409', meta: { userId: 1 } };
@@ -145,7 +145,7 @@ describe('Unit | Component | routes/campaigns/join/associate-sco-student-with-me
         });
       });
 
-      describe('When student mistyped its information, has an error, and correct it', () => {
+      describe('When student mistyped its information, has an error, and correct it', function () {
         it('should reconcile', async function () {
           // given
           const error = { status: '409', meta: { userId: 1 } };
@@ -165,7 +165,7 @@ describe('Unit | Component | routes/campaigns/join/associate-sco-student-with-me
         });
       });
 
-      describe('When user has an invalid reconciliation', () => {
+      describe('When user has an invalid reconciliation', function () {
         it('should return a bad request error and display the invalid reconciliation error message', async function () {
           // given
           const expectedErrorMessage = this.intl.t('pages.join.sco.invalid-reconciliation-error');

--- a/mon-pix/tests/unit/components/signin-form_test.js
+++ b/mon-pix/tests/unit/components/signin-form_test.js
@@ -8,9 +8,9 @@ import createGlimmerComponent from '../../helpers/create-glimmer-component';
 describe('Unit | Component | signin-form', function () {
   setupTest();
 
-  describe('#signin', () => {
+  describe('#signin', function () {
     context('when user should change password', function () {
-      it('should save reset password token and redirect to update-expired-password', async () => {
+      it('should save reset password token and redirect to update-expired-password', async function () {
         // given
         const eventStub = { preventDefault: sinon.stub() };
         const createRecordStub = sinon.stub();
@@ -44,7 +44,7 @@ describe('Unit | Component | signin-form', function () {
     });
 
     context('when user sign in', function () {
-      it('should authenticate the user even if email contains spaces', async () => {
+      it('should authenticate the user even if email contains spaces', async function () {
         // given
         const foundUser = EmberObject.create({ id: 12 });
         const eventStub = { preventDefault: sinon.stub() };

--- a/mon-pix/tests/unit/components/signup-form_test.js
+++ b/mon-pix/tests/unit/components/signup-form_test.js
@@ -27,8 +27,8 @@ describe('Unit | Component | signup-form', function () {
     component = createGlimmerComponent('component:signup-form');
   });
 
-  describe('#signup', () => {
-    it('should save user without spaces', () => {
+  describe('#signup', function () {
+    it('should save user without spaces', function () {
       // given
       const userWithSpaces = EmberObject.create({
         firstName: '  Chris  ',
@@ -53,7 +53,7 @@ describe('Unit | Component | signup-form', function () {
       expect(pick(user, ['firstName', 'lastName', 'email'])).to.deep.equal(expectedUser);
     });
 
-    it('should authenticate user after sign up', async () => {
+    it('should authenticate user after sign up', async function () {
       const userWithSpaces = EmberObject.create({
         firstName: 'Chris',
         lastName: 'MylastName',
@@ -74,7 +74,7 @@ describe('Unit | Component | signup-form', function () {
       sinon.assert.calledWith(authenticateStub, userWithSpaces.email, userWithSpaces.password);
     });
 
-    it('should send campaignCode when is defined', () => {
+    it('should send campaignCode when is defined', function () {
       // given
       const userWithSpaces = EmberObject.create({
         firstName: '  Chris  ',

--- a/mon-pix/tests/unit/components/update-expired-password-form_test.js
+++ b/mon-pix/tests/unit/components/update-expired-password-form_test.js
@@ -20,7 +20,7 @@ const VALIDATION_MAP = {
   },
 };
 
-describe('Unit | Component | Update Expired Password Form', () => {
+describe('Unit | Component | Update Expired Password Form', function () {
   setupTest();
   setupIntl();
 
@@ -30,12 +30,12 @@ describe('Unit | Component | Update Expired Password Form', () => {
     component = this.owner.lookup('component:update-expired-password-form');
   });
 
-  describe('#validatePassword', () => {
-    it('should set validation status to default, when component is used', () => {
+  describe('#validatePassword', function () {
+    it('should set validation status to default, when component is used', function () {
       expect(component.validation).to.deep.equal(VALIDATION_MAP.default);
     });
 
-    it('should set validation status to error, when there is an validation error on password field', () => {
+    it('should set validation status to error, when there is an validation error on password field', function () {
       //given
       const wrongPassword = 'pix123';
       component.newPassword = wrongPassword;
@@ -47,7 +47,7 @@ describe('Unit | Component | Update Expired Password Form', () => {
       expect(component.validation).to.deep.equal(VALIDATION_MAP.error);
     });
 
-    it('should set validation status to success, when password is valid', () => {
+    it('should set validation status to success, when password is valid', function () {
       //given
       const goodPassword = 'Pix12345';
       component.newPassword = goodPassword;
@@ -60,7 +60,7 @@ describe('Unit | Component | Update Expired Password Form', () => {
     });
   });
 
-  describe('#handleUpdatePasswordAndAuthenticate', () => {
+  describe('#handleUpdatePasswordAndAuthenticate', function () {
     const login = 'beth.rave1203';
     const newPassword = 'Pix67890';
     const scope = 'mon-pix';
@@ -80,8 +80,8 @@ describe('Unit | Component | Update Expired Password Form', () => {
       component.newPassword = newPassword;
     });
 
-    describe('When user password is saved', () => {
-      it('should update validation with success data', async () => {
+    describe('When user password is saved', function () {
+      it('should update validation with success data', async function () {
         // when
         await component.actions.handleUpdatePasswordAndAuthenticate.call(component);
 
@@ -89,7 +89,7 @@ describe('Unit | Component | Update Expired Password Form', () => {
         expect(component.validation).to.deep.equal(VALIDATION_MAP.default);
       });
 
-      it('should remove user password from the store', async () => {
+      it('should remove user password from the store', async function () {
         // when
         await component.actions.handleUpdatePasswordAndAuthenticate.call(component);
 
@@ -97,7 +97,7 @@ describe('Unit | Component | Update Expired Password Form', () => {
         sinon.assert.called(component.resetExpiredPasswordDemand.unloadRecord);
       });
 
-      it('should authenticate with username and newPassword', async () => {
+      it('should authenticate with username and newPassword', async function () {
         // given
         const expectedAuthenticator = 'authenticator:oauth2';
         const expectedParameters = {
@@ -114,8 +114,8 @@ describe('Unit | Component | Update Expired Password Form', () => {
       });
     });
 
-    describe('When update password is rejected by api', () => {
-      it('should set validation with errors data if http 400 error', async () => {
+    describe('When update password is rejected by api', function () {
+      it('should set validation with errors data if http 400 error', async function () {
         // given
         const response = {
           errors: [{ status: '400' }],
@@ -129,7 +129,7 @@ describe('Unit | Component | Update Expired Password Form', () => {
         expect(component.validation).to.deep.equal(VALIDATION_MAP.error);
       });
 
-      it('should set error message if http 401 error', async () => {
+      it('should set error message if http 401 error', async function () {
         // given
         const expectedErrorMessage = component.intl.t('api-error-messages.login-unauthorized-error');
         const response = {
@@ -144,7 +144,7 @@ describe('Unit | Component | Update Expired Password Form', () => {
         expect(component.errorMessage).to.equal(expectedErrorMessage);
       });
 
-      it('should set validation with errors data', async () => {
+      it('should set validation with errors data', async function () {
         // given
         const expectedErrorMessage = component.intl.t('api-error-messages.internal-server-error');
         component.resetExpiredPasswordDemand.updateExpiredPassword.rejects();
@@ -157,8 +157,8 @@ describe('Unit | Component | Update Expired Password Form', () => {
       });
     });
 
-    describe('When authentication after update fails', () => {
-      it('should set authenticationHasFailed to true', async () => {
+    describe('When authentication after update fails', function () {
+      it('should set authenticationHasFailed to true', async function () {
         // given
         component.session.authenticate.rejects();
 

--- a/mon-pix/tests/unit/controllers/campaigns/invited/fill-in-participant-external-id_test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/invited/fill-in-participant-external-id_test.js
@@ -18,8 +18,8 @@ describe('Unit | Controller | Campaigns | Invited | FillInParticipantExternalId'
     controller.router = { transitionTo: sinon.stub() };
   });
 
-  describe('#onSubmitParticipantExternalId', () => {
-    it('should transition to route campaigns.entrance when participant external id is fulfilled', () => {
+  describe('#onSubmitParticipantExternalId', function () {
+    it('should transition to route campaigns.entrance when participant external id is fulfilled', function () {
       // when
       controller.actions.onSubmitParticipantExternalId.call(controller, participantExternalId);
 
@@ -28,8 +28,8 @@ describe('Unit | Controller | Campaigns | Invited | FillInParticipantExternalId'
     });
   });
 
-  describe('#onCancel', () => {
-    it('should transition to landing page', () => {
+  describe('#onCancel', function () {
+    it('should transition to landing page', function () {
       // when
       controller.actions.onCancel.call(controller);
 

--- a/mon-pix/tests/unit/controllers/fill-in-campaign-code_test.js
+++ b/mon-pix/tests/unit/controllers/fill-in-campaign-code_test.js
@@ -122,7 +122,7 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
       });
     });
 
-    it('should set error when campaign code is empty', async () => {
+    it('should set error when campaign code is empty', async function () {
       // given
       controller.set('campaignCode', '');
 
@@ -133,7 +133,7 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
       expect(controller.get('errorMessage')).to.equal('Veuillez saisir un code.');
     });
 
-    it('should set error when no campaign found with code', async () => {
+    it('should set error when no campaign found with code', async function () {
       // given
       const campaignCode = 'azerty1';
       controller.set('campaignCode', campaignCode);
@@ -154,7 +154,7 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
       );
     });
 
-    it('should set error when student is not authorized in campaign', async () => {
+    it('should set error when student is not authorized in campaign', async function () {
       // given
       const campaignCode = 'azerty1';
       controller.set('campaignCode', campaignCode);
@@ -176,9 +176,9 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
     });
   });
 
-  describe('get firstTitle', () => {
+  describe('get firstTitle', function () {
     context('When user is not authenticated', function () {
-      it('should return the not connected first title', () => {
+      it('should return the not connected first title', function () {
         // given
         sessionStub.isAuthenticated = false;
         const expectedFirstTitle = controller.intl.t('pages.fill-in-campaign-code.first-title-not-connected');
@@ -192,7 +192,7 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
     });
 
     context('When user is authenticated', function () {
-      it('should return the connected first title with user firstName', () => {
+      it('should return the connected first title with user firstName', function () {
         // given
         sessionStub.isAuthenticated = true;
         const expectedFirstTitle = controller.intl.t('pages.fill-in-campaign-code.first-title-connected', {
@@ -208,7 +208,7 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
     });
 
     context('When user is anonymous', function () {
-      it('should return the not connected first title', () => {
+      it('should return the not connected first title', function () {
         // given
         sessionStub.isAuthenticated = true;
         currentUserStub.user.isAnonymous = true;
@@ -223,8 +223,8 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
     });
   });
 
-  describe('get isUserAuthenticatedByPix', () => {
-    it('should return session.isAuthenticated', () => {
+  describe('get isUserAuthenticatedByPix', function () {
+    it('should return session.isAuthenticated', function () {
       // given
       sessionStub.isAuthenticated = true;
 
@@ -236,8 +236,8 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
     });
   });
 
-  describe('get isUserAuthenticatedByGAR', () => {
-    it('returns true if an external user token is present', () => {
+  describe('get isUserAuthenticatedByGAR', function () {
+    it('returns true if an external user token is present', function () {
       // given
       sessionStub.get.withArgs('data.externalUser').returns('TOKEN_FROM_GAR');
       controller.set('session', sessionStub);
@@ -249,7 +249,7 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
       expect(isUserAuthenticatedByGAR).to.equal(true);
     });
 
-    it('returns false if there is no external user token in session', () => {
+    it('returns false if there is no external user token in session', function () {
       // given
       sessionStub.get.withArgs('data.externalUser').returns(undefined);
       controller.set('session', sessionStub);
@@ -262,8 +262,8 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
     });
   });
 
-  describe('get showWarningMessage', () => {
-    it('should return true if user is authenticated and not anonymous', () => {
+  describe('get showWarningMessage', function () {
+    it('should return true if user is authenticated and not anonymous', function () {
       // given
       sessionStub.isAuthenticated = true;
       currentUserStub.user.isAnonymous = false;
@@ -275,7 +275,7 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
       expect(showWarningMessage).to.be.true;
     });
 
-    it('should return false if user is not authenticated', () => {
+    it('should return false if user is not authenticated', function () {
       // given
       sessionStub.isAuthenticated = false;
 
@@ -286,7 +286,7 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
       expect(showWarningMessage).to.be.false;
     });
 
-    it('should return false if user is authenticated and anonymous', () => {
+    it('should return false if user is authenticated and anonymous', function () {
       // given
       sessionStub.isAuthenticated = true;
       currentUserStub.user.isAnonymous = true;
@@ -299,8 +299,8 @@ describe('Unit | Controller | Fill in Campaign Code', function () {
     });
   });
 
-  describe('#disconnect', () => {
-    it('should invalidate the session', () => {
+  describe('#disconnect', function () {
+    it('should invalidate the session', function () {
       // when
       controller.disconnect();
 

--- a/mon-pix/tests/unit/controllers/fill-in-certificate-verification-code_test.js
+++ b/mon-pix/tests/unit/controllers/fill-in-certificate-verification-code_test.js
@@ -19,8 +19,8 @@ describe('Unit | Controller | Fill in certificate verification Code', function (
     controller.set('showNotFoundCertificationErrorMessage', false);
   });
 
-  describe('#checkCertificate', () => {
-    it('should set error when certificateVerificationCode code is empty', async () => {
+  describe('#checkCertificate', function () {
+    it('should set error when certificateVerificationCode code is empty', async function () {
       // given
       controller.set('certificateVerificationCode', '');
       const event = { preventDefault: sinon.stub() };
@@ -32,7 +32,7 @@ describe('Unit | Controller | Fill in certificate verification Code', function (
       expect(controller.get('errorMessage')).to.equal('Merci de renseigner le code de vérification.');
     });
 
-    it('should set error when certificateVerificationCode code is not matching the right format', async () => {
+    it('should set error when certificateVerificationCode code is not matching the right format', async function () {
       // given
       controller.set('certificateVerificationCode', 'P-879888');
       const event = { preventDefault: sinon.stub() };
@@ -44,7 +44,7 @@ describe('Unit | Controller | Fill in certificate verification Code', function (
       expect(controller.get('errorMessage')).to.equal('Veuillez vérifier le format de votre code (P-XXXXXXXX).');
     });
 
-    it('should set showNotFoundCertificationErrorMessage to true when no certificate is found', async () => {
+    it('should set showNotFoundCertificationErrorMessage to true when no certificate is found', async function () {
       // given
       controller.set('certificateVerificationCode', 'P-222BBB78');
       storeStub.queryRecord.rejects({ errors: [{ status: '404' }] });
@@ -57,7 +57,7 @@ describe('Unit | Controller | Fill in certificate verification Code', function (
       expect(controller.get('showNotFoundCertificationErrorMessage')).to.equal(true);
     });
 
-    it('should NOT set showNotFoundCertificationErrorMessage to true when a certificate is found', async () => {
+    it('should NOT set showNotFoundCertificationErrorMessage to true when a certificate is found', async function () {
       // given
       controller.set('certificateVerificationCode', 'P-222BBBDD');
       storeStub.queryRecord.resolves({ result: { status: '200' } });

--- a/mon-pix/tests/unit/utils/labeled-checkboxes_test.js
+++ b/mon-pix/tests/unit/utils/labeled-checkboxes_test.js
@@ -100,7 +100,7 @@ describe('Unit | Utility | labeled checkboxes', function () {
           JSON.stringify(testCase.output) +
           ' when ' +
           testCase.when,
-        () => {
+        function () {
           expect(JSON.stringify(labeledCheckboxes(testCase.proposals, testCase.answers))).to.equal(
             JSON.stringify(testCase.output)
           );

--- a/mon-pix/tests/unit/utils/proposals-as-blocks_test.js
+++ b/mon-pix/tests/unit/utils/proposals-as-blocks_test.js
@@ -146,7 +146,7 @@ describe('Unit | Utility | proposals as blocks', function () {
   ];
 
   testData.forEach(({ data, expected }) => {
-    it(`"${data}" retourne ${JSON.stringify(expected)}`, () => {
+    it(`"${data}" retourne ${JSON.stringify(expected)}`, function () {
       expect(proposalsAsBlocks(data)).to.deep.equal(expected);
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement sur Pix App, on trouve des expects dans des beforeEach (pas clean) et dans des fonctions privées, ce qui complique notre migration vers QUnit.

## :gift: Proposition
Déplacer ces expect aux bons endroits.

## :star2: Remarques
On a également supprimé des fonctions fléchées.

## :santa: Pour tester
Les tests doivent passer.
