### PR TITLE
[FEATURE] Trier les résumés de jury de certification par leur nombre de signalements (PIX-6332)

### DIFF
--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -70,7 +70,7 @@
     {{#if this.sessionModel.finalizedAt}}
       <ul class="session-info__list">
         <li class="session-info__list-item">
-          <span>Nombre de signalements impactants non résolus:</span>
+          <span>Nombre de signalements impactants non résolus :</span>
           <span>{{this.sessionModel.countCertificationIssueReportsWithActionRequired}}</span>
         </li>
         <li class="session-info__list-item">

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -7,6 +7,10 @@ const {
 const {
   CertificationIssueReportCategories,
   CertificationIssueReportSubcategories,
+  ImpactfulCategories,
+  ImpactfulSubcategories,
+  DeprecatedCategories,
+  DeprecatedSubcategories,
 } = require('./CertificationIssueReportCategory');
 
 const categoryNonBlockingTechnicalIssueJoiSchema = Joi.object({
@@ -81,40 +85,6 @@ const categorySchemas = {
   [CertificationIssueReportCategories.NON_BLOCKING_TECHNICAL_ISSUE]: categoryNonBlockingTechnicalIssueJoiSchema,
   [CertificationIssueReportCategories.TECHNICAL_PROBLEM]: categoryTechnicalProblemJoiSchema,
 };
-
-const categoryCodeImpactful = [
-  CertificationIssueReportCategories.TECHNICAL_PROBLEM,
-  CertificationIssueReportCategories.OTHER,
-  CertificationIssueReportCategories.FRAUD,
-];
-
-const subcategoryCodeImpactful = [
-  CertificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
-  CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
-  CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
-  CertificationIssueReportSubcategories.FILE_NOT_OPENING,
-  CertificationIssueReportSubcategories.WEBSITE_UNAVAILABLE,
-  CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
-  CertificationIssueReportSubcategories.LINK_NOT_WORKING,
-  CertificationIssueReportSubcategories.OTHER,
-  CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
-  CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
-  CertificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT,
-  CertificationIssueReportSubcategories.SKIP_ON_OOPS,
-  CertificationIssueReportSubcategories.ACCESSIBILITY_ISSUE,
-];
-
-const deprecatedSubcategories = [
-  CertificationIssueReportSubcategories.LINK_NOT_WORKING,
-  CertificationIssueReportSubcategories.OTHER,
-  CertificationIssueReportSubcategories.LEFT_EXAM_ROOM,
-];
-
-const deprecatedCategories = [
-  CertificationIssueReportCategories.TECHNICAL_PROBLEM,
-  CertificationIssueReportCategories.OTHER,
-  CertificationIssueReportCategories.LATE_OR_LEAVING,
-];
 
 class CertificationIssueReport {
   constructor({
@@ -215,13 +185,13 @@ class CertificationIssueReport {
 module.exports = CertificationIssueReport;
 
 function _isImpactful({ category, subcategory }) {
-  return categoryCodeImpactful.includes(category) || subcategoryCodeImpactful.includes(subcategory);
+  return ImpactfulCategories.includes(category) || ImpactfulSubcategories.includes(subcategory);
 }
 
 function _isCategoryDeprecated(category) {
-  return deprecatedCategories.includes(category);
+  return DeprecatedCategories.includes(category);
 }
 
 function _isSubcategoryDeprecated(subcategory) {
-  return deprecatedSubcategories.includes(subcategory);
+  return DeprecatedSubcategories.includes(subcategory);
 }

--- a/api/lib/domain/models/CertificationIssueReportCategory.js
+++ b/api/lib/domain/models/CertificationIssueReportCategory.js
@@ -1,31 +1,72 @@
+const CertificationIssueReportCategories = {
+  OTHER: 'OTHER',
+  CANDIDATE_INFORMATIONS_CHANGES: 'CANDIDATE_INFORMATIONS_CHANGES',
+  SIGNATURE_ISSUE: 'SIGNATURE_ISSUE',
+  CONNECTION_OR_END_SCREEN: 'CONNECTION_OR_END_SCREEN',
+  IN_CHALLENGE: 'IN_CHALLENGE',
+  FRAUD: 'FRAUD',
+  TECHNICAL_PROBLEM: 'TECHNICAL_PROBLEM',
+  NON_BLOCKING_CANDIDATE_ISSUE: 'NON_BLOCKING_CANDIDATE_ISSUE',
+  NON_BLOCKING_TECHNICAL_ISSUE: 'NON_BLOCKING_TECHNICAL_ISSUE',
+  LATE_OR_LEAVING: 'LATE_OR_LEAVING',
+};
+const CertificationIssueReportSubcategories = {
+  LEFT_EXAM_ROOM: 'LEFT_EXAM_ROOM',
+  NAME_OR_BIRTHDATE: 'NAME_OR_BIRTHDATE',
+  EXTRA_TIME_PERCENTAGE: 'EXTRA_TIME_PERCENTAGE',
+  IMAGE_NOT_DISPLAYING: 'IMAGE_NOT_DISPLAYING',
+  LINK_NOT_WORKING: 'LINK_NOT_WORKING',
+  EMBED_NOT_WORKING: 'EMBED_NOT_WORKING',
+  FILE_NOT_OPENING: 'FILE_NOT_OPENING',
+  WEBSITE_UNAVAILABLE: 'WEBSITE_UNAVAILABLE',
+  WEBSITE_BLOCKED: 'WEBSITE_BLOCKED',
+  EXTRA_TIME_EXCEEDED: 'EXTRA_TIME_EXCEEDED',
+  SOFTWARE_NOT_WORKING: 'SOFTWARE_NOT_WORKING',
+  UNINTENTIONAL_FOCUS_OUT: 'UNINTENTIONAL_FOCUS_OUT',
+  OTHER: 'OTHER',
+  SKIP_ON_OOPS: 'SKIP_ON_OOPS',
+  ACCESSIBILITY_ISSUE: 'ACCESSIBILITY_ISSUE',
+};
+
+const ImpactfulCategories = [
+  CertificationIssueReportCategories.TECHNICAL_PROBLEM,
+  CertificationIssueReportCategories.OTHER,
+  CertificationIssueReportCategories.FRAUD,
+];
+
+const ImpactfulSubcategories = [
+  CertificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
+  CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
+  CertificationIssueReportSubcategories.EMBED_NOT_WORKING,
+  CertificationIssueReportSubcategories.FILE_NOT_OPENING,
+  CertificationIssueReportSubcategories.WEBSITE_UNAVAILABLE,
+  CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
+  CertificationIssueReportSubcategories.LINK_NOT_WORKING,
+  CertificationIssueReportSubcategories.OTHER,
+  CertificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED,
+  CertificationIssueReportSubcategories.SOFTWARE_NOT_WORKING,
+  CertificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT,
+  CertificationIssueReportSubcategories.SKIP_ON_OOPS,
+  CertificationIssueReportSubcategories.ACCESSIBILITY_ISSUE,
+];
+
+const DeprecatedSubcategories = [
+  CertificationIssueReportSubcategories.LINK_NOT_WORKING,
+  CertificationIssueReportSubcategories.OTHER,
+  CertificationIssueReportSubcategories.LEFT_EXAM_ROOM,
+];
+
+const DeprecatedCategories = [
+  CertificationIssueReportCategories.TECHNICAL_PROBLEM,
+  CertificationIssueReportCategories.OTHER,
+  CertificationIssueReportCategories.LATE_OR_LEAVING,
+];
+
 module.exports = {
-  CertificationIssueReportCategories: {
-    OTHER: 'OTHER',
-    CANDIDATE_INFORMATIONS_CHANGES: 'CANDIDATE_INFORMATIONS_CHANGES',
-    SIGNATURE_ISSUE: 'SIGNATURE_ISSUE',
-    CONNECTION_OR_END_SCREEN: 'CONNECTION_OR_END_SCREEN',
-    IN_CHALLENGE: 'IN_CHALLENGE',
-    FRAUD: 'FRAUD',
-    TECHNICAL_PROBLEM: 'TECHNICAL_PROBLEM',
-    NON_BLOCKING_CANDIDATE_ISSUE: 'NON_BLOCKING_CANDIDATE_ISSUE',
-    NON_BLOCKING_TECHNICAL_ISSUE: 'NON_BLOCKING_TECHNICAL_ISSUE',
-    LATE_OR_LEAVING: 'LATE_OR_LEAVING',
-  },
-  CertificationIssueReportSubcategories: {
-    LEFT_EXAM_ROOM: 'LEFT_EXAM_ROOM',
-    NAME_OR_BIRTHDATE: 'NAME_OR_BIRTHDATE',
-    EXTRA_TIME_PERCENTAGE: 'EXTRA_TIME_PERCENTAGE',
-    IMAGE_NOT_DISPLAYING: 'IMAGE_NOT_DISPLAYING',
-    LINK_NOT_WORKING: 'LINK_NOT_WORKING',
-    EMBED_NOT_WORKING: 'EMBED_NOT_WORKING',
-    FILE_NOT_OPENING: 'FILE_NOT_OPENING',
-    WEBSITE_UNAVAILABLE: 'WEBSITE_UNAVAILABLE',
-    WEBSITE_BLOCKED: 'WEBSITE_BLOCKED',
-    EXTRA_TIME_EXCEEDED: 'EXTRA_TIME_EXCEEDED',
-    SOFTWARE_NOT_WORKING: 'SOFTWARE_NOT_WORKING',
-    UNINTENTIONAL_FOCUS_OUT: 'UNINTENTIONAL_FOCUS_OUT',
-    OTHER: 'OTHER',
-    SKIP_ON_OOPS: 'SKIP_ON_OOPS',
-    ACCESSIBILITY_ISSUE: 'ACCESSIBILITY_ISSUE',
-  },
+  CertificationIssueReportCategories,
+  CertificationIssueReportSubcategories,
+  ImpactfulCategories,
+  ImpactfulSubcategories,
+  DeprecatedCategories,
+  DeprecatedSubcategories,
 };


### PR DESCRIPTION
## :christmas_tree: Problème
Dans Pix Admin, lorsque l’on se rend sur les “sessions de certification”, puis dans les “sessions à traiter”, on peut visualiser celles qui sont à publier mais qui nécessitent un traitement préalable par le Pôle certif (signalement impactant à résoudre avant la publication). 

Lorsqu'on clique sur une session, on arrive sur les informations de la session de certification présentant notamment le nombre de signalements impactants non résolus (SINR). 
<img width="1374" alt="image" src="https://user-images.githubusercontent.com/35962680/202725608-6df665f3-fd95-40cb-a1e6-120b675bd5d4.png">

Si des SINR sont présents sur une certification présentée ailleurs que sur la première page de l'onglet "Certifications", ceux-ci ne seront pas comptabilisés dans le récapitulatif de l'onglet "Informations". 
<img width="1702" alt="image" src="https://user-images.githubusercontent.com/35962680/202725807-6e1ca27a-9974-4ab8-a869-13fcbd9c7ddd.png">
Ce bug est dû au fait qu'une pagination des résultats de résumés de jury est réalisée côté backend, cette pagination ignore donc les informations présentes après la page 1, ce qui biaise le total affiché dans l'onglet "Informations".

## :gift: Proposition
On met en place un tri des résultats de jury qui met en première position les certifications qui contiennent des signalements impactants non résolus. Ce tri facilitera le travail du pôle certif pour accéder aux certifications pour lesquelles une action est requise. Il permettra dans la majorité des cas de fixer le problème de compteur de l'onglet "Informations" car dans la plupart des cas, moins de 10 certifications (longueur de chaque page de l'onglet "Certifications") présentent des SINR. 

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Se connecter à Pix Admin avec des les données de recette.
- Se rendre sur la page Sessions de certification
- Consulter la session 100000003
- Constater que le nombre de  signalements impactants non résolus est à 1.
- Se rendre sur l'onglet "Certifications" et vérifier que la première certification de la liste est celle comportant un SINR. 