### PR TITLE
[FEATURE][CERTIF] Rediriger l'utilisateur selon le statut de l'invitation (PIX-5007)

### DIFF
--- a/certif/app/components/login-form.hbs
+++ b/certif/app/components/login-form.hbs
@@ -8,6 +8,14 @@
     <p class="login-header__information paragraph">
       L'accès à Pix Certif est limité aux centres de certification Pix.
     </p>
+
+    {{#if @hasInvitationAlreadyBeenAccepted}}
+      <p class="login-header__invitation-error">{{t "pages.login.errors.invitation-already-accepted" htmlSafe=true}}</p>
+    {{/if}}
+
+    {{#if @isInvitationCancelled}}
+      <p class="login-header__invitation-error">{{t "pages.login.errors.invitation-was-cancelled" htmlSafe=true}}</p>
+    {{/if}}
   </header>
 
   <main class="login__main">

--- a/certif/app/routes/join.js
+++ b/certif/app/routes/join.js
@@ -1,5 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import get from 'lodash/get';
+
 export default class JoinRoute extends Route {
   @service store;
   @service router;
@@ -15,8 +17,15 @@ export default class JoinRoute extends Route {
         invitationId: params.invitationId,
         code: params.code,
       })
-      .catch(() => {
-        this.router.replaceWith('login');
+      .catch((errorResponse) => {
+        const status = get(errorResponse, 'errors[0].status');
+        const transition = this.router.replaceWith('login');
+
+        if (status === '403') {
+          transition.data.isInvitationCancelled = true;
+        } else if (status === '412') {
+          transition.data.hasInvitationAlreadyBeenAccepted = true;
+        }
       });
   }
 }

--- a/certif/app/routes/login.js
+++ b/certif/app/routes/login.js
@@ -7,4 +7,13 @@ export default class LoginRoute extends Route {
   beforeModel() {
     this.session.prohibitAuthentication('authenticated');
   }
+
+  setupController(controller, model, transition) {
+    if (transition?.data?.isInvitationCancelled) {
+      controller.set('isInvitationCancelled', true);
+    }
+    if (transition?.data?.hasInvitationAlreadyBeenAccepted) {
+      controller.set('hasInvitationAlreadyBeenAccepted', true);
+    }
+  }
 }

--- a/certif/app/styles/components/login-form.scss
+++ b/certif/app/styles/components/login-form.scss
@@ -35,6 +35,15 @@
     max-width: 400px;
     width: 100%;
   }
+
+  &__invitation-error {
+    border-radius: 3px;
+    color: $pix-error-70;
+    font-size: 0.875rem;
+    margin: 10px 0 16px;
+    padding: 9px;
+    text-align: center;
+  }
 }
 
 .login-main {

--- a/certif/app/templates/login.hbs
+++ b/certif/app/templates/login.hbs
@@ -1,4 +1,7 @@
 {{page-title (t "pages.login.title")}}
 <div class="login-page">
-  <LoginForm />
+  <LoginForm
+    @hasInvitationAlreadyBeenAccepted={{this.hasInvitationAlreadyBeenAccepted}}
+    @isInvitationCancelled={{this.isInvitationCancelled}}
+  />
 </div>

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -261,7 +261,16 @@ export default function () {
 
   this.get('/certification-center-invitations/:id', (schema, request) => {
     const certificationCenterInvitationId = request.params.id;
-    return schema.certificationCenterInvitations.find(certificationCenterInvitationId);
+    const code = request.queryParams?.code;
+
+    switch (code) {
+      case 'CANCELLED':
+        return new Response(403, {}, { errors: [{ status: '403' }] });
+      case 'ACCEPTED':
+        return new Response(412, {}, { errors: [{ status: '412' }] });
+      default:
+        return schema.certificationCenterInvitations.find(certificationCenterInvitationId);
+    }
   });
 
   this.post('/certification-center-invitations/:id/accept', (schema) => {

--- a/certif/tests/acceptance/routes/join_test.js
+++ b/certif/tests/acceptance/routes/join_test.js
@@ -33,4 +33,57 @@ module('Acceptance | Routes | join', function (hooks) {
       assert.dom(screen.getByText('Super Centre de Certif', { exact: false })).exists();
     });
   });
+
+  module('when a user tries to join a certification center', function () {
+    module('with a cancelled invitation link', function () {
+      test('it should redirect the user to the login page and display an error message', async function (assert) {
+        // given
+        const certificationCenterInvitation = server.create('certification-center-invitation', {
+          id: 1,
+          certificationCenterName: 'Super Centre de Certif',
+        });
+
+        // when
+        const screen = await visit(`/rejoindre?invitationId=${certificationCenterInvitation.id}&code=CANCELLED`);
+
+        // then
+        assert.strictEqual(currentURL(), '/connexion');
+        assert
+          .dom(
+            screen.getByText((content) => {
+              return (
+                content === 'Cette invitation n’est plus valide.Contactez l’administrateur de votre espace Pix Certif.'
+              );
+            })
+          )
+          .exists();
+      });
+    });
+
+    module('with an already accepted invitation link', function () {
+      test('it should redirect the user to the login page and display an error message', async function (assert) {
+        // given
+        const certificationCenterInvitation = server.create('certification-center-invitation', {
+          id: 1,
+          certificationCenterName: 'Super Centre de Certif',
+        });
+
+        // when
+        const screen = await visit(`/rejoindre?invitationId=${certificationCenterInvitation.id}&code=ACCEPTED`);
+
+        // then
+        assert.strictEqual(currentURL(), '/connexion');
+        assert
+          .dom(
+            screen.getByText((content) => {
+              return (
+                content ===
+                'Cette invitation a déjà été acceptée.Connectez-vous ou contactez l’administrateur de votre espace Pix Certif.'
+              );
+            })
+          )
+          .exists();
+      });
+    });
+  });
 });

--- a/certif/tests/integration/components/login-form_test.js
+++ b/certif/tests/integration/components/login-form_test.js
@@ -1,5 +1,4 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { click, fillIn } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
@@ -8,13 +7,15 @@ import { reject, resolve } from 'rsvp';
 import ENV from 'pix-certif/config/environment';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+
 const errorMessages = {
   NOT_LINKED_CERTIFICATION_MSG:
     "L'accès à Pix Certif est limité aux centres de certification Pix. Contactez le référent de votre centre de certification si vous pensez avoir besoin d'y accéder.",
 };
 
 module('Integration | Component | login-form', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   let sessionStub;
   class SessionStub extends Service {
@@ -150,5 +151,42 @@ module('Integration | Component | login-form', function (hooks) {
 
     // then
     assert.dom(screen.getByText(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE)).exists();
+  });
+
+  module('when an invitation is cancelled', function () {
+    test('it should display an error message', async function (assert) {
+      // given & when
+      const screen = await renderScreen(hbs`<LoginForm @isInvitationCancelled="true" />`);
+
+      // then
+      assert
+        .dom(
+          screen.getByText((content) => {
+            return (
+              content === 'Cette invitation n’est plus valide.Contactez l’administrateur de votre espace Pix Certif.'
+            );
+          })
+        )
+        .exists();
+    });
+  });
+
+  module('when an invitation has already been accepted', function () {
+    test('it should display an error message', async function (assert) {
+      // given & when
+      const screen = await renderScreen(hbs`<LoginForm @hasInvitationAlreadyBeenAccepted="true" />`);
+
+      // then
+      assert
+        .dom(
+          screen.getByText((content) => {
+            return (
+              content ===
+              'Cette invitation a déjà été acceptée.Connectez-vous ou contactez l’administrateur de votre espace Pix Certif.'
+            );
+          })
+        )
+        .exists();
+    });
   });
 });

--- a/certif/tests/unit/routes/login_test.js
+++ b/certif/tests/unit/routes/login_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 
 module('Unit | Route | login', function (hooks) {
   setupTest(hooks);
@@ -7,5 +8,35 @@ module('Unit | Route | login', function (hooks) {
   test('it exists', function (assert) {
     const route = this.owner.lookup('route:login');
     assert.ok(route);
+  });
+
+  module('#setupController', function () {
+    test('it should set property "isInvitationCancelled" to true', function (assert) {
+      // given
+      const route = this.owner.lookup('route:login');
+      const controller = { set: sinon.stub() };
+      const model = {};
+      const transition = { data: { isInvitationCancelled: true } };
+
+      // when
+      route.setupController(controller, model, transition);
+
+      // then
+      assert.ok(controller.set.calledWith('isInvitationCancelled', true));
+    });
+
+    test('it should set property "hasInvitationAlreadyBeenAccepted" to true', function (assert) {
+      // given
+      const route = this.owner.lookup('route:login');
+      const controller = { set: sinon.stub() };
+      const model = {};
+      const transition = { data: { hasInvitationAlreadyBeenAccepted: true } };
+
+      // when
+      route.setupController(controller, model, transition);
+
+      // then
+      assert.ok(controller.set.calledWith('hasInvitationAlreadyBeenAccepted', true));
+    });
   });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -21,7 +21,11 @@
   },
   "pages": {
     "login": {
-      "title": "Login"
+      "title": "Login",
+      "errors": {
+        "invitation-was-cancelled": "This invitation is no longer valid.<br/>Please contact the administrator of your Pix Certif space.",
+        "invitation-already-accepted": "This invitation has already been accepted.<br/>Please log in or contact the administrator of your Pix Certif space."
+      }
     },
     "login-or-register": {
       "title": "You have been invited to join the certification center {certificationCenterName}",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -21,7 +21,11 @@
   },
   "pages": {
     "login": {
-      "title": "Connectez-vous"
+      "title": "Connectez-vous",
+      "errors": {
+        "invitation-was-cancelled": "Cette invitation n’est plus valide.<br/>Contactez l’administrateur de votre espace Pix Certif.",
+        "invitation-already-accepted": "Cette invitation a déjà été acceptée.<br/>Connectez-vous ou contactez l’administrateur de votre espace Pix Certif."
+      }
     },
     "login-or-register": {
       "title": "Vous êtes invité(e) à rejoindre le centre de certification {certificationCenterName}",


### PR DESCRIPTION
## :christmas_tree: Problème

Lorsqu'un utilisateur clique sur le lien d'une invitation qu'il a déjà accepté, ou que ce lien n'est plus valide, l'utilisateur arrivera sur la page de connexion de l'application Pix Certif sans aucun message pour l'informer de **pourquoi** il est arrivé sur cette page.

## :gift: Proposition

Gérer les 2 erreurs liées à une invitation annulée ou une invitation déjà acceptée en passant cette information lors de la redirection vers la page de connexion, ce qui permettra l'affichage d'un message en fonction de l'erreur obtenu.

## :star2: Remarques

RAS

## :santa: Pour tester

Pour les tests vous avez le choix de créer des invitations au préalable et de les annuler et accepter, ou en modifiant uniquement l'url dans le navigateur avec les informations des invitations des seeds.

#### Modification via l'URL du navigateur

- Invitation acceptée
  - Ouvrir le lien https://certif-pr5244.review.pix.fr/rejoindre?invitationId=101261&code=ABCDEF123
  - Constatez que vous êtes sur la page de connexion avec un message en rouge affiché vous indiquant que l'invitation a déjà été accepté
- Invitation annulée
  - Ouvrir le lien https://certif-pr5244.review.pix.fr/rejoindre?invitationId=101262&code=ABCDEF123
  - Constatez que vous êtes sur la page de connexion avec un message en rouge affiché vous indiquant que l'invitation a été annulée