### PR TITLE
[TECH] Supprimer les erreurs remontées par la migration QUnit sur Pix App - partie 2 (PIX-6347).

### DIFF
--- a/mon-pix/tests/integration/components/campaign-start-block_test.js
+++ b/mon-pix/tests/integration/components/campaign-start-block_test.js
@@ -87,7 +87,7 @@ describe('Integration | Component | campaign-start-block', function () {
     });
 
     context('when the campaign is a PROFILES_COLLECTION type', function () {
-      this.beforeEach(function () {
+      beforeEach(function () {
         this.set('campaign', { type: 'PROFILES_COLLECTION' });
       });
 
@@ -119,7 +119,7 @@ describe('Integration | Component | campaign-start-block', function () {
     });
 
     context('when the campaign is a ASSESSMENT type', function () {
-      this.beforeEach(function () {
+      beforeEach(function () {
         this.set('campaign', { isAssessment: true });
       });
       it('should display all text arguments correctly', async function () {
@@ -186,7 +186,7 @@ describe('Integration | Component | campaign-start-block', function () {
     });
 
     context('when the campaign is a PROFILES_COLLECTION type', function () {
-      this.beforeEach(function () {
+      beforeEach(function () {
         this.set('campaign', { type: 'PROFILES_COLLECTION' });
       });
 
@@ -203,7 +203,7 @@ describe('Integration | Component | campaign-start-block', function () {
     });
 
     context('when the campaign is a ASSESSMENT type', function () {
-      this.beforeEach(function () {
+      beforeEach(function () {
         this.set('campaign', { isAssessment: true });
       });
 
@@ -256,7 +256,7 @@ describe('Integration | Component | campaign-start-block', function () {
     });
 
     context('when the campaign is a PROFILES_COLLECTION type', function () {
-      this.beforeEach(function () {
+      beforeEach(function () {
         this.set('campaign', { type: 'PROFILES_COLLECTION' });
       });
 
@@ -273,7 +273,7 @@ describe('Integration | Component | campaign-start-block', function () {
     });
 
     context('when the campaign is a ASSESSMENT type', function () {
-      this.beforeEach(function () {
+      beforeEach(function () {
         this.set('campaign', { isAssessment: true });
       });
 

--- a/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
@@ -19,7 +19,7 @@ describe('Integration | Component | Challenge Embed Simulator', function () {
     });
   });
 
-  describe('Launch simulator button', () => {
+  describe('Launch simulator button', function () {
     it('should have text "Je lance l\'application"', async function () {
       // when
       await render(hbs`<ChallengeEmbedSimulator />`);
@@ -40,7 +40,7 @@ describe('Integration | Component | Challenge Embed Simulator', function () {
     });
   });
 
-  describe('Reload simulator button', () => {
+  describe('Reload simulator button', function () {
     it('should have text "Réinitialiser"', async function () {
       // when
       await render(hbs`<ChallengeEmbedSimulator />`);

--- a/mon-pix/tests/integration/components/feedback-panel_test.js
+++ b/mon-pix/tests/integration/components/feedback-panel_test.js
@@ -230,7 +230,6 @@ describe('Integration | Component | feedback-panel', function () {
       this.set('challenge', challenge);
 
       await render(hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`);
-      expect(find('.feedback-panel__form')).not.to.exist;
       await click(OPEN_FEEDBACK_BUTTON);
     });
 

--- a/mon-pix/tests/integration/components/form-textfield_test.js
+++ b/mon-pix/tests/integration/components/form-textfield_test.js
@@ -176,7 +176,7 @@ describe('Integration | Component | form textfield', function () {
     });
 
     describe('#When password is hidden', function () {
-      this.beforeEach(async function () {
+      beforeEach(async function () {
         this.set('label', 'Mot de passe');
         this.set('validationStatus', 'default');
         this.set('validationMessage', 'message');

--- a/mon-pix/tests/integration/components/reached-stage_test.js
+++ b/mon-pix/tests/integration/components/reached-stage_test.js
@@ -23,7 +23,13 @@ describe('Integration | Component | reached-stage', function () {
     // then
     expect(find('.reached-stage-score__stars')).to.exist;
     expect(find('.reached-stage-score__percentage-text').textContent.trim()).to.equal('50\u00A0% de réussite');
-    _expectStars(this.reachedStageStarCount, this.stageCount);
+
+    const fullStarCount = this.reachedStageStarCount > 0 ? this.reachedStageStarCount - 1 : 0;
+    const fullStarElement = findAll(".reached-stage-score__stars img[data-test-status='acquired']");
+    const emptyStarElement = findAll(".reached-stage-score__stars img[data-test-status='unacquired']");
+
+    expect(fullStarElement.length).to.equal(fullStarCount);
+    expect(emptyStarElement.length).to.equal(this.stageCount - this.reachedStageStarCount);
   });
 
   describe('stars rendering', function () {
@@ -46,17 +52,13 @@ describe('Integration | Component | reached-stage', function () {
         );
 
         // then
-        _expectStars(starCount, stageCount);
+        const fullStarCount = starCount > 0 ? starCount - 1 : 0;
+        const fullStarElement = findAll(".reached-stage-score__stars img[data-test-status='acquired']");
+        const emptyStarElement = findAll(".reached-stage-score__stars img[data-test-status='unacquired']");
+
+        expect(fullStarElement.length).to.equal(fullStarCount);
+        expect(emptyStarElement.length).to.equal(stageCount - starCount);
       });
     });
   });
 });
-
-function _expectStars(starCount, stageCount) {
-  const fullStarCount = starCount > 0 ? starCount - 1 : 0;
-  const fullStarElement = findAll(".reached-stage-score__stars img[data-test-status='acquired']");
-  const emptyStarElement = findAll(".reached-stage-score__stars img[data-test-status='unacquired']");
-
-  expect(fullStarElement.length).to.equal(fullStarCount);
-  expect(emptyStarElement.length).to.equal(stageCount - starCount);
-}

--- a/mon-pix/tests/integration/components/routes/login-or-register_test.js
+++ b/mon-pix/tests/integration/components/routes/login-or-register_test.js
@@ -11,7 +11,7 @@ describe('Integration | Routes | routes/login-or-register', function () {
     this.set('toggleFormsVisibility', '');
   });
 
-  it('should display the organization name the user is invited to', async () => {
+  it('should display the organization name the user is invited to', async function () {
     // when
     await render(
       hbs`<Routes::LoginOrRegister @organizationName="Organization Aztec" @toggleFormsVisibility=toggleFormsVisibility/>`

--- a/mon-pix/tests/integration/components/signup-form_test.js
+++ b/mon-pix/tests/integration/components/signup-form_test.js
@@ -643,7 +643,7 @@ describe('Integration | Component | SignupForm', function () {
     });
   });
 
-  describe('Loading management', () => {
+  describe('Loading management', function () {
     it('should not display any loading spinner by default', async function () {
       // given
       this.set('user', userEmpty);

--- a/mon-pix/tests/integration/components/user-account/email-with-validation-form-test.js
+++ b/mon-pix/tests/integration/components/user-account/email-with-validation-form-test.js
@@ -8,7 +8,7 @@ import { contains } from '../../../helpers/contains';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
-describe('Integration | Component | user-account | email-with-validation-form', () => {
+describe('Integration | Component | user-account | email-with-validation-form', function () {
   setupIntlRenderingTest();
 
   context('when editing e-mail', function () {

--- a/mon-pix/tests/unit/components/routes/campaigns/invited/associate-sco-student-form_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/invited/associate-sco-student-form_test.js
@@ -150,7 +150,7 @@ describe('Unit | Component | routes/campaigns/invited/associate-sco-student-form
         expect(component.errorMessage.string).to.equal(expectedErrorMessage);
       });
 
-      describe('When student is already reconciled', () => {
+      describe('When student is already reconciled', function () {
         it('should open information modal and set reconciliationError', async function () {
           // given
           const error = { status: '409', meta: { userId: 1 } };
@@ -191,7 +191,7 @@ describe('Unit | Component | routes/campaigns/invited/associate-sco-student-form
         });
       });
 
-      describe('When student mistyped its information, has an error, and correct it', () => {
+      describe('When student mistyped its information, has an error, and correct it', function () {
         it('should reconcile', async function () {
           // given
           const error = { status: '409', meta: { userId: 1 } };
@@ -212,7 +212,7 @@ describe('Unit | Component | routes/campaigns/invited/associate-sco-student-form
         });
       });
 
-      describe('When user has an invalid reconciliation', () => {
+      describe('When user has an invalid reconciliation', function () {
         it('should return a bad request error and display the invalid reconciliation error message', async function () {
           // given
           const expectedErrorMessage = this.intl.t('pages.join.sco.invalid-reconciliation-error');
@@ -228,7 +228,7 @@ describe('Unit | Component | routes/campaigns/invited/associate-sco-student-form
         });
       });
 
-      describe('When user is trying to reconcile on another account', () => {
+      describe('When user is trying to reconcile on another account', function () {
         it('should open information modal and set reconciliationError', async function () {
           // given
           const error = { status: '422', code: 'ACCOUNT_SEEMS_TO_BELONGS_TO_ANOTHER_USER' };

--- a/mon-pix/tests/unit/components/routes/campaigns/invited/fill-in-participant-external-id_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/invited/fill-in-participant-external-id_test.js
@@ -30,8 +30,8 @@ describe('Unit | Component | routes/campaigns/invited/fill-in-participant-extern
     });
   });
 
-  describe('#submit', () => {
-    it('should succeed when participantExternalId is correct', async () => {
+  describe('#submit', function () {
+    it('should succeed when participantExternalId is correct', async function () {
       // given
       component.participantExternalId = participantExternalId;
 
@@ -43,7 +43,7 @@ describe('Unit | Component | routes/campaigns/invited/fill-in-participant-extern
       sinon.assert.called(eventStub.preventDefault);
     });
 
-    it('should display error when participant external id is empty', async () => {
+    it('should display error when participant external id is empty', async function () {
       // given
       component.participantExternalId = '';
 
@@ -54,7 +54,7 @@ describe('Unit | Component | routes/campaigns/invited/fill-in-participant-extern
       expect(component.errorMessage).to.equal(`Merci de renseigner votre ${component.args.campaign.idPixLabel}.`);
     });
 
-    it('should display error when participant external id exceed 255 characters', async () => {
+    it('should display error when participant external id exceed 255 characters', async function () {
       // given
       component.participantExternalId =
         '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
@@ -69,8 +69,8 @@ describe('Unit | Component | routes/campaigns/invited/fill-in-participant-extern
     });
   });
 
-  describe('#cancel', () => {
-    it('should abort and call its parent method', async () => {
+  describe('#cancel', function () {
+    it('should abort and call its parent method', async function () {
       // when
       await component.actions.cancel.call(component);
 

--- a/mon-pix/tests/unit/components/routes/login-form_test.js
+++ b/mon-pix/tests/unit/components/routes/login-form_test.js
@@ -40,7 +40,7 @@ describe('Unit | Component | routes/login-form', function () {
     component.args.addGarAuthenticationMethodToUser = addGarAuthenticationMethodToUserStub;
   });
 
-  describe('#authenticate', () => {
+  describe('#authenticate', function () {
     context('when user is a Pix user', function () {
       it('should not notify error when authentication succeeds', async function () {
         // when

--- a/mon-pix/tests/unit/controllers/account-recovery/update-sco-record-test.js
+++ b/mon-pix/tests/unit/controllers/account-recovery/update-sco-record-test.js
@@ -7,7 +7,7 @@ import Service from '@ember/service';
 describe('Unit | Controller | account-recovery | update-sco-record', function () {
   setupTest();
 
-  describe('#updateRecord', () => {
+  describe('#updateRecord', function () {
     context('when user is already authenticated', function () {
       it('should update account-recovery-demand, invalidate the session and authenticate user', async function () {
         // given

--- a/mon-pix/tests/unit/controllers/assessments/challenge_test.js
+++ b/mon-pix/tests/unit/controllers/assessments/challenge_test.js
@@ -20,7 +20,7 @@ describe('Unit | Controller | Assessments | Challenge', function () {
     sinon.restore();
   });
 
-  describe('#pageTitle', () => {
+  describe('#pageTitle', function () {
     it('should return Épreuve 2 sur 5', function () {
       // given
       controller.model = {
@@ -60,7 +60,7 @@ describe('Unit | Controller | Assessments | Challenge', function () {
     });
   });
 
-  describe('#displayHomeLink', () => {
+  describe('#displayHomeLink', function () {
     it('should not display home link', function () {
       // given
       controller.currentUser = Service.create({ user: { isAnonymous: true } });
@@ -78,7 +78,7 @@ describe('Unit | Controller | Assessments | Challenge', function () {
     });
   });
 
-  describe('#showLevelup', () => {
+  describe('#showLevelup', function () {
     it('should display level up pop-in', function () {
       // given
       controller.newLevel = true;

--- a/mon-pix/tests/unit/controllers/assessments/checkpoint_test.js
+++ b/mon-pix/tests/unit/controllers/assessments/checkpoint_test.js
@@ -15,7 +15,7 @@ describe('Unit | Controller | Assessments | Checkpoint', function () {
     controller = this.owner.lookup('controller:assessments/checkpoint');
   });
 
-  describe('#nextPageButtonText', () => {
+  describe('#nextPageButtonText', function () {
     it('should propose to continue the assessment if it is not the final checkpoint', function () {
       // when
       controller.set('finalCheckpoint', false);
@@ -33,14 +33,14 @@ describe('Unit | Controller | Assessments | Checkpoint', function () {
     });
   });
 
-  describe('#finalCheckpoint', () => {
+  describe('#finalCheckpoint', function () {
     it('should equal false by default', function () {
       // then
       expect(controller.finalCheckpoint).to.be.false;
     });
   });
 
-  describe('#completionPercentage', () => {
+  describe('#completionPercentage', function () {
     it('should equal 100 if it is the final checkpoint', function () {
       // when
       controller.set('finalCheckpoint', true);
@@ -63,7 +63,7 @@ describe('Unit | Controller | Assessments | Checkpoint', function () {
     });
   });
 
-  describe('#shouldDisplayAnswers', () => {
+  describe('#shouldDisplayAnswers', function () {
     it('should be true when answers are present', function () {
       // when
       const model = {
@@ -85,7 +85,7 @@ describe('Unit | Controller | Assessments | Checkpoint', function () {
     });
   });
 
-  describe('#displayHomeLink', () => {
+  describe('#displayHomeLink', function () {
     it('should not display home link when user is anonymous', function () {
       // given
       controller.currentUser = Service.create({ user: { isAnonymous: true } });
@@ -109,7 +109,7 @@ describe('Unit | Controller | Assessments | Checkpoint', function () {
     });
   });
 
-  describe('#showLevelup', () => {
+  describe('#showLevelup', function () {
     it('should display level up pop-in when user has level up', function () {
       // given
       controller.newLevel = true;

--- a/mon-pix/tests/unit/controllers/campaigns/campaign-landing-page_test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/campaign-landing-page_test.js
@@ -12,7 +12,7 @@ describe('Unit | Controller | Campaigns | Landing Page', function () {
     controller.router = { transitionTo: sinon.stub() };
   });
 
-  describe('#startCampaignParticipation', () => {
+  describe('#startCampaignParticipation', function () {
     it('should redirect to route campaigns.access', function () {
       // given
       controller.set('model', { code: 'konami' });

--- a/mon-pix/tests/unit/controllers/campaigns/join/student-sco_test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/join/student-sco_test.js
@@ -2,7 +2,7 @@ import { beforeEach, describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
 
-describe('Unit | Controller | campaigns | join | student-sco', () => {
+describe('Unit | Controller | campaigns | join | student-sco', function () {
   setupTest();
 
   let controller;
@@ -31,8 +31,8 @@ describe('Unit | Controller | campaigns | join | student-sco', () => {
     controller.set('currentUser', currentUserStub);
   });
 
-  describe('#addGarAuthenticationMethodToUser', () => {
-    it('should add GAR authentication method and clear IdToken', async () => {
+  describe('#addGarAuthenticationMethodToUser', function () {
+    it('should add GAR authentication method and clear IdToken', async function () {
       // given
       const externalUserToken = 'ABCD';
 
@@ -60,7 +60,7 @@ describe('Unit | Controller | campaigns | join | student-sco', () => {
       sinon.assert.calledWith(sessionStub.set, 'data.expectedUserId', null);
     });
 
-    it('should reconcile user', async () => {
+    it('should reconcile user', async function () {
       // given
       const expectedExternalUserAuthenticationRequest = {
         save: sinon.stub(),

--- a/mon-pix/tests/unit/instance-initializers/session-test.js
+++ b/mon-pix/tests/unit/instance-initializers/session-test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { describe, it, beforeEach, afterEach } from 'mocha';
+import { describe, it } from 'mocha';
 import Application from '@ember/application';
 import { initialize } from 'mon-pix/instance-initializers/session';
 import { run } from '@ember/runloop';
@@ -8,29 +8,20 @@ import PixWindow from 'mon-pix/utils/pix-window';
 import sinon from 'sinon';
 
 describe('Unit | Instance Initializer | session', function () {
-  beforeEach(function () {
-    run(() => {
-      // eslint-disable-next-line ember/no-classic-classes
-      this.TestApplication = Application.extend();
-      this.TestApplication.instanceInitializer({
-        name: 'initializer under test',
-        initialize,
-      });
-      this.application = this.TestApplication.create({ autoboot: false, Resolver, modulePrefix: 'mon-pix-test' });
-      this.instance = this.application.buildInstance();
-    });
-  });
-  afterEach(function () {
-    run(this.instance, 'destroy');
-    run(this.application, 'destroy');
-
-    sinon.restore();
-  });
-
   context('when a session exists', function () {
     context('when a user finalizes a GAR authentication process', function () {
       it('should remove the current session before the application loads', async function () {
         // given
+        run(() => {
+          // eslint-disable-next-line ember/no-classic-classes
+          this.TestApplication = Application.extend();
+          this.TestApplication.instanceInitializer({
+            name: 'initializer under test',
+            initialize,
+          });
+          this.application = this.TestApplication.create({ autoboot: false, Resolver, modulePrefix: 'mon-pix-test' });
+          this.instance = this.application.buildInstance();
+        });
         const key = 'ember_simple_auth-session';
         sinon.stub(PixWindow, 'getLocationHref').returns('/connexion/gar#access_token');
         window.localStorage.setItem(
@@ -54,12 +45,25 @@ describe('Unit | Instance Initializer | session', function () {
         // then
         const session = window.localStorage.getItem(key);
         expect(session).to.be.null;
+        run(this.instance, 'destroy');
+        run(this.application, 'destroy');
+        sinon.restore();
       });
     });
 
     context('when current URL contains externalUser as query parameter', function () {
       it('should remove the current session before the application loads', async function () {
         // given
+        run(() => {
+          // eslint-disable-next-line ember/no-classic-classes
+          this.TestApplication = Application.extend();
+          this.TestApplication.instanceInitializer({
+            name: 'initializer under test',
+            initialize,
+          });
+          this.application = this.TestApplication.create({ autoboot: false, Resolver, modulePrefix: 'mon-pix-test' });
+          this.instance = this.application.buildInstance();
+        });
         const key = 'ember_simple_auth-session';
         sinon.stub(PixWindow, 'getLocationHref').returns('/campagnes?externalUser=EXTERNAL_USER_TOKEN');
         window.localStorage.setItem(
@@ -83,6 +87,9 @@ describe('Unit | Instance Initializer | session', function () {
         // then
         const session = window.localStorage.getItem(key);
         expect(session).to.be.null;
+        run(this.instance, 'destroy');
+        run(this.application, 'destroy');
+        sinon.restore();
       });
     });
   });

--- a/mon-pix/tests/unit/utils/pix-window_test.js
+++ b/mon-pix/tests/unit/utils/pix-window_test.js
@@ -2,8 +2,11 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import PixWindow from 'mon-pix/utils/pix-window';
 import sinon from 'sinon';
+import { setupTest } from 'ember-mocha';
 
 describe('Unit | Utilities | pix-window', function () {
+  setupTest();
+
   afterEach(function () {
     sinon.restore();
   });


### PR DESCRIPTION
## :christmas_tree: Problème
Sur Pix App, plusieurs erreurs provoquent un mauvais fonctionnement du script de migration de mocha vers QUnit : 
- l'utilisation du this pour le beforeEach
- ENCORE des fonctions fléchées 
- des expect aux mauvais endroits
- setupTest manquants

## :gift: Proposition
Corriger ces quatre cas de figure

## :santa: Pour tester
- Les tests passent