### PR TITLE
[BUGFIX] Couleur des titre et body sur la page de finalisation (PIX-5791)

### DIFF
--- a/certif/app/components/session-finalization-step-container.hbs
+++ b/certif/app/components/session-finalization-step-container.hbs
@@ -1,10 +1,10 @@
 <div class="panel session-finalization-step-container">
   <div class="session-finalization-step-container__header">
-    <img src={{@icon}} alt={{@iconAlt}} class="session-finalization-step-container__icon" />
+    <img src={{@icon}} alt={{@iconAlt}} />
     <div class="session-finalization-step-container__titles">
-      <div>{{@title}}</div>
+      <div class="session-finalization-step-container__page-title">{{@title}}</div>
       {{#if @subtitle}}
-        <div class="session-finalization-step-container__subtitle">{{@subtitle}}</div>
+        <p>{{@subtitle}}</p>
       {{/if}}
     </div>
   </div>

--- a/certif/app/styles/components/session-finalization-step-container.scss
+++ b/certif/app/styles/components/session-finalization-step-container.scss
@@ -3,25 +3,34 @@
   flex-direction: column;
   margin-bottom: 24px;
 
-  &__header {
-    align-items: center;
-    border-radius: 8px;
-    display: flex;
-    background: $pix-neutral-10;
-    margin: 8px;
-    color: $pix-neutral-60;
-    font-weight: bold;
-    padding: 20px 0 19px 24px;
+  &__page-title {
+    color: $pix-neutral-90;
+    font-family: $font-open-sans;
+    font-size: 1rem;
+    font-weight: 700;
+    margin: 0;
   }
 
-  &__subtitle {
+  p {
+    color: $pix-neutral-60;
     font-size: 0.875rem;
     font-weight: normal;
-    margin-top: 8px;
+    margin: 8px 0 0;
   }
 
-  &__icon {
-    margin-right: 24px;
+  &__header {
+    align-items: center;
+    background: $pix-neutral-10;
+    border-radius: 8px;
+    display: flex;
+    margin: 16px;
+    padding: 20px 24px;
+  }
+
+  &__titles {
+    display: flex;
+    flex-direction: column;
+    margin-left: 24px;
   }
 
   &__border {


### PR DESCRIPTION
## :christmas_tree: Problème
Dans la page détails d’une session sur Pix Certif, lorsque je clique sur le bouton “finaliser” en bas à droite de l'écran, j’arrive sur la page de finalisation d’une session.

Les couleurs des textes ne sont pas raccord avec l'usage conventionnel.

## :gift: Proposition
Changer la couleur des textes et de la taille des margin. 
Voir maquette : https://www.figma.com/file/IWVcwbasXoFUQPhIG097XT/Pix-Certif?node-id=714%3A14758&t=lKu9jy8mhGZYof8t-0

## :santa: Pour tester
Dans la page détails d’une session sur Pix Certif, lorsque je clique sur le bouton “finaliser” en bas à droite de l'écran, j’arrive sur la page de finalisation d’une session.

Avant :
![Screenshot 2022-11-18 at 15-27-22 Finalisation Session 11 Pix Certif](https://user-images.githubusercontent.com/11388201/202727959-dc66c0da-522b-49c5-aa30-9e80a2e08c30.png)

Après : 
![Screenshot 2022-11-18 at 15-26-50 Finalisation Session 11 Pix Certif](https://user-images.githubusercontent.com/11388201/202727995-8bbec4fc-3eea-4b8b-a71d-4e17d10c291b.png)

