### PR TITLE
[TECH] Supprimer les contains dans les tests de Pix App (PIX-6350).

### DIFF
--- a/mon-pix/tests/acceptance/account-recovery/find-sco-record_test.js
+++ b/mon-pix/tests/acceptance/account-recovery/find-sco-record_test.js
@@ -3,12 +3,11 @@ import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { currentURL } from '@ember/test-helpers';
-import { visit } from '@1024pix/ember-testing-library';
 import setupIntl from '../../helpers/setup-intl';
 import { fillInByLabel } from '../../helpers/fill-in-by-label';
 import { clickByLabel } from '../../helpers/click-by-label';
-import { contains } from '../../helpers/contains';
 import { Response } from 'miragejs';
+import { visit } from '@1024pix/ember-testing-library';
 
 describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
   setupApplicationTest();
@@ -79,13 +78,19 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
       server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
 
       // when
-      await visit('/recuperer-mon-compte');
+      const screen = await visit('/recuperer-mon-compte');
       await fillStudentInformationFormAndSubmit(this);
 
       // then
-      expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.not.exist;
       expect(
-        contains(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.good-news', { firstName }))
+        screen.queryByRole('heading', {
+          name: this.intl.t('pages.account-recovery.find-sco-record.student-information.title'),
+        })
+      ).to.not.exist;
+      expect(
+        screen.getByRole('heading', {
+          name: this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.good-news', { firstName }),
+        })
       ).to.exist;
     });
 
@@ -105,13 +110,21 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
       server.post('/sco-organization-learners/account-recovery', () => errorsApi);
 
       // when
-      await visit('/recuperer-mon-compte');
+      const screen = await visit('/recuperer-mon-compte');
       await fillStudentInformationFormAndSubmit(this);
 
       // then
-      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-      expect(contains(this.intl.t('pages.account-recovery.errors.key-used'))).to.exist;
-      expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+      expect(
+        screen.getByRole('heading', {
+          name: this.intl.t('pages.account-recovery.errors.title'),
+        })
+      ).to.exist;
+      expect(screen.getByText(this.intl.t('pages.account-recovery.errors.key-used'))).to.exist;
+      expect(
+        screen.getByRole('link', {
+          name: this.intl.t('navigation.back-to-homepage'),
+        })
+      ).to.exist;
     });
 
     context('click on "Cancel" button', function () {
@@ -120,16 +133,22 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
         server.create('user', { id: 1, firstName, lastName, username });
         server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
 
-        await visit('/recuperer-mon-compte');
+        const screen = await visit('/recuperer-mon-compte');
         await fillStudentInformationFormAndSubmit(this);
 
         // when
         await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.cancel'));
 
         // then
-        expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.exist;
         expect(
-          contains(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.good-news', { firstName }))
+          screen.getByRole('heading', {
+            name: this.intl.t('pages.account-recovery.find-sco-record.student-information.title'),
+          })
+        ).to.exist;
+        expect(
+          screen.queryByText(
+            this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.good-news', { firstName })
+          )
         ).to.not.exist;
       });
     });
@@ -138,13 +157,19 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
   context('when submitting information form with invalid data', function () {
     it('should show a not found error', async function () {
       // given & when
-      await visit('/recuperer-mon-compte');
+      const screen = await visit('/recuperer-mon-compte');
       await fillStudentInformationFormAndSubmit(this);
 
       // then
-      expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.exist;
       expect(
-        contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.errors.not-found'))
+        screen.getByRole('heading', {
+          name: this.intl.t('pages.account-recovery.find-sco-record.student-information.title'),
+        })
+      ).to.exist;
+      expect(
+        screen.getByRole('link', {
+          name: this.intl.t('pages.account-recovery.find-sco-record.contact-support.link-text'),
+        })
       ).to.exist;
     });
   });
@@ -167,14 +192,18 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
       });
 
       //when
-      await visit('/recuperer-mon-compte');
+      const screen = await visit('/recuperer-mon-compte');
       await fillStudentInformationFormAndSubmit(this);
 
       // then
       expect(
-        contains(this.intl.t('pages.account-recovery.find-sco-record.conflict.found-you-but', { firstName }))
+        screen.queryByRole('heading', {
+          name: this.intl.t('pages.account-recovery.find-sco-record.student-information.title'),
+        })
+      ).to.not.exist;
+      expect(
+        screen.getByText(this.intl.t('pages.account-recovery.find-sco-record.conflict.found-you-but', { firstName }))
       ).to.exist;
-      expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.not.exist;
     });
   });
 
@@ -185,7 +214,7 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
         server.create('user', { id: 1, firstName, lastName, username });
         server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
 
-        await visit('/recuperer-mon-compte');
+        const screen = await visit('/recuperer-mon-compte');
         await fillStudentInformationFormAndSubmit(this);
 
         // when
@@ -194,14 +223,19 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
 
         // then
         expect(
-          contains(
-            this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.email-is-needed-message', {
-              firstName,
-            })
-          )
+          screen.getByRole('heading', {
+            name: this.intl.t(
+              'pages.account-recovery.find-sco-record.backup-email-confirmation.email-is-needed-message',
+              {
+                firstName,
+              }
+            ),
+          })
         ).to.exist;
         expect(
-          contains(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.good-news', { firstName }))
+          screen.queryByRole('heading', {
+            name: this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.good-news', { firstName }),
+          })
         ).to.not.exist;
       });
 
@@ -212,7 +246,7 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
         server.create('user', { id: 1, firstName, lastName, username, email });
         server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
 
-        await visit('/recuperer-mon-compte');
+        const screen = await visit('/recuperer-mon-compte');
         await fillStudentInformationFormAndSubmit(this);
         await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
         await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'));
@@ -228,7 +262,7 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
 
         // then
         expect(
-          contains(
+          screen.getByText(
             this.intl.t(
               'pages.account-recovery.find-sco-record.backup-email-confirmation.form.error.new-email-already-exist'
             )
@@ -243,7 +277,7 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
         server.create('user', { id: 1, firstName, lastName, username });
         server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
 
-        await visit('/recuperer-mon-compte');
+        const screen = await visit('/recuperer-mon-compte');
         await fillStudentInformationFormAndSubmit(this);
 
         await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
@@ -260,13 +294,20 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
 
         // then
         expect(
-          contains(
-            this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.email-is-needed-message', {
-              firstName,
-            })
-          )
+          screen.getByRole('heading', {
+            name: this.intl.t('pages.account-recovery.find-sco-record.send-email-confirmation.title'),
+          })
+        ).to.exist;
+        expect(
+          screen.queryByRole('heading', {
+            name: this.intl.t(
+              'pages.account-recovery.find-sco-record.backup-email-confirmation.email-is-needed-message',
+              {
+                firstName,
+              }
+            ),
+          })
         ).to.not.exist;
-        expect(contains(this.intl.t('pages.account-recovery.find-sco-record.send-email-confirmation.title'))).to.exist;
       });
 
       it('should redirect to error page when user has already left SCO', async function () {
@@ -289,7 +330,7 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
         );
         server.post('/account-recovery', () => errorsApi);
 
-        await visit('/recuperer-mon-compte');
+        const screen = await visit('/recuperer-mon-compte');
         await fillStudentInformationFormAndSubmit(this);
 
         await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
@@ -305,9 +346,17 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
         );
 
         // then
-        expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-        expect(contains(this.intl.t('pages.account-recovery.errors.key-used'))).to.exist;
-        expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+        expect(
+          screen.getByRole('heading', {
+            name: this.intl.t('pages.account-recovery.errors.title'),
+          })
+        ).to.exist;
+        expect(screen.getByText(this.intl.t('pages.account-recovery.errors.key-used'))).to.exist;
+        expect(
+          screen.getByRole('link', {
+            name: this.intl.t('navigation.back-to-homepage'),
+          })
+        ).to.exist;
       });
 
       it("should redirect to error page when there's an internal error", async function () {
@@ -330,7 +379,7 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
         );
         server.post('/account-recovery', () => errorsApi);
 
-        await visit('/recuperer-mon-compte');
+        const screen = await visit('/recuperer-mon-compte');
         await fillStudentInformationFormAndSubmit(this);
 
         await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
@@ -346,9 +395,17 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
         );
 
         // then
-        expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-        expect(contains(this.intl.t('api-error-messages.internal-server-error'))).to.exist;
-        expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+        expect(
+          screen.getByRole('heading', {
+            name: this.intl.t('pages.account-recovery.errors.title'),
+          })
+        ).to.exist;
+        expect(screen.getByText(this.intl.t('api-error-messages.internal-server-error'))).to.exist;
+        expect(
+          screen.getByRole('link', {
+            name: this.intl.t('navigation.back-to-homepage'),
+          })
+        ).to.exist;
       });
     });
 
@@ -359,7 +416,7 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
         server.create('user', { id: 1, firstName, lastName, username });
         server.create('student-information', { id: 2, ineIna, firstName, lastName, birthdate });
 
-        await visit('/recuperer-mon-compte');
+        const screen = await visit('/recuperer-mon-compte');
         await fillStudentInformationFormAndSubmit(this);
 
         // when
@@ -369,13 +426,20 @@ describe('Acceptance | account-recovery | FindScoRecordRoute', function () {
 
         // then
         expect(
-          contains(
-            this.intl.t('pages.account-recovery.find-sco-record.backup-email-confirmation.email-is-needed-message', {
-              firstName,
-            })
-          )
+          screen.getByRole('heading', {
+            name: this.intl.t('pages.account-recovery.find-sco-record.student-information.title'),
+          })
+        ).to.exist;
+        expect(
+          screen.queryByRole('heading', {
+            name: this.intl.t(
+              'pages.account-recovery.find-sco-record.backup-email-confirmation.email-is-needed-message',
+              {
+                firstName,
+              }
+            ),
+          })
         ).to.not.exist;
-        expect(contains(this.intl.t('pages.account-recovery.find-sco-record.student-information.title'))).to.exist;
       });
     });
   });

--- a/mon-pix/tests/acceptance/account-recovery/update-sco-record_test.js
+++ b/mon-pix/tests/acceptance/account-recovery/update-sco-record_test.js
@@ -6,10 +6,8 @@ import { currentURL, click } from '@ember/test-helpers';
 import { Response } from 'miragejs';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { visit, fillByLabel } from '@1024pix/ember-testing-library';
-
 import setupIntl from '../../helpers/setup-intl';
 import { clickByLabel } from '../../helpers/click-by-label';
-import { contains } from '../../helpers/contains';
 
 describe('Acceptance | account-recovery | UpdateScoRecordRoute', function () {
   setupApplicationTest();
@@ -22,12 +20,15 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function () {
       const temporaryKey = '6fe76ea1bb34a1d17e7b2253ee0f7f4b2bc66ddde37d50ee661cbbf3c00cfdc9';
 
       //when
-      await visit(`/recuperer-mon-compte/${temporaryKey}`);
+      const screen = await visit(`/recuperer-mon-compte/${temporaryKey}`);
 
       // then
       expect(currentURL()).to.equal(`/recuperer-mon-compte/${temporaryKey}`);
+
       expect(
-        contains(this.intl.t('pages.account-recovery.update-sco-record.welcome-message', { firstName: 'George' }))
+        screen.getByRole('heading', {
+          name: this.intl.t('pages.account-recovery.update-sco-record.welcome-message', { firstName: 'George' }),
+        })
       ).to.exist;
     });
 
@@ -50,12 +51,16 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function () {
       server.get(`/account-recovery/${temporaryKey}`, () => errorsApi);
 
       //when
-      await visit(`/recuperer-mon-compte/${temporaryKey}`);
+      const screen = await visit(`/recuperer-mon-compte/${temporaryKey}`);
 
       // then
-      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-      expect(contains(this.intl.t('pages.account-recovery.errors.account-exists'))).to.exist;
-      expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+      expect(
+        screen.getByRole('heading', {
+          name: this.intl.t('pages.account-recovery.errors.title'),
+        })
+      ).to.exist;
+      expect(screen.getByText(this.intl.t('pages.account-recovery.errors.account-exists'))).to.exist;
+      expect(screen.getByRole('link', { name: this.intl.t('navigation.back-to-homepage') })).to.exist;
     });
 
     it('should display an error message when user has already left SCO', async function () {
@@ -76,12 +81,16 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function () {
       server.get(`/account-recovery/${temporaryKey}`, () => errorsApi);
 
       //when
-      await visit(`/recuperer-mon-compte/${temporaryKey}`);
+      const screen = await visit(`/recuperer-mon-compte/${temporaryKey}`);
 
       // then
-      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-      expect(contains(this.intl.t('pages.account-recovery.errors.key-used'))).to.exist;
-      expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+      expect(
+        screen.getByRole('heading', {
+          name: this.intl.t('pages.account-recovery.errors.title'),
+        })
+      ).to.exist;
+      expect(screen.getByText(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
+      expect(screen.getByRole('link', { name: this.intl.t('navigation.back-to-homepage') })).to.exist;
     });
 
     it('should display an error message when temporary key not found', async function () {
@@ -102,12 +111,16 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function () {
       server.get(`/account-recovery/${temporaryKey}`, () => errorsApi);
 
       //when
-      await visit(`/recuperer-mon-compte/${temporaryKey}`);
+      const screen = await visit(`/recuperer-mon-compte/${temporaryKey}`);
 
       // then
-      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-      expect(contains(this.intl.t('pages.account-recovery.errors.key-invalid'))).to.exist;
-      expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+      expect(
+        screen.getByRole('heading', {
+          name: this.intl.t('pages.account-recovery.errors.title'),
+        })
+      ).to.exist;
+      expect(screen.getByText(this.intl.t('pages.account-recovery.errors.key-invalid'))).to.exist;
+      expect(screen.getByRole('link', { name: this.intl.t('navigation.back-to-homepage') })).to.exist;
     });
 
     it('should display an error message when temporary key has expired', async function () {
@@ -128,12 +141,17 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function () {
       server.get(`/account-recovery/${temporaryKey}`, () => errorsApi);
 
       //when
-      await visit(`/recuperer-mon-compte/${temporaryKey}`);
+      const screen = await visit(`/recuperer-mon-compte/${temporaryKey}`);
 
       // then
-      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-      expect(contains(this.intl.t('pages.account-recovery.errors.key-expired'))).to.exist;
-      expect(contains(this.intl.t('pages.account-recovery.errors.key-expired-renew-demand-link'))).to.exist;
+      expect(
+        screen.getByRole('heading', {
+          name: this.intl.t('pages.account-recovery.errors.title'),
+        })
+      ).to.exist;
+      expect(
+        screen.getByRole('link', { name: this.intl.t('pages.account-recovery.errors.key-expired-renew-demand-link') })
+      ).to.exist;
     });
   });
 
@@ -185,9 +203,13 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function () {
       await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
       // then
-      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-      expect(contains(this.intl.t('pages.account-recovery.errors.account-exists'))).to.exist;
-      expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+      expect(
+        screen.getByRole('heading', {
+          name: this.intl.t('pages.account-recovery.errors.title'),
+        })
+      ).to.exist;
+      expect(screen.getByText(this.intl.t('pages.account-recovery.errors.account-exists'))).to.exist;
+      expect(screen.getByRole('link', { name: this.intl.t('navigation.back-to-homepage') })).to.exist;
     });
 
     it('should display an error message when user has already left SCO', async function () {
@@ -216,9 +238,13 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function () {
       await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
       // then
-      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-      expect(contains(this.intl.t('pages.account-recovery.errors.key-used'))).to.exist;
-      expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+      expect(
+        screen.getByRole('heading', {
+          name: this.intl.t('pages.account-recovery.errors.title'),
+        })
+      ).to.exist;
+      expect(screen.getByText(this.intl.t('pages.account-recovery.errors.key-used'))).to.exist;
+      expect(screen.getByRole('link', { name: this.intl.t('navigation.back-to-homepage') })).to.exist;
     });
 
     it('should display an error message when temporary key not found', async function () {
@@ -247,9 +273,13 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function () {
       await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
       // then
-      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-      expect(contains(this.intl.t('pages.account-recovery.errors.key-invalid'))).to.exist;
-      expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+      expect(
+        screen.getByRole('heading', {
+          name: this.intl.t('pages.account-recovery.errors.title'),
+        })
+      ).to.exist;
+      expect(screen.getByText(this.intl.t('pages.account-recovery.errors.key-invalid'))).to.exist;
+      expect(screen.getByRole('link', { name: this.intl.t('navigation.back-to-homepage') })).to.exist;
     });
 
     it('should display an error message when temporary key has expired', async function () {
@@ -278,9 +308,14 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function () {
       await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
       // then
-      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-      expect(contains(this.intl.t('pages.account-recovery.errors.key-expired'))).to.exist;
-      expect(contains(this.intl.t('pages.account-recovery.errors.key-expired-renew-demand-link'))).to.exist;
+      expect(
+        screen.getByRole('heading', {
+          name: this.intl.t('pages.account-recovery.errors.title'),
+        })
+      ).to.exist;
+      expect(
+        screen.getByRole('link', { name: this.intl.t('pages.account-recovery.errors.key-expired-renew-demand-link') })
+      ).to.exist;
     });
 
     it('should display an error message when internal server error returned', async function () {
@@ -309,9 +344,13 @@ describe('Acceptance | account-recovery | UpdateScoRecordRoute', function () {
       await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
       // then
-      expect(contains(this.intl.t('pages.account-recovery.errors.title'))).to.exist;
-      expect(contains(this.intl.t('api-error-messages.internal-server-error'))).to.exist;
-      expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+      expect(
+        screen.getByRole('heading', {
+          name: this.intl.t('pages.account-recovery.errors.title'),
+        })
+      ).to.exist;
+      expect(screen.getByText(this.intl.t('api-error-messages.internal-server-error'))).to.exist;
+      expect(screen.getByRole('link', { name: this.intl.t('navigation.back-to-homepage') })).to.exist;
     });
   });
 });

--- a/mon-pix/tests/acceptance/existing-participation-test.js
+++ b/mon-pix/tests/acceptance/existing-participation-test.js
@@ -1,11 +1,10 @@
-import { describe, it, beforeEach } from 'mocha';
-import { visit } from '@ember/test-helpers';
+import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { authenticateByEmail } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import setupIntl from '../helpers/setup-intl';
-import { contains } from '../helpers/contains';
+import { visit } from '@1024pix/ember-testing-library';
 
 describe('Acceptance | Existing Participation', function () {
   setupApplicationTest();
@@ -13,7 +12,8 @@ describe('Acceptance | Existing Participation', function () {
   setupIntl();
 
   describe('Authenticated cases as simple user', function () {
-    beforeEach(async function () {
+    it('displays an error message', async function () {
+      // given
       const user = server.create('user', 'withEmail');
       server.create('campaign', { code: '123' });
       server.create('organization-learner-identity', {
@@ -21,15 +21,17 @@ describe('Acceptance | Existing Participation', function () {
         lastName: 'Last',
       });
       await authenticateByEmail(user);
-    });
 
-    it('displays an error message', async function () {
-      await visit('/campagnes/123/participation-existante');
-      expect(contains("Le parcours n'est pas accessible pour vous.")).to.exist;
-      expect(contains('Il y a déjà une participation associée au nom de')).to.exist;
-      expect(contains('First Last.')).to.exist;
-      expect(contains("Rapprochez-vous de votre enseignant pour qu'il supprime votre participation dans Pix Orga.")).to
-        .exist;
+      // when
+      const screen = await visit('/campagnes/123/participation-existante');
+
+      //then
+      expect(screen.getByText("Le parcours n'est pas accessible pour vous.")).to.exist;
+      expect(screen.getByText('Il y a déjà une participation associée au nom de')).to.exist;
+      expect(screen.getByText('First Last.')).to.exist;
+      expect(
+        screen.getByText("Rapprochez-vous de votre enseignant pour qu'il supprime votre participation dans Pix Orga.")
+      ).to.exist;
     });
   });
 });

--- a/mon-pix/tests/acceptance/fill-in-campaign-code_test.js
+++ b/mon-pix/tests/acceptance/fill-in-campaign-code_test.js
@@ -5,7 +5,6 @@ import { beforeEach, describe, it } from 'mocha';
 import { expect } from 'chai';
 import { visit } from '@1024pix/ember-testing-library';
 import { authenticateByEmail } from '../helpers/authentication';
-import { contains } from '../helpers/contains';
 import setupIntl from '../helpers/setup-intl';
 import { clickByLabel } from '../helpers/click-by-label';
 import { waitForDialog } from '../helpers/wait-for';
@@ -25,14 +24,14 @@ describe('Acceptance | Fill in campaign code page', function () {
     it('should disconnect when cliking on the link', async function () {
       // given
       await authenticateByEmail(user);
-      await visit('/campagnes');
+      const screen = await visit('/campagnes');
 
       // when
       await clickByLabel(this.intl.t('pages.fill-in-campaign-code.warning-message-logout'));
 
       // then
-      expect(contains(user.firstName)).to.be.null;
-      expect(contains(this.intl.t('navigation.not-logged.sign-in')));
+      expect(screen.queryByText(user.firstName)).to.not.exist;
+      expect(screen.getByRole('link', { name: this.intl.t('navigation.not-logged.sign-in') })).to.exist;
     });
   });
 

--- a/mon-pix/tests/acceptance/personal-information_test.js
+++ b/mon-pix/tests/acceptance/personal-information_test.js
@@ -1,10 +1,9 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
-import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { contains } from '../helpers/contains';
 import { authenticateByEmail } from '../helpers/authentication';
+import { visit } from '@1024pix/ember-testing-library';
 
 describe('Acceptance | personal-information', function () {
   setupApplicationTest();
@@ -24,11 +23,12 @@ describe('Acceptance | personal-information', function () {
       await authenticateByEmail(user);
 
       // when
-      await visit('/mon-compte/informations-personnelles');
+      const screen = await visit('/mon-compte/informations-personnelles');
 
       // then
-      expect(contains(user.firstName)).to.exist;
-      expect(contains(user.lastName)).to.exist;
+      const userNames = screen.getAllByText(user.firstName).length;
+      expect(userNames).to.equal(2);
+      expect(screen.getByText(user.lastName)).to.exist;
     });
   });
 });

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
@@ -1,4 +1,4 @@
-import { click, fillIn, currentURL, visit } from '@ember/test-helpers';
+import { click, fillIn, currentURL } from '@ember/test-helpers';
 import { beforeEach, describe, it } from 'mocha';
 import { expect } from 'chai';
 import { authenticateByEmail } from '../helpers/authentication';
@@ -9,8 +9,8 @@ import {
 import { invalidateSession } from '../helpers/invalidate-session';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { contains } from '../helpers/contains';
 import { clickByLabel } from '../helpers/click-by-label';
+import { visit } from '@1024pix/ember-testing-library';
 
 const PROFILES_COLLECTION = 'PROFILES_COLLECTION';
 
@@ -80,12 +80,13 @@ describe('Acceptance | Campaigns | Resume Campaigns with type Profiles Collectio
         await completeCampaignOfTypeProfilesCollectionByCode(campaign.code);
 
         // when
-        await visit(`/campagnes/${campaign.code}`);
+        const screen = await visit(`/campagnes/${campaign.code}`);
 
         // then
-        expect(contains('156')).to.exist;
-        expect(contains('AREA_1_TITLE')).to.exist;
-        expect(contains('Area_1_Competence_1_name')).to.exist;
+        expect(screen.getByText('156')).to.exist;
+        const area1Titles = screen.getAllByText('Area_1_title').length;
+        expect(area1Titles).to.equal(2);
+        expect(screen.getByText('Area_1_Competence_1_name')).to.exist;
       });
     });
 

--- a/mon-pix/tests/acceptance/skill-review_test.js
+++ b/mon-pix/tests/acceptance/skill-review_test.js
@@ -1,14 +1,14 @@
-import { findAll, currentURL, visit } from '@ember/test-helpers';
+import { findAll, currentURL } from '@ember/test-helpers';
 import { beforeEach, describe, it } from 'mocha';
 import { expect } from 'chai';
 import { authenticateByEmail } from '../helpers/authentication';
-import { contains } from '../helpers/contains';
 import setupIntl from '../helpers/setup-intl';
 import { clickByLabel } from '../helpers/click-by-label';
 import { click, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-mocha';
 import { currentSession } from 'ember-simple-auth/test-support';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { visit } from '@1024pix/ember-testing-library';
 
 describe('Acceptance | Campaigns | Campaigns Result', function () {
   setupApplicationTest();
@@ -70,11 +70,11 @@ describe('Acceptance | Campaigns | Campaigns Result', function () {
         const COMPETENCE_MASTERY_PERCENTAGE = '85%';
 
         // when
-        await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+        const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
 
         // then
-        expect(contains(competenceResultName)).to.exist;
-        expect(contains(COMPETENCE_MASTERY_PERCENTAGE)).to.exist;
+        expect(screen.getByText(competenceResultName)).to.exist;
+        expect(screen.getByText(COMPETENCE_MASTERY_PERCENTAGE)).to.exist;
       });
 
       context('When the campaign is restricted and organization learner is disabled', function () {
@@ -85,11 +85,11 @@ describe('Acceptance | Campaigns | Campaigns Result', function () {
 
         it('should display results page', async function () {
           // when
-          await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+          const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
 
           // then
           expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/resultats`);
-          expect(contains('Parcours restreint')).to.exist;
+          expect(screen.getByText('Parcours restreint')).to.exist;
         });
       });
 
@@ -118,11 +118,11 @@ describe('Acceptance | Campaigns | Campaigns Result', function () {
         });
 
         // when
-        await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+        const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
 
         // then
-        expect(contains(skillSetResultName)).to.exist;
-        expect(contains(BADGE_SKILL_SET_MASTERY_PERCENTAGE)).to.exist;
+        expect(screen.getByText(skillSetResultName)).to.exist;
+        expect(screen.getByText(BADGE_SKILL_SET_MASTERY_PERCENTAGE)).to.exist;
       });
 
       it('should display the Pix emploi badge when badge is acquired', async function () {
@@ -137,18 +137,18 @@ describe('Acceptance | Campaigns | Campaigns Result', function () {
         campaignParticipationResult.update({ campaignParticipationBadges: [badge] });
 
         // when
-        await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+        const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
 
         // then
-        expect(contains('Congrats, you won a Pix Emploi badge')).to.exist;
+        expect(screen.getByText('Congrats, you won a Pix Emploi badge')).to.exist;
       });
 
       it('should not display the Pix emploi badge when badge is not acquired', async function () {
         // when
-        await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+        const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
 
         // then
-        expect(contains(this.intl.t('pages.skill-review.badges-title'))).to.not.exist;
+        expect(screen.queryByText(this.intl.t('pages.skill-review.badges-title'))).to.be.null;
       });
 
       it('should display acquired badges', async function () {
@@ -200,10 +200,10 @@ describe('Acceptance | Campaigns | Campaigns Result', function () {
           campaignParticipationResult.update({ stageCount: 5 });
 
           // when
-          await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+          const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
 
           // then
-          expect(contains('You reached Stage 1')).to.exist;
+          expect(screen.getByText('You reached Stage 1')).to.exist;
         });
 
         it('should not display reached stage when CLEA badge acquired', async function () {
@@ -231,26 +231,26 @@ describe('Acceptance | Campaigns | Campaigns Result', function () {
           campaignParticipationResult.update({ reachedStage });
 
           // when
-          await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+          const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
 
           // then
-          expect(contains('You reached Stage 1')).to.not.exist;
-          expect(contains(cleaBadge.message)).to.exist;
+          expect(screen.queryByText('You reached Stage 1')).to.not.exist;
+          expect(screen.getByText(cleaBadge.message)).to.exist;
         });
       });
 
       it('should share the results', async function () {
         // when
-        await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
+        const screen = await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
 
         // when
         await clickByLabel(this.intl.t('pages.skill-review.actions.send'));
 
         // then
-        expect(contains(this.intl.t('pages.skill-review.already-shared'))).to.exist;
-        expect(contains(this.intl.t('pages.skill-review.actions.continue'))).to.exist;
-        expect(contains(this.intl.t('pages.skill-review.send-results'))).to.be.null;
-        expect(contains(this.intl.t('pages.skill-review.actions.improve'))).to.be.null;
+        expect(screen.getByText(this.intl.t('pages.skill-review.already-shared'))).to.exist;
+        expect(screen.getByText(this.intl.t('pages.skill-review.actions.continue'))).to.exist;
+        expect(screen.queryByText(this.intl.t('pages.skill-review.send-results'))).to.be.null;
+        expect(screen.queryByText(this.intl.t('pages.skill-review.actions.improve'))).to.be.null;
       });
 
       it('should redirect to default page on click', async function () {

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -6,16 +6,15 @@ import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { Response } from 'miragejs';
 
-import { contains } from '../helpers/contains';
 import { clickByLabel } from '../helpers/click-by-label';
 import { fillInByLabel } from '../helpers/fill-in-by-label';
-import { visit } from '@1024pix/ember-testing-library';
 import { authenticateByEmail, authenticateByGAR } from '../helpers/authentication';
 import { startCampaignByCode, startCampaignByCodeAndExternalId } from '../helpers/campaign';
 import { currentSession } from 'ember-simple-auth/test-support';
 import ENV from 'mon-pix/config/environment';
 import setupIntl from '../helpers/setup-intl';
 import { t } from 'ember-intl/test-support';
+import { visit } from '@1024pix/ember-testing-library';
 
 const AUTHENTICATED_SOURCE_FROM_GAR = ENV.APP.AUTHENTICATED_SOURCE_FROM_GAR;
 
@@ -692,11 +691,11 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
 
         it('should show an error message when user starts the campaign', async function () {
           // when
-          await visit(`/campagnes/${campaign.code}`);
+          const screen = await visit(`/campagnes/${campaign.code}`);
           await clickByLabel('Je commence');
 
           // then
-          expect(contains('Oups, la page demandée n’est pas accessible.')).to.exist;
+          expect(screen.getByText('Oups, la page demandée n’est pas accessible.')).to.exist;
         });
       });
 

--- a/mon-pix/tests/acceptance/update-expired-password_test.js
+++ b/mon-pix/tests/acceptance/update-expired-password_test.js
@@ -8,21 +8,18 @@ import { Response } from 'miragejs';
 
 import { authenticateByUsername } from '../helpers/authentication';
 import setupIntl from '../helpers/setup-intl';
-import { contains } from '../helpers/contains';
 import { clickByLabel } from '../helpers/click-by-label';
+import { visit } from '@1024pix/ember-testing-library';
 
 describe('Acceptance | Update Expired Password', function () {
   setupApplicationTest();
   setupMirage();
   setupIntl();
 
-  beforeEach(async function () {
-    const userShouldChangePassword = server.create('user', 'withUsername', 'shouldChangePassword');
-    await authenticateByUsername(userShouldChangePassword);
-  });
-
   it('should land on default page when password is successfully updated', async function () {
     // given
+    const userShouldChangePassword = server.create('user', 'withUsername', 'shouldChangePassword');
+    await authenticateByUsername(userShouldChangePassword);
     await fillIn('#password', 'newPass12345!');
 
     // when
@@ -34,8 +31,11 @@ describe('Acceptance | Update Expired Password', function () {
 
   it('should display validation error message when update password fails with http 400 error', async function () {
     // given
-    const expectedValidationErrorMessage = this.intl.t('pages.update-expired-password.fields.error');
-
+    const userShouldChangePassword = server.create('user', 'withUsername', 'shouldChangePassword');
+    const screen = await visit('/connexion');
+    await fillIn('#login', userShouldChangePassword.username);
+    await fillIn('#password', userShouldChangePassword.password);
+    await clickByLabel('Je me connecte');
     this.server.post('/expired-password-updates', () => {
       return new Response(
         400,
@@ -49,17 +49,22 @@ describe('Acceptance | Update Expired Password', function () {
     await fillIn('#password', 'newPass12345!');
 
     // when
-    await clickByLabel(this.intl.t('pages.update-expired-password.button'));
 
+    await clickByLabel(this.intl.t('pages.update-expired-password.button'));
     // then
+
     expect(currentURL()).to.equal('/mise-a-jour-mot-de-passe-expire');
-    expect(contains(expectedValidationErrorMessage)).to.exist;
+    const expectedValidationErrorMessage = this.intl.t('pages.update-expired-password.fields.error');
+    expect(screen.getByText(expectedValidationErrorMessage)).to.exist;
   });
 
   it('should display error message when update password fails with http 401 error', async function () {
     // given
-    const expectedErrorMessage = this.intl.t('api-error-messages.login-unauthorized-error');
-
+    const userShouldChangePassword = server.create('user', 'withUsername', 'shouldChangePassword');
+    const screen = await visit('/connexion');
+    await fillIn('#login', userShouldChangePassword.username);
+    await fillIn('#password', userShouldChangePassword.password);
+    await clickByLabel('Je me connecte');
     this.server.post('/expired-password-updates', () => {
       return new Response(
         401,
@@ -73,15 +78,19 @@ describe('Acceptance | Update Expired Password', function () {
     await fillIn('#password', 'newPass12345!');
 
     // when
-    await clickByLabel(this.intl.t('pages.update-expired-password.button'));
 
+    await clickByLabel(this.intl.t('pages.update-expired-password.button'));
     // then
+
     expect(currentURL()).to.equal('/mise-a-jour-mot-de-passe-expire');
-    expect(contains(expectedErrorMessage)).to.exist;
+    const expectedErrorMessage = this.intl.t('api-error-messages.login-unauthorized-error');
+    expect(screen.getByText(expectedErrorMessage)).to.exist;
   });
 
   it('should display error message when update password fails with http 404 error', async function () {
     // given
+    const userShouldChangePassword = server.create('user', 'withUsername', 'shouldChangePassword');
+    await authenticateByUsername(userShouldChangePassword);
     this.server.post('/expired-password-updates', () => {
       return new Response(
         401,
@@ -103,16 +112,21 @@ describe('Acceptance | Update Expired Password', function () {
 
   it('should display error message when update password fails', async function () {
     // given
-    const expectedErrorMessage = this.intl.t('api-error-messages.internal-server-error');
-
+    const userShouldChangePassword = server.create('user', 'withUsername', 'shouldChangePassword');
+    const screen = await visit('/connexion');
+    await fillIn('#login', userShouldChangePassword.username);
+    await fillIn('#password', userShouldChangePassword.password);
+    await clickByLabel('Je me connecte');
     this.server.post('/expired-password-updates', () => new Response(500));
 
     await fillIn('#password', 'newPass12345!');
 
     // when
     await clickByLabel(this.intl.t('pages.update-expired-password.button'));
+
     // then
     expect(currentURL()).to.equal('/mise-a-jour-mot-de-passe-expire');
-    expect(contains(expectedErrorMessage)).to.exist;
+    const expectedErrorMessage = this.intl.t('api-error-messages.internal-server-error');
+    expect(screen.getByText(expectedErrorMessage)).to.exist;
   });
 });

--- a/mon-pix/tests/acceptance/user-dashboard_test.js
+++ b/mon-pix/tests/acceptance/user-dashboard_test.js
@@ -1,13 +1,13 @@
-import { currentURL, click, find, visit } from '@ember/test-helpers';
+import { currentURL, click, find } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { invalidateSession } from '../helpers/invalidate-session';
 import { setupApplicationTest } from 'ember-mocha';
 import { beforeEach, describe, it } from 'mocha';
 import { expect } from 'chai';
 import { authenticateByEmail } from '../helpers/authentication';
-import { contains } from '../helpers/contains';
 import setupIntl from '../helpers/setup-intl';
 import { clickByLabel } from '../helpers/click-by-label';
+import { visit } from '@1024pix/ember-testing-library';
 
 const ASSESSMENT = 'ASSESSMENT';
 
@@ -52,14 +52,14 @@ describe('Acceptance | User dashboard page', function () {
       it('it should change menu on click on disconnect link', async function () {
         // given
         await authenticateByEmail(user);
-        await visit('/campagnes');
+        const screen = await visit('/campagnes');
 
         // when
         await clickByLabel(this.intl.t('pages.fill-in-campaign-code.warning-message-logout'));
 
         // then
-        expect(contains(user.firstName)).to.be.null;
-        expect(contains(this.intl.t('navigation.not-logged.sign-in')));
+        expect(screen.queryByText('Hermione Granger')).to.be.null;
+        expect(screen.getByText(this.intl.t('navigation.not-logged.sign-in'))).to.exist;
       });
     });
 
@@ -142,30 +142,46 @@ describe('Acceptance | User dashboard page', function () {
   });
 
   describe('recommended-competences', function () {
-    beforeEach(async function () {
-      user = server.create('user', 'withEmail');
+    it('should display recommended-competences section', async function () {
+      // given
+      const user = server.create('user', 'withEmail');
       await authenticateByEmail(user);
-      await visit('/accueil');
-    });
 
-    it('should display recommended-competences section', function () {
+      // when
+      await visit('/accueil');
+
+      // then
       expect(find('section[data-test-recommended-competences]')).to.exist;
     });
 
-    it('should display the link to profile', function () {
-      expect(contains(this.intl.t('pages.dashboard.recommended-competences.profile-link'))).to.exist;
+    it('should display the link to profile', async function () {
+      // given
+      const user = server.create('user', 'withEmail');
+      await authenticateByEmail(user);
+
+      // when
+      const screen = await visit('/accueil');
+
+      // then
+      // todo : ajouter des aria-label dans les 2 boutons pour distinguer les compétences recommandées ou à retester
+      const competencesButtons = screen.getAllByText(
+        this.intl.t('pages.dashboard.recommended-competences.profile-link')
+      ).length;
+      expect(competencesButtons).to.equal(2);
     });
   });
 
   describe('retryable-competences', function () {
-    beforeEach(async function () {
-      user = server.create('user', 'withEmail');
+    it('should display the improvable-competences section', async function () {
+      // given
+      const user = server.create('user', 'withEmail');
       await authenticateByEmail(user);
-      await visit('/accueil');
-    });
 
-    it('should display the improvable-competences section', function () {
-      expect(contains(this.intl.t('pages.dashboard.improvable-competences.subtitle'))).to.exist;
+      // when
+      const screen = await visit('/accueil');
+
+      // then
+      expect(screen.getByText(this.intl.t('pages.dashboard.improvable-competences.subtitle'))).to.exist;
     });
   });
 

--- a/mon-pix/tests/integration/components/account-recovery/recovery-errors-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/recovery-errors-test.js
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { render, find } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { contains } from '../../../helpers/contains';
+import { render } from '@1024pix/ember-testing-library';
 
 describe('Integration | Component | recovery-errors', function () {
   setupIntlRenderingTest();
@@ -17,13 +17,14 @@ describe('Integration | Component | recovery-errors', function () {
     this.set('message', errorMessage);
 
     // when
-    await render(hbs`<AccountRecovery::RecoveryErrors @title={{this.title}} @message={{this.message}} />`);
+    const screen = await render(
+      hbs`<AccountRecovery::RecoveryErrors @title={{this.title}} @message={{this.message}} />`
+    );
 
     // then
-    expect(contains(title)).to.exist;
-    expect(contains(errorMessage)).to.exist;
-    expect(contains(this.intl.t('pages.account-recovery.support.url-text'))).to.exist;
-    expect(contains(this.intl.t('pages.account-recovery.support.recover'))).to.exist;
+    expect(screen.getByText(title)).to.exist;
+    expect(screen.getByText(errorMessage)).to.exist;
+    expect(screen.getByRole('link', { name: this.intl.t('pages.account-recovery.support.url-text') })).to.exist;
   });
 
   it('should display renew demand link when asked for', async function () {
@@ -31,10 +32,12 @@ describe('Integration | Component | recovery-errors', function () {
     this.set('showRenewLink', true);
 
     // when
-    await render(hbs`<AccountRecovery::RecoveryErrors @showRenewLink={{this.showRenewLink}} />`);
+    const screen = await render(hbs`<AccountRecovery::RecoveryErrors @showRenewLink={{this.showRenewLink}} />`);
 
     // then
-    expect(contains(this.intl.t('pages.account-recovery.errors.key-expired-renew-demand-link'))).to.exist;
+    expect(
+      screen.getByRole('link', { name: this.intl.t('pages.account-recovery.errors.key-expired-renew-demand-link') })
+    ).to.exist;
   });
 
   it('should display back to home link when asked for', async function () {
@@ -42,10 +45,12 @@ describe('Integration | Component | recovery-errors', function () {
     this.set('showBackToHomeButton', true);
 
     // when
-    await render(hbs`<AccountRecovery::RecoveryErrors @showBackToHomeButton={{this.showBackToHomeButton}} />`);
+    const screen = await render(
+      hbs`<AccountRecovery::RecoveryErrors @showBackToHomeButton={{this.showBackToHomeButton}} />`
+    );
 
     // then
-    expect(contains(this.intl.t('navigation.back-to-homepage'))).to.exist;
+    expect(screen.getByRole('link', { name: this.intl.t('navigation.back-to-homepage') })).to.exist;
   });
 
   it('should display support link', async function () {

--- a/mon-pix/tests/integration/components/account-recovery/update-sco-record-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/update-sco-record-form-test.js
@@ -19,23 +19,29 @@ describe('Integration | Component | account-recovery | update-sco-record', funct
     this.set('email', newEmail);
 
     // when
-    await render(hbs`<AccountRecovery::UpdateScoRecordForm @firstName={{this.firstName}} @email={{this.email}}/>`);
+    const screen = await render(
+      hbs`<AccountRecovery::UpdateScoRecordForm @firstName={{this.firstName}} @email={{this.email}}/>`
+    );
 
     // then
-    expect(contains(this.intl.t('pages.account-recovery.update-sco-record.welcome-message', { firstName }))).to.exist;
-    expect(contains(this.intl.t('pages.account-recovery.update-sco-record.fill-password'))).to.exist;
-    expect(contains(this.intl.t('pages.account-recovery.update-sco-record.form.email-label'))).to.exist;
-    expect(contains(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'))).to.exist;
+    expect(
+      screen.getByRole('heading', {
+        name: this.intl.t('pages.account-recovery.update-sco-record.welcome-message', { firstName }),
+      })
+    ).to.exist;
+    expect(screen.getByText(this.intl.t('pages.account-recovery.update-sco-record.fill-password'))).to.exist;
+    expect(
+      screen.getByRole('textbox', { name: this.intl.t('pages.account-recovery.update-sco-record.form.email-label') })
+    ).to.exist;
+    expect(screen.getByLabelText(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'))).to.exist;
+
     const submitButton = findByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
     expect(submitButton).to.exist;
     expect(submitButton.disabled).to.be.true;
-    expect(contains('philippe.example.net'));
 
     expect(find('input[type="checkbox"]')).to.exist;
-    expect(contains(this.intl.t('common.cgu.accept'))).to.exist;
-    expect(contains(this.intl.t('common.cgu.cgu'))).to.exist;
-    expect(contains(this.intl.t('common.cgu.and'))).to.exist;
-    expect(contains(this.intl.t('common.cgu.data-protection-policy'))).to.exist;
+    expect(screen.getByRole('link', { name: this.intl.t('common.cgu.cgu') })).to.exist;
+    expect(screen.getByRole('link', { name: this.intl.t('common.cgu.data-protection-policy') })).to.exist;
   });
 
   context('Form submission', function () {
@@ -117,7 +123,9 @@ describe('Integration | Component | account-recovery | update-sco-record', funct
         this.set('email', newEmail);
         const invalidPassword = 'invalidpassword';
 
-        await render(hbs`<AccountRecovery::UpdateScoRecordForm @firstName={{this.firstName}} @email={{this.email}}/>`);
+        const screen = await render(
+          hbs`<AccountRecovery::UpdateScoRecordForm @firstName={{this.firstName}} @email={{this.email}}/>`
+        );
 
         // when
         await fillInByLabel(
@@ -127,20 +135,24 @@ describe('Integration | Component | account-recovery | update-sco-record', funct
         await triggerEvent('#password', 'focusout');
 
         // then
-        expect(contains(this.intl.t('pages.account-recovery.update-sco-record.form.errors.invalid-password'))).to.exist;
+        expect(
+          screen.getByText(this.intl.t('pages.account-recovery.update-sco-record.form.errors.invalid-password'))
+        ).to.exist;
       });
 
       it('should display a required field error message on focus-out if password field is empty', async function () {
         // given
         const password = '';
-        await render(hbs`<AccountRecovery::UpdateScoRecordForm />`);
+        const screen = await render(hbs`<AccountRecovery::UpdateScoRecordForm />`);
 
         // when
         await fillInByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.password-label'), password);
         await triggerEvent('#password', 'focusout');
 
         // then
-        expect(contains(this.intl.t('pages.account-recovery.update-sco-record.form.errors.empty-password'))).to.exist;
+        expect(
+          screen.getByText(this.intl.t('pages.account-recovery.update-sco-record.form.errors.empty-password'))
+        ).to.exist;
       });
     });
   });

--- a/mon-pix/tests/integration/components/certification-starter_test.js
+++ b/mon-pix/tests/integration/components/certification-starter_test.js
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import Service from '@ember/service';
 import { describe, it } from 'mocha';
-import { render, fillIn } from '@ember/test-helpers';
+import { fillIn } from '@ember/test-helpers';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
-import { contains } from '../../helpers/contains';
+import { render } from '@1024pix/ember-testing-library';
 import { clickByLabel } from '../../helpers/click-by-label';
 
 describe('Integration | Component | certification-starter', function () {
@@ -25,18 +25,18 @@ describe('Integration | Component | certification-starter', function () {
       this.set('certificationCandidateSubscription', { eligibleSubscriptions: [], nonEligibleSubscriptions: [] });
 
       // when
-      await render(
+      const screen = await render(
         hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
       );
 
-      // expect
+      // then
       expect(
-        contains(
-          'Vous êtes inscrit aux certification(s) complémentaire(s) suivante(s) en plus de la certification Pix :'
+        screen.queryByText(
+          "'Vous êtes inscrit aux certification(s) complémentaire(s) suivante(s) en plus de la certification Pix :'"
         )
       ).to.not.exist;
       expect(
-        contains(
+        screen.queryByText(
           "Vous avez été inscrit à/aux certification(s) complémentaire(s) suivantes : mais vous n'y êtes pas éligible.\n"
         )
       ).to.not.exist;
@@ -57,17 +57,18 @@ describe('Integration | Component | certification-starter', function () {
         );
 
         // when
-        await render(
+        const screen = await render(
           hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
         );
 
         // then
         expect(
-          contains('Vous êtes inscrit aux certifications complémentaires suivantes en plus de la certification Pix :'),
-          'Vous êtes inscrit...'
+          screen.getByText(
+            'Vous êtes inscrit aux certifications complémentaires suivantes en plus de la certification Pix :'
+          )
         ).to.exist;
-        expect(contains('Certif complémentaire 1'), 'Certif complémentaire 1').to.exist;
-        expect(contains('Certif complémentaire 2'), 'Certif complémentaire 2').to.exist;
+        expect(screen.getByText('Certif complémentaire 1')).to.exist;
+        expect(screen.getByText('Certif complémentaire 2')).to.exist;
       });
 
       it('should not display subscription non eligible panel', async function () {
@@ -82,13 +83,13 @@ describe('Integration | Component | certification-starter', function () {
         );
 
         // when
-        await render(
+        const screen = await render(
           hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
         );
 
-        // expect
+        // then
         expect(
-          contains(
+          screen.queryByText(
             "Vous avez été inscrit aux certifications complémentaires suivantes : mais vous n'y êtes pas éligible."
           )
         ).to.not.exist;
@@ -108,14 +109,14 @@ describe('Integration | Component | certification-starter', function () {
         );
 
         // when
-        await render(
+        const screen = await render(
           hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
         );
 
-        // expect
+        // then
         expect(
-          contains(
-            'Vous n’êtes pas éligible à Certif complémentaire 1. Vous pouvez néanmoins passer votre certification Pix et Certif complémentaire 2'
+          screen.getByText(
+            'Vous n’êtes pas éligible à Certif complémentaire 1. Vous pouvez néanmoins passer votre certification Pix et Certif complémentaire 2.'
           )
         ).to.exist;
       });
@@ -132,14 +133,14 @@ describe('Integration | Component | certification-starter', function () {
         );
 
         // when
-        await render(
+        const screen = await render(
           hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
         );
 
-        // expect
+        // then
         expect(
-          contains(
-            'Vous n’êtes pas éligible à Certif complémentaire 1, Certif complémentaire 2. Vous pouvez néanmoins passer votre certification Pix'
+          screen.getByText(
+            'Vous n’êtes pas éligible à Certif complémentaire 1, Certif complémentaire 2. Vous pouvez néanmoins passer votre certification Pix.'
           )
         ).to.exist;
       });
@@ -156,35 +157,21 @@ describe('Integration | Component | certification-starter', function () {
         );
 
         // when
-        await render(
+        const screen = await render(
           hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
         );
 
-        // expect
+        // then
         expect(
-          contains('Vous êtes inscrit aux certifications complémentaires suivantes en plus de la certification Pix :')
+          screen.getByText(
+            'Vous êtes inscrit aux certifications complémentaires suivantes en plus de la certification Pix :'
+          )
         ).to.exist;
       });
     });
   });
 
   describe('#submit', function () {
-    context('when no access code is provided', function () {
-      it('should display an appropriated error message', async function () {
-        // given
-        this.set('certificationCandidateSubscription', { sessionId: 123 });
-        await render(
-          hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
-        );
-
-        // when
-        await clickByLabel(this.intl.t('pages.certification-start.actions.submit'));
-
-        // then
-        expect(contains('Merci de saisir un code d’accès valide.'));
-      });
-    });
-
     context('when access code is provided', function () {
       context('when the creation of certification course is successful', function () {
         it('should redirect to certifications.resume', async function () {
@@ -269,7 +256,7 @@ describe('Integration | Component | certification-starter', function () {
           };
           createRecordStub.returns(certificationCourse);
           this.set('certificationCandidateSubscription', { sessionId: 123 });
-          await render(
+          const screen = await render(
             hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
           );
           await fillIn('#certificationStarterSessionCode', 'ABC123');
@@ -279,7 +266,7 @@ describe('Integration | Component | certification-starter', function () {
           await clickByLabel(this.intl.t('pages.certification-start.actions.submit'));
 
           // then
-          expect(contains('Ce code n’existe pas ou n’est plus valide.'));
+          expect(screen.getByText('Ce code n’existe pas ou n’est plus valide.')).to.exist;
         });
 
         it('should display the appropriate error message when error status is 412', async function () {
@@ -305,7 +292,7 @@ describe('Integration | Component | certification-starter', function () {
           };
           createRecordStub.returns(certificationCourse);
           this.set('certificationCandidateSubscription', { sessionId: 123 });
-          await render(
+          const screen = await render(
             hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
           );
           await fillIn('#certificationStarterSessionCode', 'ABC123');
@@ -315,45 +302,93 @@ describe('Integration | Component | certification-starter', function () {
           await clickByLabel(this.intl.t('pages.certification-start.actions.submit'));
 
           // then
-          expect(contains("La session de certification n'est plus accessible."));
+          expect(screen.getByText("La session de certification n'est plus accessible.")).to.exist;
         });
 
-        it('should display the appropriate error message when error status is 403', async function () {
-          // given
-          const replaceWithStub = sinon.stub();
+        context('when error status is 403', function () {
+          it('should display the appropriate error message when error candidate not authorized to join session', async function () {
+            // given
+            const replaceWithStub = sinon.stub();
 
-          class RouterServiceStub extends Service {
-            replaceWith = replaceWithStub;
-          }
+            class RouterServiceStub extends Service {
+              replaceWith = replaceWithStub;
+            }
 
-          this.owner.register('service:router', RouterServiceStub);
-          const createRecordStub = sinon.stub();
+            this.owner.register('service:router', RouterServiceStub);
+            const createRecordStub = sinon.stub();
 
-          class StoreStubService extends Service {
-            createRecord = createRecordStub;
-          }
+            class StoreStubService extends Service {
+              createRecord = createRecordStub;
+            }
 
-          this.owner.register('service:store', StoreStubService);
-          const certificationCourse = {
-            id: 123,
-            save: sinon.stub(),
-            deleteRecord: sinon.stub(),
-          };
-          createRecordStub.returns(certificationCourse);
-          this.set('certificationCandidateSubscription', { sessionId: 123 });
-          await render(
-            hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
-          );
-          await fillIn('#certificationStarterSessionCode', 'ABC123');
-          certificationCourse.save.rejects({
-            errors: [{ status: '403', detail: "Message d'erreur envoyé par l 'API" }],
+            this.owner.register('service:store', StoreStubService);
+            const certificationCourse = {
+              id: 123,
+              save: sinon.stub(),
+              deleteRecord: sinon.stub(),
+            };
+            createRecordStub.returns(certificationCourse);
+            this.set('certificationCandidateSubscription', { sessionId: 123 });
+            const screen = await render(
+              hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
+            );
+            await fillIn('#certificationStarterSessionCode', 'ABC123');
+            certificationCourse.save.rejects({
+              errors: [{ status: '403', code: 'CANDIDATE_NOT_AUTHORIZED_TO_JOIN_SESSION' }],
+            });
+
+            // when
+            await clickByLabel(this.intl.t('pages.certification-start.actions.submit'));
+
+            // then
+            expect(
+              screen.getByText(
+                this.intl.t('pages.certification-start.error-messages.candidate-not-authorized-to-start')
+              )
+            ).to.exist;
           });
 
-          // when
-          await clickByLabel(this.intl.t('pages.certification-start.actions.submit'));
+          it('should display the appropriate error message when error candidate not authorized to resume session', async function () {
+            // given
+            const replaceWithStub = sinon.stub();
 
-          // then
-          expect(contains("'Message d'erreur envoyé par l'API'"));
+            class RouterServiceStub extends Service {
+              replaceWith = replaceWithStub;
+            }
+
+            this.owner.register('service:router', RouterServiceStub);
+            const createRecordStub = sinon.stub();
+
+            class StoreStubService extends Service {
+              createRecord = createRecordStub;
+            }
+
+            this.owner.register('service:store', StoreStubService);
+            const certificationCourse = {
+              id: 123,
+              save: sinon.stub(),
+              deleteRecord: sinon.stub(),
+            };
+            createRecordStub.returns(certificationCourse);
+            this.set('certificationCandidateSubscription', { sessionId: 123 });
+            const screen = await render(
+              hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
+            );
+            await fillIn('#certificationStarterSessionCode', 'ABC123');
+            certificationCourse.save.rejects({
+              errors: [{ status: '403', code: 'CANDIDATE_NOT_AUTHORIZED_TO_RESUME_SESSION' }],
+            });
+
+            // when
+            await clickByLabel(this.intl.t('pages.certification-start.actions.submit'));
+
+            // then
+            expect(
+              screen.getByText(
+                this.intl.t('pages.certification-start.error-messages.candidate-not-authorized-to-resume')
+              )
+            ).to.exist;
+          });
         });
 
         it('should display a generic error message when error status unknown', async function () {
@@ -379,7 +414,7 @@ describe('Integration | Component | certification-starter', function () {
           };
           createRecordStub.returns(certificationCourse);
           this.set('certificationCandidateSubscription', { sessionId: 123 });
-          await render(
+          const screen = await render(
             hbs`<CertificationStarter @certificationCandidateSubscription={{this.certificationCandidateSubscription}}/>`
           );
           await fillIn('#certificationStarterSessionCode', 'ABC123');
@@ -389,7 +424,7 @@ describe('Integration | Component | certification-starter', function () {
           await clickByLabel(this.intl.t('pages.certification-start.actions.submit'));
 
           // then
-          expect(contains('Une erreur serveur inattendue vient de se produire.'));
+          expect(screen.getByText('Une erreur serveur inattendue vient de se produire.')).to.exist;
         });
       });
     });

--- a/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { find, render } from '@ember/test-helpers';
+import { find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { contains } from '../../helpers/contains';
 import { clickByLabel } from '../../helpers/click-by-label';
+import { render } from '@1024pix/ember-testing-library';
 
 describe('Integration | Component | Challenge Embed Simulator', function () {
   setupIntlRenderingTest();
@@ -22,10 +22,10 @@ describe('Integration | Component | Challenge Embed Simulator', function () {
   describe('Launch simulator button', function () {
     it('should have text "Je lance l\'application"', async function () {
       // when
-      await render(hbs`<ChallengeEmbedSimulator />`);
+      const screen = await render(hbs`<ChallengeEmbedSimulator />`);
 
       // then
-      expect(contains(this.intl.t('pages.challenge.embed-simulator.actions.launch')));
+      expect(screen.getByText(this.intl.t('pages.challenge.embed-simulator.actions.launch'))).to.exist;
     });
 
     it('should close the acknowledgment overlay when clicked', async function () {

--- a/mon-pix/tests/integration/components/user-logged-menu_test.js
+++ b/mon-pix/tests/integration/components/user-logged-menu_test.js
@@ -2,9 +2,9 @@ import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { click, find, findAll, render, triggerKeyEvent } from '@ember/test-helpers';
+import { click, find, findAll, triggerKeyEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { contains } from '../../helpers/contains';
+import { render } from '@1024pix/ember-testing-library';
 
 describe('Integration | Component | user logged menu', function () {
   setupIntlRenderingTest();
@@ -59,31 +59,31 @@ describe('Integration | Component | user logged menu', function () {
       const MENU_ITEMS_COUNT = 4;
 
       // when
-      await render(hbs`<UserLoggedMenu/>`);
+      const screen = await render(hbs`<UserLoggedMenu/>`);
       await click('.logged-user-name__link');
 
       // then
       expect(find('.logged-user-menu')).to.exist;
       expect(findAll('.logged-user-menu__link')).to.have.lengthOf(MENU_ITEMS_COUNT);
-      expect(contains('Hermione Granger')).to.exist;
+      expect(screen.getByText('Hermione Granger')).to.exist;
     });
 
     it('should display link to user certifications', async function () {
       // when
-      await render(hbs`<UserLoggedMenu/>`);
+      const screen = await render(hbs`<UserLoggedMenu/>`);
       await click('.logged-user-name');
 
       // then
-      expect(contains('Mes certifications')).to.exist;
+      expect(screen.getByRole('link', { name: 'Mes certifications' })).to.exist;
     });
 
     it('should display link to help center', async function () {
       // when
-      await render(hbs`<UserLoggedMenu/>`);
+      const screen = await render(hbs`<UserLoggedMenu/>`);
       await click('.logged-user-name');
 
       // then
-      expect(contains('Aide')).to.exist;
+      expect(screen.getByRole('link', { name: 'Aide' })).to.exist;
     });
 
     it('should hide user menu, when it was previously open and user-name is clicked one more time', async function () {
@@ -140,22 +140,22 @@ describe('Integration | Component | user logged menu', function () {
 
         it('should display link to user tests', async function () {
           // when
-          await render(hbs`<UserLoggedMenu/>`);
+          const screen = await render(hbs`<UserLoggedMenu/>`);
           await click('.logged-user-name');
 
           // then
-          expect(contains('Mes parcours')).to.exist;
+          expect(screen.getByRole('link', { name: 'Mes parcours' })).to.exist;
         });
       });
 
       describe('when user has no participation', function () {
         it('should not display link to user tests', async function () {
           // when
-          await render(hbs`<UserLoggedMenu/>`);
+          const screen = await render(hbs`<UserLoggedMenu/>`);
           await click('.logged-user-name');
 
           // then
-          expect(contains('Mes parcours')).to.not.exist;
+          expect(screen.queryByRole('link', { name: 'Mes parcours' })).to.not.exist;
         });
       });
     });


### PR DESCRIPTION
## :christmas_tree: Problème
Sur Pix App, les contains provoquent un mauvais fonctionnement du script de migration de mocha vers QUnit

## :gift: Proposition
Remplacer les contains par testing-library

Il reste encore des contains dans l'app mais on ne se concentre que sur ceux qui posent problème pour la migration

## :santa: Pour tester
Les test passent
