### PR TITLE
[TECH] Déplacement de tests d'acceptance des controllers dans des sous dossiers

### DIFF
--- a/api/tests/acceptance/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/acceptance/application/organization-invitations/organization-invitation-controller_test.js
@@ -1,9 +1,9 @@
-const { expect, knex, databaseBuilder } = require('../../test-helper');
+const { expect, knex, databaseBuilder } = require('../../../test-helper');
 
-const Membership = require('../../../lib/domain/models/Membership');
-const OrganizationInvitation = require('../../../lib/domain/models/OrganizationInvitation');
+const Membership = require('../../../../lib/domain/models/Membership');
+const OrganizationInvitation = require('../../../../lib/domain/models/OrganizationInvitation');
 
-const createServer = require('../../../server');
+const createServer = require('../../../../server');
 
 describe('Acceptance | Application | organization-invitation-controller', function () {
   let server;

--- a/api/tests/acceptance/application/organization-learners/organization-learner-controller_test.js
+++ b/api/tests/acceptance/application/organization-learners/organization-learner-controller_test.js
@@ -3,9 +3,9 @@ const {
   expect,
   insertUserWithRoleSuperAdmin,
   generateValidRequestAuthorizationHeader,
-} = require('../../test-helper');
+} = require('../../../test-helper');
 
-const createServer = require('../../../server');
+const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | organization-learner', function () {
   let server;

--- a/api/tests/acceptance/application/passwords/password-controller_test.js
+++ b/api/tests/acceptance/application/passwords/password-controller_test.js
@@ -1,11 +1,11 @@
-const { databaseBuilder, expect, knex, sinon } = require('../../test-helper');
-const tokenService = require('../../../lib/domain/services/token-service');
-const resetPasswordService = require('../../../lib/domain/services/reset-password-service');
-const resetPasswordDemandRepository = require('../../../lib/infrastructure/repositories/reset-password-demands-repository');
+const { databaseBuilder, expect, knex, sinon } = require('../../../test-helper');
+const tokenService = require('../../../../lib/domain/services/token-service');
+const resetPasswordService = require('../../../../lib/domain/services/reset-password-service');
+const resetPasswordDemandRepository = require('../../../../lib/infrastructure/repositories/reset-password-demands-repository');
 
-const config = require('../../../lib/config');
+const config = require('../../../../lib/config');
 
-const createServer = require('../../../server');
+const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | password-controller', function () {
   const email = 'user@example.net';

--- a/api/tests/acceptance/application/prescribers/prescriber-controller_test.js
+++ b/api/tests/acceptance/application/prescribers/prescriber-controller_test.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 
-const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../test-helper');
-const createServer = require('../../../server');
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | Prescriber-controller', function () {
   let user;

--- a/api/tests/acceptance/application/progressions/progression-controller_test.js
+++ b/api/tests/acceptance/application/progressions/progression-controller_test.js
@@ -4,8 +4,8 @@ const {
   databaseBuilder,
   mockLearningContent,
   learningContentBuilder,
-} = require('../../test-helper');
-const createServer = require('../../../server');
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
 
 describe('Acceptance | API | Progressions', function () {
   let server;

--- a/api/tests/acceptance/application/sco-organization-learners/sco-organization-learner-controller_test.js
+++ b/api/tests/acceptance/application/sco-organization-learners/sco-organization-learner-controller_test.js
@@ -4,10 +4,10 @@ const {
   generateValidRequestAuthorizationHeader,
   knex,
   generateIdTokenForExternalUser,
-} = require('../../test-helper');
+} = require('../../../test-helper');
 
-const createServer = require('../../../server');
-const AuthenticationMethod = require('../../../lib/domain/models/AuthenticationMethod');
+const createServer = require('../../../../server');
+const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
 
 describe('Acceptance | Controller | sco-organization-learners', function () {
   let server;

--- a/api/tests/acceptance/application/scorecards/scorecard-controller_test.js
+++ b/api/tests/acceptance/application/scorecards/scorecard-controller_test.js
@@ -4,11 +4,11 @@ const {
   knex,
   generateValidRequestAuthorizationHeader,
   mockLearningContent,
-} = require('../../test-helper');
-const KnowledgeElement = require('../../../lib/domain/models/KnowledgeElement');
-const { FRENCH_SPOKEN } = require('../../../lib/domain/constants').LOCALE;
+} = require('../../../test-helper');
+const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
+const { FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 
-const createServer = require('../../../server');
+const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | scorecard-controller', function () {
   let options;

--- a/api/tests/acceptance/application/sup-organization-learners/sup-organization-learner-controller_test.js
+++ b/api/tests/acceptance/application/sup-organization-learners/sup-organization-learner-controller_test.js
@@ -1,7 +1,7 @@
-const { databaseBuilder, expect, generateValidRequestAuthorizationHeader } = require('../../test-helper');
+const { databaseBuilder, expect, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 
-const createServer = require('../../../server');
-const Membership = require('../../../lib/domain/models/Membership');
+const createServer = require('../../../../server');
+const Membership = require('../../../../lib/domain/models/Membership');
 
 describe('Acceptance | Controller | sup-organization-learners', function () {
   let server;

--- a/api/tests/acceptance/application/user-orga-settings/user-orga-settings-controller_test.js
+++ b/api/tests/acceptance/application/user-orga-settings/user-orga-settings-controller_test.js
@@ -1,5 +1,5 @@
-const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, knex } = require('../../test-helper');
-const createServer = require('../../../server');
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, knex } = require('../../../test-helper');
+const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | user-orga-settings-controller', function () {
   let server;


### PR DESCRIPTION
## :christmas_tree: Problème
Les tests d'acceptances sont plutôt mis dans une arborescence similaire a celle dans lib/application, mais des fois non, ils sont juste dans tests/acceptance/application, mal aimé, mal rangé.

## :gift: Proposition
Déplacement des tests d'acceptances dans les sous dossiers correspondant.

## :star2: Remarques
Suite de #5226

## :santa: Pour tester
:green_circle: CI
