### PR TITLE
[TECH] Préparer la migration vers QUnit sur Pix App (PIX-6375)

### DIFF
--- a/mon-pix/app/components/certification-starter.js
+++ b/mon-pix/app/components/certification-starter.js
@@ -10,7 +10,7 @@ export default class CertificationJoiner extends Component {
   @service intl;
   @service focusedCertificationChallengeWarningManager;
 
-  @tracked inputAccessCode = null;
+  @tracked inputAccessCode = '';
   @tracked errorMessage = null;
   @tracked classNames = [];
   @tracked certificationCourse = null;

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -199,7 +199,7 @@ export default class SkillReview extends Component {
     } catch (errorResponse) {
       if (!errorResponse?.errors) {
         this.showGlobalErrorMessage = true;
-        throw errorResponse;
+        return;
       }
       errorResponse.errors.forEach((error) => {
         if (error.status === '409') {
@@ -207,7 +207,6 @@ export default class SkillReview extends Component {
         } else {
           this.isShareButtonClicked = false;
           this.showGlobalErrorMessage = true;
-          throw error;
         }
       });
     }

--- a/mon-pix/mirage/routes/post-shared-certifications.js
+++ b/mon-pix/mirage/routes/post-shared-certifications.js
@@ -364,6 +364,7 @@ const validResponse = {
       status: 'validated',
       'pix-score': 518,
       'clea-certification-status': 'acquired',
+      'certified-badge-images': [],
     },
     relationships: {
       'result-competence-tree': {

--- a/mon-pix/tests/acceptance/challenge-item-qcm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcm_test.js
@@ -93,13 +93,13 @@ describe('Acceptance | Displaying a QCM challenge', function () {
     it('should mark checkboxes corresponding to the answer and propose to continue', async function () {
       // then
       expect(findAll('input[type="checkbox"]')[0].checked).to.be.false;
+      expect(findAll('input[type="checkbox"]')[0].disabled).to.be.true;
       expect(findAll('input[type="checkbox"]')[1].checked).to.be.true;
+      expect(findAll('input[type="checkbox"]')[1].disabled).to.be.true;
       expect(findAll('input[type="checkbox"]')[2].checked).to.be.false;
+      expect(findAll('input[type="checkbox"]')[2].disabled).to.be.true;
       expect(findAll('input[type="checkbox"]')[3].checked).to.be.true;
-
-      findAll('input[type=checkbox]').forEach((checkbox) => {
-        expect(checkbox.disabled).to.equal(true);
-      });
+      expect(findAll('input[type="checkbox"]')[3].disabled).to.be.true;
 
       expect(find('.challenge-actions__action-continue')).to.exist;
       expect(find('.challenge-actions__action-validate')).to.not.exist;

--- a/mon-pix/tests/acceptance/challenge-item-qcm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcm_test.js
@@ -97,7 +97,9 @@ describe('Acceptance | Displaying a QCM challenge', function () {
       expect(findAll('input[type="checkbox"]')[2].checked).to.be.false;
       expect(findAll('input[type="checkbox"]')[3].checked).to.be.true;
 
-      findAll('input[type=checkbox]').forEach((checkbox) => expect(checkbox.disabled).to.equal(true));
+      findAll('input[type=checkbox]').forEach((checkbox) => {
+        expect(checkbox.disabled).to.equal(true);
+      });
 
       expect(find('.challenge-actions__action-continue')).to.exist;
       expect(find('.challenge-actions__action-validate')).to.not.exist;

--- a/mon-pix/tests/acceptance/challenge-item-qcu_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcu_test.js
@@ -95,7 +95,9 @@ describe('Acceptance | Displaying a QCU challenge', function () {
       expect(radioButtons[2].checked).to.be.false;
       expect(radioButtons[3].checked).to.be.false;
 
-      findAll('input[type=radio][name="radio"]').forEach((radioButton) => expect(radioButton.disabled).to.equal(true));
+      findAll('input[type=radio][name="radio"]').forEach((radioButton) => {
+        expect(radioButton.disabled).to.equal(true);
+      });
 
       expect(find('.challenge-actions__action-continue')).to.exist;
       expect(find('.challenge-actions__action-validate')).to.not.exist;

--- a/mon-pix/tests/acceptance/challenge-item-qcu_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcu_test.js
@@ -91,13 +91,13 @@ describe('Acceptance | Displaying a QCU challenge', function () {
       // then
       const radioButtons = findAll('input[type=radio][name="radio"]');
       expect(radioButtons[0].checked).to.be.false;
+      expect(radioButtons[0].disabled).to.be.true;
       expect(radioButtons[1].checked).to.be.true;
+      expect(radioButtons[1].disabled).to.be.true;
       expect(radioButtons[2].checked).to.be.false;
+      expect(radioButtons[2].disabled).to.be.true;
       expect(radioButtons[3].checked).to.be.false;
-
-      findAll('input[type=radio][name="radio"]').forEach((radioButton) => {
-        expect(radioButton.disabled).to.equal(true);
-      });
+      expect(radioButtons[3].disabled).to.be.true;
 
       expect(find('.challenge-actions__action-continue')).to.exist;
       expect(find('.challenge-actions__action-validate')).to.not.exist;

--- a/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
@@ -140,11 +140,9 @@ describe('Acceptance | Displaying a QROCM challenge', function () {
         expect(find('div[data-test="qrocm-label-0"]').innerHTML).to.contains('Station <strong>1</strong> :');
         expect(find('div[data-test="qrocm-label-1"]').innerHTML).to.contains('Station <em>2</em> :');
         expect(findAll('.challenge-response__proposal')[0].value).to.equal('Republique');
+        expect(findAll('.challenge-response__proposal')[0].disabled).to.be.true;
         expect(findAll('.challenge-response__proposal')[1].value).to.equal('Chatelet');
-
-        findAll('.challenge-response__proposal').forEach((input) => {
-          expect(input.disabled).to.equal(true);
-        });
+        expect(findAll('.challenge-response__proposal')[1].disabled).to.be.true;
 
         expect(find('.challenge-actions__action-continue')).to.exist;
         expect(find('.challenge-actions__action-validate')).to.not.exist;

--- a/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
@@ -142,7 +142,9 @@ describe('Acceptance | Displaying a QROCM challenge', function () {
         expect(findAll('.challenge-response__proposal')[0].value).to.equal('Republique');
         expect(findAll('.challenge-response__proposal')[1].value).to.equal('Chatelet');
 
-        findAll('.challenge-response__proposal').forEach((input) => expect(input.disabled).to.equal(true));
+        findAll('.challenge-response__proposal').forEach((input) => {
+          expect(input.disabled).to.equal(true);
+        });
 
         expect(find('.challenge-actions__action-continue')).to.exist;
         expect(find('.challenge-actions__action-validate')).to.not.exist;

--- a/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
@@ -167,7 +167,7 @@ describe('Acceptance | Displaying a QROCM challenge', function () {
 
       it('should set the select with previous answer and propose to continue', async function () {
         // then
-        expect(findAll('select[data-test="challenge-response-proposal-selector"] option')[1].hasAttribute('selected'));
+        expect(findAll('select[data-test="challenge-response-proposal-selector"] option')[1].selected);
 
         expect(find('.challenge-actions__action-continue')).to.exist;
         expect(find('.challenge-actions__action-validate')).to.not.exist;

--- a/mon-pix/tests/acceptance/challenge-page-banner_test.js
+++ b/mon-pix/tests/acceptance/challenge-page-banner_test.js
@@ -29,7 +29,7 @@ describe('Acceptance | Challenge page banner', function () {
       await clickByLabel(this.intl.t('pages.tutorial.pass'));
 
       // then
-      find('.assessment-banner');
+      expect(find('.assessment-banner'));
     });
 
     it('should display accessibility information in the banner', async function () {

--- a/mon-pix/tests/acceptance/compare-answer-solution_test.js
+++ b/mon-pix/tests/acceptance/compare-answer-solution_test.js
@@ -18,6 +18,10 @@ describe('Compare answers and solutions for QCM questions', function () {
       result: 'ko',
       challenge,
       assessment,
+      correction: server.create('correction', {
+        solution: '1',
+        hint: 'Cliquer sur 1',
+      }),
     });
     challenge = server.create('challenge', 'forCompetenceEvaluation', 'QCM');
     server.create('answer', {

--- a/mon-pix/tests/acceptance/oidc/oidc-authentication-flow_test.js
+++ b/mon-pix/tests/acceptance/oidc/oidc-authentication-flow_test.js
@@ -4,6 +4,7 @@ import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { visit } from '@1024pix/ember-testing-library';
 import setupIntl from '../../helpers/setup-intl';
 import { expect } from 'chai';
+import { it, describe, context } from 'mocha';
 
 describe('Acceptance | OIDC | authentication flow', function () {
   setupApplicationTest();

--- a/mon-pix/tests/acceptance/resume-competence-evaluations_test.js
+++ b/mon-pix/tests/acceptance/resume-competence-evaluations_test.js
@@ -49,7 +49,7 @@ describe('Acceptance | Competence Evaluations | Resume Competence Evaluations',
 
         it('should redirect to assessment', async function () {
           // then
-          expect(currentURL()).to.contains(/assessments/);
+          expect(currentURL()).to.contains('/assessments/');
           expect(find('.assessment-banner')).to.exist;
         });
       });

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
@@ -237,7 +237,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', functi
             await clickByLabel(this.intl.t('pages.tutorial.pass'));
 
             // then
-            expect(currentURL()).to.contains(/assessments/);
+            expect(currentURL()).to.contains('/assessments/');
           });
         });
 
@@ -271,7 +271,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', functi
             await clickByLabel(this.intl.t('pages.tutorial.pass'));
 
             // then
-            expect(currentURL()).to.contains(/assessments/);
+            expect(currentURL()).to.contains('/assessments/');
           });
         });
       });

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -382,7 +382,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function () {
       context('When campaign code does not exist', function () {
         it('should display an error message on fill-in-campaign-code page', async function () {
           // given
-          const campaignCode = 'NONEXISTENT';
+          const campaignCode = 'NONEXIST';
           await visit('/campagnes');
 
           // when

--- a/mon-pix/tests/integration/components/account-recovery/backup-email-confirmation-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/backup-email-confirmation-form-test.js
@@ -216,9 +216,10 @@ describe('Integration | Component | account-recovery::backup-email-confirmation-
       // given
       const resetErrors = sinon.stub();
       this.set('resetErrors', resetErrors);
+      this.set('sendEmail', () => {});
       const email = 'Philipe@example.net';
       await render(
-        hbs`<AccountRecovery::BackupEmailConfirmationForm @firstName={{this.firstName}} @resetErrors={{this.resetErrors}}/>`
+        hbs`<AccountRecovery::BackupEmailConfirmationForm @firstName={{this.firstName}} @resetErrors={{this.resetErrors}} @sendEmail={{this.sendEmail}}/>`
       );
 
       // when

--- a/mon-pix/tests/integration/components/challenge-statement_test.js
+++ b/mon-pix/tests/integration/components/challenge-statement_test.js
@@ -28,6 +28,7 @@ describe('Integration | Component | ChallengeStatement', function () {
         hasSeenFocusedChallengeTooltip: false,
       };
     }
+
     this.owner.unregister('service:currentUser');
     this.owner.register('service:currentUser', currentUser);
   });
@@ -163,9 +164,9 @@ describe('Integration | Component | ChallengeStatement', function () {
       await renderChallengeStatement(this);
 
       // then
-      expect(find('.challenge-statement__instruction-section > .sr-only'))
-        .to.have.property('textContent')
-        .that.contains(this.intl.t('pages.challenge.statement.sr-only.embed'));
+      expect(find('.challenge-statement__instruction-section > .sr-only').textContent).to.contains(
+        this.intl.t('pages.challenge.statement.sr-only.embed')
+      );
     });
 
     it('should have a screen reader only warning if challenge has an alternative instruction', async function () {
@@ -181,9 +182,9 @@ describe('Integration | Component | ChallengeStatement', function () {
       await renderChallengeStatement(this);
 
       // then
-      expect(find('.challenge-statement__instruction-section > .sr-only'))
-        .to.have.property('textContent')
-        .that.contains(this.intl.t('pages.challenge.statement.sr-only.alternative-instruction'));
+      expect(find('.challenge-statement__instruction-section > .sr-only').textContent).to.contains(
+        this.intl.t('pages.challenge.statement.sr-only.alternative-instruction')
+      );
     });
   });
 

--- a/mon-pix/tests/integration/components/challenge/item_test.js
+++ b/mon-pix/tests/integration/components/challenge/item_test.js
@@ -9,12 +9,16 @@ describe('Integration | Component | Challenge | Item', function () {
 
   it('should render', async function () {
     // given
-    this.set('challenge', {
-      type: 'QROC',
-      timer: false,
-      format: 'phrase',
-      proposals: '${myInput}',
-    });
+    const store = this.owner.lookup('service:store');
+    this.set(
+      'challenge',
+      store.createRecord('challenge', {
+        type: 'QROC',
+        timer: false,
+        format: 'phrase',
+        proposals: '${myInput}',
+      })
+    );
     this.set('answer', {});
 
     // when

--- a/mon-pix/tests/integration/components/comparison-window_test.js
+++ b/mon-pix/tests/integration/components/comparison-window_test.js
@@ -78,7 +78,8 @@ describe('Integration | Component | comparison-window', function () {
       );
 
       // then
-      expect(find('.tutorial-panel')).to.contain.text('Conseil : mangez des épinards.');
+      expect(find('.tutorial-panel__hint-title')).to.contain.text('Pour réussir la prochaine fois');
+      expect(find('.tutorial-panel__hint-content')).to.contain.text('Conseil : mangez des épinards.');
     });
 
     it('should render a learningMoreTutorials panel when correction has a list of LearningMoreTutorials elements', async function () {

--- a/mon-pix/tests/integration/components/congratulations-certification-banner_test.js
+++ b/mon-pix/tests/integration/components/congratulations-certification-banner_test.js
@@ -11,10 +11,15 @@ describe('Integration | Component | Congratulations Certification Banner', funct
 
   it('renders a banner indicating the user certifiability', async function () {
     // given
+    const store = this.owner.lookup('service:store');
     this.set('fullName', 'Fifi Brindacier');
+    this.set('closeBanner', () => {});
+    this.set('certificationEligibility', store.createRecord('is-certifiable', {}));
 
     // when
-    const screen = await render(hbs`<CongratulationsCertificationBanner @fullName={{this.fullName}}/>`);
+    const screen = await render(
+      hbs`<CongratulationsCertificationBanner @fullName={{this.fullName}} @closeBanner={{this.closeBanner}} @certificationEligibility={{this.certificationEligibility}}/>`
+    );
 
     // then
     expect(screen.getByText('Bravo Fifi Brindacier, votre profil Pix est certifiable.')).to.exist;
@@ -22,11 +27,14 @@ describe('Integration | Component | Congratulations Certification Banner', funct
 
   it('calls the closeBanner method when closing the banner', async function () {
     // given
+    const store = this.owner.lookup('service:store');
     const closeBannerStub = sinon.stub();
     this.set('closeBanner', closeBannerStub);
     this.set('fullName', 'Fifi Brindacier');
+    this.set('certificationEligibility', store.createRecord('is-certifiable', {}));
+
     const screen = await render(
-      hbs`<CongratulationsCertificationBanner @fullName={{this.fullName}} @closeBanner={{this.closeBanner}}/>`
+      hbs`<CongratulationsCertificationBanner @fullName={{this.fullName}} @closeBanner={{this.closeBanner}} @certificationEligibility={{this.certificationEligibility}}/>`
     );
 
     // when
@@ -46,10 +54,11 @@ describe('Integration | Component | Congratulations Certification Banner', funct
         });
         this.set('certificationEligibility', certificationEligibility);
         this.set('fullName', 'Fifi Brindacier');
+        this.set('closeBanner', () => {});
 
         // when
         const screen = await render(
-          hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}}/>`
+          hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}} @closeBanner={{this.closeBanner}}/>`
         );
 
         // then
@@ -71,10 +80,11 @@ describe('Integration | Component | Congratulations Certification Banner', funct
         });
         this.set('certificationEligibility', certificationEligibility);
         this.set('fullName', 'Fifi Brindacier');
+        this.set('closeBanner', () => {});
 
         // when
         const screen = await render(
-          hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}}/>`
+          hbs`<CongratulationsCertificationBanner @certificationEligibility={{this.certificationEligibility}} @fullName={{this.fullName}} @closeBanner={{this.closeBanner}}/>`
         );
 
         // then

--- a/mon-pix/tests/integration/components/dashboard/content_test.js
+++ b/mon-pix/tests/integration/components/dashboard/content_test.js
@@ -11,45 +11,26 @@ describe('Integration | Component | Dashboard | Content', function () {
   setupIntlRenderingTest();
 
   const pixScore = 105;
-  class CurrentUserStub extends Service {
-    user = {
-      firstName: 'Banana',
-      email: 'banana.split@example.net',
-      fullName: 'Banana Split',
-      profile: EmberObject.create({
-        pixScore,
-      }),
-      hasSeenNewDashboardInfo: false,
-    };
-  }
+  let store;
 
-  class CurrentUserWithCodeStub extends Service {
-    user = {
-      firstName: 'Banana',
-      email: 'banana.split@example.net',
-      fullName: 'Banana Split',
-      profile: EmberObject.create({
-        pixScore,
-      }),
-      hasSeenNewDashboardInfo: false,
-      codeForLastProfileToShare: 'SNAP1234',
-    };
-  }
-
-  class HasSeenNewDashboardInformationCurrentUserStub extends Service {
-    user = {
-      firstName: 'Banana',
-      email: 'banana.split@example.net',
-      fullName: 'Banana Split',
-      profile: {
-        pixScore,
-      },
-      hasSeenNewDashboardInfo: true,
-    };
-  }
+  beforeEach(function () {
+    store = this.owner.lookup('service:store');
+  });
 
   it('should render component', async function () {
     // given
+    class CurrentUserStub extends Service {
+      user = store.createRecord('user', {
+        firstName: 'Banana',
+        lastName: 'Split',
+        email: 'banana.split@example.net',
+        profile: store.createRecord('profile', {
+          pixScore,
+        }),
+        hasSeenNewDashboardInfo: false,
+      });
+    }
+
     this.owner.register('service:currentUser', CurrentUserStub);
     this.set('model', {
       campaignParticipationOverviews: [],
@@ -66,6 +47,18 @@ describe('Integration | Component | Dashboard | Content', function () {
 
   describe('campaign-participation-overview rendering', function () {
     beforeEach(function () {
+      class CurrentUserStub extends Service {
+        user = store.createRecord('user', {
+          firstName: 'Banana',
+          lastName: 'Split',
+          email: 'banana.split@example.net',
+          profile: store.createRecord('profile', {
+            pixScore,
+          }),
+          hasSeenNewDashboardInfo: false,
+        });
+      }
+
       this.owner.register('service:currentUser', CurrentUserStub);
     });
 
@@ -131,6 +124,18 @@ describe('Integration | Component | Dashboard | Content', function () {
 
   describe('recommended competence-card rendering', function () {
     beforeEach(function () {
+      class CurrentUserStub extends Service {
+        user = store.createRecord('user', {
+          firstName: 'Banana',
+          lastName: 'Split',
+          email: 'banana.split@example.net',
+          profile: store.createRecord('profile', {
+            pixScore,
+          }),
+          hasSeenNewDashboardInfo: false,
+        });
+      }
+
       this.owner.register('service:currentUser', CurrentUserStub);
     });
 
@@ -191,6 +196,18 @@ describe('Integration | Component | Dashboard | Content', function () {
 
   describe('improvable competence-card rendering', function () {
     beforeEach(function () {
+      class CurrentUserStub extends Service {
+        user = store.createRecord('user', {
+          firstName: 'Banana',
+          lastName: 'Split',
+          email: 'banana.split@example.net',
+          profile: store.createRecord('profile', {
+            pixScore,
+          }),
+          hasSeenNewDashboardInfo: false,
+        });
+      }
+
       this.owner.register('service:currentUser', CurrentUserStub);
     });
 
@@ -251,6 +268,18 @@ describe('Integration | Component | Dashboard | Content', function () {
 
   describe('started competence-card rendering', function () {
     beforeEach(function () {
+      class CurrentUserStub extends Service {
+        user = store.createRecord('user', {
+          firstName: 'Banana',
+          lastName: 'Split',
+          email: 'banana.split@example.net',
+          profile: store.createRecord('profile', {
+            pixScore,
+          }),
+          hasSeenNewDashboardInfo: false,
+        });
+      }
+
       this.owner.register('service:currentUser', CurrentUserStub);
     });
 
@@ -312,6 +341,18 @@ describe('Integration | Component | Dashboard | Content', function () {
   describe('new dashboard info rendering', function () {
     it('should display NewInformation on dashboard if user has not close it before', async function () {
       // given
+      class CurrentUserStub extends Service {
+        user = store.createRecord('user', {
+          firstName: 'Banana',
+          lastName: 'Split',
+          email: 'banana.split@example.net',
+          profile: store.createRecord('profile', {
+            pixScore,
+          }),
+          hasSeenNewDashboardInfo: false,
+        });
+      }
+
       this.owner.register('service:currentUser', CurrentUserStub);
       this.set('model', {
         campaignParticipationOverviews: [],
@@ -328,6 +369,18 @@ describe('Integration | Component | Dashboard | Content', function () {
 
     it('should not display NewInformation on dashboard if user has close it before', async function () {
       // given
+      class HasSeenNewDashboardInformationCurrentUserStub extends Service {
+        user = store.createRecord('user', {
+          firstName: 'Banana',
+          lastName: 'Split',
+          email: 'banana.split@example.net',
+          profile: store.createRecord('profile', {
+            pixScore,
+          }),
+          hasSeenNewDashboardInfo: true,
+        });
+      }
+
       this.owner.register('service:currentUser', HasSeenNewDashboardInformationCurrentUserStub);
       this.set('model', {
         campaignParticipationOverviews: [],
@@ -349,6 +402,19 @@ describe('Integration | Component | Dashboard | Content', function () {
           return true;
         }
       }
+
+      class CurrentUserStub extends Service {
+        user = store.createRecord('user', {
+          firstName: 'Banana',
+          lastName: 'Split',
+          email: 'banana.split@example.net',
+          profile: store.createRecord('profile', {
+            pixScore,
+          }),
+          hasSeenNewDashboardInfo: false,
+        });
+      }
+
       this.owner.register('service:currentUser', CurrentUserStub);
       this.owner.register('service:url', UrlStub);
       this.set('model', {
@@ -372,6 +438,19 @@ describe('Integration | Component | Dashboard | Content', function () {
           return false;
         }
       }
+
+      class CurrentUserStub extends Service {
+        user = store.createRecord('user', {
+          firstName: 'Banana',
+          lastName: 'Split',
+          email: 'banana.split@example.net',
+          profile: store.createRecord('profile', {
+            pixScore,
+          }),
+          hasSeenNewDashboardInfo: false,
+        });
+      }
+
       this.owner.register('service:currentUser', CurrentUserStub);
       this.owner.register('service:url', UrlStub);
       this.set('model', {
@@ -392,6 +471,18 @@ describe('Integration | Component | Dashboard | Content', function () {
   describe('empty dashboard info rendering', function () {
     it('should display Empty Dashboard Information if user has nothing to do', async function () {
       // given
+      class CurrentUserStub extends Service {
+        user = store.createRecord('user', {
+          firstName: 'Banana',
+          lastName: 'Split',
+          email: 'banana.split@example.net',
+          profile: store.createRecord('profile', {
+            pixScore,
+          }),
+          hasSeenNewDashboardInfo: false,
+        });
+      }
+
       this.owner.register('service:currentUser', CurrentUserStub);
       this.set('model', {
         campaignParticipationOverviews: [],
@@ -408,6 +499,18 @@ describe('Integration | Component | Dashboard | Content', function () {
 
     it('should not display Empty Dashboard Information on dashboard if user has competence to continue', async function () {
       // given
+      class HasSeenNewDashboardInformationCurrentUserStub extends Service {
+        user = store.createRecord('user', {
+          firstName: 'Banana',
+          lastName: 'Split',
+          email: 'banana.split@example.net',
+          profile: store.createRecord('profile', {
+            pixScore,
+          }),
+          hasSeenNewDashboardInfo: true,
+        });
+      }
+
       this.owner.register('service:currentUser', HasSeenNewDashboardInformationCurrentUserStub);
       this.set('model', {
         campaignParticipationOverviews: [],
@@ -429,6 +532,18 @@ describe('Integration | Component | Dashboard | Content', function () {
   describe('user pix score rendering', function () {
     it('should display user score', async function () {
       // given
+      class CurrentUserStub extends Service {
+        user = store.createRecord('user', {
+          firstName: 'Banana',
+          lastName: 'Split',
+          email: 'banana.split@example.net',
+          profile: store.createRecord('profile', {
+            pixScore,
+          }),
+          hasSeenNewDashboardInfo: false,
+        });
+      }
+
       this.owner.register('service:currentUser', CurrentUserStub);
       this.set('model', {
         campaignParticipationOverviews: [],
@@ -448,6 +563,19 @@ describe('Integration | Component | Dashboard | Content', function () {
   describe('participation to a profile collection campaign to resume', function () {
     it('should display the banner to resume participation', async function () {
       // given
+      class CurrentUserWithCodeStub extends Service {
+        user = store.createRecord('user', {
+          firstName: 'Banana',
+          lastName: 'Split',
+          email: 'banana.split@example.net',
+          profile: store.createRecord('profile', {
+            pixScore,
+          }),
+          hasSeenNewDashboardInfo: false,
+          codeForLastProfileToShare: 'SNAP1234',
+        });
+      }
+
       this.owner.register('service:currentUser', CurrentUserWithCodeStub);
       this.set('model', {
         campaignParticipationOverviews: [],
@@ -464,6 +592,18 @@ describe('Integration | Component | Dashboard | Content', function () {
 
     it('should not display the banner when there is no code', async function () {
       // given
+      class CurrentUserStub extends Service {
+        user = store.createRecord('user', {
+          firstName: 'Banana',
+          lastName: 'Split',
+          email: 'banana.split@example.net',
+          profile: store.createRecord('profile', {
+            pixScore,
+          }),
+          hasSeenNewDashboardInfo: false,
+        });
+      }
+
       this.owner.register('service:currentUser', CurrentUserStub);
       this.set('model', {
         campaignParticipationOverviews: [],

--- a/mon-pix/tests/integration/components/dashboard/content_test.js
+++ b/mon-pix/tests/integration/components/dashboard/content_test.js
@@ -449,6 +449,11 @@ describe('Integration | Component | Dashboard | Content', function () {
     it('should display the banner to resume participation', async function () {
       // given
       this.owner.register('service:currentUser', CurrentUserWithCodeStub);
+      this.set('model', {
+        campaignParticipationOverviews: [],
+        campaignParticipations: [],
+        scorecards: [],
+      });
 
       // when
       await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
@@ -460,6 +465,11 @@ describe('Integration | Component | Dashboard | Content', function () {
     it('should not display the banner when there is no code', async function () {
       // given
       this.owner.register('service:currentUser', CurrentUserStub);
+      this.set('model', {
+        campaignParticipationOverviews: [],
+        campaignParticipations: [],
+        scorecards: [],
+      });
 
       // when
       await render(hbs`<Dashboard::Content @model={{this.model}}/>`);

--- a/mon-pix/tests/integration/components/feedback-panel_test.js
+++ b/mon-pix/tests/integration/components/feedback-panel_test.js
@@ -213,10 +213,8 @@ describe('Integration | Component | feedback-panel', function () {
     });
 
     it('should not be able to hide the form view', async function () {
-      // when
-      await click(OPEN_FEEDBACK_BUTTON);
-
       // then
+      expect(find(OPEN_FEEDBACK_BUTTON).disabled).to.be.true;
       expect(find('.feedback-panel__form')).to.exist;
     });
   });

--- a/mon-pix/tests/integration/components/navbar-burger-menu_test.js
+++ b/mon-pix/tests/integration/components/navbar-burger-menu_test.js
@@ -14,6 +14,7 @@ describe('Integration | Component | navbar-burger-menu', function () {
         fullName: 'Bobby Carotte',
       };
     }
+
     this.owner.register('service:currentUser', currentUser);
   });
 
@@ -56,6 +57,7 @@ describe('Integration | Component | navbar-burger-menu', function () {
           hasAssessmentParticipations: true,
         };
       }
+
       this.owner.unregister('service:currentUser');
       this.owner.register('service:currentUser', currentUser);
     });
@@ -73,9 +75,11 @@ describe('Integration | Component | navbar-burger-menu', function () {
     beforeEach(async function () {
       class currentUser extends Service {
         user = {
+          fullName: 'John Doe',
           hasAssessmentParticipations: false,
         };
       }
+
       this.owner.unregister('service:currentUser');
       this.owner.register('service:currentUser', currentUser);
     });
@@ -92,9 +96,11 @@ describe('Integration | Component | navbar-burger-menu', function () {
     beforeEach(async function () {
       class currentUser extends Service {
         user = {
+          fullName: 'John Doe',
           hasRecommendedTrainings: true,
         };
       }
+
       this.owner.unregister('service:currentUser');
       this.owner.register('service:currentUser', currentUser);
     });

--- a/mon-pix/tests/integration/components/navbar-header_test.js
+++ b/mon-pix/tests/integration/components/navbar-header_test.js
@@ -38,6 +38,7 @@ describe('Integration | Component | navbar-header', function () {
     it('should be rendered in mobile/tablet mode with a burger', async function () {
       // when
       this.owner.register('service:session', Service.extend({ isAuthenticated: true }));
+      this.owner.register('service:currentUser', Service.extend({ user: { fullName: 'John Doe' } }));
       this.set('burger', {
         state: {
           actions: {
@@ -61,6 +62,8 @@ describe('Integration | Component | navbar-header', function () {
     });
 
     it('should render skip links', async function () {
+      this.owner.register('service:currentUser', Service.extend({ user: { fullName: 'John Doe' } }));
+
       await render(hbs`<NavbarHeader/>`);
 
       expect(contains(this.intl.t('common.skip-links.skip-to-content'))).to.exist;

--- a/mon-pix/tests/integration/components/qcm-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qcm-solution-panel_test.js
@@ -212,11 +212,10 @@ describe('Integration | Component | qcm-solution-panel.js', function () {
         );
 
         // Then
-        findAll('.comparison-window .qcm-proposal-label__checkbox-picture').forEach((c, index) => {
-          expect(
-            find('.comparison-window .qcm-proposal-label__checkbox-picture:eq(' + index + ')').getAttribute('disabled')
-          ).to.equal('disabled');
-        });
+        expect(findAll('.qcm-panel__proposal-checkbox')[0].getAttribute('disabled')).to.equal('disabled');
+        expect(findAll('.qcm-panel__proposal-checkbox')[1].getAttribute('disabled')).to.equal('disabled');
+        expect(findAll('.qcm-panel__proposal-checkbox')[2].getAttribute('disabled')).to.equal('disabled');
+        expect(findAll('.qcm-panel__proposal-checkbox')[3].getAttribute('disabled')).to.equal('disabled');
       });
     });
   });

--- a/mon-pix/tests/integration/components/qcm-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qcm-solution-panel_test.js
@@ -16,7 +16,9 @@ describe('Integration | Component | qcm-solution-panel.js', function () {
 
   describe('#Component should renders: ', function () {
     it('Should renders', async function () {
-      await render(hbs`<QcmSolutionPanel />`);
+      this.set('answer', {});
+
+      await render(hbs`<QcmSolutionPanel @answer={{this.answer}} />`);
 
       expect(find('.qcm-solution-panel')).to.exist;
       expect(findAll('.qcm-proposal-label__answer-details')).to.have.lengthOf(0);

--- a/mon-pix/tests/integration/components/qcm-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qcm-solution-panel_test.js
@@ -4,7 +4,6 @@ import { describe, it, before } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import times from 'lodash/times';
 
 const assessment = {};
 let challenge = null;
@@ -213,8 +212,7 @@ describe('Integration | Component | qcm-solution-panel.js', function () {
         );
 
         // Then
-        const size = findAll('.comparison-window .qcm-proposal-label__checkbox-picture').length;
-        times(size, function (index) {
+        findAll('.comparison-window .qcm-proposal-label__checkbox-picture').forEach((c, index) => {
           expect(
             find('.comparison-window .qcm-proposal-label__checkbox-picture:eq(' + index + ')').getAttribute('disabled')
           ).to.equal('disabled');

--- a/mon-pix/tests/integration/components/qcu-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qcu-solution-panel_test.js
@@ -4,7 +4,6 @@ import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import times from 'lodash/times';
 
 const assessment = {};
 let challenge = null;
@@ -86,7 +85,7 @@ describe('Integration | Component | qcu-solution-panel.js', function () {
       );
 
       // Then
-      times(findAll('.comparison-window .qcu-solution-panel__radio-button').length, function (index) {
+      findAll('.comparison-window .qcu-solution-panel__radio-button').forEach((button, index) => {
         expect(
           find('.comparison-window .qcu-solution-panel__radio-button:eq(' + index + ')').getAttribute('disabled')
         ).to.equal('disabled');
@@ -288,7 +287,7 @@ describe('Integration | Component | qcu-solution-panel.js', function () {
       );
 
       // Then
-      times(findAll('.comparison-window .qcu-solution-panel__radio-button').length, function (index) {
+      findAll('.comparison-window .qcu-solution-panel__radio-button').forEach((button, index) => {
         expect(
           find('.comparison-window .qcu-solution-panel__radio-button:eq(' + index + ')').getAttribute('disabled')
         ).to.equal('disabled');

--- a/mon-pix/tests/integration/components/qcu-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qcu-solution-panel_test.js
@@ -31,7 +31,9 @@ describe('Integration | Component | qcu-solution-panel.js', function () {
   };
 
   it('Should render', async function () {
-    await render(hbs`<QcuSolutionPanel/>`);
+    this.set('answer', {});
+
+    await render(hbs`<QcuSolutionPanel @answer={{this.answer}}/>`);
     expect(find('.qcu-solution-panel')).to.exist;
   });
 

--- a/mon-pix/tests/integration/components/qcu-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qcu-solution-panel_test.js
@@ -71,26 +71,6 @@ describe('Integration | Component | qcu-solution-panel.js', function () {
       // Then
       expect(findAll('[data-goodness=good]').length).to.equal(1);
     });
-
-    it('should not be editable', async function () {
-      //Given
-      this.set('answer', answer);
-      this.set('solution', solution);
-      this.set('solutionToDisplay', null);
-      this.set('challenge', challenge);
-
-      // When
-      await render(
-        hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}} @solutionToDisplay={{this.solutionToDisplay}}/>`
-      );
-
-      // Then
-      findAll('.comparison-window .qcu-solution-panel__radio-button').forEach((button, index) => {
-        expect(
-          find('.comparison-window .qcu-solution-panel__radio-button:eq(' + index + ')').getAttribute('disabled')
-        ).to.equal('disabled');
-      });
-    });
   });
 
   describe('When answer is correct', function () {
@@ -272,26 +252,6 @@ describe('Integration | Component | qcu-solution-panel.js', function () {
       expect(findAll('.qcu-solution-panel__proposition')[2].getAttribute('data-checked')).to.equal('yes');
       expect(findAll('.qcu-solution-panel__proposition')[2].getAttribute('data-goodness')).to.equal('bad');
       expect(findAll('.qcu-solution-panel__radio-button')[2].innerHTML).to.contains('Votre réponse');
-    });
-
-    it('Should avoid click on radio button', async function () {
-      //Given
-      this.set('answer', answer);
-      this.set('solution', solution);
-      this.set('solutionToDisplay', null);
-      this.set('challenge', challenge);
-
-      // When
-      await render(
-        hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}} @solutionToDisplay={{this.solutionToDisplay}}/>`
-      );
-
-      // Then
-      findAll('.comparison-window .qcu-solution-panel__radio-button').forEach((button, index) => {
-        expect(
-          find('.comparison-window .qcu-solution-panel__radio-button:eq(' + index + ')').getAttribute('disabled')
-        ).to.equal('disabled');
-      });
     });
   });
 });

--- a/mon-pix/tests/integration/components/result-item-campaign_test.js
+++ b/mon-pix/tests/integration/components/result-item-campaign_test.js
@@ -77,7 +77,7 @@ describe('Integration | Component | result-item', function () {
       await render(hbs`<ResultItem @answer={{this.answer}} @openAnswerDetails={{this.openComparisonWindow}}/>`);
 
       // Then
-      expect(find('result-item__icon-img'));
+      expect(find('.result-item__icon--red'));
     });
 
     [

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -4,6 +4,7 @@ import { clickByLabel } from '../../../../../helpers/click-by-label';
 import { findAll } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { render } from '@1024pix/ember-testing-library';
+import { it, describe, beforeEach, context } from 'mocha';
 
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 import sinon from 'sinon';

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -335,9 +335,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
 
       // Then
-      expect(screen.getByRole('link', { name: 'Badge 1' }))
-        .to.have.property('href')
-        .that.contains('#Badge%201');
+      expect(screen.getByRole('link', { name: 'Badge 1' }).href).to.contains('#Badge%201');
     });
   });
 
@@ -545,9 +543,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
 
               // Then
               expect(screen.getByRole('link', { name: 'Next step' })).to.exist;
-              expect(screen.getByRole('link', { name: 'Next step' }))
-                .to.have.property('target')
-                .that.equals('_blank');
+              expect(screen.getByRole('link', { name: 'Next step' }).target).to.equals('_blank');
               expect(screen.getByText('Next step')).to.exist;
             });
           }
@@ -578,9 +574,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
 
               // Then
               expect(screen.getByRole('link', { name: 'Next step' })).to.exist;
-              expect(screen.getByRole('link', { name: 'Next step' }))
-                .to.have.property('target')
-                .that.equals('_blank');
+              expect(screen.getByRole('link', { name: 'Next step' }).target).to.equals('_blank');
               expect(screen.getByText('Next step')).to.exist;
             });
           }
@@ -814,9 +808,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         // Then
         expect(screen.getByText(this.intl.t('pages.skill-review.net-promoter-score.link.label'))).to.exist;
         expect(screen.getByRole('link', { name: 'Je donne mon avis' })).to.exist;
-        expect(screen.getByRole('link', { name: 'Je donne mon avis' }))
-          .to.have.property('target')
-          .that.equals('_blank');
+        expect(screen.getByRole('link', { name: 'Je donne mon avis' }).target).to.equals('_blank');
       });
     });
 

--- a/mon-pix/tests/integration/components/signup-form_test.js
+++ b/mon-pix/tests/integration/components/signup-form_test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { clickByLabel } from '../../helpers/click-by-label';
 import Service from '@ember/service';
 
-import { fillIn, find, findAll, settled, triggerEvent, waitUntil } from '@ember/test-helpers';
+import { fillIn, find, findAll, settled, triggerEvent } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
 
 import ArrayProxy from '@ember/array/proxy';
@@ -263,6 +263,7 @@ describe('Integration | Component | SignupForm', function () {
       class sessionService extends Service {
         authenticateUser = sinon.stub().resolves();
       }
+
       this.owner.register('service:session', sessionService);
       session = this.owner.lookup('service:session', sessionService);
     });
@@ -660,6 +661,7 @@ describe('Integration | Component | SignupForm', function () {
       class sessionService extends Service {
         authenticateUser = sinon.stub().resolves();
       }
+
       this.owner.register('service:session', sessionService);
 
       const validUser = EmberObject.create({
@@ -679,7 +681,7 @@ describe('Integration | Component | SignupForm', function () {
       await clickByLabel("Je m'inscris");
 
       // then
-      await waitUntil(() => find('.loader-in-button'));
+      expect(find('.loader-in-button'));
     });
   });
 });

--- a/mon-pix/tests/integration/components/training/card_test.js
+++ b/mon-pix/tests/integration/components/training/card_test.js
@@ -22,14 +22,14 @@ describe('Integration | Component | Training | Card', function () {
 
     // then
     expect(find('.training-card')).to.exist;
-    expect(find('.training-card__content')).to.have.property('href').that.equals('https://training.net/');
+    expect(find('.training-card__content').href).to.equal('https://training.net/');
     expect(find('.training-card-content__title').textContent.trim()).to.equal('Mon super training');
     expect(find('.training-card-content__infos')).to.exist;
     expect(find('.training-card-content-infos-list__type').textContent.trim()).to.equal('Webinaire');
     expect(find('.training-card-content-infos-list__duration').textContent.trim()).to.equal('6h');
-    expect(find('.training-card-content-illustration__image')).to.have.property('alt').to.be.empty;
-    expect(find('.training-card-content-illustration__logo'))
-      .to.have.property('alt')
-      .that.equals(this.intl.t('common.french-education-ministry'));
+    expect(find('.training-card-content-illustration__image').alt).to.be.empty;
+    expect(find('.training-card-content-illustration__logo').alt).to.equal(
+      this.intl.t('common.french-education-ministry')
+    );
   });
 });

--- a/mon-pix/tests/integration/components/tutorials/card_test.js
+++ b/mon-pix/tests/integration/components/tutorials/card_test.js
@@ -14,6 +14,7 @@ describe('Integration | Component | Tutorials | Card', function () {
       class CurrentUserStub extends Service {
         user = { firstName: 'John' };
       }
+
       this.owner.register('service:currentUser', CurrentUserStub);
       this.set('tutorial', {
         title: 'Mon super tutoriel',
@@ -31,13 +32,11 @@ describe('Integration | Component | Tutorials | Card', function () {
       // then
       expect(find('.tutorial-card')).to.exist;
       expect(find('.tutorial-card__content')).to.exist;
-      expect(find('.tutorial-card-content__link')).to.have.property('textContent').that.contains('Mon super tutoriel');
-      expect(find('.tutorial-card-content__link')).to.have.property('href').that.equals('https://exemple.net/');
-      expect(find('.tutorial-card-content__details'))
-        .to.have.property('textContent')
-        .that.contains('mon-tuto')
-        .and.contains('vidéo')
-        .and.contains('une minute');
+      expect(find('.tutorial-card-content__link').textContent).to.contains('Mon super tutoriel');
+      expect(find('.tutorial-card-content__link').href).to.equals('https://exemple.net/');
+      expect(find('.tutorial-card-content__details').textContent).to.contains('mon-tuto');
+      expect(find('.tutorial-card-content__details').textContent).to.contains('vidéo');
+      expect(find('.tutorial-card-content__details').textContent).to.contains('une minute');
       expect(find('.tutorial-card-content__actions')).to.exist;
       expect(find('[aria-label="Ne plus considérer ce tuto comme utile"]')).to.exist;
       expect(find('[aria-label="Retirer de ma liste de tutos"]')).to.exist;
@@ -51,6 +50,7 @@ describe('Integration | Component | Tutorials | Card', function () {
       class CurrentUserStub extends Service {
         user = null;
       }
+
       this.owner.register('service:currentUser', CurrentUserStub);
       this.set('tutorial', {
         title: 'Mon super tutoriel',
@@ -68,13 +68,11 @@ describe('Integration | Component | Tutorials | Card', function () {
       // then
       expect(find('.tutorial-card')).to.exist;
       expect(find('.tutorial-card__content')).to.exist;
-      expect(find('.tutorial-card-content__link')).to.have.property('textContent').that.contains('Mon super tutoriel');
-      expect(find('.tutorial-card-content__link')).to.have.property('href').that.equals('https://exemple.net/');
-      expect(find('.tutorial-card-content__details'))
-        .to.have.property('textContent')
-        .that.contains('mon-tuto')
-        .and.contains('vidéo')
-        .and.contains('une minute');
+      expect(find('.tutorial-card-content__link').textContent).to.contains('Mon super tutoriel');
+      expect(find('.tutorial-card-content__link').href).to.equals('https://exemple.net/');
+      expect(find('.tutorial-card-content__details').textContent).to.contains('mon-tuto');
+      expect(find('.tutorial-card-content__details').textContent).to.contains('vidéo');
+      expect(find('.tutorial-card-content__details').textContent).to.contains('une minute');
       expect(find('.tutorial-card-content__actions')).to.not.exist;
     });
   });

--- a/mon-pix/tests/integration/components/user-tutorials/filters/sidebar_test.js
+++ b/mon-pix/tests/integration/components/user-tutorials/filters/sidebar_test.js
@@ -17,9 +17,13 @@ describe('Integration | Component | User-Tutorials | Filters | Sidebar', functio
         { id: 'area2', title: 'Area 2' },
         { id: 'area3', title: 'Area 3' },
       ]);
+      this.set('onSubmit', () => {});
+      this.set('onClose', () => {});
 
       // when
-      await render(hbs`<UserTutorials::Filters::Sidebar @isVisible={{this.isVisible}} @areas={{this.areas}} />`);
+      await render(
+        hbs`<UserTutorials::Filters::Sidebar @isVisible={{this.isVisible}} @onSubmit={{this.onSubmit}} @onClose={{this.onClose}} @areas={{this.areas}}/>`
+      );
 
       // then
       expect(find('.tutorials-filters')).to.exist;
@@ -34,8 +38,12 @@ describe('Integration | Component | User-Tutorials | Filters | Sidebar', functio
           { id: 'area1', title: 'Area 1', sortedCompetences: [{ id: 'competence1', name: 'Ma superbe compétence' }] },
         ]);
         this.set('onSubmit', () => {});
+        this.set('onSubmit', () => {});
+        this.set('onClose', () => {});
+
+        // when
         const screen = await render(
-          hbs`<UserTutorials::Filters::Sidebar @isVisible={{this.isVisible}} @areas={{this.areas}} @onSubmit={{this.onSubmit}} />`
+          hbs`<UserTutorials::Filters::Sidebar @isVisible={{this.isVisible}} @onSubmit={{this.onSubmit}} @onClose={{this.onClose}} @areas={{this.areas}}/>`
         );
         await click(screen.getByRole('button', { name: 'Area 1' }));
         const checkbox = screen.getByRole('checkbox', { name: 'Ma superbe compétence' });
@@ -57,8 +65,11 @@ describe('Integration | Component | User-Tutorials | Filters | Sidebar', functio
             { id: 'area1', title: 'Area 1', sortedCompetences: [{ id: 'competence1', name: 'Ma superbe compétence' }] },
           ]);
           this.set('onSubmit', () => {});
+          this.set('onClose', () => {});
+
+          // when
           const screen = await render(
-            hbs`<UserTutorials::Filters::Sidebar @isVisible={{this.isVisible}} @areas={{this.areas}} @onSubmit={{this.onSubmit}} />`
+            hbs`<UserTutorials::Filters::Sidebar @isVisible={{this.isVisible}} @onSubmit={{this.onSubmit}} @onClose={{this.onClose}} @areas={{this.areas}}/>`
           );
           await click(screen.getByRole('button', { name: 'Area 1' }));
           const checkbox = screen.getByRole('checkbox', { name: 'Ma superbe compétence' });
@@ -78,9 +89,13 @@ describe('Integration | Component | User-Tutorials | Filters | Sidebar', functio
     it('should not show sidebar', async function () {
       // given
       this.set('isVisible', false);
+      this.set('onSubmit', () => {});
+      this.set('onClose', () => {});
 
       // when
-      await render(hbs`<UserTutorials::Filters::Sidebar @isVisible={{this.isVisible}} />`);
+      await render(
+        hbs`<UserTutorials::Filters::Sidebar @isVisible={{this.isVisible}} @onSubmit={{this.onSubmit}} @onClose={{this.onClose}} @areas={{this.areas}}/>`
+      );
 
       // then
       expect(find('.pix-sidebar--hidden')).to.exist;

--- a/mon-pix/tests/unit/adapters/shared-profile-for-campaign_test.js
+++ b/mon-pix/tests/unit/adapters/shared-profile-for-campaign_test.js
@@ -19,7 +19,7 @@ describe('Unit | Adapters | shared-profile-for-campaign', function () {
       const url = await adapter.urlForQueryRecord(query);
 
       expect(url.endsWith('/api/users/userId1/campaigns/campaignId1/profile')).to.be.true;
-      expect(query).to.be.empty;
+      expect(query).to.deep.equal({});
     });
     it('should build default url if no campaign and user ids', async function () {
       const query = {};

--- a/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
@@ -92,13 +92,9 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function ()
         component.args.model.campaignParticipationResult.isShared = false;
         adapter.share.rejects();
 
-        try {
-          await component.actions.shareCampaignParticipation.call(component);
-        } catch (err) {
-          expect(component.args.model.campaignParticipationResult.isShared).to.equal(false);
-          return;
-        }
-        sinon.assert.fail('shareCampaignParticipation should have throw an error.');
+        await component.actions.shareCampaignParticipation.call(component);
+
+        expect(component.args.model.campaignParticipationResult.isShared).to.equal(false);
       });
 
       it('should display not-finished-yet message if status is 409', async function () {
@@ -112,13 +108,9 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function ()
       it('should display global error message if status is not 409', async function () {
         adapter.share.rejects({ errors: [{ status: '412' }] });
 
-        try {
-          await component.actions.shareCampaignParticipation.call(component);
-        } catch (err) {
-          expect(component.showGlobalErrorMessage).to.equal(true);
-          return;
-        }
-        sinon.assert.fail('shareCampaignParticipation should have throw an error.');
+        await component.actions.shareCampaignParticipation.call(component);
+
+        expect(component.showGlobalErrorMessage).to.equal(true);
       });
     });
   });

--- a/mon-pix/tests/unit/components/user-tutorials/filters/sidebar_test.js
+++ b/mon-pix/tests/unit/components/user-tutorials/filters/sidebar_test.js
@@ -49,7 +49,7 @@ describe('Unit | Component | User-Tutorials | Filters | Sidebar', function () {
       component.handleResetFilters();
 
       // then
-      expect(component.filters).to.have.property('competences');
+      expect(component.filters.competences);
       expect(component.filters.competences).to.have.lengthOf(0);
     });
   });

--- a/mon-pix/tests/unit/serializers/assessment_test.js
+++ b/mon-pix/tests/unit/serializers/assessment_test.js
@@ -18,10 +18,8 @@ describe('Unit | Serializer | assessment', function () {
     const json = serializer.serialize(snapshot);
 
     expect(json.data.type).to.equal('assessments');
-    expect(json.data.attributes).to.include({
-      'certification-number': 'cert123',
-      'code-campaign': 'campaign123',
-    });
+    expect(json.data.attributes['certification-number']).to.equal('cert123');
+    expect(json.data.attributes['code-campaign']).to.equal('campaign123');
   });
 
   describe('when adapter options are given', function () {

--- a/mon-pix/tests/unit/services/authentication_test.js
+++ b/mon-pix/tests/unit/services/authentication_test.js
@@ -1,6 +1,6 @@
 import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
-import { it } from 'mocha';
+import { it, describe, beforeEach, afterEach, context } from 'mocha';
 
 describe('Unit | Services | authentication', function () {
   setupTest();

--- a/mon-pix/tests/unit/services/oidc-identity-providers_test.js
+++ b/mon-pix/tests/unit/services/oidc-identity-providers_test.js
@@ -31,8 +31,14 @@ describe('Unit | Service | oidc-identity-providers', function () {
       await oidcIdentityProvidersService.load();
 
       // then
-      expect(oidcIdentityProvidersService['oidc-partner']).to.deep.contain(oidcPartner);
-      expect(oidcIdentityProvidersService.list[0]).to.deep.contain(oidcPartner);
+      expect(oidcIdentityProvidersService['oidc-partner'].code).to.equal(oidcPartner.code);
+      expect(oidcIdentityProvidersService['oidc-partner'].organizationName).to.equal(oidcPartner.organizationName);
+      expect(oidcIdentityProvidersService['oidc-partner'].hasLogoutUrl).to.equal(oidcPartner.hasLogoutUrl);
+      expect(oidcIdentityProvidersService['oidc-partner'].source).to.equal(oidcPartner.source);
+      expect(oidcIdentityProvidersService.list[0].code).to.equal(oidcPartner.code);
+      expect(oidcIdentityProvidersService.list[0].organizationName).to.equal(oidcPartner.organizationName);
+      expect(oidcIdentityProvidersService.list[0].hasLogoutUrl).to.equal(oidcPartner.hasLogoutUrl);
+      expect(oidcIdentityProvidersService.list[0].source).to.equal(oidcPartner.source);
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, lorsque nous essayons de faire la migration vers QUnit plusieurs problèmes nous font face. 

## :gift: Proposition
Régler ces problèmes : 
- Il y a le cas d'argument manquant dans l'appel des composants
- Des objets mal instanciés : il devrait s'agir d'objet du store mais nous créons des objets js et nous bénéficions donc pas des getters intégrés dans les models du store.
- Nous faisons des expects compliqués pour QUnit comme des `forEach` ou `to.have.property`
- Nous traitons des assertions mal écrite ou qui ne passent pas pour les bonnes raions
- Nous réparons les erreurs soulevés qui deviennent bloquantes dans les tests
- Nous ajoutons les imports manquants

## :star2: Remarques
- Des fichiers de tests vide ont été supprimé

## :santa: Pour tester
Les tests passent
