### PR TITLE
[FEATURE] Monter la version Pix UI de Certif de 14.8.1 à 16.1.0 (PIX-6357)

### DIFF
--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^14.8.1",
+        "@1024pix/pix-ui": "^16.1.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/test-helpers": "^2.8.1",
         "@fortawesome/ember-fontawesome": "^0.4.1",
@@ -302,10 +302,11 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "14.8.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-14.8.1.tgz",
-      "integrity": "sha512-ssxER96IMoxhy0AYQsgqdSwQxIHEC3FJ/mKxWI/ghpH315gqMLFJbIs5dP9Ovv2+6nC5L5eJFSuwkWxPubKyhQ==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-16.1.0.tgz",
+      "integrity": "sha512-4BCdL/sEcLC0ko5/X8Ou8JhA9cb9YZkvg9K0Wmts7iVPUFR8W5tmeCPf4XX1exN/m8FFI/c3wqXBlqVMSsnoUA==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.6",
         "ember-cli-htmlbars": "^5.6.2",
@@ -316,7 +317,8 @@
         "ember-truth-helpers": "^3.0.0"
       },
       "engines": {
-        "node": "^16.13.0"
+        "node": "16.14.0",
+        "npm": ">=8.3.1 <=8.13.2"
       }
     },
     "node_modules/@1024pix/pix-ui/node_modules/async-disk-cache": {
@@ -31864,9 +31866,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "14.8.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-14.8.1.tgz",
-      "integrity": "sha512-ssxER96IMoxhy0AYQsgqdSwQxIHEC3FJ/mKxWI/ghpH315gqMLFJbIs5dP9Ovv2+6nC5L5eJFSuwkWxPubKyhQ==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-16.1.0.tgz",
+      "integrity": "sha512-4BCdL/sEcLC0ko5/X8Ou8JhA9cb9YZkvg9K0Wmts7iVPUFR8W5tmeCPf4XX1exN/m8FFI/c3wqXBlqVMSsnoUA==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/certif/package.json
+++ b/certif/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^14.8.1",
+    "@1024pix/pix-ui": "^16.1.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.8.1",
     "@fortawesome/ember-fontawesome": "^0.4.1",


### PR DESCRIPTION
## :christmas_tree: Problème
On a du retard sur les versions de PIX UI sur l'application Pix Certif. 

## :gift: Proposition
Monter dans un premier temps la version de 14.8.1 à 16.1.0 comprenant les changements suivants : 
Changes embarqués dans cette version : 

[#232](https://github.com/1024pix/pix-ui/pull/232) [FEATURE] Ajout du composant checkbox (PIX-3030)

[#238](https://github.com/1024pix/pix-ui/pull/238) [TECH] Monter de version fontawesome (PIX-5325)

[#237](https://github.com/1024pix/pix-ui/pull/237) [TECH] Changer les pré-requis engine du package.json (PIX-5319)

[#236](https://github.com/1024pix/pix-ui/pull/236) [BUGFIX] Correction du déploiement de Storybook

[#234](https://github.com/1024pix/pix-ui/pull/234) [BUGFIX] Laisser les filtres à côté du label dans le FilterBanner (PIX-5301)

[#231](https://github.com/1024pix/pix-ui/pull/231) [BUGFIX] PixButton de type submit affiche un loader si @isLoading=true

[#229](https://github.com/1024pix/pix-ui/pull/229) [TECH] Retirer la taille par defaut du composant PixMultiSelect

[#224](https://github.com/1024pix/pix-ui/pull/224) [TECH] Fixer la version NodeJS à 16.14.0


## :santa: Pour tester
Lancer Pix Certif et s'assurer qu'il n'y a pas de régression. Notamment sur l'ajout de candidats SCO (multi select de candidats)