### PR TITLE
[FEATURE] Création d'une route pour récupérer une liste paginée des contenus formatifs

### DIFF
--- a/api/lib/application/trainings/index.js
+++ b/api/lib/application/trainings/index.js
@@ -7,6 +7,38 @@ const securityPreHandlers = require('../security-pre-handlers');
 exports.register = async (server) => {
   server.route([
     {
+      method: 'GET',
+      path: '/api/admin/training-summaries',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          options: {
+            allowUnknown: true,
+          },
+          query: Joi.object({
+            'page[number]': Joi.number().integer().empty('').allow(null).optional(),
+            'page[size]': Joi.number().integer().empty('').allow(null).optional(),
+          }),
+        },
+        handler: trainingsController.findPaginatedTrainingSummaries,
+        tags: ['api', 'admin', 'trainings'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            '- Elle permet de récupérer une liste paginée de résumés de contenus formatifs',
+        ],
+      },
+    },
+    {
       method: 'PATCH',
       path: '/api/admin/trainings/{trainingId}',
       config: {

--- a/api/lib/application/trainings/training-controller.js
+++ b/api/lib/application/trainings/training-controller.js
@@ -1,7 +1,14 @@
 const trainingSerializer = require('../../infrastructure/serializers/jsonapi/training-serializer');
+const trainingSummarySerializer = require('../../infrastructure/serializers/jsonapi/training-summary-serializer');
 const usecases = require('../../domain/usecases');
+const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 
 module.exports = {
+  async findPaginatedTrainingSummaries(request) {
+    const { page } = queryParamsUtils.extractParameters(request.query);
+    const { trainings, meta } = await usecases.findPaginatedTrainingSummaries({ page });
+    return trainingSummarySerializer.serialize(trainings, meta);
+  },
   async update(request) {
     const { trainingId } = request.params;
     const training = await trainingSerializer.deserialize(request.payload);

--- a/api/lib/domain/read-models/TrainingSummary.js
+++ b/api/lib/domain/read-models/TrainingSummary.js
@@ -1,0 +1,7 @@
+class TrainingSummary {
+  constructor({ id, title } = {}) {
+    this.id = id;
+    this.title = title;
+  }
+}
+module.exports = TrainingSummary;

--- a/api/lib/domain/usecases/find-paginated-training-summaries.js
+++ b/api/lib/domain/usecases/find-paginated-training-summaries.js
@@ -1,0 +1,8 @@
+module.exports = async function findPaginatedTrainingSummaries({ page, trainingRepository }) {
+  const { trainings, pagination } = await trainingRepository.findPaginatedSummaries({ page });
+
+  return {
+    trainings,
+    meta: { pagination },
+  };
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -280,6 +280,7 @@ module.exports = injectDependencies(
     findPaginatedFilteredTargetProfileOrganizations: require('./find-paginated-filtered-target-profile-organizations'),
     findPaginatedFilteredUsers: require('./find-paginated-filtered-users'),
     findPaginatedParticipationsForCampaignManagement: require('./find-paginated-participations-for-campaign-management'),
+    findPaginatedTrainingSummaries: require('./find-paginated-training-summaries'),
     findPaginatedUserRecommendedTrainings: require('./find-paginated-user-recommended-trainings'),
     findPendingCertificationCenterInvitations: require('./find-pending-certification-center-invitations'),
     findPendingOrganizationInvitations: require('./find-pending-organization-invitations'),

--- a/api/lib/infrastructure/repositories/training-repository.js
+++ b/api/lib/infrastructure/repositories/training-repository.js
@@ -1,4 +1,5 @@
 const Training = require('../../domain/models/Training');
+const TrainingSummary = require('../../domain/read-models/TrainingSummary');
 const { knex } = require('../../../db/knex-database-connection');
 const { NotFoundError } = require('../../domain/errors');
 const DomainTransaction = require('../DomainTransaction');
@@ -32,6 +33,15 @@ module.exports = {
     const targetProfileTrainings = await knex('target-profile-trainings').where('trainingId', training.id);
 
     return _toDomain(training, targetProfileTrainings);
+  },
+
+  async findPaginatedSummaries({ page, domainTransaction = DomainTransaction.emptyTransaction() }) {
+    const knexConn = domainTransaction?.knexTransaction || knex;
+    const query = knexConn(TABLE_NAME).select('trainings.*').orderBy('id', 'asc');
+    const { results, pagination } = await fetchPage(query, page);
+
+    const trainings = results.map((training) => new TrainingSummary(training));
+    return { trainings, pagination };
   },
 
   async findByCampaignParticipationIdAndLocale({

--- a/api/lib/infrastructure/serializers/jsonapi/training-summary-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/training-summary-serializer.js
@@ -1,0 +1,10 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(trainingSummaries, meta) {
+    return new Serializer('training-summaries', {
+      attributes: ['title'],
+      meta,
+    }).serialize(trainingSummaries);
+  },
+};

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -64,4 +64,47 @@ describe('Acceptance | Controller | training-controller', function () {
       });
     });
   });
+
+  describe('GET /api/admin/training-summaries', function () {
+    let options;
+
+    describe('nominal case', function () {
+      it('should find training summaries and respond with a 200', async function () {
+        // given
+        const superAdmin = await insertUserWithRoleSuperAdmin();
+        const training = databaseBuilder.factory.buildTraining();
+        await databaseBuilder.commit();
+
+        options = {
+          method: 'GET',
+          url: `/api/admin/training-summaries?page[number]=1&page[size]=2`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(superAdmin.id),
+          },
+        };
+
+        const expectedResponse = {
+          data: {
+            type: 'training-summaries',
+            id: '1',
+            attributes: {
+              title: training.title,
+            },
+          },
+        };
+
+        const expectedPagination = { page: 1, pageSize: 2, rowCount: 1, pageCount: 1 };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data[0].type).to.deep.equal(expectedResponse.data.type);
+        expect(response.result.data[0].id).to.exist;
+        expect(response.result.data[0].attributes.title).to.deep.equal(expectedResponse.data.attributes.title);
+        expect(response.result.meta.pagination).to.deep.equal(expectedPagination);
+      });
+    });
+  });
 });

--- a/api/tests/tooling/domain-builder/factory/build-training-summary.js
+++ b/api/tests/tooling/domain-builder/factory/build-training-summary.js
@@ -1,0 +1,8 @@
+const Training = require('../../../../lib/domain/read-models/TrainingSummary');
+
+module.exports = function buildTrainingSummary({ id = 1, title = 'Training Summary 1' } = {}) {
+  return new Training({
+    id,
+    title,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -126,6 +126,7 @@ module.exports = {
   buildTargetProfileSummaryForAdmin: require('./build-target-profile-summary-for-admin'),
   buildThematic: require('./build-thematic'),
   buildTraining: require('./build-training'),
+  buildTrainingSummary: require('./build-training-summary'),
   buildTube: require('./build-tube'),
   buildTutorial: require('./build-tutorial'),
   buildTutorialForUser: require('./build-tutorial-for-user'),

--- a/api/tests/unit/application/trainings/index_test.js
+++ b/api/tests/unit/application/trainings/index_test.js
@@ -100,4 +100,157 @@ describe('Unit | Router | training-router', function () {
       expect(result.statusCode).to.equal(403);
     });
   });
+
+  describe('GET /api/admin/training-summaries', function () {
+    const method = 'GET';
+    const url = '/api/admin/training-summaries';
+
+    context("when user has role 'SUPER_ADMIN', 'SUPPORT', 'METIER'", function () {
+      // eslint-disable-next-line mocha/no-setup-in-describe
+      [
+        {
+          role: 'SUPER_ADMIN',
+          securityPreHandlersResponses: {
+            checkAdminMemberHasRoleSuperAdmin: (request, h) => h.response(true),
+            checkAdminMemberHasRoleMetier: (request, h) => h.response({ errors: new Error('forbidden') }).code(403),
+            checkAdminMemberHasRoleSupport: (request, h) => h.response({ errors: new Error('forbidden') }).code(403),
+          },
+        },
+        {
+          role: 'METIER',
+          securityPreHandlersResponses: {
+            checkAdminMemberHasRoleSuperAdmin: (request, h) => h.response({ errors: new Error('forbidden') }).code(403),
+            checkAdminMemberHasRoleMetier: (request, h) => h.response(true),
+            checkAdminMemberHasRoleSupport: (request, h) => h.response({ errors: new Error('forbidden') }).code(403),
+          },
+        },
+        {
+          role: 'SUPPORT',
+          securityPreHandlersResponses: {
+            checkAdminMemberHasRoleSuperAdmin: (request, h) => h.response({ errors: new Error('forbidden') }).code(403),
+            checkAdminMemberHasRoleMetier: (request, h) => h.response({ errors: new Error('forbidden') }).code(403),
+            checkAdminMemberHasRoleSupport: (request, h) => h.response(true),
+          },
+        },
+      ].forEach(({ role, securityPreHandlersResponses }) => {
+        it(`should verify user identity and return success update when user role is "${role}"`, async function () {
+          // given
+          sinon.stub(trainingController, 'findPaginatedTrainingSummaries').returns('ok');
+          sinon
+            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+            .callsFake(securityPreHandlersResponses.checkAdminMemberHasRoleSuperAdmin);
+          sinon
+            .stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier')
+            .callsFake(securityPreHandlersResponses.checkAdminMemberHasRoleMetier);
+          sinon
+            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+            .callsFake(securityPreHandlersResponses.checkAdminMemberHasRoleSupport);
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const result = await httpTestServer.request(method, url);
+
+          // then
+          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
+          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleMetier);
+          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
+          sinon.assert.calledOnce(trainingController.findPaginatedTrainingSummaries);
+          expect(result.statusCode).to.equal(200);
+        });
+      });
+    });
+
+    context('when user has role "CERTIF"', function () {
+      it('should return a response with an HTTP status code 403', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .withArgs([
+            securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            securityPreHandlers.checkAdminMemberHasRoleSupport,
+            securityPreHandlers.checkAdminMemberHasRoleMetier,
+          ])
+          .callsFake(
+            () => (request, h) =>
+              h
+                .response({ errors: new Error('forbidden') })
+                .code(403)
+                .takeover()
+          );
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const result = await httpTestServer.request(method, url);
+
+        // then
+        expect(result.statusCode).to.equal(403);
+      });
+    });
+
+    context('when there is no pagination', function () {
+      it('should resolve with HTTP code 200', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon
+          .stub(trainingController, 'findPaginatedTrainingSummaries')
+          .callsFake((request, h) => h.response('ok').code(200));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const result = await httpTestServer.request(method, url);
+
+        // then
+        expect(result.statusCode).to.equal(200);
+      });
+    });
+
+    context('when there are pagination', function () {
+      it('should resolve with HTTP code 200', async function () {
+        // given
+        sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns(() => true);
+        sinon
+          .stub(trainingController, 'findPaginatedTrainingSummaries')
+          .callsFake((request, h) => h.response('ok').code(200));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(method, `${url}?page[size]=10&page[number]=1`);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    context('when page size is not an integer', function () {
+      it('should reject request with HTTP code 400', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(method, `${url}?page[size]=azerty`);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+
+    context('when page number is not an integer', function () {
+      it('should reject request with HTTP code 400', async function () {
+        // given
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(method, `${url}?page[number]=azerty`);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+  });
 });

--- a/api/tests/unit/application/trainings/training-controller_test.js
+++ b/api/tests/unit/application/trainings/training-controller_test.js
@@ -1,10 +1,42 @@
 const { sinon, expect, hFake } = require('../../../test-helper');
-
 const trainingController = require('../../../../lib/application/trainings/training-controller');
 const usecases = require('../../../../lib/domain/usecases');
 const trainingSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/training-serializer');
+const trainingSummarySerializer = require('../../../../lib/infrastructure/serializers/jsonapi/training-summary-serializer');
+const queryParamsUtils = require('../../../../lib/infrastructure/utils/query-params-utils');
 
 describe('Unit | Controller | training-controller', function () {
+  describe('#findPaginatedTrainingSummaries', function () {
+    it('should call the training findPaginatedTrainingSummaries use-case', async function () {
+      // given
+      const expectedResult = Symbol('serialized-training-summaries');
+      const trainingSummaries = Symbol('trainingSummary');
+      const meta = Symbol('meta');
+      const useCaseParameters = {
+        page: { size: 2, number: 1 },
+      };
+
+      sinon.stub(usecases, 'findPaginatedTrainingSummaries').resolves({ trainings: trainingSummaries, meta });
+      sinon.stub(trainingSummarySerializer, 'serialize').returns(expectedResult);
+      sinon.stub(queryParamsUtils, 'extractParameters').returns(useCaseParameters);
+      // when
+      const response = await trainingController.findPaginatedTrainingSummaries(
+        {
+          params: {
+            page: { size: 2, number: 1 },
+          },
+        },
+        hFake
+      );
+
+      // then
+      expect(usecases.findPaginatedTrainingSummaries).to.have.been.calledWith(useCaseParameters);
+      expect(trainingSummarySerializer.serialize).to.have.been.calledOnce;
+      expect(queryParamsUtils.extractParameters).to.have.been.calledOnce;
+      expect(response).to.deep.equal(expectedResult);
+    });
+  });
+
   describe('#update', function () {
     const deserializedTraining = { title: 'new title' };
     const updatedTraining = { title: 'new title' };

--- a/api/tests/unit/domain/usecases/find-paginated-trainings-summary_test.js
+++ b/api/tests/unit/domain/usecases/find-paginated-trainings-summary_test.js
@@ -1,0 +1,28 @@
+const { expect, sinon } = require('../../../test-helper');
+const findPaginatedTrainingSummaries = require('../../../../lib/domain/usecases/find-paginated-training-summaries');
+
+describe('Unit | UseCase | find-paginated-training-summaries', function () {
+  it('should find all training summaries with pagination', async function () {
+    // given
+    const page = { number: 1, size: 2 };
+
+    const trainingRepository = {
+      findPaginatedSummaries: sinon.stub(),
+    };
+
+    const resolvedPagination = Symbol('pagination');
+    const trainingSummaries = Symbol('training-summaries');
+
+    trainingRepository.findPaginatedSummaries
+      .withArgs({ page })
+      .resolves({ trainings: trainingSummaries, pagination: resolvedPagination });
+
+    // when
+    const response = await findPaginatedTrainingSummaries({ page, trainingRepository });
+
+    // then
+    expect(trainingRepository.findPaginatedSummaries).to.have.been.calledWithExactly({ page });
+    expect(response.trainings).to.equal(trainingSummaries);
+    expect(response.meta.pagination).to.equal(resolvedPagination);
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-summary-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-summary-serializer_test.js
@@ -1,0 +1,46 @@
+const { expect, domainBuilder } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/training-summary-serializer');
+
+describe('Unit | Serializer | JSONAPI | training-summary-serializer', function () {
+  describe('#serialize', function () {
+    it('should serialize training summaries to JSONAPI with meta data', function () {
+      // given
+      const trainingSummaries = [
+        domainBuilder.buildTrainingSummary({ id: 1, title: 'Training Summary 1' }),
+        domainBuilder.buildTrainingSummary({ id: 2, title: 'Training Summary 2' }),
+      ];
+      const meta = { pagination: { page: 1, pageSize: 3, pageCount: 1, rowCount: 2 } };
+
+      // when
+      const serializedTrainingSummaries = serializer.serialize(trainingSummaries, meta);
+
+      // then
+      expect(serializedTrainingSummaries).to.deep.equal({
+        data: [
+          {
+            type: 'training-summaries',
+            id: '1',
+            attributes: {
+              title: 'Training Summary 1',
+            },
+          },
+          {
+            type: 'training-summaries',
+            id: '2',
+            attributes: {
+              title: 'Training Summary 2',
+            },
+          },
+        ],
+        meta: {
+          pagination: {
+            page: 1,
+            pageCount: 1,
+            pageSize: 3,
+            rowCount: 2,
+          },
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
On avait pas encore de route pour récupérer tous les contenus formatifs.

## :gift: Proposition
Ajout de la route `/api/admin/trainings-summary` qui retourne une liste paginée.

## :santa: Pour tester
Vérifier [/api/admin/trainings-summary 🔗](https://api-pr5257.review.pix.fr/api/admin/trainings-summary)
