### PR TITLE
[FEATURE][ADMIN] Lors de l'anonymisation, désactiver l'utilisateur des organisations dont il est membre (PIX-155)

### DIFF
--- a/api/db/database-builder/factory/build-membership.js
+++ b/api/db/database-builder/factory/build-membership.js
@@ -9,6 +9,8 @@ module.exports = function buildMembership({
   organizationRole = Membership.roles.MEMBER,
   organizationId,
   userId,
+  createdAt = new Date(),
+  updatedAt = new Date(),
   disabledAt,
 } = {}) {
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -19,6 +21,8 @@ module.exports = function buildMembership({
     organizationId,
     organizationRole,
     userId,
+    createdAt,
+    updatedAt,
     disabledAt,
   };
   return databaseBuffer.pushInsertable({

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -315,6 +315,47 @@ function _buildMiddleSchools({ databaseBuilder }) {
     lastName: userWhoHasLeftSCO.lastName,
     used: true,
   });
+
+  // Great Oak School - anonymization purpose
+  const greatOakSchool = databaseBuilder.factory.buildOrganization({
+    type: 'SCO',
+    name: 'Great Oak School',
+    isManagingStudents: true,
+    email: 'great.oak.school@example.net',
+    externalId: SCO_COLLEGE_EXTERNAL_ID,
+    documentationUrl: 'https://pix.fr/',
+    provinceCode: '12',
+    identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
+    createdBy: middleSchoolsCreator.id,
+  });
+  const greatOakSchoolAdmin = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Haldir',
+    lastName: 'Adceran',
+    email: 'haldir.adceran@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: true,
+    pixOrgaTermsOfServiceAccepted: true,
+    lastPixOrgaTermsOfServiceValidatedAt: new Date(),
+  });
+  const greatOakSchoolMember = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Katar',
+    lastName: 'Orilee',
+    email: 'katar.orilee@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: true,
+    pixOrgaTermsOfServiceAccepted: true,
+    lastPixOrgaTermsOfServiceValidatedAt: new Date(),
+  });
+  databaseBuilder.factory.buildMembership({
+    userId: greatOakSchoolAdmin.id,
+    organizationId: greatOakSchool.id,
+    organizationRole: Membership.roles.ADMIN,
+  });
+  databaseBuilder.factory.buildMembership({
+    userId: greatOakSchoolMember.id,
+    organizationId: greatOakSchool.id,
+    organizationRole: Membership.roles.MEMBER,
+  });
 }
 
 function _buildHighSchools({ databaseBuilder }) {

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -266,8 +266,9 @@ module.exports = {
   },
 
   async anonymizeUser(request, h) {
-    const userId = request.params.id;
-    const user = await usecases.anonymizeUser({ userId });
+    const userToAnonymizeId = request.params.id;
+    const adminMemberId = request.auth.credentials.userId;
+    const user = await usecases.anonymizeUser({ userId: userToAnonymizeId, updatedByUserId: adminMemberId });
     return h.response(userAnonymizedDetailsForAdminSerializer.serialize(user)).code(200);
   },
 

--- a/api/lib/domain/usecases/anonymize-user.js
+++ b/api/lib/domain/usecases/anonymize-user.js
@@ -1,7 +1,9 @@
 module.exports = async function anonymizeUser({
+  updatedByUserId,
   userId,
   userRepository,
   authenticationMethodRepository,
+  membershipRepository,
   refreshTokenService,
 }) {
   const anonymizedUser = {
@@ -13,5 +15,6 @@ module.exports = async function anonymizeUser({
 
   await authenticationMethodRepository.removeAllAuthenticationMethodsByUserId({ userId });
   await refreshTokenService.revokeRefreshTokensForUserId({ userId });
+  await membershipRepository.disableMembershipsByUserId({ userId, updatedByUserId });
   return userRepository.updateUserDetailsForAdministration(userId, anonymizedUser);
 };

--- a/api/lib/infrastructure/repositories/membership-repository.js
+++ b/api/lib/infrastructure/repositories/membership-repository.js
@@ -5,6 +5,7 @@ const User = require('../../domain/models/User');
 const Organization = require('../../domain/models/Organization');
 const bookshelfUtils = require('../utils/knex-utils');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
+const { knex } = require('../../../db/knex-database-connection');
 
 const DEFAULT_PAGE_SIZE = 10;
 const DEFAULT_PAGE_NUMBER = 1;
@@ -126,5 +127,9 @@ module.exports = {
       withRelated: ['user', 'organization'],
     });
     return bookshelfToDomainConverter.buildDomainObject(BookshelfMembership, updatedMembershipWithUserAndOrganization);
+  },
+
+  async disableMembershipsByUserId({ userId, updatedByUserId }) {
+    await knex('memberships').where({ userId }).update({ disabledAt: new Date(), updatedByUserId });
   },
 };

--- a/api/tests/acceptance/application/users/users-controller-anonymize-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-anonymize-user_test.js
@@ -8,21 +8,26 @@ const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | users-controller-anonymize-user', function () {
   describe('POST /admin/users/:id/anonymize', function () {
-    it('should anomymize user and remove authentication methods', async function () {
+    it('anomymizes user, removes authentication methods and disables user organisation memberships', async function () {
       // given
       const server = await createServer();
-      const user = databaseBuilder.factory.buildUser.withRawPassword();
       const superAdmin = await insertUserWithRoleSuperAdmin();
-      const options = {
+      const user = databaseBuilder.factory.buildUser.withRawPassword();
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildMembership({
+        organizationId,
+        userId: user.id,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
         method: 'POST',
         url: `/api/admin/users/${user.id}/anonymize`,
         payload: {},
         headers: { authorization: generateValidRequestAuthorizationHeader(superAdmin.id) },
-      };
-      await databaseBuilder.commit();
-
-      // when
-      const response = await server.inject(options);
+      });
 
       // then
       expect(response.statusCode).to.equal(200);

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -918,28 +918,24 @@ describe('Unit | Controller | user-controller', function () {
     it('should call the anonymize user usecase', async function () {
       // given
       const userId = 1;
-      const request = {
-        auth: {
-          credentials: {
-            userId,
-          },
-        },
-        params: {
-          id: userId,
-        },
-      };
+      const updatedByUserId = 2;
       const anonymizedUserSerialized = Symbol('anonymizedUserSerialized');
       const userDetailsForAdmin = Symbol('userDetailsForAdmin');
-      sinon.stub(usecases, 'anonymizeUser').withArgs({ userId }).resolves(userDetailsForAdmin);
-      sinon
-        .stub(userAnonymizedDetailsForAdminSerializer, 'serialize')
-        .withArgs(userDetailsForAdmin)
-        .returns(anonymizedUserSerialized);
+      sinon.stub(usecases, 'anonymizeUser').resolves(userDetailsForAdmin);
+      sinon.stub(userAnonymizedDetailsForAdminSerializer, 'serialize').returns(anonymizedUserSerialized);
 
       // when
-      const response = await userController.anonymizeUser(request, hFake);
+      const response = await userController.anonymizeUser(
+        {
+          auth: { credentials: { userId: updatedByUserId } },
+          params: { id: userId },
+        },
+        hFake
+      );
 
       // then
+      expect(usecases.anonymizeUser).to.have.been.calledWith({ userId, updatedByUserId });
+      expect(userAnonymizedDetailsForAdminSerializer.serialize).to.have.been.calledWith(userDetailsForAdmin);
       expect(response.statusCode).to.equal(200);
       expect(response.source).to.deep.equal(anonymizedUserSerialized);
     });

--- a/api/tests/unit/domain/usecases/anonymize-user_test.js
+++ b/api/tests/unit/domain/usecases/anonymize-user_test.js
@@ -2,7 +2,7 @@ const { expect, sinon } = require('../../../test-helper');
 const anonymizeUser = require('../../../../lib/domain/usecases/anonymize-user');
 
 describe('Unit | UseCase | anonymize-user', function () {
-  it('should anonymize user and delete all authentication methods', async function () {
+  it("should delete all authentication methods, revoke all user's refresh tokens and anonymize user", async function () {
     // given
     const userId = 1;
     const expectedAnonymizedUser = {
@@ -23,24 +23,10 @@ describe('Unit | UseCase | anonymize-user', function () {
     expect(authenticationMethodRepository.removeAllAuthenticationMethodsByUserId).to.have.been.calledWithExactly({
       userId,
     });
-
+    expect(refreshTokenService.revokeRefreshTokensForUserId).to.have.been.calledWithExactly({ userId });
     expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWithExactly(
       userId,
       expectedAnonymizedUser
     );
-  });
-
-  it("should revoke all user's refresh tokens", async function () {
-    // given
-    const userId = 1;
-    const userRepository = { updateUserDetailsForAdministration: sinon.stub() };
-    const authenticationMethodRepository = { removeAllAuthenticationMethodsByUserId: sinon.stub() };
-    const refreshTokenService = { revokeRefreshTokensForUserId: sinon.stub() };
-
-    // when
-    await anonymizeUser({ userId, userRepository, authenticationMethodRepository, refreshTokenService });
-
-    // then
-    expect(refreshTokenService.revokeRefreshTokensForUserId).to.have.been.calledWithExactly({ userId });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement, le processus d'anonymisation ne fait que retirer toutes les méthodes d'authentification, supprimer tous les refresh tokens de l'utilisateur et anonymiser les détails de l'utilisateur.

Si ce dernier est membre d'une organisation, il le restera et on pourra se connecter à l'application Pix Orga en utilisant les données anonymisées.

## :gift: Proposition

Ajouter une étape en plus dans le processus d'anonymisation qui sera de désactiver l'utilisateur sur toutes les organisations dont l'utilisateur fait partie.

## :star2: Remarques

⚠️ C'est peut-être le moment d'utiliser une transaction pour l'anonymisation vu que l'on fait des modifications en base de données à plusieurs endroits.
⚠️ Le bouton d'anonymisation sur Pix Admin est toujours disponible après l'anonymisation. Il faudrait peut être désactiver le bouton.

## :santa: Pour tester

- Se connecter à Pix Admin avec un compte ayant les droits pour anonymiser un utilisateur
- Ouvrir les détails de l'organisation **Great Oak School**
- Constater dans la liste des membres l'affichage de l'utilisateur **Katar Orilee**
- Ouvrir la page de détails de cet utilisateur
- Cliquez sur le bouton **Anonymiser cet utilisateur**
- Revenir sur la page de détails de l'organisation **Great Oak School**
- Constatez que l'utilisateur **Katar Orilee** n'est plus membre de cet organisation