### PR TITLE
[TECH] Raccourcir le temps d'exécution de la recherche par prénom dans PixAdmin

### DIFF
--- a/api/db/migrations/20221123110714_add_index_gin_users_firstName.js
+++ b/api/db/migrations/20221123110714_add_index_gin_users_firstName.js
@@ -1,0 +1,7 @@
+exports.up = async function (knex) {
+  await knex.raw(`CREATE INDEX "users_firstName_gin" ON users USING GIN ("firstName" GIN_TRGM_OPS)`);
+};
+
+exports.down = async function (knex) {
+  await knex.raw(`DROP INDEX "users_firstName_gin"`);
+};

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -554,7 +554,7 @@ function _setSearchFiltersForQueryBuilder(filter, qb) {
   const { firstName, lastName, email, username } = filter;
 
   if (firstName) {
-    qb.whereRaw('LOWER("firstName") LIKE ?', `%${firstName.toLowerCase()}%`);
+    qb.whereRaw('"firstName" ILIKE ?', `%${firstName}%`);
   }
   if (lastName) {
     qb.whereRaw('LOWER("lastName") LIKE ?', `%${lastName.toLowerCase()}%`);

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -52,6 +52,7 @@
         "ms": "^2.1.3",
         "node-cache": "^5.1.2",
         "node-stream-zip": "^1.15.0",
+        "number-to-words": "^1.2.4",
         "oppsy": "https://github.com/1024pix/oppsy#main",
         "papaparse": "^5.3.2",
         "pdf-lib": "^1.17.1",
@@ -10510,6 +10511,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/number-to-words": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/number-to-words/-/number-to-words-1.2.4.tgz",
+      "integrity": "sha512-/fYevVkXRcyBiZDg6yzZbm0RuaD6i0qRfn8yr+6D0KgBMOndFPxuW10qCHpzs50nN8qKuv78k8MuotZhcVX6Pw=="
     },
     "node_modules/nyc": {
       "version": "15.1.0",
@@ -22835,6 +22841,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "number-to-words": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/number-to-words/-/number-to-words-1.2.4.tgz",
+      "integrity": "sha512-/fYevVkXRcyBiZDg6yzZbm0RuaD6i0qRfn8yr+6D0KgBMOndFPxuW10qCHpzs50nN8qKuv78k8MuotZhcVX6Pw=="
     },
     "nyc": {
       "version": "15.1.0",

--- a/api/package.json
+++ b/api/package.json
@@ -58,6 +58,7 @@
     "ms": "^2.1.3",
     "node-cache": "^5.1.2",
     "node-stream-zip": "^1.15.0",
+    "number-to-words": "^1.2.4",
     "oppsy": "https://github.com/1024pix/oppsy#main",
     "papaparse": "^5.3.2",
     "pdf-lib": "^1.17.1",

--- a/api/scripts/tests/create-users.js
+++ b/api/scripts/tests/create-users.js
@@ -1,0 +1,42 @@
+require('dotenv').config();
+const converter = require('number-to-words');
+const { performance } = require('perf_hooks');
+const logger = require('../../lib/infrastructure/logger');
+const { knex, disconnect } = require('../../db/knex-database-connection');
+
+const defaultUserCount = 9000000;
+
+const insertUsers = async (userCount = defaultUserCount) => {
+  logger.info(`Creating ${userCount} (${converter.toWords(userCount)}) users in database, it may take a while..`);
+  // eslint-disable-next-line knex/avoid-injections
+  await knex.raw(`INSERT INTO users ( "firstName", "lastName")
+                  SELECT MD5(id::text), 'Doe'
+                  FROM generate_series (1, ${userCount}) AS id;`);
+};
+
+const isLaunchedFromCommandLine = require.main === module;
+
+async function main() {
+  const startTime = performance.now();
+  logger.info(`Script ${__filename} has started`);
+  const userCount = process.argv[2];
+  await insertUsers(userCount);
+  const endTime = performance.now();
+  const duration = Math.round(endTime - startTime);
+  logger.info(`Script has ended: took ${duration} milliseconds`);
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();
+
+module.exports = { insertUsers };


### PR DESCRIPTION
## :christmas_tree: Problème
Le temps d'exécution de la recherche par prénom [est de 2 secondes](https://app.datadoghq.eu/dashboard/32h-s2s-f92/tour-de-contrle?fullscreen_end_ts=1669204278572&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1666522278572&fullscreen_widget=5649597124834454&from_ts=1666517673977&to_ts=1669199673977&live=true).

Le support ayant souvent besoin de cette fonctionnalité, ce temps est trop élevé.

Le plan d'exécution est le suivant en production

```sql
EXPLAIN (ANALYZE, BUFFERS)
SELECT * FROM users
WHERE 1=1
    AND "firstName" ILIKE '%foo%';
```

```
 Gather  (cost=1000.00..173145.83 rows=738 width=131) (actual time=685.902..693.357 rows=0 loops=1)
   Workers Planned: 4
   Workers Launched: 4
   Buffers: shared hit=7 read=142083
   ->  Parallel Seq Scan on users  (cost=0.00..172072.03 rows=184 width=131) (actual time=644.074..644.075 rows=0 loops=5)
         Filter: (("firstName")::text ~~ '%terms%'::text)
         Rows Removed by Filter: 1918850
         Buffers: shared hit=7 read=142083
 Planning Time: 0.169 ms
 JIT:
   Functions: 10
   Options: Inlining false, Optimization false, Expressions true, Deforming true
   Timing: Generation 1.544 ms, Inlining 0.000 ms, Optimization 1.553 ms, Emission 20.984 ms, Total 24.081 ms
 Execution Time: 693.926 ms
```

## :gift: Proposition
Expérimenter l'optimisation du prénom.
D'autres PR suivront pour le nom de famille et l'identifiant si cette solution est satisfaisante.

Suite à https://www.cybertec-postgresql.com/en/postgresql-more-performance-for-like-and-ilike-statements/

Ajouter un index [GIN](https://www.postgresql.org/docs/13/gin-intro.html) 
```sql
CREATE INDEX "users_firstName_gin" ON users USING GIN ("firstName" GIN_TRGM_OPS);
```

Cela a un coût de stockage: 100 Mb d'index pour une table de 1 Gb.
```sql
SELECT pg_size_pretty(pg_table_size('users'));
SELECT pg_size_pretty(pg_table_size('"users_firstName_gin"'));
```
On obtient  le plan d'exécution suivant en production
```
 Bitmap Heap Scan on users  (cost=16.72..762.95 rows=738 width=131) (actual time=0.314..0.315 rows=0 loops=1)
   Recheck Cond: (("firstName")::text ~~ '%terms%'::text)
   Buffers: shared hit=20
   ->  Bitmap Index Scan on "users_firstName_gin"  (cost=0.00..16.54 rows=738 width=0) (actual time=0.311..0.312 rows=0 loops=1)
         Index Cond: (("firstName")::text ~~ '%terms%'::text)
         Buffers: shared hit=20
 Planning:
   Buffers: shared hit=3
 Planning Time: 0.387 ms
 Execution Time: 0.372 ms
(10 rows)

Time: 1.888 ms
```

## :star2: Remarques
Simplification du code pour permettre l'optimisation en utilisant ILIKE.

La création d'index prend moins d'une minute sur  `pix-datawarehouse-production`, ce qui est compatible avec le hook de post-deploy scalingo.
```bash
scalingo --region osc-secnum-fr1 -a pix-datawarehouse-production psql-console
pix_datawar_7855=> \timing
Timing is on.
pix_datawar_7855=> DROP INDEX "users_firstName_gin";
DROP INDEX
Time: 82.787 ms
pix_datawar_7855=> CREATE INDEX "users_firstName_gin" ON users USING GIN ("firstName" GIN_TRGM_OPS);
CREATE INDEX
Time: 31 333.499 ms (00:31.333)
```
Création d'un script de génération d'utilisateur pour effectuer des tests en local/RA.

## :santa: Pour tester

### review-app
:warning:  Attendre le provisonnement du plan BDD Starter 512Mb

### Local

Créer une volumétrie du même ordre de grandeur que la production (9 millions d'utilisateurs)
```bash
 node ./scripts/tests/create-users.js
[11:09:49] INFO: Script /home/topi/Documents/OCTO/Missions/Pix/code/repo/pix/api/scripts/tests/create-users.js has started
[11:09:49] INFO: Creating 9000000 (nine million) users in database, it may take a while..
[11:14:32] INFO: Script has ended: took 283432 milliseconds
```

Revenir à la version précédente
```bash
npm run db:rollback:latest
> Using environment: development
> Batch 2 rolled back the following migrations:
> 20221123110714_aadd_index_gin_users_firstName.js
```


Obtenir le plan d'exécution
```sql
EXPLAIN (ANALYZE, BUFFERS)
SELECT * FROM users
WHERE 1=1
    AND "firstName" ILIKE '%foo%';
```

Ce qui donne
```
Parallel Seq Scan on user
Time: 3270,035 ms (00:03,270)
```

Créer l'index ( 5 minutes) 
```
npm run db:migrate
>Batch 2 run: 1 migrations
```


Obtenir le plan d'exécution
```sql
EXPLAIN (ANALYZE, BUFFERS)
SELECT * FROM users
WHERE 1=1
    AND "firstName" ILIKE '%foo%';
```

Ce qui donne
```
->  Bitmap Index Scan on "users_firstName_gin"  
Execution Time: 0.290 ms
```

Vérifier que le temps d'exécution est plus bas: 0.290 ms < 3 270 ms

Effectuer une recherche [via l'IHM](https://admin-pr5261.review.pix.fr/login) et le compte superadmin@example.net / pix123
