### PR TITLE
[TECH] Correction d'un test flaky pour certif

### DIFF
--- a/api/tests/acceptance/scripts/certification/trigger-session-finalized-handler_test.js
+++ b/api/tests/acceptance/scripts/certification/trigger-session-finalized-handler_test.js
@@ -10,8 +10,14 @@ describe('Acceptance | Scripts | trigger-session-finalized-handler', function ()
     sinon.stub(logger, 'error');
   });
 
-  afterEach(function () {
-    return knex('finalized-sessions').delete();
+  afterEach(async function () {
+    await knex('finalized-sessions').delete();
+    await knex('supervisor-accesses').delete();
+    await knex('assessment-results').delete();
+    await knex('assessments').delete();
+    await knex('certification-courses').delete();
+    await knex('sessions').delete();
+    await knex('users').delete();
   });
 
   it('should leave untouched finalized-session rows that are not affected by the script', async function () {


### PR DESCRIPTION
## :christmas_tree: Problème

Le fichier `trigger-session-finalized-handler` contient un test flaky dû au fait que les données ne sont pas nettoyées en base après chaque test.

![image](https://user-images.githubusercontent.com/36371437/203559133-c90adf2a-a41e-4f59-b32d-5066c000cfd5.png)

## :gift: Proposition

Suppression des données entre chaque test

## :star2: Remarques
N/A

## :santa: Pour tester

CI verte et adios le test flaky ? 
