### PR TITLE
[TECH] Supprime l'utilisation de la propriété onLoadOptions avec le composant PixMultiSelect (PIX-6383)

### DIFF
--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -19,7 +19,8 @@
     @title={{t "pages.sco-organization-participants.filter.division.label"}}
     @onSelect={{@onFilter}}
     @selectedOption={{@divisionsFilter}}
-    @onLoadOptions={{this.loadDivisions}}
+    @isLoading={{this.isLoadingDivisions}}
+    @options={{this.divisions}}
     @placeholder={{t "pages.sco-organization-participants.filter.division.label"}}
     @ariaLabel={{t "pages.sco-organization-participants.filter.division.aria-label"}}
     @emptyMessage={{t "pages.sco-organization-participants.filter.division.empty"}}

--- a/orga/app/components/sco-organization-participant/list.js
+++ b/orga/app/components/sco-organization-participant/list.js
@@ -6,8 +6,25 @@ import { CONNECTION_TYPES } from '../../models/sco-organization-participant';
 export default class ScoList extends Component {
   @service currentUser;
   @service intl;
+  @tracked isLoadingDivisions;
   @tracked student = null;
   @tracked isShowingAuthenticationMethodModal = false;
+
+  constructor() {
+    super(...arguments);
+
+    this.isLoadingDivisions = true;
+    this.currentUser.organization.divisions.then(() => {
+      this.isLoadingDivisions = false;
+    });
+  }
+
+  get divisions() {
+    return this.currentUser.organization.divisions.map(({ name }) => ({
+      label: name,
+      value: name,
+    }));
+  }
 
   get connectionTypesOptions() {
     return [
@@ -34,16 +51,6 @@ export default class ScoList extends Component {
       },
     ];
   }
-
-  loadDivisions = async () => {
-    const divisions = await this.currentUser.organization.divisions;
-    return divisions.map(({ name }) => {
-      return {
-        label: name,
-        value: name,
-      };
-    });
-  };
 
   @action
   openAuthenticationMethodModal(student) {

--- a/orga/app/components/sup-organization-participant/list.hbs
+++ b/orga/app/components/sup-organization-participant/list.hbs
@@ -25,7 +25,8 @@
     @title={{t "pages.sup-organization-participants.table.column.group"}}
     @onSelect={{@onFilter}}
     @selectedOption={{@groupsFilter}}
-    @onLoadOptions={{this.loadGroups}}
+    @isLoading={{this.isLoadingGroups}}
+    @options={{this.groups}}
     @placeholder={{t "pages.sup-organization-participants.filter.group.label"}}
     @ariaLabel={{t "pages.sup-organization-participants.filter.group.aria-label"}}
     @emptyMessage={{t "pages.sup-organization-participants.filter.group.empty"}}

--- a/orga/app/components/sup-organization-participant/list.js
+++ b/orga/app/components/sup-organization-participant/list.js
@@ -8,16 +8,26 @@ export default class ListItems extends Component {
   @service intl;
   @tracked selectedStudent = null;
   @tracked isShowingEditStudentNumberModal = false;
+  @tracked isLoadingGroups;
 
-  loadGroups = async () => {
-    const groups = await this.currentUser.organization.groups;
+  constructor() {
+    super(...arguments);
+
+    this.isLoadingGroups = true;
+    this.currentUser.organization.groups.then(() => {
+      this.isLoadingGroups = false;
+    });
+  }
+
+  get groups() {
+    const groups = this.currentUser.organization.groups;
     return groups.map(({ name }) => {
       return {
         label: name,
         value: name,
       };
     });
-  };
+  }
 
   get certificabilityOptions() {
     return [

--- a/orga/app/components/ui/divisions-filter.hbs
+++ b/orga/app/components/ui/divisions-filter.hbs
@@ -1,16 +1,19 @@
-<PixMultiSelect
-  @id="division"
-  @label={{t "common.filters.divisions.title"}}
-  @innerText={{@placeholder}}
-  @screenReaderOnly={{true}}
-  @emptyMessage={{t "common.filters.divisions.empty"}}
-  @loadingMessage={{t "common.filters.loading"}}
-  @selected={{@selected}}
-  @onSelect={{@onSelect}}
-  @onLoadOptions={{this.onLoadDivisions}}
-  @isSearchable={{true}}
-  ...attributes
-  as |option|
->
-  {{option.label}}
-</PixMultiSelect>
+{{#if this.isLoading}}
+  <div class="divisions-filter--is-loading placeholder-box"></div>
+{{else}}
+  <PixMultiSelect
+    @id="division"
+    @label={{t "common.filters.divisions.title"}}
+    @innerText={{@placeholder}}
+    @emptyMessage={{t "common.filters.divisions.empty"}}
+    @screenReaderOnly={{true}}
+    @selected={{@selected}}
+    @onSelect={{@onSelect}}
+    @options={{this.options}}
+    @isSearchable={{true}}
+    ...attributes
+    as |option|
+  >
+    {{option.label}}
+  </PixMultiSelect>
+{{/if}}

--- a/orga/app/components/ui/divisions-filter.js
+++ b/orga/app/components/ui/divisions-filter.js
@@ -1,10 +1,19 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export default class DivisionsFilter extends Component {
-  @action
-  async onLoadDivisions() {
-    const divisions = await this.args.model.divisions;
-    return divisions?.map(({ name }) => ({ value: name, label: name }));
+  @tracked isLoading;
+
+  constructor() {
+    super(...arguments);
+
+    this.isLoading = true;
+    this.args.model.divisions.then(() => {
+      this.isLoading = false;
+    });
+  }
+
+  get options() {
+    return this.args.model.divisions?.map(({ name }) => ({ value: name, label: name }));
   }
 }

--- a/orga/app/components/ui/groups-filter.hbs
+++ b/orga/app/components/ui/groups-filter.hbs
@@ -1,16 +1,19 @@
-<PixMultiSelect
-  @id="group"
-  @label={{t "pages.campaign-results.filters.type.groups.title"}}
-  @innerText={{t "pages.campaign-results.filters.type.groups.title"}}
-  @screenReaderOnly={{true}}
-  @loadingMessage={{t "common.filters.loading"}}
-  @emptyMessage={{t "pages.campaign-results.filters.type.groups.empty"}}
-  @isSearchable={{true}}
-  @onSelect={{@onSelect}}
-  @selected={{@selectedGroups}}
-  @onLoadOptions={{this.onLoadGroups}}
-  ...attributes
-  as |option|
->
-  {{option.label}}
-</PixMultiSelect>
+{{#if this.isLoading}}
+  <div class="groups-filter--is-loading placeholder-box"></div>
+{{else}}
+  <PixMultiSelect
+    @id="group"
+    @label={{t "pages.campaign-results.filters.type.groups.title"}}
+    @innerText={{t "pages.campaign-results.filters.type.groups.title"}}
+    @emptyMessage={{t "pages.campaign-results.filters.type.groups.empty"}}
+    @screenReaderOnly={{true}}
+    @isSearchable={{true}}
+    @onSelect={{@onSelect}}
+    @selected={{@selectedGroups}}
+    @options={{this.options}}
+    ...attributes
+    as |option|
+  >
+    {{option.label}}
+  </PixMultiSelect>
+{{/if}}

--- a/orga/app/components/ui/groups-filter.js
+++ b/orga/app/components/ui/groups-filter.js
@@ -1,9 +1,19 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
 export default class GroupsFilter extends Component {
-  @action
-  async onLoadGroups() {
-    const groups = await this.args.campaign.groups;
-    return groups?.map(({ name }) => ({ value: name, label: name }));
+  @tracked isLoading;
+
+  constructor() {
+    super(...arguments);
+
+    this.isLoading = true;
+    this.args.campaign.groups.then(() => {
+      this.isLoading = false;
+    });
+  }
+
+  get options() {
+    return this.args.campaign.groups?.map(({ name }) => ({ value: name, label: name }));
   }
 }

--- a/orga/app/components/ui/multi-select-filter.hbs
+++ b/orga/app/components/ui/multi-select-filter.hbs
@@ -1,16 +1,20 @@
-<PixMultiSelect
-  @id="multi-select-{{@field}}"
-  @label={{@title}}
-  @innerText={{@placeholder}}
-  @screenReaderOnly={{true}}
-  @loadingMessage={{t "common.filters.loading"}}
-  @emptyMessage={{@emptyMessage}}
-  @isSearchable={{true}}
-  @onSelect={{this.onSelect}}
-  @selected={{@selectedOption}}
-  @options={{@options}}
-  @onLoadOptions={{@onLoadOptions}}
-  as |option|
->
-  {{option.label}}
-</PixMultiSelect>
+{{#if @isLoading}}
+  <div class="multi-select-filter--is-loading placeholder-box"></div>
+{{else}}
+  <PixMultiSelect
+    @id="multi-select-{{@field}}"
+    @label={{@title}}
+    @innerText={{@placeholder}}
+    @screenReaderOnly={{true}}
+    @loadingMessage={{t "common.filters.loading"}}
+    @emptyMessage={{@emptyMessage}}
+    @isSearchable={{true}}
+    @onSelect={{this.onSelect}}
+    @selected={{@selectedOption}}
+    @options={{@options}}
+    @onLoadOptions={{@onLoadOptions}}
+    as |option|
+  >
+    {{option.label}}
+  </PixMultiSelect>
+{{/if}}

--- a/orga/app/components/ui/multi-select-filter.hbs
+++ b/orga/app/components/ui/multi-select-filter.hbs
@@ -6,13 +6,11 @@
     @label={{@title}}
     @innerText={{@placeholder}}
     @screenReaderOnly={{true}}
-    @loadingMessage={{t "common.filters.loading"}}
     @emptyMessage={{@emptyMessage}}
     @isSearchable={{true}}
     @onSelect={{this.onSelect}}
     @selected={{@selectedOption}}
     @options={{@options}}
-    @onLoadOptions={{@onLoadOptions}}
     as |option|
   >
     {{option.label}}

--- a/orga/app/styles/components/ui/filters.scss
+++ b/orga/app/styles/components/ui/filters.scss
@@ -1,4 +1,5 @@
-.groups-filter {
+.groups-filter,
+.divisions-filter {
   &--is-loading.placeholder-box {
     flex: 1;
     height: 36px;

--- a/orga/app/styles/components/ui/filters.scss
+++ b/orga/app/styles/components/ui/filters.scss
@@ -1,5 +1,6 @@
 .groups-filter,
-.divisions-filter {
+.divisions-filter,
+.multi-select-filter {
   &--is-loading.placeholder-box {
     flex: 1;
     height: 36px;

--- a/orga/app/styles/components/ui/filters.scss
+++ b/orga/app/styles/components/ui/filters.scss
@@ -1,0 +1,6 @@
+.groups-filter {
+  &--is-loading.placeholder-box {
+    flex: 1;
+    height: 36px;
+  }
+}

--- a/orga/app/styles/components/ui/index.scss
+++ b/orga/app/styles/components/ui/index.scss
@@ -1,5 +1,6 @@
-@import "cards";
-@import "chart";
-@import "empty-state";
-@import "placeholders";
-@import "certificability-tooltip";
+@import 'cards';
+@import 'chart';
+@import 'empty-state';
+@import 'placeholders';
+@import 'filters';
+@import 'certificability-tooltip';

--- a/orga/tests/integration/components/campaign/activity/participants-list_test.js
+++ b/orga/tests/integration/components/campaign/activity/participants-list_test.js
@@ -187,8 +187,12 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
     test('it should filter on participation divisions', async function (assert) {
       // given
       this.owner.register('service:current-user', CurrentUserStub);
+      const store = this.owner.lookup('service:store');
+      this.campaign = store.createRecord('campaign', {
+        idPixLabel: 'id',
+        divisions: [store.createRecord('division', { name: '3B' }), store.createRecord('division', { name: '3A' })],
+      });
 
-      this.campaign = { idPixLabel: 'id', divisions: [{ name: '3B' }, { name: '3A' }] };
       this.participations = [];
       this.onFilter = sinon.stub();
 
@@ -198,6 +202,7 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
       await clickByText('Classes');
       await clickByText('3A');
 
+      // then
       assert.ok(this.onFilter.calledWith('divisions', ['3A']));
     });
   });

--- a/orga/tests/integration/components/campaign/activity/participants-list_test.js
+++ b/orga/tests/integration/components/campaign/activity/participants-list_test.js
@@ -210,8 +210,11 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
     test('it should filter on participants groups', async function (assert) {
       // given
       this.owner.register('service:current-user', CurrentUserStub);
-
-      this.campaign = { idPixLabel: 'id', groups: [{ name: 'M1' }, { name: 'M2' }] };
+      const store = this.owner.lookup('service:store');
+      this.campaign = store.createRecord('campaign', {
+        idPixLabel: 'id',
+        groups: [store.createRecord('group', { name: 'M1' }), store.createRecord('group', { name: 'M2' })],
+      });
       this.participations = [];
       this.onFilter = sinon.stub();
 
@@ -221,6 +224,7 @@ module('Integration | Component | Campaign::Activity::ParticipantsList', functio
       await clickByText('Groupes');
       await clickByText('M2');
 
+      // then
       assert.ok(this.onFilter.calledWith('groups', ['M2']));
     });
   });

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "signal-github": "./scripts/signal_deploy_to_pr.sh",
     "signal-jira": "node ./scripts/jira/comment-with-review-app-url.js",
     "compute-lead-times": "node ./scripts/compute-lead-times",
-    "clean": "run-p --print-label clean:api clean:mon-pix clean:orga clean:certif clean:admin clean:coverage && npm run clean:root",
+    "clean": "run-p --print-label clean:api clean:mon-pix clean:orga clean:certif clean:admin && npm run clean:root",
     "clean:admin": "cd admin && npm run clean",
     "clean:api": "cd api && npm run clean",
     "clean:certif": "cd certif && npm run clean",


### PR DESCRIPTION
## :christmas_tree: Problème
Le fonctionnement de la propriété **onLoadOptions** sur le composant **PixMultiSelect** est problématique car il sort de nos standards en terme d'interface de composant. 

Pour passer de l'information à un composant on utilise des types comme **string**, **object**, **number**, ...
Pour communiquer de l'information en dehors d'un composant, on utilise des callbacks. Le composant se charge d'appeler la fonction au moment opportuns avec les données à communiquer en paramètre mais ne se soucie pas d'attendre un retour de la fonction.

Ici la propriété **onLoadOptions** attend une fonction qui retourne en promesse. Le composant pourra ensuite accéder aux options à afficher lorsque la promesse sera résolu. Cela permet notamment au composant de décider tout seul si il doit afficher ou non un état de chargement. 

Je pense que le composant ne devrait pas avoir cette responsabilité. Le code qui appelle le composant à la charge de gérer comment la donnée est chargée et la passer au composant. Cependant le composant peut fournir la possibilité d'afficher un état de chargement (par exemple au travers d'une propriété **isLoading**). Il incombe alors à l'appelant de dire au composant quand afficher cet état ou non.

## :gift: Proposition

Dans cette PR je supprime les utilisations de la propriété onLoadOptions sur le composant **PixMultiSelect** pour les remplacer par l'usage de la propriété options. Je gère aussi du coté des applications l'affichage d'un état de chargement. 

Dans une future PR côté PixUI je prévois de supprimer la propriété onLoadOptions et ajouter un propriété **isLoading** pour rapatrier la logique d'affichage d'une placeholder dans PixUI plutôt que dans les applications.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Se connecter à PixOrga et vérifier sur les pages suivantes que les filtres pour les divisions et groups fonctionnent bien : 
  - La page d'activité d'une campagne SCO (évaluation et collecte de profils)  
  - La page d'activité d'une campagne SUP (évaluation et collecte de profils)
  - La page des participants d'une organisation SCO
  - La page des participants d'une organisation SUP
- Pour vérifier l'affichage des placeholders il faudra ralentir le chargement de la page avec les dev tools