### PR TITLE
[TECH] Préparer Pix Certif pour la montée de version d'Ember en 4.X (PIX-6386)

### DIFF
--- a/certif/app/routes/authenticated/sessions/add-student.js
+++ b/certif/app/routes/authenticated/sessions/add-student.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 
 export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
   @service currentUser;
+  @service store;
 
   queryParams = {
     pageNumber: { refreshModel: true },

--- a/certif/app/routes/authenticated/sessions/details.js
+++ b/certif/app/routes/authenticated/sessions/details.js
@@ -4,6 +4,7 @@ import EmberObject from '@ember/object';
 
 export default class SessionsDetailsRoute extends Route {
   @service currentUser;
+  @service store;
 
   beforeModel() {
     this.currentUser.checkRestrictedAccess();

--- a/certif/app/routes/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/routes/authenticated/sessions/details/certification-candidates.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 
 export default class CertificationCandidatesRoute extends Route {
   @service currentUser;
+  @service store;
 
   beforeModel() {
     this.currentUser.checkRestrictedAccess();

--- a/certif/app/routes/authenticated/sessions/finalize.js
+++ b/certif/app/routes/authenticated/sessions/finalize.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 export default class SessionsFinalizeRoute extends Route {
   @service notifications;
   @service currentUser;
+  @service store;
 
   beforeModel() {
     this.currentUser.checkRestrictedAccess();

--- a/certif/app/routes/authenticated/sessions/list.js
+++ b/certif/app/routes/authenticated/sessions/list.js
@@ -12,6 +12,7 @@ export default class ListRoute extends Route {
   };
 
   @service currentUser;
+  @service store;
 
   beforeModel() {
     this.currentUser.checkRestrictedAccess();

--- a/certif/app/routes/authenticated/sessions/new.js
+++ b/certif/app/routes/authenticated/sessions/new.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 
 export default class SessionsNewRoute extends Route {
   @service currentUser;
+  @service store;
 
   beforeModel() {
     this.currentUser.checkRestrictedAccess();

--- a/certif/app/routes/authenticated/sessions/update.js
+++ b/certif/app/routes/authenticated/sessions/update.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 
 export default class SessionsUpdateRoute extends Route {
   @service currentUser;
+  @service store;
 
   beforeModel() {
     this.currentUser.checkRestrictedAccess();

--- a/certif/app/routes/authenticated/team.js
+++ b/certif/app/routes/authenticated/team.js
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 
 export default class AuthenticatedTeamRoute extends Route {
   @service currentUser;
+  @service store;
 
   model() {
     const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;

--- a/certif/app/routes/session-supervising.js
+++ b/certif/app/routes/session-supervising.js
@@ -1,8 +1,11 @@
 import Route from '@ember/routing/route';
 import ENV from 'pix-certif/config/environment';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class SessionSupervisingRoute extends Route {
+  @service store;
+
   model(params) {
     const sessionForSupervising = this.store.queryRecord('session-for-supervising', { sessionId: params.session_id });
 

--- a/certif/tests/integration/components/certif-checkbox_test.js
+++ b/certif/tests/integration/components/certif-checkbox_test.js
@@ -17,7 +17,7 @@ module('Integration | Component | certif-checkbox', function (hooks) {
       const fakeFunc = sinon.spy();
       this.set('fakeFunc', fakeFunc);
       this.set('state', state);
-      await render(hbs`<CertifCheckbox @state={{state}} {{on 'click' (fn fakeFunc)}}></CertifCheckbox>`);
+      await render(hbs`<CertifCheckbox @state={{this.state}} {{on 'click' (fn this.fakeFunc)}}></CertifCheckbox>`);
 
       // when
       await click('.checkbox');

--- a/certif/tests/integration/components/enrolled-candidates_test.js
+++ b/certif/tests/integration/components/enrolled-candidates_test.js
@@ -29,7 +29,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
     const screen = await renderScreen(hbs`
         <EnrolledCandidates
           @sessionId="1"
-          @certificationCandidates={{certificationCandidates}}
+          @certificationCandidates={{this.certificationCandidates}}
           >
         </EnrolledCandidates>
       `);
@@ -57,8 +57,8 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
     const screen = await renderScreen(hbs`
         <EnrolledCandidates
           @sessionId="1"
-          @certificationCandidates={{certificationCandidates}}
-          @displayComplementaryCertification={{displayComplementaryCertification}}
+          @certificationCandidates={{this.certificationCandidates}}
+          @displayComplementaryCertification={{this.displayComplementaryCertification}}
           >
         </EnrolledCandidates>
       `);
@@ -91,8 +91,8 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
     const screen = await renderScreen(hbs`
         <EnrolledCandidates
           @sessionId="1"
-          @certificationCandidates={{certificationCandidates}}
-          @displayComplementaryCertification={{displayComplementaryCertification}}
+          @certificationCandidates={{this.certificationCandidates}}
+          @displayComplementaryCertification={{this.displayComplementaryCertification}}
           >
         </EnrolledCandidates>
       `);
@@ -112,7 +112,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
     const screen = await renderScreen(hbs`
         <EnrolledCandidates
           @sessionId="1"
-          @certificationCandidates={{certificationCandidates}}
+          @certificationCandidates={{this.certificationCandidates}}
         >
         </EnrolledCandidates>
     `);
@@ -172,8 +172,8 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
       const screen = await renderScreen(hbs`
           <EnrolledCandidates
             @sessionId="1"
-            @certificationCandidates={{certificationCandidates}}
-            @shouldDisplayPaymentOptions={{shouldDisplayPaymentOptions}}
+            @certificationCandidates={{this.certificationCandidates}}
+            @shouldDisplayPaymentOptions={{this.shouldDisplayPaymentOptions}}
             >
           </EnrolledCandidates>
         `);
@@ -255,7 +255,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
       const screen = await renderScreen(hbs`
         <EnrolledCandidates
           @sessionId="1"
-          @certificationCandidates={{certificationCandidates}}
+          @certificationCandidates={{this.certificationCandidates}}
           @shouldDisplayPrescriptionScoStudentRegistrationFeature={{this.shouldDisplayPrescriptionScoStudentRegistrationFeature}}
         >
         </EnrolledCandidates>


### PR DESCRIPTION
## :christmas_tree: Problème
Pour passer vers Ember4. certains prérequis sont nécessaire pour ne pas tout casser

## :gift: Proposition
* Ajouter les this. manquants aux différents tests
* Ajouter les `service store;` manquant aux fichiers utilisant le this.store.

## :star2: Remarques
Je n'ai pas modifié les tests de paginationControl étant donnée qu'il sont supprimé dans cette PR : https://github.com/1024pix/pix/pull/5263/

## :santa: Pour tester
