### PR TITLE
[FEATURE] Intégrer l'interconnexion avec le nouveau partenaire : FWB (PIX-6381)

### DIFF
--- a/api/db/migrations/20221123144416_add-fwb-identity-provider-to-authentication-methods-table.js
+++ b/api/db/migrations/20221123144416_add-fwb-identity-provider-to-authentication-methods-table.js
@@ -1,0 +1,17 @@
+exports.up = async function (knex) {
+  await knex.raw(
+    'ALTER TABLE "authentication-methods" DROP CONSTRAINT "authentication_methods_identityProvider_check" '
+  );
+  return knex.raw(
+    "ALTER TABLE \"authentication-methods\" ADD CONSTRAINT \"authentication_methods_identityProvider_check\" CHECK ( \"identityProvider\" IN ('PIX', 'GAR', 'POLE_EMPLOI', 'CNAV', 'FWB') )"
+  );
+};
+
+exports.down = async function (knex) {
+  await knex.raw(
+    'ALTER TABLE "authentication-methods" DROP CONSTRAINT "authentication_methods_identityProvider_check" '
+  );
+  return knex.raw(
+    "ALTER TABLE \"authentication-methods\" ADD CONSTRAINT \"authentication_methods_identityProvider_check\" CHECK ( \"identityProvider\" IN ('PIX', 'GAR', 'POLE_EMPLOI', 'CNAV') )"
+  );
+};

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -253,6 +253,15 @@ module.exports = (function () {
       accessTokenLifespanMs: ms(process.env.CNAV_ACCESS_TOKEN_LIFESPAN || '7d'),
     },
 
+    fwb: {
+      clientId: process.env.FWB_CLIENT_ID,
+      clientSecret: process.env.FWB_CLIENT_SECRET,
+      tokenUrl: process.env.FWB_TOKEN_URL,
+      authenticationUrl: process.env.FWB_AUTHENTICATION_URL,
+      userInfoUrl: process.env.FWB_USER_INFO_URL,
+      accessTokenLifespanMs: ms(process.env.FWB_ACCESS_TOKEN_LIFESPAN || '7d'),
+    },
+
     authenticationSession: {
       temporaryStorage: {
         expirationDelaySeconds:

--- a/api/lib/domain/constants/oidc-identity-providers.js
+++ b/api/lib/domain/constants/oidc-identity-providers.js
@@ -1,7 +1,9 @@
 const PoleEmploiOidcAuthenticationService = require('../services/authentication/pole-emploi-oidc-authentication-service');
 const CnavOidcAuthenticationService = require('../services/authentication/cnav-oidc-authentication-service');
+const FwbOidcAuthenticationService = require('../services/authentication/fwb-oidc-authentication-service');
 
 module.exports = {
   POLE_EMPLOI: new PoleEmploiOidcAuthenticationService(),
   CNAV: new CnavOidcAuthenticationService(),
+  FWB: new FwbOidcAuthenticationService(),
 };

--- a/api/lib/domain/models/AuthenticationMethod.js
+++ b/api/lib/domain/models/AuthenticationMethod.js
@@ -56,19 +56,21 @@ class GARAuthenticationComplement {
 const validationSchema = Joi.object({
   id: Joi.number().optional(),
   identityProvider: Joi.string()
-    .valid(...Object.values(identityProviders), 'POLE_EMPLOI', 'CNAV')
+    .valid(...Object.values(identityProviders), 'POLE_EMPLOI', 'CNAV', 'FWB')
     .required(),
   authenticationComplement: Joi.when('identityProvider', [
     { is: identityProviders.PIX, then: Joi.object().instance(PixAuthenticationComplement).required() },
     { is: 'POLE_EMPLOI', then: Joi.object().instance(OidcAuthenticationComplement).required() },
     { is: identityProviders.GAR, then: Joi.any().empty() },
     { is: 'CNAV', then: Joi.any().empty() },
+    { is: 'FWB', then: Joi.any().empty() },
   ]),
   externalIdentifier: Joi.when('identityProvider', [
     { is: identityProviders.GAR, then: Joi.string().required() },
     { is: 'POLE_EMPLOI', then: Joi.string().required() },
     { is: identityProviders.PIX, then: Joi.any().forbidden() },
     { is: 'CNAV', then: Joi.string().required() },
+    { is: 'FWB', then: Joi.string().required() },
   ]),
   userId: Joi.number().integer().required(),
   createdAt: Joi.date().optional(),

--- a/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/fwb-oidc-authentication-service.js
@@ -1,0 +1,23 @@
+const settings = require('../../../config');
+const OidcAuthenticationService = require('./oidc-authentication-service');
+
+class FwbOidcAuthenticationService extends OidcAuthenticationService {
+  constructor() {
+    super({
+      source: 'fwb',
+      identityProvider: 'FWB',
+      slug: 'fwb',
+      organizationName: 'Fédération Wallonie-Bruxelles',
+      hasLogoutUrl: false,
+      jwtOptions: { expiresIn: settings.fwb.accessTokenLifespanMs / 1000 },
+      clientSecret: settings.fwb.clientSecret,
+      clientId: settings.fwb.clientId,
+      tokenUrl: settings.fwb.tokenUrl,
+      authenticationUrl: settings.fwb.authenticationUrl,
+      authenticationUrlParameters: [{ key: 'scope', value: 'openid profile' }],
+      userInfoUrl: settings.fwb.userInfoUrl,
+    });
+  }
+}
+
+module.exports = FwbOidcAuthenticationService;

--- a/api/sample.env
+++ b/api/sample.env
@@ -574,6 +574,48 @@ AUTH_SECRET=Change me!
 
 
 # ===================
+# FWB CONFIGURATION
+# ===================
+
+# Client ID
+#
+# presence: required for FWB authentication, optional otherwise
+# type: string
+# sample: FWB_CLIENT_ID=
+
+# Client secret
+#
+# presence: required for FWB authentication, optional otherwise
+# type: string
+# sample: FWB_CLIENT_SECRET=
+
+# Token URL
+#
+# presence: required for FWB authentication, optional otherwise
+# type: URL
+# sample: FWB_TOKEN_URL=
+
+# Authentication URL
+#
+# presence: required for FWB authentication, optional otherwise
+# type: URL
+# sample: FWB_AUTHENTICATION_URL=
+
+# User info URL
+#
+# presence: required for FWB authentication, optional otherwise
+# type: URL
+# sample: FWB_USER_INFO_URL=
+
+# Temporary storage idToken expiration delay in milliseconds
+#
+# presence: optional
+# type: Integer
+# default: 7d
+# sample: FWB_ACCESS_TOKEN_LIFESPAN=
+
+
+# ===================
 # AUTHENTICATION SESSION CONFIGURATION
 # ===================
 


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement nous ne gérons que 2 partenaires (Pôle Emploi et CNAV) avec un SSO de type OIDC.

## :gift: Proposition

Intégrer la gestion de l'interconnexion avec le nouveau partenaire : FWB en suivant les règles de la brique générique OIDC.

## :star2: Remarques

⚠️ Ajouter les variables d'environnement en Intégration, Recette et Production. Voir confluence pour les informations.

## :santa: Pour tester

- Ouvrir le lien suivant https://app-pr5268.review.pix.org/connexion/fwb
- Utilisez les informations de connexion se trouvant sur Confluence
- Constatez que vous arrivez sur la double mire
- Constatez que sur la partie gauche les informations de l'utilisateur sont affichées
- Créer le compte
- Constatez que vous arrivez sur la page d'accueil
- Se déconnecter
- Constatez que vous arrivez sur la page de connexion de Pix App
- Ouvrir le lien précédent
- Constatez que vous arrivez sur la page d'accueil parce que vous êtes déjà connecté chez le partenaire et que le compte chez Pix est déjà créé.
