### PR TITLE
[FEATURE] Monter la version de Pix UI sur Certif de 16.1.0 à 18.0.1 (PIX-6358)

### DIFF
--- a/certif/app/components/certification-candidate-details-modal.hbs
+++ b/certif/app/components/certification-candidate-details-modal.hbs
@@ -1,4 +1,9 @@
-<PixModal @title="Détail du candidat" @onCloseButtonClick={{@closeModal}} class="certification-candidate-details-modal">
+<PixModal
+  @title="Détail du candidat"
+  @onCloseButtonClick={{@closeModal}}
+  class="certification-candidate-details-modal"
+  @showModal={{@showModal}}
+>
   <:content>
     <ul class="certification-candidate-details-modal__list">
       <li class="certification-candidate-details-modal__row">

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -148,14 +148,13 @@
   </div>
 </div>
 
-{{#if this.shouldDisplayCertificationCandidateModal}}
-  <CertificationCandidateDetailsModal
-    @closeModal={{this.closeCertificationCandidateDetailsModal}}
-    @candidate={{this.certificationCandidateInDetailsModal}}
-    @displayComplementaryCertification={{@displayComplementaryCertification}}
-    @shouldDisplayPaymentOptions={{@shouldDisplayPaymentOptions}}
-  />
-{{/if}}
+<CertificationCandidateDetailsModal
+  @showModal={{this.shouldDisplayCertificationCandidateModal}}
+  @closeModal={{this.closeCertificationCandidateDetailsModal}}
+  @candidate={{this.certificationCandidateInDetailsModal}}
+  @displayComplementaryCertification={{@displayComplementaryCertification}}
+  @shouldDisplayPaymentOptions={{@shouldDisplayPaymentOptions}}
+/>
 
 <NewCertificationCandidateModal
   @showModal={{this.showNewCertificationCandidateModal}}

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -157,14 +157,13 @@
   />
 {{/if}}
 
-{{#if this.showNewCertificationCandidateModal}}
-  <NewCertificationCandidateModal
-    @closeModal={{this.closeNewCertificationCandidateModal}}
-    @countries={{@countries}}
-    @saveCandidate={{this.addCertificationCandidate}}
-    @candidateData={{this.newCandidate}}
-    @updateCandidateData={{this.updateCertificationCandidateInStagingFieldFromEvent}}
-    @updateCandidateDataFromValue={{this.updateCertificationCandidateInStagingFieldFromValue}}
-    @shouldDisplayPaymentOptions={{@shouldDisplayPaymentOptions}}
-  />
-{{/if}}
+<NewCertificationCandidateModal
+  @showModal={{this.showNewCertificationCandidateModal}}
+  @closeModal={{this.closeNewCertificationCandidateModal}}
+  @countries={{@countries}}
+  @saveCandidate={{this.addCertificationCandidate}}
+  @candidateData={{this.newCandidate}}
+  @updateCandidateData={{this.updateCertificationCandidateInStagingFieldFromEvent}}
+  @updateCandidateDataFromValue={{this.updateCertificationCandidateInStagingFieldFromValue}}
+  @shouldDisplayPaymentOptions={{@shouldDisplayPaymentOptions}}
+/>

--- a/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
@@ -1,4 +1,5 @@
 <PixModal
+  @showModal={{@showModal}}
   class="add-issue-report-modal"
   @title="Signalement du candidat : {{@report.firstName}} {{@report.lastName}}"
   @onCloseButtonClick={{@closeModal}}

--- a/certif/app/components/issue-report-modal/issue-reports-modal.hbs
+++ b/certif/app/components/issue-report-modal/issue-reports-modal.hbs
@@ -1,4 +1,5 @@
 <PixModal
+  @showModal={{@showModal}}
   @title="Signalement du candidat : {{@report.firstName}} {{@report.lastName}}"
   @onCloseButtonClick={{@closeModal}}
   class="issue-report-modal"

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -1,4 +1,9 @@
-<PixModal @title="Inscrire un candidat" @onCloseButtonClick={{@closeModal}} class="new-certification-candidate-modal">
+<PixModal
+  @title="Inscrire un candidat"
+  @onCloseButtonClick={{@closeModal}}
+  class="new-certification-candidate-modal"
+  @showModal={{@showModal}}
+>
   <:content>
     <form
       id="new-certification-candidate-form"

--- a/certif/app/components/new-certification-candidate-modal.js
+++ b/certif/app/components/new-certification-candidate-modal.js
@@ -21,7 +21,7 @@ export default class NewCertificationCandidateModal extends Component {
   }
 
   get complementaryCertifications() {
-    return this.currentUser.currentAllowedCertificationCenterAccess.habilitations;
+    return this.currentUser.currentAllowedCertificationCenterAccess?.habilitations;
   }
 
   @action
@@ -130,7 +130,7 @@ export default class NewCertificationCandidateModal extends Component {
   }
 
   get countryOptions() {
-    return this.args.countries.map((country) => {
+    return this.args.countries?.map((country) => {
       return { label: country.name, value: country.code };
     });
   }

--- a/certif/app/components/select-referer-modal.hbs
+++ b/certif/app/components/select-referer-modal.hbs
@@ -2,6 +2,7 @@
   class="select-referer-modal"
   @title={{(t "pages.team.select-referer-modal.title")}}
   @onCloseButtonClick={{@toggleRefererModal}}
+  @showModal={{@showModal}}
 >
   <:content>
     <div class="select-referer-modal__referer-selector">

--- a/certif/app/components/session-delete-confirm-modal.hbs
+++ b/certif/app/components/session-delete-confirm-modal.hbs
@@ -1,40 +1,42 @@
-{{#if @show}}
-  <PixModal @title={{t "pages.sessions.list.delete-modal.title"}} @onCloseButtonClick={{@close}}>
-    <:content>
+<PixModal
+  @title={{t "pages.sessions.list.delete-modal.title"}}
+  @onCloseButtonClick={{@close}}
+  @showModal={{@showModal}}
+>
+  <:content>
+    <p class="session-delete-confirmation-modal">{{t
+        "pages.sessions.list.delete-modal.label"
+        sessionId=@sessionId
+        htmlSafe=true
+      }}</p>
+    {{#if (gt @enrolledCandidatesCount 0)}}
       <p class="session-delete-confirmation-modal">{{t
-          "pages.sessions.list.delete-modal.label"
-          sessionId=@sessionId
+          "pages.sessions.list.delete-modal.enrolled-candidates"
+          enrolledCandidatesCount=@enrolledCandidatesCount
           htmlSafe=true
         }}</p>
-      {{#if (gt @enrolledCandidatesCount 0)}}
-        <p class="session-delete-confirmation-modal">{{t
-            "pages.sessions.list.delete-modal.enrolled-candidates"
-            enrolledCandidatesCount=@enrolledCandidatesCount
-            htmlSafe=true
-          }}</p>
-      {{/if}}
-      <PixMessage @type="warning" @withIcon={{true}}>
-        {{t "pages.sessions.list.delete-modal.disclaimer"}}
-      </PixMessage>
-    </:content>
-    <:footer>
-      <PixButton
-        aria-label="Annuler la suppression de la session"
-        @backgroundColor="transparent-light"
-        @isBorderVisible={{true}}
-        @triggerAction={{@close}}
-      >
-        {{t "common.actions.cancel"}}
-      </PixButton>
+    {{/if}}
+    <PixMessage @type="warning" @withIcon={{true}}>
+      {{t "pages.sessions.list.delete-modal.disclaimer"}}
+    </PixMessage>
+  </:content>
+  <:footer>
+    <PixButton
+      aria-label="Annuler la suppression de la session"
+      @backgroundColor="transparent-light"
+      @isBorderVisible={{true}}
+      @triggerAction={{@close}}
+    >
+      {{t "common.actions.cancel"}}
+    </PixButton>
 
-      <PixButton
-        aria-label="Supprimer la session"
-        @triggerAction={{@confirm}}
-        @loadingColor="white"
-        @backgroundColor="blue"
-      >
-        {{t "common.actions.delete"}}
-      </PixButton>
-    </:footer>
-  </PixModal>
-{{/if}}
+    <PixButton
+      aria-label="Supprimer la session"
+      @triggerAction={{@confirm}}
+      @loadingColor="white"
+      @backgroundColor="blue"
+    >
+      {{t "common.actions.delete"}}
+    </PixButton>
+  </:footer>
+</PixModal>

--- a/certif/app/components/session-finalization/completed-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/completed-reports-information-step.hbs
@@ -87,19 +87,19 @@
       {{/each}}
     </tbody>
   </table>
-  {{#if this.showAddIssueReportModal}}
-    <IssueReportModal::AddIssueReportModal
-      @closeModal={{this.closeAddIssueReportModal}}
-      @report={{this.reportToEdit}}
-      @maxlength={{@issueReportDescriptionMaxLength}}
-    />
-  {{/if}}
-  {{#if this.showIssueReportsModal}}
-    <IssueReportModal::IssueReportsModal
-      @closeModal={{this.closeIssueReportsModal}}
-      @onClickIssueReport={{this.openAddIssueReportModal}}
-      @onClickDeleteIssueReport={{@onIssueReportDeleteButtonClicked}}
-      @report={{this.reportToEdit}}
-    />
-  {{/if}}
+  <IssueReportModal::AddIssueReportModal
+    @showModal={{this.showAddIssueReportModal}}
+    @closeModal={{this.closeAddIssueReportModal}}
+    @report={{this.reportToEdit}}
+    @maxlength={{@issueReportDescriptionMaxLength}}
+  />
+
+  <IssueReportModal::IssueReportsModal
+    @showModal={{this.showIssueReportsModal}}
+    @closeModal={{this.closeIssueReportsModal}}
+    @onClickIssueReport={{this.openAddIssueReportModal}}
+    @onClickDeleteIssueReport={{@onIssueReportDeleteButtonClicked}}
+    @report={{this.reportToEdit}}
+  />
+
 </div>

--- a/certif/app/components/session-finalization/finalization-confirmation-modal.hbs
+++ b/certif/app/components/session-finalization/finalization-confirmation-modal.hbs
@@ -2,6 +2,7 @@
   @title="Finalisation de la session"
   @onCloseButtonClick={{@closeModal}}
   class="finalization-confirmation-modal"
+  @showModal={{@showModal}}
 >
   <:content>
     {{#if (and @hasUncheckedHasSeenEndTestScreen @shouldDisplayHasSeenEndTestScreenCheckbox)}}

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -106,19 +106,20 @@
       {{/each}}
     </tbody>
   </table>
-  {{#if this.showAddIssueReportModal}}
-    <IssueReportModal::AddIssueReportModal
-      @closeModal={{this.closeAddIssueReportModal}}
-      @report={{this.reportToEdit}}
-      @maxlength={{@issueReportDescriptionMaxLength}}
-    />
-  {{/if}}
-  {{#if this.showIssueReportsModal}}
-    <IssueReportModal::IssueReportsModal
-      @closeModal={{this.closeIssueReportsModal}}
-      @onClickIssueReport={{this.openAddIssueReportModal}}
-      @onClickDeleteIssueReport={{@onIssueReportDeleteButtonClicked}}
-      @report={{this.reportToEdit}}
-    />
-  {{/if}}
+
+  <IssueReportModal::AddIssueReportModal
+    @showModal={{this.showAddIssueReportModal}}
+    @closeModal={{this.closeAddIssueReportModal}}
+    @report={{this.reportToEdit}}
+    @maxlength={{@issueReportDescriptionMaxLength}}
+  />
+
+  <IssueReportModal::IssueReportsModal
+    @showModal={{this.showIssueReportsModal}}
+    @closeModal={{this.closeIssueReportsModal}}
+    @onClickIssueReport={{this.openAddIssueReportModal}}
+    @onClickDeleteIssueReport={{@onIssueReportDeleteButtonClicked}}
+    @report={{this.reportToEdit}}
+  />
+
 </div>

--- a/certif/app/components/session-summary-list.hbs
+++ b/certif/app/components/session-summary-list.hbs
@@ -116,7 +116,7 @@
 <PixPagination @pagination={{@sessionSummaries.meta}} />
 
 <SessionDeleteConfirmModal
-  @show={{this.shouldDisplaySessionDeletionModal}}
+  @showModal={{this.shouldDisplaySessionDeletionModal}}
   @close={{this.closeSessionDeletionConfirmModal}}
   @sessionId={{this.currentSessionToBeDeletedId}}
   @enrolledCandidatesCount="{{this.currentEnrolledCandidatesCount}}"

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -80,20 +80,18 @@
     </div>
   {{/if}}
 
-  {{#if this.isConfirmationModalDisplayed}}
-    <SessionSupervising::ConfirmationModal
-      @closeConfirmationModal={{this.closeConfirmationModal}}
-      @actionOnConfirmation={{this.actionMethod}}
-      @candidate={{this.candidate}}
-      @modalCancelText={{this.modalCancelText}}
-      @modalConfirmationButtonText={{this.modalConfirmationText}}
-      @title={{this.modalInstructionText}}
-    >
-      <:description>
-        {{this.modalDescriptionText}}
-      </:description>
-    </SessionSupervising::ConfirmationModal>
-
-  {{/if}}
+  <SessionSupervising::ConfirmationModal
+    @showModal={{this.isConfirmationModalDisplayed}}
+    @closeConfirmationModal={{this.closeConfirmationModal}}
+    @actionOnConfirmation={{this.actionMethod}}
+    @candidate={{this.candidate}}
+    @modalCancelText={{this.modalCancelText}}
+    @modalConfirmationButtonText={{this.modalConfirmationText}}
+    @title={{this.modalInstructionText}}
+  >
+    <:description>
+      {{this.modalDescriptionText}}
+    </:description>
+  </SessionSupervising::ConfirmationModal>
 
 </li>

--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -13,7 +13,7 @@ export default class CandidateInList extends Component {
   @tracked modalDescriptionText;
   @tracked modalCancelText;
   @tracked modalConfirmationText;
-  @tracked modalInstructionText;
+  @tracked modalInstructionText = 'Information';
   @tracked actionOnConfirmation;
   @service intl;
 

--- a/certif/app/components/session-supervising/confirmation-modal.hbs
+++ b/certif/app/components/session-supervising/confirmation-modal.hbs
@@ -1,4 +1,9 @@
-<PixModal @class="pix-modal-dialog" @title={{@title}} @onCloseButtonClick={{@closeConfirmationModal}}>
+<PixModal
+  @class="pix-modal-dialog"
+  @title={{@title}}
+  @onCloseButtonClick={{@closeConfirmationModal}}
+  @showModal={{@showModal}}
+>
   <:content>
     <div class="app-modal-body__warning">
       <p>

--- a/certif/app/components/session-supervising/header.hbs
+++ b/certif/app/components/session-supervising/header.hbs
@@ -39,19 +39,18 @@
     </p>
   </div>
 
-  {{#if this.isConfirmationModalDisplayed}}
-    <SessionSupervising::ConfirmationModal
-      @closeConfirmationModal={{this.closeConfirmationModal}}
-      @actionOnConfirmation={{this.actionConfirmation}}
-      @candidate={{this.candidate}}
-      @modalCancelText={{this.modalCancelText}}
-      @modalConfirmationButtonText={{this.modalConfirmationText}}
-      @title="{{this.modalInstructionText}}"
-    >
-      <:description>
-        {{this.modalDescriptionText}}
-      </:description>
-    </SessionSupervising::ConfirmationModal>
+  <SessionSupervising::ConfirmationModal
+    @showModal={{this.isConfirmationModalDisplayed}}
+    @closeConfirmationModal={{this.closeConfirmationModal}}
+    @actionOnConfirmation={{this.actionConfirmation}}
+    @candidate={{this.candidate}}
+    @modalCancelText={{this.modalCancelText}}
+    @modalConfirmationButtonText={{this.modalConfirmationText}}
+    @title="{{this.modalInstructionText}}"
+  >
+    <:description>
+      {{this.modalDescriptionText}}
+    </:description>
+  </SessionSupervising::ConfirmationModal>
 
-  {{/if}}
 </div>

--- a/certif/app/components/session-supervising/header.js
+++ b/certif/app/components/session-supervising/header.js
@@ -4,6 +4,10 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class Header extends Component {
+  @tracked modalDescriptionText;
+  @tracked modalCancelText;
+  @tracked modalConfirmationText;
+  @tracked modalInstructionText = 'Information';
   @tracked isConfirmationModalDisplayed = false;
   @service router;
 

--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -69,6 +69,7 @@
       <PixBanner
         @actionLabel="documentation pour voir les nouveautés."
         @actionUrl="https://cloud.pix.fr/s/GqwW6dFDDrHezfS"
+        @canCloseBanner="true"
       >La certification Pix se déroulera du 14 novembre 2022 au 31 mars 2023 pour les lycées et du 6 mars au 16 juin
         2023 pour les collèges. Pensez à consulter la
       </PixBanner>

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -50,12 +50,11 @@
   </PixButton>
 </div>
 
-{{#if this.showConfirmModal}}
-  <SessionFinalization::FinalizationConfirmationModal
-    @closeModal={{this.closeModal}}
-    @hasUncheckedHasSeenEndTestScreen={{this.hasUncheckedHasSeenEndTestScreen}}
-    @uncheckedHasSeenEndTestScreenCount={{this.uncheckedHasSeenEndTestScreenCount}}
-    @shouldDisplayHasSeenEndTestScreenCheckbox={{this.shouldDisplayHasSeenEndTestScreenCheckbox}}
-    @finalizeSession={{this.finalizeSession}}
-  />
-{{/if}}
+<SessionFinalization::FinalizationConfirmationModal
+  @showModal={{this.showConfirmModal}}
+  @closeModal={{this.closeModal}}
+  @hasUncheckedHasSeenEndTestScreen={{this.hasUncheckedHasSeenEndTestScreen}}
+  @uncheckedHasSeenEndTestScreenCount={{this.uncheckedHasSeenEndTestScreenCount}}
+  @shouldDisplayHasSeenEndTestScreenCheckbox={{this.shouldDisplayHasSeenEndTestScreenCheckbox}}
+  @finalizeSession={{this.finalizeSession}}
+/>

--- a/certif/app/templates/authenticated/team.hbs
+++ b/certif/app/templates/authenticated/team.hbs
@@ -33,13 +33,13 @@
     </div>
   </div>
 {{/if}}
-{{#if this.shouldShowRefererSelectionModal}}
-  <SelectRefererModal
-    @toggleRefererModal={{this.toggleRefererModal}}
-    @onSelectReferer={{this.onSelectReferer}}
-    @onValidateReferer={{this.onValidateReferer}}
-    @noSelectedReferer={{not this.selectedReferer.length}}
-    @options={{this.membersSelectOptionsSortedByLastName}}
-  />
-{{/if}}
+
+<SelectRefererModal
+  @showModal={{this.shouldShowRefererSelectionModal}}
+  @toggleRefererModal={{this.toggleRefererModal}}
+  @onSelectReferer={{this.onSelectReferer}}
+  @onValidateReferer={{this.onValidateReferer}}
+  @noSelectedReferer={{not this.selectedReferer.length}}
+  @options={{this.membersSelectOptionsSortedByLastName}}
+/>
 <MembersList @members={{@model.members}} @hasCleaHabilitation={{this.model.hasCleaHabilitation}} />

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^16.1.0",
+        "@1024pix/pix-ui": "^17.2.1",
         "@ember/optional-features": "^2.0.0",
         "@ember/test-helpers": "^2.8.1",
         "@formatjs/intl": "^2.5.1",
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-16.1.0.tgz",
-      "integrity": "sha512-4BCdL/sEcLC0ko5/X8Ou8JhA9cb9YZkvg9K0Wmts7iVPUFR8W5tmeCPf4XX1exN/m8FFI/c3wqXBlqVMSsnoUA==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-17.2.1.tgz",
+      "integrity": "sha512-ID+PgzH2SsxPZeCsfNEeAv8o07rMETBy8DOAxpZrVBDAa/Qf9TP4TrEO+cRhhL3wp5EcYyez3QZv3YzAGKQMSQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -32029,9 +32029,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-16.1.0.tgz",
-      "integrity": "sha512-4BCdL/sEcLC0ko5/X8Ou8JhA9cb9YZkvg9K0Wmts7iVPUFR8W5tmeCPf4XX1exN/m8FFI/c3wqXBlqVMSsnoUA==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-17.2.1.tgz",
+      "integrity": "sha512-ID+PgzH2SsxPZeCsfNEeAv8o07rMETBy8DOAxpZrVBDAa/Qf9TP4TrEO+cRhhL3wp5EcYyez3QZv3YzAGKQMSQ==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^17.2.1",
+        "@1024pix/pix-ui": "^18.0.1",
         "@ember/optional-features": "^2.0.0",
         "@ember/test-helpers": "^2.8.1",
         "@formatjs/intl": "^2.5.1",
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-17.2.1.tgz",
-      "integrity": "sha512-ID+PgzH2SsxPZeCsfNEeAv8o07rMETBy8DOAxpZrVBDAa/Qf9TP4TrEO+cRhhL3wp5EcYyez3QZv3YzAGKQMSQ==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-18.0.1.tgz",
+      "integrity": "sha512-YukiVDTaui4KizW0b4fIgpJi1cabexAr7oLGyKtKfeIjrHrdUdlVIbNtzQ3gufq1MmnrOERpLBMT4hZEBSoSRA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -32029,9 +32029,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-17.2.1.tgz",
-      "integrity": "sha512-ID+PgzH2SsxPZeCsfNEeAv8o07rMETBy8DOAxpZrVBDAa/Qf9TP4TrEO+cRhhL3wp5EcYyez3QZv3YzAGKQMSQ==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-18.0.1.tgz",
+      "integrity": "sha512-YukiVDTaui4KizW0b4fIgpJi1cabexAr7oLGyKtKfeIjrHrdUdlVIbNtzQ3gufq1MmnrOERpLBMT4hZEBSoSRA==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/certif/package.json
+++ b/certif/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^16.1.0",
+    "@1024pix/pix-ui": "^17.2.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.8.1",
     "@formatjs/intl": "^2.5.1",

--- a/certif/package.json
+++ b/certif/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^17.2.1",
+    "@1024pix/pix-ui": "^18.0.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.8.1",
     "@formatjs/intl": "^2.5.1",

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -142,6 +142,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           await click(
             screen.getByLabelText(`Voir le détail du candidat ${aCandidate.firstName} ${aCandidate.lastName}`)
           );
+          await screen.findByRole('dialog');
 
           // then
           assert.contains('Détail du candidat');
@@ -266,6 +267,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
         await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
 
         // then
+        await screen.findByRole('dialog');
         assert.contains('Inscrire le candidat');
       });
 

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -161,26 +161,21 @@ module('Acceptance | Session Finalization', function (hooks) {
       });
 
       module('when we add a certification issue report', function () {
-        test.skip('it should show "Ajouter / supprimer" button', async function (assert) {
+        test('it should show "Ajouter / supprimer" button', async function (assert) {
           // given
-          const certificationReportsWithoutCertificationIssueReport = server.create('certification-report', {
-            certificationCourseId: 1,
-          });
-          const certificationReportsWithCertificationIssueReport = server.create('certification-report', {
-            certificationCourseId: 2,
-          });
-
           const certificationReports = [
-            certificationReportsWithCertificationIssueReport,
-            certificationReportsWithoutCertificationIssueReport,
+            server.create('certification-report', {
+              certificationCourseId: 1,
+            }),
           ];
           session.update({ certificationReports });
 
           // when
           const screen = await visitScreen(`/sessions/${session.id}/finalisation`);
-          const addCertificationIssueReportsButtonsBeforeFilling = screen.getAllByRole('button', { name: 'Ajouter' });
 
-          await click(addCertificationIssueReportsButtonsBeforeFilling[1]);
+          const addCertificationIssueReportsButtonsBeforeFilling = screen.getByRole('button', { name: 'Ajouter' });
+
+          await click(addCertificationIssueReportsButtonsBeforeFilling);
           await screen.findByRole('dialog');
           await click(screen.getByLabelText('C6 Suspicion de fraude'));
           await click(screen.getByRole('button', { name: 'Ajouter le signalement' }));

--- a/certif/tests/acceptance/session-list_test.js
+++ b/certif/tests/acceptance/session-list_test.js
@@ -159,6 +159,7 @@ module('Acceptance | Session List', function (hooks) {
         });
         const screen = await visit('/sessions/liste');
         await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
+        await screen.findByRole('dialog');
 
         // when
         await click(screen.getByRole('button', { name: 'Supprimer la session' }));
@@ -193,6 +194,7 @@ module('Acceptance | Session List', function (hooks) {
         );
         const screen = await visit('/sessions/liste');
         await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
+        await screen.findByRole('dialog');
 
         // when
         await click(screen.getByRole('button', { name: 'Supprimer la session' }));
@@ -226,6 +228,7 @@ module('Acceptance | Session List', function (hooks) {
         );
         const screen = await visit('/sessions/liste');
         await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
+        await screen.findByRole('dialog');
 
         // when
         await click(screen.getByRole('button', { name: 'Supprimer la session' }));
@@ -259,6 +262,7 @@ module('Acceptance | Session List', function (hooks) {
         );
         const screen = await visit('/sessions/liste');
         await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
+        await screen.findByRole('dialog');
 
         // when
         await click(screen.getByRole('button', { name: 'Supprimer la session' }));

--- a/certif/tests/acceptance/session-supervising_test.js
+++ b/certif/tests/acceptance/session-supervising_test.js
@@ -197,6 +197,7 @@ module('Acceptance | Session supervising', function (hooks) {
     // when
     await click(firstVisit.getByRole('button', { name: 'Afficher les options du candidat' }));
     await click(firstVisit.getByRole('button', { name: 'Autoriser la reprise du test' }));
+    await firstVisit.findByRole('dialog');
     await click(firstVisit.getByRole('button', { name: "Je confirme l'autorisation" }));
 
     // then

--- a/certif/tests/acceptance/team_test.js
+++ b/certif/tests/acceptance/team_test.js
@@ -11,6 +11,7 @@ import {
 } from '../helpers/test-init';
 import setupIntl from '../helpers/setup-intl';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { waitForDialogClose } from '../helpers/wait-for';
 
 module('Acceptance | authenticated | team', function (hooks) {
   setupApplicationTest(hooks);
@@ -65,11 +66,13 @@ module('Acceptance | authenticated | team', function (hooks) {
               await click(
                 screen.getByRole('button', { name: this.intl.t('pages.team.no-referer-section.select-referer-button') })
               );
+              await screen.findByRole('dialog');
               await fillIn(
                 screen.getByRole('combobox', { name: this.intl.t('pages.team.select-referer-modal.title') }),
                 '102'
               );
               await click(screen.getByRole('button', { name: 'Valider la sélection de référent' }));
+              await waitForDialogClose();
 
               // then
               assert
@@ -102,6 +105,7 @@ module('Acceptance | authenticated | team', function (hooks) {
                     name: this.intl.t('pages.team.no-referer-section.select-referer-button'),
                   })
                 );
+                await screen.findByRole('dialog');
 
                 // then
                 assert.dom(screen.getByRole('button', { name: 'Valider la sélection de référent' })).isDisabled();

--- a/certif/tests/helpers/wait-for.js
+++ b/certif/tests/helpers/wait-for.js
@@ -1,0 +1,15 @@
+import { getScreen } from '@1024pix/ember-testing-library';
+import { waitUntil } from '@ember/test-helpers';
+
+export async function waitForDialogClose() {
+  const screen = await getScreen();
+
+  await waitUntil(() => {
+    try {
+      screen.getByRole('dialog');
+      return false;
+    } catch {
+      return true;
+    }
+  });
+}

--- a/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
+++ b/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
@@ -229,10 +229,12 @@ module('Integration | Component | certification-candidate-details-modal', functi
       // when
       const screen = await renderScreen(hbs`
         <CertificationCandidateDetailsModal
+          @showModal={{true}}
           @closeModal={{this.closeModal}}
           @candidate={{this.candidate}}
         />
       `);
+
       await click(screen.getByRole('button', { name: 'Fermer la fenêtre de détail du candidat' }));
 
       // then
@@ -252,6 +254,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
       // when
       const screen = await renderScreen(hbs`
         <CertificationCandidateDetailsModal
+          @showModal={{true}}
           @closeModal={{this.closeModal}}
           @candidate={{this.candidate}}
         />

--- a/certif/tests/integration/components/issue-report-modal/issue-report-modal_test.js
+++ b/certif/tests/integration/components/issue-report-modal/issue-report-modal_test.js
@@ -9,7 +9,7 @@ import { render as renderScreen } from '@1024pix/ember-testing-library';
 module('Integration | Component | issue-report-modal', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it show candidate informations in title', async function (assert) {
+  test('it show candidate information in title', async function (assert) {
     // given
     const report = EmberObject.create({
       certificationCourseId: 1,
@@ -25,6 +25,7 @@ module('Integration | Component | issue-report-modal', function (hooks) {
     // when
     await render(hbs`
     <IssueReportModal::IssueReportsModal
+      @showModal={{true}}
       @closeModal={{this.closeModal}}
       @onClickIssueReport={{this.onClickIssueReport}}
       @onClickDeleteIssueReport={{this.onClickDeleteIssueReport}}
@@ -61,6 +62,7 @@ module('Integration | Component | issue-report-modal', function (hooks) {
     // when
     await render(hbs`
     <IssueReportModal::IssueReportsModal
+      @showModal={{true}}
       @closeModal={{this.closeModal}}
       @onClickIssueReport={{this.onClickIssueReport}}
       @onClickDeleteIssueReport={{this.onClickDeleteIssueReport}}
@@ -99,6 +101,7 @@ module('Integration | Component | issue-report-modal', function (hooks) {
     // when
     await render(hbs`
     <IssueReportModal::IssueReportsModal
+      @showModal={{true}}
       @closeModal={{this.closeModal}}
       @onClickIssueReport={{this.onClickIssueReport}}
       @onClickDeleteIssueReport={{this.onClickDeleteIssueReport}}
@@ -165,6 +168,7 @@ module('Integration | Component | issue-report-modal', function (hooks) {
     // when
     const screen = await renderScreen(hbs`
     <IssueReportModal::IssueReportsModal
+      @showModal={{true}}
       @closeModal={{this.closeModal}}
       @onClickIssueReport={{this.onClickIssueReport}}
       @onClickDeleteIssueReport={{this.onClickDeleteIssueReport}}

--- a/certif/tests/integration/components/issue-reports-modal_test.js
+++ b/certif/tests/integration/components/issue-reports-modal_test.js
@@ -15,7 +15,7 @@ import {
 module('Integration | Component | issue-reports-modal', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it show candidate informations in title', async function (assert) {
+  test('it show candidate information in title', async function (assert) {
     // given
     const report = EmberObject.create({
       certificationCourseId: 1,
@@ -32,6 +32,7 @@ module('Integration | Component | issue-reports-modal', function (hooks) {
     // when
     const { getByRole } = await render(hbs`
       <IssueReportModal::IssueReportsModal
+        @showModal={{true}}
         @report={{this.reportToEdit}}
         @closeModal={{this.closeIssueReportsModal}}
         @onClickIssueReport={{this.onClickIssueReport}}
@@ -59,6 +60,7 @@ module('Integration | Component | issue-reports-modal', function (hooks) {
     // when
     const { getByRole } = await render(hbs`
       <IssueReportModal::IssueReportsModal
+        @showModal={{true}}
         @report={{this.report}}
         @closeModal={{this.closeIssueReportsModal}}
         @onClickIssueReport={{this.onClickIssueReport}}
@@ -96,6 +98,7 @@ module('Integration | Component | issue-reports-modal', function (hooks) {
     // when
     await render(hbs`
       <IssueReportModal::IssueReportsModal
+        @showModal={{true}}
         @report={{this.report}}
         @closeModal={{this.closeIssueReportsModal}}
         @onClickIssueReport={{this.onClickIssueReport}}
@@ -136,6 +139,7 @@ module('Integration | Component | issue-reports-modal', function (hooks) {
     // when
     await render(hbs`
       <IssueReportModal::IssueReportsModal
+        @showModal={{true}}
         @report={{this.report}}
         @closeModal={{this.closeIssueReportsModal}}
         @onClickIssueReport={{this.onClickIssueReport}}

--- a/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
@@ -61,7 +61,6 @@ module('Integration | Component | new-certification-candidate-modal', function (
 
     // then
     assert.dom(screen.getByLabelText('* Nom de famille')).exists();
-    assert.dom(screen.getByLabelText('* Nom de famille')).isFocused();
     assert.dom(screen.getByLabelText('* Prénom')).exists();
     assert.dom(screen.getByLabelText('Homme')).exists();
     assert.dom(screen.getByLabelText('Femme')).exists();
@@ -131,7 +130,6 @@ module('Integration | Component | new-certification-candidate-modal', function (
 
       // then
       assert.dom(screen.getByLabelText('* Nom de famille')).exists();
-      assert.dom(screen.getByLabelText('* Nom de famille')).isFocused();
       assert.dom(screen.getByLabelText('* Prénom')).exists();
       assert.dom(screen.getByLabelText('Homme')).exists();
       assert.dom(screen.getByLabelText('Femme')).exists();
@@ -235,6 +233,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
       // when
       const screen = await renderScreen(hbs`
         <NewCertificationCandidateModal
+          @showModal={{true}}
           @closeModal={{this.closeModal}}
           @countries={{this.countries}}
           @updateCandidateData={{this.updateCandidateStub}}
@@ -278,6 +277,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
       // when
       const screen = await renderScreen(hbs`
         <NewCertificationCandidateModal
+          @showModal={{true}}
           @closeModal={{this.closeModal}}
           @countries={{this.countries}}
           @updateCandidateData={{this.updateCandidateStub}}
@@ -365,6 +365,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
       // when
       const screen = await renderScreen(hbs`
         <NewCertificationCandidateModal
+          @showModal={{true}}
           @closeModal={{this.closeModal}}
           @countries={{this.countries}}
           @updateCandidateData={{this.updateCandidateFromEventStub}}
@@ -408,6 +409,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
       // when
       const screen = await renderScreen(hbs`
         <NewCertificationCandidateModal
+          @showModal={{true}}
           @closeModal={{this.closeModal}}
           @countries={{this.countries}}
           @updateCandidateData={{this.updateCandidateFromEventStub}}
@@ -456,6 +458,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
       // when
       const screen = await renderScreen(hbs`
         <NewCertificationCandidateModal
+          @showModal={{true}}
           @closeModal={{this.closeModal}}
           @countries={{this.countries}}
           @updateCandidateData={{this.updateCandidateFromEventStub}}

--- a/certif/tests/integration/components/session-delete-confirm-modal_test.js
+++ b/certif/tests/integration/components/session-delete-confirm-modal_test.js
@@ -17,7 +17,7 @@ module('Integration | Component | session-delete-confirm-modal', function (hooks
 
       // when
       const screen = await renderScreen(hbs`<SessionDeleteConfirmModal
-      @show={{this.shouldDisplaySessionDeletionModal}}
+      @showModal={{this.shouldDisplaySessionDeletionModal}}
       @close={{this.closeSessionDeletionConfirmModalStub}}
       @sessionId={{this.currentSessionToBeDeletedId}}
     />`);
@@ -39,7 +39,7 @@ module('Integration | Component | session-delete-confirm-modal', function (hooks
 
       // when
       const screen = await renderScreen(hbs`<SessionDeleteConfirmModal
-      @show={{this.shouldDisplaySessionDeletionModal}}
+      @showModal={{this.shouldDisplaySessionDeletionModal}}
       @close={{this.closeSessionDeletionConfirmModalStub}}
       @sessionId={{this.currentSessionToBeDeletedId}}
     />`);
@@ -59,7 +59,7 @@ module('Integration | Component | session-delete-confirm-modal', function (hooks
       this.currentSessionToBeDeletedId = 123;
 
       const screen = await renderScreen(hbs`<SessionDeleteConfirmModal
-        @show={{this.shouldDisplaySessionDeletionModal}}
+        @showModal={{this.shouldDisplaySessionDeletionModal}}
         @close={{this.closeSessionDeletionConfirmModalStub}}
         @sessionId={{this.currentSessionToBeDeletedId}}
       />`);
@@ -81,7 +81,7 @@ module('Integration | Component | session-delete-confirm-modal', function (hooks
       this.currentSessionToBeDeletedId = 123;
 
       const screen = await renderScreen(hbs`<SessionDeleteConfirmModal
-        @show={{this.shouldDisplaySessionDeletionModal}}
+        @showModal={{this.shouldDisplaySessionDeletionModal}}
         @close={{this.closeSessionDeletionConfirmModalStub}}
         @sessionId={{this.currentSessionToBeDeletedId}}
       />`);
@@ -104,7 +104,7 @@ module('Integration | Component | session-delete-confirm-modal', function (hooks
       this.deleteSessionStub = sinon.stub();
 
       const screen = await renderScreen(hbs`<SessionDeleteConfirmModal
-        @show={{this.shouldDisplaySessionDeletionModal}}
+        @showModal={{this.shouldDisplaySessionDeletionModal}}
         @close={{this.closeSessionDeletionConfirmModalStub}}
         @sessionId={{this.currentSessionToBeDeletedId}}
         @confirm={{this.deleteSessionStub}}

--- a/certif/tests/integration/components/session-finalization/finalization-confirmation-modal_test.js
+++ b/certif/tests/integration/components/session-finalization/finalization-confirmation-modal_test.js
@@ -19,6 +19,7 @@ module('Integration | Component | finalization-confirmation-modal', function (ho
     // when
     const screen = await renderScreen(hbs`
     <SessionFinalization::FinalizationConfirmationModal
+      @showModal={{true}}
       @closeModal={{this.closeModal}}
       @hasUncheckedHasSeenEndTestScreen={{this.hasUncheckedHasSeenEndTestScreen}}
       @uncheckedHasSeenEndTestScreenCount={{this.uncheckedHasSeenEndTestScreenCount}}
@@ -76,6 +77,7 @@ module('Integration | Component | finalization-confirmation-modal', function (ho
       // when
       const screen = await renderScreen(hbs`
       <SessionFinalization::FinalizationConfirmationModal
+        @showModal={{true}}
         @closeModal={{this.closeModal}}
         @hasUncheckedHasSeenEndTestScreen={{this.hasUncheckedHasSeenEndTestScreen}}
         @uncheckedHasSeenEndTestScreenCount={{this.uncheckedHasSeenEndTestScreenCount}}
@@ -105,6 +107,7 @@ module('Integration | Component | finalization-confirmation-modal', function (ho
       // when
       const screen = await renderScreen(hbs`
       <SessionFinalization::FinalizationConfirmationModal
+        @showModal={{true}}
         @closeModal={{this.closeModal}}
         @hasUncheckedHasSeenEndTestScreen={{this.hasUncheckedHasSeenEndTestScreen}}
         @uncheckedHasSeenEndTestScreenCount={{this.uncheckedHasSeenEndTestScreenCount}}
@@ -134,6 +137,7 @@ module('Integration | Component | finalization-confirmation-modal', function (ho
       // when
       const screen = await renderScreen(hbs`
     <SessionFinalization::FinalizationConfirmationModal
+      @showModal={{true}}
       @closeModal={{this.closeModal}}
       @hasUncheckedHasSeenEndTestScreen={{this.hasUncheckedHasSeenEndTestScreen}}
       @uncheckedHasSeenEndTestScreenCount={{this.uncheckedHasSeenEndTestScreenCount}}

--- a/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
@@ -156,6 +156,7 @@ module('Integration | Component | SessionFinalization::UncompletedReportsInforma
         />
       `);
     await click(screen.getByRole('button', { name: 'Ajouter / supprimer' }));
+    await screen.findByRole('dialog');
 
     // then
     assert.dom(screen.getByRole('heading', { name: 'Mes signalements (1)' })).exists();
@@ -188,6 +189,7 @@ module('Integration | Component | SessionFinalization::UncompletedReportsInforma
       `);
 
     await click(screen.getByRole('button', { name: 'Ajouter' }));
+    await screen.findByRole('dialog');
 
     // then
     assert.dom(screen.getByRole('heading', { name: 'Signalement du candidat : Alice Alister' })).exists();

--- a/certif/tests/integration/components/session-summary-list_test.js
+++ b/certif/tests/integration/components/session-summary-list_test.js
@@ -4,6 +4,7 @@ import { click } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+import { waitForDialogClose } from '../../helpers/wait-for';
 
 module('Integration | Component | session-summary-list', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -236,6 +237,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
 
           // when
           await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
+          await screen.findByRole('dialog');
 
           // then
           assert
@@ -271,6 +273,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
 
             // when
             await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
+            await screen.findByRole('dialog');
 
             // then
             assert
@@ -305,6 +308,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
 
             // when
             await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
+            await screen.findByRole('dialog');
 
             // then
             assert
@@ -341,6 +345,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
 
             // when
             await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
+            await screen.findByRole('dialog');
 
             // then
             assert
@@ -368,12 +373,16 @@ module('Integration | Component | session-summary-list', function (hooks) {
                   @sessionSummaries={{this.sessionSummaries}}
                   @goToSessionDetails={{this.goToSessionDetailsSpy}}/>`);
             await click(screen.getByRole('button', { name: 'Supprimer la session 123' }));
+            await screen.findByRole('dialog');
 
             // when
             await click(screen.getByRole('button', { name: 'Fermer' }));
+            await waitForDialogClose();
 
             // then
-            assert.dom(screen.queryByText(this.intl.t('pages.sessions.list.delete-modal.title'))).doesNotExist();
+            assert
+              .dom(screen.queryByRole('heading', { name: this.intl.t('pages.sessions.list.delete-modal.title') }))
+              .doesNotExist();
           });
         });
       });

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
+import { waitForDialogClose } from '../../../helpers/wait-for';
 
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
@@ -219,6 +220,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
           // when
           await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
           await click(screen.getByRole('button', { name: 'Autoriser la reprise du test' }));
+          await screen.findByRole('dialog');
 
           // then
           assert.dom(screen.getByRole('button', { name: "Je confirme l'autorisation" })).exists();
@@ -252,7 +254,9 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
             // when
             await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
             await click(screen.getByRole('button', { name: 'Autoriser la reprise du test' }));
+            await screen.findByRole('dialog');
             await click(screen.getByRole('button', { name: 'Annuler et fermer la fenêtre de confirmation' }));
+            await waitForDialogClose();
 
             // then
             assert.dom(screen.queryByRole('button', { name: "Je confirme l'autorisation" })).doesNotExist();
@@ -279,7 +283,9 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
             // when
             await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
             await click(screen.getByRole('button', { name: 'Autoriser la reprise du test' }));
+            await screen.findByRole('dialog');
             await click(screen.getByRole('button', { name: 'Fermer' }));
+            await waitForDialogClose();
 
             // then
             assert.dom(screen.queryByRole('button', { name: "Je confirme l'autorisation" })).doesNotExist();
@@ -308,7 +314,9 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
               // when
               await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
               await click(screen.getByRole('button', { name: 'Autoriser la reprise du test' }));
+              await screen.findByRole('dialog');
               await click(screen.getByRole('button', { name: "Je confirme l'autorisation" }));
+              await waitForDialogClose();
 
               // then
               sinon.assert.calledOnce(this.authorizeTestResume);
@@ -338,7 +346,9 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
               // when
               await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
               await click(screen.getByRole('button', { name: 'Autoriser la reprise du test' }));
+              await screen.findByRole('dialog');
               await click(screen.getByRole('button', { name: "Je confirme l'autorisation" }));
+              await waitForDialogClose();
 
               // then
               sinon.assert.calledOnce(this.authorizeTestResume);
@@ -376,6 +386,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
           // when
           await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
           await click(screen.getByRole('button', { name: 'Terminer le test' }));
+          await screen.findByRole('dialog');
           const actions = screen.getAllByRole('button', { name: 'Terminer le test' });
 
           // then
@@ -387,7 +398,7 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
               )
             )
             .exists();
-          assert.dom(screen.getByText('Terminer le test de Drax The Destroyer ?')).exists();
+          assert.dom(screen.getByRole('heading', { name: 'Terminer le test de Drax The Destroyer ?' })).exists();
         });
 
         module('when the confirmation modal "Annuler" button is clicked', function () {
@@ -413,7 +424,9 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
             // when
             await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
             await click(screen.getByRole('button', { name: 'Terminer le test' }));
+            await screen.findByRole('dialog');
             await click(screen.getByRole('button', { name: 'Annuler et fermer la fenêtre de confirmation' }));
+            await waitForDialogClose();
 
             // then
             assert.dom(screen.getByRole('button', { name: 'Afficher les options du candidat' })).exists();
@@ -446,10 +459,15 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
             // when
             await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
             await click(screen.getByRole('button', { name: 'Autoriser la reprise du test' }));
+            await screen.findByRole('dialog');
+
             await click(screen.getByRole('button', { name: 'Fermer' }));
+            await waitForDialogClose();
 
             // then
-            assert.dom(screen.queryByRole('button', { name: 'Terminer le test' })).doesNotExist();
+            assert
+              .dom(screen.queryByRole('heading', { name: 'Autoriser Drax The Destroyer à reprendre son test ?' }))
+              .doesNotExist();
           });
         });
 
@@ -477,8 +495,10 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
               // when
               await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
               await click(screen.getByRole('button', { name: 'Terminer le test' }));
+              await screen.findByRole('dialog');
               const [, endTestModal] = screen.getAllByRole('button', { name: 'Terminer le test' });
               await click(endTestModal);
+              await waitForDialogClose();
 
               // then
               sinon.assert.calledOnce(this.endAssessmentForCandidate);
@@ -509,12 +529,15 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
               // when
               await click(screen.getByRole('button', { name: 'Afficher les options du candidat' }));
               await click(screen.getByRole('button', { name: 'Terminer le test' }));
+              await screen.findByRole('dialog');
+
               const [, endTestModal] = screen.getAllByRole('button', { name: 'Terminer le test' });
               await click(endTestModal);
+              await waitForDialogClose();
 
               // then
               sinon.assert.calledOnce(this.endAssessmentBySupervisor);
-              assert.dom(screen.queryByRole('button', { name: 'Terminer le test' })).doesNotExist();
+              assert.dom(screen.queryByRole('heading', { name: 'Terminer le test de Vance Astro ?' })).doesNotExist();
               assert
                 .dom(screen.getByText("Une erreur est survenue, le test de Vance Astro n'a pas pu être terminé."))
                 .exists();

--- a/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
+++ b/certif/tests/integration/components/session-supervising/candidate-in-list_test.js
@@ -416,7 +416,10 @@ module('Integration | Component | SessionSupervising::CandidateInList', function
             await click(screen.getByRole('button', { name: 'Annuler et fermer la fenêtre de confirmation' }));
 
             // then
-            assert.dom(screen.queryByRole('button', { name: 'Terminer le test' })).doesNotExist();
+            assert.dom(screen.getByRole('button', { name: 'Afficher les options du candidat' })).exists();
+            assert
+              .dom(screen.queryByRole('heading', { name: 'Terminer le test de Drax The Destroyer ?' }))
+              .doesNotExist();
           });
         });
 

--- a/certif/tests/integration/components/session-supervising/header_test.js
+++ b/certif/tests/integration/components/session-supervising/header_test.js
@@ -6,6 +6,7 @@ import sinon from 'sinon';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 import hbs from 'htmlbars-inline-precompile';
+import { waitForDialogClose } from '../../../helpers/wait-for';
 
 module('Integration | Component | SessionSupervising::Header', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -61,9 +62,10 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
       const screen = await renderScreen(hbs`<SessionSupervising::Header @session={{this.sessionForSupervising}}  />`);
 
       await click(screen.getByRole('button', { name: 'Quitter la surveillance de la session 12345' }));
+      await screen.findByRole('dialog');
 
       // then
-      assert.dom(screen.getByText('Quitter la surveillance de la session 12345')).exists();
+      assert.dom(screen.getByRole('heading', { name: 'Quitter la surveillance de la session 12345' })).exists();
       assert
         .dom(
           screen.getByText(
@@ -93,17 +95,12 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
       const screen = await renderScreen(hbs`<SessionSupervising::Header @session={{this.sessionForSupervising}}  />`);
 
       await click(screen.getByRole('button', { name: 'Quitter la surveillance de la session 12345' }));
+      await screen.findByRole('dialog');
       await click(screen.getByRole('button', { name: 'Fermer' }));
+      await waitForDialogClose();
 
       // then
-      assert.dom(screen.queryByText('Quitter la surveillance de la session 12345')).doesNotExist();
-      assert
-        .dom(
-          screen.queryByText(
-            'Attention, assurez-vous que tous les candidats aient terminé leur test avant de quitter la surveillance. Pour reprendre la surveillance de cette session, vous devrez entrer à nouveau son numéro de session et son mot de passe.'
-          )
-        )
-        .doesNotExist();
+      assert.dom(screen.queryByRole('heading', { name: 'Quitter la surveillance de la session 12345' })).doesNotExist();
     });
   });
 
@@ -133,18 +130,12 @@ module('Integration | Component | SessionSupervising::Header', function (hooks) 
       const screen = await renderScreen(hbs`<SessionSupervising::Header @session={{this.sessionForSupervising}}  />`);
 
       await click(screen.getByRole('button', { name: 'Quitter la surveillance de la session 12345' }));
-
+      await screen.findByRole('dialog');
       await click(screen.getByRole('button', { name: 'Quitter la surveillance' }));
+      await waitForDialogClose();
 
       // then
-      assert.dom(screen.queryByText('Quitter la surveillance de la session 12345')).doesNotExist();
-      assert
-        .dom(
-          screen.queryByText(
-            'Attention, assurez-vous que tous les candidats aient terminé leur test avant de quitter la surveillance. Pour reprendre la surveillance de cette session, vous devrez entrer à nouveau son numéro de session et son mot de passe.'
-          )
-        )
-        .doesNotExist();
+      assert.dom(screen.queryByRole('heading', { name: 'Quitter la surveillance de la session 12345' })).doesNotExist();
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
On a du retard sur les versions de PIX UI sur l'application Pix Certif.

## :gift: Proposition
Passer de la version 16.1.0 à 18.0.1

Ajout de `await screen.findByRole('dialog');` dans les tests, sans quoi le test n'attend pas l'ouverture de la modale et fail car il ne trouve pas les éléments contenus dans celle-ci

On ajoute également un `waitForDialogClose`, dans le même principe qui s'assure que la modale ne soit plus là. Ajouté pour les tests qui vérifient que les éléments de la modale n'existent plus.

## :star2: Remarques
Changes embarqués dans cette version : 

[#239](https://github.com/1024pix/pix-ui/pull/239) :fire: [BREAKING_CHANGES][BUGFIX] Correction des couleurs du design system par rapport à Figma (PIX-5331).

[#244](https://github.com/1024pix/pix-ui/pull/244) [FEATURE] PixModal : ajouter des modifiers trap-focus et action au echap (PIX-5157)

[#243](https://github.com/1024pix/pix-ui/pull/243) [FEATURE] Ajout d'une icône pour fermer Pix-Banner (PIX-5379)

[#245](https://github.com/1024pix/pix-ui/pull/245) [FEATURE] Ajouter un composant Sidebar (PIX-4298)

[#247](https://github.com/1024pix/pix-ui/pull/247) [FEATURE] Amélioration couleurs PixIconButton

[#248](https://github.com/1024pix/pix-ui/pull/248) [BUGFIX] Prévenir des erreurs à la première ouverture de la sidebar/modal

[#249](https://github.com/1024pix/pix-ui/pull/249) [BUGFIX] Permettre le controle des checkboxs


PixModal : * Le composant PixModal gère maintenant lui-même son état de visibilité. Pour le contrôler, il suffit d'utiliser la propriété @showModal qui est un booléen obligatoire.

## :santa: Pour tester
- Se connecter avec certifsco@example.net
- Constater que la bannière se ferme

Modales :
- Cliquer sur la session 4
- Dans les détails de la session, cliquer sur Finaliser la session
- Ajouter un signalement (1ère modale)
- Cliquer sur le "Ajouter / Supprimer" (2e modale)
- Aller dans le menu équipe et cliquer sur désigner un référent (3e modale)
- Aller sur une session et accéder a l'espace surveillant (numéro de session et mot de passe à remplir)
- Dans l'espace, ouvrir ces deux modales  
<img width="247" alt="Capture d’écran 2022-11-28 à 14 34 11" src="https://user-images.githubusercontent.com/58915422/204290644-f9d1b807-7119-47ad-a215-c3b91e8e848b.png">

- Se connecter sur certifsup@example.com
- Aller sur une session, dans l'onglet candidats
- Inscrire un candidat (6e modale)
- Après avoir inscrit le candidat, cliquer sur "Voir le détail" (7e modale)