### PR TITLE
[TECH] Ajout de shell.nix pour le gestionnaire de package nix.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,30 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  lib = import <nixpkgs/lib>;
+  buildNodeJs = pkgs.callPackage <nixpkgs/pkgs/development/web/nodejs/nodejs.nix> {
+    python = pkgs.python310;
+  };
+
+  nodejsVersion = lib.fileContents ./.nvmrc;
+
+  nodejs = buildNodeJs {
+    enableNpm = true;
+    version = nodejsVersion;
+    sha256 = "sha256-BetkGT45H6iiwVnA9gwXGCRxUWX4DGf8q528lE4wxiM=";
+  };
+
+  NPM_CONFIG_PREFIX = toString ./npm_config_prefix;
+
+in pkgs.mkShell {
+  packages = with pkgs; [
+    nodejs
+  ];
+
+  inherit NPM_CONFIG_PREFIX;
+
+  shellHook = ''
+    export PATH="${NPM_CONFIG_PREFIX}/bin:$PATH"
+  '';
+}
+


### PR DESCRIPTION
## :christmas_tree: Problème
La version de Node spécifiée par le `.nvm` n'est pas disponible dans le repository de package de Nixos [https://search.nixos.org/](https://search.nixos.org/)

Nix utilise le repository de package de Nixos
> Nix is a purely functional package manager. This means that it treats packages like values in purely functional programming languages such as Haskell — they are built by functions that don’t have side-effects, and they never change after they have been built.

## :gift: Proposition
Il faut donc construire une _dérivation_ (ensemble d'actions de construction) pour la version de Node spécifiée dans le `.nvmrc.`  
Création d'un shell.nix qui permet de créer une dérivation et de la plug dans un shell avec la version de node et npm spécifiée dans le `.nvmrc`

## :star2: Remarques
Le sha spécifié dans la définition de la dérivation va changer à chaque version... il faudra le mettre à jour quand on changera la version dans le `.nvmrc` - c'est un système de protection contre des attaques de changement de dépendance. 

## :santa: Pour tester

### Installer nix
`sh <(curl -L https://nixos.org/nix/install)`
https://nixos.org/manual/nix/stable/installation/installing-binary.html

### Installer node
Se positionner à la racine du monorepo.

Puis
```bash
nix-shell
# attendre que l'installation finisse (deux heures sur Ubuntu 20 HP 8 coeurs)
node --version
```

Vérifier que la version renvoyée est celle du `.nvmrc`, à savoir `16.14.0`

Installer les dépendances et vérifier que le code retour ets 0
```bash
npm ci
```