### PR TITLE
[TECH] Augmenter le timeout sur les tests qui ont une longue exécution (PIX-???)

### DIFF
--- a/api/tests/acceptance/scripts/certification/trigger-session-finalized-handler_test.js
+++ b/api/tests/acceptance/scripts/certification/trigger-session-finalized-handler_test.js
@@ -3,6 +3,7 @@ const main = require('../../../../scripts/certification/trigger-session-finalize
 const logger = require('../../../../lib/infrastructure/logger');
 
 describe('Acceptance | Scripts | trigger-session-finalized-handler', function () {
+  this.timeout(5000);
   beforeEach(async function () {
     databaseBuilder.factory.buildCertificationCenter({ id: 55, name: 'Super centre' });
     await databaseBuilder.commit();


### PR DESCRIPTION
## :christmas_tree: Problème
Le test `api/tests/acceptance/scripts/certification/trigger-session-finalized-handler_test.js` timeout souvent. C'est dû à son long setup et à son exécution.

## :gift: Proposition
exceptionnellement pour ce test augmenter le timeout.

## :star2: Remarques
Proposition alternative : si c'est pas un script qui a vocation a être ré-éxecuté, supprimer les tests.

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
