### PR TITLE
[TECH] Préparer la montée de version de Pix Admin pour Ember 4.X (PIX-6390)

### DIFF
--- a/admin/app/controllers/authenticated/certification-centers/get/team.js
+++ b/admin/app/controllers/authenticated/certification-centers/get/team.js
@@ -7,6 +7,7 @@ import { tracked } from '@glimmer/tracking';
 export default class AuthenticatedCertificationCentersGetTeamController extends Controller {
   @service notifications;
   @service errorResponseHandler;
+  @service store;
 
   @tracked userEmailToAdd;
   @tracked errorMessage;

--- a/admin/app/routes/authenticated/certification-centers/get/invitations.js
+++ b/admin/app/routes/authenticated/certification-centers/get/invitations.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class AuthenticatedCertificationCentersGetInvitationsRoute extends Route {
+  @service store;
+
   async model() {
     this.store.unloadAll('certification-center-invitation');
     const { certificationCenter } = this.modelFor('authenticated.certification-centers.get');

--- a/admin/app/routes/authenticated/certification-centers/get/team.js
+++ b/admin/app/routes/authenticated/certification-centers/get/team.js
@@ -1,7 +1,10 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class AuthenticatedCertificationCentersGetTeamRoute extends Route {
+  @service store;
+
   async model() {
     const { certificationCenter } = this.modelFor('authenticated.certification-centers.get');
     const certificationCenterId = certificationCenter.id;

--- a/admin/app/routes/authenticated/organizations/get/places/new.js
+++ b/admin/app/routes/authenticated/organizations/get/places/new.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 export default class New extends Route {
   @service accessControl;
+  @service store;
 
   beforeModel() {
     this.accessControl.restrictAccessTo(['isSuperAdmin', 'isMetier'], 'authenticated');

--- a/admin/app/routes/authenticated/team/list.js
+++ b/admin/app/routes/authenticated/team/list.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 
 export default class ListRoute extends Route {
   @service accessControl;
+  @service store;
 
   beforeModel() {
     this.accessControl.restrictAccessTo(['isSuperAdmin'], 'authenticated');

--- a/admin/tests/integration/components/campaigns/participation-row_test.js
+++ b/admin/tests/integration/components/campaigns/participation-row_test.js
@@ -29,7 +29,7 @@ module('Integration | Component | Campaigns | participation-row', function (hook
       this.set('participation', participation);
 
       // when
-      const screen = await render(hbs`<Campaigns::ParticipationRow @participation={{participation}}/>`);
+      const screen = await render(hbs`<Campaigns::ParticipationRow @participation={{this.participation}}/>`);
 
       // then
       assert.dom(screen.getByText('Jean Claude')).exists();
@@ -48,7 +48,7 @@ module('Integration | Component | Campaigns | participation-row', function (hook
 
       // when
       const screen = await render(
-        hbs`<Campaigns::ParticipationRow @participation={{participation}} @idPixLabel={{idPixLabel}}/>`
+        hbs`<Campaigns::ParticipationRow @participation={{this.participation}} @idPixLabel={{this.idPixLabel}}/>`
       );
 
       // then
@@ -65,7 +65,7 @@ module('Integration | Component | Campaigns | participation-row', function (hook
 
       // when
       const screen = await render(
-        hbs`<Campaigns::ParticipationRow @participation={{participation}} @idPixLabel={{idPixLabel}}/>`
+        hbs`<Campaigns::ParticipationRow @participation={{this.participation}} @idPixLabel={{this.idPixLabel}}/>`
       );
 
       // then
@@ -81,7 +81,7 @@ module('Integration | Component | Campaigns | participation-row', function (hook
       this.set('participation', participation);
 
       // when
-      const screen = await render(hbs`<Campaigns::ParticipationRow @participation={{participation}}/>`);
+      const screen = await render(hbs`<Campaigns::ParticipationRow @participation={{this.participation}}/>`);
 
       // then
       assert.dom(screen.getByText('01/01/2020')).exists();
@@ -96,7 +96,7 @@ module('Integration | Component | Campaigns | participation-row', function (hook
       this.set('participation', participation);
 
       // when
-      const screen = await render(hbs`<Campaigns::ParticipationRow @participation={{participation}}/>`);
+      const screen = await render(hbs`<Campaigns::ParticipationRow @participation={{this.participation}}/>`);
 
       // then
       assert.dom(screen.getByText('01/01/2022 par')).exists();
@@ -215,7 +215,7 @@ module('Integration | Component | Campaigns | participation-row', function (hook
 
       //when
       const screen = await render(
-        hbs`<Campaigns::ParticipationRow @participation={{participation}} @idPixLabel={{idPixLabel}}/>`
+        hbs`<Campaigns::ParticipationRow @participation={{this.participation}} @idPixLabel={{this.idPixLabel}}/>`
       );
 
       // expect

--- a/admin/tests/integration/components/campaigns/participations-section_test.js
+++ b/admin/tests/integration/components/campaigns/participations-section_test.js
@@ -31,7 +31,7 @@ module('Integration | Component | Campaigns | participations-section', function 
     participations.meta = { rowCount: 2 };
 
     // when
-    const screen = await render(hbs`<Campaigns::ParticipationsSection @participations={{participations}}/>`);
+    const screen = await render(hbs`<Campaigns::ParticipationsSection @participations={{this.participations}}/>`);
 
     // then
     assert.strictEqual(screen.getAllByLabelText('participation').length, 2);
@@ -49,7 +49,7 @@ module('Integration | Component | Campaigns | participations-section', function 
 
     // when
     const screen = await render(
-      hbs`<Campaigns::ParticipationsSection @participations={{participations}} @idPixLabel={{idPixLabel}}/>`
+      hbs`<Campaigns::ParticipationsSection @participations={{this.participations}} @idPixLabel={{this.idPixLabel}}/>`
     );
 
     // then
@@ -63,7 +63,7 @@ module('Integration | Component | Campaigns | participations-section', function 
     participations.meta = { rowCount: 2 };
 
     // when
-    const screen = await render(hbs`<Campaigns::ParticipationsSection @participations={{participations}}/>`);
+    const screen = await render(hbs`<Campaigns::ParticipationsSection @participations={{this.participations}}/>`);
 
     // then
     assert.dom(screen.getByText('Aucune participation')).exists();

--- a/admin/tests/integration/components/certification-centers/invitations-action_test.js
+++ b/admin/tests/integration/components/certification-centers/invitations-action_test.js
@@ -17,8 +17,8 @@ module('Integration | Component | certification-center-invitations-action', func
     // when
     await render(
       hbs`<CertificationCenters::InvitationsAction
-        @createInvitation={{createInvitation}}
-        @onChangeUserEmailToInvite={{noop}}/>`
+        @createInvitation={{this.createInvitation}}
+        @onChangeUserEmailToInvite={{this.noop}}/>`
     );
     await clickByText('Inviter');
 
@@ -35,8 +35,8 @@ module('Integration | Component | certification-center-invitations-action', func
     // when
     await render(
       hbs`<CertificationCenters::InvitationsAction
-        @createInvitation={{createInvitation}}
-        @onChangeUserEmailToInvite={{noop}}/>`
+        @createInvitation={{this.createInvitation}}
+        @onChangeUserEmailToInvite={{this.noop}}/>`
     );
     await selectByLabelAndOption('Choisir la langue de l’email d’invitation', 'en');
     await clickByText('Inviter');

--- a/admin/tests/integration/components/certification-centers/invitations_test.js
+++ b/admin/tests/integration/components/certification-centers/invitations_test.js
@@ -14,7 +14,7 @@ module('Integration | Component | Certification Centers | Invitations', function
 
       // when
       const screen = await render(
-        hbs`<CertificationCenters::Invitations @certificationCenterInvitations={{certificationCenterInvitations}} />`
+        hbs`<CertificationCenters::Invitations @certificationCenterInvitations={{this.certificationCenterInvitations}} />`
       );
 
       // then

--- a/admin/tests/integration/components/certification-centers/memberships-section_test.js
+++ b/admin/tests/integration/components/certification-centers/memberships-section_test.js
@@ -30,7 +30,7 @@ module('Integration | Component | certification-centers/memberships-section', fu
     // when
     const screen = await render(
       hbs`<CertificationCenters::MembershipsSection
-        @certificationCenterMemberships={{certificationCenterMemberships}}
+        @certificationCenterMemberships={{this.certificationCenterMemberships}}
         @disableCertificationCenterMembership={{this.disableCertificationCenterMembership}} />`
     );
 
@@ -66,7 +66,7 @@ module('Integration | Component | certification-centers/memberships-section', fu
     // when
     const screen = await render(
       hbs`<CertificationCenters::MembershipsSection
-        @certificationCenterMemberships={{certificationCenterMemberships}}
+        @certificationCenterMemberships={{this.certificationCenterMemberships}}
         @disableCertificationCenterMembership={{this.disableCertificationCenterMembership}} />`
     );
 

--- a/admin/tests/integration/components/certifications/candidate-edit-modal_test.js
+++ b/admin/tests/integration/components/certifications/candidate-edit-modal_test.js
@@ -24,7 +24,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
 
       // when
       const screen = await render(
-        hbs`<Certifications::CandidateEditModal @candidate={{candidate}} @countries={{countries}} />`
+        hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`
       );
 
       // then
@@ -54,7 +54,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
 
       // when
       const screen = await render(
-        hbs`<Certifications::CandidateEditModal @candidate={{this.candidate}} @countries={{this.countries}} />`
+        hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`
       );
 
       // then
@@ -85,7 +85,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
 
         // when
         const screen = await render(
-          hbs`<Certifications::CandidateEditModal @candidate={{this.candidate}} @countries={{this.countries}} />`
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`
         );
 
         // then
@@ -113,7 +113,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
 
         // when
         const screen = await render(
-          hbs`<Certifications::CandidateEditModal @candidate={{this.candidate}} @countries={{this.countries}} />`
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`
         );
 
         // then
@@ -143,7 +143,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
 
         // when
         const screen = await render(
-          hbs`<Certifications::CandidateEditModal @candidate={{this.candidate}} @countries={{this.countries}} />`
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`
         );
 
         // then
@@ -176,7 +176,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
 
         // when
         const screen = await render(
-          hbs`<Certifications::CandidateEditModal @candidate={{this.candidate}} @countries={{this.countries}} />`
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`
         );
 
         // then
@@ -209,7 +209,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
 
         // when
         const screen = await render(
-          hbs`<Certifications::CandidateEditModal @candidate={{this.candidate}} @countries={{this.countries}} />`
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} />`
         );
 
         // then
@@ -241,7 +241,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
       ];
       this.onCancelButtonsClickedStub = sinon.stub();
       const screen = await render(
-        hbs`<Certifications::CandidateEditModal @candidate={{candidate}}  @onCancelButtonsClicked={{this.onCancelButtonsClickedStub}} @countries={{countries}} />`
+        hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @onCancelButtonsClicked={{this.onCancelButtonsClickedStub}} @countries={{this.countries}} />`
       );
 
       await fillByLabel('Nom de famille', 'Belmans');
@@ -287,7 +287,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
       ];
       this.onCancelButtonsClickedStub = sinon.stub();
       await render(
-        hbs`<Certifications::CandidateEditModal @candidate={{candidate}}  @onCancelButtonsClicked={{this.onCancelButtonsClickedStub}} @countries={{countries}} />`
+        hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @onCancelButtonsClicked={{this.onCancelButtonsClickedStub}} @countries={{this.countries}} />`
       );
       await fillByLabel('Nom de famille', 'Belmans');
       await fillByLabel('Prénom', 'Gideona');
@@ -312,7 +312,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
       this.countries = [];
       this.onCancelButtonsClickedStub = sinon.stub();
       await render(
-        hbs`<Certifications::CandidateEditModal @candidate={{candidate}}  @onCancelButtonsClicked={{this.onCancelButtonsClickedStub}} @countries={{countries}} />`
+        hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @onCancelButtonsClicked={{this.onCancelButtonsClickedStub}} @countries={{this.countries}} />`
       );
 
       // when
@@ -330,7 +330,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
       this.countries = [];
       this.onFormSubmitStub = sinon.stub();
       await render(
-        hbs`<Certifications::CandidateEditModal @candidate={{candidate}} @onFormSubmit={{this.onFormSubmitStub}} @countries={{countries}} />`
+        hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @onFormSubmit={{this.onFormSubmitStub}} @countries={{this.countries}} />`
       );
 
       // when
@@ -359,7 +359,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
       ];
       this.onFormSubmitStub = sinon.stub();
       await render(
-        hbs`<Certifications::CandidateEditModal @candidate={{candidate}} @onFormSubmit={{this.onFormSubmitStub}} @countries={{countries}} />`
+        hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @onFormSubmit={{this.onFormSubmitStub}} @countries={{this.countries}} />`
       );
       await fillByLabel('Nom de famille', 'Belmans');
       await fillByLabel('Prénom', 'Gideon');
@@ -399,7 +399,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         this.onFormSubmitStub = sinon.stub();
         this.onFormSubmitStub.resolves();
         await render(
-          hbs`<Certifications::CandidateEditModal @candidate={{candidate}} @countries={{this.countries}} @onFormSubmit={{this.onFormSubmitStub}}/>`
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} @onFormSubmit={{this.onFormSubmitStub}}/>`
         );
 
         // when
@@ -443,7 +443,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         this.onFormSubmitStub = sinon.stub();
         this.onFormSubmitStub.resolves();
         await render(
-          hbs`<Certifications::CandidateEditModal @candidate={{candidate}} @countries={{this.countries}} @onFormSubmit={{this.onFormSubmitStub}}/>`
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} @onFormSubmit={{this.onFormSubmitStub}}/>`
         );
 
         // when
@@ -488,7 +488,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         this.onFormSubmitStub = sinon.stub();
         this.onFormSubmitStub.resolves();
         await render(
-          hbs`<Certifications::CandidateEditModal @candidate={{candidate}} @countries={{this.countries}} @onFormSubmit={{this.onFormSubmitStub}}/>`
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}} @onFormSubmit={{this.onFormSubmitStub}}/>`
         );
 
         // when
@@ -533,7 +533,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
           run(() => store.createRecord('country', { code: '99100', name: 'FRANCE' })),
         ];
         const screen = await render(
-          hbs`<Certifications::CandidateEditModal @candidate={{candidate}} @countries={{this.countries}}/>`
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}}/>`
         );
 
         // when
@@ -562,7 +562,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         );
         this.countries = [];
         const screen = await render(
-          hbs`<Certifications::CandidateEditModal @candidate={{candidate}} @countries={{this.countries}}/>`
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}}/>`
         );
 
         // when
@@ -591,7 +591,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         );
         this.countries = [];
         const screen = await render(
-          hbs`<Certifications::CandidateEditModal @candidate={{candidate}} @countries={{this.countries}}/>`
+          hbs`<Certifications::CandidateEditModal @isDisplayed={{true}} @candidate={{this.candidate}} @countries={{this.countries}}/>`
         );
 
         // when

--- a/admin/tests/integration/components/certifications/details-answer_test.js
+++ b/admin/tests/integration/components/certifications/details-answer_test.js
@@ -25,7 +25,7 @@ module('Integration | Component | certifications/details-answer', function (hook
 
     // when
     const screen = await render(
-      hbs`<Certifications::DetailsAnswer @answer={{answer}} @onUpdateRate={{onUpdateRate}} />`
+      hbs`<Certifications::DetailsAnswer @answer={{this.answer}} @onUpdateRate={{this.onUpdateRate}} />`
     );
 
     // then
@@ -41,7 +41,7 @@ module('Integration | Component | certifications/details-answer', function (hook
 
     // when
     const screen = await render(
-      hbs`<Certifications::DetailsAnswer @answer={{answer}} @onUpdateRate={{onUpdateRate}} />`
+      hbs`<Certifications::DetailsAnswer @answer={{this.answer}} @onUpdateRate={{this.onUpdateRate}} />`
     );
 
     // then
@@ -57,7 +57,7 @@ module('Integration | Component | certifications/details-answer', function (hook
 
     // when
     const screen = await render(
-      hbs`<Certifications::DetailsAnswer @answer={{answer}} @onUpdateRate={{onUpdateRate}} />`
+      hbs`<Certifications::DetailsAnswer @answer={{this.answer}} @onUpdateRate={{this.onUpdateRate}} />`
     );
 
     // then
@@ -82,7 +82,7 @@ module('Integration | Component | certifications/details-answer', function (hook
 
       // when
       const screen = await render(
-        hbs`<Certifications::DetailsAnswer @answer={{answer}} @onUpdateRate={{onUpdateRate}} />`
+        hbs`<Certifications::DetailsAnswer @answer={{this.answer}} @onUpdateRate={{this.onUpdateRate}} />`
       );
 
       // then
@@ -101,7 +101,7 @@ module('Integration | Component | certifications/details-answer', function (hook
       onUpdateRate: () => {},
     });
     const screen = await render(
-      hbs`<Certifications::DetailsAnswer @answer={{answer}} @onUpdateRate={{onUpdateRate}} />`
+      hbs`<Certifications::DetailsAnswer @answer={{this.answer}} @onUpdateRate={{this.onUpdateRate}} />`
     );
     // when
     await selectByLabelAndOption('Sélectionner un résultat', 'ok');
@@ -123,7 +123,7 @@ module('Integration | Component | certifications/details-answer', function (hook
         return resolve();
       },
     });
-    await render(hbs`<Certifications::DetailsAnswer @answer={{answer}} @onUpdateRate={{onUpdateRate}} />`);
+    await render(hbs`<Certifications::DetailsAnswer @answer={{this.answer}} @onUpdateRate={{this.onUpdateRate}} />`);
 
     // when
     await selectByLabelAndOption('Sélectionner un résultat', 'ok');
@@ -135,7 +135,7 @@ module('Integration | Component | certifications/details-answer', function (hook
       answer: answerData,
       onUpdateRate: () => resolve(),
     });
-    await render(hbs`<Certifications::DetailsAnswer @answer={{answer}} @onUpdateRate={{onUpdateRate}} />`);
+    await render(hbs`<Certifications::DetailsAnswer @answer={{this.answer}} @onUpdateRate={{this.onUpdateRate}} />`);
 
     // when
     await selectByLabelAndOption('Sélectionner un résultat', 'ok');
@@ -154,7 +154,7 @@ module('Integration | Component | certifications/details-answer', function (hook
     });
 
     // when
-    const screen = await render(hbs`<Certifications::DetailsAnswer @answer={{answer}} />`);
+    const screen = await render(hbs`<Certifications::DetailsAnswer @answer={{this.answer}} />`);
 
     // then
     assert

--- a/admin/tests/integration/components/certifications/details-competence_test.js
+++ b/admin/tests/integration/components/certifications/details-competence_test.js
@@ -35,7 +35,7 @@ module('Integration | Component | certifications/details-competence', function (
 
     // when
     const screen = await render(
-      hbs`<Certifications::DetailsCompetence @competence={{competenceData}} rate={{60}} @juryRate={{false}} @onUpdateRate={{externalAction}}/>`
+      hbs`<Certifications::DetailsCompetence @competence={{this.competenceData}} rate={{60}} @juryRate={{false}} @onUpdateRate={{this.externalAction}}/>`
     );
 
     // then
@@ -51,7 +51,7 @@ module('Integration | Component | certifications/details-competence', function (
 
     // when
     const screen = await render(
-      hbs`<Certifications::DetailsCompetence @competence={{competenceData}} rate={{60}} @juryRate={{false}} @onUpdateRate={{externalAction}}/>`
+      hbs`<Certifications::DetailsCompetence @competence={{this.competenceData}} rate={{60}} @juryRate={{false}} @onUpdateRate={{this.externalAction}}/>`
     );
 
     // then
@@ -65,7 +65,7 @@ module('Integration | Component | certifications/details-competence', function (
 
     // when
     const screen = await render(
-      hbs`<Certifications::DetailsCompetence @competence={{competenceData}} rate={{60}} juryRate={{70}} @onUpdateRate={{externalAction}} />`
+      hbs`<Certifications::DetailsCompetence @competence={{this.competenceData}} rate={{60}} juryRate={{70}} @onUpdateRate={{this.externalAction}} />`
     );
 
     // then

--- a/admin/tests/integration/components/certifications/list_test.js
+++ b/admin/tests/integration/components/certifications/list_test.js
@@ -24,7 +24,7 @@ module('Integration | Component | certifications/list', function (hooks) {
     this.pagination = {};
 
     // when
-    await render(hbs`<Certifications::List @certifications={{certifications}} @pagination={{pagination}} />`);
+    await render(hbs`<Certifications::List @certifications={{this.certifications}} @pagination={{this.pagination}} />`);
 
     const numberOfCertificationIssueReportsWithRequiredAction =
       this.element.querySelector('tbody > tr td:nth-child(5)');
@@ -41,7 +41,7 @@ module('Integration | Component | certifications/list', function (hooks) {
 
     // when
     const screen = await render(
-      hbs`<Certifications::List @certifications={{certifications}} @pagination={{pagination}}/>`
+      hbs`<Certifications::List @certifications={{this.certifications}} @pagination={{this.pagination}}/>`
     );
 
     // then
@@ -59,7 +59,7 @@ module('Integration | Component | certifications/list', function (hooks) {
 
       // when
       const screen = await render(
-        hbs`<Certifications::List @certifications={{certifications}} @displayHasSeenEndTestScreenColumn={{true}} @pagination={{pagination}}/>`
+        hbs`<Certifications::List @certifications={{this.certifications}} @displayHasSeenEndTestScreenColumn={{true}} @pagination={{this.pagination}}/>`
       );
 
       // then
@@ -78,7 +78,7 @@ module('Integration | Component | certifications/list', function (hooks) {
 
       // when
       const screen = await render(
-        hbs`<Certifications::List @certifications={{certifications}} @displayHasSeenEndTestScreenColumn={{false}} @pagination={{pagination}}/>`
+        hbs`<Certifications::List @certifications={{this.certifications}} @displayHasSeenEndTestScreenColumn={{false}} @pagination={{this.pagination}}/>`
       );
 
       // then

--- a/admin/tests/integration/components/certifications/status_test.js
+++ b/admin/tests/integration/components/certifications/status_test.js
@@ -24,7 +24,7 @@ module('Integration | Component | certifications/status', function (hooks) {
         this.set('record', record);
 
         // when
-        await render(hbs`<Certifications::Status @record={{record}} />`);
+        await render(hbs`<Certifications::Status @record={{this.record}} />`);
 
         // then
         assert.dom('span.certification-list-page__cell--important').exists();
@@ -38,7 +38,7 @@ module('Integration | Component | certifications/status', function (hooks) {
       this.set('record', record);
 
       // when
-      await render(hbs`<Certifications::Status @record={{record}} />`);
+      await render(hbs`<Certifications::Status @record={{this.record}} />`);
 
       // then
       assert.dom('span.certification-list-page__cell--important').exists();
@@ -58,7 +58,7 @@ module('Integration | Component | certifications/status', function (hooks) {
         this.set('record', record);
 
         // when
-        await render(hbs`<Certifications::Status @record={{record}} />`);
+        await render(hbs`<Certifications::Status @record={{this.record}} />`);
 
         // then
         assert.dom('span.certification-list-page__cell--important').doesNotExist();

--- a/admin/tests/integration/components/organizations/campaigns-section-test.js
+++ b/admin/tests/integration/components/organizations/campaigns-section-test.js
@@ -12,7 +12,7 @@ module('Integration | Component | organizations/campaigns-section', function (ho
       this.set('campaigns', []);
 
       // when
-      const screen = await render(hbs`<Organizations::CampaignsSection @campaigns={{ campaigns }}/>`);
+      const screen = await render(hbs`<Organizations::CampaignsSection @campaigns={{this.campaigns}}/>`);
 
       // then
       assert.dom(screen.getByText('Aucune campagne')).exists();
@@ -37,7 +37,7 @@ module('Integration | Component | organizations/campaigns-section', function (ho
       this.set('campaigns', campaigns);
 
       // when
-      const screen = await render(hbs`<Organizations::CampaignsSection @campaigns={{ campaigns }}/>`);
+      const screen = await render(hbs`<Organizations::CampaignsSection @campaigns={{this.campaigns}}/>`);
 
       // then
       assert.dom(screen.getByText('ID')).exists();
@@ -76,7 +76,7 @@ module('Integration | Component | organizations/campaigns-section', function (ho
       this.set('campaigns', campaigns);
 
       // when
-      const screen = await render(hbs`<Organizations::CampaignsSection @campaigns={{ campaigns }}/>`);
+      const screen = await render(hbs`<Organizations::CampaignsSection @campaigns={{this.campaigns}}/>`);
 
       // then
       assert.strictEqual(screen.getAllByLabelText('campagne').length, 2);
@@ -112,7 +112,7 @@ module('Integration | Component | organizations/campaigns-section', function (ho
       this.set('campaigns', campaigns);
 
       // when
-      const screen = await render(hbs`<Organizations::CampaignsSection @campaigns={{ campaigns }}/>`);
+      const screen = await render(hbs`<Organizations::CampaignsSection @campaigns={{this.campaigns}}/>`);
 
       // then
       assert.dom(screen.getByText('C1')).exists();
@@ -149,7 +149,7 @@ module('Integration | Component | organizations/campaigns-section', function (ho
       this.set('campaigns', campaigns);
 
       // when
-      const screen = await render(hbs`<Organizations::CampaignsSection @campaigns={{ campaigns }}/>`);
+      const screen = await render(hbs`<Organizations::CampaignsSection @campaigns={{this.campaigns}}/>`);
 
       // then
       assert.dom(screen.getByText('-')).exists();

--- a/admin/tests/integration/components/organizations/form_test.js
+++ b/admin/tests/integration/components/organizations/form_test.js
@@ -16,7 +16,7 @@ module('Integration | Component | organizations/form', function (hooks) {
   test('it renders', async function (assert) {
     // when
     const screen = await render(
-      hbs`<Organizations::Form @organization={{this.organization}} @onSubmit={{action onSubmit}} @onCancel={{action onCancel}} />`
+      hbs`<Organizations::Form @organization={{this.organization}} @onSubmit={{action this.onSubmit}} @onCancel={{action this.onCancel}} />`
     );
 
     // then
@@ -31,7 +31,7 @@ module('Integration | Component | organizations/form', function (hooks) {
     test('should update attribute organization.type', async function (assert) {
       // given
       const screen = await render(
-        hbs`<Organizations::Form @organization={{this.organization}} @onSubmit={{action onSubmit}} @onCancel={{action onCancel}} />`
+        hbs`<Organizations::Form @organization={{this.organization}} @onSubmit={{action this.onSubmit}} @onCancel={{action this.onCancel}} />`
       );
 
       // when

--- a/admin/tests/integration/components/organizations/invitations-action_test.js
+++ b/admin/tests/integration/components/organizations/invitations-action_test.js
@@ -17,8 +17,8 @@ module('Integration | Component | organization-invitations-action', function (ho
     // when
     await render(
       hbs`<Organizations::InvitationsAction
-        @createOrganizationInvitation={{createOrganizationInvitation}}
-        @onChangeUserEmailToInvite={{noop}}/>`
+        @createOrganizationInvitation={{this.createOrganizationInvitation}}
+        @onChangeUserEmailToInvite={{this.noop}}/>`
     );
     await clickByText('Inviter');
 

--- a/admin/tests/integration/components/organizations/invitations_test.js
+++ b/admin/tests/integration/components/organizations/invitations_test.js
@@ -24,7 +24,7 @@ module('Integration | Component | organization-invitations', function (hooks) {
         this.set('invitations', []);
 
         // when
-        const screen = await render(hbs`<Organizations::Invitations @invitations={{invitations}}/>`);
+        const screen = await render(hbs`<Organizations::Invitations @invitations={{this.invitations}}/>`);
 
         // then
         assert.dom(screen.getByText('Aucune invitation en attente')).exists();
@@ -60,7 +60,7 @@ module('Integration | Component | organization-invitations', function (hooks) {
         // when
         const screen = await render(
           hbs`<Organizations::Invitations
-          @invitations={{invitations}}
+          @invitations={{this.invitations}}
           @onCancelOrganizationInvitation={{this.cancelOrganizationInvitation}}/>`
         );
 
@@ -121,7 +121,7 @@ module('Integration | Component | organization-invitations', function (hooks) {
         this.set('invitations', []);
 
         // when
-        const screen = await render(hbs`<Organizations::Invitations @invitations={{invitations}}/>`);
+        const screen = await render(hbs`<Organizations::Invitations @invitations={{this.invitations}}/>`);
 
         // then
         assert.dom(screen.getByText('Aucune invitation en attente')).exists();
@@ -157,7 +157,7 @@ module('Integration | Component | organization-invitations', function (hooks) {
         // when
         const screen = await render(
           hbs`<Organizations::Invitations
-          @invitations={{invitations}}
+          @invitations={{this.invitations}}
           @onCancelOrganizationInvitation={{this.cancelOrganizationInvitation}}/>`
         );
 

--- a/admin/tests/integration/components/organizations/target-profiles-section_test.js
+++ b/admin/tests/integration/components/organizations/target-profiles-section_test.js
@@ -27,7 +27,7 @@ module('Integration | Component | organizations/target-profiles-section', functi
       this.set('organization', organization);
 
       // when
-      const screen = await render(hbs`<Organizations::TargetProfilesSection @organization={{organization}} />`);
+      const screen = await render(hbs`<Organizations::TargetProfilesSection @organization={{this.organization}} />`);
 
       // then
       assert.dom(screen.getByRole('button', { name: 'Valider' })).isDisabled();
@@ -46,7 +46,7 @@ module('Integration | Component | organizations/target-profiles-section', functi
       this.set('organization', organization);
 
       // when
-      await render(hbs`<Organizations::TargetProfilesSection @organization={{organization}} />`);
+      await render(hbs`<Organizations::TargetProfilesSection @organization={{this.organization}} />`);
       await fillByLabel('ID du ou des profil(s) cible(s)', '1');
       await clickByName('Valider');
 
@@ -69,7 +69,7 @@ module('Integration | Component | organizations/target-profiles-section', functi
       this.owner.register('service:access-control', AccessControlStub);
 
       // when
-      const screen = await render(hbs`<Organizations::TargetProfilesSection @organization={{organization}} />`);
+      const screen = await render(hbs`<Organizations::TargetProfilesSection @organization={{this.organization}} />`);
 
       // expect
       assert.dom(screen.queryByRole('button', { name: 'Valider' })).doesNotExist();

--- a/admin/tests/integration/components/organizations/team-section_test.js
+++ b/admin/tests/integration/components/organizations/team-section_test.js
@@ -34,11 +34,11 @@ module('Integration | Component | organization-team-section', function (hooks) {
 
     // when
     const screen = await render(hbs`<Organizations::TeamSection
-      @organizationMemberships={{organizationMemberships}}
-      @addOrganizationMembership={{noop}}
-      @createOrganizationInvitation={{noop}}
-      @triggerFiltering={{noop}}
-      @selectRoleForSearch={{noop}}/>`);
+      @organizationMemberships={{this.organizationMemberships}}
+      @addOrganizationMembership={{this.noop}}
+      @createOrganizationInvitation={{this.noop}}
+      @triggerFiltering={{this.noop}}
+      @selectRoleForSearch={{this.noop}}/>`);
 
     // then
     assert.strictEqual(screen.getAllByLabelText('Membre').length, 2);

--- a/admin/tests/integration/components/target-profiles/badge-form_test.js
+++ b/admin/tests/integration/components/target-profiles/badge-form_test.js
@@ -55,7 +55,7 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
       reloadStub.resolves();
       this.targetProfile = { id: 123, reload: reloadStub };
 
-      const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{targetProfile}} />`);
+      const screen = await render(hbs`<TargetProfiles::BadgeForm @targetProfile={{this.targetProfile}} />`);
 
       // when
       await fillByLabel("Nom de l'image (svg) :", 'nom_de_limage.svg');

--- a/admin/tests/integration/components/team-actions-section_test.js
+++ b/admin/tests/integration/components/team-actions-section_test.js
@@ -16,10 +16,10 @@ module('Integration | Component | organization-team-actions-section', function (
 
     // when
     await render(hbs`<Organizations::TeamActionsSection
-      @addOrganizationMembership={{addOrganizationMembership}}
-      @createOrganizationInvitation={{noop}}
-      @triggerFiltering={{noop}}
-      @onChangeUserEmailToAdd={{noop}} />`);
+      @addOrganizationMembership={{this.addOrganizationMembership}}
+      @createOrganizationInvitation={{this.noop}}
+      @triggerFiltering={{this.noop}}
+      @onChangeUserEmailToAdd={{this.noop}} />`);
 
     await fillByLabel('Ajouter un membre', 'user@example.net');
     await clickByName('Ajouter un membre');

--- a/admin/tests/integration/components/users/campaign-participations_test.js
+++ b/admin/tests/integration/components/users/campaign-participations_test.js
@@ -29,7 +29,7 @@ module('Integration | Component | users | campaign-participation', function (hoo
       this.set('participations', participations);
 
       // when
-      const screen = await render(hbs`<Users::CampaignParticipations @participations={{participations}}/>`);
+      const screen = await render(hbs`<Users::CampaignParticipations @participations={{this.participations}}/>`);
 
       // then
       assert.strictEqual(screen.getAllByLabelText('Participation').length, 2);
@@ -41,7 +41,7 @@ module('Integration | Component | users | campaign-participation', function (hoo
       this.set('participations', participations);
 
       // when
-      const screen = await render(hbs`<Users::CampaignParticipations @participations={{participations}}/>`);
+      const screen = await render(hbs`<Users::CampaignParticipations @participations={{this.participations}}/>`);
 
       // then
       assert.dom(screen.getByText('Aucune participation')).exists();
@@ -56,7 +56,7 @@ module('Integration | Component | users | campaign-participation', function (hoo
       this.set('participations', [participation]);
 
       // when
-      const screen = await render(hbs`<Users::CampaignParticipations @participations={{participations}}/>`);
+      const screen = await render(hbs`<Users::CampaignParticipations @participations={{this.participations}}/>`);
 
       // then
       assert.dom(screen.getByText('SOMECODE')).exists();
@@ -71,7 +71,7 @@ module('Integration | Component | users | campaign-participation', function (hoo
       this.set('participations', [participation]);
 
       // when
-      const screen = await render(hbs`<Users::CampaignParticipations @participations={{participations}}/>`);
+      const screen = await render(hbs`<Users::CampaignParticipations @participations={{this.participations}}/>`);
 
       // then
       assert.dom(screen.getByText('Un nom bien long')).exists();
@@ -87,7 +87,7 @@ module('Integration | Component | users | campaign-participation', function (hoo
       this.set('participations', [participation]);
 
       // when
-      const screen = await render(hbs`<Users::CampaignParticipations @participations={{participations}}/>`);
+      const screen = await render(hbs`<Users::CampaignParticipations @participations={{this.participations}}/>`);
 
       // then
       assert.dom(screen.getByText('Some external id')).exists();
@@ -103,7 +103,7 @@ module('Integration | Component | users | campaign-participation', function (hoo
       this.set('participations', [participation]);
 
       // when
-      const screen = await render(hbs`<Users::CampaignParticipations @participations={{participations}}/>`);
+      const screen = await render(hbs`<Users::CampaignParticipations @participations={{this.participations}}/>`);
 
       // then
       assert.dom(screen.getByText('01/01/2020')).exists();
@@ -118,7 +118,7 @@ module('Integration | Component | users | campaign-participation', function (hoo
       this.set('participations', [participation]);
 
       // when
-      const screen = await render(hbs`<Users::CampaignParticipations @participations={{participations}}/>`);
+      const screen = await render(hbs`<Users::CampaignParticipations @participations={{this.participations}}/>`);
 
       // then
       assert.dom(screen.getByText('01/01/2022 par')).exists();
@@ -134,7 +134,7 @@ module('Integration | Component | users | campaign-participation', function (hoo
       this.set('participations', [participation]);
 
       // When
-      const screen = await render(hbs`<Users::CampaignParticipations @participations={{participations}}/>`);
+      const screen = await render(hbs`<Users::CampaignParticipations @participations={{this.participations}}/>`);
 
       // Then
       assert.dom(screen.queryByRole('button', { name: 'Supprimer' })).doesNotExist();
@@ -155,7 +155,7 @@ module('Integration | Component | users | campaign-participation', function (hoo
       this.owner.register('service:access-control', AccessControlStub);
 
       // When
-      const screen = await render(hbs`<Users::CampaignParticipations @participations={{participations}}/>`);
+      const screen = await render(hbs`<Users::CampaignParticipations @participations={{this.participations}}/>`);
 
       // Then
       assert.dom(screen.queryByRole('button', { name: 'Supprimer' })).exists();
@@ -175,7 +175,7 @@ module('Integration | Component | users | campaign-participation', function (hoo
       this.owner.register('service:access-control', AccessControlStub);
 
       // When
-      const screen = await render(hbs`<Users::CampaignParticipations @participations={{participations}}/>`);
+      const screen = await render(hbs`<Users::CampaignParticipations @participations={{this.participations}}/>`);
 
       // Then
       assert.dom(screen.queryByRole('button', { name: 'Supprimer' })).doesNotExist();
@@ -196,7 +196,7 @@ module('Integration | Component | users | campaign-participation', function (hoo
 
       // When
       const screen = await render(
-        hbs`<Users::CampaignParticipations @participations={{participations}} @removeParticipation={{this.removeParticipation}}/>`
+        hbs`<Users::CampaignParticipations @participations={{this.participations}} @removeParticipation={{this.removeParticipation}}/>`
       );
       await clickByName('Supprimer');
 

--- a/admin/tests/integration/components/users/certification-center-memberships_test.js
+++ b/admin/tests/integration/components/users/certification-center-memberships_test.js
@@ -16,7 +16,7 @@ module('Integration | Component | users | certification-center-memberships', fun
 
       // when
       const screen = await render(
-        hbs`<Users::CertificationCenterMemberships @certificationCenterMemberships={{certificationCenterMemberships}} />`
+        hbs`<Users::CertificationCenterMemberships @certificationCenterMemberships={{this.certificationCenterMemberships}} />`
       );
 
       // then
@@ -42,7 +42,7 @@ module('Integration | Component | users | certification-center-memberships', fun
 
       // when
       const screen = await render(
-        hbs`<Users::CertificationCenterMemberships @certificationCenterMemberships={{certificationCenterMemberships}} />`
+        hbs`<Users::CertificationCenterMemberships @certificationCenterMemberships={{this.certificationCenterMemberships}} />`
       );
 
       // then
@@ -78,7 +78,7 @@ module('Integration | Component | users | certification-center-memberships', fun
 
     // when
     await render(
-      hbs`<Users::CertificationCenterMemberships @certificationCenterMemberships={{certificationCenterMemberships}} />`
+      hbs`<Users::CertificationCenterMemberships @certificationCenterMemberships={{this.certificationCenterMemberships}} />`
     );
     await clickByName('Désactiver');
 
@@ -115,7 +115,7 @@ module('Integration | Component | users | certification-center-memberships', fun
 
     // when
     await render(
-      hbs`<Users::CertificationCenterMemberships @certificationCenterMemberships={{certificationCenterMemberships}} />`
+      hbs`<Users::CertificationCenterMemberships @certificationCenterMemberships={{this.certificationCenterMemberships}} />`
     );
     await clickByName('Désactiver');
 

--- a/admin/tests/integration/components/users/user-organization-memberships_test.js
+++ b/admin/tests/integration/components/users/user-organization-memberships_test.js
@@ -21,7 +21,7 @@ module('Integration | Component | users | organization-memberships', function (h
 
       // when
       const screen = await render(
-        hbs`<Users::UserOrganizationMemberships @organizationMemberships={{organizationMemberships}} />`
+        hbs`<Users::UserOrganizationMemberships @organizationMemberships={{this.organizationMemberships}} />`
       );
 
       // then
@@ -57,7 +57,7 @@ module('Integration | Component | users | organization-memberships', function (h
 
       // when
       const screen = await render(
-        hbs`<Users::UserOrganizationMemberships @organizationMemberships={{organizationMemberships}} />`
+        hbs`<Users::UserOrganizationMemberships @organizationMemberships={{this.organizationMemberships}} />`
       );
 
       // then

--- a/admin/tests/integration/components/users/user-profile_test.js
+++ b/admin/tests/integration/components/users/user-profile_test.js
@@ -17,7 +17,7 @@ module('Integration | Component |  users | user-profile', function (hooks) {
     });
 
     //  when
-    const component = await render(hbs`<Users::UserProfile @profile={{profile}} />`);
+    const component = await render(hbs`<Users::UserProfile @profile={{this.profile}} />`);
 
     // then
     assert.dom(component.getByText(this.profile.pixScore)).exists();
@@ -37,7 +37,7 @@ module('Integration | Component |  users | user-profile', function (hooks) {
       });
 
       //  when
-      const component = await render(hbs`<Users::UserProfile @profile={{profile}} />`);
+      const component = await render(hbs`<Users::UserProfile @profile={{this.profile}} />`);
 
       // then
       assert.dom(component.getByText('Aucun résultat')).exists();


### PR DESCRIPTION
## :christmas_tree: Problème
Poru une montée de version avec le moins de douleur possible, il faut ajouter aux fichiers manquant les this. pour les tests, et les service store pour les controller appelant le store

## :gift: Proposition
Corriges ces deux éléments dans cette pull request

## :star2: Remarques
Je n'ai pas mofier les tests de la dialog_test . elle sera remplacé par la modal PixUI, ces tests disparaitront

## :santa: Pour tester
Vérifier que la CI passe
