### PR TITLE
[FEATURE] Créer la nouvelle table user-logins (PIX-6392)

### DIFF
--- a/api/db/migrations/20221124093117_create-user-logins-table.js
+++ b/api/db/migrations/20221124093117_create-user-logins-table.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'user-logins';
+
+exports.up = (knex) => {
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.bigIncrements().primary();
+    t.bigInteger('userId').references('users.id').notNullable().unique();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    t.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+    t.dateTime('blockedAt').nullable();
+    t.dateTime('temporaryBlockedUntil').nullable();
+    t.integer('failureCount').notNullable().defaultTo(0);
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};


### PR DESCRIPTION
## :christmas_tree: Problème

Dans le cadre du partenariat avec la CNIL, nous avons besoin de persister certaines données notamment pour les tentatives infructueuses afin de bloquer le compte. Aujourd'hui nous n'avons aucune table pour sauvegarder ces données. 

## :gift: Proposition

Créer un script de migration pour ajouter cette nouvelle table dans la base de données.

## :star2: Remarques

RAS

## :santa: Pour tester

- Exécutez en local `npm run db:migrate`
- Constatez que la nouvelle table a bien été créé
- Exécutez en local `npm run db:rollback:latest`
- Constatez que la nouvelle table a bien été supprimé
