### PR TITLE
[FEATURE] Création de la page des contenus formatif dans Pix Admin (PIX-6329)

### DIFF
--- a/admin/app/adapters/training-summary.js
+++ b/admin/app/adapters/training-summary.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+
+export default class TrainingSummaryAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+}

--- a/admin/app/components/trainings/list-summary-items.hbs
+++ b/admin/app/components/trainings/list-summary-items.hbs
@@ -1,0 +1,31 @@
+<div class="content-text content-text--small">
+  <div class="table-admin">
+    <table>
+      <thead>
+        <tr>
+          <th class="table__column table__column--id" id="training-id">ID</th>
+          <th id="training-titre">Titre</th>
+        </tr>
+      </thead>
+
+      {{#if @summaries}}
+        <tbody>
+          {{#each @summaries as |summary|}}
+            <tr aria-label="Contenu formatif">
+              <td headers="training-id" class="table__column table__column--id">{{summary.id}}</td>
+              <td headers="training-title">{{summary.title}}</td>
+            </tr>
+          {{/each}}
+        </tbody>
+      {{/if}}
+    </table>
+
+    {{#unless @summaries}}
+      <div class="table__empty">Aucun résultat</div>
+    {{/unless}}
+  </div>
+</div>
+
+{{#if @summaries}}
+  <PaginationControl @pagination={{@summaries.meta.pagination}} />
+{{/if}}

--- a/admin/app/controllers/authenticated/trainings/list.js
+++ b/admin/app/controllers/authenticated/trainings/list.js
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default class ListController extends Controller {}

--- a/admin/app/models/training-summary.js
+++ b/admin/app/models/training-summary.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class TrainingSummary extends Model {
+  @attr() title;
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -106,6 +106,10 @@ Router.map(function () {
       });
     });
 
+    this.route('trainings', function () {
+      this.route('list');
+    });
+
     this.route('tools');
   });
 });

--- a/admin/app/routes/authenticated/trainings/list.js
+++ b/admin/app/routes/authenticated/trainings/list.js
@@ -1,0 +1,36 @@
+import Route from '@ember/routing/route';
+import isEmpty from 'lodash/isEmpty';
+import { inject as service } from '@ember/service';
+
+export default class ListRoute extends Route {
+  @service accessControl;
+
+  queryParams = {
+    pageNumber: { refreshModel: true },
+    pageSize: { refreshModel: true },
+    id: { refreshModel: true },
+    name: { refreshModel: true },
+  };
+
+  beforeModel() {
+    this.accessControl.restrictAccessTo(['isSuperAdmin', 'isSupport', 'isMetier'], 'authenticated');
+  }
+
+  async model(params) {
+    let trainingSummaries;
+    try {
+      trainingSummaries = await this.store.query('training-summary', {
+        page: {
+          number: params.pageNumber,
+          size: params.pageSize,
+        },
+      });
+    } catch (errorResponse) {
+      if (!isEmpty(errorResponse)) {
+        errorResponse.errors.forEach((error) => this.notifications.error(error.detail));
+      }
+      return [];
+    }
+    return trainingSummaries;
+  }
+}

--- a/admin/app/templates/authenticated/trainings.hbs
+++ b/admin/app/templates/authenticated/trainings.hbs
@@ -1,0 +1,4 @@
+{{page-title "Contenus formatifs"}}
+<div class="page">
+  {{outlet}}
+</div>

--- a/admin/app/templates/authenticated/trainings/list.hbs
+++ b/admin/app/templates/authenticated/trainings/list.hbs
@@ -1,0 +1,9 @@
+<header class="page-header">
+  <h1 class="page-title">Tous les contenus formatifs</h1>
+</header>
+
+<main class="page-body">
+  <section class="page-section">
+    <Trainings::ListSummaryItems @summaries={{@model}} @id={{this.id}} @name={{this.name}} />
+  </section>
+</main>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -28,6 +28,7 @@ import {
 } from './handlers/organizations';
 import { getPaginatedJuryCertificationSummariesBySessionId } from './handlers/get-jury-certification-summaries-by-session-id';
 import { createAdminMember } from './handlers/admin-members';
+import { findPaginatedTrainingSummaries } from './handlers/trainings';
 
 export default function () {
   this.logging = true;
@@ -160,6 +161,7 @@ export default function () {
   this.get('/admin/organizations/:id/places/capacity', getOrganizationPlacesCapacity);
   this.get('/admin/badges/:id', getBadge);
   this.post('/admin/badges/:id/badge-criteria', createBadgeCriterion);
+
   this.post('/admin/target-profiles');
   this.get('/admin/target-profile-summaries', findPaginatedFilteredTargetProfileSummaries);
   this.get('/admin/target-profiles/:id');
@@ -171,6 +173,8 @@ export default function () {
   this.patch('/admin/target-profiles/:id', updateTargetProfile);
   this.put('/admin/target-profiles/:id/outdate', outdate);
   this.post('/admin/target-profiles/:id/badges', createBadge);
+
+  this.get('/admin/training-summaries', findPaginatedTrainingSummaries);
 
   this.post('/admin/stages', createStage);
 

--- a/admin/mirage/factories/training.js
+++ b/admin/mirage/factories/training.js
@@ -1,0 +1,8 @@
+import { Factory } from 'ember-cli-mirage';
+import faker from 'faker';
+
+export default Factory.extend({
+  title() {
+    return faker.random.word();
+  },
+});

--- a/admin/mirage/handlers/find-paginated-and-filtered-sessions.js
+++ b/admin/mirage/handlers/find-paginated-and-filtered-sessions.js
@@ -1,7 +1,7 @@
 import filter from 'lodash/filter';
-import slice from 'lodash/slice';
 
 import { Response } from 'ember-cli-mirage';
+import { getPaginationFromQueryParams, applyPagination } from './pagination-utils';
 
 export function findPaginatedAndFilteredSessions(schema, request) {
   const queryParams = request.queryParams;
@@ -9,7 +9,7 @@ export function findPaginatedAndFilteredSessions(schema, request) {
   const rowCount = sessions.length;
 
   const filters = _getFiltersFromQueryParams(queryParams);
-  const pagination = _getPaginationFromQueryParams(queryParams);
+  const pagination = getPaginationFromQueryParams(queryParams);
   if (!_areFiltersValid(filters)) {
     return new Response(
       422,
@@ -26,7 +26,7 @@ export function findPaginatedAndFilteredSessions(schema, request) {
     );
   }
   const filteredSessions = _applyFilters(sessions, filters);
-  const paginatedSessions = _applyPagination(filteredSessions, pagination);
+  const paginatedSessions = applyPagination(filteredSessions, pagination);
 
   const json = this.serialize({ modelName: 'session', models: paginatedSessions }, 'session');
   json.meta = {
@@ -67,13 +67,6 @@ function _getFiltersFromQueryParams(queryParams) {
     certificationCenterExternalIdFilter,
     statusFilter,
     resultsSentToPrescriberAtFilter,
-  };
-}
-
-function _getPaginationFromQueryParams(queryParams) {
-  return {
-    pageSize: queryParams ? parseInt(queryParams['page[size]']) : 10,
-    page: queryParams ? parseInt(queryParams['page[number]']) : 1,
   };
 }
 
@@ -133,11 +126,4 @@ function _applyFilters(
   }
 
   return filteredSessions;
-}
-
-function _applyPagination(sessions, { page, pageSize }) {
-  const start = (page - 1) * pageSize;
-  const end = start + pageSize;
-
-  return slice(sessions, start, end);
 }

--- a/admin/mirage/handlers/get-jury-certification-summaries-by-session-id.js
+++ b/admin/mirage/handlers/get-jury-certification-summaries-by-session-id.js
@@ -1,13 +1,12 @@
-import get from 'lodash/get';
-import slice from 'lodash/slice';
+import { getPaginationFromQueryParams, applyPagination } from './pagination-utils';
 
 export function getPaginatedJuryCertificationSummariesBySessionId(schema, request) {
   const queryParams = request.queryParams;
   const [{ juryCertificationSummaries }] = schema.sessions.where({ id: request.params.id }).models;
   const rowCount = juryCertificationSummaries.length;
 
-  const pagination = _getPaginationFromQueryParams(queryParams);
-  const paginatedJuryCertificationSummaries = _applyPagination(juryCertificationSummaries.models, pagination);
+  const pagination = getPaginationFromQueryParams(queryParams);
+  const paginatedJuryCertificationSummaries = applyPagination(juryCertificationSummaries.models, pagination);
 
   const json = this.serialize(
     { modelName: 'jury-certification-summary', models: paginatedJuryCertificationSummaries },
@@ -21,17 +20,4 @@ export function getPaginatedJuryCertificationSummariesBySessionId(schema, reques
     pageCount: Math.ceil(rowCount / pagination.pageSize),
   };
   return json;
-}
-
-function _getPaginationFromQueryParams(queryParams) {
-  return {
-    pageSize: parseInt(get(queryParams, 'page[size]', 10)),
-    page: parseInt(get(queryParams, 'page[number]', 1)),
-  };
-}
-
-function _applyPagination(juryCertificationSummaries, { page, pageSize }) {
-  const start = (page - 1) * pageSize;
-  const end = start + pageSize;
-  return slice(juryCertificationSummaries, start, end);
 }

--- a/admin/mirage/handlers/organizations.js
+++ b/admin/mirage/handlers/organizations.js
@@ -1,5 +1,4 @@
-import get from 'lodash/get';
-import slice from 'lodash/slice';
+import { getPaginationFromQueryParams, applyPagination } from './pagination-utils';
 
 function getOrganizationPlaces(schema) {
   return schema.organizationPlaces.all();
@@ -51,8 +50,8 @@ function findPaginatedOrganizationMemberships(schema, request) {
 
   const rowCount = organizationMemberships.length;
 
-  const pagination = _getPaginationFromQueryParams(queryParams);
-  const paginatedMemberships = _applyPagination(organizationMemberships, pagination);
+  const pagination = getPaginationFromQueryParams(queryParams);
+  const paginatedMemberships = applyPagination(organizationMemberships, pagination);
 
   const json = this.serialize(
     { modelName: 'organizationMembership', models: paginatedMemberships },
@@ -73,20 +72,6 @@ function archiveOrganization(schema, request) {
 
   const organization = schema.organizations.find(id);
   return organization.update({ archivistFullName: 'Clément Tine', archivedAt: new Date('2022-02-02') });
-}
-
-function _getPaginationFromQueryParams(queryParams) {
-  return {
-    pageSize: parseInt(get(queryParams, 'page[size]', 10)),
-    page: parseInt(get(queryParams, 'page[number]', 1)),
-  };
-}
-
-function _applyPagination(memberships, { page, pageSize }) {
-  const start = (page - 1) * pageSize;
-  const end = start + pageSize;
-
-  return slice(memberships, start, end);
 }
 
 export {

--- a/admin/mirage/handlers/pagination-utils.js
+++ b/admin/mirage/handlers/pagination-utils.js
@@ -1,0 +1,17 @@
+import slice from 'lodash/slice';
+
+const TEST_DEFAULT_PAGE_SIZE = 10;
+
+export function getPaginationFromQueryParams(queryParams) {
+  return {
+    pageSize: parseInt(queryParams['page[size]']) || TEST_DEFAULT_PAGE_SIZE,
+    page: parseInt(queryParams['page[number]']) || 1,
+  };
+}
+
+export function applyPagination(data, { page, pageSize }) {
+  const start = (page - 1) * pageSize;
+  const end = start + pageSize;
+
+  return slice(data, start, end);
+}

--- a/admin/mirage/handlers/target-profiles.js
+++ b/admin/mirage/handlers/target-profiles.js
@@ -1,6 +1,5 @@
 import { Response } from 'ember-cli-mirage';
-import _get from 'lodash/get';
-import _slice from 'lodash/slice';
+import { getPaginationFromQueryParams, applyPagination } from './pagination-utils';
 
 function attachTargetProfiles(schema, request) {
   const params = JSON.parse(request.requestBody);
@@ -37,8 +36,8 @@ function findPaginatedTargetProfileOrganizations(schema, request) {
   const organizations = schema.organizations.all().models;
   const rowCount = organizations.length;
 
-  const pagination = _getPaginationFromQueryParams(queryParams);
-  const paginatedOrganizations = _applyPagination(organizations, pagination);
+  const pagination = getPaginationFromQueryParams(queryParams);
+  const paginatedOrganizations = applyPagination(organizations, pagination);
 
   const json = this.serialize({ modelName: 'organization', models: paginatedOrganizations }, 'organization');
   json.meta = {
@@ -68,20 +67,6 @@ function findTargetProfileBadges(schema) {
 
 function findTargetProfileStages(schema) {
   return schema.stages.all();
-}
-
-function _getPaginationFromQueryParams(queryParams) {
-  return {
-    pageSize: parseInt(_get(queryParams, 'page[size]', 10)),
-    page: parseInt(_get(queryParams, 'page[number]', 1)),
-  };
-}
-
-function _applyPagination(organizations, { page, pageSize }) {
-  const start = (page - 1) * pageSize;
-  const end = start + pageSize;
-
-  return _slice(organizations, start, end);
 }
 
 function updateTargetProfile(schema, request) {

--- a/admin/mirage/handlers/trainings.js
+++ b/admin/mirage/handlers/trainings.js
@@ -1,0 +1,27 @@
+import { getPaginationFromQueryParams, applyPagination } from './pagination-utils';
+
+function findPaginatedTrainingSummaries(schema, request) {
+  const trainingSummaries = schema.trainingSummaries.all().models;
+
+  const queryParams = request.queryParams;
+
+  const rowCount = trainingSummaries.length;
+  const pagination = getPaginationFromQueryParams(queryParams);
+  const paginatedTrainingSummaries = applyPagination(trainingSummaries, pagination);
+
+  const json = this.serialize(
+    { modelName: 'training-summary', models: paginatedTrainingSummaries },
+    'training-summary'
+  );
+
+  json.meta = {
+    pagination: {
+      ...pagination,
+      rowCount,
+      pageCount: Math.ceil(rowCount / pagination.pageSize),
+    },
+  };
+  return json;
+}
+
+export { findPaginatedTrainingSummaries };

--- a/admin/mirage/serializers/training-summary.js
+++ b/admin/mirage/serializers/training-summary.js
@@ -1,0 +1,3 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({});

--- a/admin/tests/acceptance/authenticated/trainings/list_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/list_test.js
@@ -1,0 +1,51 @@
+import { module, test } from 'qunit';
+import { currentURL, click } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit } from '@1024pix/ember-testing-library';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+module('Acceptance | Trainings | List', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('When admin member is not logged in', function () {
+    test('it should not be accessible by an unauthenticated user', async function (assert) {
+      // when
+      await visit('/trainings/list');
+
+      // then
+      assert.strictEqual(currentURL(), '/login');
+    });
+  });
+
+  module('When admin member is logged in', function () {
+    module('when admin member has role "SUPER_ADMIN", "SUPPORT" or "METIER"', function (hooks) {
+      hooks.beforeEach(async () => {
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+      });
+
+      test('it should be accessible for an authenticated user', async function (assert) {
+        // when
+        await visit('/trainings/list');
+
+        // then
+        assert.strictEqual(currentURL(), '/trainings/list');
+      });
+
+      test('it should list training summaries', async function (assert) {
+        // given
+        server.createList('training-summary', 10);
+        server.create('training-summary', { id: 11, title: 'Formation 11' });
+        server.create('training-summary', { id: 12, title: 'Formation 12' });
+
+        // when
+        const screen = await visit('/trainings/list');
+        await click(screen.getByRole('link', { name: 'Aller à la page suivante' }));
+
+        // then
+        assert.dom(screen.getByText('Formation 11')).exists();
+        assert.dom(screen.getByText('Formation 12')).exists();
+      });
+    });
+  });
+});

--- a/admin/tests/integration/components/routes/authenticated/trainings/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/trainings/list-items_test.js
@@ -1,0 +1,51 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@1024pix/ember-testing-library';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | routes/authenticated/trainings | list-items', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should display header with id and title', async function (assert) {
+    // when
+    const screen = await render(hbs`<Trainings::ListSummaryItems />`);
+
+    // then
+    assert.dom(screen.getByText('ID')).exists();
+    assert.dom(screen.getByText('Titre')).exists();
+  });
+
+  test('it should display trainings summaries list', async function (assert) {
+    // given
+    const summaries = [
+      { id: 1, title: "Apprendre en s'amusant" },
+      { id: 2, title: 'Speed training' },
+    ];
+    summaries.meta = {
+      pagination: { rowCount: 2 },
+    };
+    this.summaries = summaries;
+
+    // when
+    const screen = await render(hbs`<Trainings::ListSummaryItems @summaries={{this.summaries}}  />`);
+
+    // then
+    assert.strictEqual(screen.getAllByLabelText('Contenu formatif').length, 2);
+  });
+
+  test('it should display trainings summaries data', async function (assert) {
+    // given
+    const summaries = [{ id: 123, title: 'Comment toiletter son chien' }];
+    summaries.meta = {
+      pagination: { rowCount: 2 },
+    };
+    this.summaries = summaries;
+
+    // when
+    const screen = await render(hbs`<Trainings::ListSummaryItems @summaries={{this.summaries}} />`);
+
+    // then
+    assert.dom(screen.getByLabelText('Contenu formatif')).containsText(123);
+    assert.dom(screen.getByLabelText('Contenu formatif')).containsText('Comment toiletter son chien');
+  });
+});

--- a/admin/tests/unit/routes/authenticated/trainings/list_test.js
+++ b/admin/tests/unit/routes/authenticated/trainings/list_test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/trainings/list', function (hooks) {
+  setupTest(hooks);
+  let route;
+
+  hooks.beforeEach(function () {
+    route = this.owner.lookup('route:authenticated/trainings/list');
+  });
+
+  module('#model', function (hooks) {
+    const params = {};
+    const expectedQueryArgs = {};
+
+    hooks.beforeEach(function () {
+      route.store.query = sinon.stub().resolves();
+      params.pageNumber = 'somePageNumber';
+      params.pageSize = 'somePageSize';
+      expectedQueryArgs.page = {
+        number: 'somePageNumber',
+        size: 'somePageSize',
+      };
+    });
+
+    test('it should call store.query', async function (assert) {
+      // when
+      await route.model(params);
+
+      // then
+      sinon.assert.calledWith(route.store.query, 'training-summary', expectedQueryArgs);
+      assert.ok(true);
+    });
+  });
+});

--- a/api/db/seeds/data/trainings-builder.js
+++ b/api/db/seeds/data/trainings-builder.js
@@ -71,6 +71,20 @@ function trainingBuilder({ databaseBuilder }) {
     duration: '10:00:00',
     locale: 'fr-fr',
   });
+  const training11 = databaseBuilder.factory.buildTraining({
+    title: 'Faire carrière dans la haute couture',
+    link: 'http://www.example11.net',
+    type: 'autoformation',
+    duration: '07:00:00',
+    locale: 'fr-fr',
+  });
+  const training12 = databaseBuilder.factory.buildTraining({
+    title: 'Devenir tiktokeur professionel',
+    link: 'http://www.example12.net',
+    type: 'autoformation',
+    duration: '12:00:00',
+    locale: 'fr-fr',
+  });
   databaseBuilder.factory.buildTargetProfileTraining({
     trainingId: training1.id,
     targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,
@@ -109,6 +123,14 @@ function trainingBuilder({ databaseBuilder }) {
   });
   databaseBuilder.factory.buildTargetProfileTraining({
     trainingId: training10.id,
+    targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,
+  });
+  databaseBuilder.factory.buildTargetProfileTraining({
+    trainingId: training11.id,
+    targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,
+  });
+  databaseBuilder.factory.buildTargetProfileTraining({
+    trainingId: training12.id,
     targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,
   });
 }


### PR DESCRIPTION
## :christmas_tree: Problème
Il n'existe pas encore d'endroit pour voir les contenus formatifs disponibles.

## :gift: Proposition
Ajouter une nouvelle page dans Pix Admin pour consulter les contenus formatifs.

## :star2: Remarques
RAS

## :santa: Pour tester
Accéder à `/trainings/list` dans Pix Admin (rôle SuperAdmin, Métier, Support) puis vérifier l'affichage et la pagination.
