### PR TITLE
[FEATURE] Bloquer temporairement un utilisateur entre plusieurs mot de passe incorrects (PIX-6384)

### DIFF
--- a/api/db/database-builder/factory/build-user-login.js
+++ b/api/db/database-builder/factory/build-user-login.js
@@ -1,0 +1,31 @@
+const databaseBuffer = require('../database-buffer');
+const buildUser = require('./build-user');
+
+function buildUserLogin({
+  id = databaseBuffer.getNextId(),
+  userId = null,
+  failureCount = 0,
+  temporaryBlockedUntil = null,
+  blockedAt = null,
+  createdAt = new Date(),
+  updatedAt = new Date(),
+} = {}) {
+  if (!userId) {
+    userId = buildUser().id;
+  }
+
+  const values = {
+    id,
+    userId,
+    failureCount,
+    temporaryBlockedUntil,
+    blockedAt,
+    createdAt,
+    updatedAt,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'user-logins',
+    values,
+  });
+}
+module.exports = buildUserLogin;

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -65,6 +65,7 @@ module.exports = {
   buildTraining: require('./build-training'),
   buildTutorialEvaluation: require('./build-tutorial-evaluation'),
   buildUser: require('./build-user'),
+  buildUserLogin: require('./build-user-login'),
   buildUserOrgaSettings: require('./build-user-orga-settings'),
   buildUserSavedTutorial: require('./build-user-saved-tutorial'),
   buildUserRecommendedTraining: require('./build-user-recommended-training'),

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -5,6 +5,7 @@ const { sendJsonApiError, BadRequestError } = require('../http-errors');
 const AuthenticationController = require('./authentication-controller');
 const responseAuthenticationObjectDoc = require('../../infrastructure/open-api-doc/authentication/response-authentication-doc');
 const responseErrorObjectDoc = require('../../infrastructure/open-api-doc/livret-scolaire/response-object-error-doc');
+const securityPreHandlers = require('../security-pre-handlers');
 
 exports.register = async (server) => {
   server.route([
@@ -49,6 +50,7 @@ exports.register = async (server) => {
             })
           ),
         },
+        pre: [{ method: securityPreHandlers.checkIfUserIsBlocked }],
         handler: AuthenticationController.createToken,
         tags: ['api'],
         notes: [

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -81,6 +81,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.UserHasAlreadyLeftSCO) {
     return new HttpErrors.ForbiddenError(error.message);
   }
+  if (error instanceof DomainErrors.UserIsTemporaryBlocked) {
+    return new HttpErrors.ForbiddenError(error.message, error.code);
+  }
   if (error instanceof DomainErrors.AccountRecoveryUserAlreadyConfirmEmail) {
     return new HttpErrors.ConflictError(error.message);
   }

--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -1,5 +1,6 @@
 /* eslint-disable  no-restricted-syntax */
 const bluebird = require('bluebird');
+const checkIfUserIsBlockedUseCase = require('./usecases/checkIfUserIsBlocked');
 const checkAdminMemberHasRoleSuperAdminUseCase = require('./usecases/checkAdminMemberHasRoleSuperAdmin');
 const checkAdminMemberHasRoleCertifUseCase = require('./usecases/checkAdminMemberHasRoleCertif');
 const checkAdminMemberHasRoleSupportUseCase = require('./usecases/checkAdminMemberHasRoleSupport');
@@ -33,6 +34,12 @@ function _replyForbiddenError(h) {
   });
 
   return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
+}
+
+async function checkIfUserIsBlocked(request, h) {
+  const { username } = request.payload;
+  await checkIfUserIsBlockedUseCase.execute(username);
+  return h.response(true);
 }
 
 async function checkAdminMemberHasRoleSuperAdmin(request, h) {
@@ -366,6 +373,7 @@ async function checkUserOwnsCertificationCourse(request, h) {
 /* eslint-enable no-restricted-syntax */
 
 module.exports = {
+  checkIfUserIsBlocked,
   checkRequestedUserIsAuthenticatedUser,
   checkUserBelongsToOrganizationManagingStudents,
   checkUserBelongsToScoOrganizationAndManagesStudents,

--- a/api/lib/application/usecases/checkIfUserIsBlocked.js
+++ b/api/lib/application/usecases/checkIfUserIsBlocked.js
@@ -1,0 +1,11 @@
+const { UserIsTemporaryBlocked } = require('../../domain/errors');
+const userLoginRepository = require('../../infrastructure/repositories/user-login-repository');
+
+module.exports = {
+  async execute(username) {
+    const foundUserLogin = await userLoginRepository.findByUsername(username);
+    if (foundUserLogin?.isUserTemporaryBlocked()) {
+      throw new UserIsTemporaryBlocked();
+    }
+  },
+};

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -172,6 +172,11 @@ module.exports = (function () {
       window: _getNumber(process.env.RATE_LIMIT_DEFAULT_WINDOW, 60),
     },
 
+    userLogins: {
+      thresholdFailureCount: _getNumber(process.env.THRESHOLD_FAILURE_COUNT || 10),
+      temporaryBlockedTime: _getNumber(process.env.TEMPORARY_BLOCKED_TIME_IN_MINUTES || 2),
+    },
+
     caching: {
       redisUrl: process.env.REDIS_URL,
       redisCacheKeyLockTTL: parseInt(process.env.REDIS_CACHE_KEY_LOCK_TTL, 10) || 60000,

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -938,6 +938,12 @@ class UserHasAlreadyLeftSCO extends DomainError {
   }
 }
 
+class UserIsTemporaryBlocked extends DomainError {
+  constructor(message = 'User has been temporary blocked.', code = 'USER_HAS_BEEN_TEMPORARY_BLOCKED') {
+    super(message, code);
+  }
+}
+
 class UserNotAuthorizedToAccessEntityError extends DomainError {
   constructor(message = 'User is not authorized to access ressource') {
     super(message);
@@ -1360,6 +1366,7 @@ module.exports = {
   UserCantBeCreatedError,
   UserCouldNotBeReconciledError,
   UserHasAlreadyLeftSCO,
+  UserIsTemporaryBlocked,
   UserNotAuthorizedToAccessEntityError,
   UserNotAuthorizedToCertifyError,
   UserNotAuthorizedToCreateCampaignError,

--- a/api/lib/domain/models/UserLogin.js
+++ b/api/lib/domain/models/UserLogin.js
@@ -1,5 +1,5 @@
 class UserLogin {
-  constructor({ id, userId, failureCount, temporaryBlockedUntil, blockedAt, createdAt, updatedAt } = {}) {
+  constructor({ id, userId, failureCount = 0, temporaryBlockedUntil, blockedAt, createdAt, updatedAt } = {}) {
     this.id = id;
     this.userId = userId;
     this.failureCount = failureCount;
@@ -7,6 +7,10 @@ class UserLogin {
     this.blockedAt = blockedAt;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
+  }
+
+  incrementFailureCount() {
+    this.failureCount++;
   }
 }
 

--- a/api/lib/domain/models/UserLogin.js
+++ b/api/lib/domain/models/UserLogin.js
@@ -1,3 +1,4 @@
+const dayjs = require('dayjs');
 const settings = require('../../config');
 
 class UserLogin {
@@ -23,6 +24,16 @@ class UserLogin {
   resetUserTemporaryBlocking() {
     this.failureCount = 0;
     this.temporaryBlockedUntil = null;
+  }
+
+  blockUserTemporarilyWhenFailureCountThresholdReached() {
+    const isThresholdReached = this.failureCount % settings.userLogins.thresholdFailureCount === 0;
+    if (isThresholdReached) {
+      const rest = this.failureCount / settings.userLogins.thresholdFailureCount;
+      this.temporaryBlockedUntil = dayjs()
+        .add(Math.pow(settings.userLogins.temporaryBlockedTime, rest), 'minute')
+        .toDate();
+    }
   }
 }
 

--- a/api/lib/domain/models/UserLogin.js
+++ b/api/lib/domain/models/UserLogin.js
@@ -12,6 +12,11 @@ class UserLogin {
   incrementFailureCount() {
     this.failureCount++;
   }
+
+  resetUserTemporaryBlocking() {
+    this.failureCount = 0;
+    this.temporaryBlockedUntil = null;
+  }
 }
 
 module.exports = UserLogin;

--- a/api/lib/domain/models/UserLogin.js
+++ b/api/lib/domain/models/UserLogin.js
@@ -1,0 +1,13 @@
+class UserLogin {
+  constructor({ id, userId, failureCount, temporaryBlockedUntil, blockedAt, createdAt, updatedAt } = {}) {
+    this.id = id;
+    this.userId = userId;
+    this.failureCount = failureCount;
+    this.temporaryBlockedUntil = temporaryBlockedUntil;
+    this.blockedAt = blockedAt;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+  }
+}
+
+module.exports = UserLogin;

--- a/api/lib/domain/models/UserLogin.js
+++ b/api/lib/domain/models/UserLogin.js
@@ -35,6 +35,10 @@ class UserLogin {
         .toDate();
     }
   }
+
+  hasBeenTemporaryBlocked() {
+    return this.failureCount > 0 || !!this.temporaryBlockedUntil;
+  }
 }
 
 module.exports = UserLogin;

--- a/api/lib/domain/models/UserLogin.js
+++ b/api/lib/domain/models/UserLogin.js
@@ -1,3 +1,5 @@
+const settings = require('../../config');
+
 class UserLogin {
   constructor({ id, userId, failureCount = 0, temporaryBlockedUntil, blockedAt, createdAt, updatedAt } = {}) {
     this.id = id;
@@ -11,6 +13,11 @@ class UserLogin {
 
   incrementFailureCount() {
     this.failureCount++;
+  }
+
+  isUserTemporaryBlocked() {
+    const now = new Date();
+    return !!this.temporaryBlockedUntil && this.temporaryBlockedUntil > now;
   }
 
   resetUserTemporaryBlocking() {

--- a/api/lib/domain/services/authentication/pix-authentication-service.js
+++ b/api/lib/domain/services/authentication/pix-authentication-service.js
@@ -1,13 +1,28 @@
+const { PasswordNotMatching } = require('../../errors');
 const encryptionService = require('../encryption-service');
+const userLoginRepository = require('../../../infrastructure/repositories/user-login-repository');
 
 async function getUserByUsernameAndPassword({ username, password, userRepository }) {
   const foundUser = await userRepository.getByUsernameOrEmailWithRolesAndPassword(username);
   const passwordHash = foundUser.authenticationMethods[0].authenticationComplement.password;
 
-  await encryptionService.checkPassword({
-    password,
-    passwordHash,
-  });
+  try {
+    await encryptionService.checkPassword({
+      password,
+      passwordHash,
+    });
+  } catch (error) {
+    if (error instanceof PasswordNotMatching) {
+      let userLogin = await userLoginRepository.findByUserId(foundUser.id);
+      if (!userLogin) {
+        userLogin = await userLoginRepository.create({ userId: foundUser.id });
+      }
+      userLogin.incrementFailureCount();
+      await userLoginRepository.update(userLogin);
+    }
+
+    throw error;
+  }
 
   return foundUser;
 }

--- a/api/lib/domain/services/authentication/pix-authentication-service.js
+++ b/api/lib/domain/services/authentication/pix-authentication-service.js
@@ -19,6 +19,7 @@ async function getUserByUsernameAndPassword({ username, password, userRepository
   } catch (error) {
     if (error instanceof PasswordNotMatching) {
       userLogin.incrementFailureCount();
+      userLogin.blockUserTemporarilyWhenFailureCountThresholdReached();
       await userLoginRepository.update(userLogin);
     }
 

--- a/api/lib/domain/services/authentication/pix-authentication-service.js
+++ b/api/lib/domain/services/authentication/pix-authentication-service.js
@@ -26,7 +26,7 @@ async function getUserByUsernameAndPassword({ username, password, userRepository
     throw error;
   }
 
-  if (userLogin.isUserTemporaryBlocked()) {
+  if (userLogin.hasBeenTemporaryBlocked()) {
     userLogin.resetUserTemporaryBlocking();
     await userLoginRepository.update(userLogin);
   }

--- a/api/lib/domain/services/encryption-service.js
+++ b/api/lib/domain/services/encryption-service.js
@@ -1,6 +1,6 @@
 const bcrypt = require('bcrypt');
 const { bcryptNumberOfSaltRounds } = require('../../config');
-const UserNotFoundError = require('../errors').UserNotFoundError;
+const PasswordNotMatching = require('../errors').PasswordNotMatching;
 
 module.exports = {
   hashPassword: (password) => bcrypt.hash(password, bcryptNumberOfSaltRounds),
@@ -11,7 +11,7 @@ module.exports = {
   checkPassword: async ({ password, passwordHash }) => {
     const matching = await bcrypt.compare(password, passwordHash);
     if (!matching) {
-      throw new UserNotFoundError();
+      throw new PasswordNotMatching();
     }
   },
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -155,6 +155,7 @@ const dependencies = {
   tutorialEvaluationRepository: require('../../infrastructure/repositories/tutorial-evaluation-repository'),
   tutorialRepository: require('../../infrastructure/repositories/tutorial-repository'),
   userEmailRepository: require('../../infrastructure/repositories/user-email-repository'),
+  userLoginRepository: require('../../infrastructure/repositories/user-login-repository'),
   userOrgaSettingsRepository: require('../../infrastructure/repositories/user-orga-settings-repository'),
   userRecommendedTrainingRepository: require('../../infrastructure/repositories/user-recommended-training-repository'),
   userReconciliationService: require('../services/user-reconciliation-service'),

--- a/api/lib/infrastructure/repositories/user-login-repository.js
+++ b/api/lib/infrastructure/repositories/user-login-repository.js
@@ -1,9 +1,26 @@
 const { knex } = require('../../../db/knex-database-connection');
 const UserLogin = require('../../domain/models/UserLogin');
 
+function _toDomain(userLoginDTO) {
+  return new UserLogin({
+    id: userLoginDTO.id,
+    userId: userLoginDTO.userId,
+    failureCount: userLoginDTO.failureCount,
+    temporaryBlockedUntil: userLoginDTO.temporaryBlockedUntil,
+    blockedAt: userLoginDTO.blockedAt,
+    createdAt: userLoginDTO.createdAt,
+    updatedAt: userLoginDTO.updatedAt,
+  });
+}
+
 module.exports = {
   async findByUserId(userId) {
     const foundUserLogin = await knex.from('user-logins').where({ userId }).first();
-    return foundUserLogin ? new UserLogin(foundUserLogin) : null;
+    return foundUserLogin ? _toDomain(foundUserLogin) : null;
+  },
+
+  async create(userLogin) {
+    const [userLoginDTO] = await knex('user-logins').insert(userLogin).returning('*');
+    return _toDomain(userLoginDTO);
   },
 };

--- a/api/lib/infrastructure/repositories/user-login-repository.js
+++ b/api/lib/infrastructure/repositories/user-login-repository.js
@@ -1,0 +1,9 @@
+const { knex } = require('../../../db/knex-database-connection');
+const UserLogin = require('../../domain/models/UserLogin');
+
+module.exports = {
+  async findByUserId(userId) {
+    const foundUserLogin = await knex.from('user-logins').where({ userId }).first();
+    return foundUserLogin ? new UserLogin(foundUserLogin) : null;
+  },
+};

--- a/api/lib/infrastructure/repositories/user-login-repository.js
+++ b/api/lib/infrastructure/repositories/user-login-repository.js
@@ -29,4 +29,16 @@ module.exports = {
     const [userLoginDTO] = await knex('user-logins').where({ id: userLogin.id }).update(userLogin).returning('*');
     return _toDomain(userLoginDTO);
   },
+
+  async findByUsername(username) {
+    const foundUserLogin = await knex
+      .select('user-logins.*')
+      .from('user-logins')
+      .where('users.email', username.toLowerCase())
+      .orWhere('users.username', username.toLowerCase())
+      .join('users', 'users.id', 'user-logins.userId')
+      .first();
+
+    return foundUserLogin ? _toDomain(foundUserLogin) : null;
+  },
 };

--- a/api/lib/infrastructure/repositories/user-login-repository.js
+++ b/api/lib/infrastructure/repositories/user-login-repository.js
@@ -23,4 +23,10 @@ module.exports = {
     const [userLoginDTO] = await knex('user-logins').insert(userLogin).returning('*');
     return _toDomain(userLoginDTO);
   },
+
+  async update(userLogin) {
+    userLogin.updatedAt = new Date();
+    const [userLoginDTO] = await knex('user-logins').where({ id: userLogin.id }).update(userLogin).returning('*');
+    return _toDomain(userLoginDTO);
+  },
 };

--- a/api/sample.env
+++ b/api/sample.env
@@ -736,6 +736,18 @@ RATE_LIMIT_DEFAULT_LIMIT=10
 # default: 60
 RATE_LIMIT_DEFAULT_WINDOW=60
 
+# Default number of failure before the user is temporary blocked
+# presence: optional
+# type: number
+# default: 10
+# THRESHOLD_FAILURE_COUNT=10
+
+# Default number of minutes the user need to wait before being unblocked
+# presence: optional
+# type: number
+# default: 2
+# TEMPORARY_BLOCKED_TIME_IN_MINUTES=2
+
 # ===================
 # FEATURE TOGGLES
 # ===================

--- a/api/tests/acceptance/application/authentication-route_test.js
+++ b/api/tests/acceptance/application/authentication-route_test.js
@@ -8,6 +8,10 @@ const { ROLES } = require('../../../lib/domain/constants').PIX_ADMIN;
 const createServer = require('../../../server');
 
 describe('Acceptance | Controller | authentication-controller', function () {
+  afterEach(async function () {
+    await knex('user-logins').delete();
+  });
+
   describe('POST /api/token', function () {
     const orgaRoleInDB = { id: 1, name: 'ADMIN' };
 

--- a/api/tests/acceptance/application/authentication/oidc/check-reconciliation-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/check-reconciliation-route-post_test.js
@@ -1,4 +1,4 @@
-const { expect, databaseBuilder } = require('../../../../test-helper');
+const { expect, databaseBuilder, knex } = require('../../../../test-helper');
 const createServer = require('../../../../../server');
 const jsonwebtoken = require('jsonwebtoken');
 const authenticationSessionService = require('../../../../../lib/domain/services/authentication/authentication-session-service');
@@ -6,6 +6,10 @@ const authenticationSessionService = require('../../../../../lib/domain/services
 describe('Acceptance | Application | Oidc | Routes', function () {
   describe('POST /api/oidc/user/check-reconciliation', function () {
     context('when user has no oidc authentication method', function () {
+      afterEach(async function () {
+        await knex('user-logins').delete();
+      });
+
       it('should return 200 HTTP status', async function () {
         // given
         const server = await createServer();

--- a/api/tests/acceptance/application/users/users-controller-update-password_test.js
+++ b/api/tests/acceptance/application/users/users-controller-update-password_test.js
@@ -24,6 +24,7 @@ describe('Acceptance | Controller | users-controller-update-password', function 
   afterEach(async function () {
     await knex('authentication-methods').delete();
     await knex('reset-password-demands').delete();
+    await knex('user-logins').delete();
   });
 
   describe('Error case', function () {

--- a/api/tests/integration/infrastructure/repositories/user-login-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-login-repository_test.js
@@ -1,4 +1,4 @@
-const { databaseBuilder, expect } = require('../../../test-helper');
+const { databaseBuilder, expect, knex } = require('../../../test-helper');
 const userLoginRepository = require('../../../../lib/infrastructure/repositories/user-login-repository');
 const UserLogin = require('../../../../lib/domain/models/UserLogin');
 
@@ -28,6 +28,29 @@ describe('Integration | Repository | UserLoginRepository', function () {
 
       // then
       expect(result).to.be.null;
+    });
+  });
+
+  describe('#create', function () {
+    afterEach(async function () {
+      await knex('user-logins').delete();
+    });
+
+    it('should return the created user-login', async function () {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const userLogin = new UserLogin({ userId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await userLoginRepository.create(userLogin);
+
+      // then
+      expect(result).to.be.an.instanceOf(UserLogin);
+      expect(result.userId).to.equal(userId);
+      expect(result.createdAt).to.be.not.null;
+      expect(result.updatedAt).to.be.not.null;
+      expect(result.failureCount).to.equal(0);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/user-login-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-login-repository_test.js
@@ -1,0 +1,33 @@
+const { databaseBuilder, expect } = require('../../../test-helper');
+const userLoginRepository = require('../../../../lib/infrastructure/repositories/user-login-repository');
+const UserLogin = require('../../../../lib/domain/models/UserLogin');
+
+describe('Integration | Repository | UserLoginRepository', function () {
+  describe('#findByUserId', function () {
+    it('should return the found user-login', async function () {
+      // given
+      const userLogin = databaseBuilder.factory.buildUserLogin({
+        id: 1,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await userLoginRepository.findByUserId(userLogin.userId);
+
+      // then
+      expect(result).to.be.an.instanceOf(UserLogin);
+      expect(result.id).to.equal(1);
+    });
+
+    it('should return null if no user is found', async function () {
+      // given
+      const nonExistentUserId = 678;
+
+      // when
+      const result = await userLoginRepository.findByUserId(nonExistentUserId);
+
+      // then
+      expect(result).to.be.null;
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/user-login-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-login-repository_test.js
@@ -96,4 +96,47 @@ describe('Integration | Repository | UserLoginRepository', function () {
       });
     });
   });
+
+  describe('#findByUsername', function () {
+    it('should return the found user-login by email', async function () {
+      // given
+      databaseBuilder.factory.buildUser({ email: 'otherUser@example.net' });
+      const userId = databaseBuilder.factory.buildUser({ email: 'pouet@example.net' }).id;
+      const userLogin = databaseBuilder.factory.buildUserLogin({ userId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await userLoginRepository.findByUsername('POUET@example.net');
+
+      // thens
+      expect(result).to.be.an.instanceOf(UserLogin);
+      expect(result.id).to.equal(userLogin.id);
+    });
+
+    it('should return the found user-login by username', async function () {
+      // given
+      databaseBuilder.factory.buildUser({ username: 'edward123' });
+      const userId = databaseBuilder.factory.buildUser({ username: 'winry123' }).id;
+      const userLogin = databaseBuilder.factory.buildUserLogin({ userId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await userLoginRepository.findByUsername('WINry123');
+
+      // thens
+      expect(result).to.be.an.instanceOf(UserLogin);
+      expect(result.id).to.equal(userLogin.id);
+    });
+
+    it('should return null if no user is found', async function () {
+      // given
+      const nonExistentUsername = 'nonExisting@example.net';
+
+      // when
+      const result = await userLoginRepository.findByUsername(nonExistentUsername);
+
+      // then
+      expect(result).to.be.null;
+    });
+  });
 });

--- a/api/tests/unit/domain/models/UserLogin_test.js
+++ b/api/tests/unit/domain/models/UserLogin_test.js
@@ -1,0 +1,17 @@
+const UserLogin = require('../../../../lib/domain/models/UserLogin');
+const { expect } = require('../../../test-helper');
+
+describe('Unit | Domain | Models | UserLogin', function () {
+  describe('#incrementFailureCount', function () {
+    it('should increment failure count', function () {
+      // given
+      const userLogin = new UserLogin({ userId: 666 });
+
+      // when
+      userLogin.incrementFailureCount();
+
+      // then
+      expect(userLogin.failureCount).to.equal(1);
+    });
+  });
+});

--- a/api/tests/unit/domain/models/UserLogin_test.js
+++ b/api/tests/unit/domain/models/UserLogin_test.js
@@ -1,5 +1,6 @@
-const UserLogin = require('../../../../lib/domain/models/UserLogin');
 const { expect } = require('../../../test-helper');
+const UserLogin = require('../../../../lib/domain/models/UserLogin');
+const settings = require('../../../../lib/config');
 
 describe('Unit | Domain | Models | UserLogin', function () {
   describe('#incrementFailureCount', function () {
@@ -30,6 +31,58 @@ describe('Unit | Domain | Models | UserLogin', function () {
       // then
       expect(userLogin.failureCount).to.equal(0);
       expect(userLogin.temporaryBlockedUntil).to.be.null;
+    });
+  });
+
+  describe('#isUserTemporaryBlocked', function () {
+    describe('when temporaryBlockedUntil is in the past', function () {
+      it('should return false', function () {
+        // given
+        const oneHourInThePast = new Date(Date.now() - 3600 * 1000);
+        const userLogin = new UserLogin({
+          userId: 666,
+          temporaryBlockedUntil: oneHourInThePast,
+        });
+
+        // when
+        const result = userLogin.isUserTemporaryBlocked();
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+
+    describe('when temporaryBlockedUntil is in the future', function () {
+      it('should return true', function () {
+        // given
+        const oneHourInTheFuture = new Date(Date.now() + 3600 * 1000);
+        const userLogin = new UserLogin({
+          userId: 666,
+          temporaryBlockedUntil: oneHourInTheFuture,
+        });
+
+        // when
+        const result = userLogin.isUserTemporaryBlocked();
+
+        // then
+        expect(result).to.be.true;
+      });
+    });
+
+    describe('when temporaryBlockedUntil is not set', function () {
+      it('should return false', function () {
+        // given
+        const userLogin = new UserLogin({
+          userId: 666,
+          temporaryBlockedUntil: null,
+        });
+
+        // when
+        const result = userLogin.isUserTemporaryBlocked();
+
+        // then
+        expect(result).to.be.false;
+      });
     });
   });
 });

--- a/api/tests/unit/domain/models/UserLogin_test.js
+++ b/api/tests/unit/domain/models/UserLogin_test.js
@@ -4,7 +4,7 @@ const settings = require('../../../../lib/config');
 
 describe('Unit | Domain | Models | UserLogin', function () {
   let clock;
-  const now = new Date();
+  const now = new Date('2022-11-28T12:00:00Z');
 
   let originalEnvThresholdFailureCount;
   let originalEnvTemporaryBlockedTime;
@@ -157,6 +157,47 @@ describe('Unit | Domain | Models | UserLogin', function () {
 
         // then
         expect(userLogin.temporaryBlockedUntil).to.be.undefined;
+      });
+    });
+  });
+
+  describe('#hasBeenTemporaryBlocked', function () {
+    context('when user has failure count greater than 0', function () {
+      it('should return true', function () {
+        // given
+        const userLogin = new UserLogin({ failureCount: 1 });
+
+        // when
+        const result = userLogin.hasBeenTemporaryBlocked();
+
+        // then
+        expect(result).to.be.true;
+      });
+    });
+
+    context('when user has a temporary blocked until date', function () {
+      it('should return true', function () {
+        // given
+        const userLogin = new UserLogin({ temporaryBlockedUntil: new Date('2022-11-28T15:00:00Z') });
+
+        // when
+        const result = userLogin.hasBeenTemporaryBlocked();
+
+        // then
+        expect(result).to.be.true;
+      });
+    });
+
+    context('when user has no failure count nor temporary blocked until date', function () {
+      it('should return false', function () {
+        // given
+        const userLogin = new UserLogin({});
+
+        // when
+        const result = userLogin.hasBeenTemporaryBlocked();
+
+        // then
+        expect(result).to.be.false;
       });
     });
   });

--- a/api/tests/unit/domain/models/UserLogin_test.js
+++ b/api/tests/unit/domain/models/UserLogin_test.js
@@ -14,4 +14,22 @@ describe('Unit | Domain | Models | UserLogin', function () {
       expect(userLogin.failureCount).to.equal(1);
     });
   });
+
+  describe('#resetUserTemporaryBlocking', function () {
+    it('should reset failure count and reset temporary blocked until', function () {
+      // given
+      const userLogin = new UserLogin({
+        userId: 666,
+        failureCount: 45,
+        temporaryBlockedUntil: new Date('2022-11-25'),
+      });
+
+      // when
+      userLogin.resetUserTemporaryBlocking();
+
+      // then
+      expect(userLogin.failureCount).to.equal(0);
+      expect(userLogin.temporaryBlockedUntil).to.be.null;
+    });
+  });
 });

--- a/api/tests/unit/domain/services/authentication/pix-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/pix-authentication-service_test.js
@@ -28,7 +28,7 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
       sinon.stub(encryptionService, 'checkPassword');
     });
 
-    context('When user exist', function () {
+    context('When user credentials are valid', function () {
       beforeEach(function () {
         userRepository.getByUsernameOrEmailWithRolesAndPassword.resolves(user);
         encryptionService.checkPassword.resolves();

--- a/api/tests/unit/domain/services/authentication/pix-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/pix-authentication-service_test.js
@@ -4,6 +4,7 @@ const { PasswordNotMatching, UserNotFoundError } = require('../../../../../lib/d
 const User = require('../../../../../lib/domain/models/User');
 const encryptionService = require('../../../../../lib/domain/services/encryption-service');
 const pixAuthenticationService = require('../../../../../lib/domain/services/authentication/pix-authentication-service');
+const userLoginRepository = require('../../../../../lib/infrastructure/repositories/user-login-repository');
 
 describe('Unit | Domain | Services | pix-authentication-service', function () {
   describe('#getUserByUsernameAndPassword', function () {
@@ -25,6 +26,10 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
       userRepository = {
         getByUsernameOrEmailWithRolesAndPassword: sinon.stub(),
       };
+      sinon.stub(userLoginRepository, 'findByUserId');
+      sinon.stub(userLoginRepository, 'create');
+      sinon.stub(userLoginRepository, 'update');
+
       sinon.stub(encryptionService, 'checkPassword');
     });
 
@@ -94,20 +99,55 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
         expect(error).to.be.an.instanceof(UserNotFoundError);
       });
 
-      it('should throw PasswordNotMatching when password does not match', async function () {
-        // given
-        userRepository.getByUsernameOrEmailWithRolesAndPassword.resolves(user);
-        encryptionService.checkPassword.rejects(new PasswordNotMatching());
+      context('When username exists and password does not match', function () {
+        context('When user failed to login for the first time', function () {
+          it('should throw passwordNotMatching error and create an user logins', async function () {
+            // given
+            userRepository.getByUsernameOrEmailWithRolesAndPassword.resolves(user);
+            encryptionService.checkPassword.rejects(new PasswordNotMatching());
+            const incrementFailureCountStub = sinon.stub();
+            const userLoginCreated = { incrementFailureCount: incrementFailureCountStub };
+            userLoginRepository.findByUserId.withArgs(user.id).resolves(null);
+            userLoginRepository.create.resolves(userLoginCreated);
 
-        // when
-        const error = await catchErr(pixAuthenticationService.getUserByUsernameAndPassword)({
-          username,
-          password,
-          userRepository,
+            // when
+            const error = await catchErr(pixAuthenticationService.getUserByUsernameAndPassword)({
+              username,
+              password,
+              userRepository,
+            });
+
+            // then
+            expect(userLoginRepository.create).to.have.been.calledWith({ userId: user.id });
+            expect(incrementFailureCountStub).to.have.been.calledOnce;
+            expect(userLoginRepository.update).to.have.been.calledWith(userLoginCreated);
+            expect(error).to.be.an.instanceof(PasswordNotMatching);
+          });
         });
 
-        // then
-        expect(error).to.be.an.instanceof(PasswordNotMatching);
+        context('When user failed to login multiple times', function () {
+          it('should throw passwordNotMatching error and update the user logins', async function () {
+            // given
+            userRepository.getByUsernameOrEmailWithRolesAndPassword.resolves(user);
+            encryptionService.checkPassword.rejects(new PasswordNotMatching());
+            const incrementFailureCountStub = sinon.stub();
+            const userLogin = { incrementFailureCount: incrementFailureCountStub };
+            userLoginRepository.findByUserId.withArgs(user.id).resolves(userLogin);
+
+            // when
+            const error = await catchErr(pixAuthenticationService.getUserByUsernameAndPassword)({
+              username,
+              password,
+              userRepository,
+            });
+
+            // then
+            expect(userLoginRepository.create).to.not.have.been.called;
+            expect(incrementFailureCountStub).to.have.been.calledOnce;
+            expect(userLoginRepository.update).to.have.been.calledWith(userLogin);
+            expect(error).to.be.an.instanceof(PasswordNotMatching);
+          });
+        });
       });
     });
   });

--- a/api/tests/unit/domain/services/authentication/pix-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/pix-authentication-service_test.js
@@ -89,7 +89,7 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
       context('when user is not temporary blocked', function () {
         it('should not reset password failure count', async function () {
           // given
-          const userLogin = { isUserTemporaryBlocked: sinon.stub().returns(false) };
+          const userLogin = { hasBeenTemporaryBlocked: sinon.stub().returns(false) };
           userLoginRepository.findByUserId.withArgs(user.id).resolves(userLogin);
 
           // when
@@ -110,7 +110,7 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
           const user = domainBuilder.buildUser({ username });
           const resetUserTemporaryBlockingStub = sinon.stub();
           const userLogin = {
-            isUserTemporaryBlocked: sinon.stub().returns(true),
+            hasBeenTemporaryBlocked: sinon.stub().returns(true),
             resetUserTemporaryBlocking: resetUserTemporaryBlockingStub,
           };
           userLoginRepository.findByUserId.withArgs(user.id).resolves(userLogin);

--- a/api/tests/unit/domain/services/authentication/pix-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/pix-authentication-service_test.js
@@ -152,7 +152,10 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
             userRepository.getByUsernameOrEmailWithRolesAndPassword.resolves(user);
             encryptionService.checkPassword.rejects(new PasswordNotMatching());
             const incrementFailureCountStub = sinon.stub();
-            const userLoginCreated = { incrementFailureCount: incrementFailureCountStub };
+            const userLoginCreated = {
+              incrementFailureCount: incrementFailureCountStub,
+              blockUserTemporarilyWhenFailureCountThresholdReached: sinon.stub(),
+            };
             userLoginRepository.findByUserId.withArgs(user.id).resolves(null);
             userLoginRepository.create.resolves(userLoginCreated);
 
@@ -177,7 +180,12 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
             userRepository.getByUsernameOrEmailWithRolesAndPassword.resolves(user);
             encryptionService.checkPassword.rejects(new PasswordNotMatching());
             const incrementFailureCountStub = sinon.stub();
-            const userLogin = { incrementFailureCount: incrementFailureCountStub };
+            const blockUserTemporarilyWhenFailureCountThresholdReachedStub = sinon.stub();
+            const userLogin = {
+              incrementFailureCount: incrementFailureCountStub,
+              blockUserTemporarilyWhenFailureCountThresholdReached:
+                blockUserTemporarilyWhenFailureCountThresholdReachedStub,
+            };
             userLoginRepository.findByUserId.withArgs(user.id).resolves(userLogin);
 
             // when
@@ -190,6 +198,7 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
             // then
             expect(userLoginRepository.create).to.not.have.been.called;
             expect(incrementFailureCountStub).to.have.been.calledOnce;
+            expect(blockUserTemporarilyWhenFailureCountThresholdReachedStub).to.have.been.calledOnce;
             expect(userLoginRepository.update).to.have.been.calledWith(userLogin);
             expect(error).to.be.an.instanceof(PasswordNotMatching);
           });

--- a/api/tests/unit/domain/services/encryption-service_test.js
+++ b/api/tests/unit/domain/services/encryption-service_test.js
@@ -2,7 +2,7 @@ const { catchErr, expect } = require('../../../test-helper');
 
 const bcrypt = require('bcrypt');
 const encryptionService = require('../../../../lib/domain/services/encryption-service');
-const UserNotFoundError = require('../../../../lib/domain/errors').UserNotFoundError;
+const PasswordNotMatching = require('../../../../lib/domain/errors').PasswordNotMatching;
 
 describe('Unit | Service | Encryption', function () {
   describe('#checkPassword', function () {
@@ -25,7 +25,7 @@ describe('Unit | Service | Encryption', function () {
     });
 
     describe('when password and hash are not matching', function () {
-      it('should reject a UserNotFoundError error ', async function () {
+      it('should reject a PasswordNotMatching error ', async function () {
         // given
         const password = 'my-expected-password';
         const passwordHash = 'ABCDEF1234';
@@ -37,12 +37,12 @@ describe('Unit | Service | Encryption', function () {
         });
 
         // then
-        expect(error).to.be.an.instanceof(UserNotFoundError);
+        expect(error).to.be.an.instanceof(PasswordNotMatching);
       });
     });
 
     describe('when password is not supplied', function () {
-      it('should reject, but not a UserNotFoundError error ', async function () {
+      it('should reject, but not a PasswordNotMatching error ', async function () {
         // given
         const password = undefined;
         // eslint-disable-next-line no-sync
@@ -54,7 +54,7 @@ describe('Unit | Service | Encryption', function () {
             passwordHash,
           });
         } catch (error) {
-          expect(error).not.to.be.an.instanceof(UserNotFoundError);
+          expect(error).not.to.be.an.instanceof(PasswordNotMatching);
         }
       });
     });


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement le ratelimiter (qui bloque un utilisateur qui se trompe plusieurs fois de mot de passe) ne bloque que 20min. 
Nous voudrions un système de bloquage plus adaptatif (bloquer temporairement de manière courte puis de plus en plus selon les échecs jusqu'à un blocage complet), qui serait plus aligné avec les recommandations de la CNIL.

## :gift: Proposition
- incrémenter le nombre de tentatives à chaque entrée d’un mauvais mot de passe
- réinitialiser le nombre de tentatives si le bon mot de passe est entré
- ajouter le temporaryBlockedUntil au bout de X tentatives 
  - Utiliser une variable d’env pour le nombre de tentatives
  - Utiliser une variable d’env pour le temps de blocage
- faire en sorte que le temporaryBlockedUntil ne permette plus de se connecter / faire des tentatives (prehandler)

## :star2: Remarques
Les valeurs les plus basse de blocage temporaire sont mise en variable d'environnement : 
`TRESHOLD_FAILURE_COUNT` : nombre de tentatives minimal pour être bloqué temporairement
`TEMPORARY_BLOCKED_TIME_IN_MINUTES` : temps d'attente minimum pour être débloqué / pouvoir faire de nouvelles tentatives de connexion

Ces valeurs pourront servir à changer les blocages de compte temporaires sans faire de nouvelle mises en production. Ces valeurs sont incrémentales pour un nombre d'échec plus grand.

## :santa: Pour tester

**Premier échec**
- Lancer Pix App
- Mettre un bon login
- Remplir un mauvais mot de passe 1 fois
- Constatez que vous avez une ligne dans la BDD "user-logins" qui s'est rajoutée

**Nombreux échecs**
- Réinitialiser en BDD la valeur de `temporaryBlockedUntil`
- Remplir 10 fois de plus un mauvais de passe
- Constater qu'au 11ème essaie que vous ne pouvez pas vous connectez et que le message d'erreur renvoyé par l'API contient le code "USER_HAS_BEEN_TEMPORARY_BLOCKED" + 403

| nombre de tentatives | temps d'attente |
|----------------------|-----------------|
|          10            |       2min          |  
|          20            |        4min         |
|           30           |        8min         | 
|           40           |        16min         | 