### PR TITLE
[FEATURE] Creer un script pour retrouver les certifications CPF non envoyés (PIX-6257)

### DIFF
--- a/api/db/database-builder/factory/build-certification-course.js
+++ b/api/db/database-builder/factory/build-certification-course.js
@@ -27,6 +27,7 @@ module.exports = function buildCertificationCourse({
   isCancelled = false,
   abortReason = null,
   cpfFilename = null,
+  cpfImportStatus = null,
   pixCertificationStatus = null,
 } = {}) {
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -55,6 +56,7 @@ module.exports = function buildCertificationCourse({
     isCancelled,
     abortReason,
     cpfFilename,
+    cpfImportStatus,
     pixCertificationStatus,
   };
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20221121154233_cpf-import-status-migration.js
+++ b/api/db/migrations/20221121154233_cpf-import-status-migration.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'certification-courses';
+const COLUMN_NAME = 'cpfImportStatus';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).defaultTo(null);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -3,6 +3,12 @@ const Joi = require('joi').extend(require('@joi/date'));
 const { EntityValidationError } = require('../errors');
 
 const ABORT_REASONS = ['candidate', 'technical'];
+const cpfImportStatus = {
+  ERROR: 'ERROR',
+  READY_TO_SEND: 'READY_TO_SEND',
+  PENDING: 'PENDING',
+  SUCCESS: 'SUCCESS',
+};
 
 class CertificationCourse {
   constructor({
@@ -249,5 +255,7 @@ function _sanitizedString(string) {
 
   return withUnifiedWithSpaces;
 }
+
+CertificationCourse.cpfImportStatus = cpfImportStatus;
 
 module.exports = CertificationCourse;

--- a/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
@@ -3,6 +3,7 @@ const logger = require('../../../logger');
 const dayjs = require('dayjs');
 const utc = require('dayjs/plugin/utc');
 const timezone = require('dayjs/plugin/timezone');
+const { cpfImportStatus } = require('../../../../domain/models/CertificationCourse');
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
@@ -40,7 +41,7 @@ module.exports = async function createAndUpload({
   await cpfCertificationResultRepository.markCertificationCoursesAsExported({
     certificationCourseIds,
     filename,
-    cpfImportStatus: 'UPLOADED',
+    cpfImportStatus: cpfImportStatus.READY_TO_SEND,
   });
 
   logger.info(`${filename} generated in ${_getTimeInSec(start)}s.`);

--- a/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
@@ -37,7 +37,12 @@ module.exports = async function createAndUpload({
     readableStream: gzipStream,
   });
 
-  await cpfCertificationResultRepository.markCertificationCoursesAsExported({ certificationCourseIds, filename });
+  await cpfCertificationResultRepository.markCertificationCoursesAsExported({
+    certificationCourseIds,
+    filename,
+    cpfImportStatus: 'UPLOADED',
+  });
+
   logger.info(`${filename} generated in ${_getTimeInSec(start)}s.`);
 };
 

--- a/api/lib/infrastructure/jobs/cpf-export/handlers/planner.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/planner.js
@@ -1,6 +1,7 @@
 const dayjs = require('dayjs');
 const { plannerJob } = require('../../../../config').cpf;
 const logger = require('../../../logger');
+const { cpfImportStatus } = require('../../../../domain/models/CertificationCourse');
 const _ = require('lodash');
 
 module.exports = async function planner({ pgBoss, cpfCertificationResultRepository, jobId }) {
@@ -21,7 +22,7 @@ module.exports = async function planner({ pgBoss, cpfCertificationResultReposito
     await cpfCertificationResultRepository.markCertificationToExport({
       certificationCourseIds,
       batchId,
-      cpfImportStatus: 'PENDING',
+      cpfImportStatus: cpfImportStatus.PENDING,
     });
 
     pgBoss.send('CpfExportBuilderJob', {

--- a/api/lib/infrastructure/jobs/cpf-export/handlers/planner.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/planner.js
@@ -21,7 +21,9 @@ module.exports = async function planner({ pgBoss, cpfCertificationResultReposito
     await cpfCertificationResultRepository.markCertificationToExport({
       certificationCourseIds,
       batchId,
+      cpfImportStatus: 'PENDING',
     });
+
     pgBoss.send('CpfExportBuilderJob', {
       jobId: batchId,
     });

--- a/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
@@ -40,6 +40,14 @@ module.exports = {
   async markCertificationToExport({ certificationCourseIds, batchId }) {
     return knex('certification-courses').update({ cpfFilename: batchId }).whereIn('id', certificationCourseIds);
   },
+
+  async updateCertificationImportStatus({ certificationCourseIds, cpfImportStatus }) {
+    const now = new Date();
+
+    return knex('certification-courses')
+      .update({ cpfImportStatus, updatedAt: now })
+      .whereIn('id', certificationCourseIds);
+  },
 };
 
 function _selectCpfCertificationResults() {

--- a/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
@@ -37,8 +37,12 @@ module.exports = {
     return knex('certification-courses').update({ cpfFilename: filename }).whereIn('id', certificationCourseIds);
   },
 
-  async markCertificationToExport({ certificationCourseIds, batchId }) {
-    return knex('certification-courses').update({ cpfFilename: batchId }).whereIn('id', certificationCourseIds);
+  async markCertificationToExport({ certificationCourseIds, batchId, cpfImportStatus }) {
+    const now = new Date();
+
+    return knex('certification-courses')
+      .update({ cpfFilename: batchId, cpfImportStatus, updatedAt: now })
+      .whereIn('id', certificationCourseIds);
   },
 
   async updateCertificationImportStatus({ certificationCourseIds, cpfImportStatus }) {

--- a/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
@@ -33,8 +33,12 @@ module.exports = {
     return cpfCertificationResults.map((certificationCourse) => new CpfCertificationResult(certificationCourse));
   },
 
-  async markCertificationCoursesAsExported({ certificationCourseIds, filename }) {
-    return knex('certification-courses').update({ cpfFilename: filename }).whereIn('id', certificationCourseIds);
+  async markCertificationCoursesAsExported({ certificationCourseIds, filename, cpfImportStatus }) {
+    const now = new Date();
+
+    return knex('certification-courses')
+      .update({ cpfFilename: filename, cpfImportStatus, updatedAt: now })
+      .whereIn('id', certificationCourseIds);
   },
 
   async markCertificationToExport({ certificationCourseIds, batchId, cpfImportStatus }) {

--- a/api/scripts/certification/get-cpf-import-status-from-xml.js
+++ b/api/scripts/certification/get-cpf-import-status-from-xml.js
@@ -1,0 +1,96 @@
+const fs = require('fs');
+const sax = require('sax');
+const saxPath = require('saxpath');
+const logger = require('../../lib/infrastructure/logger');
+
+const xml2js = require('xml2js');
+
+const { disconnect } = require('../../db/knex-database-connection');
+const cpfCertificationResultRepository = require('../../lib/infrastructure/repositories/cpf-certification-result-repository');
+const { cpfImportStatus } = require('../../lib/domain/models/CertificationCourse');
+
+const isLaunchedFromCommandLine = require.main === module;
+
+async function main(path) {
+  logger.info("Récupération des résultats d'import CPF...");
+  const filePath = path || process.argv[2];
+
+  const { cpfImportErrorIds, cpfImportSuccessIds } = await getCpfImportResults(filePath);
+
+  if (cpfImportErrorIds.length) {
+    await cpfCertificationResultRepository.updateCertificationImportStatus({
+      certificationCourseIds: cpfImportErrorIds,
+      cpfImportStatus: cpfImportStatus.ERROR,
+    });
+  }
+
+  if (cpfImportSuccessIds.length) {
+    await cpfCertificationResultRepository.updateCertificationImportStatus({
+      certificationCourseIds: cpfImportSuccessIds,
+      cpfImportStatus: cpfImportStatus.SUCCESS,
+    });
+  }
+
+  logger.info(`${cpfImportErrorIds.length} certifications en erreur`);
+  logger.info(`${cpfImportSuccessIds.length} certifications importées avec succès`);
+  logger.info(`Done! ...`);
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();
+
+function getCpfImportResults(filePath) {
+  const xmlStream = fs.createReadStream(filePath);
+  const saxStream = sax.createStream({
+    strict: true,
+  });
+  return new Promise((resolve, reject) => {
+    const cpfImportErrors = new saxPath.SaXPath(saxStream, '//passage');
+    const cpfImportSuccess = new saxPath.SaXPath(saxStream, '//PassagesOK/idTechnique');
+
+    const cpfImportErrorIds = [];
+    const cpfImportSuccessIds = [];
+
+    cpfImportErrors.on('match', (xmlNode) => {
+      xml2js.parseString(xmlNode, async (err, { passage }) => {
+        const [errorMessage] = passage['messageErreur'];
+        const [certificationId] = passage.idTechnique;
+
+        if (errorMessage.includes('existe déjà en base')) {
+          cpfImportSuccessIds.push(certificationId);
+        }
+        if (errorMessage.includes('Aucun titulaire')) {
+          cpfImportErrorIds.push(certificationId);
+        }
+      });
+    });
+
+    cpfImportSuccess.on('match', (xmlNode) => {
+      xml2js.parseString(xmlNode, async (err, { idTechnique }) => {
+        cpfImportSuccessIds.push(idTechnique);
+      });
+    });
+
+    xmlStream
+      .pipe(saxStream)
+      .on('error', reject)
+      .on('end', async () => {
+        resolve({ cpfImportErrorIds, cpfImportSuccessIds });
+      });
+  });
+}
+
+module.exports = {
+  getCpfImportResults,
+  main,
+};

--- a/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
@@ -4,6 +4,7 @@ const { CLEA } = require('../../../../lib/domain/models/ComplementaryCertificati
 
 describe('Acceptance | Controller | session-controller-get-jury-certification-summaries', function () {
   let server;
+  this.timeout(5000);
 
   beforeEach(async function () {
     server = await createServer();

--- a/api/tests/integration/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
+++ b/api/tests/integration/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
@@ -1,5 +1,6 @@
 const { domainBuilder, expect, sinon } = require('../../../../../test-helper');
 const createAndUpload = require('../../../../../../lib/infrastructure/jobs/cpf-export/handlers/create-and-upload');
+const { cpfImportStatus } = require('../../../../../../lib/domain/models/CertificationCourse');
 const { createUnzip } = require('node:zlib');
 const fs = require('fs');
 const proxyquire = require('proxyquire');
@@ -79,7 +80,7 @@ describe('Integration | Infrastructure | jobs | cpf-export | create-and-upload',
     expect(cpfCertificationResultRepository.markCertificationCoursesAsExported).to.have.been.calledWith({
       certificationCourseIds: [12, 20],
       filename: expectedFileName,
-      cpfImportStatus: 'UPLOADED',
+      cpfImportStatus: cpfImportStatus.READY_TO_SEND,
     });
   });
 });

--- a/api/tests/integration/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
+++ b/api/tests/integration/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
@@ -79,6 +79,7 @@ describe('Integration | Infrastructure | jobs | cpf-export | create-and-upload',
     expect(cpfCertificationResultRepository.markCertificationCoursesAsExported).to.have.been.calledWith({
       certificationCourseIds: [12, 20],
       filename: expectedFileName,
+      cpfImportStatus: 'UPLOADED',
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -1,6 +1,7 @@
 const { databaseBuilder, domainBuilder, expect, knex } = require('../../../test-helper');
 const cpfCertificationResultRepository = require('../../../../lib/infrastructure/repositories/cpf-certification-result-repository');
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
+const { cpfImportStatus } = require('../../../../lib/domain/models/CertificationCourse');
 
 describe('Integration | Repository | CpfCertificationResult', function () {
   describe('#getIdsByTimeRange', function () {
@@ -519,14 +520,14 @@ describe('Integration | Repository | CpfCertificationResult', function () {
       // when
       await cpfCertificationResultRepository.updateCertificationImportStatus({
         certificationCourseIds: [123, 456],
-        cpfImportStatus: 'PENDING',
+        cpfImportStatus: cpfImportStatus.PENDING,
       });
 
       // then
       const certificationCourses = await knex('certification-courses').select('id', 'cpfImportStatus').orderBy('id');
       expect(certificationCourses).to.deep.equal([
-        { id: 123, cpfImportStatus: 'PENDING' },
-        { id: 456, cpfImportStatus: 'PENDING' },
+        { id: 123, cpfImportStatus: cpfImportStatus.PENDING },
+        { id: 456, cpfImportStatus: cpfImportStatus.PENDING },
         { id: 789, cpfImportStatus: null },
       ]);
     });

--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -501,6 +501,30 @@ describe('Integration | Repository | CpfCertificationResult', function () {
       expect(certificationCourses.find(({ id }) => id === 789).cpfFilename).to.equal('1234-75834#0');
     });
   });
+
+  describe('#updateCertificationImportStatus', function () {
+    it('should update certification import status', async function () {
+      // given
+      databaseBuilder.factory.buildCertificationCourse({ id: 123, cpfImportStatus: null });
+      databaseBuilder.factory.buildCertificationCourse({ id: 456, cpfImportStatus: null });
+      databaseBuilder.factory.buildCertificationCourse({ id: 789, cpfImportStatus: null });
+      await databaseBuilder.commit();
+
+      // when
+      await cpfCertificationResultRepository.updateCertificationImportStatus({
+        certificationCourseIds: [123, 456],
+        cpfImportStatus: 'PENDING',
+      });
+
+      // then
+      const certificationCourses = await knex('certification-courses').select('id', 'cpfImportStatus').orderBy('id');
+      expect(certificationCourses).to.deep.equal([
+        { id: 123, cpfImportStatus: 'PENDING' },
+        { id: 456, cpfImportStatus: 'PENDING' },
+        { id: 789, cpfImportStatus: null },
+      ]);
+    });
+  });
 });
 function createCertificationCourseWithCompetenceMarks({
   certificationCourseId = 145,

--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -489,16 +489,19 @@ describe('Integration | Repository | CpfCertificationResult', function () {
       await databaseBuilder.commit();
 
       // when
-      await cpfCertificationResultRepository.markCertificationCoursesAsExported({
+      await cpfCertificationResultRepository.markCertificationToExport({
         certificationCourseIds: [456, 789],
-        filename: '1234-75834#0',
+        batchId: '1234-75834#0',
+        cpfImportStatus: 'PENDING',
       });
 
       // then
-      const certificationCourses = await knex('certification-courses').select('id', 'cpfFilename');
-      expect(certificationCourses.find(({ id }) => id === 123).cpfFilename).to.be.null;
-      expect(certificationCourses.find(({ id }) => id === 456).cpfFilename).to.equal('1234-75834#0');
-      expect(certificationCourses.find(({ id }) => id === 789).cpfFilename).to.equal('1234-75834#0');
+      const certificationCourses = await knex('certification-courses').select('id', 'cpfFilename', 'cpfImportStatus');
+      expect(certificationCourses).to.deep.equal([
+        { id: 123, cpfImportStatus: null, cpfFilename: null },
+        { id: 456, cpfImportStatus: 'PENDING', cpfFilename: '1234-75834#0' },
+        { id: 789, cpfImportStatus: 'PENDING', cpfFilename: '1234-75834#0' },
+      ]);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -470,13 +470,16 @@ describe('Integration | Repository | CpfCertificationResult', function () {
       await cpfCertificationResultRepository.markCertificationCoursesAsExported({
         certificationCourseIds: [456, 789],
         filename: 'filename.xml',
+        cpfImportStatus: 'GENERATED',
       });
 
       // then
-      const certificationCourses = await knex('certification-courses').select('id', 'cpfFilename');
-      expect(certificationCourses.find(({ id }) => id === 123).cpfFilename).to.be.null;
-      expect(certificationCourses.find(({ id }) => id === 456).cpfFilename).to.equal('filename.xml');
-      expect(certificationCourses.find(({ id }) => id === 789).cpfFilename).to.equal('filename.xml');
+      const certificationCourses = await knex('certification-courses').select('id', 'cpfFilename', 'cpfImportStatus');
+      expect(certificationCourses).to.deep.equal([
+        { id: 123, cpfImportStatus: null, cpfFilename: null },
+        { id: 456, cpfImportStatus: 'GENERATED', cpfFilename: 'filename.xml' },
+        { id: 789, cpfImportStatus: 'GENERATED', cpfFilename: 'filename.xml' },
+      ]);
     });
   });
 

--- a/api/tests/integration/scripts/certification/files/xml/cpfImportLog.xml
+++ b/api/tests/integration/scripts/certification/files/xml/cpfImportLog.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rapport xmlns:ns2="urn:cdc:cpf:pc5:rapport:schema">
+    <nomFichier>pix-cpf-export-20221003-324234.xml</nomFichier>
+    <idFlux>1234-abcd</idFlux>
+    <idTraitement>1</idTraitement>
+    <PassagesKO>
+        <passage>
+            <idTechnique>1234</idTechnique>
+            <messageErreur>Aucun titulaire ne correspond aux critères obligatoires</messageErreur>
+        </passage>
+        <passage>
+            <idTechnique>4567</idTechnique>
+            <messageErreur>Le passage certification avec le bcr émetteur 03VML243 et l'id technique partenaire 1559735 existe déjà en base</messageErreur>
+        </passage>
+    </PassagesKO>
+    <PassagesOK>
+        <idTechnique>891011</idTechnique>
+    </PassagesOK>
+</rapport>

--- a/api/tests/integration/scripts/certification/files/xml/cpfImportLogEmpty.xml
+++ b/api/tests/integration/scripts/certification/files/xml/cpfImportLogEmpty.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rapport xmlns:ns2="urn:cdc:cpf:pc5:rapport:schema">
+  <nomFichier>pix-cpf-export-20221003-324234.xml</nomFichier>
+  <idFlux>1234-abcd</idFlux>
+  <idTraitement>1</idTraitement>
+</rapport>

--- a/api/tests/integration/scripts/certification/get-cpf-import-status-from-xml_test.js
+++ b/api/tests/integration/scripts/certification/get-cpf-import-status-from-xml_test.js
@@ -1,0 +1,74 @@
+const { knex, expect, databaseBuilder } = require('../../../test-helper');
+const { main } = require('../../../../scripts/certification/get-cpf-import-status-from-xml');
+const { cpfImportStatus } = require('../../../../lib/domain/models/CertificationCourse');
+
+describe('Integration | Scripts | Certification | get-cpf-import-status-from-xml', function () {
+  afterEach(async function () {
+    await knex('certification-courses').delete();
+    await knex('sessions').delete();
+    await knex('users').delete();
+  });
+  describe('#main', function () {
+    describe('when xml is not empty', function () {
+      it('should update cpf import status', async function () {
+        // given
+        const xmlPath = `${__dirname}/files/xml/cpfImportLog.xml`;
+        databaseBuilder.factory.buildCertificationCourse({ id: 1234, cpfImportStatus: null });
+        databaseBuilder.factory.buildCertificationCourse({ id: 4567, cpfImportStatus: null });
+        databaseBuilder.factory.buildCertificationCourse({ id: 891011, cpfImportStatus: null });
+        await databaseBuilder.commit();
+
+        // when
+        await main(xmlPath);
+
+        // then
+        const [certificationCourse1, certificationCourse2, certificationCourse3] = await knex('certification-courses')
+          .select('id', 'cpfImportStatus')
+          .whereIn('id', [1234, 4567, 891011]);
+        expect(certificationCourse1).to.deep.equal({
+          id: 1234,
+          cpfImportStatus: cpfImportStatus.ERROR,
+        });
+        expect(certificationCourse2).to.deep.equal({
+          id: 4567,
+          cpfImportStatus: cpfImportStatus.SUCCESS,
+        });
+        expect(certificationCourse3).to.deep.equal({
+          id: 891011,
+          cpfImportStatus: cpfImportStatus.SUCCESS,
+        });
+      });
+    });
+
+    describe('when xml is empty', function () {
+      it('should not update cpf import status', async function () {
+        // given
+        const xmlPath = `${__dirname}/files/xml/cpfImportLogEmpty.xml`;
+        databaseBuilder.factory.buildCertificationCourse({ id: 1234, cpfImportStatus: null });
+        databaseBuilder.factory.buildCertificationCourse({ id: 4567, cpfImportStatus: null });
+        databaseBuilder.factory.buildCertificationCourse({ id: 891011, cpfImportStatus: null });
+        await databaseBuilder.commit();
+
+        // when
+        await main(xmlPath);
+
+        // then
+        const [certificationCourse1, certificationCourse2, certificationCourse3] = await knex('certification-courses')
+          .select('id', 'cpfImportStatus')
+          .whereIn('id', [1234, 4567, 891011]);
+        expect(certificationCourse1).to.deep.equal({
+          id: 1234,
+          cpfImportStatus: null,
+        });
+        expect(certificationCourse2).to.deep.equal({
+          id: 4567,
+          cpfImportStatus: null,
+        });
+        expect(certificationCourse3).to.deep.equal({
+          id: 891011,
+          cpfImportStatus: null,
+        });
+      });
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
@@ -1,5 +1,6 @@
 const { domainBuilder, expect, sinon } = require('../../../../../test-helper');
 const createAndUpload = require('../../../../../../lib/infrastructure/jobs/cpf-export/handlers/create-and-upload');
+const { cpfImportStatus } = require('../../../../../../lib/domain/models/CertificationCourse');
 const { PassThrough, Readable } = require('stream');
 const dayjs = require('dayjs');
 const utc = require('dayjs/plugin/utc');
@@ -72,7 +73,7 @@ describe('Unit | Infrastructure | jobs | cpf-export | create-and-upload', functi
       expect(cpfCertificationResultRepository.markCertificationCoursesAsExported).to.have.been.calledWith({
         certificationCourseIds: [12, 20, 33, 98, 114],
         filename: 'pix-cpf-export-20220101-114327.xml.gz',
-        cpfImportStatus: 'UPLOADED',
+        cpfImportStatus: cpfImportStatus.READY_TO_SEND,
       });
 
       expect(loggerSpy).to.not.have.been.called;

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
@@ -72,6 +72,7 @@ describe('Unit | Infrastructure | jobs | cpf-export | create-and-upload', functi
       expect(cpfCertificationResultRepository.markCertificationCoursesAsExported).to.have.been.calledWith({
         certificationCourseIds: [12, 20, 33, 98, 114],
         filename: 'pix-cpf-export-20220101-114327.xml.gz',
+        cpfImportStatus: 'UPLOADED',
       });
 
       expect(loggerSpy).to.not.have.been.called;

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/planner_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/planner_test.js
@@ -1,5 +1,6 @@
 const { expect, sinon } = require('../../../../../test-helper');
 const planner = require('../../../../../../lib/infrastructure/jobs/cpf-export/handlers/planner');
+const { cpfImportStatus } = require('../../../../../../lib/domain/models/CertificationCourse');
 const dayjs = require('dayjs');
 const { cpf } = require('../../../../../../lib/config');
 const utc = require('dayjs/plugin/utc');
@@ -40,17 +41,17 @@ describe('Unit | Infrastructure | jobs | cpf-export | planner', function () {
     expect(cpfCertificationResultRepository.markCertificationToExport.getCall(0)).to.have.been.calledWithExactly({
       certificationCourseIds: ['1', '2'],
       batchId: '237584-7648#0',
-      cpfImportStatus: 'PENDING',
+      cpfImportStatus: cpfImportStatus.PENDING,
     });
     expect(cpfCertificationResultRepository.markCertificationToExport.getCall(1)).to.have.been.calledWithExactly({
       certificationCourseIds: ['3', '4'],
       batchId: '237584-7648#1',
-      cpfImportStatus: 'PENDING',
+      cpfImportStatus: cpfImportStatus.PENDING,
     });
     expect(cpfCertificationResultRepository.markCertificationToExport.getCall(2)).to.have.been.calledWithExactly({
       certificationCourseIds: ['5'],
       batchId: '237584-7648#2',
-      cpfImportStatus: 'PENDING',
+      cpfImportStatus: cpfImportStatus.PENDING,
     });
     expect(cpfCertificationResultRepository.getIdsByTimeRange).to.have.been.calledWith({ startDate, endDate });
     expect(pgBoss.send.firstCall).to.have.been.calledWith('CpfExportBuilderJob', {

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/planner_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/planner_test.js
@@ -13,6 +13,7 @@ describe('Unit | Infrastructure | jobs | cpf-export | planner', function () {
     cpfCertificationResultRepository = {
       getIdsByTimeRange: sinon.stub(),
       markCertificationToExport: sinon.stub(),
+      updateCertificationImportStatus: sinon.stub(),
     };
     pgBoss = {
       send: sinon.stub(),
@@ -39,14 +40,17 @@ describe('Unit | Infrastructure | jobs | cpf-export | planner', function () {
     expect(cpfCertificationResultRepository.markCertificationToExport.getCall(0)).to.have.been.calledWithExactly({
       certificationCourseIds: ['1', '2'],
       batchId: '237584-7648#0',
+      cpfImportStatus: 'PENDING',
     });
     expect(cpfCertificationResultRepository.markCertificationToExport.getCall(1)).to.have.been.calledWithExactly({
       certificationCourseIds: ['3', '4'],
       batchId: '237584-7648#1',
+      cpfImportStatus: 'PENDING',
     });
     expect(cpfCertificationResultRepository.markCertificationToExport.getCall(2)).to.have.been.calledWithExactly({
       certificationCourseIds: ['5'],
       batchId: '237584-7648#2',
+      cpfImportStatus: 'PENDING',
     });
     expect(cpfCertificationResultRepository.getIdsByTimeRange).to.have.been.calledWith({ startDate, endDate });
     expect(pgBoss.send.firstCall).to.have.been.calledWith('CpfExportBuilderJob', {

--- a/api/tests/unit/scripts/files/xml/cpfImportLog.xml
+++ b/api/tests/unit/scripts/files/xml/cpfImportLog.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rapport xmlns:ns2="urn:cdc:cpf:pc5:rapport:schema">
+    <nomFichier>pix-cpf-export-20221003-324234.xml</nomFichier>
+    <idFlux>1234-abcd</idFlux>
+    <idTraitement>1</idTraitement>
+    <PassagesKO>
+        <passage>
+            <idTechnique>1234</idTechnique>
+            <messageErreur>Aucun titulaire ne correspond aux critères obligatoires</messageErreur>
+        </passage>
+        <passage>
+            <idTechnique>4567</idTechnique>
+            <messageErreur>Le passage certification avec le bcr émetteur 03VML243 et l'id technique partenaire 1559735 existe déjà en base</messageErreur>
+        </passage>
+    </PassagesKO>
+    <PassagesOK>
+        <idTechnique>891011</idTechnique>
+    </PassagesOK>
+</rapport>

--- a/api/tests/unit/scripts/files/xml/cpfImportLogEmpty.xml
+++ b/api/tests/unit/scripts/files/xml/cpfImportLogEmpty.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<rapport xmlns:ns2="urn:cdc:cpf:pc5:rapport:schema">
+  <nomFichier>pix-cpf-export-20221003-324234.xml</nomFichier>
+  <idFlux>1234-abcd</idFlux>
+  <idTraitement>1</idTraitement>
+</rapport>

--- a/api/tests/unit/scripts/get-cpf-import-status-from-xml_test.js
+++ b/api/tests/unit/scripts/get-cpf-import-status-from-xml_test.js
@@ -1,0 +1,41 @@
+const { expect } = require('../../test-helper');
+const { getCpfImportResults } = require('../../../scripts/certification/get-cpf-import-status-from-xml');
+
+describe('UNIT | Scripts | Certification | get-cpf-import-status-from-xml', function () {
+  describe('#getCpfImportResults', function () {
+    describe('when xml is not empty', function () {
+      it('should retrieve certification ids from xml', async function () {
+        // given
+        const xmlPath = `${__dirname}/files/xml/cpfImportLog.xml`;
+
+        // when
+        const result = await getCpfImportResults(xmlPath);
+
+        // then
+        const expectedCpfImportErrorIds = ['1234'];
+        const expectedCpfImportSuccessIds = ['4567', '891011'];
+
+        expect(result).to.deep.equal({
+          cpfImportErrorIds: expectedCpfImportErrorIds,
+          cpfImportSuccessIds: expectedCpfImportSuccessIds,
+        });
+      });
+    });
+
+    describe('when xml is empty', function () {
+      it('should return empty arrays', async function () {
+        // given
+        const xmlPath = `${__dirname}/files/xml/cpfImportLogEmpty.xml`;
+
+        // when
+        const result = await getCpfImportResults(xmlPath);
+
+        // then
+        expect(result).to.deep.equal({
+          cpfImportErrorIds: [],
+          cpfImportSuccessIds: [],
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
Après import des resultats de certification sur le site du CPF, des rapports XML sont édités avec le statut de l'import par certification.

Le but de ce ticket est d'enregistrer en base le statut de ces imports


## :gift: Proposition
- Ajout colonne ```cpfImportStatus``` dans la table ```certification-courses```

- Créer un script qui prend en paramètre un XML et enregistre en base le statut de l'import de chaque certification concernée ( "SUCCESS", "ERROR" )

- Permettre de renseigner un statut ( "GENERATED", "PENDING" ) lors de la génération des xml de resultats côté Pix via le job de plannification d'envoi ( api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js )

## :santa: Pour tester

- Générer un xml selon ce modèle ( les id contenus dans les balises ```<idTechnique>``` doivent correspondre à des certifications en base ) : 
```<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<rapport xmlns:ns2="urn:cdc:cpf:pc5:rapport:schema">
    <nomFichier>pix-cpf-export-20221003-170948692.xml</nomFichier>
    <idFlux>3c5e4a85-adbd-4b98-b60f-d8a5666ea4d7</idFlux>
    <idTraitement>13407</idTraitement>
    <PassagesKO>
        <passage>
            <idTechnique>106362</idTechnique>
            <messageErreur>Aucun titulaire ne correspond aux critères obligatoires</messageErreur>
        </passage>
        <passage>
            <idTechnique>106367</idTechnique>
            <messageErreur>Le passage certification avec le bcr émetteur 03VML243 et l'id technique partenaire 1559735 existe déjà en base</messageErreur>
        </passage>
    </PassagesKO>
    <PassagesOK>
        <idTechnique>106372</idTechnique>
        <idTechnique>106586</idTechnique>
    </PassagesOK>
</rapport>
```


- Executer le script ```node api/scripts/certification/get-cpf-import-status-from-xml.js <chemin vers le XML>```

- Constater que les statuts d'upload sont bien enregistrés dans la table

![image](https://user-images.githubusercontent.com/37305474/204243724-e37b8d73-c304-495c-be10-c29a25ec47cb.png)
