### PR TITLE
[FEATURE] Envoi du fichier d'import de sessions et validations des champs de session (PIX-6173).

### DIFF
--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -815,6 +815,13 @@ exports.register = async (server) => {
       path: '/api/sessions/import',
       config: {
         handler: sessionController.importSessions,
+        payload: {
+          maxBytes: 20715200,
+          output: 'file',
+          parse: true,
+          allow: 'multipart/form-data',
+          multipart: true,
+        },
         tags: ['api', 'sessions'],
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -810,6 +810,18 @@ exports.register = async (server) => {
         ],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/sessions/import',
+      config: {
+        handler: sessionController.importSessions,
+        tags: ['api', 'sessions'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            "- Elle permet d'importer un fichier contenant une liste de sessions à créer",
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -19,10 +19,10 @@ const certificationResultUtils = require('../../infrastructure/utils/csv/certifi
 const fillCandidatesImportSheet = require('../../infrastructure/files/candidates-import/fill-candidates-import-sheet');
 const { getHeaders } = require('../../infrastructure/files/sessions-import');
 const supervisorKitPdf = require('../../infrastructure/utils/pdf/supervisor-kit-pdf');
-
 const trim = require('lodash/trim');
 const UserLinkedToCertificationCandidate = require('../../domain/events/UserLinkedToCertificationCandidate');
 const logger = require('../../infrastructure/logger');
+const csvHelpers = require('../../../scripts/helpers/csvHelpers');
 
 module.exports = {
   async findPaginatedFilteredJurySessions(request) {
@@ -359,8 +359,10 @@ module.exports = {
       .code(200);
   },
 
-  importSessions(request, h) {
-    return h.response().code(201);
+  async importSessions(request, h) {
+    const data = await csvHelpers.parseCsvWithHeader(request.payload.file.path);
+    await usecases.createSessions({ data });
+    return h.response().code(200);
   },
 };
 

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -358,6 +358,10 @@ module.exports = {
       .header('content-disposition', 'filename=import-sessions')
       .code(200);
   },
+
+  importSessions(request, h) {
+    return h.response().code(201);
+  },
 };
 
 function _logSessionBatchPublicationErrors(result) {

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -321,6 +321,7 @@ module.exports = (function () {
     config.features.pixCertifScoBlockedAccessDateCollege = null;
 
     config.featureToggles.isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled = false;
+    config.featureToggles.isMassiveSessionManagementEnabled = false;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'sendinblue';

--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -1,0 +1,1 @@
+module.exports = async function createSessions({ data }) {};

--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -1,1 +1,25 @@
-module.exports = async function createSessions({ data }) {};
+const sessionValidator = require('../validators/session-validator');
+const { EntityValidationError } = require('../errors');
+const { UnprocessableEntityError } = require('../../application/http-errors');
+
+module.exports = async function createSessions({ data }) {
+  if (data.length === 0) {
+    throw new UnprocessableEntityError('No data in table');
+  }
+  try {
+    data.forEach((session) => {
+      const sessionToValidate = {
+        address: session['* Nom du site'],
+        room: session['* Nom de la salle'],
+        date: session['* Date de début'],
+        time: session['* Heure de début (heure locale)'],
+        examiner: session['* Surveillant(s)'],
+        description: session['Observations (optionnel)'],
+      };
+      sessionValidator.validate(sessionToValidate);
+    });
+  } catch (e) {
+    throw new EntityValidationError(e);
+  }
+  return;
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -224,6 +224,7 @@ module.exports = injectDependencies(
     createOrganizationPlacesLot: require('./create-organization-places-lot'),
     createPasswordResetDemand: require('./create-password-reset-demand'),
     createSession: require('./create-session'),
+    createSessions: require('./create-sessions'),
     createStage: require('./create-stage'),
     createTag: require('./create-tag'),
     createTargetProfile: require('./create-target-profile'),

--- a/api/scripts/helpers/csvHelpers.js
+++ b/api/scripts/helpers/csvHelpers.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const { readFile, access } = require('fs').promises;
-const path = require('path');
 const { difference, isEmpty } = require('lodash');
 const papa = require('papaparse');
 
@@ -38,14 +37,6 @@ const optionsWithHeader = {
   },
 };
 
-function checkCsvExtensionFile(filePath) {
-  const fileExtension = path.extname(filePath);
-
-  if (fileExtension !== '.csv') {
-    throw new FileValidationError(ERRORS.INVALID_FILE_EXTENSION, { fileExtension });
-  }
-}
-
 async function checkCsvHeader({ filePath, requiredFieldNames = [] }) {
   if (isEmpty(requiredFieldNames)) {
     throw new FileValidationError(ERRORS.MISSING_REQUIRED_FIELD_NAMES);
@@ -71,7 +62,6 @@ async function readCsvFile(filePath) {
   } catch (err) {
     throw new NotFoundError(`File ${filePath} not found!`);
   }
-  checkCsvExtensionFile(filePath);
 
   const rawData = await readFile(filePath, 'utf8');
 
@@ -115,7 +105,6 @@ async function parseCsvWithHeaderAndRequiredFields({ filePath, requiredFieldName
 }
 
 module.exports = {
-  checkCsvExtensionFile,
   checkCsvHeader,
   readCsvFile,
   parseCsvData,

--- a/api/tests/acceptance/application/session/files/sessions-import/sessions.csv
+++ b/api/tests/acceptance/application/session/files/sessions-import/sessions.csv
@@ -1,0 +1,3 @@
+N° de session;* Nom du site;* Nom de la salle;* Date de début;* Heure de début (heure locale);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: jj/mm/aaaa);* Sexe (M ou F);Code Insee;Code postal;Nom de la commune;* Pays;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant local;Temps majoré ?
+;site;salle;2022-10-19;12:00;surveillant;non;;;;;;;;;;;;
+;truc;lala;2022-09-18;14:00;nfue;bucdev;;;;;;;;;;;;

--- a/api/tests/acceptance/application/session/session-controller-post-import-sessions_test.js
+++ b/api/tests/acceptance/application/session/session-controller-post-import-sessions_test.js
@@ -1,5 +1,9 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 const createServer = require('../../../../server');
+const FormData = require('form-data');
+const fs = require('node:fs');
+const { stat } = require('node:fs/promises');
+const streamToPromise = require('stream-to-promise');
 
 describe('Acceptance | Controller | session-controller-post-import-sessions', function () {
   let server;
@@ -10,22 +14,37 @@ describe('Acceptance | Controller | session-controller-post-import-sessions', fu
 
   describe('POST /api/sessions/import', function () {
     context('when user imports sessions', function () {
-      it('should return status 201', async function () {
+      it('should return status 200', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
         await databaseBuilder.commit();
 
+        const csvFileName = 'files/sessions-import/sessions.csv';
+        const csvFilePath = `${__dirname}/${csvFileName}`;
+        const options = await createRequest({ csvFilePath, userId });
+
         // when
-        const response = await server.inject({
-          method: 'POST',
-          url: '/api/sessions/import',
-          payload: {},
-          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
-        });
+        const response = await server.inject(options);
 
         // then
-        expect(response.statusCode).to.equal(201);
+        expect(response.statusCode).to.equal(200);
       });
     });
   });
 });
+
+async function createRequest({ csvFilePath, userId }) {
+  const form = new FormData();
+  const knownLength = await stat(csvFilePath).size;
+  form.append('file', fs.createReadStream(csvFilePath), { knownLength });
+  const payload = await streamToPromise(form);
+  const authHeader = generateValidRequestAuthorizationHeader(userId);
+  const token = authHeader.replace('Bearer ', '');
+  const headers = Object.assign({}, form.getHeaders(), { authorization: `Bearer ${token}` });
+  return {
+    method: 'POST',
+    url: `/api/sessions/import`,
+    headers,
+    payload,
+  };
+}

--- a/api/tests/acceptance/application/session/session-controller-post-import-sessions_test.js
+++ b/api/tests/acceptance/application/session/session-controller-post-import-sessions_test.js
@@ -1,0 +1,31 @@
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | session-controller-post-import-sessions', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('POST /api/sessions/import', function () {
+    context('when user imports sessions', function () {
+      it('should return status 201', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        await databaseBuilder.commit();
+
+        // when
+        const response = await server.inject({
+          method: 'POST',
+          url: '/api/sessions/import',
+          payload: {},
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        });
+
+        // then
+        expect(response.statusCode).to.equal(201);
+      });
+    });
+  });
+});

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -1056,4 +1056,18 @@ describe('Unit | Application | Sessions | Routes', function () {
       expect(response.statusCode).to.equal(200);
     });
   });
+
+  describe('POST /api/sessions/import', function () {
+    it('should exist', async function () {
+      // given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/sessions/import');
+
+      // then
+      expect(response.statusCode).to.equal(201);
+    });
+  });
 });

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -1058,16 +1058,36 @@ describe('Unit | Application | Sessions | Routes', function () {
   });
 
   describe('POST /api/sessions/import', function () {
+    const testFilePath = `${__dirname}/testFile_temp.csv`;
+
+    let headers;
+    let payload;
+
+    beforeEach(async function () {
+      await writeFile(testFilePath, Buffer.alloc(0));
+      const form = new FormData();
+      const knownLength = await stat(testFilePath).size;
+      form.append('file', fs.createReadStream(testFilePath), { knownLength });
+
+      headers = form.getHeaders();
+      payload = await streamToPromise(form);
+    });
+
+    afterEach(async function () {
+      await unlink(testFilePath);
+    });
+
     it('should exist', async function () {
       // given
+      sinon.stub(sessionController, 'importSessions').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);
 
       // when
-      const response = await httpTestServer.request('POST', '/api/sessions/import');
+      const response = await httpTestServer.request('POST', '/api/sessions/import', payload, null, headers);
 
       // then
-      expect(response.statusCode).to.equal(201);
+      expect(response.statusCode).to.equal(200);
     });
   });
 });

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -20,6 +20,7 @@ const { SessionPublicationBatchResult } = require('../../../../lib/domain/models
 const logger = require('../../../../lib/infrastructure/logger');
 const { SessionPublicationBatchError } = require('../../../../lib/application/http-errors');
 const supervisorKitPdf = require('../../../../lib/infrastructure/utils/pdf/supervisor-kit-pdf');
+const csvHelpers = require('../../../../scripts/helpers/csvHelpers');
 
 describe('Unit | Controller | sessionController', function () {
   let request;
@@ -1097,6 +1098,28 @@ describe('Unit | Controller | sessionController', function () {
       });
       expect(response.source).to.deep.equal(supervisorKitBuffer);
       expect(response.headers['Content-Disposition']).to.contains(`attachment; filename=kit-surveillant-1.pdf`);
+    });
+  });
+
+  describe('#importSessions', function () {
+    it('should call the usecase to import sessions', async function () {
+      // given
+      const request = {
+        payload: { file: { path: 'csv-path' } },
+      };
+      sinon.stub(csvHelpers, 'parseCsvWithHeader');
+      sinon.stub(usecases, 'createSessions');
+
+      csvHelpers.parseCsvWithHeader.resolves('result data');
+      usecases.createSessions.resolves();
+
+      // when
+      await sessionController.importSessions(request, hFake);
+
+      // then
+      expect(usecases.createSessions).to.have.been.calledWith({
+        data: 'result data',
+      });
     });
   });
 });

--- a/api/tests/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/unit/domain/usecases/create-sessions_test.js
@@ -1,0 +1,68 @@
+const { expect, catchErr } = require('../../../test-helper');
+const createSessions = require('../../../../lib/domain/usecases/create-sessions');
+const { EntityValidationError } = require('../../../../lib/domain/errors');
+const { UnprocessableEntityError } = require('../../../../lib/application/http-errors');
+
+describe('Unit | UseCase | create-sessions', function () {
+  context('when session fields are correct', function () {
+    it('should validate data for session', async function () {
+      // given
+      const data = [
+        {
+          'N° de session': '',
+          '* Nom du site': 'site',
+          '* Nom de la salle': 'salle',
+          '* Date de début': '2022-12-22',
+          '* Heure de début (heure locale)': '12:00',
+          '* Surveillant(s)': 'surveillant',
+          'Observations (optionnel)': 'non',
+          '* Nom de naissance': '',
+          '* Prénom': '',
+          '* Date de naissance (format: jj/mm/aaaa)': '',
+        },
+      ];
+
+      // when
+      await createSessions({ data });
+
+      // then
+      expect(createSessions).to.be.ok;
+    });
+  });
+
+  context('when session fields are not correct', function () {
+    it('should throw an error', async function () {
+      // given
+      const data = [
+        {
+          'N° de session': '',
+          '* Nom du site': 'site',
+          '* Nom de la salle': 'salle',
+          '* Date de début': '',
+          '* Heure de début (heure locale)': '12:00',
+          '* Surveillant(s)': 'surveillant',
+          'Observations (optionnel)': 'non',
+        },
+      ];
+
+      // when
+      const err = await catchErr(createSessions)({ data });
+
+      // then
+      expect(err).to.be.instanceOf(EntityValidationError);
+    });
+  });
+
+  context('when there is no session data', function () {
+    it('should throw an error', async function () {
+      // given
+      const data = [];
+
+      // when
+      const err = await catchErr(createSessions)({ data });
+
+      // then
+      expect(err).to.be.instanceOf(UnprocessableEntityError);
+    });
+  });
+});

--- a/api/tests/unit/scripts/helpers/csvHelpers_test.js
+++ b/api/tests/unit/scripts/helpers/csvHelpers_test.js
@@ -1,7 +1,6 @@
 const { expect, catchErr } = require('../../../test-helper');
 const { NotFoundError, FileValidationError } = require('../../../../lib/domain/errors');
 const {
-  checkCsvExtensionFile,
   parseCsv,
   readCsvFile,
   parseCsvWithHeader,
@@ -15,7 +14,6 @@ const {
 describe('Unit | Scripts | Helpers | csvHelpers.js', function () {
   const notExistFilePath = 'notExist.csv';
   const emptyFilePath = `${__dirname}/files/organizations-empty-file.csv`;
-  const badExtensionFilePath = `${__dirname}/files/bad_extension.html`;
   const validFilePath = `${__dirname}/files/valid-organizations-test.csv`;
   const organizationWithTagsAndTargetProfilesFilePath = `${__dirname}/files/organizations-with-tags-and-target-profiles-test.csv`;
   const utf8FilePath = `${__dirname}/files/utf8_excel-test.csv`;
@@ -30,23 +28,6 @@ describe('Unit | Scripts | Helpers | csvHelpers.js', function () {
       // then
       expect(error).to.be.instanceOf(NotFoundError);
       expect(error.message).to.equal(`File ${notExistFilePath} not found!`);
-    });
-  });
-
-  describe('#checkCsvExtensionFile', function () {
-    it('should throw a FileValidationError when file extension is not ".csv"', async function () {
-      // when
-      const error = await catchErr(checkCsvExtensionFile)(badExtensionFilePath);
-
-      // then
-      expect(error).to.be.instanceOf(FileValidationError);
-      expect(error.code).to.equal('INVALID_FILE_EXTENSION');
-      expect(error.meta).to.deep.equal({ fileExtension: '.html' });
-    });
-
-    it('should not throw if file is valid', async function () {
-      // then
-      expect(await checkCsvExtensionFile(validFilePath)).to.not.throw;
     });
   });
 

--- a/certif/app/components/sessions/panel-header.hbs
+++ b/certif/app/components/sessions/panel-header.hbs
@@ -8,6 +8,18 @@
       >
         {{t "pages.sessions.list.header.session-import-template"}}
       </PixButton>
+
+      <FileUpload
+        @name="file-upload"
+        @for="import-sessions"
+        @accept=".csv"
+        @multiple={{false}}
+        @onfileadd={{this.importSessions}}
+      >
+        <PixButtonLink role="button" tabindex="0">
+          {{t "pages.sessions.list.header.session-import-upload"}}
+        </PixButtonLink>
+      </FileUpload>
     {{/if}}
     <PixButtonLink @route="authenticated.sessions.new">
       {{t "pages.sessions.list.header.session-creation"}}

--- a/certif/app/components/sessions/panel-header.js
+++ b/certif/app/components/sessions/panel-header.js
@@ -23,4 +23,19 @@ export default class PanelHeader extends Component {
       this.notifications.error(this.intl.t('pages.sessions.list.header.session-import-template-dl-error'));
     }
   }
+
+  @action
+  async importSessions(file) {
+    const url = '/api/sessions/import';
+    const token = this.session.data.authenticated.access_token;
+    this.errorMessage = '';
+    try {
+      await file.upload(url, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      this.notifications.success('La liste des sessions a été importée avec succès.');
+    } catch (err) {
+      this.notifications.error(err.body.errors[0].detail);
+    }
+  }
 }

--- a/certif/tests/integration/components/sessions/panel-header_test.js
+++ b/certif/tests/integration/components/sessions/panel-header_test.js
@@ -22,32 +22,64 @@ module('Integration | Component | panel-header', function (hooks) {
   });
 
   module('isMassiveSessionManagementEnabled feature toggle', function () {
-    test('it does not render a download button for the mass import template when toggle is set to false', async function (assert) {
-      // given
-      class FeatureTogglesStub extends Service {
-        featureToggles = { isMassiveSessionManagementEnabled: false };
-      }
-      this.owner.register('service:featureToggles', FeatureTogglesStub);
+    module('isMassiveSessionManagementEnabled feature toggle is true', function () {
+      test('it renders a download button for the mass import template', async function (assert) {
+        // given
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isMassiveSessionManagementEnabled: true };
+        }
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
 
-      // when
-      const { queryByLabelText } = await render(hbs`<Sessions::PanelHeader />`);
+        // when
+        const { getByLabelText } = await render(hbs`<Sessions::PanelHeader />`);
 
-      // then
-      assert.dom(queryByLabelText("Télécharger le template d'import en masse")).doesNotExist();
+        // then
+        assert.dom(getByLabelText("Télécharger le template d'import en masse")).exists();
+      });
+
+      test('it renders an import button for the session mass import', async function (assert) {
+        // given
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isMassiveSessionManagementEnabled: true };
+        }
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+
+        // when
+        const { getByLabelText } = await render(hbs`<Sessions::PanelHeader />`);
+
+        // then
+        assert.dom(getByLabelText('Importer en masse')).exists();
+      });
     });
 
-    test('it renders a download button for the mass import template when toggle is set to true', async function (assert) {
-      // given
-      class FeatureTogglesStub extends Service {
-        featureToggles = { isMassiveSessionManagementEnabled: true };
-      }
-      this.owner.register('service:featureToggles', FeatureTogglesStub);
+    module('isMassiveSessionManagementEnabled feature toggle is false', function () {
+      test('it does not render a download button for the mass import template', async function (assert) {
+        // given
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isMassiveSessionManagementEnabled: false };
+        }
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
 
-      // when
-      const { getByLabelText } = await render(hbs`<Sessions::PanelHeader />`);
+        // when
+        const { queryByLabelText } = await render(hbs`<Sessions::PanelHeader />`);
 
-      // then
-      assert.dom(getByLabelText("Télécharger le template d'import en masse")).exists();
+        // then
+        assert.dom(queryByLabelText("Télécharger le template d'import en masse")).doesNotExist();
+      });
+
+      test('it does not render an import button for the session mass import', async function (assert) {
+        // given
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isMassiveSessionManagementEnabled: false };
+        }
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+
+        // when
+        const { queryByLabelText } = await render(hbs`<Sessions::PanelHeader />`);
+
+        // then
+        assert.dom(queryByLabelText('Importer en masse')).doesNotExist();
+      });
     });
   });
 });

--- a/certif/tests/unit/components/sessions/panel-header_test.js
+++ b/certif/tests/unit/components/sessions/panel-header_test.js
@@ -62,4 +62,59 @@ module('Unit | Component | panel-header', function (hooks) {
       assert.ok(component);
     });
   });
+
+  module('#importSessions', function () {
+    test('should call upload with the right parameters', async function (assert) {
+      // given
+      const token = 'a token';
+
+      component.session = {
+        isAuthenticated: true,
+        data: {
+          authenticated: {
+            access_token: token,
+          },
+        },
+      };
+      const file = {
+        upload: sinon.stub(),
+      };
+      component.notifications = { success: sinon.stub() };
+
+      // when
+      await component.importSessions(file);
+
+      // then
+      sinon.assert.calledOnce(component.notifications.success);
+      assert.ok(
+        file.upload.calledWith('/api/sessions/import', {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+      );
+    });
+
+    test('should call the notifications service in case of an error', async function (assert) {
+      // given
+      const token = 'a token';
+      component.session = {
+        isAuthenticated: true,
+        data: {
+          authenticated: {
+            access_token: token,
+          },
+        },
+      };
+      const file = {
+        upload: sinon.stub().rejects({ body: { errors: [{ detail: 'error message' }] } }),
+      };
+      component.notifications = { error: sinon.stub() };
+
+      // when
+      await component.importSessions(file);
+
+      // then
+      sinon.assert.calledOnce(component.notifications.error);
+      assert.ok(component);
+    });
+  });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -113,7 +113,8 @@
           "session-creation": "Créer une session",
           "session-import-template": "Template d'import de sessions",
           "session-import-template-dl-error": "Une erreur s'est produite pendant le téléchargement",
-          "session-import-template-label": "Télécharger le template d'import en masse"
+          "session-import-template-label": "Télécharger le template d'import en masse",
+          "session-import-upload": "Importer en masse"
         },
         "delete-modal": {
           "title": "Supprimer la session",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -113,7 +113,8 @@
           "session-creation": "Créer une session",
           "session-import-template": "Template d'import de sessions",
           "session-import-template-dl-error": "Une erreur s'est produite pendant le téléchargement",
-          "session-import-template-label": "Télécharger le template d'import en masse"
+          "session-import-template-label": "Télécharger le template d'import en masse",
+          "session-import-upload": "Importer en masse"
         },
         "delete-modal": {
           "title": "Supprimer la session",


### PR DESCRIPTION
## :christmas_tree: Problème

La PR #5248 nous permet de télécharger le template d'import de sessions en masse mais nous ne pouvons à l'heure actuelle pas le renvoyer.

## :gift: Proposition

- Ajout d'une nouvelle route `POST /api/sessions/import` utilisée pour l'import du fichier CSV
- Vérification UNIQUEMENT des champs liés à la session dans le CSV
- Ajout d'un bouton sur la page de liste de sessions permettant d'uploader le fichier en question

## :star2: Remarques

Front-End : 
Pas de notifications d'erreur ou de succès pour l'instant, nous avons préféré attendre le développement de la globalité de la feature pour cela.
En cas d'erreur un simple message apparait en dessous du bouton.

## :santa: Pour tester


```
N° de session;* Nom du site;* Nom de la salle;* Date de début;* Heure de début (heure locale);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: jj/mm/aaaa);* Sexe (M ou F);Code Insee;Code postal;Nom de la commune;* Pays;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant local;Temps majoré ?
;site;salle;2022-10-12;12:00;surveillant;non;;;;;;;;;;;;
;truc;lala;2022-12-24;14:00;nfue;bucdev;;;;;;;;;;;;
```
**Cas passant:**

- Une fois le FT IS_MASSIVE_SESSION_MANAGEMENT_ENABLED activé en RA 
- Créer un fichier CSV avec le contenu ci-dessus 👆
- Ouvrir les outils de développement
- Dans la page de sessions de certif, importer le fichier à l'aide du nouveau bouton
- Dans l'onglet `Network` vérifier que le statut renvoyé est égal à `200`

**Cas d'erreurs:**

- Réitérer l'expérience avec :
- un CSV vide de tout contenu
- contenant uniquement des headers
- contenant des erreurs dans le champs

Pour ces cas, vérifier que l'erreur renvoyée est égale à `422`

