### PR TITLE
[TECH] Analyser les lenteurs de BDD

### DIFF
--- a/api/.psqlrc
+++ b/api/.psqlrc
@@ -1,0 +1,4 @@
+\set last_autovaccum 'SELECT schemaname,relname, last_vacuum, last_autovacuum FROM pg_stat_user_tables WHERE last_autovacuum IS NOT NULL ORDER BY last_autovacuum DESC;'
+\set active_queries 'SELECT query_start, query from pg_stat_activity FROM state <> \'idle\' ORDER BY query_start;'
+\set active_queries_count 'SELECT count(*) from pg_stat_activity FROM state <> \'idle\';'
+\set vacuum_in_progress 'SELECT * FROM pg_stat_progress_vacuum INNER JOIN pg_stat_user_tables USING(relid);'


### PR DESCRIPTION
## :christmas_tree: Problème
Pour analyser les lenteurs de BDD, on utilise tout le temps les mêmes requêtes.
Elles sont rangées en local à des endroits différents, et chaque captain doit les récupérer.

## :gift: Proposition
Les mettre à disposition dans le client de BDD

## :star2: Remarques
Cela n'aura aucun effet sur le code API car il n'utilise pas le client en ligne de commande  `psql`

>psql attempts to read and execute commands from the system-wide startup file (psqlrc) and then the user's personal startup file (~/.psqlrc), after connecting to the database but before accepting normal commands. These files can be used to set up the client and/or the server to taste, typically with \set and SET commands.
https://www.postgresql.org/docs/current/app-psql.html#Files

## :santa: Pour tester

### Se connecter à la BDD

#### Local

Se connecter à la BDD
```shell
PSQLRC=./.psqlrc psql postgresql://postgres@localhost:5432/pix
```

#### Review app

``` shell
scalingo --app pix-api-review-pr5285 --region=osc-fr1 psql-console
```

### Tester les alias

Exécuter
``` sql
:active_queries;
:active_queries_count;
:last_autovaccum;
:vacuum_in_progress;
```

Lister les alias
``` sql
\set
```

Les requêtes sont à la fin
```
(...)
VERSION_NUM = '150001'
active_queries = 'SELECT query_start, query FROM pg_stat_activity WHERE state <> 'idle' ORDER BY query_start;'
active_queries_count = 'SELECT COUNT(*) FROM pg_stat_activity WHERE state <> 'idle';'
last_autovaccum = 'SELECT schemaname,relname, last_vacuum, last_autovacuum FROM pg_stat_user_tables WHERE last_autovacuum IS NOT NULL ORDER BY last_autovacuum DESC;'
vacuum_in_progress = 'SELECT * FROM pg_stat_progress_vacuum INNER JOIN pg_stat_user_tables USING(relid);'
````
