### PR TITLE
[TECH] Supprime les log de niveau de log au démarrage

### DIFF
--- a/api/lib/infrastructure/logger.js
+++ b/api/lib/infrastructure/logger.js
@@ -23,10 +23,4 @@ const logger = pino(
   prettyPrint
 );
 
-logger.error('ERROR logs enabled');
-logger.warn('WARN logs enabled');
-logger.info('INFO logs enabled');
-logger.debug('DEBUG logs enabled');
-logger.trace('TRACE logs enabled');
-
 module.exports = logger;


### PR DESCRIPTION
## :christmas_tree: Problème
Au demarrage du logger, on affiche un log pour chaque niveau, ce qui finalement est un test fonctionnel pas utile
<img width="731" alt="image" src="https://user-images.githubusercontent.com/3769147/204031329-3e10ab32-1631-4949-852d-39b9e16c35c7.png">


## :gift: Proposition
Supprimer!

## :star2: Remarques
/

## :santa: Pour tester
Lancer l'appli, un script, les tests et voir que le message "XXX logs enabled" ne s'affiche pas