### PR TITLE
[BUGFIX] Test instable sur `inMemoryTemporaryStorage.update()`

### DIFF
--- a/api/tests/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
@@ -105,22 +105,23 @@ describe('Unit | Infrastructure | temporary-storage | InMemoryTemporaryStorage',
       expect(result).to.deep.equal({ url: 'url' });
     });
 
-    it('should not change the time to live', function () {
+    it('should not change the time to live', async function () {
       // given
       const keyWithTtl = inMemoryTemporaryStorage.save({
         value: {},
-        expirationDelaySeconds: 1000,
+        expirationDelaySeconds: 0.2,
       });
-      const initialTtl = inMemoryTemporaryStorage._client.getTtl(keyWithTtl);
       const keyWithoutTtl = inMemoryTemporaryStorage.save({ value: {} });
 
       // when
+      await new Promise((resolve) => setTimeout(resolve, 150));
       inMemoryTemporaryStorage.update(keyWithTtl, {});
       inMemoryTemporaryStorage.update(keyWithoutTtl, {});
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
       // then
-      expect(inMemoryTemporaryStorage._client.getTtl(keyWithTtl)).to.equal(initialTtl);
-      expect(inMemoryTemporaryStorage._client.getTtl(keyWithoutTtl)).to.equal(0);
+      expect(inMemoryTemporaryStorage.get(keyWithTtl)).to.be.undefined;
+      expect(inMemoryTemporaryStorage.get(keyWithoutTtl)).not.to.be.undefined;
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
On a un test instable sur `inMemoryTemporaryStorage.update()`:

![image](https://user-images.githubusercontent.com/19571875/204242338-15a793f9-8655-4af2-9b9e-09ec3bcc94c5.png)

## :gift: Proposition
Corriger le test.

## :star2: Remarques
N/A

## :santa: Pour tester
Voir le résultat des tests sur CircleCI.
