### PR TITLE
[FEATURE] Créer l'entrée de menu pour les contenus formatifs dans Admin (PIX-6319)

### DIFF
--- a/admin/app/components/menu-bar.hbs
+++ b/admin/app/components/menu-bar.hbs
@@ -88,6 +88,18 @@
         </PixTooltip>
       </li>
     {{/if}}
+    {{#if this.accessControl.hasAccessToTrainingsActionsScope}}
+      <li class="menu-bar__entry">
+        <PixTooltip @position="right">
+          <:triggerElement>
+            <LinkTo @route="authenticated.trainings.list" class="menu-bar__link">
+              <FaIcon @icon="book-open" @title="Contenus formatifs" />
+            </LinkTo>
+          </:triggerElement>
+          <:tooltip>Contenus formatifs</:tooltip>
+        </PixTooltip>
+      </li>
+    {{/if}}
     <li class="menu-bar__entry">
       <PixTooltip @position="right" @inline={{true}}>
         <:triggerElement>

--- a/admin/app/services/access-control.js
+++ b/admin/app/services/access-control.js
@@ -17,6 +17,14 @@ export default class AccessControlService extends Service {
     );
   }
 
+  get hasAccessToTrainingsActionsScope() {
+    return !!(
+      this.currentUser.adminMember.isSuperAdmin ||
+      this.currentUser.adminMember.isSupport ||
+      this.currentUser.adminMember.isMetier
+    );
+  }
+
   restrictAccessTo(roles, redirectionUrl) {
     const currentUserIsAllowed = roles.some((role) => this.currentUser.adminMember[role]);
     if (!currentUserIsAllowed) {

--- a/admin/tests/integration/components/menu-bar_test.js
+++ b/admin/tests/integration/components/menu-bar_test.js
@@ -61,6 +61,36 @@ module('Integration | Component | menu-bar', function (hooks) {
     });
   });
 
+  module('Trainings tab', function () {
+    module('when admin member have "SUPER_ADMIN", "SUPPORT" or "METIER" as role', function () {
+      test('should contain link to "Trainings" page', async function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:currentUser');
+        currentUser.adminMember = { isSuperAdmin: true };
+
+        // when
+        const screen = await render(hbs`{{menu-bar}}`);
+
+        // then
+        assert.dom(screen.getByRole('link', { name: 'Contenus formatifs' })).exists();
+      });
+    });
+
+    module('when admin member have "CERTIF" as role', function () {
+      test('should not contain link to "Trainings" page', async function (assert) {
+        // given
+        const currentUser = this.owner.lookup('service:currentUser');
+        currentUser.adminMember = { isCertif: true };
+
+        // when
+        const screen = await render(hbs`{{menu-bar}}`);
+
+        // then
+        assert.dom(screen.queryByRole('link', { name: 'Contenus formatifs' })).doesNotExist();
+      });
+    });
+  });
+
   module('Team tab', function () {
     test('should contain link to "team" management page when admin member have "SUPER_ADMIN" as role', async function (assert) {
       // given

--- a/admin/tests/unit/services/access-control-test.js
+++ b/admin/tests/unit/services/access-control-test.js
@@ -119,6 +119,48 @@ module('Unit | Service | access-control', function (hooks) {
     });
   });
 
+  module('#hasAccessToTrainingsActionsScope', function () {
+    test('should be true if admin member has role "SUPER_ADMIN"', function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:current-user');
+      currentUser.adminMember = { isSuperAdmin: true };
+      const service = this.owner.lookup('service:access-control');
+
+      // when & then
+      assert.true(service.hasAccessToTrainingsActionsScope);
+    });
+
+    test('should be true if admin member has role "SUPPORT"', function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:current-user');
+      currentUser.adminMember = { isSupport: true };
+      const service = this.owner.lookup('service:access-control');
+
+      // when & then
+      assert.true(service.hasAccessToTrainingsActionsScope);
+    });
+
+    test('should be true if admin member has role "METIER"', function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:current-user');
+      currentUser.adminMember = { isMetier: true };
+      const service = this.owner.lookup('service:access-control');
+
+      // when & then
+      assert.true(service.hasAccessToTrainingsActionsScope);
+    });
+
+    test('should be false if admin member has role "CERTIF"', function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:current-user');
+      currentUser.adminMember = { isCertif: true };
+      const service = this.owner.lookup('service:access-control');
+
+      // when & then
+      assert.false(service.hasAccessToTrainingsActionsScope);
+    });
+  });
+
   module('#hasAccessToOrganizationActionsScope', function () {
     test('should be true if current admin member is Super Admin', function (assert) {
       // given


### PR DESCRIPTION
## :christmas_tree: Problème
La page des contenus formatifs n'est pas accessible dans la barre de menu.

## :gift: Proposition
Créer l'entrée dans la barre de menu.

## :santa: Pour tester
- [Aller sur la RA](https://admin-pr5291.review.pix.fr/)
- Se connecter avec le compte `superadmin@example.net`
- Aller sur la page des contenus formatifs via le menu

Sur la même RA

- Se connecter avec le compte `pixcertif@example.net`
- Vérifier que le bouton n'est pas dans le menu
