### PR TITLE
[FEATURE] Afficher "Mes parcours" dans le menu user au lancement d'une campagne (PIX-6327)

### DIFF
--- a/mon-pix/app/routes/campaigns/entrance.js
+++ b/mon-pix/app/routes/campaigns/entrance.js
@@ -47,6 +47,12 @@ export default class Entrance extends Route {
 
     try {
       await campaignParticipation.save();
+
+      // Reload the user to display "My customised tests" link on the navbar menu
+      if (!this.currentUser.user?.hasAssessmentParticipations) {
+        this.currentUser.load();
+      }
+
       this.campaignStorage.set(campaign.code, 'hasParticipated', true);
     } catch (err) {
       const error = get(err, 'errors[0]', {});

--- a/mon-pix/tests/unit/routes/campaigns/entrance_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/entrance_test.js
@@ -52,7 +52,7 @@ module('Unit | Route | Entrance', function (hooks) {
     hooks.beforeEach(function () {
       campaignParticipationStub = { save: sinon.stub(), deleteRecord: sinon.stub() };
       route.store = { createRecord: sinon.stub().returns(campaignParticipationStub), queryRecord: sinon.stub() };
-      route.currentUser = { user: {} };
+      route.currentUser = { user: {}, load: sinon.stub() };
     });
 
     test('should save new campaign participation', async function (assert) {
@@ -67,6 +67,7 @@ module('Unit | Route | Entrance', function (hooks) {
 
       //then
       sinon.assert.called(campaignParticipationStub.save);
+      sinon.assert.called(route.currentUser.load);
       assert.ok(true);
     });
 
@@ -78,12 +79,14 @@ module('Unit | Route | Entrance', function (hooks) {
       });
       route.campaignStorage.get.withArgs(campaign.code, 'hasParticipated').returns(true);
       route.campaignStorage.get.withArgs(campaign.code, 'retry').returns(true);
+      route.currentUser.user.hasAssessmentParticipations = true;
 
       //when
       await route.afterModel(campaign);
 
       //then
       sinon.assert.called(campaignParticipationStub.save);
+      sinon.assert.notCalled(route.currentUser.load);
       assert.ok(true);
     });
 
@@ -99,6 +102,7 @@ module('Unit | Route | Entrance', function (hooks) {
 
       //then
       sinon.assert.notCalled(route.store.createRecord);
+      sinon.assert.notCalled(route.currentUser.load);
       assert.ok(true);
     });
 
@@ -116,6 +120,7 @@ module('Unit | Route | Entrance', function (hooks) {
         // eslint-disable-next-line no-empty
       } catch (err) {}
       sinon.assert.called(campaignParticipationStub.deleteRecord);
+      sinon.assert.notCalled(route.currentUser.load);
       assert.ok(true);
     });
 
@@ -133,6 +138,7 @@ module('Unit | Route | Entrance', function (hooks) {
       await route.afterModel(campaign);
 
       //then
+      sinon.assert.notCalled(route.currentUser.load);
       sinon.assert.calledWith(route.campaignStorage.set, campaign.code, 'participantExternalId', null);
       sinon.assert.calledWith(
         route.router.replaceWith,
@@ -155,6 +161,7 @@ module('Unit | Route | Entrance', function (hooks) {
       //when
       await route.afterModel(campaign);
 
+      sinon.assert.notCalled(route.currentUser.load);
       sinon.assert.calledWith(route.router.replaceWith, 'campaigns.existing-participation', campaign.code);
       assert.ok(true);
     });


### PR DESCRIPTION
## :christmas_tree: Problème
Le lien "Mes parcours" dans le menu-utilisateur n'apparait pas sans F5.

## :gift: Proposition
Forcer Ember à reload user lorsqu'on entre dans une campagne de type "assessment".

## :star2: Remarques
Rien à signaler.

## :santa: Pour tester
- [Aller sur la RA](https://app-pr5293.review.pix.fr/campagnes)
- Commencer une campagne jusqu'à pouvoir la quitter via un bouton
- Ouvrir le menu-utilisateur et visualiser le lien "Mes parcours"
