### PR TITLE
[TECH] Supprimer @ember/jquery sur Pix Admin (PIX-6261). 

### DIFF
--- a/admin/config/optional-features.json
+++ b/admin/config/optional-features.json
@@ -1,5 +1,5 @@
 {
   "application-template-wrapper": false,
-  "jquery-integration": true,
+  "jquery-integration": false,
   "template-only-glimmer-components": true
 }

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -12,7 +12,6 @@
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
         "@1024pix/pix-ui": "^16.1.0",
-        "@ember/jquery": "^1.1.0",
         "@ember/optional-features": "^2.0.0",
         "@ember/test-helpers": "^2.2.0",
         "@formatjs/intl": "^2.4.0",
@@ -3952,23 +3951,6 @@
       "resolved": "https://registry.npmjs.org/@ember/edition-utils/-/edition-utils-1.2.0.tgz",
       "integrity": "sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog==",
       "dev": true
-    },
-    "node_modules/@ember/jquery": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ember/jquery/-/jquery-1.1.0.tgz",
-      "integrity": "sha512-zePT3LiK4/2bS4xafrbOlwoLJrDFseOZ95OOuVDyswv8RjFL+9lar+uxX6+jxRb0w900BcQSWP/4nuFSK6HXXw==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-funnel": "^2.0.2",
-        "broccoli-merge-trees": "^3.0.2",
-        "ember-cli-babel": "^7.11.1",
-        "ember-cli-version-checker": "^3.1.3",
-        "jquery": "^3.4.1",
-        "resolve": "^1.11.1"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
     },
     "node_modules/@ember/optional-features": {
       "version": "2.0.0",
@@ -37140,20 +37122,6 @@
       "resolved": "https://registry.npmjs.org/@ember/edition-utils/-/edition-utils-1.2.0.tgz",
       "integrity": "sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog==",
       "dev": true
-    },
-    "@ember/jquery": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ember/jquery/-/jquery-1.1.0.tgz",
-      "integrity": "sha512-zePT3LiK4/2bS4xafrbOlwoLJrDFseOZ95OOuVDyswv8RjFL+9lar+uxX6+jxRb0w900BcQSWP/4nuFSK6HXXw==",
-      "dev": true,
-      "requires": {
-        "broccoli-funnel": "^2.0.2",
-        "broccoli-merge-trees": "^3.0.2",
-        "ember-cli-babel": "^7.11.1",
-        "ember-cli-version-checker": "^3.1.3",
-        "jquery": "^3.4.1",
-        "resolve": "^1.11.1"
-      }
     },
     "@ember/optional-features": {
       "version": "2.0.0",

--- a/admin/package.json
+++ b/admin/package.json
@@ -37,7 +37,6 @@
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
     "@1024pix/pix-ui": "^16.1.0",
-    "@ember/jquery": "^1.1.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.0",
     "@formatjs/intl": "^2.4.0",


### PR DESCRIPTION
## :christmas_tree: Problème
Nous intégrons JQuery sur Pix Admin, alors que nous l'utilisons plus. 

## :gift: Proposition
Supprimer @ember/jquery  et son intégration 

## :santa: Pour tester
- Vérifier le bon fonctionnement de Pix Admin
- Ouvrir l'extension Ember et dans l'onglet info constater qu'il n'y a plus JQuery