### PR TITLE
[FEATURE] Monter la version de Pix UI sur Certif de 18.0.1 à 20.2.3 (PIX-6361).

### DIFF
--- a/certif/app/components/add-student-list.hbs
+++ b/certif/app/components/add-student-list.hbs
@@ -4,13 +4,13 @@
     <div class="add-student-list__filters">
       <span>Filtrer</span>
       <PixMultiSelect
-        @title="Filtrer la liste des élèves en cochant la ou les classes souhaitées"
+        @label="Filtrer la liste des élèves en cochant la ou les classes souhaitées"
         @emptyMessage={{this.emptyMessage}}
         @id={{"add-student-list__multi-select"}}
         @onSelect={{this.selectDivision}}
-        @placeholder={{"Chercher une classe ..."}}
+        @innerText={{"Chercher une classe ..."}}
         @isSearchable={{true}}
-        @showOptionsOnInput={{true}}
+        @screenReaderOnly={{true}}
         @selected={{this.selectedDivisions}}
         @options={{@certificationCenterDivisions}}
         as |option|

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -268,7 +268,7 @@
           <label for="prepayment-code" class="label">
             Code de prépaiement
           </label>
-          <PixTooltip @id="tooltip-prepayment-code" @position="left" @isWide={{true}} class="label">
+          <PixTooltip @id="tooltip-prepayment-code" @position="left">
             <:triggerElement>
               <FaIcon
                 @icon="info-circle"

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^18.0.1",
+        "@1024pix/pix-ui": "^20.2.3",
         "@ember/optional-features": "^2.0.0",
         "@ember/test-helpers": "^2.8.1",
         "@formatjs/intl": "^2.5.1",
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-18.0.1.tgz",
-      "integrity": "sha512-YukiVDTaui4KizW0b4fIgpJi1cabexAr7oLGyKtKfeIjrHrdUdlVIbNtzQ3gufq1MmnrOERpLBMT4hZEBSoSRA==",
+      "version": "20.2.3",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.2.3.tgz",
+      "integrity": "sha512-DOMKXaSE5vaUlNZeEqD8e27hKBSgmVtzVnWZsI/Gx66W7Z8WILqxbjxrmnASKUaNd6CwVIjF7cWxrBc8dbeX0g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -32029,9 +32029,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-18.0.1.tgz",
-      "integrity": "sha512-YukiVDTaui4KizW0b4fIgpJi1cabexAr7oLGyKtKfeIjrHrdUdlVIbNtzQ3gufq1MmnrOERpLBMT4hZEBSoSRA==",
+      "version": "20.2.3",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.2.3.tgz",
+      "integrity": "sha512-DOMKXaSE5vaUlNZeEqD8e27hKBSgmVtzVnWZsI/Gx66W7Z8WILqxbjxrmnASKUaNd6CwVIjF7cWxrBc8dbeX0g==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",

--- a/certif/package.json
+++ b/certif/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^18.0.1",
+    "@1024pix/pix-ui": "^20.2.3",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.8.1",
     "@formatjs/intl": "^2.5.1",

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -120,6 +120,7 @@ module('Acceptance | Session Add Sco Students', function (hooks) {
         await click(
           screen.getByRole('textbox', { name: 'Filtrer la liste des élèves en cochant la ou les classes souhaitées' })
         );
+        await screen.findByRole('menu');
         await click(screen.getByRole('checkbox', { name: '3A' }));
 
         // then

--- a/certif/tests/integration/components/add-student-list_test.js
+++ b/certif/tests/integration/components/add-student-list_test.js
@@ -65,6 +65,7 @@ module('Integration | Component | add-student-list', function (hooks) {
       await click(
         screen.getByRole('textbox', { name: 'Filtrer la liste des élèves en cochant la ou les classes souhaitées' })
       );
+      await screen.findByRole('menu');
 
       // then
       assert.dom(screen.getByRole('checkbox', { name: '3A' })).exists();


### PR DESCRIPTION
## :christmas_tree: Problème
Pix UI n'est pas à jour sur Pix Certif.

## :gift: Proposition
Mettre à jour Pix UI à la dernière version

## :star2: Remarques
[CHANGELOG ](https://ui.pix.fr/?path=/docs/changelog--page)

Les breaking changes : 

**PixCheckBox** : L'argument label n'est plus disponible en tant qu'argument.

=> Pas de PixCheckBox sur certif ✅ 

**PixMultiSelect :**
- L'argument title a été supprimé et ne doit plus être utilisé. Utilisez à la place l'argument label, ce label est présent pour définir le champ input ou le bouton.
- L'argument placeholder a été remplacé. Utilisez à la place l'argument innerText, il fait office de placeholder pour le multiselect searchable ou de contenu pour le bouton. 
- L'argument showOnInput a été supprimé, pour un comportement non a11y compliant. 
- L'argument screenReaderOnly a été ajouté afin de caché de manière accessible le label à l'écran

**PixModal :** Centre la PixModal en hauteur
⚠️ Le scroll est géré par l'overlay, conteneur de la modale. Si vous avez fait du code spécifique pour que ce soit la modale qui contienne son scroll, cela peut entraîner du contenu non visible dans le viewport.

## :santa: Pour tester
- Se connecter sur Pix certif avec `certifsco@example.net`
- Aller sur Centre SCO Lycée
- Cliquer sur une session > onglet Candidat
- Cliquer sur inscrire un candidat
- Tester le bon fonctionnement du filtre des classes
- Vérifier que les modales n'ont pas un comportement différent (voir scénarios dans la [PR suivante](https://github.com/1024pix/pix/pull/5269))
- Vérifier le bon fonctionnement des tooltips
