### PR TITLE
[TECH] Vide les tables après les tests d'integration et acceptance

### DIFF
--- a/api/tests/acceptance/application/campaign-participations/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participations/campaign-participation-controller_test.js
@@ -18,6 +18,7 @@ describe('Acceptance | API | Campaign Participations', function () {
 
   afterEach(async function () {
     await knex('pgboss.job').delete();
+    await knex('knowledge-element-snapshots').delete();
   });
 
   beforeEach(async function () {

--- a/api/tests/acceptance/db/migrations/20220721115757_alter-answers-id-from-int-to-bigint_test.js
+++ b/api/tests/acceptance/db/migrations/20220721115757_alter-answers-id-from-int-to-bigint_test.js
@@ -21,34 +21,4 @@ describe('#changeAnswerIdTypeToBigint', function () {
     );
     expect(sequenceDataType[0]['data_type']).to.equal('bigint');
   });
-
-  it('should sequence are correctly reassigned', async function () {
-    // given
-    const [{ id: answerIdInsertedBeforeSwitch }] = await knex('answers')
-      .insert({
-        value: 'Some value for answer',
-        result: 'Some result for answer',
-        challengeId: 'rec123ABC',
-        createdAt: new Date('2020-01-01'),
-        updatedAt: new Date('2020-01-02'),
-        resultDetails: 'Some result details for answer.',
-        timeSpent: 30,
-      })
-      .returning('id');
-
-    // when migration 20220721115757_alter-answers-id-from-int-to-bigint.js is done
-    const [{ id: answerIdInsertedAfterSwitch }] = await knex('answers')
-      .insert({
-        value: 'Some value for answer',
-        result: 'Some result for answer',
-        challengeId: 'rec123ABC',
-        createdAt: new Date('2020-01-01'),
-        updatedAt: new Date('2020-01-02'),
-        resultDetails: 'Some result details for answer.',
-        timeSpent: 30,
-      })
-      .returning('id');
-    // then
-    expect(answerIdInsertedAfterSwitch).to.equal(answerIdInsertedBeforeSwitch + 1);
-  });
 });

--- a/api/tests/acceptance/scripts/create-sco-certification-centers_test.js
+++ b/api/tests/acceptance/scripts/create-sco-certification-centers_test.js
@@ -1,4 +1,4 @@
-const { expect } = require('../../test-helper');
+const { expect, knex } = require('../../test-helper');
 
 const BookshelfCertificationCenter = require('../../../lib/infrastructure/orm-models/CertificationCenter');
 
@@ -9,6 +9,10 @@ describe('Acceptance | Scripts | create-sco-certification-centers.js', function 
     const getNumberOfCertificationCenters = () => {
       return BookshelfCertificationCenter.count().then((number) => parseInt(number, 10));
     };
+
+    afterEach(async function () {
+      await knex('certification-centers').delete();
+    });
 
     it('should insert 2 sco certification centers', async function () {
       // given

--- a/api/tests/integration/domain/usecases/create-password-reset-demand_test.js
+++ b/api/tests/integration/domain/usecases/create-password-reset-demand_test.js
@@ -1,4 +1,4 @@
-const { catchErr, databaseBuilder, expect } = require('../../../test-helper');
+const { catchErr, databaseBuilder, expect, knex } = require('../../../test-helper');
 
 const mailService = require('../../../../lib/domain/services/mail-service');
 const resetPasswordService = require('../../../../lib/domain/services/reset-password-service');
@@ -17,6 +17,10 @@ describe('Integration | UseCases | create-password-reset-demand', function () {
     const userId = databaseBuilder.factory.buildUser({ email }).id;
     databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({ userId });
     await databaseBuilder.commit();
+  });
+
+  afterEach(function () {
+    return knex('reset-password-demands').delete();
   });
 
   it('should return a password reset demand', async function () {

--- a/api/tests/integration/infrastructure/repositories/sessions/finalized-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/finalized-session-repository_test.js
@@ -5,8 +5,8 @@ const { NotFoundError } = require('../../../../../lib/domain/errors');
 
 describe('Integration | Repository | Finalized-session', function () {
   describe('#save', function () {
-    afterEach(function () {
-      return knex('finalized-sessions').delete();
+    afterEach(async function () {
+      await knex('finalized-sessions').delete();
     });
 
     context('When the session does not exist', function () {
@@ -41,7 +41,7 @@ describe('Integration | Repository | Finalized-session', function () {
     });
 
     context('When the session does exist', function () {
-      it('is idempotent', async function () {
+      it('is idempotent', function (done) {
         // given
         const finalizedSession = new FinalizedSession({
           sessionId: 1234,
@@ -56,6 +56,7 @@ describe('Integration | Repository | Finalized-session', function () {
         expect(async () => {
           await finalizedSessionRepository.save(finalizedSession);
           await finalizedSessionRepository.save(finalizedSession);
+          done();
         }).not.to.throw();
       });
 

--- a/api/tests/integration/infrastructure/repositories/tutorial-evaluation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-evaluation-repository_test.js
@@ -14,6 +14,7 @@ describe('Integration | Infrastructure | Repository | tutorialEvaluationReposito
 
   afterEach(async function () {
     await knex('tutorial-evaluations').delete();
+    await knex('user-saved-tutorials').delete();
   });
 
   describe('#createOrUpdate', function () {

--- a/api/tests/integration/infrastructure/repositories/user-saved-tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-saved-tutorial-repository_test.js
@@ -10,6 +10,10 @@ describe('Integration | Infrastructure | Repository | user-saved-tutorial-reposi
     await databaseBuilder.commit();
   });
 
+  afterEach(async function () {
+    await knex('user-saved-tutorials').delete();
+  });
+
   describe('#addTutorial', function () {
     const tutorialId = 'tutorialId';
 

--- a/api/tests/integration/scripts/create-target-profile-trainings_test.js
+++ b/api/tests/integration/scripts/create-target-profile-trainings_test.js
@@ -4,7 +4,7 @@ const {
   checkTargetProfileExistence,
 } = require('../../../scripts/create-target-profile-trainings');
 
-describe('Unit | Scripts | create-target-profile-trainings.js', function () {
+describe('Integration | Scripts | create-target-profile-trainings.js', function () {
   describe('#checkTrainingExistence', function () {
     it(`should throw an error when training doesn't exist`, async function () {
       // given


### PR DESCRIPTION
## :christmas_tree: Problème
Lors des tests integration et acceptance les données inserees en base via le domainBuilder sont supprimees automatiquement, en revanche les autres insertions doivent etre supprimes manuellement. Si ce n'est pas fait cela peut impacter d'autres tests.

## :gift: Proposition
Supprimer ces données 

## :star2: Remarques
Pour savoir quelles tables ne sont pas vidées après un test, il faut faire une verification dans le afterEach du test helper:

```javascript
await databaseBuilder.clean();
  try {
    const tables = await knex.raw(`
    WITH tbl AS
      (SELECT TABLE_NAME
      FROM information_schema.tables
      WHERE TABLE_NAME not like 'pg_%' and TABLE_NAME not like 'knex_%'
        AND table_schema = 'public'
      )
    SELECT TABLE_NAME, (xpath('/row/c/text()', query_to_xml(format('select count(*) as c from public.%I', TABLE_NAME), FALSE, TRUE, '')))[1]::text::int AS rows_n
    FROM tbl
    ORDER BY rows_n DESC;`);
    const data = tables.rows.filter(({ rows_n }) => Boolean(rows_n));
    if (data.length) {
      console.log(this.currentTest.fullTitle());
      tables.rows
        .filter(({ rows_n }) => Boolean(rows_n))
        .forEach(({ table_name, rows_n }) => console.log(`TABLE: ${table_name}: ${rows_n} line(s)`));
    }
  } catch (e) {
    console.error(e);
  }
```

## :santa: Pour tester
Remettre le bout de code dans le test helper et s'assurer que rien ne ressort en lancant les tests inte/acceptance.
