### PR TITLE
[TECH] Eviter de supprimer la BDD dans les tests unitaires

### DIFF
--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -25,13 +25,18 @@ const learningContentBuilder = require('./tooling/learning-content-builder');
 const tokenService = require('../lib/domain/services/token-service');
 const Membership = require('../lib/domain/models/Membership');
 const EMPTY_BLANK_AND_NULL = ['', '\t \n', null];
+const isUnitRegExp = new RegExp('/*/unit/*/');
+const isUnit = (path) => isUnitRegExp.test(path);
 
 /* eslint-disable mocha/no-top-level-hooks */
 afterEach(function () {
   sinon.restore();
-  cache.flushAll();
   nock.cleanAll();
-  return databaseBuilder.clean();
+  cache.flushAll();
+
+  if (!isUnit(this.currentTest.file)) {
+    return databaseBuilder.clean();
+  }
 });
 
 after(function () {


### PR DESCRIPTION
## :christmas_tree: Problème
On "clean" la BDD après chaque test api.

## :gift: Proposition
Ne pas le faire pour les tests unitaires qui ne sont pas censé utiliser la BDD

## :star2: Remarques
/
## :santa: Pour tester
/
