### PR TITLE
[BUGFIX][API] Ne pas vérifier si l'utilisateur est bloqué lorsqu'une requête pour rafraichir le token d'accès est initiée (PIX-6432)

### DIFF
--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -37,8 +37,12 @@ function _replyForbiddenError(h) {
 }
 
 async function checkIfUserIsBlocked(request, h) {
-  const { username } = request.payload;
-  await checkIfUserIsBlockedUseCase.execute(username);
+  const { username, grant_type: grantType } = request.payload;
+
+  if (grantType === 'password') {
+    await checkIfUserIsBlockedUseCase.execute(username);
+  }
+
   return h.response(true);
 }
 

--- a/api/tests/integration/application/security-pre-handlers_test.js
+++ b/api/tests/integration/application/security-pre-handlers_test.js
@@ -261,7 +261,10 @@ describe('Integration | Application | SecurityPreHandlers', function () {
         const response = await httpServerTest.requestObject({
           method: 'POST',
           url: '/api/token',
-          payload: { username: 'lucy123' },
+          payload: {
+            username: 'lucy123',
+            grant_type: 'password',
+          },
         });
 
         // then
@@ -283,12 +286,34 @@ describe('Integration | Application | SecurityPreHandlers', function () {
         const response = await httpServerTest.requestObject({
           method: 'POST',
           url: '/api/token',
-          payload: { username: 'natsu123' },
+          payload: {
+            username: 'natsu123',
+            grant_type: 'password',
+          },
         });
 
         // then
         expect(response.statusCode).to.equal(403);
         expect(response.result.errors[0].code).to.equal('USER_HAS_BEEN_TEMPORARY_BLOCKED');
+      });
+    });
+
+    describe('when the application tries to refresh the access token', function () {
+      before(async function () {
+        // given
+        databaseBuilder.factory.buildUser({ username: 'refresh_token_user_1' });
+        await databaseBuilder.commit();
+      });
+      it('returns 200', async function () {
+        // when
+        const { statusCode } = await httpServerTest.requestObject({
+          method: 'POST',
+          url: '/api/token',
+          payload: { grant_type: 'refresh_token' },
+        });
+
+        // then
+        expect(statusCode).to.equal(200);
       });
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement, lorsqu'une requête pour rafraichir le token d'un utilisateur est exécutée, cette dernière retourne un code HTTP 500 Internal Server Error.

Cela est dû à l'ajout d'un nouveau [pre-handler](https://github.com/1024pix/pix/pull/5276/files#diff-68ef144cf66c6f109ddbd4041e7f27fd01f0aaa0e039215b1b67c94c7f89a978) qui vérifie que l'utilisateur qui tente de s'authentifier n'est pas bloqué.

## :gift: Proposition

Dans le cas d'une requête pour rafraichir l'access token (grant_type=refresh_token), nous ne devons pas faire la vérification de blocage du compte.

## :star2: Remarques

RAS

## :santa: Pour tester

- Définir une expiration moins longue pour l'access token (ex: 10 secondes)
- Ouvrir la console développeur de votre navigateur sur l'onglet réseaux
- Se connecter sur **Pix App**, **Pix Certif** et/ou **Pix Orga**
- Constatez que les requêtes `/token` pour rafraichir le token retournent un code HTTP 200
