### PR TITLE
[FEATURE] Utiliser un handler pour verifier l'appartenance à un membre du centre de certification lors de la création de session (PIX-6339)

### DIFF
--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -7,11 +7,21 @@ const divisionSerializer = require('../../infrastructure/serializers/jsonapi/div
 const studentCertificationSerializer = require('../../infrastructure/serializers/jsonapi/student-certification-serializer');
 const sessionSummarySerializer = require('../../infrastructure/serializers/jsonapi/session-summary-serializer');
 const certificationCenterInvitationSerializer = require('../../infrastructure/serializers/jsonapi/certification-center-invitation-serializer');
+const sessionSerializer = require('../../infrastructure/serializers/jsonapi/session-serializer');
 
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 const map = require('lodash/map');
 
 module.exports = {
+  async saveSession(request) {
+    const userId = request.auth.credentials.userId;
+    const session = sessionSerializer.deserialize(request.payload);
+
+    const newSession = await usecases.createSession({ userId, session });
+
+    return sessionSerializer.serialize({ session: newSession });
+  },
+
   async create(request) {
     const certificationCenter = certificationCenterSerializer.deserialize(request.payload);
     const complementaryCertificationIds = map(request.payload.data.relationships?.habilitations?.data, 'id');

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -175,6 +175,29 @@ exports.register = async function (server) {
   server.route([
     ...adminRoutes,
     {
+      method: 'POST',
+      path: '/api/certification-centers/{certificationCenterId}/session',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsMemberOfCertificationCenter,
+            assign: 'isMemberOfCertificationCenter',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            certificationCenterId: identifiersType.certificationCenterId,
+          }),
+        },
+        handler: certificationCenterController.saveSession,
+        tags: ['api', 'certification-center', 'sessions'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            '- Elle permet de créer une session de certification liée au centre de certification de l’utilisateur',
+        ],
+      },
+    },
+    {
       method: 'GET',
       path: '/api/certification-centers/{certificationCenterId}/sessions/{sessionId}/students',
       config: {

--- a/api/tests/acceptance/application/certification-centers/certification-centers-route-post-session_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-centers-route-post-session_test.js
@@ -1,0 +1,67 @@
+const { expect, knex, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | certification-centers-controller-post-session', function () {
+  let server;
+
+  beforeEach(async function () {
+    server = await createServer();
+  });
+
+  describe('POST /certification-centers/{certificationCenterId}/session', function () {
+    let options;
+
+    beforeEach(function () {
+      const userId = databaseBuilder.factory.buildUser().id;
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ name: 'Tour Gamma' }).id;
+      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
+      options = {
+        method: 'POST',
+        url: `/api/certification-centers/${certificationCenterId}/session`,
+        payload: {
+          data: {
+            type: 'sessions',
+            attributes: {
+              'certification-center-id': certificationCenterId,
+              address: 'Nice',
+              date: '2017-12-08',
+              description: '',
+              examiner: 'Michel Essentiel',
+              room: '28D',
+              time: '14:30',
+            },
+          },
+        },
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+      return databaseBuilder.commit();
+    });
+
+    afterEach(function () {
+      return knex('sessions').delete();
+    });
+
+    it('should return an OK status after saving in database', async function () {
+      // when
+      const response = await server.inject(options);
+
+      // then
+      const sessions = await knex('sessions').select();
+      expect(response.statusCode).to.equal(200);
+      expect(sessions).to.have.lengthOf(1);
+    });
+
+    describe('Resource access management', function () {
+      it('should respond with a 401 - unauthorized access - if user is not authenticated', async function () {
+        // given
+        options.headers.authorization = 'invalid.access.token';
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+    });
+  });
+});

--- a/api/tests/unit/application/certification-centers/index_test.js
+++ b/api/tests/unit/application/certification-centers/index_test.js
@@ -5,6 +5,56 @@ const moduleUnderTest = require('../../../../lib/application/certification-cente
 const certificationCenterController = require('../../../../lib/application/certification-centers/certification-center-controller');
 
 describe('Unit | Router | certification-center-router', function () {
+  describe('POST /api/certification-centers/{certificationCenterId}/session', function () {
+    it('should return CREATED (200) when everything does as expected', async function () {
+      // given
+      sinon.stub(certificationCenterController, 'saveSession').returns('ok');
+      sinon
+        .stub(securityPreHandlers, 'checkUserIsMemberOfCertificationCenter')
+        .callsFake((request, h) => h.response(true));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      /// when
+      const response = await httpTestServer.request('POST', '/api/certification-centers/123/session');
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should reject an invalid certification-centers id', async function () {
+      //given
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/certification-centers/invalid/session');
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return 403 if user is not member of the given certification center', async function () {
+      //given
+      sinon.stub(securityPreHandlers, 'checkUserIsMemberOfCertificationCenter').callsFake((request, h) =>
+        h
+          .response({ errors: new Error('forbidden') })
+          .code(403)
+          .takeover()
+      );
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/certification-centers/123/session');
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
+
   describe('GET /api/certification-centers/{certificationCenterId}/divisions', function () {
     it('should reject an invalid certification center id', async function () {
       // given

--- a/certif/app/adapters/session.js
+++ b/certif/app/adapters/session.js
@@ -1,6 +1,9 @@
 import ApplicationAdapter from './application';
+import { inject as service } from '@ember/service';
 
 export default class SessionAdapter extends ApplicationAdapter {
+  @service currentUser;
+
   urlForUpdateRecord(id, modelName, { adapterOptions }) {
     const url = super.urlForUpdateRecord(...arguments);
     if (adapterOptions && adapterOptions.finalization) {
@@ -9,6 +12,11 @@ export default class SessionAdapter extends ApplicationAdapter {
     }
 
     return url;
+  }
+
+  urlForCreateRecord() {
+    const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
+    return `${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/session`;
   }
 
   updateRecord(store, type, snapshot) {

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -45,7 +45,7 @@ export default function () {
     }
   });
 
-  this.post('/sessions');
+  this.post('/certification-centers/:certificationCenterId/session');
 
   this.get('/sessions/:id', function (schema, request) {
     const sessionId = request.params.id;

--- a/certif/tests/unit/adapters/session_test.js
+++ b/certif/tests/unit/adapters/session_test.js
@@ -1,4 +1,5 @@
 import { module, test } from 'qunit';
+import Service from '@ember/service';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
@@ -29,6 +30,27 @@ module('Unit | Adapter | session', function (hooks) {
 
       // then
       assert.ok(url.endsWith('/sessions/123/finalization'));
+    });
+  });
+
+  module('#urlForCreateRecord', () => {
+    test('should build save url from certification center id', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+        id: 123,
+      });
+      class CurrentUserStub extends Service {
+        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+      const adapter = this.owner.lookup('adapter:session');
+
+      // when
+      const url = await adapter.urlForCreateRecord();
+
+      // then
+      assert.ok(url.endsWith('/certification-centers/123/session'));
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Lors de la creation de la session, on vérifie dans le use case que le user est membre du centre de certification.

## :gift: Proposition
Verifier cela au niveau d’un handler sur la route


## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- Tester la non régression sur la création de session depuis pix-certif