### PR TITLE
[BUGFIX] Modification du texte de l'erreur E11 (PIX-6370)

### DIFF
--- a/certif/app/models/certification-issue-report.js
+++ b/certif/app/models/certification-issue-report.js
@@ -52,7 +52,7 @@ export const subcategoryToLabel = {
   [certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT]:
     'Le candidat a été contraint de cliquer en dehors du cadre autorisé pour une question en mode focus',
   [certificationIssueReportSubcategories.SKIP_ON_OOPS]:
-    'Une page «Oups une erreur est survenue» ou tout autre problème technique lié à la plateforme a empêché le candidat de répondre à la question',
+    'Un problème technique lié à la plateforme Pix a empêché le candidat de répondre à la question',
   [certificationIssueReportSubcategories.ACCESSIBILITY_ISSUE]:
     'Problème avec l’accessibilité de la question (ex : daltonisme)',
 };

--- a/certif/tests/integration/components/issue-report-modal/candidate-information-change-certification-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/candidate-information-change-certification-issue-report-fields_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import { certificationIssueReportSubcategories } from 'pix-certif/models/certification-issue-report';

--- a/certif/tests/integration/components/issue-report-modal/in-challenge-certification-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/in-challenge-certification-issue-report-fields_test.js
@@ -1,14 +1,14 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import {
-  certificationIssueReportCategories,
   categoryToLabel,
+  certificationIssueReportCategories,
   certificationIssueReportSubcategories,
-  subcategoryToLabel,
   subcategoryToCode,
+  subcategoryToLabel,
 } from 'pix-certif/models/certification-issue-report';
 import { RadioButtonCategoryWithSubcategoryAndQuestionNumber } from 'pix-certif/components/issue-report-modal/add-issue-report-modal';
 

--- a/certif/tests/unit/models/certification-issue-report_test.js
+++ b/certif/tests/unit/models/certification-issue-report_test.js
@@ -3,12 +3,12 @@ import { setupTest } from 'ember-qunit';
 import map from 'lodash/map';
 
 import {
+  categoryToCode,
+  categoryToLabel,
   certificationIssueReportCategories,
   certificationIssueReportSubcategories,
-  categoryToLabel,
-  subcategoryToLabel,
-  categoryToCode,
   subcategoryToCode,
+  subcategoryToLabel,
 } from 'pix-certif/models/certification-issue-report';
 
 module('Unit | Model | certification issue report', function (hooks) {


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, le texte du signalement E11 ne s’affiche pas en entier dans le menu déroulant : "Une page « Oups une erreur est survenue» ou tout autre problème technique lié à la plateforme a empêché le candidat de (répondre à la question)."

## :gift: Proposition
Remplacer le texte du signalement E11 avec le message suivant : "Un problème technique lié à la plateforme Pix a empêché le candidat de répondre à la question."

## :santa: Pour tester
- Se connecter à Pix Certif avec le compte certifsco@example.net
- Aller sur une session créée mais par encore finalisée (ex: la session 4)
- Dans le detail de la session cliquer sur finaliser et ajouter un signalement sur un des eleves
- Choisir la derniere option "E1-E12 Problème technique sur une question" et ouvrir le menu déroulant
- Observer que l'option E11 a désormais le texte: "Un problème technique lié à la plateforme Pix a empêché le candidat de répondre à la question." et qu'il est lisible en entier
 
 
![Capture d’écran 2022-11-29 à 16 40 40](https://user-images.githubusercontent.com/103997660/204574590-1ea3f0d8-54a9-45bc-8e08-f60e4366da97.png)
