### PR TITLE
[FEATURE/TECH/BUGFIX] Design tabulation (PIX-5790)

### DIFF
--- a/certif/app/styles/globals/panels.scss
+++ b/certif/app/styles/globals/panels.scss
@@ -7,22 +7,20 @@
 .navbar {
   height: $navbar-height;
   border: none;
-  padding: 0 10px;
+  padding: 0 12px;
 
   &-item {
-    width: 150px;
     align-items: center;
     display: flex;
-    justify-content: center;
-    background-color: transparent;
     border: none;
     border-bottom: 2px solid transparent;
     outline: none;
     cursor: pointer;
-    color: $pix-neutral-50;
+    color: $pix-neutral-60;
     font-family: $font-roboto;
     font-size: 0.9rem;
     font-weight: 500;
+    margin: 0 12px;
     transition: all ease-in-out 0.2s;
     text-decoration: none;
 


### PR DESCRIPTION
## :christmas_tree: Problème

Dans le cadre de l’audit design Pix Certif, une anomalie a été remontée sur la page détail d’une session dans Pix Certif concernant le design de la tabulation.

Le design du composant de tabulation sur Pix Certif, Orga et le DS n'est pas le même

## :gift: Proposition
Aligner le design de la tabulation sur celle du design system : https://www.figma.com/file/8RJ3aCSfdeQ8AZZVBBYKS8/Design-System-Pix?node-id=429%3A6346

Margin, font size, couleur de l'èlement inactif (actuellement : #5E6C84 pour : #505F79). Vérifier les autres paramètres graphiques.

**Avant**
![Screenshot 2022-11-29 at 16-55-31 Détails Session 11 Pix Certif](https://user-images.githubusercontent.com/11388201/204578592-c4fd5d07-acec-4697-ba12-b816e7cf1c85.png)

**Après**
![Screenshot 2022-11-29 at 16-55-57 Détails Session 11 Pix Certif](https://user-images.githubusercontent.com/11388201/204578646-2d570f0a-3e82-4c03-809d-2f459adddcd8.png)

## :santa: Pour tester
Dans Sessions > Détails, vérifier que les tabulations fonctionnent toujours