### PR TITLE
[TECH] Ajouter les catégories et sous-catégories de signalements en BDD (PIX-6510)

### DIFF
--- a/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
@@ -4,7 +4,6 @@ const { CLEA } = require('../../../../lib/domain/models/ComplementaryCertificati
 
 describe('Acceptance | Controller | session-controller-get-jury-certification-summaries', function () {
   let server;
-  this.timeout(5000);
 
   beforeEach(async function () {
     server = await createServer();

--- a/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -47,8 +47,6 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
         startedCertification = dbf.buildCertificationCourse({ sessionId, lastName: 'CCC' });
         otherStartedCertification = dbf.buildCertificationCourse({ sessionId, lastName: 'DDD' });
 
-        categoryId = dbf.buildIssueReportCategory({ name: CertificationIssueReportCategories.OTHER }).id;
-
         const manyAsrAssessmentId = dbf.buildAssessment({ certificationCourseId: manyAsrCertification.id }).id;
         dbf.buildAssessment({ certificationCourseId: startedCertification.id });
 

--- a/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -3,7 +3,7 @@ const JuryCertificationSummary = require('../../../../lib/domain/read-models/Jur
 const CertificationIssueReport = require('../../../../lib/domain/models/CertificationIssueReport');
 const {
   CertificationIssueReportCategories,
-  ImpactfulCategories,
+  CertificationIssueReportSubcategories,
   ImpactfulSubcategories,
 } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
 const { status: assessmentResultStatuses } = require('../../../../lib/domain/models/AssessmentResult');
@@ -38,7 +38,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
       let otherStartedCertification;
       const description = 'Super candidat !';
       let certificationIssueReport;
-      let issueReportCategoryId;
+      let categoryId;
 
       beforeEach(function () {
         const dbf = databaseBuilder.factory;
@@ -47,15 +47,20 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
         startedCertification = dbf.buildCertificationCourse({ sessionId, lastName: 'CCC' });
         otherStartedCertification = dbf.buildCertificationCourse({ sessionId, lastName: 'DDD' });
 
-        issueReportCategoryId = dbf.buildIssueReportCategory({ name: CertificationIssueReportCategories.OTHER }).id;
+        categoryId = dbf.buildIssueReportCategory({ name: CertificationIssueReportCategories.OTHER }).id;
 
         const manyAsrAssessmentId = dbf.buildAssessment({ certificationCourseId: manyAsrCertification.id }).id;
         dbf.buildAssessment({ certificationCourseId: startedCertification.id });
 
+        categoryId = dbf.buildIssueReportCategory({
+          name: CertificationIssueReportCategories.OTHER,
+          isImpactful: false,
+        }).id;
+
         certificationIssueReport = dbf.buildCertificationIssueReport({
           certificationCourseId: manyAsrCertification.id,
           category: CertificationIssueReportCategories.OTHER,
-          categoryId: issueReportCategoryId,
+          categoryId,
           description,
         });
 
@@ -90,10 +95,10 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
               id: certificationIssueReport.id,
               certificationCourseId: manyAsrCertification.id,
               description,
+              categoryId,
               subcategory: null,
               questionNumber: null,
               category: CertificationIssueReportCategories.OTHER,
-              categoryId: issueReportCategoryId,
               hasBeenAutomaticallyResolved: null,
               resolvedAt: null,
               resolution: null,
@@ -202,7 +207,10 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
 
         const manyAsrAssessmentId = dbf.buildAssessment({ certificationCourseId: manyAsrCertification.id }).id;
 
-        const categoryId = dbf.buildIssueReportCategory({ name: CertificationIssueReportCategories.OTHER }).id;
+        const categoryId = dbf.buildIssueReportCategory({
+          name: CertificationIssueReportCategories.OTHER,
+          isImpactful: false,
+        }).id;
 
         const issueReport1 = dbf.buildCertificationIssueReport({
           certificationCourseId: manyAsrCertification.id,
@@ -331,7 +339,10 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           status: assessmentResultStatuses.VALIDATED,
         });
 
-        const categoryId = dbf.buildIssueReportCategory({ name: CertificationIssueReportCategories.OTHER }).id;
+        const categoryId = dbf.buildIssueReportCategory({
+          name: CertificationIssueReportCategories.OTHER,
+          isImpactful: false,
+        }).id;
 
         const issueReport1 = dbf.buildCertificationIssueReport({
           certificationCourseId: manyAsrCertification.id,
@@ -339,6 +350,11 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           categoryId,
           description: 'first certification issue report',
           hasBeenAutomaticallyResolved: false,
+        });
+        dbf.buildIssueReportCategory({
+          name: CertificationIssueReportCategories.OTHER,
+          isImpactful: true,
+          isDeprecated: true,
         });
         const issueReport2 = dbf.buildCertificationIssueReport({
           certificationCourseId: manyAsrCertification.id,
@@ -445,76 +461,114 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
       });
 
       context('when some certifications have issue reports', function () {
-        it('should return certifications with unresolved impactful issue reports first', async function () {
-          // given
-          const page = { size: 4, number: 1 };
-          const dbf = databaseBuilder.factory;
-          const sessionId = dbf.buildSession().id;
-          const certificationWithResolvedImpactfulAndNotImpactfulIssueReportsId = dbf.buildCertificationCourse({
-            id: 101,
-            sessionId,
-            lastName: 'AAA',
-          }).id;
-          const certificationWithOneImpactfulIssueReportId = dbf.buildCertificationCourse({
-            id: 102,
-            sessionId,
-            lastName: 'BBB',
-          }).id;
-          const certificationWithTwoImpactfulIssueReportsId = dbf.buildCertificationCourse({
-            id: 103,
-            sessionId,
-            lastName: 'CCC',
-          }).id;
-          const certificationWithoutIssueReportsId = dbf.buildCertificationCourse({
-            id: 104,
-            sessionId,
-            lastName: 'DDD',
-          }).id;
+        context('when the issue reports are from categories', function () {
+          it('should return certifications with unresolved impactful issue reports first', async function () {
+            // given
+            const page = { size: 4, number: 1 };
+            const dbf = databaseBuilder.factory;
+            const sessionId = dbf.buildSession().id;
+            const certificationWithNotImpactfulCategoryIssueReportId = dbf.buildCertificationCourse({
+              id: 101,
+              sessionId,
+              lastName: 'AAA',
+            }).id;
+            const certificationWithOneImpactfulCategoryIssueReportId = dbf.buildCertificationCourse({
+              id: 102,
+              sessionId,
+              lastName: 'BBB',
+            }).id;
 
-          dbf.buildCertificationIssueReport({
-            certificationCourseId: certificationWithOneImpactfulIssueReportId,
-            isActionRequired: true,
-            category: ImpactfulCategories[0],
-          });
-          dbf.buildCertificationIssueReport({
-            certificationCourseId: certificationWithTwoImpactfulIssueReportsId,
-            isActionRequired: true,
-            subcategory: ImpactfulSubcategories[0],
-          });
-          dbf.buildCertificationIssueReport({
-            certificationCourseId: certificationWithTwoImpactfulIssueReportsId,
-            isActionRequired: true,
-            subcategory: ImpactfulSubcategories[1],
-          });
-          dbf.buildCertificationIssueReport({
-            certificationCourseId: certificationWithResolvedImpactfulAndNotImpactfulIssueReportsId,
-            isActionRequired: true,
-            resolvedAt: new Date(),
-            category: ImpactfulCategories[0],
-          });
-          dbf.buildCertificationIssueReport({
-            certificationCourseId: certificationWithResolvedImpactfulAndNotImpactfulIssueReportsId,
-            isActionRequired: true,
-            category: CertificationIssueReportCategories.NON_BLOCKING_TECHNICAL_ISSUE,
-          });
+            // issue reports
+            const impactfulIssueReportId = dbf.buildIssueReportCategory({
+              name: 'FRAUD',
+              isImpactful: true,
+              isDeprecated: false,
+            }).id;
+            const notImpactfulIssueReportId = dbf.buildIssueReportCategory({
+              name: 'NON_BLOCKING_TECHNICAL_ISSUE',
+              isImpactful: false,
+              isDeprecated: false,
+            }).id;
 
-          await databaseBuilder.commit();
+            // certification issue reports
+            dbf.buildCertificationIssueReport({
+              certificationCourseId: certificationWithNotImpactfulCategoryIssueReportId,
+              isActionRequired: true,
+              categoryId: notImpactfulIssueReportId,
+            });
+            dbf.buildCertificationIssueReport({
+              certificationCourseId: certificationWithOneImpactfulCategoryIssueReportId,
+              isActionRequired: true,
+              categoryId: impactfulIssueReportId,
+            });
 
-          // when
-          const { juryCertificationSummaries } = await juryCertificationSummaryRepository.findBySessionIdPaginated({
-            page,
-            sessionId,
+            await databaseBuilder.commit();
+
+            // when
+            const { juryCertificationSummaries } = await juryCertificationSummaryRepository.findBySessionIdPaginated({
+              page,
+              sessionId,
+            });
+
+            // then
+            expect(juryCertificationSummaries[0].id).to.equal(certificationWithOneImpactfulCategoryIssueReportId);
+            expect(juryCertificationSummaries[1].id).to.equal(certificationWithNotImpactfulCategoryIssueReportId);
+            expect(juryCertificationSummaries[0].certificationIssueReports.length).to.equal(1);
+            expect(juryCertificationSummaries[1].certificationIssueReports.length).to.equal(1);
           });
+        });
 
-          // then
-          expect(juryCertificationSummaries[0].id).to.equal(certificationWithTwoImpactfulIssueReportsId);
-          expect(juryCertificationSummaries[1].id).to.equal(certificationWithOneImpactfulIssueReportId);
-          expect(juryCertificationSummaries[2].id).to.equal(
-            certificationWithResolvedImpactfulAndNotImpactfulIssueReportsId
-          );
-          expect(juryCertificationSummaries[3].id).to.equal(certificationWithoutIssueReportsId);
-          expect(juryCertificationSummaries[0].certificationIssueReports.length).to.equal(2);
-          expect(juryCertificationSummaries[1].certificationIssueReports.length).to.equal(1);
+        context('when the issue reports are from subcategories', function () {
+          it('should return certifications with unresolved impactful issue reports first', async function () {
+            // given
+            const page = { size: 4, number: 1 };
+            const dbf = databaseBuilder.factory;
+            const sessionId = dbf.buildSession().id;
+            const certificationWithOneImpactfulSubcategoryIssueReportsId = dbf.buildCertificationCourse({
+              id: 101,
+              sessionId,
+              lastName: 'AAA',
+            }).id;
+            const certificationWithoutImpactfulIssueReportId = dbf.buildCertificationCourse({
+              id: 102,
+              sessionId,
+              lastName: 'BBB',
+            }).id;
+
+            dbf.buildIssueReportCategory({
+              id: 3,
+              name: CertificationIssueReportCategories.IN_CHALLENGE,
+              isImpactful: true,
+              isDeprecated: false,
+            });
+            dbf.buildIssueReportCategory({
+              name: CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
+              isImpactful: true,
+              isDeprecated: false,
+              categoryId: 3,
+            });
+
+            dbf.buildCertificationIssueReport({
+              certificationCourseId: certificationWithOneImpactfulSubcategoryIssueReportsId,
+              isActionRequired: true,
+              subcategory: ImpactfulSubcategories[0],
+            });
+
+            await databaseBuilder.commit();
+
+            // when
+            const { juryCertificationSummaries } = await juryCertificationSummaryRepository.findBySessionIdPaginated({
+              page,
+              sessionId,
+            });
+
+            // then
+            expect(juryCertificationSummaries[0].id).to.equal(certificationWithOneImpactfulSubcategoryIssueReportsId);
+            expect(juryCertificationSummaries[1].id).to.equal(certificationWithoutImpactfulIssueReportId);
+
+            expect(juryCertificationSummaries[0].certificationIssueReports.length).to.equal(1);
+            expect(juryCertificationSummaries[1].certificationIssueReports.length).to.equal(0);
+          });
         });
       });
     });

--- a/api/tests/tooling/domain-builder/factory/build-certification-issue-report.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-issue-report.js
@@ -7,7 +7,7 @@ const {
 const buildCertificationIssueReport = function ({
   id = 123,
   certificationCourseId,
-  categoryId = null,
+  categoryId,
   category = CertificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES,
   subcategory = CertificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
   description = 'Une super description',
@@ -38,7 +38,6 @@ buildCertificationIssueReport.impactful = function ({
   resolvedAt,
   resolution,
   hasBeenAutomaticallyResolved,
-  category = CertificationIssueReportCategories.FRAUD,
   categoryId,
 } = {}) {
   return buildCertificationIssueReport({
@@ -49,7 +48,7 @@ buildCertificationIssueReport.impactful = function ({
     resolvedAt,
     resolution,
     categoryId,
-    category,
+    category: CertificationIssueReportCategories.FRAUD,
     subcategory: null,
     hasBeenAutomaticallyResolved,
   });
@@ -63,7 +62,6 @@ buildCertificationIssueReport.notImpactful = function ({
   resolvedAt,
   resolution,
   hasBeenAutomaticallyResolved,
-  category = CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN,
   categoryId,
 } = {}) {
   return buildCertificationIssueReport({
@@ -74,7 +72,7 @@ buildCertificationIssueReport.notImpactful = function ({
     resolvedAt,
     resolution,
     categoryId,
-    category,
+    category: CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN,
     subcategory: null,
     hasBeenAutomaticallyResolved,
   });


### PR DESCRIPTION
## :christmas_tree: Problème
Suite à un bug d’affichage des signalements impactants sur la page d’informations d’une session, une première modification avait été apportée à la requête qui récupère l’ensemble des certifications d’une session, la pagine puis les retourne à l’affichage d’une session de certification dans Pix Admin. (https://1024pix.atlassian.net/browse/PIX-6332)

La requête est devenue trop lourde et cause des tests flaky en CI. Ces tests en erreur deviennent une douleur pour chaque déploiement, il est donc important de trouver une solution pérenne à ce problème.

## :gift: Proposition
Utiliser la nouvelle table pour les catégories de signalements en parallèle du fonctionnement par catégorie et sous-catégorie des certification issue reports dans la requête posant problème. 

## :star2: Remarques


## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._


[PIX-6332]: https://1024pix.atlassian.net/browse/PIX-6332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ