### PR TITLE
[BUGFIX] Stabiliser le test flaky sur InMemoryTemporaryStorage.update()

### DIFF
--- a/api/tests/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
+++ b/api/tests/unit/infrastructure/temporary-storage/InMemoryTemporaryStorage_test.js
@@ -109,15 +109,15 @@ describe('Unit | Infrastructure | temporary-storage | InMemoryTemporaryStorage',
       // given
       const keyWithTtl = inMemoryTemporaryStorage.save({
         value: {},
-        expirationDelaySeconds: 0.2,
+        expirationDelaySeconds: 1,
       });
       const keyWithoutTtl = inMemoryTemporaryStorage.save({ value: {} });
 
       // when
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      await new Promise((resolve) => setTimeout(resolve, 500));
       inMemoryTemporaryStorage.update(keyWithTtl, {});
       inMemoryTemporaryStorage.update(keyWithoutTtl, {});
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await new Promise((resolve) => setTimeout(resolve, 600));
 
       // then
       expect(inMemoryTemporaryStorage.get(keyWithTtl)).to.be.undefined;


### PR DESCRIPTION
## :christmas_tree: Problème
Le test sur InMemoryTemporaryStorage.update() est toujours flaky.

## :gift: Proposition
Stabiliser le test.

## :star2: Remarques
N/A

## :santa: Pour tester
Voir les builds CircleCI, 5 builds stables sur la PR.