### PR TITLE
[TECH] Better blocking error codes

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -939,13 +939,13 @@ class UserHasAlreadyLeftSCO extends DomainError {
 }
 
 class UserIsTemporaryBlocked extends DomainError {
-  constructor(message = 'User has been temporary blocked.', code = 'USER_HAS_BEEN_TEMPORARY_BLOCKED') {
+  constructor(message = 'User has been temporary blocked.', code = 'USER_IS_TEMPORARY_BLOCKED') {
     super(message, code);
   }
 }
 
 class UserIsBlocked extends DomainError {
-  constructor(message = 'User has been blocked.', code = 'USER_HAS_BEEN_BLOCKED') {
+  constructor(message = 'User has been blocked.', code = 'USER_IS_BLOCKED') {
     super(message, code);
   }
 }

--- a/api/tests/integration/application/security-pre-handlers_test.js
+++ b/api/tests/integration/application/security-pre-handlers_test.js
@@ -294,7 +294,7 @@ describe('Integration | Application | SecurityPreHandlers', function () {
 
         // then
         expect(response.statusCode).to.equal(403);
-        expect(response.result.errors[0].code).to.equal('USER_HAS_BEEN_TEMPORARY_BLOCKED');
+        expect(response.result.errors[0].code).to.equal('USER_IS_TEMPORARY_BLOCKED');
       });
     });
 
@@ -336,7 +336,7 @@ describe('Integration | Application | SecurityPreHandlers', function () {
 
         // then
         expect(response.statusCode).to.equal(403);
-        expect(response.result.errors[0].code).to.equal('USER_HAS_BEEN_BLOCKED');
+        expect(response.result.errors[0].code).to.equal('USER_IS_BLOCKED');
       });
     });
   });

--- a/mon-pix/app/components/signin-form.js
+++ b/mon-pix/app/components/signin-form.js
@@ -50,13 +50,13 @@ export default class SigninForm extends Component {
     let httpStatusCodeMessages;
 
     switch (errorCode) {
-      case 'USER_HAS_BEEN_TEMPORARY_BLOCKED':
-        return this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_HAS_BEEN_TEMPORARY_BLOCKED.MESSAGE, {
+      case 'USER_IS_TEMPORARY_BLOCKED':
+        return this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_IS_TEMPORARY_BLOCKED.MESSAGE, {
           url: '/mot-de-passe-oublie',
           htmlSafe: true,
         });
-      case 'USER_HAS_BEEN_BLOCKED':
-        return this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_HAS_BEEN_BLOCKED.MESSAGE, {
+      case 'USER_IS_BLOCKED':
+        return this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_IS_BLOCKED.MESSAGE, {
           url: 'https://support.pix.org/support/tickets/new',
           htmlSafe: true,
         });

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -83,11 +83,11 @@ module.exports = function (environment) {
           CODE: '401',
           MESSAGE: 'api-error-messages.login-unauthorized-error',
         },
-        USER_HAS_BEEN_TEMPORARY_BLOCKED: {
+        USER_IS_TEMPORARY_BLOCKED: {
           CODE: '403',
           MESSAGE: 'api-error-messages.login-user-temporary-blocked-error',
         },
-        USER_HAS_BEEN_BLOCKED: {
+        USER_IS_BLOCKED: {
           CODE: '403',
           MESSAGE: 'api-error-messages.login-user-blocked-error',
         },

--- a/mon-pix/mirage/routes/authentication/post-authentications.js
+++ b/mon-pix/mirage/routes/authentication/post-authentications.js
@@ -13,11 +13,11 @@ export default function (schema, request) {
   const queryParams = parseQueryString(request.requestBody);
 
   if (queryParams.username === 'user.blocked@example.net') {
-    return new Response(403, {}, 'USER_HAS_BEEN_BLOCKED');
+    return new Response(403, {}, 'USER_IS_BLOCKED');
   }
 
   if (queryParams.username == 'user.temporary-blocked@example.net') {
-    return new Response(403, {}, 'USER_HAS_BEEN_TEMPORARY_BLOCKED');
+    return new Response(403, {}, 'USER_IS_TEMPORARY_BLOCKED');
   }
 
   let foundUser = schema.users.findBy({ email: queryParams.username });

--- a/mon-pix/tests/integration/components/signin-form_test.js
+++ b/mon-pix/tests/integration/components/signin-form_test.js
@@ -125,14 +125,14 @@ module('Integration | Component | signin form', function (hooks) {
         module('when is user is temporary blocked', function () {
           test('displays a specific error', async function (assert) {
             // given
-            const expectedErrorMessage = this.intl.t(ApiErrorMessages.USER_HAS_BEEN_TEMPORARY_BLOCKED.MESSAGE, {
+            const expectedErrorMessage = this.intl.t(ApiErrorMessages.USER_IS_TEMPORARY_BLOCKED.MESSAGE, {
               url: '/mot-de-passe-oublie',
               htmlSafe: true,
             });
             class sessionService extends Service {
               authenticateUser = sinon
                 .stub()
-                .rejects({ status: 403, responseJSON: { errors: [{ code: 'USER_HAS_BEEN_TEMPORARY_BLOCKED' }] } });
+                .rejects({ status: 403, responseJSON: { errors: [{ code: 'USER_IS_TEMPORARY_BLOCKED' }] } });
             }
             this.owner.register('service:session', sessionService);
             await render(hbs`<SigninForm />`);
@@ -150,14 +150,14 @@ module('Integration | Component | signin form', function (hooks) {
         module('when is user blocked', function () {
           test('displays a specific error', async function (assert) {
             // given
-            const expectedErrorMessage = this.intl.t(ApiErrorMessages.USER_HAS_BEEN_BLOCKED.MESSAGE, {
+            const expectedErrorMessage = this.intl.t(ApiErrorMessages.USER_IS_BLOCKED.MESSAGE, {
               url: 'https://support.pix.org/support/tickets/new',
               htmlSafe: true,
             });
             class sessionService extends Service {
               authenticateUser = sinon
                 .stub()
-                .rejects({ status: 403, responseJSON: { errors: [{ code: 'USER_HAS_BEEN_BLOCKED' }] } });
+                .rejects({ status: 403, responseJSON: { errors: [{ code: 'USER_IS_BLOCKED' }] } });
             }
             this.owner.register('service:session', sessionService);
             await render(hbs`<SigninForm />`);


### PR DESCRIPTION
## :christmas_tree: Problème

Les codes `USER_HAS_BEEN_TEMPORARY_BLOCKED` et `USER_HAS_BEEN_BLOCKED` sont mal nommés :
* en laissant penser que l'utilisateur a été bloqué mais ne l'est pas plus forcément
* en n'étant pas en cohérence avec le nommage des fonctions du modèle `UserLogin`

## :gift: Proposition

Simplement renommer les codes `USER_HAS_BEEN_TEMPORARY_BLOCKED` et `USER_HAS_BEEN_BLOCKED` respectivement en `USER_IS_TEMPORARY_BLOCKED` et `USER_IS_BLOCKED`.

## :star2: Remarques

RAS

## :santa: Pour tester

Tester fonctionnellement les fonctionnalités de blocage, temporaire et définitif, de comptes et s'assurer qu'il n'y a pas de régression.
