### PR TITLE
[BUGFIX] Éviter les erreurs 500 quand il n'y a pas de palier à 0 et que l'utilisateur rate tout (PIX-6378)

### DIFF
--- a/api/lib/domain/read-models/participant-results/ReachedStage.js
+++ b/api/lib/domain/read-models/participant-results/ReachedStage.js
@@ -1,14 +1,22 @@
+const FALLBACK_STAGE = {
+  id: -1,
+  title: '',
+  message: '',
+  threshold: 0,
+};
+
 class ReachedStage {
+  static FALLBACK_STAGE = FALLBACK_STAGE;
+
   constructor(masteryRate, stages) {
     const stagesOrdered = stages.sort((a, b) => a.threshold - b.threshold);
     const stagesReached = stagesOrdered.filter(({ threshold }) => threshold <= masteryRate * 100);
-    const lastStageReached = stagesReached[stagesReached.length - 1];
+    const lastStageReached = stagesReached[stagesReached.length - 1] || FALLBACK_STAGE;
 
     this.id = lastStageReached.id;
     this.title = lastStageReached.title;
     this.message = lastStageReached.message;
     this.threshold = lastStageReached.threshold;
-
     this.starCount = stagesReached.length;
   }
 }

--- a/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
+++ b/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
@@ -8,6 +8,7 @@ const {
 } = require('../../../test-helper');
 const _ = require('lodash');
 const BadgeCriterion = require('../../../../lib/domain/models/BadgeCriterion');
+const ReachedStage = require('../../../../lib/domain/read-models/participant-results/ReachedStage');
 
 describe('Acceptance | API | Campaign Assessment Result', function () {
   const JAFFA_COLOR = 'jaffa';
@@ -18,70 +19,28 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
 
   let server, badge, skillSet, stage;
 
+  let oldDate, recentDate, futureDate, skillIds, options;
+
   beforeEach(async function () {
     server = await createServer();
 
-    const oldDate = new Date('2018-02-03');
-    const recentDate = new Date('2018-05-06');
-    const futureDate = new Date('2018-07-10');
+    oldDate = new Date('2018-02-03');
+    recentDate = new Date('2018-05-06');
+    futureDate = new Date('2018-07-10');
 
     user = databaseBuilder.factory.buildUser();
     targetProfile = databaseBuilder.factory.buildTargetProfile();
     campaign = databaseBuilder.factory.buildCampaign({
       targetProfileId: targetProfile.id,
     });
-    campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
-      campaignId: campaign.id,
-      userId: user.id,
-      sharedAt: recentDate,
-      masteryRate: 0.38,
-    });
-    assessment = databaseBuilder.factory.buildAssessment({
-      campaignParticipationId: campaignParticipation.id,
-      userId: user.id,
-      type: 'CAMPAIGN',
-      state: 'completed',
-    });
 
-    const skillIds = [
-      'recSkill1',
-      'recSkill2',
-      'recSkill3',
-      'recSkill4',
-      'recSkill5',
-      'recSkill6',
-      'recSkill7',
-      'recSkill8',
-    ];
+    skillIds = ['recSkill1', 'recSkill2', 'recSkill3', 'recSkill4', 'recSkill5', 'recSkill6', 'recSkill7', 'recSkill8'];
 
     targetProfileSkills = _.times(8, (index) => {
       return databaseBuilder.factory.buildTargetProfileSkill({
         targetProfileId: targetProfile.id,
         skillId: skillIds[index],
       });
-    });
-
-    badge = databaseBuilder.factory.buildBadge({
-      id: 1,
-      altMessage: 'Banana',
-      imageUrl: '/img/banana.svg',
-      message: 'You won a Banana Badge',
-      title: 'Banana',
-      key: 'PIX_BANANA',
-      targetProfileId: targetProfile.id,
-    });
-    databaseBuilder.factory.buildBadgeCriterion({
-      badgeId: 1,
-      scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
-      threshold: 0,
-    });
-
-    skillSet = databaseBuilder.factory.buildSkillSet({
-      id: 1,
-      badgeId: 1,
-      name: 'Pix Emploi',
-      color: 'emerald',
-      skillIds,
     });
 
     stage = databaseBuilder.factory.buildStage({
@@ -98,23 +57,6 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
       title: 'palier 2',
       threshold: 50,
       targetProfileId: targetProfile.id,
-    });
-
-    targetProfileSkills.slice(2).forEach((targetProfileSkill, index) => {
-      databaseBuilder.factory.buildKnowledgeElement({
-        userId: user.id,
-        assessmentId: assessment.id,
-        skillId: targetProfileSkill.skillId,
-        status: index < 3 ? 'validated' : 'invalidated',
-        createdAt: index < 5 ? oldDate : futureDate,
-      });
-    });
-
-    databaseBuilder.factory.buildKnowledgeElement({
-      userId: user.id,
-      assessmentId: assessment.id,
-      skillId: 'otherSkillId',
-      createdAt: oldDate,
     });
 
     const learningContent = [
@@ -173,189 +115,390 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
     ];
     const learningContentObjects = learningContentBuilder.buildLearningContent.fromAreas(learningContent);
     mockLearningContent(learningContentObjects);
-    await databaseBuilder.commit();
+
+    options = {
+      method: 'GET',
+      url: `/api/users/${user.id}/campaigns/${campaign.id}/assessment-result`,
+      headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+    };
   });
 
   describe('GET /api/users/{userId}/campaigns/{campaignId}/assessment-result', function () {
-    let options;
+    describe('when user has some success', function () {
+      beforeEach(async function () {
+        campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          userId: user.id,
+          sharedAt: recentDate,
+          masteryRate: 0.38,
+        });
 
-    beforeEach(async function () {
-      options = {
-        method: 'GET',
-        url: `/api/users/${user.id}/campaigns/${campaign.id}/assessment-result`,
-        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
-      };
+        badge = databaseBuilder.factory.buildBadge({
+          id: 1,
+          altMessage: 'Banana',
+          imageUrl: '/img/banana.svg',
+          message: 'You won a Banana Badge',
+          title: 'Banana',
+          key: 'PIX_BANANA',
+          targetProfileId: targetProfile.id,
+        });
+        databaseBuilder.factory.buildBadgeCriterion({
+          badgeId: 1,
+          scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
+          threshold: 0,
+        });
+
+        skillSet = databaseBuilder.factory.buildSkillSet({
+          id: 1,
+          badgeId: 1,
+          name: 'Pix Emploi',
+          color: 'emerald',
+          skillIds,
+        });
+
+        assessment = databaseBuilder.factory.buildAssessment({
+          campaignParticipationId: campaignParticipation.id,
+          userId: user.id,
+          type: 'CAMPAIGN',
+          state: 'completed',
+        });
+
+        targetProfileSkills.slice(2).forEach((targetProfileSkill, index) => {
+          databaseBuilder.factory.buildKnowledgeElement({
+            userId: user.id,
+            assessmentId: assessment.id,
+            skillId: targetProfileSkill.skillId,
+            status: index < 3 ? 'validated' : 'invalidated',
+            createdAt: index < 5 ? oldDate : futureDate,
+          });
+        });
+
+        databaseBuilder.factory.buildKnowledgeElement({
+          userId: user.id,
+          assessmentId: assessment.id,
+          skillId: 'otherSkillId',
+          createdAt: oldDate,
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should return the campaign assessment result', async function () {
+        // given
+        const expectedResponse = {
+          data: {
+            type: 'campaign-participation-results',
+            id: campaignParticipation.id.toString(),
+            attributes: {
+              'mastery-rate': 0.38,
+              'total-skills-count': 8,
+              'tested-skills-count': 5,
+              'validated-skills-count': 3,
+              'is-completed': true,
+              'is-shared': true,
+              'stage-count': 2,
+              'can-retry': false,
+              'can-improve': false,
+              'is-disabled': false,
+              'participant-external-id': 'participantExternalId',
+              'estimated-flash-level': undefined,
+            },
+            relationships: {
+              'campaign-participation-badges': {
+                data: [
+                  {
+                    id: `${badge.id}`,
+                    type: 'campaignParticipationBadges',
+                  },
+                ],
+              },
+              'competence-results': {
+                data: [
+                  {
+                    id: '1',
+                    type: 'competenceResults',
+                  },
+                  {
+                    id: '2',
+                    type: 'competenceResults',
+                  },
+                  {
+                    id: '3',
+                    type: 'competenceResults',
+                  },
+                ],
+              },
+              'reached-stage': {
+                data: {
+                  id: `${stage.id}`,
+                  type: 'reached-stages',
+                },
+              },
+            },
+          },
+          included: [
+            {
+              attributes: {
+                'area-color': undefined,
+                'mastery-percentage': 38,
+                name: 'Pix Emploi',
+                'tested-skills-count': 5,
+                'total-skills-count': 8,
+                'validated-skills-count': 3,
+              },
+              id: skillSet.id.toString(),
+              type: 'skillSetResults',
+            },
+            {
+              attributes: {
+                'area-color': undefined,
+                'mastery-percentage': 38,
+                name: 'Pix Emploi',
+                'tested-skills-count': 5,
+                'total-skills-count': 8,
+                'validated-skills-count': 3,
+              },
+              id: skillSet.id.toString(),
+              type: 'partnerCompetenceResults',
+            },
+            {
+              attributes: {
+                'alt-message': 'Banana',
+                'image-url': '/img/banana.svg',
+                'is-acquired': false,
+                'is-always-visible': false,
+                'is-certifiable': false,
+                'is-valid': true,
+                key: 'PIX_BANANA',
+                title: 'Banana',
+                message: 'You won a Banana Badge',
+              },
+              id: '1',
+              type: 'campaignParticipationBadges',
+              relationships: {
+                'skill-set-results': {
+                  data: [
+                    {
+                      id: '1',
+                      type: 'skillSetResults',
+                    },
+                  ],
+                },
+                'partner-competence-results': {
+                  data: [
+                    {
+                      id: '1',
+                      type: 'partnerCompetenceResults',
+                    },
+                  ],
+                },
+              },
+            },
+            {
+              type: 'competenceResults',
+              id: '1',
+              attributes: {
+                name: 'Agir collectivement',
+                index: '1.2',
+                'mastery-percentage': 0,
+                'total-skills-count': 1,
+                'tested-skills-count': 0,
+                'validated-skills-count': 0,
+                'area-color': JAFFA_COLOR,
+              },
+            },
+            {
+              type: 'competenceResults',
+              id: '2',
+              attributes: {
+                name: 'Nécessité de la pensée radicale',
+                index: '2.1',
+                'mastery-percentage': 67,
+                'total-skills-count': 3,
+                'tested-skills-count': 2,
+                'validated-skills-count': 2,
+                'area-color': EMERALD_COLOR,
+              },
+            },
+            {
+              type: 'competenceResults',
+              id: '3',
+              attributes: {
+                name: 'Changer efficacement le monde',
+                index: '2.2',
+                'mastery-percentage': 25,
+                'total-skills-count': 4,
+                'tested-skills-count': 3,
+                'validated-skills-count': 1,
+                'area-color': EMERALD_COLOR,
+              },
+            },
+            {
+              attributes: {
+                message: 'Tu as le palier 1',
+                title: 'palier 1',
+                threshold: 20,
+                'star-count': 1,
+              },
+              id: stage.id.toString(),
+              type: 'reached-stages',
+            },
+          ],
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.result).to.deep.equal(expectedResponse);
+        expect(response.statusCode).to.equal(200);
+      });
     });
 
-    it('should return the campaign assessment result', async function () {
-      // given
-      const expectedResponse = {
-        data: {
-          type: 'campaign-participation-results',
-          id: campaignParticipation.id.toString(),
-          attributes: {
-            'mastery-rate': 0.38,
-            'total-skills-count': 8,
-            'tested-skills-count': 5,
-            'validated-skills-count': 3,
-            'is-completed': true,
-            'is-shared': true,
-            'stage-count': 2,
-            'can-retry': false,
-            'can-improve': false,
-            'is-disabled': false,
-            'participant-external-id': 'participantExternalId',
-            'estimated-flash-level': undefined,
-          },
-          relationships: {
-            'campaign-participation-badges': {
-              data: [
-                {
-                  id: `${badge.id}`,
-                  type: 'campaignParticipationBadges',
-                },
-              ],
-            },
-            'competence-results': {
-              data: [
-                {
-                  id: '1',
-                  type: 'competenceResults',
-                },
-                {
-                  id: '2',
-                  type: 'competenceResults',
-                },
-                {
-                  id: '3',
-                  type: 'competenceResults',
-                },
-              ],
-            },
-            'reached-stage': {
-              data: {
-                id: `${stage.id}`,
-                type: 'reached-stages',
-              },
-            },
-          },
-        },
-        included: [
-          {
+    describe('when user fails everything', function () {
+      beforeEach(async function () {
+        campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          userId: user.id,
+          sharedAt: recentDate,
+          masteryRate: 0,
+        });
+
+        assessment = databaseBuilder.factory.buildAssessment({
+          campaignParticipationId: campaignParticipation.id,
+          userId: user.id,
+          type: 'CAMPAIGN',
+          state: 'completed',
+        });
+
+        targetProfileSkills.slice(2).forEach((targetProfileSkill, index) => {
+          databaseBuilder.factory.buildKnowledgeElement({
+            userId: user.id,
+            assessmentId: assessment.id,
+            skillId: targetProfileSkill.skillId,
+            status: 'invalidated',
+            createdAt: index < 5 ? oldDate : futureDate,
+          });
+        });
+
+        databaseBuilder.factory.buildKnowledgeElement({
+          userId: user.id,
+          assessmentId: assessment.id,
+          skillId: 'otherSkillId',
+          createdAt: oldDate,
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should return the campaign assessment result', async function () {
+        // given
+        const expectedResponse = {
+          data: {
+            type: 'campaign-participation-results',
+            id: campaignParticipation.id.toString(),
             attributes: {
-              'area-color': undefined,
-              'mastery-percentage': 38,
-              name: 'Pix Emploi',
-              'tested-skills-count': 5,
+              'mastery-rate': 0,
               'total-skills-count': 8,
-              'validated-skills-count': 3,
-            },
-            id: skillSet.id.toString(),
-            type: 'skillSetResults',
-          },
-          {
-            attributes: {
-              'area-color': undefined,
-              'mastery-percentage': 38,
-              name: 'Pix Emploi',
               'tested-skills-count': 5,
-              'total-skills-count': 8,
-              'validated-skills-count': 3,
-            },
-            id: skillSet.id.toString(),
-            type: 'partnerCompetenceResults',
-          },
-          {
-            attributes: {
-              'alt-message': 'Banana',
-              'image-url': '/img/banana.svg',
-              'is-acquired': false,
-              'is-always-visible': false,
-              'is-certifiable': false,
-              'is-valid': true,
-              key: 'PIX_BANANA',
-              title: 'Banana',
-              message: 'You won a Banana Badge',
-            },
-            id: '1',
-            type: 'campaignParticipationBadges',
-            relationships: {
-              'skill-set-results': {
-                data: [
-                  {
-                    id: '1',
-                    type: 'skillSetResults',
-                  },
-                ],
-              },
-              'partner-competence-results': {
-                data: [
-                  {
-                    id: '1',
-                    type: 'partnerCompetenceResults',
-                  },
-                ],
-              },
-            },
-          },
-          {
-            type: 'competenceResults',
-            id: '1',
-            attributes: {
-              name: 'Agir collectivement',
-              index: '1.2',
-              'mastery-percentage': 0,
-              'total-skills-count': 1,
-              'tested-skills-count': 0,
               'validated-skills-count': 0,
-              'area-color': JAFFA_COLOR,
+              'is-completed': true,
+              'is-shared': true,
+              'stage-count': 2,
+              'can-retry': false,
+              'can-improve': false,
+              'is-disabled': false,
+              'participant-external-id': 'participantExternalId',
+              'estimated-flash-level': undefined,
+            },
+            relationships: {
+              'campaign-participation-badges': {
+                data: [],
+              },
+              'competence-results': {
+                data: [
+                  {
+                    id: '1',
+                    type: 'competenceResults',
+                  },
+                  {
+                    id: '2',
+                    type: 'competenceResults',
+                  },
+                  {
+                    id: '3',
+                    type: 'competenceResults',
+                  },
+                ],
+              },
+              'reached-stage': {
+                data: {
+                  id: `${ReachedStage.FALLBACK_STAGE.id}`,
+                  type: 'reached-stages',
+                },
+              },
             },
           },
-          {
-            type: 'competenceResults',
-            id: '2',
-            attributes: {
-              name: 'Nécessité de la pensée radicale',
-              index: '2.1',
-              'mastery-percentage': 67,
-              'total-skills-count': 3,
-              'tested-skills-count': 2,
-              'validated-skills-count': 2,
-              'area-color': EMERALD_COLOR,
+          included: [
+            {
+              type: 'competenceResults',
+              id: '1',
+              attributes: {
+                name: 'Agir collectivement',
+                index: '1.2',
+                'mastery-percentage': 0,
+                'total-skills-count': 1,
+                'tested-skills-count': 0,
+                'validated-skills-count': 0,
+                'area-color': JAFFA_COLOR,
+              },
             },
-          },
-          {
-            type: 'competenceResults',
-            id: '3',
-            attributes: {
-              name: 'Changer efficacement le monde',
-              index: '2.2',
-              'mastery-percentage': 25,
-              'total-skills-count': 4,
-              'tested-skills-count': 3,
-              'validated-skills-count': 1,
-              'area-color': EMERALD_COLOR,
+            {
+              type: 'competenceResults',
+              id: '2',
+              attributes: {
+                name: 'Nécessité de la pensée radicale',
+                index: '2.1',
+                'mastery-percentage': 0,
+                'total-skills-count': 3,
+                'tested-skills-count': 2,
+                'validated-skills-count': 0,
+                'area-color': EMERALD_COLOR,
+              },
             },
-          },
-          {
-            attributes: {
-              message: 'Tu as le palier 1',
-              title: 'palier 1',
-              threshold: 20,
-              'star-count': 1,
+            {
+              type: 'competenceResults',
+              id: '3',
+              attributes: {
+                name: 'Changer efficacement le monde',
+                index: '2.2',
+                'mastery-percentage': 0,
+                'total-skills-count': 4,
+                'tested-skills-count': 3,
+                'validated-skills-count': 0,
+                'area-color': EMERALD_COLOR,
+              },
             },
-            id: stage.id.toString(),
-            type: 'reached-stages',
-          },
-        ],
-      };
+            {
+              attributes: {
+                title: ReachedStage.FALLBACK_STAGE.title,
+                message: ReachedStage.FALLBACK_STAGE.message,
+                threshold: ReachedStage.FALLBACK_STAGE.threshold,
+                'star-count': 0,
+              },
+              id: ReachedStage.FALLBACK_STAGE.id.toString(),
+              type: 'reached-stages',
+            },
+          ],
+        };
 
-      // when
-      const response = await server.inject(options);
+        // when
+        const response = await server.inject(options);
 
-      // then
-      expect(response.result).to.deep.equal(expectedResponse);
-      expect(response.statusCode).to.equal(200);
+        // then
+        expect(response.result).to.deep.equal(expectedResponse);
+        expect(response.statusCode).to.equal(200);
+      });
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
@@ -584,38 +584,6 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
           threshold: 100,
         });
         databaseBuilder.factory.buildStage({ targetProfileId: otherTargetProfileId });
-        const knowledgeElementsAttributes = [
-          {
-            userId,
-            skillId: 'skill1',
-            competenceId: 'rec1',
-            createdAt: new Date('2020-01-01'),
-            status: KnowledgeElement.StatusType.VALIDATED,
-          },
-          {
-            userId,
-            skillId: 'skill2',
-            competenceId: 'rec1',
-            createdAt: new Date('2020-01-01'),
-            status: KnowledgeElement.StatusType.VALIDATED,
-          },
-          {
-            userId,
-            skillId: 'skill3',
-            competenceId: 'rec2',
-            createdAt: new Date('2020-01-01'),
-            status: KnowledgeElement.StatusType.INVALIDATED,
-          },
-          {
-            userId,
-            skillId: 'skill4',
-            competenceId: 'rec2',
-            createdAt: new Date('2020-01-01'),
-            status: KnowledgeElement.StatusType.VALIDATED,
-          },
-        ];
-
-        knowledgeElementsAttributes.forEach((attributes) => databaseBuilder.factory.buildKnowledgeElement(attributes));
 
         await databaseBuilder.commit();
         const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
@@ -633,6 +601,55 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
           title: 'Stage2',
         });
         expect(participantResult.stageCount).to.equal(4);
+      });
+
+      it('returns no stage if their is no stage 0 and the user fails everything', async function () {
+        const { id: otherTargetProfileId } = databaseBuilder.factory.buildTargetProfile();
+        const { id: userId } = databaseBuilder.factory.buildUser();
+        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
+          userId,
+          campaignId,
+          masteryRate: 0,
+          sharedAt: new Date('2020-01-02'),
+        });
+
+        databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId, state: 'completed' });
+        databaseBuilder.factory.buildStage({
+          id: 1,
+          title: 'Stage1',
+          message: 'Message1',
+          targetProfileId: targetProfile.id,
+          threshold: 10,
+        });
+        databaseBuilder.factory.buildStage({
+          id: 2,
+          title: 'Stage2',
+          message: 'Message2',
+          targetProfileId: targetProfile.id,
+          threshold: 50,
+        });
+        databaseBuilder.factory.buildStage({
+          id: 3,
+          title: 'Stage3',
+          message: 'Message3',
+          targetProfileId: targetProfile.id,
+          threshold: 100,
+        });
+        databaseBuilder.factory.buildStage({ targetProfileId: otherTargetProfileId });
+
+        await databaseBuilder.commit();
+        const participantResult = await participantResultRepository.getByUserIdAndCampaignId({
+          userId,
+          campaignId,
+          targetProfile,
+          badges: [],
+          locale: 'FR',
+        });
+        expect(participantResult.reachedStage).to.deep.include({
+          starCount: 0,
+        });
+        expect(participantResult.stageCount).to.equal(3);
       });
     });
 

--- a/api/tests/unit/domain/models/CampaignParticipationResult_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipationResult_test.js
@@ -85,15 +85,16 @@ describe('Unit | Domain | Models | CampaignParticipationResult', function () {
     });
 
     context('when stages', function () {
-      const stages = [
-        { title: 'palier 1', message: 'Tu as le palier 1', threshold: 0 },
-        { title: 'palier 2', message: 'Tu as le palier 2', threshold: 20 },
-        { title: 'palier 3', message: 'Tu as le palier 3', threshold: 40 },
-        { title: 'palier 4', message: 'Tu as le palier 4', threshold: 60 },
-        { title: 'palier 5', message: 'Tu as le palier 5', threshold: 80 },
-      ];
-
       it('when user has reached a stage', function () {
+        // given
+        const stages = [
+          { title: 'palier 1', message: 'Tu as le palier 1', threshold: 0 },
+          { title: 'palier 2', message: 'Tu as le palier 2', threshold: 20 },
+          { title: 'palier 3', message: 'Tu as le palier 3', threshold: 40 },
+          { title: 'palier 4', message: 'Tu as le palier 4', threshold: 60 },
+          { title: 'palier 5', message: 'Tu as le palier 5', threshold: 80 },
+        ];
+
         // when
         const result = CampaignParticipationResult.buildFrom({
           campaignParticipationId,
@@ -129,6 +130,66 @@ describe('Unit | Domain | Models | CampaignParticipationResult', function () {
               totalSkillsCount: 1,
               testedSkillsCount: 1,
               validatedSkillsCount: 1,
+            },
+            {
+              id: 2,
+              name: 'Désobéissance civile',
+              index: '6.9',
+              areaColor: 'wild-strawberry',
+              areaName: 'area 2',
+              totalSkillsCount: 3,
+              testedSkillsCount: 1,
+              validatedSkillsCount: 0,
+            },
+          ],
+        });
+      });
+
+      it('when user has not reached a stage', function () {
+        // given
+        const stages = [
+          { title: 'palier 1', message: 'Tu as le palier 1', threshold: 20 },
+          { title: 'palier 2', message: 'Tu as le palier 2', threshold: 40 },
+          { title: 'palier 3', message: 'Tu as le palier 3', threshold: 60 },
+          { title: 'palier 4', message: 'Tu as le palier 4', threshold: 80 },
+        ];
+
+        // when
+        const result = CampaignParticipationResult.buildFrom({
+          campaignParticipationId,
+          assessment,
+          competences,
+          stages,
+          skillIds,
+          knowledgeElements: [
+            new KnowledgeElement({ skillId: 1, status: 'invalidated' }),
+            new KnowledgeElement({ skillId: 2, status: 'invalidated' }),
+            new KnowledgeElement({ skillId: 7, status: 'invalidated' }),
+          ],
+        });
+
+        // then
+        expect(result).to.deep.equal({
+          id: campaignParticipationId,
+          isCompleted: false,
+          totalSkillsCount: 4,
+          testedSkillsCount: 2,
+          validatedSkillsCount: 0,
+          knowledgeElementsCount: 2,
+          reachedStage: {
+            starCount: 0,
+          },
+          stageCount: 4,
+          competenceResults: [
+            {
+              id: 1,
+              name: 'Economie symbiotique',
+              index: '5.1',
+              areaColor: 'jaffa',
+              areaName: 'area 1',
+              totalSkillsCount: 1,
+              testedSkillsCount: 1,
+              validatedSkillsCount: 0,
             },
             {
               id: 2,

--- a/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
@@ -257,6 +257,44 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
       expect(assessmentResult.reachedStage).to.deep.include({ id: 2, title: 'Stage2', starCount: 2 });
       expect(assessmentResult.stageCount).to.equal(3);
     });
+
+    it('gives no reached stage if user fails everything', function () {
+      const competences = [
+        {
+          id: 'rec1',
+          name: 'C1',
+          index: '1.1',
+          areaName: 'Domaine1',
+          areaColor: 'Couleur1',
+          skillIds: ['skill1', 'skill2', 'skill3'],
+        },
+      ];
+
+      const knowledgeElements = [
+        domainBuilder.buildKnowledgeElement({ skillId: 'skill1', status: KnowledgeElement.StatusType.INVALIDATED }),
+        domainBuilder.buildKnowledgeElement({ skillId: 'skill2', status: KnowledgeElement.StatusType.INVALIDATED }),
+        domainBuilder.buildKnowledgeElement({ skillId: 'skill3', status: KnowledgeElement.StatusType.INVALIDATED }),
+      ];
+      const participationResults = { knowledgeElements, acquiredBadgeIds: [], masteryRate: '0' };
+
+      const stages = [
+        { id: 1, title: 'Stage1', message: 'message1', threshold: 25 },
+        { id: 2, title: 'Stage2', message: 'message2', threshold: 60 },
+        { id: 3, title: 'Stage3', message: 'message3', threshold: 90 },
+      ];
+
+      const assessmentResult = new AssessmentResult({
+        participationResults,
+        stages,
+        badgeResultsDTO: [],
+        competences,
+        isCampaignMultipleSendings: false,
+        isOrganizationLearnerActive: false,
+      });
+
+      expect(assessmentResult.reachedStage).to.deep.include({ starCount: 0 });
+      expect(assessmentResult.stageCount).to.equal(3);
+    });
   });
 
   describe('when the target profile has badges', function () {

--- a/api/tests/unit/domain/read-models/participant-results/ReachedStage_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/ReachedStage_test.js
@@ -2,13 +2,16 @@ const { expect } = require('../../../../test-helper');
 const ReachedStage = require('../../../../../lib/domain/read-models/participant-results/ReachedStage');
 
 describe('Unit | Domain | Read-Models | ParticipantResults | ReachedStage', function () {
-  it('gives the stage reached and the number of stars', function () {
-    const stages = [
+  let stages;
+  beforeEach(function () {
+    stages = [
       { id: 1, title: 'Stage1', message: 'message1', threshold: 25 },
       { id: 2, title: 'Stage2', message: 'message2', threshold: 60 },
       { id: 3, title: 'Stage3', message: 'message3', threshold: 90 },
     ];
+  });
 
+  it('gives the stage reached and the number of stars', function () {
     const profileStage = new ReachedStage(0.66, stages);
 
     expect(profileStage).to.deep.equal({
@@ -17,6 +20,18 @@ describe('Unit | Domain | Read-Models | ParticipantResults | ReachedStage', func
       message: 'message2',
       threshold: 60,
       starCount: 2,
+    });
+  });
+
+  it('gives undefined stage values and 0 stars if reached stage is below minimum threshold', function () {
+    const profileStage = new ReachedStage(0, stages);
+
+    expect(profileStage).to.deep.equal({
+      id: -1,
+      title: '',
+      message: '',
+      threshold: 0,
+      starCount: 0,
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -2,214 +2,348 @@ const { expect, domainBuilder } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/participant-result-serializer');
 const AssessmentResult = require('../../../../../lib/domain/read-models/participant-results/AssessmentResult');
 const KnowledgeElement = require('../../../../../lib/domain/models/KnowledgeElement');
+const ReachedStage = require('../../../../../lib/domain/read-models/participant-results/ReachedStage');
 
 describe('Unit | Serializer | JSON API | participant-result-serializer', function () {
   describe('#serialize', function () {
     let assessmentResult;
 
-    beforeEach(function () {
-      const isCampaignMultipleSendings = true;
-      const isOrganizationLearnerActive = true;
-      const isCampaignArchived = false;
-      const knowledgeElements = [
-        domainBuilder.buildKnowledgeElement({
-          skillId: 'skill1',
-          createdAt: new Date('2020-01-01'),
-          status: KnowledgeElement.StatusType.VALIDATED,
-        }),
-        domainBuilder.buildKnowledgeElement({
-          skillId: 'skill2',
-          createdAt: new Date('2020-01-01'),
-          status: KnowledgeElement.StatusType.INVALIDATED,
-        }),
-      ];
+    describe('when user reaches minimum stage threshold', function () {
+      beforeEach(function () {
+        const isCampaignMultipleSendings = true;
+        const isOrganizationLearnerActive = true;
+        const isCampaignArchived = false;
+        const knowledgeElements = [
+          domainBuilder.buildKnowledgeElement({
+            skillId: 'skill1',
+            createdAt: new Date('2020-01-01'),
+            status: KnowledgeElement.StatusType.VALIDATED,
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: 'skill2',
+            createdAt: new Date('2020-01-01'),
+            status: KnowledgeElement.StatusType.INVALIDATED,
+          }),
+        ];
 
-      const participationResults = {
-        campaignParticipationId: 1,
-        isCompleted: true,
-        sharedAt: new Date('2020-01-01'),
-        knowledgeElements: knowledgeElements,
-        acquiredBadgeIds: [3],
-        participantExternalId: 'greg@lafleche.fr',
-        masteryRate: 0.5,
-        estimatedFlashLevel: -2.4672347856,
-        isDeleted: false,
-      };
+        const participationResults = {
+          campaignParticipationId: 1,
+          isCompleted: true,
+          sharedAt: new Date('2020-01-01'),
+          knowledgeElements: knowledgeElements,
+          acquiredBadgeIds: [3],
+          participantExternalId: 'greg@lafleche.fr',
+          masteryRate: 0.5,
+          estimatedFlashLevel: -2.4672347856,
+          isDeleted: false,
+        };
 
-      const competences = [
-        {
-          id: 'C1',
-          name: 'Competence1',
-          index: '1.1',
-          areaName: 'AreaName',
-          areaColor: 'AreaColor',
-          skillIds: ['skill1', 'skill2'],
-        },
-      ];
+        const competences = [
+          {
+            id: 'C1',
+            name: 'Competence1',
+            index: '1.1',
+            areaName: 'AreaName',
+            areaColor: 'AreaColor',
+            skillIds: ['skill1', 'skill2'],
+          },
+        ];
 
-      const stages = [
-        { id: 2, title: 'Stage1', message: 'Message1', threshold: 0 },
-        { id: 3, title: 'Stage2', message: 'Message2', threshold: 50 },
-        { id: 4, title: 'Stage1', message: 'Message1', threshold: 100 },
-      ];
-      const badgeResultsDTO = [
-        {
-          id: 3,
-          altMessage: 'Badge2 AltMessage',
-          message: 'Badge2 Message',
-          title: 'Badge2 Title',
-          imageUrl: 'Badge2 ImgUrl',
-          key: 'Badge2 Key',
-          badgeCompetences: [{ id: 31, name: 'BadgeC1', color: 'BadgeColor', skillIds: ['skill1'] }],
-          isAlwaysVisible: true,
-          isCertifiable: false,
-          isValid: true,
-        },
-      ];
+        const stages = [
+          { id: 2, title: 'Stage1', message: 'Message1', threshold: 0 },
+          { id: 3, title: 'Stage2', message: 'Message2', threshold: 50 },
+          { id: 4, title: 'Stage1', message: 'Message1', threshold: 100 },
+        ];
+        const badgeResultsDTO = [
+          {
+            id: 3,
+            altMessage: 'Badge2 AltMessage',
+            message: 'Badge2 Message',
+            title: 'Badge2 Title',
+            imageUrl: 'Badge2 ImgUrl',
+            key: 'Badge2 Key',
+            badgeCompetences: [{ id: 31, name: 'BadgeC1', color: 'BadgeColor', skillIds: ['skill1'] }],
+            isAlwaysVisible: true,
+            isCertifiable: false,
+            isValid: true,
+          },
+        ];
 
-      assessmentResult = new AssessmentResult({
-        participationResults,
-        competences,
-        stages,
-        badgeResultsDTO,
-        isCampaignMultipleSendings,
-        isOrganizationLearnerActive,
-        isCampaignArchived,
+        assessmentResult = new AssessmentResult({
+          participationResults,
+          competences,
+          stages,
+          badgeResultsDTO,
+          isCampaignMultipleSendings,
+          isOrganizationLearnerActive,
+          isCampaignArchived,
+        });
       });
-    });
 
-    it('should convert a CampaignParticipationResult model object into JSON API data', function () {
-      const expectedSerializedCampaignParticipationResult = {
-        data: {
-          attributes: {
-            'is-completed': true,
-            'is-shared': true,
-            'mastery-rate': 0.5,
-            'tested-skills-count': 2,
-            'total-skills-count': 2,
-            'validated-skills-count': 1,
-            'stage-count': 3,
-            'can-retry': true,
-            'can-improve': false,
-            'is-disabled': false,
-            'participant-external-id': 'greg@lafleche.fr',
-            'estimated-flash-level': -2.4672347856,
-          },
-          id: '1',
-          relationships: {
-            'campaign-participation-badges': {
-              data: [
-                {
-                  id: '3',
-                  type: 'campaignParticipationBadges',
-                },
-              ],
-            },
-            'competence-results': {
-              data: [
-                {
-                  id: 'C1',
-                  type: 'competenceResults',
-                },
-              ],
-            },
-            'reached-stage': {
-              data: {
-                id: '3',
-                type: 'reached-stages',
-              },
-            },
-          },
-          type: 'campaign-participation-results',
-        },
-        included: [
-          {
+      it('should convert a CampaignParticipationResult model object into JSON API data', function () {
+        const expectedSerializedCampaignParticipationResult = {
+          data: {
             attributes: {
-              'area-color': undefined,
-              'mastery-percentage': 100,
-              name: 'BadgeC1',
-              'tested-skills-count': 1,
-              'total-skills-count': 1,
-              'validated-skills-count': 1,
-            },
-            id: '31',
-            type: 'skillSetResults',
-          },
-          {
-            attributes: {
-              'area-color': undefined,
-              'mastery-percentage': 100,
-              name: 'BadgeC1',
-              'tested-skills-count': 1,
-              'total-skills-count': 1,
-              'validated-skills-count': 1,
-            },
-            id: '31',
-            type: 'partnerCompetenceResults',
-          },
-          {
-            attributes: {
-              'alt-message': 'Badge2 AltMessage',
-              message: 'Badge2 Message',
-              title: 'Badge2 Title',
-              'image-url': 'Badge2 ImgUrl',
-              key: 'Badge2 Key',
-              'is-acquired': true,
-              'is-always-visible': true,
-              'is-certifiable': false,
-              'is-valid': true,
-            },
-            id: '3',
-            type: 'campaignParticipationBadges',
-            relationships: {
-              'skill-set-results': {
-                data: [
-                  {
-                    id: '31',
-                    type: 'skillSetResults',
-                  },
-                ],
-              },
-              'partner-competence-results': {
-                data: [
-                  {
-                    id: '31',
-                    type: 'partnerCompetenceResults',
-                  },
-                ],
-              },
-            },
-          },
-          {
-            attributes: {
-              'area-color': 'AreaColor',
-              index: '1.1',
-              name: 'Competence1',
-              'mastery-percentage': 50,
+              'is-completed': true,
+              'is-shared': true,
+              'mastery-rate': 0.5,
               'tested-skills-count': 2,
               'total-skills-count': 2,
               'validated-skills-count': 1,
+              'stage-count': 3,
+              'can-retry': true,
+              'can-improve': false,
+              'is-disabled': false,
+              'participant-external-id': 'greg@lafleche.fr',
+              'estimated-flash-level': -2.4672347856,
             },
-            id: 'C1',
-            type: 'competenceResults',
-          },
-          {
-            attributes: {
-              title: 'Stage2',
-              message: 'Message2',
-              threshold: 50,
-              'star-count': 2,
+            id: '1',
+            relationships: {
+              'campaign-participation-badges': {
+                data: [
+                  {
+                    id: '3',
+                    type: 'campaignParticipationBadges',
+                  },
+                ],
+              },
+              'competence-results': {
+                data: [
+                  {
+                    id: 'C1',
+                    type: 'competenceResults',
+                  },
+                ],
+              },
+              'reached-stage': {
+                data: {
+                  id: '3',
+                  type: 'reached-stages',
+                },
+              },
             },
-            id: '3',
-            type: 'reached-stages',
+            type: 'campaign-participation-results',
           },
-        ],
-      };
+          included: [
+            {
+              attributes: {
+                'area-color': undefined,
+                'mastery-percentage': 100,
+                name: 'BadgeC1',
+                'tested-skills-count': 1,
+                'total-skills-count': 1,
+                'validated-skills-count': 1,
+              },
+              id: '31',
+              type: 'skillSetResults',
+            },
+            {
+              attributes: {
+                'area-color': undefined,
+                'mastery-percentage': 100,
+                name: 'BadgeC1',
+                'tested-skills-count': 1,
+                'total-skills-count': 1,
+                'validated-skills-count': 1,
+              },
+              id: '31',
+              type: 'partnerCompetenceResults',
+            },
+            {
+              attributes: {
+                'alt-message': 'Badge2 AltMessage',
+                message: 'Badge2 Message',
+                title: 'Badge2 Title',
+                'image-url': 'Badge2 ImgUrl',
+                key: 'Badge2 Key',
+                'is-acquired': true,
+                'is-always-visible': true,
+                'is-certifiable': false,
+                'is-valid': true,
+              },
+              id: '3',
+              type: 'campaignParticipationBadges',
+              relationships: {
+                'skill-set-results': {
+                  data: [
+                    {
+                      id: '31',
+                      type: 'skillSetResults',
+                    },
+                  ],
+                },
+                'partner-competence-results': {
+                  data: [
+                    {
+                      id: '31',
+                      type: 'partnerCompetenceResults',
+                    },
+                  ],
+                },
+              },
+            },
+            {
+              attributes: {
+                'area-color': 'AreaColor',
+                index: '1.1',
+                name: 'Competence1',
+                'mastery-percentage': 50,
+                'tested-skills-count': 2,
+                'total-skills-count': 2,
+                'validated-skills-count': 1,
+              },
+              id: 'C1',
+              type: 'competenceResults',
+            },
+            {
+              attributes: {
+                title: 'Stage2',
+                message: 'Message2',
+                threshold: 50,
+                'star-count': 2,
+              },
+              id: '3',
+              type: 'reached-stages',
+            },
+          ],
+        };
 
-      // when
-      const json = serializer.serialize(assessmentResult);
-      // then
-      expect(json).to.deep.equal(expectedSerializedCampaignParticipationResult);
+        // when
+        const json = serializer.serialize(assessmentResult);
+        // then
+        expect(json).to.deep.equal(expectedSerializedCampaignParticipationResult);
+      });
+    });
+
+    describe('when user does not reach minimum stage threshold', function () {
+      beforeEach(function () {
+        const isCampaignMultipleSendings = true;
+        const isOrganizationLearnerActive = true;
+        const isCampaignArchived = false;
+        const knowledgeElements = [
+          domainBuilder.buildKnowledgeElement({
+            skillId: 'skill1',
+            createdAt: new Date('2020-01-01'),
+            status: KnowledgeElement.StatusType.INVALIDATED,
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: 'skill2',
+            createdAt: new Date('2020-01-01'),
+            status: KnowledgeElement.StatusType.INVALIDATED,
+          }),
+        ];
+
+        const participationResults = {
+          campaignParticipationId: 1,
+          isCompleted: true,
+          sharedAt: new Date('2020-01-01'),
+          knowledgeElements: knowledgeElements,
+          acquiredBadgeIds: [],
+          participantExternalId: 'greg@lafleche.fr',
+          masteryRate: 0,
+          estimatedFlashLevel: -10,
+          isDeleted: false,
+        };
+
+        const competences = [
+          {
+            id: 'C1',
+            name: 'Competence1',
+            index: '1.1',
+            areaName: 'AreaName',
+            areaColor: 'AreaColor',
+            skillIds: ['skill1', 'skill2'],
+          },
+        ];
+
+        const stages = [
+          { id: 3, title: 'Stage1', message: 'Message1', threshold: 50 },
+          { id: 4, title: 'Stage2', message: 'Message2', threshold: 100 },
+        ];
+        const badgeResultsDTO = [];
+
+        assessmentResult = new AssessmentResult({
+          participationResults,
+          competences,
+          stages,
+          badgeResultsDTO,
+          isCampaignMultipleSendings,
+          isOrganizationLearnerActive,
+          isCampaignArchived,
+        });
+      });
+
+      it('should convert a CampaignParticipationResult model object into JSON API data', function () {
+        const expectedSerializedCampaignParticipationResult = {
+          data: {
+            attributes: {
+              'is-completed': true,
+              'is-shared': true,
+              'mastery-rate': 0,
+              'tested-skills-count': 2,
+              'total-skills-count': 2,
+              'validated-skills-count': 0,
+              'stage-count': 2,
+              'can-retry': true,
+              'can-improve': false,
+              'is-disabled': false,
+              'participant-external-id': 'greg@lafleche.fr',
+              'estimated-flash-level': -10,
+            },
+            id: '1',
+            relationships: {
+              'campaign-participation-badges': {
+                data: [],
+              },
+              'competence-results': {
+                data: [
+                  {
+                    id: 'C1',
+                    type: 'competenceResults',
+                  },
+                ],
+              },
+              'reached-stage': {
+                data: {
+                  id: '-1',
+                  type: 'reached-stages',
+                },
+              },
+            },
+            type: 'campaign-participation-results',
+          },
+          included: [
+            {
+              attributes: {
+                'area-color': 'AreaColor',
+                index: '1.1',
+                name: 'Competence1',
+                'mastery-percentage': 0,
+                'tested-skills-count': 2,
+                'total-skills-count': 2,
+                'validated-skills-count': 0,
+              },
+              id: 'C1',
+              type: 'competenceResults',
+            },
+            {
+              attributes: {
+                title: ReachedStage.FALLBACK_STAGE.title,
+                message: ReachedStage.FALLBACK_STAGE.message,
+                threshold: ReachedStage.FALLBACK_STAGE.threshold,
+                'star-count': 0,
+              },
+              id: ReachedStage.FALLBACK_STAGE.id.toString(),
+              type: 'reached-stages',
+            },
+          ],
+        };
+
+        // when
+        const json = serializer.serialize(assessmentResult);
+        // then
+        expect(json).to.deep.equal(expectedSerializedCampaignParticipationResult);
+      });
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Il est possible via Pix Admin qu'un Profil Cible n'ait pas de palier à 0. On ne prévoit pas ce cas dans le code de Pix App/Pix Orga. Côté Pix App l'utilisateur se retrouve avec une erreur 500 si on atteint le palier suivant.

## :gift: Proposition
Objectifs :
- éviter les 500 sur Pix App
- pas d'impact sur le nombre d'étoiles affichés à l'utilisateur
- solution pérène jusqu'à une reprise plus en profondeur

Notre proposition consiste à renvoyer une Reached Stage "fallback" si le palier à 0% n'a pas été créé côté Pix Admin. C'est un palier avec un id reconnaissable -1, le threshold à 0%, un titre vide et un message vide.

D'après nos tests, cette proposition n'a aucun impact sur les cas où l'utilisateur atteint un palier existant.

La 500 disparaît bien dans le cas remonté ici où l'user atteint un % de réussite < au premier pallier. Le front fait apparaître une étoile (grise) supplémentaire que les petits camarades qui auraient atteint un meilleur score.

## :star2: Remarques
La vraie solution sera de bloquer dans Pix Admin la possibilité de créer des paliers sans palier à 0. Ce sujet sera traité sur une refonte plus globale des paliers et permettra de corriger le problème d'affichage Pix Orga.

## :santa: Pour tester
On souhaite vérifier que l'affichage des paliers sur Pix App est ISO avec ce qu'on avait avant :

Soit `n` le nombre de paliers.

### Si un palier à 0 est précisé
On affiche `n-1` étoiles quelque soit le score.

Si l'utilisateur n'a que le palier avec le threshold 0, elles sont toutes grises.

Si l'utilisateur atteint un palier au delà du threshold 0, une étoile jaune apparaît par palier.

### Si il n'y a pas de palier à 0
On affiche `n-1` étoiles si l'utilisateur atteint le palier au delà de 0.

Si l'utilisateur n'atteint pas le palier au delà de 0, on affiches `n` étoiles grises et l'utilisateur n'a plus de 500.