### PR TITLE
[BUGFIX] Modale signalements lors finalisation session et modale inscription candidat individuel (PIX-6463)

### DIFF
--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -148,21 +148,25 @@
   </div>
 </div>
 
-<CertificationCandidateDetailsModal
-  @showModal={{this.shouldDisplayCertificationCandidateModal}}
-  @closeModal={{this.closeCertificationCandidateDetailsModal}}
-  @candidate={{this.certificationCandidateInDetailsModal}}
-  @displayComplementaryCertification={{@displayComplementaryCertification}}
-  @shouldDisplayPaymentOptions={{@shouldDisplayPaymentOptions}}
-/>
+{{#if this.shouldDisplayCertificationCandidateModal}}
+  <CertificationCandidateDetailsModal
+    @showModal={{this.shouldDisplayCertificationCandidateModal}}
+    @closeModal={{this.closeCertificationCandidateDetailsModal}}
+    @candidate={{this.certificationCandidateInDetailsModal}}
+    @displayComplementaryCertification={{@displayComplementaryCertification}}
+    @shouldDisplayPaymentOptions={{@shouldDisplayPaymentOptions}}
+  />
+{{/if}}
 
-<NewCertificationCandidateModal
-  @showModal={{this.showNewCertificationCandidateModal}}
-  @closeModal={{this.closeNewCertificationCandidateModal}}
-  @countries={{@countries}}
-  @saveCandidate={{this.addCertificationCandidate}}
-  @candidateData={{this.newCandidate}}
-  @updateCandidateData={{this.updateCertificationCandidateInStagingFieldFromEvent}}
-  @updateCandidateDataFromValue={{this.updateCertificationCandidateInStagingFieldFromValue}}
-  @shouldDisplayPaymentOptions={{@shouldDisplayPaymentOptions}}
-/>
+{{#if this.showNewCertificationCandidateModal}}
+  <NewCertificationCandidateModal
+    @showModal={{this.showNewCertificationCandidateModal}}
+    @closeModal={{this.closeNewCertificationCandidateModal}}
+    @countries={{@countries}}
+    @saveCandidate={{this.addCertificationCandidate}}
+    @candidateData={{this.newCandidate}}
+    @updateCandidateData={{this.updateCertificationCandidateInStagingFieldFromEvent}}
+    @updateCandidateDataFromValue={{this.updateCertificationCandidateInStagingFieldFromValue}}
+    @shouldDisplayPaymentOptions={{@shouldDisplayPaymentOptions}}
+  />
+{{/if}}

--- a/certif/app/components/session-finalization/completed-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/completed-reports-information-step.hbs
@@ -87,19 +87,22 @@
       {{/each}}
     </tbody>
   </table>
-  <IssueReportModal::AddIssueReportModal
-    @showModal={{this.showAddIssueReportModal}}
-    @closeModal={{this.closeAddIssueReportModal}}
-    @report={{this.reportToEdit}}
-    @maxlength={{@issueReportDescriptionMaxLength}}
-  />
+  {{#if this.showAddIssueReportModal}}
+    <IssueReportModal::AddIssueReportModal
+      @showModal={{this.showAddIssueReportModal}}
+      @closeModal={{this.closeAddIssueReportModal}}
+      @report={{this.reportToEdit}}
+      @maxlength={{@issueReportDescriptionMaxLength}}
+    />
+  {{/if}}
 
-  <IssueReportModal::IssueReportsModal
-    @showModal={{this.showIssueReportsModal}}
-    @closeModal={{this.closeIssueReportsModal}}
-    @onClickIssueReport={{this.openAddIssueReportModal}}
-    @onClickDeleteIssueReport={{@onIssueReportDeleteButtonClicked}}
-    @report={{this.reportToEdit}}
-  />
-
+  {{#if this.showIssueReportsModal}}
+    <IssueReportModal::IssueReportsModal
+      @showModal={{this.showIssueReportsModal}}
+      @closeModal={{this.closeIssueReportsModal}}
+      @onClickIssueReport={{this.openAddIssueReportModal}}
+      @onClickDeleteIssueReport={{@onIssueReportDeleteButtonClicked}}
+      @report={{this.reportToEdit}}
+    />
+  {{/if}}
 </div>

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -107,19 +107,23 @@
     </tbody>
   </table>
 
-  <IssueReportModal::AddIssueReportModal
-    @showModal={{this.showAddIssueReportModal}}
-    @closeModal={{this.closeAddIssueReportModal}}
-    @report={{this.reportToEdit}}
-    @maxlength={{@issueReportDescriptionMaxLength}}
-  />
+  {{#if this.showAddIssueReportModal}}
+    <IssueReportModal::AddIssueReportModal
+      @showModal={{this.showAddIssueReportModal}}
+      @closeModal={{this.closeAddIssueReportModal}}
+      @report={{this.reportToEdit}}
+      @maxlength={{@issueReportDescriptionMaxLength}}
+    />
+  {{/if}}
 
-  <IssueReportModal::IssueReportsModal
-    @showModal={{this.showIssueReportsModal}}
-    @closeModal={{this.closeIssueReportsModal}}
-    @onClickIssueReport={{this.openAddIssueReportModal}}
-    @onClickDeleteIssueReport={{@onIssueReportDeleteButtonClicked}}
-    @report={{this.reportToEdit}}
-  />
+  {{#if this.showIssueReportsModal}}
+    <IssueReportModal::IssueReportsModal
+      @showModal={{this.showIssueReportsModal}}
+      @closeModal={{this.closeIssueReportsModal}}
+      @onClickIssueReport={{this.openAddIssueReportModal}}
+      @onClickDeleteIssueReport={{@onIssueReportDeleteButtonClicked}}
+      @report={{this.reportToEdit}}
+    />
+  {{/if}}
 
 </div>


### PR DESCRIPTION
## :christmas_tree: Problème
Depuis la montée de version pix-ui(#5269), les modales d'inscription de candidat et d'ajout de signalement sont buggées.

## :gift: Proposition
Poser une condition autour du layer des modales

## :santa: Pour tester
- Tester l'inscription de plusieurs candidats
- Tester l'ajout de plusieurs signalements