### PR TITLE
[TECH] Supprimer le texte RGPD sur la double mire Pix Certif (PIX-6136)

### DIFF
--- a/certif/app/components/auth/register-form.hbs
+++ b/certif/app/components/auth/register-form.hbs
@@ -94,8 +94,4 @@
     </div>
 
   </form>
-
-  <p class="legal-text register-form-legal-text">
-    {{t "pages.login-or-register.register-form.legal-text"}}
-  </p>
 </div>

--- a/certif/app/styles/components/register-form.scss
+++ b/certif/app/styles/components/register-form.scss
@@ -29,8 +29,4 @@
       margin: 1px 6px 0 0;
     }
   }
-
-  .register-form-legal-text {
-    margin-top: $spacing-m;
-  }
 }

--- a/certif/app/styles/globals/texts.scss
+++ b/certif/app/styles/globals/texts.scss
@@ -32,13 +32,6 @@
   }
 }
 
-.legal-text {
-  color: $pix-neutral-60;
-  font-family: $font-roboto;
-  font-size: 0.6875rem;
-  font-weight: 300;
-}
-
 .link {
   outline: none;
   border: none;

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -91,7 +91,6 @@
             "label": "Password"
           }
         },
-        "legal-text": "The information collected in this form is saved in a computer file by Pix to enable access to the service offered by Pix. They are kept for the duration of use of the service and are intended for Pix. Test results may be communicated to third parties, with your consent, if you have been invited to take a specific customised test. In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), you can exercise the right to access and rectify your data by emailing our Data Protection Officer at dpo@pix.fr.",
         "errors": {
           "default": "The service is temporarily unavailable. Please try again later.",
           "email-already-exists": "This email address is already registered, please login."

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -91,7 +91,6 @@
             "label": "Mot de passe"
           }
         },
-        "legal-text": "Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix pour permettre l’accès au service offert. Elles sont conservées pendant la durée d’utilisation du service et sont destinées à Pix. Les résultats des tests pourront être communiqués à des tiers, avec votre consentement, dans le cas où vous avez été invité à suivre un parcours spécifique. Conformément à la loi « Informatique et Libertés », vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en contactant le Délégué à la Protection des Données de Pix à dpo@pix.fr.",
         "errors": {
           "default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
           "email-already-exists": "Cette adresse e-mail est déjà enregistrée, connectez-vous."


### PR DESCRIPTION
## :christmas_tree: Problème
Le texte concernant les conditions générales d'utilisation des données est maintenant inclus dans la politique de confidentialité auquel on fait référence sur la ligne avec la checkbox _"J'accepte les [conditions d'utilisation de Pix ](https://pix.localhost/conditions-generales-d-utilisation)et la [politique de confidentialité](https://pix.localhost/politique-protection-donnees-personnelles-app)"_.

Il y a donc un doublon.

## :gift: Proposition
Supprimer tout le texte sous le bouton “Je m’inscris”.

## :star2: Remarques
RAS.

## :santa: Pour tester

- Se rendre sur l'app Pix Certif.
- Modifier l'url en ajoutant : `/rejoindre?invitationId=101264&code=ABCDEF123`
- Arriver sur la double mire et voir qu'il n'y a plus de texte sous le bouton `Je m'inscris`.
