### PR TITLE
[TECH] Améliorer le temps d'exécution des tests sur Pix App (PIX-6468).

### DIFF
--- a/mon-pix/tests/acceptance/authentication_test.js
+++ b/mon-pix/tests/acceptance/authentication_test.js
@@ -18,17 +18,13 @@ module('Acceptance | Authentication', function (hooks) {
   });
 
   module('Success cases', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('Accessing to the default page page while disconnected', async function () {
+    module('Accessing to the default page page while disconnected', function () {
       test('should redirect to the connexion page', async function (assert) {
         // when
         await visit('/');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/connexion');
+        assert.strictEqual(currentURL(), '/connexion');
       });
     });
 
@@ -38,9 +34,7 @@ module('Acceptance | Authentication', function (hooks) {
         await authenticateByEmail(user);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/accueil');
+        assert.strictEqual(currentURL(), '/accueil');
       });
     });
   });
@@ -56,9 +50,7 @@ module('Acceptance | Authentication', function (hooks) {
       await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/connexion');
+      assert.strictEqual(currentURL(), '/connexion');
     });
 
     module('when user should change password', function () {
@@ -70,9 +62,7 @@ module('Acceptance | Authentication', function (hooks) {
         await authenticateByUsername(user);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/mise-a-jour-mot-de-passe-expire');
+        assert.strictEqual(currentURL(), '/mise-a-jour-mot-de-passe-expire');
       });
     });
   });

--- a/mon-pix/tests/acceptance/certification-course_test.js
+++ b/mon-pix/tests/acceptance/certification-course_test.js
@@ -2,7 +2,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { click, currentURL, find, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { fillCertificationJoiner, fillCertificationStarter } from '../helpers/certification';
 import setupIntl from '../helpers/setup-intl';
 import { contains } from '../helpers/contains';
@@ -33,7 +33,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
       module('When user is not certifiable', function (hooks) {
         hooks.beforeEach(async function () {
           user = server.create('user', 'withEmail', 'notCertifiable');
-          await authenticateByEmail(user);
+          await authenticate(user);
           return visit('/certifications');
         });
 
@@ -50,7 +50,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
       module('When user is certifiable', function (hooks) {
         hooks.beforeEach(async function () {
           user = server.create('user', 'withEmail', 'certifiable', { hasSeenOtherChallengesTooltip: true });
-          await authenticateByEmail(user);
+          await authenticate(user);
           return visit('/certifications');
         });
 
@@ -320,7 +320,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
             nonEligibleSubscriptions: [],
           });
 
-          await authenticateByEmail(user);
+          await authenticate(user);
           await visit('/certifications');
           await fillCertificationJoiner({
             sessionId: '1',
@@ -357,7 +357,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
           });
 
           // when
-          await authenticateByEmail(user);
+          await authenticate(user);
           await visit(`/certifications/${certificationCourse.id}/results`);
 
           // then
@@ -397,7 +397,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
               nonEligibleSubscriptions: [],
             });
 
-            await authenticateByEmail(user);
+            await authenticate(user);
             await visit('/certifications');
             await fillCertificationJoiner({
               sessionId: '1',
@@ -438,7 +438,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
           });
 
           // when
-          await authenticateByEmail(user);
+          await authenticate(user);
           await visit(`/certifications/${certificationCourse.id}/results`);
 
           // then

--- a/mon-pix/tests/acceptance/challenge-commons_test.js
+++ b/mon-pix/tests/acceptance/challenge-commons_test.js
@@ -1,6 +1,6 @@
 import { find, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
@@ -12,7 +12,7 @@ module('Acceptance | Common behavior to all challenges', function (hooks) {
   module('Challenge answered: the answers inputs should be disabled', function (hooks) {
     hooks.beforeEach(async function () {
       user = server.create('user', 'withEmail');
-      await authenticateByEmail(user);
+      await authenticate(user);
       const assessment = server.create('assessment', 'ofCompetenceEvaluationType');
       const challenge = server.create('challenge', 'forCompetenceEvaluation');
       const answer = server.create('answer', 'skipped', { assessment, challenge });
@@ -36,7 +36,7 @@ module('Acceptance | Common behavior to all challenges', function (hooks) {
 
     hooks.beforeEach(async function () {
       user = server.create('user', 'withEmail');
-      await authenticateByEmail(user);
+      await authenticate(user);
       assessment = server.create('assessment', 'ofCompetenceEvaluationType');
       server.create('challenge', 'forCompetenceEvaluation', 'QROCM', {
         instruction: 'Instruction [lien](http://www.a.link.example.url)',
@@ -117,7 +117,7 @@ module('Acceptance | Common behavior to all challenges', function (hooks) {
         isAnonymous: true,
       });
 
-      await authenticateByEmail(user);
+      await authenticate(user);
 
       // when
       await visit(`/assessments/${assessment.id}/challenges/0`);

--- a/mon-pix/tests/acceptance/challenge-item_test.js
+++ b/mon-pix/tests/acceptance/challenge-item_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { getPageTitle } from 'ember-page-title/test-support';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { click, find, triggerEvent, visit } from '@ember/test-helpers';
 
 module('Acceptance | Displaying a challenge of any type', function (hooks) {
@@ -33,7 +33,7 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
               const user = server.create('user', 'withEmail', {
                 hasSeenFocusedChallengeTooltip: false,
               });
-              await authenticateByEmail(user);
+              await authenticate(user);
 
               assessment = server.create('assessment', 'ofCompetenceEvaluationType');
               server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
@@ -126,7 +126,7 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
               const user = server.create('user', 'withEmail', {
                 hasSeenFocusedChallengeTooltip: true,
               });
-              await authenticateByEmail(user);
+              await authenticate(user);
 
               assessment = server.create('assessment', 'ofCompetenceEvaluationType');
               server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
@@ -178,7 +178,7 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
             const user = server.create('user', 'withEmail', {
               hasSeenFocusedChallengeTooltip: true,
             });
-            await authenticateByEmail(user);
+            await authenticate(user);
           });
 
           module('when assessment is of type certification', function (hooks) {
@@ -243,7 +243,7 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
             const user = server.create('user', 'withEmail', {
               hasSeenFocusedChallengeTooltip: true,
             });
-            await authenticateByEmail(user);
+            await authenticate(user);
             assessment = server.create('assessment', 'ofCompetenceEvaluationType', 'withCurrentChallengeUnfocus');
             server.create('challenge', 'forCompetenceEvaluation', data.challengeType, 'withFocused');
 
@@ -269,7 +269,7 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
             const user = server.create('user', 'withEmail', {
               hasSeenFocusedChallengeTooltip: true,
             });
-            await authenticateByEmail(user);
+            await authenticate(user);
           });
 
           module('when user goes to another assessment', function () {
@@ -328,7 +328,7 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
                 const user = server.create('user', 'withEmail', {
                   hasSeenOtherChallengesTooltip: false,
                 });
-                await authenticateByEmail(user);
+                await authenticate(user);
 
                 assessment = server.create('assessment', 'ofCompetenceEvaluationType');
                 server.create('challenge', 'forCompetenceEvaluation', data.challengeType);
@@ -372,7 +372,7 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
                 const user = server.create('user', 'withEmail', {
                   hasSeenOtherChallengesTooltip: true,
                 });
-                await authenticateByEmail(user);
+                await authenticate(user);
 
                 assessment = server.create('assessment', 'ofCompetenceEvaluationType');
                 server.create('challenge', 'forCompetenceEvaluation', data.challengeType);
@@ -441,7 +441,7 @@ module('Acceptance | Displaying a challenge of any type', function (hooks) {
             hooks.beforeEach(async function () {
               // given
               const user = server.create('user', 'withEmail');
-              await authenticateByEmail(user);
+              await authenticate(user);
               assessment = server.create('assessment', 'ofCompetenceEvaluationType');
               server.create('challenge', 'forCompetenceEvaluation', data.challengeType);
 

--- a/mon-pix/tests/acceptance/challenge-page-banner_test.js
+++ b/mon-pix/tests/acceptance/challenge-page-banner_test.js
@@ -1,7 +1,7 @@
 import { click, find } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { visit } from '@ember/test-helpers';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { clickByLabel } from '../helpers/click-by-label';
@@ -17,7 +17,7 @@ module('Acceptance | Challenge page banner', function (hooks) {
   hooks.beforeEach(async function () {
     user = server.create('user', 'withEmail');
     campaign = server.create('campaign', { title: 'SomeTitle' });
-    await authenticateByEmail(user);
+    await authenticate(user);
   });
 
   module('When user is starting a campaign assessment', function () {

--- a/mon-pix/tests/acceptance/checkpoint_test.js
+++ b/mon-pix/tests/acceptance/checkpoint_test.js
@@ -2,7 +2,7 @@ import { find, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 
 module('Acceptance | Checkpoint', function (hooks) {
   setupApplicationTest(hooks);
@@ -67,7 +67,7 @@ module('Acceptance | Checkpoint', function (hooks) {
       const user = server.create('user', 'withEmail', {
         isAnonymous: true,
       });
-      await authenticateByEmail(user);
+      await authenticate(user);
 
       // when
       await visit(`/assessments/${assessment.id}/checkpoint?finalCheckpoint=true`);

--- a/mon-pix/tests/acceptance/competence-profile_test.js
+++ b/mon-pix/tests/acceptance/competence-profile_test.js
@@ -1,6 +1,6 @@
 import { click, currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setBreakpoint } from 'ember-responsive/test-support';
@@ -16,7 +16,7 @@ module('Acceptance | Profile | Start competence', function (hooks) {
 
   module('Authenticated cases as simple user', function (hooks) {
     hooks.beforeEach(async function () {
-      await authenticateByEmail(user);
+      await authenticate(user);
     });
 
     test('can start a competence', async function (assert) {

--- a/mon-pix/tests/acceptance/competences-details_test.js
+++ b/mon-pix/tests/acceptance/competences-details_test.js
@@ -1,6 +1,6 @@
 import { find, click, currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import setupIntl from '../helpers/setup-intl';
@@ -26,7 +26,7 @@ module("Acceptance | Competence details | Afficher la page de détails d'une co
     let scorecardWithoutRemainingDaysBeforeImproving;
 
     hooks.beforeEach(async function () {
-      await authenticateByEmail(user);
+      await authenticate(user);
       scorecardWithPoints = user.scorecards.models[0];
       scorecardWithRemainingDaysBeforeReset = user.scorecards.models[1];
       scorecardWithoutPoints = user.scorecards.models[2];

--- a/mon-pix/tests/acceptance/competences-results_test.js
+++ b/mon-pix/tests/acceptance/competences-results_test.js
@@ -1,6 +1,6 @@
 import { find, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
@@ -17,7 +17,7 @@ module('Acceptance | competences results', function (hooks) {
 
   module('Authenticated cases as simple user', function (hooks) {
     hooks.beforeEach(async function () {
-      await authenticateByEmail(user);
+      await authenticate(user);
 
       this.server.create('assessment', {
         id: assessmentId,

--- a/mon-pix/tests/acceptance/error-redirection_test.js
+++ b/mon-pix/tests/acceptance/error-redirection_test.js
@@ -1,6 +1,6 @@
 import { currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
@@ -15,7 +15,7 @@ module('Acceptance | Error page', function (hooks) {
 
   test('should display the error page when the api returned an error which is not 401', async function (assert) {
     // given
-    await authenticateByEmail(user);
+    await authenticate(user);
     this.server.get('/certifications', { errors: [{ code: 500 }] }, 500);
 
     // when

--- a/mon-pix/tests/acceptance/existing-participation-test.js
+++ b/mon-pix/tests/acceptance/existing-participation-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import setupIntl from '../helpers/setup-intl';
@@ -19,7 +19,7 @@ module('Acceptance | Existing Participation', function (hooks) {
         firstName: 'First',
         lastName: 'Last',
       });
-      await authenticateByEmail(user);
+      await authenticate(user);
 
       // when
       const screen = await visit('/campagnes/123/participation-existante');

--- a/mon-pix/tests/acceptance/fill-in-campaign-code_test.js
+++ b/mon-pix/tests/acceptance/fill-in-campaign-code_test.js
@@ -3,7 +3,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 import { visit } from '@1024pix/ember-testing-library';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import setupIntl from '../helpers/setup-intl';
 import { clickByLabel } from '../helpers/click-by-label';
 import { waitForDialog } from '../helpers/wait-for';
@@ -22,7 +22,7 @@ module('Acceptance | Fill in campaign code page', function (hooks) {
   module('When connected', function () {
     test('should disconnect when cliking on the link', async function (assert) {
       // given
-      await authenticateByEmail(user);
+      await authenticate(user);
       const screen = await visit('/campagnes');
 
       // when
@@ -37,7 +37,7 @@ module('Acceptance | Fill in campaign code page', function (hooks) {
   module('Explanation link', function () {
     test('should redirect on the right support page', async function (assert) {
       // given
-      await authenticateByEmail(user);
+      await authenticate(user);
       await visit('/campagnes');
 
       // when

--- a/mon-pix/tests/acceptance/footer_test.js
+++ b/mon-pix/tests/acceptance/footer_test.js
@@ -2,7 +2,7 @@ import { find } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { resumeCampaignOfTypeAssessmentByCode } from '../helpers/campaign';
 import { visit } from '@ember/test-helpers';
 import setupIntl from '../helpers/setup-intl';
@@ -19,7 +19,7 @@ module('Acceptance | Footer', function (hooks) {
 
   module('Authenticated cases as simple user', function (hooks) {
     hooks.beforeEach(async function () {
-      await authenticateByEmail(user);
+      await authenticate(user);
     });
 
     test('should not be displayed while in campaign', async function (assert) {

--- a/mon-pix/tests/acceptance/navigation_test.js
+++ b/mon-pix/tests/acceptance/navigation_test.js
@@ -2,7 +2,7 @@ import { click, currentURL, find, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { resumeCampaignOfTypeAssessmentByCode } from '../helpers/campaign';
 import setupIntl from '../helpers/setup-intl';
 
@@ -18,7 +18,7 @@ module('Acceptance | Navbar', function (hooks) {
 
   module('Authenticated cases as simple user', function (hooks) {
     hooks.beforeEach(async function () {
-      await authenticateByEmail(user);
+      await authenticate(user);
     });
 
     [

--- a/mon-pix/tests/acceptance/oidc/start-campaigns-workflow-for-oidc-partner_test.js
+++ b/mon-pix/tests/acceptance/oidc/start-campaigns-workflow-for-oidc-partner_test.js
@@ -48,9 +48,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
         await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+        assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
       });
 
       test('should redirect to an oidc authentication form when landing page has been seen', async function (assert) {
@@ -62,9 +60,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
 
         // then
         sinon.assert.called(replaceLocationStub);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/connexion/oidc-partner');
+        assert.strictEqual(currentURL(), '/connexion/oidc-partner');
         assert.ok(true);
       });
 
@@ -94,9 +90,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
         const screen = await visit(`/connexion/oidc-partner?code=test&state=${state}`);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), `/connexion/oidc?authenticationKey=key&identityProviderSlug=oidc-partner`);
+        assert.strictEqual(currentURL(), `/connexion/oidc?authenticationKey=key&identityProviderSlug=oidc-partner`);
         assert.ok(screen.getByRole('heading', { name: this.intl.t('pages.login-or-register-oidc.title') }));
       });
 
@@ -116,9 +110,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
         await click(screen.getByRole('button', { name: 'Je créé mon compte' }));
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+        assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
       });
     });
 
@@ -156,9 +148,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
           await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
         });
 
         test('should begin campaign participation', async function (assert) {
@@ -171,9 +161,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
           await clickByLabel('Je commence');
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
         });
       });
 
@@ -187,9 +175,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
           await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
         });
 
         test('should redirect to oidc authentication form when landing page has been seen', async function (assert) {
@@ -201,9 +187,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow | OIDC', function (hoo
 
           // then
           sinon.assert.called(replaceLocationStub);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), '/connexion/oidc-partner');
+          assert.strictEqual(currentURL(), '/connexion/oidc-partner');
           assert.ok(true);
         });
       });

--- a/mon-pix/tests/acceptance/personal-information_test.js
+++ b/mon-pix/tests/acceptance/personal-information_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { visit } from '@1024pix/ember-testing-library';
 
 module('Acceptance | personal-information', function (hooks) {
@@ -19,7 +19,7 @@ module('Acceptance | personal-information', function (hooks) {
         password: 'pixi',
         lang: 'fr',
       });
-      await authenticateByEmail(user);
+      await authenticate(user);
 
       // when
       const screen = await visit('/mon-compte/informations-personnelles');

--- a/mon-pix/tests/acceptance/profile_test.js
+++ b/mon-pix/tests/acceptance/profile_test.js
@@ -1,6 +1,6 @@
 import { click, fillIn, currentURL, find, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { clickByLabel } from '../helpers/click-by-label';
@@ -18,7 +18,7 @@ module('Acceptance | Profile', function (hooks) {
 
   module('Authenticated cases as simple user', function (hooks) {
     hooks.beforeEach(async function () {
-      await authenticateByEmail(user);
+      await authenticate(user);
     });
 
     test('can visit /competences', async function (assert) {

--- a/mon-pix/tests/acceptance/reset-password_test.js
+++ b/mon-pix/tests/acceptance/reset-password_test.js
@@ -1,6 +1,6 @@
 import { currentURL, fillIn, find, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { clickByLabel } from '../helpers/click-by-label';
@@ -78,7 +78,7 @@ module('Acceptance | Reset Password Form', function (hooks) {
       email: 'brandone.martins@pix.com',
     });
 
-    await authenticateByEmail(user);
+    await authenticate(user);
 
     // when
     await visit('/changer-mot-de-passe/brandone-reset-key');

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-assessment_test.js
@@ -1,6 +1,6 @@
 import { click, fillIn, currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { resumeCampaignOfTypeAssessmentByCode } from '../helpers/campaign';
 import { clickByLabel } from '../helpers/click-by-label';
 import { invalidateSession } from '../helpers/invalidate-session';
@@ -17,7 +17,7 @@ module('Acceptance | Campaigns | Resume Campaigns with type Assessment', functio
 
   hooks.beforeEach(async function () {
     studentInfo = server.create('user', 'withEmail');
-    await authenticateByEmail(studentInfo);
+    await authenticate(studentInfo);
     campaign = server.create('campaign', { idPixLabel: 'email', type: ASSESSMENT });
     await resumeCampaignOfTypeAssessmentByCode(campaign.code, true);
   });

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
@@ -1,6 +1,6 @@
 import { click, fillIn, currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import {
   resumeCampaignOfTypeProfilesCollectionByCode,
   completeCampaignOfTypeProfilesCollectionByCode,
@@ -21,7 +21,7 @@ module('Acceptance | Campaigns | Resume Campaigns with type Profiles Collection'
 
   hooks.beforeEach(async function () {
     studentInfo = server.create('user', 'withEmail');
-    await authenticateByEmail(studentInfo);
+    await authenticate(studentInfo);
     campaign = server.create('campaign', { idPixLabel: 'email', type: PROFILES_COLLECTION });
     await resumeCampaignOfTypeProfilesCollectionByCode(campaign.code, true);
   });

--- a/mon-pix/tests/acceptance/resume-competence-evaluations_test.js
+++ b/mon-pix/tests/acceptance/resume-competence-evaluations_test.js
@@ -1,6 +1,6 @@
 import { fillIn, currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { clickByLabel } from '../helpers/click-by-label';
@@ -40,7 +40,7 @@ module('Acceptance | Competence Evaluations | Resume Competence Evaluations', f
 
     module('When user is logged in', function (hooks) {
       hooks.beforeEach(async function () {
-        await authenticateByEmail(user);
+        await authenticate(user);
       });
 
       module('When competence evaluation exists', function (hooks) {

--- a/mon-pix/tests/acceptance/sitemap_test.js
+++ b/mon-pix/tests/acceptance/sitemap_test.js
@@ -3,7 +3,7 @@ import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { setupApplicationTest } from 'ember-qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 
 module('Acceptance | Sitemap', function (hooks) {
   setupApplicationTest(hooks);
@@ -16,7 +16,7 @@ module('Acceptance | Sitemap', function (hooks) {
 
   module('When visiting /plan-du-site', function (hooks) {
     hooks.beforeEach(async function () {
-      await authenticateByEmail(user);
+      await authenticate(user);
       await visit('/plan-du-site');
     });
 

--- a/mon-pix/tests/acceptance/skill-review_test.js
+++ b/mon-pix/tests/acceptance/skill-review_test.js
@@ -1,6 +1,6 @@
 import { findAll, currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import setupIntl from '../helpers/setup-intl';
 import { clickByLabel } from '../helpers/click-by-label';
 import { click, fillIn } from '@ember/test-helpers';
@@ -48,7 +48,7 @@ module('Acceptance | Campaigns | Campaigns Result', function (hooks) {
 
       hooks.beforeEach(async function () {
         // given
-        await authenticateByEmail(user);
+        await authenticate(user);
         const competenceResult = server.create('competence-result', {
           name: competenceResultName,
           masteryPercentage: 85,
@@ -293,7 +293,7 @@ module('Acceptance | Campaigns | Campaigns Result', function (hooks) {
 
     test('should redirect to default page on click when user is connected', async function (assert) {
       // given
-      await authenticateByEmail(user);
+      await authenticate(user);
       await visit(`/campagnes/${campaignForNovice.code}`);
       await clickByLabel(this.intl.t('pages.checkpoint.actions.next-page.results'));
       await clickByLabel(this.intl.t('pages.skill-review.actions.continue'));

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
@@ -1,6 +1,6 @@
 import { click, fillIn, currentURL, find, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { startCampaignByCode, startCampaignByCodeAndExternalId } from '../helpers/campaign';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -172,7 +172,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
 
     module('When user is logged in', function (hooks) {
       hooks.beforeEach(async function () {
-        await authenticateByEmail(prescritUser);
+        await authenticate(prescritUser);
       });
 
       module('When campaign is not restricted', function () {

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
@@ -1,7 +1,7 @@
 import { click, fillIn, currentURL, find } from '@ember/test-helpers';
 import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { startCampaignByCode, startCampaignByCodeAndExternalId } from '../helpers/campaign';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -160,7 +160,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
 
     module('When user is logged in', function (hooks) {
       hooks.beforeEach(async function () {
-        await authenticateByEmail(campaignParticipant);
+        await authenticate(campaignParticipant);
       });
 
       module('When campaign is not restricted', function () {

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -7,7 +7,7 @@ import { Response } from 'miragejs';
 
 import { clickByLabel } from '../helpers/click-by-label';
 import { fillInByLabel } from '../helpers/fill-in-by-label';
-import { authenticateByEmail, authenticateByGAR } from '../helpers/authentication';
+import { authenticate, authenticateByGAR } from '../helpers/authentication';
 import { startCampaignByCode, startCampaignByCodeAndExternalId } from '../helpers/campaign';
 import { currentSession } from 'ember-simple-auth/test-support';
 import ENV from 'mon-pix/config/environment';
@@ -525,7 +525,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
 
     module('When user is logged in', function (hooks) {
       hooks.beforeEach(async function () {
-        await authenticateByEmail(prescritUser);
+        await authenticate(prescritUser);
       });
 
       module('When campaign is not restricted', function () {

--- a/mon-pix/tests/acceptance/tutorial-actions_test.js
+++ b/mon-pix/tests/acceptance/tutorial-actions_test.js
@@ -1,6 +1,6 @@
 import { click, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
@@ -21,7 +21,7 @@ module('Acceptance | Tutorial | Actions', function (hooks) {
     server.create('competence-evaluation', { user, competenceId, assessment });
 
     // when
-    await authenticateByEmail(user);
+    await authenticate(user);
     await visit('/mes-tutos');
   });
 

--- a/mon-pix/tests/acceptance/user-account/connection-methods_test.js
+++ b/mon-pix/tests/acceptance/user-account/connection-methods_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import {
-  authenticateByEmail,
+  authenticate,
   authenticateByGAR,
   authenticateByUsername,
   generateGarAuthenticationURLHash,
@@ -30,7 +30,7 @@ module('Acceptance | user-account | connection-methods', function (hooks) {
       };
       const user = server.create('user', 'withEmail', userDetails);
       server.create('authentication-method', 'withPixIdentityProvider', { user });
-      await authenticateByEmail(user);
+      await authenticate(user);
 
       // when
       await visit('/mon-compte/methodes-de-connexion');
@@ -64,7 +64,7 @@ module('Acceptance | user-account | connection-methods', function (hooks) {
       server.create('authentication-method', 'withGenericOidcIdentityProvider', { user });
 
       // when
-      await authenticateByEmail(user);
+      await authenticate(user);
       await visit('/mon-compte/methodes-de-connexion');
 
       // then
@@ -97,7 +97,7 @@ module('Acceptance | user-account | connection-methods', function (hooks) {
         email: 'john.doe@example.net',
       };
       const user = server.create('user', 'withEmail', userDetails);
-      await authenticateByEmail(user);
+      await authenticate(user);
 
       // when
       await visit('/mon-compte/methodes-de-connexion');
@@ -112,7 +112,7 @@ module('Acceptance | user-account | connection-methods', function (hooks) {
       // given
       const user = server.create('user', 'withEmail');
       server.create('authentication-method', 'withPixIdentityProvider', { user });
-      await authenticateByEmail(user);
+      await authenticate(user);
       await visit('/mon-compte/methodes-de-connexion');
       await clickByLabel(this.intl.t('pages.user-account.connexion-methods.edit-button'));
 
@@ -128,7 +128,7 @@ module('Acceptance | user-account | connection-methods', function (hooks) {
       // given
       const user = server.create('user', 'withEmail');
       server.create('authentication-method', 'withPixIdentityProvider', { user });
-      await authenticateByEmail(user);
+      await authenticate(user);
       const newEmail = 'new-email@example.net';
       await visit('/mon-compte/methodes-de-connexion');
 

--- a/mon-pix/tests/acceptance/user-account_test.js
+++ b/mon-pix/tests/acceptance/user-account_test.js
@@ -1,6 +1,6 @@
 import { currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { contains } from '../helpers/contains';
@@ -30,7 +30,7 @@ module('Acceptance | User account page', function (hooks) {
     hooks.beforeEach(async function () {
       // given
       user = server.create('user', 'withEmail');
-      await authenticateByEmail(user);
+      await authenticate(user);
     });
 
     test('should display my account page', async function (assert) {

--- a/mon-pix/tests/acceptance/user-certifications_test.js
+++ b/mon-pix/tests/acceptance/user-certifications_test.js
@@ -1,6 +1,6 @@
 import { currentURL, findAll, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
@@ -26,7 +26,7 @@ module('Acceptance | User certifications page', function (hooks) {
 
     test('should be accessible when user is connected', async function (assert) {
       // given
-      await authenticateByEmail(userWithNoCertificates);
+      await authenticate(userWithNoCertificates);
 
       // when
       await visit('/mes-certifications');
@@ -41,7 +41,7 @@ module('Acceptance | User certifications page', function (hooks) {
   module('Display', function () {
     test('should render the banner', async function (assert) {
       // when
-      await authenticateByEmail(userWithNoCertificates);
+      await authenticate(userWithNoCertificates);
       await visit('/mes-certifications');
 
       // then
@@ -50,7 +50,7 @@ module('Acceptance | User certifications page', function (hooks) {
 
     test('should render a title for the page', async function (assert) {
       // when
-      await authenticateByEmail(userWithNoCertificates);
+      await authenticate(userWithNoCertificates);
       await visit('/mes-certifications');
 
       // then
@@ -59,7 +59,7 @@ module('Acceptance | User certifications page', function (hooks) {
 
     test('should render the panel which contains informations about certifications of the connected user', async function (assert) {
       // when
-      await authenticateByEmail(userWithNoCertificates);
+      await authenticate(userWithNoCertificates);
       await visit('/mes-certifications');
 
       // then
@@ -69,7 +69,7 @@ module('Acceptance | User certifications page', function (hooks) {
     module('when user has no certificates', function () {
       test('should dislpay the no certificates panel', async function (assert) {
         // when
-        await authenticateByEmail(userWithNoCertificates);
+        await authenticate(userWithNoCertificates);
         await visit('/mes-certifications');
 
         // then
@@ -83,7 +83,7 @@ module('Acceptance | User certifications page', function (hooks) {
         const userWithSomeCertificates = server.create('user', 'withEmail', 'withSomeCertificates');
 
         // when
-        await authenticateByEmail(userWithSomeCertificates);
+        await authenticate(userWithSomeCertificates);
         await visit('/mes-certifications');
 
         // then

--- a/mon-pix/tests/acceptance/user-dashboard_test.js
+++ b/mon-pix/tests/acceptance/user-dashboard_test.js
@@ -3,7 +3,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { invalidateSession } from '../helpers/invalidate-session';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import setupIntl from '../helpers/setup-intl';
 import { clickByLabel } from '../helpers/click-by-label';
 import { visit } from '@1024pix/ember-testing-library';
@@ -34,7 +34,7 @@ module('Acceptance | User dashboard page', function (hooks) {
 
     test('is possible when user is connected', async function (assert) {
       // given
-      await authenticateByEmail(user);
+      await authenticate(user);
 
       // when
       await visit('/accueil');
@@ -54,7 +54,7 @@ module('Acceptance | User dashboard page', function (hooks) {
     module('when user is on campaign start page', function () {
       test('it should change menu on click on disconnect link', async function (assert) {
         // given
-        await authenticateByEmail(user);
+        await authenticate(user);
         const screen = await visit('/campagnes');
 
         // when
@@ -88,7 +88,7 @@ module('Acceptance | User dashboard page', function (hooks) {
             createdAt: new Date('2020-04-20T04:05:06Z'),
             isShared: false,
           });
-          await authenticateByEmail(user);
+          await authenticate(user);
         });
 
         hooks.afterEach(async function () {
@@ -126,7 +126,7 @@ module('Acceptance | User dashboard page', function (hooks) {
             createdAt: new Date('2020-04-20T04:05:06Z'),
             isShared: false,
           });
-          await authenticateByEmail(user);
+          await authenticate(user);
         });
 
         hooks.afterEach(async function () {
@@ -152,7 +152,7 @@ module('Acceptance | User dashboard page', function (hooks) {
     test('should display recommended-competences section', async function (assert) {
       // given
       const user = server.create('user', 'withEmail');
-      await authenticateByEmail(user);
+      await authenticate(user);
 
       // when
       await visit('/accueil');
@@ -164,7 +164,7 @@ module('Acceptance | User dashboard page', function (hooks) {
     test('should display the link to profile', async function (assert) {
       // given
       const user = server.create('user', 'withEmail');
-      await authenticateByEmail(user);
+      await authenticate(user);
 
       // when
       const screen = await visit('/accueil');
@@ -184,7 +184,7 @@ module('Acceptance | User dashboard page', function (hooks) {
     test('should display the improvable-competences section', async function (assert) {
       // given
       const user = server.create('user', 'withEmail');
-      await authenticateByEmail(user);
+      await authenticate(user);
 
       // when
       const screen = await visit('/accueil');
@@ -197,7 +197,7 @@ module('Acceptance | User dashboard page', function (hooks) {
   module('started-competences', function (hooks) {
     hooks.beforeEach(async function () {
       user = server.create('user', 'withEmail');
-      await authenticateByEmail(user);
+      await authenticate(user);
       await visit('/accueil');
     });
 
@@ -230,7 +230,7 @@ module('Acceptance | User dashboard page', function (hooks) {
       module('when user has closable information', function () {
         test('should close new dashboard information on user click', async function (assert) {
           // given
-          await authenticateByEmail(user);
+          await authenticate(user);
           await visit('/accueil');
           assert.dom('.new-information').exists();
 
@@ -262,7 +262,7 @@ module('Acceptance | User dashboard page', function (hooks) {
           campaignParticipation.assessment.update({ state: 'completed' });
           user.update({ codeForLastProfileToShare: campaign.code });
 
-          await authenticateByEmail(user);
+          await authenticate(user);
         });
 
         module('when user has not shared his results', function () {
@@ -310,7 +310,7 @@ module('Acceptance | User dashboard page', function (hooks) {
         user = server.create('user', 'withEmail', 'hasSeenNewDashboardInfo');
 
         // when
-        await authenticateByEmail(user);
+        await authenticate(user);
 
         // then
         assert.dom('.new-information__content').doesNotExist();

--- a/mon-pix/tests/acceptance/user-tests_test.js
+++ b/mon-pix/tests/acceptance/user-tests_test.js
@@ -1,6 +1,6 @@
 import { currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 import { contains } from '../helpers/contains';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -16,7 +16,7 @@ module('Acceptance | User tests', function (hooks) {
 
   module('Authenticated cases as simple user', function (hooks) {
     hooks.beforeEach(async function () {
-      await authenticateByEmail(user);
+      await authenticate(user);
     });
 
     test('can visit /mes-parcours', async function (assert) {

--- a/mon-pix/tests/acceptance/user-trainings_test.js
+++ b/mon-pix/tests/acceptance/user-trainings_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { visit, currentURL, find } from '@ember/test-helpers';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 
 module('Acceptance | mes-formations', function (hooks) {
   setupApplicationTest(hooks);
@@ -15,7 +15,7 @@ module('Acceptance | mes-formations', function (hooks) {
       user = server.create('user', 'withEmail', 'withSomeTrainings');
 
       // when
-      await authenticateByEmail(user);
+      await authenticate(user);
       await visit('/');
 
       // then
@@ -30,7 +30,7 @@ module('Acceptance | mes-formations', function (hooks) {
       user = server.create('user', 'withEmail', 'withSomeTrainings');
 
       // when
-      await authenticateByEmail(user);
+      await authenticate(user);
       await visit('/mes-formations');
 
       // then

--- a/mon-pix/tests/acceptance/user-tutorials/recommended_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials/recommended_test.js
@@ -3,7 +3,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { find, click, currentURL } from '@ember/test-helpers';
 import { visit } from '@1024pix/ember-testing-library';
-import { authenticateByEmail } from '../../helpers/authentication';
+import { authenticate } from '../../helpers/authentication';
 import { waitForDialog } from '../../helpers/wait-for';
 
 module('Acceptance | User-tutorials | Recommended', function (hooks) {
@@ -13,7 +13,7 @@ module('Acceptance | User-tutorials | Recommended', function (hooks) {
 
   hooks.beforeEach(async function () {
     user = server.create('user', 'withEmail');
-    await authenticateByEmail(user);
+    await authenticate(user);
     await server.db.tutorials.remove();
   });
 
@@ -91,9 +91,7 @@ module('Acceptance | User-tutorials | Recommended', function (hooks) {
         await click(screen.getByRole('button', { name: 'Voir les résultats' }));
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/mes-tutos/recommandes?competences=1&pageNumber=1');
+        assert.strictEqual(currentURL(), '/mes-tutos/recommandes?competences=1&pageNumber=1');
         assert.dom('.tutorial-card').exists({ count: 1 });
         assert.dom('.pix-sidebar--hidden').exists();
       });
@@ -101,6 +99,7 @@ module('Acceptance | User-tutorials | Recommended', function (hooks) {
       module('when user access again to tutorials recommended page', function () {
         test('should reset competences filters', async function (assert) {
           // given
+          server.createList('tutorial', 1);
           const screen = await visit('/mes-tutos/recommandes?competences=1&pageNumber=1');
 
           // when
@@ -108,9 +107,7 @@ module('Acceptance | User-tutorials | Recommended', function (hooks) {
           await click(screen.getByRole('link', { name: 'Recommandés' }));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), '/mes-tutos/recommandes');
+          assert.strictEqual(currentURL(), '/mes-tutos/recommandes');
         });
       });
     });

--- a/mon-pix/tests/acceptance/user-tutorials/saved_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials/saved_test.js
@@ -3,7 +3,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { find, click } from '@ember/test-helpers';
 import { visit } from '@1024pix/ember-testing-library';
-import { authenticateByEmail } from '../../helpers/authentication';
+import { authenticate } from '../../helpers/authentication';
 
 module('Acceptance | User-tutorials | Saved', function (hooks) {
   setupApplicationTest(hooks);
@@ -13,7 +13,7 @@ module('Acceptance | User-tutorials | Saved', function (hooks) {
   hooks.beforeEach(async function () {
     const numberOfTutorials = 100;
     user = server.create('user', 'withEmail');
-    await authenticateByEmail(user);
+    await authenticate(user);
     await server.db.tutorials.remove();
     server.createList('tutorial', numberOfTutorials, 'withUserSavedTutorial');
   });

--- a/mon-pix/tests/acceptance/user-tutorials_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { visit, currentURL } from '@ember/test-helpers';
-import { authenticateByEmail } from '../helpers/authentication';
+import { authenticate } from '../helpers/authentication';
 
 module('Acceptance | mes-tutos', function (hooks) {
   setupApplicationTest(hooks);
@@ -12,7 +12,7 @@ module('Acceptance | mes-tutos', function (hooks) {
   module('When the new tutorials page is disabled', function (hooks) {
     hooks.beforeEach(async function () {
       user = server.create('user', 'withEmail');
-      await authenticateByEmail(user);
+      await authenticate(user);
     });
 
     test('user is redirected to /mes-tutos/recommandes when visiting /mes-tutos', async function (assert) {

--- a/mon-pix/tests/helpers/authentication.js
+++ b/mon-pix/tests/helpers/authentication.js
@@ -1,5 +1,15 @@
 import { fillIn, visit } from '@ember/test-helpers';
 import { clickByLabel } from './click-by-label';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+
+export async function authenticate(user) {
+  return authenticateSession({
+    user_id: user.id,
+    access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
+    expires_in: 3600,
+    token_type: 'Bearer token type',
+  });
+}
 
 export async function authenticateByEmail(user) {
   await visit('/connexion');


### PR DESCRIPTION
## :christmas_tree: Problème
Depuis, le passage à QUnit sur Pix App, nous pouvons observer que le temps d'exécution des tests a augmenté de 20% :
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/26384707/205096411-b00d8985-0036-4cf2-9f4a-6367ee01a280.png">


## :gift: Proposition
Actuellement, Pix App est la seule app du monorepo qui pour authentifier l'utilisateur passe par le formulaire de connexion. Pour authentifier l'utilisateur, il suffit de lui créer un jeton valide, ce qui fait gagner du temps car il n'est donc pas nécessaire d'attendre que les pages chargent. 

## :star2: Remarques
Certains tests utilisent encore la méthode en passant par la page de connexion car cela est nécessaire.

## :santa: Pour tester
- Constater que la CI passe