### PR TITLE
[FEATURE] Renommage Profil Cible en Parcours dans export csv (pix-6058)

### DIFF
--- a/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -108,7 +108,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
-      '"Nom du Profil Cible";' +
+      '"Parcours";' +
       '"Nom du Participant";' +
       '"Prénom du Participant";' +
       '"% de progression";' +
@@ -172,7 +172,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
-      '"Nom du Profil Cible";' +
+      '"Parcours";' +
       '"Nom du Participant";' +
       '"Prénom du Participant";' +
       `"${idPixLabel}";` +
@@ -232,7 +232,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
-      '"Nom du Profil Cible";' +
+      '"Parcours";' +
       '"Nom du Participant";' +
       '"Prénom du Participant";' +
       '"% de progression";' +
@@ -291,7 +291,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
-      '"Nom du Profil Cible";' +
+      '"Parcours";' +
       '"Nom du Participant";' +
       '"Prénom du Participant";' +
       '"% de progression";' +
@@ -359,7 +359,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
-      '"Nom du Profil Cible";' +
+      '"Parcours";' +
       '"Nom du Participant";' +
       '"Prénom du Participant";' +
       '"% de progression";' +
@@ -427,7 +427,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
-      '"Nom du Profil Cible";' +
+      '"Parcours";' +
       '"Nom du Participant";' +
       '"Prénom du Participant";' +
       '"% de progression";' +
@@ -487,7 +487,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
         '\uFEFF"Nom de l\'organisation";' +
         '"ID Campagne";' +
         '"Nom de la campagne";' +
-        '"Nom du Profil Cible";' +
+        '"Parcours";' +
         '"Nom du Participant";' +
         '"Prénom du Participant";' +
         '"Groupe";' +
@@ -547,7 +547,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
         '\uFEFF"Nom de l\'organisation";' +
         '"ID Campagne";' +
         '"Nom de la campagne";' +
-        '"Nom du Profil Cible";' +
+        '"Parcours";' +
         '"Nom du Participant";' +
         '"Prénom du Participant";' +
         '"Classe";' +
@@ -627,7 +627,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-
       '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
-      '"Nom du Profil Cible";' +
+      '"Parcours";' +
       '"Nom du Participant";' +
       '"Prénom du Participant";' +
       '"% de progression";' +

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -22,7 +22,7 @@
         "ok": "OK"
       },
       "success-rate": "Success rate (/{{value}})",
-      "target-profile-name": "Target profile’s name",
+      "target-profile-name": "Customised test",
       "thematic-result-name": "{{name}} (Y/N)"
     },
     "common": {

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -34,7 +34,7 @@
         "ok": "OK"
       },
       "success-rate": "Palier obtenu (/{{value}})",
-      "target-profile-name": "Nom du Profil Cible",
+      "target-profile-name": "Parcours",
       "thematic-result-name": "{{name}} obtenu (O/N)"
     },
     "common": {


### PR DESCRIPTION
## :christmas_tree: Problème
Les profils Cibles s'appellent maintenant Parcours

## :gift: Proposition
Remplacer “profil cible” par parcours dans l’export .csv des résultats ("parcours" est le nouveau wording retenu)

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Se connecter à Pix Orga, sélectionner une campagne d'évaluation, puis faire l'export .csv via le bouton.
Vérifier le changement sur la 4eme colonne de l'en tête ( en français & en anglais ).
