### PR TITLE
[TECH] Supprimer le texte RGPD sur la double mire Pix Orga (PIX-6244)

### DIFF
--- a/orga/app/components/auth/register-form.hbs
+++ b/orga/app/components/auth/register-form.hbs
@@ -96,8 +96,4 @@
     </div>
 
   </form>
-
-  <div class="legal-text">
-    {{t "pages.login-or-register.register-form.legal-text"}}
-  </div>
 </div>

--- a/orga/app/styles/globals/texts.scss
+++ b/orga/app/styles/globals/texts.scss
@@ -11,13 +11,6 @@
   font-size: 0.75rem;
 }
 
-.legal-text {
-  color: $pix-neutral-60;
-  font-family: $font-roboto;
-  font-size: 0.6875rem;
-  font-weight: 300;
-}
-
 .information-text {
   color: $pix-neutral-60;
   font-family: $font-open-sans;

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -645,7 +645,6 @@
             "label": "Password"
           }
         },
-        "legal-text": "The information collected in this form is saved in a computer file by Pix to enable access to the service offered by Pix. They are kept for the duration of use of the service and are intended for Pix. Test results may be communicated to third parties, with your consent, if you have been invited to take a specific customised test. In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), you can exercise the right to access and rectify your data by emailing our Data Protection Officer at dpo@pix.fr.",
         "errors": {
           "default": "The service is temporarily unavailable. Please try again later.",
           "email-already-exists": "This email address is already registered, please login."

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -645,7 +645,6 @@
             "label": "Mot de passe"
           }
         },
-        "legal-text": "Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix pour permettre l’accès au service offert. Elles sont conservées pendant la durée d’utilisation du service et sont destinées à Pix. Les résultats des tests pourront être communiqués à des tiers, avec votre consentement, dans le cas où vous avez été invité à suivre un parcours spécifique. Conformément à la loi « Informatique et Libertés », vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en contactant le Délégué à la Protection des Données de Pix à dpo@pix.fr.",
         "errors": {
           "default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
           "email-already-exists": "Cette adresse e-mail est déjà enregistrée, connectez-vous."


### PR DESCRIPTION
## :christmas_tree: Problème
Le texte concernant les conditions générales d'utilisation des données est maintenant inclus dans la politique de confidentialité auquel on fait référence sur la ligne avec la checkbox "J'accepte les [conditions d'utilisation de Pix ](https://pix.localhost/conditions-generales-d-utilisation)et la [politique de confidentialité](https://pix.localhost/politique-protection-donnees-personnelles-app)".

Il y a donc un doublon.

## :gift: Proposition
Supprimer tout le texte sous le bouton “Je m’inscris”.

## :star2: Remarques
RAS.

## :santa: Pour tester

- Se rendre sur l'app Pix Orga.
- Modifier l'url en ajoutant : /rejoindre?invitationId=100046&code=INVIABC123
- Arriver sur la double mire et voir qu'il n'y a plus de texte sous le bouton Je m'inscris.
