### PR TITLE
[FEATURE] Améliorer l'accessibilité des pages sur Pix-App (PIX-6471)

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y.test.js
@@ -57,7 +57,7 @@ describe('a11y', () => {
       { url: '/competences/recH9MjIzN54zXlwr/details', skipFailures: true },
       { url: '/mes-certifications' },
       { url: '/mes-formations' },
-      { url: '/mes-parcours', skipFailures: true },
+      { url: '/mes-parcours' },
       { url: '/mes-tutos/enregistres' },
       { url: '/mes-tutos/recommandes' },
       { url: '/mon-compte/informations-personnelles' },

--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y.test.js
@@ -52,7 +52,7 @@ describe('a11y', () => {
       { url: '/accueil' },
       { url: '/campagnes' },
       { url: '/campagnes/NERA/evaluation/resultats' },
-      { url: '/certifications', skipFailures: true },
+      { url: '/certifications' },
       { url: '/competences' },
       { url: '/competences/recH9MjIzN54zXlwr/details', skipFailures: true },
       { url: '/mes-certifications' },

--- a/high-level-tests/e2e/cypress/integration/pix-app/a11y.test.js
+++ b/high-level-tests/e2e/cypress/integration/pix-app/a11y.test.js
@@ -54,7 +54,7 @@ describe('a11y', () => {
       { url: '/campagnes/NERA/evaluation/resultats' },
       { url: '/certifications' },
       { url: '/competences' },
-      { url: '/competences/recH9MjIzN54zXlwr/details', skipFailures: true },
+      { url: '/competences/recH9MjIzN54zXlwr/details' },
       { url: '/mes-certifications' },
       { url: '/mes-formations' },
       { url: '/mes-parcours' },

--- a/mon-pix/app/components/campaign-participation-overview/card/disabled.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/disabled.hbs
@@ -3,7 +3,7 @@
     <PixTag class="campaign-participation-overview-card-header__tag" @compact={{true}} @color="grey-light">
       {{t "pages.campaign-participation-overview.card.tag.disabled"}}
     </PixTag>
-    <h3 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h3>
+    <h2 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h2>
     <strong class="campaign-participation-overview-card-header__subtitle">{{@model.campaignTitle}}</strong>
     <time class="campaign-participation-overview-card-header__date" datetime="{{@model.createdAt}}">
       {{t "pages.campaign-participation-overview.card.started-at" date=(dayjs-format @model.createdAt "DD/MM/YYYY")}}

--- a/mon-pix/app/components/campaign-participation-overview/card/ended.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ended.hbs
@@ -3,7 +3,7 @@
     <PixTag class="campaign-participation-overview-card-header__tag" @compact={{true}} @color="grey-light">
       {{t "pages.campaign-participation-overview.card.tag.finished"}}
     </PixTag>
-    <h3 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h3>
+    <h2 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h2>
     <strong class="campaign-participation-overview-card-header__subtitle">{{@model.campaignTitle}}</strong>
     <time class="campaign-participation-overview-card-header__date" datetime="{{@model.sharedAt}}">
       {{t "pages.campaign-participation-overview.card.finished-at" date=(dayjs-format @model.sharedAt "DD/MM/YYYY")}}

--- a/mon-pix/app/components/campaign-participation-overview/card/ongoing.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ongoing.hbs
@@ -3,7 +3,7 @@
     <PixTag class="campaign-participation-overview-card-header__tag" @compact={{true}} @color="green-light">
       {{t "pages.campaign-participation-overview.card.tag.started"}}
     </PixTag>
-    <h3 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h3>
+    <h2 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h2>
     <strong class="campaign-participation-overview-card-header__subtitle">{{@model.campaignTitle}}</strong>
     <time class="campaign-participation-overview-card-header__date" datetime="{{@model.createdAt}}">
       {{t "pages.campaign-participation-overview.card.started-at" date=(dayjs-format @model.createdAt "DD/MM/YYYY")}}

--- a/mon-pix/app/components/campaign-participation-overview/card/to-share.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/to-share.hbs
@@ -3,7 +3,7 @@
     <PixTag class="campaign-participation-overview-card-header__tag" @compact={{true}} @color="yellow-light">
       {{t "pages.campaign-participation-overview.card.tag.completed"}}
     </PixTag>
-    <h3 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h3>
+    <h2 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h2>
     <strong class="campaign-participation-overview-card-header__subtitle">{{@model.campaignTitle}}</strong>
     <time class="campaign-participation-overview-card-header__date" datetime="{{@model.createdAt}}">
       {{t "pages.campaign-participation-overview.card.started-at" date=(dayjs-format @model.createdAt "DD/MM/YYYY")}}

--- a/mon-pix/app/components/certification-not-certifiable.hbs
+++ b/mon-pix/app/components/certification-not-certifiable.hbs
@@ -1,7 +1,7 @@
 <PixBlock class="certification-not-certifiable__panel">
-  <h3 class="certification-not-certifiable__title">
+  <h1 class="certification-not-certifiable__title">
     {{t "pages.certification-not-certifiable.title"}}
-  </h3>
+  </h1>
   <p class="certification-not-certifiable__text">
     {{t "pages.certification-not-certifiable.text"}}
   </p>

--- a/mon-pix/app/components/scorecard-details.hbs
+++ b/mon-pix/app/components/scorecard-details.hbs
@@ -8,9 +8,9 @@
       <div class="scorecard-details-content-left__area scorecard-details-content-left__area--{{@scorecard.area.color}}">
         {{@scorecard.area.title}}
       </div>
-      <h3 class="scorecard-details-content-left__name">
+      <h1 class="scorecard-details-content-left__name">
         {{@scorecard.name}}
-      </h3>
+      </h1>
       <div class="scorecard-details-content-left__description">
         {{@scorecard.description}}
       </div>

--- a/mon-pix/app/styles/components/_certification-not-certifiable.scss
+++ b/mon-pix/app/styles/components/_certification-not-certifiable.scss
@@ -20,6 +20,8 @@
 
 .certification-not-certifiable__title {
   text-align: center;
+  font-family: $font-open-sans;
+  font-weight: $font-light;
 }
 
 .certification-not-certifiable__text {

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -162,6 +162,8 @@
 
   &__name {
     margin: 15px 0;
+    font-family: $font-open-sans;
+    font-weight: $font-light;
   }
 
   &__description {

--- a/mon-pix/app/styles/pages/_user-tests.scss
+++ b/mon-pix/app/styles/pages/_user-tests.scss
@@ -40,6 +40,7 @@
     margin: 0 0 8px;
     width: 100%;
     font-size: 3rem;
+    font-weight: 300;
     color: $pix-neutral-0;
   }
 }

--- a/mon-pix/app/templates/authenticated/user-tests.hbs
+++ b/mon-pix/app/templates/authenticated/user-tests.hbs
@@ -8,7 +8,7 @@
   <PixBackgroundHeader>
     <div class="user-tests-banner">
       <img src="/images/background/user-test-banner.svg" class="user-tests-banner__icon" role="none" alt="" />
-      <h3 class="user-tests-banner__title">{{t "pages.user-tests.title"}}</h3>
+      <h1 class="user-tests-banner__title">{{t "pages.user-tests.title"}}</h1>
     </div>
   </PixBackgroundHeader>
 


### PR DESCRIPTION
## :christmas_tree: Problème
Des pages sur Pix-App avait des problèmes d'accessibilité. 

## :gift: Proposition
Enlever le `skipFailures` présent dans les tests et corriger les problèmes de hiérarchie de titres.

## :santa: Pour tester
Vérifier la non régression des pages 'mes-parcours', 'certifications' et details des compétences
