### PR TITLE
[TECH] Supprimer le texte RGPD sur la page inscription sur Pix App (PIX-6243)

### DIFF
--- a/mon-pix/app/components/account-recovery/update-sco-record-form.hbs
+++ b/mon-pix/app/components/account-recovery/update-sco-record-form.hbs
@@ -52,8 +52,4 @@
       {{t "pages.account-recovery.update-sco-record.form.login-button"}}
     </PixButton>
   </div>
-
-  <div class="update-sco-record-form__legal-details-container">
-    {{t "pages.sign-up.legal-information"}}
-  </div>
 </form>

--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -133,10 +133,5 @@
         </PixButton>
       {{/if}}
     </div>
-
-    <div class="legal-notice">
-      {{t "pages.sign-up.legal-information"}}
-    </div>
-
   </form>
 </main>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -951,7 +951,6 @@
             "label": "My username"
           }
         },
-        "legal-text": "The information collected in this form is saved in a computer file by Pix to enable access to the service offered by Pix. They are kept for the duration of use of the service and are intended for Pix. Test results may be communicated to third parties, with your consent, if you have been invited to take a specific customised test. In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), you can exercise the right to access and rectify your data by emailing our Data Protection Officer at dpo@pix.fr.",
         "not-me": "That's not me",
         "rgpd-legal-notice": "To know how your personnal data is processed, and what your rights are, you can read",
         "rgpd-legal-notice-link": "Mentions d'information.",
@@ -1310,7 +1309,6 @@
       },
       "first-title": "Sign up",
       "instructions": "The fields marked '<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' are required",
-      "legal-information": "The information collected in this form is saved in a computer file by Pix to enable access to the service offered by Pix. It will be stored for a maximum of 5 years from the date of the last access to the user account and archived according to the statutory period of limitation (5 years). It will only be shared with Pix and its technical service providers. In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), you can exercise the right to access and rectify your data by emailing dpd@pix.fr.",
       "subtitle": {
         "link": "log into your account"
       }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -951,7 +951,6 @@
             "label": "Mon identifiant"
           }
         },
-        "legal-text": "Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix pour permettre l’accès au service offert. Elles sont conservées pendant la durée d’utilisation du service et sont destinées à Pix. Les résultats des tests pourront être communiqués à des tiers, avec votre consentement, dans le cas où vous avez été invité à suivre un parcours spécifique. Conformément à la loi « informatique et libertés », vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en contactant le Délégué à la Protection des Données de Pix à dpo@pix.fr.",
         "not-me": "Ce n'est pas moi",
         "rgpd-legal-notice": "Pour savoir comment tes données sont traitées et quels sont tes droits, tu peux lire les",
         "rgpd-legal-notice-link": "Mentions d'information.",
@@ -1310,7 +1309,6 @@
       },
       "first-title": "Inscrivez-vous",
       "instructions": "Les champs marqués de '<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' sont obligatoires",
-      "legal-information": "Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix pour permettre l'accès au service offert par Pix. Elles sont conservées pendant une durée de 5 ans maximum à compter du dernier accès au compte utilisateur, et archivées selon les délais de prescription légale (5 ans). Elles sont destinées à Pix et à ses prestataires techniques exclusivement. Conformément à la loi « informatique et libertés », vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en envoyant un mail à dpd@pix.fr.",
       "subtitle": {
         "link": "connectez-vous à votre compte"
       }


### PR DESCRIPTION
## :christmas_tree: Problème
Le texte concernant les conditions générales d'utilisation des données est maintenant inclus dans la politique de confidentialité auquel on fait référence sur la ligne avec la checkbox "J'accepte les [conditions d'utilisation de Pix ](https://pix.localhost/conditions-generales-d-utilisation)et la [politique de confidentialité](https://pix.localhost/politique-protection-donnees-personnelles-app)".

Il y a donc un doublon.

## :gift: Proposition
Supprimer tout le texte sous le bouton “Je m’inscris” sur la page d'inscription.

Supprimer également tout le texte sous le bouton "Je me connecte" sur la page de réconciliation SCO (lorsqu'un élève ayant changé d'adresse e-mail, met à jour son mot de passe). 

## :star2: Remarques
RAS.

## :santa: Pour tester

- Se rendre sur **Pix App** et cliquer sur `Créez un compte`.
- Arriver sur la page d'inscription et voir qu'il n'y a plus de texte sous le bouton `Je m'inscris.`
