### PR TITLE
[FEATURE] Voir les informations d'un compte Pix bloqué sur Pix Admin (PIX-6387).

### DIFF
--- a/admin/app/components/users/user-overview.hbs
+++ b/admin/app/components/users/user-overview.hbs
@@ -130,6 +130,23 @@
             <span>CGU Pix Certif validé : </span>
             <span>{{this.userHasValidatePixCertifTermsOfService}}</span>
           </div>
+          <br />
+          <div>
+            <span>Nombre de tentatives de connexion en erreur : </span>
+            <span>{{@user.userLogin.failureCount}}</span>
+          </div>
+          {{#if @user.userLogin.blockedAt}}
+            <div>
+              <span>Utilisateur totalement bloqué le : </span>
+              <span> {{dayjs-format @user.userLogin.blockedAt "DD/MM/YYYY HH:mm"}}</span>
+            </div>
+          {{/if}}
+          {{#if this.shouldDisplayTemporaryBlockedDate}}
+            <div>
+              <span>Utilisateur temporairement bloqué jusqu'au : </span>
+              <span>{{dayjs-format @user.userLogin.temporaryBlockedUntil "DD/MM/YYYY HH:mm"}}</span>
+            </div>
+          {{/if}}
         </div>
         <div>
           <PixButtonLink

--- a/admin/app/components/users/user-overview.js
+++ b/admin/app/components/users/user-overview.js
@@ -106,6 +106,14 @@ export default class UserOverview extends Component {
     return !!(this.args.user.email || this.args.user.username);
   }
 
+  get shouldDisplayTemporaryBlockedDate() {
+    const userIsTemporaryBlockedUntilDate = this.args.user?.userLogin?.get('temporaryBlockedUntil');
+    if (userIsTemporaryBlockedUntilDate) {
+      return dayjs().isBefore(dayjs(userIsTemporaryBlockedUntilDate));
+    }
+    return false;
+  }
+
   get userHasValidatePixAppTermsOfService() {
     return this._formatValidatedTermsOfServiceText(this.args.user.lastTermsOfServiceValidatedAt, this.args.user.cgu);
   }

--- a/admin/app/models/user-login.js
+++ b/admin/app/models/user-login.js
@@ -1,0 +1,7 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class UserLogin extends Model {
+  @attr() blockedAt;
+  @attr() temporaryBlockedUntil;
+  @attr() failureCount;
+}

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -20,6 +20,7 @@ export default class User extends Model {
 
   // includes
   @belongsTo('profile') profile;
+  @belongsTo('user-login') userLogin;
 
   @hasMany('organization-membership') organizationMemberships;
   @hasMany('certification-center-membership') certificationCenterMemberships;

--- a/admin/tests/integration/components/users/user-overview_test.js
+++ b/admin/tests/integration/components/users/user-overview_test.js
@@ -69,6 +69,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
           const screen = await render(hbs`<Users::UserOverview @user={{this.user}} />`);
 
           // then
+          assert.dom(screen.getByText('CGU Pix App validé :')).exists();
           assert.dom(screen.getByText('OUI, le 10/12/2021')).exists();
         });
 
@@ -94,6 +95,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
           const screen = await render(hbs`<Users::UserOverview @user={{this.user}} />`);
 
           // then
+          assert.dom(screen.getByText('CGU Pix Orga validé :')).exists();
           assert.dom(screen.getByText('OUI, le 14/12/2021')).exists();
         });
 
@@ -119,6 +121,7 @@ module('Integration | Component | users | user-overview', function (hooks) {
           const screen = await render(hbs`<Users::UserOverview @user={{this.user}} />`);
 
           // then
+          assert.dom(screen.getByText('CGU Pix Certif validé :')).exists();
           assert.dom(screen.getByText('OUI, le 14/12/2021')).exists();
         });
 

--- a/admin/tests/unit/components/users/user-overview_test.js
+++ b/admin/tests/unit/components/users/user-overview_test.js
@@ -26,9 +26,7 @@ module('Unit | Component | users | user-overview', function (hooks) {
       const actualUrl = component.externalURL;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actualUrl, expectedUrl);
+      assert.strictEqual(actualUrl, expectedUrl);
     });
   });
 
@@ -66,6 +64,61 @@ module('Unit | Component | users | user-overview', function (hooks) {
 
         // when & then
         assert.false(component.canModifyEmail);
+      });
+    });
+  });
+
+  module('#shouldDisplayTemporaryBlockedDate', function () {
+    module('when user has no login informations yet', function () {
+      test('should not display temporary blocked date', function (assert) {
+        // given
+        const component = createGlimmerComponent('component:users/user-overview');
+
+        // when && then
+        assert.false(component.shouldDisplayTemporaryBlockedDate);
+      });
+    });
+
+    module('when user has login but not temporary blocked', function () {
+      test('should not display temporary blocked date', function (assert) {
+        // given
+        const component = createGlimmerComponent('component:users/user-overview');
+        const user = { firstName: 'Lisa', lastName: 'Dupont' };
+        component.args.user = user;
+        const getTemporaryBlockedUntilProperty = () => null;
+        const userLoginProxy = { get: getTemporaryBlockedUntilProperty };
+        component.args.user.userLogin = userLoginProxy;
+
+        // when && then
+        assert.false(component.shouldDisplayTemporaryBlockedDate);
+      });
+    });
+
+    module('when user has login and temporary blocked date', function () {
+      test('should display temporary blocked date when now date is after temporaty blocked date', function (assert) {
+        // given
+        const component = createGlimmerComponent('component:users/user-overview');
+        const user = { firstName: 'Lisa', lastName: 'Dupont' };
+        const getTemporaryBlockedUntilProperty = () => new Date(Date.now() + 3600 * 1000);
+        const userLoginProxy = { get: getTemporaryBlockedUntilProperty };
+        component.args.user = user;
+        component.args.user.userLogin = userLoginProxy;
+
+        // when && then
+        assert.true(component.shouldDisplayTemporaryBlockedDate);
+      });
+
+      test('should not display temporary blocked date when now date is before temporaty blocked date', function (assert) {
+        // given
+        const component = createGlimmerComponent('component:users/user-overview');
+        const user = { firstName: 'Lisa', lastName: 'Dupont' };
+        component.args.user = user;
+        const getTemporaryBlockedUntilProperty = () => new Date(Date.now() - 3600 * 1000);
+        const userLoginProxy = { get: getTemporaryBlockedUntilProperty };
+        component.args.user.userLogin = userLoginProxy;
+
+        // when && then
+        assert.false(component.shouldDisplayTemporaryBlockedDate);
       });
     });
   });

--- a/admin/tests/unit/models/user_test.js
+++ b/admin/tests/unit/models/user_test.js
@@ -22,9 +22,7 @@ module('Unit | Model | user', function (hooks) {
       const fullName = user.fullName;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(fullName, 'Jean-Baptiste Poquelin');
+      assert.strictEqual(fullName, 'Jean-Baptiste Poquelin');
     });
   });
 });

--- a/api/lib/domain/models/UserDetailsForAdmin.js
+++ b/api/lib/domain/models/UserDetailsForAdmin.js
@@ -17,6 +17,7 @@ class UserDetailsForAdmin {
     lastPixCertifTermsOfServiceValidatedAt,
     lastLoggedAt,
     emailConfirmedAt,
+    userLogin,
   } = {}) {
     this.id = id;
     this.cgu = cgu;
@@ -35,6 +36,7 @@ class UserDetailsForAdmin {
     this.lastPixCertifTermsOfServiceValidatedAt = lastPixCertifTermsOfServiceValidatedAt;
     this.lastLoggedAt = lastLoggedAt;
     this.emailConfirmedAt = emailConfirmedAt;
+    this.userLogin = userLogin;
   }
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
@@ -32,6 +32,7 @@ module.exports = {
         'participations',
         'organizationMemberships',
         'certificationCenterMemberships',
+        'userLogin',
       ],
       organizationLearners: {
         ref: 'id',
@@ -54,6 +55,11 @@ module.exports = {
         ref: 'id',
         includes: true,
         attributes: ['identityProvider'],
+      },
+      userLogin: {
+        ref: 'id',
+        includes: true,
+        attributes: ['blockedAt', 'temporaryBlockedUntil', 'failureCount'],
       },
       profile: {
         ref: 'id',
@@ -128,6 +134,11 @@ module.exports = {
         ref: 'id',
         includes: true,
         attributes: ['identityProvider'],
+      },
+      userLogin: {
+        ref: 'id',
+        includes: true,
+        attributes: ['blockedAt', 'createdAt', 'updatedAt', 'temporaryBlockedUntil', 'failureCount'],
       },
     }).serialize(usersDetailsForAdmin);
   },

--- a/api/tests/acceptance/application/users/users-controller-get-user-details-for-admin_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-details-for-admin_test.js
@@ -55,6 +55,14 @@ describe('Acceptance | Controller | users-controller-get-user-details-for-admin'
         const superAdmin = await insertUserWithRoleSuperAdmin();
 
         const user = databaseBuilder.factory.buildUser({ username: 'brice.glace0712' });
+        const blockedAt = new Date('2022-12-07');
+        const temporaryBlockedUntil = new Date('2022-12-06');
+        const userLoginId = databaseBuilder.factory.buildUserLogin({
+          failureCount: 666,
+          blockedAt,
+          temporaryBlockedUntil,
+          userId: user.id,
+        }).id;
 
         await databaseBuilder.commit();
 
@@ -69,61 +77,72 @@ describe('Acceptance | Controller | users-controller-get-user-details-for-admin'
         });
 
         // then
-        const expectedScorecardJSONApi = {
-          data: {
-            attributes: {
-              cgu: true,
-              'created-at': new Date(),
-              email: user.email,
-              'email-confirmed-at': null,
-              'first-name': user.firstName,
-              lang: 'fr',
-              'last-logged-at': new Date(),
-              'last-name': user.lastName,
-              'last-pix-certif-terms-of-service-validated-at': null,
-              'last-pix-orga-terms-of-service-validated-at': null,
-              'last-terms-of-service-validated-at': null,
-              'pix-certif-terms-of-service-accepted': false,
-              'pix-orga-terms-of-service-accepted': false,
-              username: user.username,
-            },
-            id: `${user.id}`,
-            relationships: {
-              'authentication-methods': {
-                data: [],
-              },
-              'certification-center-memberships': {
-                links: {
-                  related: `/api/admin/users/${user.id}/certification-center-memberships`,
-                },
-              },
-              'organization-learners': {
-                data: [],
-              },
-              profile: {
-                links: {
-                  related: `/api/admin/users/${user.id}/profile`,
-                },
-              },
-              'organization-memberships': {
-                links: {
-                  related: `/api/admin/users/${user.id}/organizations`,
-                },
-              },
-              participations: {
-                links: {
-                  related: `/api/admin/users/${user.id}/participations`,
-                },
-              },
-            },
-            type: 'users',
-          },
-          included: undefined,
-        };
-
         expect(response.statusCode).to.equal(200);
-        expect(response.result.data).to.deep.equal(expectedScorecardJSONApi.data);
-        expect(response.result.included).to.deep.equal(expectedScorecardJSONApi.included);
+        expect(response.result.data.id).to.deep.equal(`${user.id}`);
+        expect(response.result.data.type).to.deep.equal('users');
+
+        expect(response.result.data.attributes).to.deep.equal({
+          cgu: true,
+          'created-at': new Date(),
+          email: user.email,
+          'email-confirmed-at': null,
+          'first-name': user.firstName,
+          lang: 'fr',
+          'last-logged-at': new Date(),
+          'last-name': user.lastName,
+          'last-pix-certif-terms-of-service-validated-at': null,
+          'last-pix-orga-terms-of-service-validated-at': null,
+          'last-terms-of-service-validated-at': null,
+          'pix-certif-terms-of-service-accepted': false,
+          'pix-orga-terms-of-service-accepted': false,
+          username: user.username,
+        });
+
+        expect(response.result.data.relationships).to.deep.equal({
+          'authentication-methods': {
+            data: [],
+          },
+          'certification-center-memberships': {
+            links: {
+              related: `/api/admin/users/${user.id}/certification-center-memberships`,
+            },
+          },
+          'organization-learners': {
+            data: [],
+          },
+          profile: {
+            links: {
+              related: `/api/admin/users/${user.id}/profile`,
+            },
+          },
+          'organization-memberships': {
+            links: {
+              related: `/api/admin/users/${user.id}/organizations`,
+            },
+          },
+          'user-login': {
+            data: {
+              id: `${userLoginId}`,
+              type: 'userLogins',
+            },
+          },
+          participations: {
+            links: {
+              related: `/api/admin/users/${user.id}/participations`,
+            },
+          },
+        });
+        expect(response.result.included).to.deep.equal([
+          {
+            id: `${userLoginId}`,
+            type: 'userLogins',
+            attributes: {
+              'failure-count': 666,
+              'blocked-at': blockedAt,
+              'temporary-blocked-until': temporaryBlockedUntil,
+            },
+          },
+        ]);
       });
     });
   });

--- a/api/tests/tooling/domain-builder/factory/build-user-details-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-user-details-for-admin.js
@@ -19,6 +19,7 @@ module.exports = function buildUserDetailsForAdmin({
   emailConfirmedAt,
   organizationLearners = [],
   authenticationMethods = [],
+  userLogin = [],
 } = {}) {
   return new UserDetailsForAdmin({
     id,
@@ -39,5 +40,6 @@ module.exports = function buildUserDetailsForAdmin({
     isAuthenticatedFromGAR,
     organizationLearners,
     authenticationMethods,
+    userLogin,
   });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-details-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-details-for-admin-serializer_test.js
@@ -16,6 +16,7 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
         emailConfirmedAt: now,
         organizationLearners: [domainBuilder.buildOrganizationLearnerForAdmin()],
         authenticationMethods: [{ id: 1, identityProvider: 'PIX' }],
+        userLogin: [{ id: 123, failureCount: 8 }],
       });
 
       // when
@@ -67,6 +68,14 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
                 related: `/api/admin/users/${userDetailsForAdmin.id}/profile`,
               },
             },
+            'user-login': {
+              data: [
+                {
+                  id: '123',
+                  type: 'userLogins',
+                },
+              ],
+            },
             'organization-memberships': {
               links: {
                 related: `/api/admin/users/${userDetailsForAdmin.id}/organizations`,
@@ -105,6 +114,11 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
             },
             id: `${userDetailsForAdmin.authenticationMethods[0].id}`,
             type: 'authenticationMethods',
+          },
+          {
+            attributes: { 'failure-count': 8 },
+            id: '123',
+            type: 'userLogins',
           },
         ],
       });


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsque le compte d'un utilisateur est bloqué sur Pix App, Pix Certif, Pix Orga, les utilisateurs de Pix Admin ne peuvent pas voir que le compte a été bloqué lors de la recherche d'un utilisateur sur Pix Admin. Il faut aller en BDD. pour le vérifier.

## :gift: Proposition
Dans Pix Admin, afficher les informations de connexion (nombre de tentatives de connexion infructueuses, compte bloqué temporairement ou définitivement) sur le détail d'un utilisateur .

## :star2: Remarques

## :santa: Pour tester

1. Bloquer le compte d'un utilisateur temporairement sur Pix App.
2. Vérifier que le compte de l'utilisateur est bloqué temporairement sur Pix Admin.
- le nombre de tentative
- la date de fin de blocage
3. Continuer au dessus de 10 et observer que la date de fin de blocage n'est plus visible jusqu'au palier de blocage suivant mais que le nombre de tentatives erronées est bien incrémenté. (il faut rafraîchir la page)
4. Bloquer définitivement le compte de l'utilisateur sur Pix App.
5. Vérifier que le compte de l'utilisateur est bloqué définitivement sur Pix Admin.
6. Effectuer la même procédure en bloquant le compte d'un utilisateur sur Pix Certif ou Pix Orga. Puis, vérifier sur Pix Admin, que le compte est bien bloqué.
