### PR TITLE
[TECH] Suppression du warning lié à browserslist lors du build des applications Pix (PIX-6475).

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -12112,9 +12112,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001352",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001352.tgz",
-      "integrity": "sha512-GUgH8w6YergqPQDGWhJGt8GDRnY0L/iJVQcU3eJ46GYf52R8tk0Wxp0PymuFVZboJYXGiCqwozAYZNRjVj6IcA==",
+      "version": "1.0.30001435",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001435.tgz",
+      "integrity": "sha512-kdCkUTjR+v4YAJelyiDTqiu82BDr4W4CP5sgTA0ZBmqn30XfS2ZghPLMowik9TPhS+psWJiUNxsqLyurDbmutA==",
       "dev": true,
       "funding": [
         {
@@ -48231,9 +48231,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001352",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001352.tgz",
-      "integrity": "sha512-GUgH8w6YergqPQDGWhJGt8GDRnY0L/iJVQcU3eJ46GYf52R8tk0Wxp0PymuFVZboJYXGiCqwozAYZNRjVj6IcA==",
+      "version": "1.0.30001435",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001435.tgz",
+      "integrity": "sha512-kdCkUTjR+v4YAJelyiDTqiu82BDr4W4CP5sgTA0ZBmqn30XfS2ZghPLMowik9TPhS+psWJiUNxsqLyurDbmutA==",
       "dev": true
     },
     "capture-exit": {

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -11066,9 +11066,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001353",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001353.tgz",
-      "integrity": "sha512-GqItFu1lCW4OGd4f47TVQXAGxca8K9Bz3cBb872ZskMo6FIQhiHCc7QjBL7Bb4XannbV+Gq0yHhFVxONW6C/XQ==",
+      "version": "1.0.30001436",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001436.tgz",
+      "integrity": "sha512-ZmWkKsnC2ifEPoWUvSAIGyOYwT+keAaaWPHiQ9DfMqS1t6tfuyFYoWR78TeZtznkEQ64+vGXH9cZrElwR2Mrxg==",
       "dev": true,
       "funding": [
         {
@@ -44185,9 +44185,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001353",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001353.tgz",
-      "integrity": "sha512-GqItFu1lCW4OGd4f47TVQXAGxca8K9Bz3cBb872ZskMo6FIQhiHCc7QjBL7Bb4XannbV+Gq0yHhFVxONW6C/XQ==",
+      "version": "1.0.30001436",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001436.tgz",
+      "integrity": "sha512-ZmWkKsnC2ifEPoWUvSAIGyOYwT+keAaaWPHiQ9DfMqS1t6tfuyFYoWR78TeZtznkEQ64+vGXH9cZrElwR2Mrxg==",
       "dev": true
     },
     "capture-exit": {

--- a/mon-pix/config/targets.js
+++ b/mon-pix/config/targets.js
@@ -2,13 +2,6 @@
 
 const browsers = ['> 1%'];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -14636,9 +14636,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001322",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz",
-      "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew==",
+      "version": "1.0.30001435",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001435.tgz",
+      "integrity": "sha512-kdCkUTjR+v4YAJelyiDTqiu82BDr4W4CP5sgTA0ZBmqn30XfS2ZghPLMowik9TPhS+psWJiUNxsqLyurDbmutA==",
       "dev": true,
       "funding": [
         {
@@ -54016,9 +54016,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001322",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz",
-      "integrity": "sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew==",
+      "version": "1.0.30001435",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001435.tgz",
+      "integrity": "sha512-kdCkUTjR+v4YAJelyiDTqiu82BDr4W4CP5sgTA0ZBmqn30XfS2ZghPLMowik9TPhS+psWJiUNxsqLyurDbmutA==",
       "dev": true
     },
     "capture-exit": {

--- a/orga/config/targets.js
+++ b/orga/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
+const browsers = ['> 1%'];
 
 module.exports = {
   browsers,


### PR DESCRIPTION
## :christmas_tree: Problème
(en attente de la montée de version de certif)

Lors du build de `mon-pix`, `admin` et `certif`, le warning suivant est affiché:
```
Browserslist: caniuse-lite is outdated. Please run:
  npx browserslist@latest --update-db
  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
```


## :gift: Proposition
Browserslist [met à disposition un script](https://github.com/browserslist/browserslist#browsers-data-updating) qui permet de mettre à jour toutes les dépendances `caniuse-lite` de son application (ie. spécifié dans le `package-lock.json`).

On met donc à jour ces dépendances en lançant :
```
npx browserslist@latest --update-db
```

## :star2: Remarques
La dépendence `caniuse-lite` utilisée par `browserslist` permet de déterminer les transpilations nécessaires au support des différents navigateurs spécifiés dans le fichier `config/targets.js`.

Cette dépendance est présente plusieurs fois dans chaque app, exemple `mon-pix` :

```
mon-pix@3.294.0 Pix/pix/mon-pix
├─┬ ember-cli-autoprefixer@2.0.0
│ └─┬ broccoli-autoprefixer@9.0.0
│   └─┬ autoprefixer@10.4.4
│     └── caniuse-lite@1.0.30001435 deduped
├─┬ ember-exam@6.0.1
│ └─┬ ember-mocha@0.16.2
│   └─┬ ember-cli-test-loader@2.2.0
│     └─┬ ember-cli-babel@6.18.0
│       └─┬ babel-preset-env@1.7.0
│         └─┬ browserslist@3.2.8
│           └── caniuse-lite@1.0.30001435 deduped
├─┬ ember-fetch@8.1.2
│ └─┬ caniuse-api@3.0.0
│   └── caniuse-lite@1.0.30001435
├─┬ stylelint@13.13.1
│ └─┬ autoprefixer@9.8.6
│   └── caniuse-lite@1.0.30001435 deduped
└─┬ webpack@5.75.0
  └─┬ browserslist@4.20.2
    └── caniuse-lite@1.0.30001435 deduped

```

## :santa: Pour tester
CI ok

