### PR TITLE
[BUGFIX] Gérer le cas de RTs définis par des critères de type "tubes cappés" dont les acquis enfants n'existent pas dans le référentiel (PIX-6477)

### DIFF
--- a/api/lib/domain/services/certification-badges-service.js
+++ b/api/lib/domain/services/certification-badges-service.js
@@ -19,6 +19,7 @@ module.exports = {
         const badgeForCalculation = await badgeForCalculationRepository.getByCertifiableBadgeAcquisition({
           certifiableBadgeAcquisition,
         });
+        if (!badgeForCalculation) return null;
         const isBadgeValid = badgeForCalculation.shouldBeObtained(knowledgeElements);
         return isBadgeValid ? certifiableBadgeAcquisition : null;
       }

--- a/api/tests/integration/infrastructure/repositories/badge-for-calculation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-for-calculation-repository_test.js
@@ -149,6 +149,7 @@ describe('Integration | Repository | BadgeForCalculation', function () {
         targetProfileId,
         campaignSkillsId
       );
+      _buildBadgeWithUnrealisableCriteria(targetProfileId, campaignSkillsId);
       await databaseBuilder.commit();
 
       // when
@@ -198,6 +199,7 @@ function _buildBadgeWithCampaignParticipationAndCappedTubes(targetProfileId, cam
   const cappedTubesDTO = [
     { id: 'recTubeA', level: 1 },
     { id: 'recTubeB', level: 4 },
+    { id: 'recTubeC', level: 1 },
   ];
   databaseBuilder.factory.buildBadgeCriterion({
     scope: BadgeCriterion.SCOPES.CAPPED_TUBES,
@@ -261,4 +263,19 @@ function _buildBadgeWithSkillSetsAndCampaignParticipationCriteria(targetProfileI
     key: 'BADGE_2_KEY',
     badgeCriteria: [criterion1, criterion2, criterion3],
   });
+}
+
+function _buildBadgeWithUnrealisableCriteria(targetProfileId) {
+  const badgeId = databaseBuilder.factory.buildBadge({
+    key: 'BADGE_3_KEY',
+    targetProfileId,
+  }).id;
+  const cappedTubesDTO = [{ id: 'recTubeC', level: 1 }];
+  databaseBuilder.factory.buildBadgeCriterion({
+    scope: BadgeCriterion.SCOPES.CAPPED_TUBES,
+    threshold: 60,
+    badgeId,
+    cappedTubes: JSON.stringify(cappedTubesDTO),
+  });
+  return null;
 }

--- a/api/tests/unit/domain/services/certification-badges-service_test.js
+++ b/api/tests/unit/domain/services/certification-badges-service_test.js
@@ -19,9 +19,11 @@ describe('Unit | Service | certification-badges-service', function () {
       const badge1 = domainBuilder.buildBadge({ id: 1 });
       const badge2 = domainBuilder.buildBadge({ id: 2 });
       const badge3 = domainBuilder.buildBadge({ id: 3 });
+      const badge4 = domainBuilder.buildBadge({ id: 4 });
       const highestBadgeAcquisition1 = domainBuilder.buildCertifiableBadgeAcquisition({ badge: badge1 });
       const highestBadgeAcquisition2 = domainBuilder.buildCertifiableBadgeAcquisition({ badge: badge2 });
       const highestBadgeAcquisition3 = domainBuilder.buildCertifiableBadgeAcquisition({ badge: badge3 });
+      const highestBadgeAcquisition4 = domainBuilder.buildCertifiableBadgeAcquisition({ badge: badge4 });
       const badgeStillValid1 = domainBuilder.buildBadgeForCalculation.mockObtainable({
         id: badge1.id,
       });
@@ -49,6 +51,9 @@ describe('Unit | Service | certification-badges-service', function () {
       getByCertifiableBadgeAcquisitionStub
         .withArgs({ certifiableBadgeAcquisition: highestBadgeAcquisition3 })
         .resolves(badgeStillValid3);
+      getByCertifiableBadgeAcquisitionStub
+        .withArgs({ certifiableBadgeAcquisition: highestBadgeAcquisition4 })
+        .resolves(null);
 
       // when
       const stillValidBadgeAcquisitions = await certificationBadgesService.findStillValidBadgeAcquisitions(args);


### PR DESCRIPTION
## :christmas_tree: Problème
Bug :
- Créer un profil-cible avec le tout premier tube de la première thématique de la première compétence du premier domain avec le niveau 1
- Créer un RT avec un critère type "tubes" et choisir le niveau 1 sur le tube choisi plus haut
- Campagne + participation + fin de campagne = CRASH

## :gift: Proposition
On n'a pas géré les cas suivants :
- Un RT avec un critère parmi plusieurs qui ne marche pas (comme décrit plus haut)
- Un RT avec aucun critère qui fonctionne

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Essaye de reproduire le bug, petit malin !
