### PR TITLE
[TECH] Améliorer la lisibilité des variables d'environnement liés au blocage de la connexion (PIX-6479)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -172,10 +172,12 @@ module.exports = (function () {
       window: _getNumber(process.env.RATE_LIMIT_DEFAULT_WINDOW, 60),
     },
 
-    userLogins: {
-      thresholdFailureCount: _getNumber(process.env.THRESHOLD_FAILURE_COUNT || 10),
-      temporaryBlockedTime: _getNumber(process.env.TEMPORARY_BLOCKED_TIME_IN_MINUTES || 2),
-      limitFailureCount: _getNumber(process.env.LIMIT_FAILURE_COUNT || 50),
+    login: {
+      temporaryBlockingThresholdFailureCount: _getNumber(
+        process.env.LOGIN_TEMPORARY_BLOCKING_THRESHOLD_FAILURE_COUNT || 10
+      ),
+      temporaryBlockingBaseTimeMs: ms(process.env.LOGIN_TEMPORARY_BLOCKING_BASE_TIME || '2m'),
+      blockingLimitFailureCount: _getNumber(process.env.LOGIN_BLOCKING_LIMIT_FAILURE_COUNT || 50),
     },
 
     caching: {

--- a/api/lib/domain/models/UserLogin.js
+++ b/api/lib/domain/models/UserLogin.js
@@ -1,4 +1,3 @@
-const dayjs = require('dayjs');
 const settings = require('../../config');
 
 class UserLogin {
@@ -27,14 +26,12 @@ class UserLogin {
   }
 
   shouldBlockUserTemporarily() {
-    return this.failureCount % settings.userLogins.thresholdFailureCount === 0;
+    return this.failureCount % settings.login.temporaryBlockingThresholdFailureCount === 0;
   }
 
   blockUserTemporarily() {
-    const rest = this.failureCount / settings.userLogins.thresholdFailureCount;
-    this.temporaryBlockedUntil = dayjs()
-      .add(Math.pow(settings.userLogins.temporaryBlockedTime, rest), 'minute')
-      .toDate();
+    const commonRatio = Math.pow(2, this.failureCount / settings.login.temporaryBlockingThresholdFailureCount - 1);
+    this.temporaryBlockedUntil = new Date(Date.now() + settings.login.temporaryBlockingBaseTimeMs * commonRatio);
   }
 
   hasBeenTemporaryBlocked() {
@@ -42,7 +39,7 @@ class UserLogin {
   }
 
   shouldBlockUser() {
-    return this.failureCount >= settings.userLogins.limitFailureCount;
+    return this.failureCount >= settings.login.blockingLimitFailureCount;
   }
 
   blockUser() {
@@ -50,7 +47,7 @@ class UserLogin {
   }
 
   isUserBlocked() {
-    return !!this.blockedAt || this.failureCount >= settings.userLogins.limitFailureCount;
+    return !!this.blockedAt || this.failureCount >= settings.login.blockingLimitFailureCount;
   }
 }
 

--- a/api/sample.env
+++ b/api/sample.env
@@ -778,23 +778,27 @@ RATE_LIMIT_DEFAULT_LIMIT=10
 # default: 60
 RATE_LIMIT_DEFAULT_WINDOW=60
 
+# ========
+# LOGIN
+# ========
+
 # Default number of failure before the user is temporary blocked
 # presence: optional
 # type: number
 # default: 10
-# THRESHOLD_FAILURE_COUNT=10
+# LOGIN_TEMPORARY_BLOCKING_THRESHOLD_FAILURE_COUNT=10
 
 # Default number of minutes the user need to wait before being unblocked
 # presence: optional
-# type: number
-# default: 2
-# TEMPORARY_BLOCKED_TIME_IN_MINUTES=2
+# type: string
+# default: '2m'
+# LOGIN_TEMPORARY_BLOCKING_BASE_TIME=2m
 
 # Default number of failure before the user is blocked
 # presence: optional
 # type: number
 # default: 50
-# LIMIT_FAILURE_COUNT=50
+# LOGIN_BLOCKING_LIMIT_FAILURE_COUNT=50
 
 # ===================
 # FEATURE TOGGLES

--- a/api/tests/unit/domain/models/UserLogin_test.js
+++ b/api/tests/unit/domain/models/UserLogin_test.js
@@ -1,28 +1,15 @@
 const { expect, sinon } = require('../../../test-helper');
 const UserLogin = require('../../../../lib/domain/models/UserLogin');
-const settings = require('../../../../lib/config');
-
 describe('Unit | Domain | Models | UserLogin', function () {
   let clock;
   const now = new Date('2022-11-28T12:00:00Z');
 
-  let originalEnvThresholdFailureCount;
-  let originalEnvTemporaryBlockedTime;
-
   beforeEach(function () {
     clock = sinon.useFakeTimers({ now });
-
-    originalEnvThresholdFailureCount = settings.userLogins.thresholdFailureCount;
-    settings.userLogins.thresholdFailureCount = 10;
-    originalEnvTemporaryBlockedTime = settings.userLogins.temporaryBlockedTime;
-    settings.userLogins.temporaryBlockedTime = 2;
   });
 
   afterEach(function () {
     clock.restore();
-
-    settings.userLogins.thresholdFailureCount = originalEnvThresholdFailureCount;
-    settings.userLogins.temporaryBlockedTime = originalEnvTemporaryBlockedTime;
   });
 
   describe('#incrementFailureCount', function () {


### PR DESCRIPTION
## :christmas_tree: Problème

Les variables `THRESHOLD_FAILURE_COUNT`, `TEMPORARY_BLOCKED_TIME_IN_MINUTES` et `LIMIT_FAILURE_COUNT` ne sont pas faciles à considérer dans leur ensemble et de manière intuitive dans Scalingo où les variables d'environnement sont listées par ordre alphabétique.

De plus il n'est pas assez souple de ne pouvoir utiliser que des minutes pour `TEMPORARY_BLOCKED_TIME_IN_MINUTES`.

Enfin `TEMPORARY_BLOCKED_TIME_IN_MINUTES` est mal nommée dans le sens où il s'agit d'un temps de blocage de base qui va aller en s'incrémentant. Dans ce nom il manque donc la notion « valeur de base qui sera ensuite incrémentée ».

## :gift: Proposition

1. Renommer ces variables d'environnement en les préfixant par `LOGIN_` pour les trouver toutes à côté par classement alphabétique
2. Pouvoir utiliser toutes les unités de temps (`m`, `s`, etc.) pour la durée de blocage
3. Ajouter le mot « BASE » dans le nouveau nommage de `TEMPORARY_BLOCKED_TIME_IN_MINUTES` pour indiquer que c'est une valeur qui va servir à créer ensuite d'autres valeurs

## :star2: Remarques

À noter dans le code l'utilisation du mot *commonRatio* qui est le terme mathématique dédié dans le contexte des progressions géométriques cf. https://en.wikipedia.org/wiki/Geometric_progression

Bien penser à mettre ensuite à jour toutes les différentes variables d'environnement sur les différents environnements, c'est à dire notamment supprimer les anciennes variables.

## :santa: Pour tester

Tester selon le même plan de test que https://github.com/1024pix/pix/pull/5276 et s'assurer qu'il n'y a pas de régression.
