### PR TITLE
[FEATURE][ADMIN] Lors de l'anonymisation, désactiver l'utilisateur des centres de certification dont il est membre (PIX-3841)

### DIFF
--- a/api/db/database-builder/factory/build-certification-center-membership.js
+++ b/api/db/database-builder/factory/build-certification-center-membership.js
@@ -6,6 +6,7 @@ const buildUser = require('./build-user');
 module.exports = function buildCertificationCenterMembership({
   id = databaseBuffer.getNextId(),
   userId,
+  updatedByUserId,
   certificationCenterId,
   createdAt = new Date('2020-01-01'),
   disabledAt,
@@ -17,6 +18,7 @@ module.exports = function buildCertificationCenterMembership({
   const values = {
     id,
     userId,
+    updatedByUserId,
     certificationCenterId,
     createdAt,
     disabledAt,

--- a/api/db/migrations/20221205153130_add-column-updatedByUserId-to-certification-center-memberships-table.js
+++ b/api/db/migrations/20221205153130_add-column-updatedByUserId-to-certification-center-memberships-table.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'certification-center-memberships';
+const COLUMN_NAME = 'updatedByUserId';
+
+exports.up = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.bigInteger(COLUMN_NAME).index().references('users.id');
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/db/seeds/data/certification/certification-centers-builder.js
+++ b/api/db/seeds/data/certification/certification-centers-builder.js
@@ -1,4 +1,6 @@
 const _ = require('lodash');
+const { DEFAULT_PASSWORD } = require('../users-builder');
+
 const SCO_COLLEGE_CERTIF_CENTER_ID = 1;
 const SCO_COLLEGE_CERTIF_CENTER_NAME = 'Centre SCO Collège des Anne-Étoiles';
 const SCO_LYCEE_CERTIF_CENTER_ID = 13;
@@ -280,6 +282,25 @@ function certificationCentersBuilder({ databaseBuilder }) {
       type: types[_.random(0, 2)],
     });
   }
+
+  // Great Oak Certification Center - anonymization purpose
+  const greatOakCertificationCenter = databaseBuilder.factory.buildCertificationCenter({
+    name: 'Great Oak Certification Center',
+    type: 'SCO',
+  });
+  const greatOakCertificationCenterMember = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Hijuro',
+    lastName: 'Butora',
+    email: 'hijuro.butora@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: true,
+    pixCertifTermsOfServiceAccepted: true,
+    lastPixCertifTermsOfServiceValidatedAt: new Date(),
+  });
+  databaseBuilder.factory.buildCertificationCenterMembership({
+    certificationCenterId: greatOakCertificationCenter.id,
+    userId: greatOakCertificationCenterMember.id,
+  });
 }
 
 module.exports = {

--- a/api/lib/domain/usecases/anonymize-user.js
+++ b/api/lib/domain/usecases/anonymize-user.js
@@ -4,6 +4,7 @@ module.exports = async function anonymizeUser({
   userRepository,
   authenticationMethodRepository,
   membershipRepository,
+  certificationCenterMembershipRepository,
   refreshTokenService,
 }) {
   const anonymizedUser = {
@@ -16,5 +17,6 @@ module.exports = async function anonymizeUser({
   await authenticationMethodRepository.removeAllAuthenticationMethodsByUserId({ userId });
   await refreshTokenService.revokeRefreshTokensForUserId({ userId });
   await membershipRepository.disableMembershipsByUserId({ userId, updatedByUserId });
+  await certificationCenterMembershipRepository.disableMembershipsByUserId({ updatedByUserId, userId });
   return userRepository.updateUserDetailsForAdministration(userId, anonymizedUser);
 };

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -153,4 +153,11 @@ module.exports = {
 
     return _toDomain(refererCertificationCenterMembership);
   },
+
+  async disableMembershipsByUserId({ userId, updatedByUserId }) {
+    await knex('certification-center-memberships')
+      .whereNull('disabledAt')
+      .andWhere({ userId })
+      .update({ disabledAt: new Date(), updatedByUserId });
+  },
 };

--- a/api/tests/acceptance/application/users/users-controller-anonymize-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-anonymize-user_test.js
@@ -8,7 +8,7 @@ const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | users-controller-anonymize-user', function () {
   describe('POST /admin/users/:id/anonymize', function () {
-    it('anomymizes user, removes authentication methods and disables user organisation memberships', async function () {
+    it("anomymizes user, removes authentication methods and disables user's certification center and organisation memberships", async function () {
       // given
       const server = await createServer();
       const superAdmin = await insertUserWithRoleSuperAdmin();
@@ -16,6 +16,11 @@ describe('Acceptance | Controller | users-controller-anonymize-user', function (
       const organizationId = databaseBuilder.factory.buildOrganization().id;
       databaseBuilder.factory.buildMembership({
         organizationId,
+        userId: user.id,
+      });
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId,
         userId: user.id,
       });
 

--- a/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -429,7 +429,8 @@ describe('Integration | Repository | Certification Center', function () {
           await certificationCenterRepository.findPaginatedFiltered({ filter, page });
 
         // then
-        expect(matchingCertificationCenters).to.deepEqualArray([
+        expect(matchingCertificationCenters.length).to.equal(3);
+        expect(matchingCertificationCenters).to.deep.include.members([
           expectedCertificationCenter1,
           expectedCertificationCenter2,
           expectedCertificationCenter3,

--- a/api/tests/unit/domain/usecases/anonymize-user_test.js
+++ b/api/tests/unit/domain/usecases/anonymize-user_test.js
@@ -3,16 +3,17 @@ const anonymizeUser = require('../../../../lib/domain/usecases/anonymize-user');
 
 describe('Unit | UseCase | anonymize-user', function () {
   let clock;
+  const now = new Date('2003-04-05T03:04:05Z');
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers(new Date('2003-04-05T03:04:05Z'));
+    clock = sinon.useFakeTimers(now);
   });
 
   afterEach(function () {
     clock.restore();
   });
 
-  it("deletes all authentication methods, revokes all user's refresh tokens, disables all user's organisation membership and anonymize user", async function () {
+  it("deletes all authentication methods, revokes all user's refresh tokens, disables all user's organisation memberships, disables all user's certification center memberships and anonymize user", async function () {
     // given
     const userId = 1;
     const updatedByUserId = 2;
@@ -27,6 +28,7 @@ describe('Unit | UseCase | anonymize-user', function () {
     const authenticationMethodRepository = { removeAllAuthenticationMethodsByUserId: sinon.stub() };
     const refreshTokenService = { revokeRefreshTokensForUserId: sinon.stub() };
     const membershipRepository = { disableMembershipsByUserId: sinon.stub() };
+    const certificationCenterMembershipRepository = { disableMembershipsByUserId: sinon.stub() };
 
     // when
     await anonymizeUser({
@@ -35,6 +37,7 @@ describe('Unit | UseCase | anonymize-user', function () {
       authenticationMethodRepository,
       refreshTokenService,
       membershipRepository,
+      certificationCenterMembershipRepository,
       updatedByUserId,
     });
 
@@ -46,6 +49,10 @@ describe('Unit | UseCase | anonymize-user', function () {
     expect(membershipRepository.disableMembershipsByUserId).to.have.been.calledWith({
       userId,
       updatedByUserId,
+    });
+    expect(certificationCenterMembershipRepository.disableMembershipsByUserId).to.have.been.calledWith({
+      updatedByUserId,
+      userId,
     });
     expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWithExactly(
       userId,


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement, le processus d'anonymisation ne fait que retirer toutes les méthodes d'authentification, supprimer tous les refresh tokens de l'utilisateur et anonymiser les détails de l'utilisateur.

Si ce dernier est membre d'un centre de certification, il le restera et on pourra se connecter à l'application Pix Certif en utilisant les données anonymisées.

## :gift: Proposition

Ajouter une étape en plus dans le processus d'anonymisation qui sera de désactiver l'utilisateur sur tous les centres de certification dont l'utilisateur fait partie.

## :star2: Remarques

⚠️ C'est peut-être le moment d'utiliser une transaction pour l'anonymisation vu que l'on fait des modifications en base de données à plusieurs endroits.
⚠️ Le bouton d'anonymisation sur Pix Admin est toujours disponible après l'anonymisation. Il faudrait peut être désactiver le bouton.

## :santa: Pour tester

- Se connecter à Pix Admin avec un compte ayant les droits pour anonymiser un utilisateur
- Ouvrir les détails du centre de certification **Great Oak Certification Center**
- Constater dans la liste des membres l'affichage de l'utilisateur **Hijuro Butora**
- Ouvrir la page de détails de cet utilisateur
- Cliquez sur le bouton **Anonymiser cet utilisateur**
- Revenir sur la page de détails du centre de certification **Great Oak Certification Center**
- Constatez que l'utilisateur **Hijuro Butora** n'est plus membre de ce centre de certification
