### PR TITLE
[TECH] Ajouter le support de Firefox 58.

### DIFF
--- a/certif/config/targets.js
+++ b/certif/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const browsers = ['> 1%'];
+const browsers = ['> 1%', 'firefox 58'];
 
 module.exports = {
   browsers,

--- a/mon-pix/config/targets.js
+++ b/mon-pix/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const browsers = ['> 1%'];
+const browsers = ['> 1%', 'firefox 58'];
 
 module.exports = {
   browsers,

--- a/orga/config/targets.js
+++ b/orga/config/targets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const browsers = ['> 1%'];
+const browsers = ['> 1%', 'firefox 58'];
 
 module.exports = {
   browsers,


### PR DESCRIPTION
## :christmas_tree: Problème
Nous avons retiré le support de Firefox 58 en enlevant ie dans les targets dans cette PR https://github.com/1024pix/pix/pull/5326
Cependant, nous avons des utilisateurs qui l'utilisent.

## :gift: Proposition
Rajouter le support de Firefox 58.

## :star2: Remarques
En prod, Pix App est innacessible en dessous de Firefox 58.

Admin n'a pas été inclut car il s'agit d'un outil interne pour lequel nous "maitrisons" davantage les navigateurs utilisés

## :santa: Pour tester
- Lancer un lambda test sur la RA
- Vérifier le bon fonctionnement sur APP, Certif, Orga,