### PR TITLE
[FEATURE] Nommer les groupes de critères d'obtention d'un RT lorsqu'ils portent sur un groupe d'acquis (PIX-6438)

### DIFF
--- a/admin/app/components/badges/capped-tubes-criterion.hbs
+++ b/admin/app/components/badges/capped-tubes-criterion.hbs
@@ -1,7 +1,14 @@
 <p data-testid="toujourstriste">
   L'évalué doit obtenir
   <strong>{{@criterion.threshold}}%</strong>
-  sur tous les sujets plafonnés par niveau suivants :
+  {{#if @criterion.name}}
+    sur le groupe
+    <strong>{{@criterion.name}}</strong>
+    possédant
+  {{else}}
+    sur tous
+  {{/if}}
+  les sujets plafonnés par niveau suivants :
 </p>
 
 {{#each this.areasForView as |area|}}

--- a/admin/app/components/target-profiles/badge-form/campaign-criterion.hbs
+++ b/admin/app/components/target-profiles/badge-form/campaign-criterion.hbs
@@ -8,7 +8,7 @@
     type="number"
     min="0"
     max="100"
-    @label="Taux de réussite pour obtenir le RT :"
+    @label="Taux de réussite requis :"
     @requiredLabel="Champ obligatoire"
     {{on "change" @onThresholdChange}}
   />

--- a/admin/app/components/target-profiles/badge-form/capped-tubes-criterion.hbs
+++ b/admin/app/components/target-profiles/badge-form/capped-tubes-criterion.hbs
@@ -7,6 +7,12 @@
   </header>
   <main>
     <PixInput
+      @id={{concat @id "criterionName"}}
+      class="badge-form-criterion__name"
+      @label="Nom du critère :"
+      {{on "change" @onNameChange}}
+    />
+    <PixInput
       @id={{@id}}
       class="badge-form-criterion__threshold"
       type="number"

--- a/admin/app/components/target-profiles/badge-form/capped-tubes-criterion.hbs
+++ b/admin/app/components/target-profiles/badge-form/capped-tubes-criterion.hbs
@@ -18,7 +18,7 @@
       type="number"
       min="1"
       max="100"
-      @label="Taux de réussite pour obtenir le RT :"
+      @label="Taux de réussite requis :"
       @requiredLabel="Champ obligatoire"
       {{on "change" @onThresholdChange}}
     />

--- a/admin/app/components/target-profiles/badge-form/criteria.hbs
+++ b/admin/app/components/target-profiles/badge-form/criteria.hbs
@@ -28,6 +28,7 @@
         @id={{concat "cappedTubeCriterion" index}}
         @areas={{@areas}}
         @onThresholdChange={{fn this.onCappedTubesThresholdChange criterion}}
+        @onNameChange={{fn this.onCappedTubesNameChange criterion}}
         @onTubesSelectionChange={{fn this.onCappedTubesSelectionChange criterion}}
         @remove={{fn this.removeCappedTubeCriterion index}}
       />

--- a/admin/app/components/target-profiles/badge-form/criteria.js
+++ b/admin/app/components/target-profiles/badge-form/criteria.js
@@ -37,6 +37,11 @@ export default class Criteria extends Component {
   }
 
   @action
+  onCappedTubesNameChange(criterion, e) {
+    criterion.name = e.target.value;
+  }
+
+  @action
   onCappedTubesSelectionChange(criterion, selection) {
     criterion.cappedTubes = selection;
   }

--- a/admin/app/models/badge-criterion.js
+++ b/admin/app/models/badge-criterion.js
@@ -5,6 +5,7 @@ export default class BadgeCriterion extends Model {
   @attr('number') threshold;
   @attr() skillSets;
   @attr() cappedTubes;
+  @attr() name;
 
   get isCampaignScope() {
     return this.scope === 'CampaignParticipation';

--- a/admin/app/styles/components/target-profiles/badge-form.scss
+++ b/admin/app/styles/components/target-profiles/badge-form.scss
@@ -100,6 +100,10 @@ input {
 
   &.badge-form-criterion {
 
+    &__name {
+      margin-bottom: 16px;
+    }
+
     &__threshold {
       width: 134px;
       margin-bottom: 16px;

--- a/admin/tests/integration/components/target-profiles/badge-form_test.js
+++ b/admin/tests/integration/components/target-profiles/badge-form_test.js
@@ -142,7 +142,7 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
 
       // then
       assert.dom(screen.getByRole('heading', { name: 'Critère d’obtention sur l’ensemble du profil cible' })).exists();
-      assert.dom(screen.getByLabelText('* Taux de réussite pour obtenir le RT :')).exists();
+      assert.dom(screen.getByLabelText('* Taux de réussite requis :')).exists();
     });
 
     test('it should display capped tubes criterion form on click', async function (assert) {
@@ -155,7 +155,7 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
         .dom(screen.getByRole('heading', { name: 'Critère d’obtention sur une sélection de sujets du profil cible' }))
         .exists();
       assert.dom(screen.getByLabelText('Nom du critère :')).exists();
-      assert.dom(screen.getByLabelText('* Taux de réussite pour obtenir le RT :')).exists();
+      assert.dom(screen.getByLabelText('* Taux de réussite requis :')).exists();
       assert.dom(screen.getByRole('button', { name: 'Supprimer' })).exists();
       assert.dom(screen.getByRole('button', { name: 'Ajouter une nouvelle sélection de sujets' })).exists();
     });

--- a/admin/tests/integration/components/target-profiles/badge-form_test.js
+++ b/admin/tests/integration/components/target-profiles/badge-form_test.js
@@ -154,6 +154,7 @@ module('Integration | Component | TargetProfiles::BadgeForm', function (hooks) {
       assert
         .dom(screen.getByRole('heading', { name: 'Critère d’obtention sur une sélection de sujets du profil cible' }))
         .exists();
+      assert.dom(screen.getByLabelText('Nom du critère :')).exists();
       assert.dom(screen.getByLabelText('* Taux de réussite pour obtenir le RT :')).exists();
       assert.dom(screen.getByRole('button', { name: 'Supprimer' })).exists();
       assert.dom(screen.getByRole('button', { name: 'Ajouter une nouvelle sélection de sujets' })).exists();

--- a/api/db/migrations/20221207095714_add-badge-criteria-name-column.js
+++ b/api/db/migrations/20221207095714_add-badge-criteria-name-column.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'badge-criteria';
+const COLUMN_NAME = 'name';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).defaultTo(null);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/domain/models/BadgeDetails.js
+++ b/api/lib/domain/models/BadgeDetails.js
@@ -15,8 +15,9 @@ class BadgeDetails {
 }
 
 class BadgeCriterion {
-  constructor({ id, scope, threshold, skillSets, cappedTubes }) {
+  constructor({ id, name, scope, threshold, skillSets, cappedTubes }) {
     this.id = id;
+    this.name = name;
     this.scope = scope;
     this.threshold = threshold;
     this.skillSets = skillSets;
@@ -26,6 +27,7 @@ class BadgeCriterion {
   toDTO() {
     return {
       id: this.id,
+      name: this.name,
       scope: this.scope,
       threshold: this.threshold,
       skillSets: this.skillSets.map((skillSet) => skillSet.toDTO()),

--- a/api/lib/domain/usecases/create-badge.js
+++ b/api/lib/domain/usecases/create-badge.js
@@ -78,6 +78,7 @@ module.exports = async function createBadge({
           {
             badgeCriterion: {
               badgeId: savedBadge.id,
+              name: criterion.name,
               threshold: criterion.threshold,
               scope: 'CappedTubes',
               cappedTubes: criterion.cappedTubes,

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-for-admin-new-format-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-for-admin-new-format-serializer.js
@@ -44,7 +44,7 @@ module.exports = {
         criteria: {
           ref: 'id',
           included: true,
-          attributes: ['threshold', 'scope', 'skillSets', 'cappedTubes'],
+          attributes: ['threshold', 'scope', 'skillSets', 'cappedTubes', 'name'],
         },
       },
       stages: {

--- a/api/tests/acceptance/application/target-profiles/index_test.js
+++ b/api/tests/acceptance/application/target-profiles/index_test.js
@@ -558,6 +558,7 @@ describe('Acceptance | Route | target-profiles', function () {
           'campaign-threshold': '99',
           'capped-tubes-criteria': [
             {
+              name: 'awesome tube group',
               threshold: '50',
               cappedTubes: [
                 {
@@ -606,6 +607,7 @@ describe('Acceptance | Route | target-profiles', function () {
         };
 
         const expectedCappedTubesCriterion = {
+          name: 'awesome tube group',
           scope: 'CappedTubes',
           threshold: 50,
           badgeId: parseInt(response.result.data.id, 10),
@@ -617,6 +619,7 @@ describe('Acceptance | Route | target-profiles', function () {
         };
 
         const expectedCampaignCriterion = {
+          name: null,
           scope: 'CampaignParticipation',
           threshold: 99,
           badgeId: parseInt(response.result.data.id, 10),

--- a/api/tests/tooling/domain-builder/factory/build-badge-details.js
+++ b/api/tests/tooling/domain-builder/factory/build-badge-details.js
@@ -33,6 +33,7 @@ const buildBadgeDetails = function buildBadgeDetails({
 buildBadgeDetails.buildBadgeCriterion_CampaignParticipation = function ({ id = 456, threshold = 80 }) {
   return new BadgeCriterion({
     id,
+    name: null,
     scope: SCOPES.CAMPAIGN_PARTICIPATION,
     threshold,
     skillSets: [],
@@ -50,6 +51,7 @@ buildBadgeDetails.buildBadgeCriterion_SkillSets = function ({
   });
   return new BadgeCriterion({
     id,
+    name: null,
     scope: SCOPES.SKILL_SET,
     threshold,
     skillSets,
@@ -59,6 +61,7 @@ buildBadgeDetails.buildBadgeCriterion_SkillSets = function ({
 
 buildBadgeDetails.buildBadgeCriterion_CappedTubes = function ({
   id = 456,
+  name = null,
   threshold = 80,
   cappedTubesDTO = [
     { tubeId: 'recTube1', level: 4 },
@@ -70,6 +73,7 @@ buildBadgeDetails.buildBadgeCriterion_CappedTubes = function ({
   });
   return new BadgeCriterion({
     id,
+    name,
     scope: SCOPES.CAPPED_TUBES,
     threshold,
     skillSets: [],

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-new-format-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-new-format-serializer_test.js
@@ -28,6 +28,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-new-format-seri
         criteria: [badge1Criteria1, badge1Criteria2],
       });
       const badge2Criteria1 = domainBuilder.buildBadgeDetails.buildBadgeCriterion_CappedTubes({
+        name: 'super tubes group',
         id: 3000,
         threshold: 50,
         cappedTubesDTO: [
@@ -194,6 +195,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-new-format-seri
             type: 'badge-criteria',
             id: '1000',
             attributes: {
+              name: null,
               threshold: 80,
               scope: SCOPES.SKILL_SET,
               'skill-sets': [
@@ -213,6 +215,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-new-format-seri
             type: 'badge-criteria',
             id: '2000',
             attributes: {
+              name: null,
               threshold: 70,
               scope: SCOPES.CAMPAIGN_PARTICIPATION,
               'skill-sets': [],
@@ -250,6 +253,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-new-format-seri
             type: 'badge-criteria',
             id: '3000',
             attributes: {
+              name: 'super tubes group',
               threshold: 50,
               scope: SCOPES.CAPPED_TUBES,
               'skill-sets': [],


### PR DESCRIPTION
## :christmas_tree: Problème

Lors de la création d’un RT il faudrait revoir les données à renseigner lors du renseignement d’un critère d’obtention portant sur un groupe de sujets.

## :gift: Proposition

Proposer un champ de saisi libre sous forme d’un input avec en libellé “Nom de critère” (facultatif)

Le champ de saisi du taux de réussite à renommer en “Taux de réussite requis”

A la consultation d’un RT possédant des critères sur des groupe de sujets l’affichage se fait comme ci-dessous : 
> L‘évalué doit obtenir 40% sur le groupe <NOM DU GROUPE CRITERE1> possédant les sujets suivants plafonnés par niveau/taux : (puis l’utilisateur peut déplier le détails pour chaque compétence)
> L‘évalué doit obtenir 30% sur le groupe <NOM DU GROUPE CRITERE2> possédant les sujets suivants plafonnés par niveau/taux : (puis l’utilisateur peut déplier le détails pour chaque compétence)

## :star2: Remarques
RAS

## :santa: Pour tester
Créer un RT avec des critères par sujets.