### PR TITLE
[FEATURE] Ajouter le bouton de fermeture de bannière sur Pix Certif (pix-6494)

### DIFF
--- a/certif/app/components/communication-banner.hbs
+++ b/certif/app/components/communication-banner.hbs
@@ -1,5 +1,5 @@
 {{#if this.isEnabled}}
-  <PixBanner @type={{this.bannerType}}>
+  <PixBanner @type={{this.bannerType}} @canCloseBanner="true">
     {{this.bannerContent}}
   </PixBanner>
 {{/if}}

--- a/certif/tests/integration/components/communication-banner_test.js
+++ b/certif/tests/integration/components/communication-banner_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import ENV from 'pix-certif/config/environment';
 
@@ -38,5 +39,19 @@ module('Integration | Component | communication-banner', function (hooks) {
     // then
     assert.dom(screen.getByText('information banner text ...')).exists();
     assert.dom(screen.getByRole('button', { name: 'Fermer' })).exists();
+  });
+
+  test('should close the information banner on click on close button', async function (assert) {
+    // given
+    ENV.APP.BANNER.CONTENT = 'information banner text ...';
+    ENV.APP.BANNER.TYPE = 'information';
+    const screen = await render(hbs`<CommunicationBanner />`);
+
+    // when
+    await click(screen.getByRole('button', { name: 'Fermer' }));
+
+    // then
+    assert.dom(screen.queryByText('information banner text ...')).doesNotExist();
+    assert.dom(screen.queryByRole('button', { name: 'Fermer' })).doesNotExist();
   });
 });

--- a/certif/tests/integration/components/communication-banner_test.js
+++ b/certif/tests/integration/components/communication-banner_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import ENV from 'pix-certif/config/environment';
 
@@ -33,10 +33,10 @@ module('Integration | Component | communication-banner', function (hooks) {
     ENV.APP.BANNER.TYPE = 'information';
 
     // when
-    await render(hbs`<CommunicationBanner />`);
+    const screen = await render(hbs`<CommunicationBanner />`);
 
     // then
-    assert.dom('.pix-banner--information').exists();
-    assert.dom('.pix-banner--information').containsText('information banner text ...');
+    assert.dom(screen.getByText('information banner text ...')).exists();
+    assert.dom(screen.getByRole('button', { name: 'Fermer' })).exists();
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
La bannière présente sur Pix Certif qui peut servir à transmettre des infos/erreurs/attentions ne peut pas être fermée.

## :gift: Proposition
Permettre la fermeture de cette bannière via la nouvelle option proposée sur Pix UI. 

## :star2: Remarques


## :santa: Pour tester
J'ai encore du mal à tester en local et en RA via les variables d'environnement. Je me renseigne.