### PR TITLE
[FEATURE] Rafraichir la liste des organisations et centres de certifications de l'utilisateur après anonymisation (PIX-6488)

### DIFF
--- a/admin/app/components/users/user-overview.js
+++ b/admin/app/components/users/user-overview.js
@@ -190,6 +190,9 @@ export default class UserOverview extends Component {
   @action
   async anonymizeUser() {
     await this.args.user.save({ adapterOptions: { anonymizeUser: true } });
+    this.args.user.organizationMemberships = [];
+    this.args.user.certificationCenterMemberships = [];
+
     this.toggleDisplayAnonymizeModal();
   }
 }


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement, une fois qu’un utilisateur est anonymisé, les listes des organisations et centres de certification dont il faisait partie ne sont pas mises à jour.

Cela pourrait entraîner une incompréhension pour l’administrateur ayant fait cette action.

## :gift: Proposition

Supprimer tous les éléments des listes sans rafraichir la page.

## :star2: Remarques

RAS

## :santa: Pour tester

- Se connecter à Pix Admin avec un compte ayant les droits pour anonymiser un utilisateur
- Ouvrir les détails de l'organisation Great Oak School
- Constater dans la liste des membres l'affichage de l'utilisateur Katar Orilee
- Ouvrir la page de détails de cet utilisateur
- Cliquez sur le bouton Anonymiser cet utilisateur
- Constatez que les détails de l'utilisateur ont été mis à jour avec les données anonymisées
- Constatez dans l'onglet Organisations que la liste est vide
- Revenir sur la page de détails de l'organisation Great Oak School
- Constatez que l'utilisateur Katar Orilee n'est plus membre de cet organisation
