### PR TITLE
[FEATURE] Nettoyer les tests de Pix App avec testing library (PIX-6382)

### DIFF
--- a/mon-pix/app/components/dashboard/banner.hbs
+++ b/mon-pix/app/components/dashboard/banner.hbs
@@ -1,5 +1,5 @@
 {{#if @show}}
-  <section class="dashboard-banner" data-test-new-dashboard-info>
+  <section class="dashboard-banner">
     {{#unless @hasSeenNewDashboardInfo}}
       <NewInformation
         @information="{{t 'pages.dashboard.presentation.message' firstname=@userFirstname}}"

--- a/mon-pix/app/components/dashboard/content.hbs
+++ b/mon-pix/app/components/dashboard/content.hbs
@@ -32,7 +32,7 @@
     />
 
     {{#if this.hasNothingToShow}}
-      <section data-test-empty-dashboard>
+      <section>
         <div>
           <NewInformation
             @information="{{t 'pages.dashboard.empty-dashboard.message'}}"
@@ -49,7 +49,6 @@
 
     {{#if this.hasCampaignParticipationOverviews}}
       <Dashboard::Section
-        data-test-campaign-participation-overviews
         @title={{t "pages.dashboard.campaigns.title"}}
         @subtitle={{t "pages.dashboard.campaigns.subtitle"}}
         @linkRoute="authenticated.user-tests"

--- a/mon-pix/app/components/signin-form.hbs
+++ b/mon-pix/app/components/signin-form.hbs
@@ -24,7 +24,7 @@
   {{/if}}
 
   <form {{on "submit" this.signin}} class="sign-form__body">
-    <p class="sign-form-body__instruction">{{t "common.form.mandatory-all-fields" htmlSafe=true}}</p>
+    <p class="sign-form-body__instruction">{{t "common.form.mandatory-all-fields"}}</p>
 
     <fieldset>
       <legend class="sr-only">{{t "pages.sign-in.fields.legend"}}</legend>

--- a/mon-pix/tests/integration/components/dashboard/content_test.js
+++ b/mon-pix/tests/integration/components/dashboard/content_test.js
@@ -1,10 +1,9 @@
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
-import { find, render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { contains } from '../../../helpers/contains';
 
 module('Integration | Component | Dashboard | Content', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -38,10 +37,10 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
     });
 
     // when
-    await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
+    const screen = await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
 
     // then
-    assert.dom('.dashboard-content').exists();
+    assert.dom(screen.getByRole('main')).exists();
   });
 
   module('campaign-participation-overview rendering', function (hooks) {
@@ -77,32 +76,11 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
 
       // then
-      assert.dom('section[data-test-campaign-participation-overviews]').exists();
-    });
-
-    test('should render campaign participations link', async function (assert) {
-      // given
-      const campaignParticipationOverview = EmberObject.create({
-        isShared: false,
-        createdAt: '2020-12-10T15:16:20.109Z',
-        assessmentState: 'started',
-        campaignTitle: 'My campaign',
-        organizationName: 'My organization',
-      });
-      this.set('model', {
-        campaignParticipationOverviews: [campaignParticipationOverview],
-        campaignParticipations: [],
-        scorecards: [],
-      });
-
-      // when
-      await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
-
-      // then
-      assert.ok(contains('Tous mes parcours'));
+      assert.dom(screen.getByRole('heading', { name: this.intl.t('pages.dashboard.campaigns.title') })).exists();
+      assert.dom(screen.getByRole('link', { name: this.intl.t('pages.dashboard.campaigns.tests-link') })).exists();
     });
 
     test('should not render campaign participations when there is no campaign participation overviews', async function (assert) {
@@ -114,10 +92,15 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
 
       // then
-      assert.dom('section[data-test-campaign-participation-overviews]').doesNotExist();
+      assert
+        .dom(screen.queryByRole('heading', { name: this.intl.t('pages.dashboard.campaigns.title') }))
+        .doesNotExist();
+      assert
+        .dom(screen.queryByRole('link', { name: this.intl.t('pages.dashboard.campaigns.tests-link') }))
+        .doesNotExist();
     });
   });
 
@@ -148,10 +131,15 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
 
       // then
-      assert.dom('section[data-test-recommended-competences]').exists();
+      assert
+        .dom(screen.getByRole('heading', { name: this.intl.t('pages.dashboard.recommended-competences.title') }))
+        .exists();
+      assert
+        .dom(screen.getByRole('link', { name: this.intl.t('pages.dashboard.recommended-competences.profile-link') }))
+        .exists();
     });
 
     test('should not render competence-card when there is no competence-card', async function (assert) {
@@ -163,21 +151,26 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
 
       // then
-      assert.dom('section[data-test-recommended-competences]').doesNotExist();
+      assert
+        .dom(screen.queryByRole('heading', { name: this.intl.t('pages.dashboard.recommended-competences.title') }))
+        .doesNotExist();
+      assert
+        .dom(screen.queryByRole('link', { name: this.intl.t('pages.dashboard.recommended-competences.profile-link') }))
+        .doesNotExist();
     });
 
     test('should render the four first non started competence cards from the received arguments', async function (assert) {
       // given
       const scorecards = [
-        { id: 1, index: '1.1', isNotStarted: true },
-        { id: 2, index: '1.2', isNotStarted: true },
-        { id: 3, index: '3.1', isNotStarted: true },
-        { id: 5, index: '1.3', isNotStarted: false },
-        { id: 4, index: '2.4', isNotStarted: true },
-        { id: 4, index: '1.4', isNotStarted: true },
+        { id: 1, index: '1.1', isNotStarted: true, name: 'Compétence 1' },
+        { id: 2, index: '1.2', isNotStarted: true, name: 'Compétence 2' },
+        { id: 3, index: '3.1', isNotStarted: true, name: 'Compétence 3' },
+        { id: 5, index: '1.3', isNotStarted: false, name: 'Compétence 4' },
+        { id: 4, index: '2.4', isNotStarted: true, name: 'Compétence 5' },
+        { id: 6, index: '1.4', isNotStarted: true, name: 'Compétence 6' },
       ];
       this.set('model', {
         campaignParticipationOverviews: [],
@@ -186,10 +179,14 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
 
       // then
-      assert.dom('.competence-card').exists({ count: 4 });
+      assert.strictEqual(screen.getAllByRole('article').length, 4);
+      assert.dom(screen.getByRole('link', { name: 'Compétence 1 Compétence non commencée' })).exists();
+      assert.dom(screen.getByRole('link', { name: 'Compétence 2 Compétence non commencée' })).exists();
+      assert.dom(screen.getByRole('link', { name: 'Compétence 5 Compétence non commencée' })).exists();
+      assert.dom(screen.getByRole('link', { name: 'Compétence 6 Compétence non commencée' })).exists();
     });
   });
 
@@ -220,10 +217,10 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
 
       // then
-      assert.ok(contains(this.intl.t('pages.dashboard.improvable-competences.subtitle')));
+      assert.ok(screen.getByText(this.intl.t('pages.dashboard.improvable-competences.subtitle')));
     });
 
     test('should not render competence-card when there is no competence-card', async function (assert) {
@@ -235,21 +232,21 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
 
       // then
-      assert.notOk(contains(this.intl.t('pages.dashboard.improvable-competences.subtitle')));
+      assert.notOk(screen.queryByText(this.intl.t('pages.dashboard.improvable-competences.subtitle')));
     });
 
     test('should render the four first non improvable competence cards from the received arguments', async function (assert) {
       // given
       const scorecards = [
-        { id: 1, index: '1.1', isImprovable: true },
-        { id: 2, index: '1.2', isImprovable: true },
-        { id: 3, index: '3.1', isImprovable: true },
-        { id: 5, index: '1.3', isImprovable: false },
-        { id: 4, index: '2.4', isImprovable: true },
-        { id: 4, index: '1.4', isImprovable: true },
+        { id: 1, index: '1.1', isImprovable: true, name: 'Compétence 1' },
+        { id: 2, index: '1.2', isImprovable: true, name: 'Compétence 2' },
+        { id: 3, index: '3.1', isImprovable: true, name: 'Compétence 3' },
+        { id: 5, index: '1.3', isImprovable: false, name: 'Compétence 4' },
+        { id: 4, index: '2.4', isImprovable: true, name: 'Compétence 5' },
+        { id: 4, index: '1.4', isImprovable: true, name: 'Compétence 6' },
       ];
       this.set('model', {
         campaignParticipationOverviews: [],
@@ -258,10 +255,22 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
 
       // then
-      assert.dom('.competence-card').exists({ count: 4 });
+      assert.strictEqual(screen.getAllByRole('article').length, 4);
+      assert
+        .dom(screen.getByRole('link', { name: 'Compétence 1 Niveau actuel: . Le prochain niveau est complété à %.' }))
+        .exists();
+      assert
+        .dom(screen.getByRole('link', { name: 'Compétence 2 Niveau actuel: . Le prochain niveau est complété à %.' }))
+        .exists();
+      assert
+        .dom(screen.getByRole('link', { name: 'Compétence 5 Niveau actuel: . Le prochain niveau est complété à %.' }))
+        .exists();
+      assert
+        .dom(screen.getByRole('link', { name: 'Compétence 6 Niveau actuel: . Le prochain niveau est complété à %.' }))
+        .exists();
     });
   });
 
@@ -292,10 +301,12 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
 
       // then
-      assert.dom('section[data-test-started-competences]').exists();
+      assert
+        .dom(screen.getByRole('heading', { name: this.intl.t('pages.dashboard.started-competences.title') }))
+        .exists();
     });
 
     test('should not render competence-card when there is no competence-card', async function (assert) {
@@ -307,21 +318,23 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
 
       // then
-      assert.dom('section[data-test-started-competences]').doesNotExist();
+      assert
+        .dom(screen.queryByRole('heading', { name: this.intl.t('pages.dashboard.started-competences.title') }))
+        .doesNotExist();
     });
 
     test('should render the four first started competence cards from the received arguments', async function (assert) {
       // given
       const scorecards = [
-        { id: 1, index: '1.1', isStarted: true },
-        { id: 2, index: '1.2', isStarted: true },
-        { id: 3, index: '3.1', isStarted: true },
-        { id: 5, index: '1.3', isStarted: false },
-        { id: 4, index: '2.4', isStarted: true },
-        { id: 4, index: '1.4', isStarted: true },
+        { id: 1, index: '1.1', isStarted: true, name: 'Compétence 1' },
+        { id: 2, index: '1.2', isStarted: true, name: 'Compétence 2' },
+        { id: 3, index: '3.1', isStarted: true, name: 'Compétence 3' },
+        { id: 5, index: '1.3', isStarted: false, name: 'Compétence 4' },
+        { id: 4, index: '2.4', isStarted: true, name: 'Compétence 5' },
+        { id: 4, index: '1.4', isStarted: true, name: 'Compétence 6' },
       ];
       this.set('model', {
         campaignParticipationOverviews: [],
@@ -330,10 +343,23 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
 
       // then
-      assert.dom('.competence-card').exists({ count: 4 });
+
+      assert.strictEqual(screen.getAllByRole('article').length, 4);
+      assert
+        .dom(screen.getByRole('link', { name: 'Compétence 1 Niveau actuel: . Le prochain niveau est complété à %.' }))
+        .exists();
+      assert
+        .dom(screen.getByRole('link', { name: 'Compétence 2 Niveau actuel: . Le prochain niveau est complété à %.' }))
+        .exists();
+      assert
+        .dom(screen.getByRole('link', { name: 'Compétence 5 Niveau actuel: . Le prochain niveau est complété à %.' }))
+        .exists();
+      assert
+        .dom(screen.getByRole('link', { name: 'Compétence 6 Niveau actuel: . Le prochain niveau est complété à %.' }))
+        .exists();
     });
   });
 
@@ -360,10 +386,10 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
 
       // then
-      assert.dom('.new-information').exists();
+      assert.dom(screen.getByRole('heading', { name: 'Bonjour Banana, découvrez votre tableau de bord.' })).exists();
     });
 
     test('should not display NewInformation on dashboard if user has close it before', async function (assert) {
@@ -388,10 +414,12 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
 
       // then
-      assert.dom('section[data-test-new-dashboard-info]').doesNotExist();
+      assert
+        .dom(screen.queryByRole('heading', { name: 'Bonjour Banana, découvrez votre tableau de bord.' }))
+        .doesNotExist();
     });
 
     test('should display link on new dashboard banner when domain is pix.fr', async function (assert) {
@@ -423,11 +451,12 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
 
       // then
-      assert.dom('.new-information').exists();
-      assert.dom('.new-information-content-text__link').exists();
+      assert
+        .dom(screen.getByRole('link', { name: this.intl.t('pages.dashboard.presentation.link.text') }))
+        .hasAttribute('href', this.intl.t('pages.dashboard.presentation.link.url'));
     });
 
     test('should hide link on new dashboard banner when domain is pix.org', async function (assert) {
@@ -459,11 +488,13 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
 
       // then
-      assert.dom('.new-information').exists();
-      assert.dom('.new-information-content-text__link').doesNotExist();
+      assert.dom(screen.getByRole('heading', { name: 'Bonjour Banana, découvrez votre tableau de bord.' })).exists();
+      assert
+        .dom(screen.queryByRole('link', { name: this.intl.t('pages.dashboard.presentation.link.text') }))
+        .doesNotExist();
     });
   });
 
@@ -490,10 +521,12 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
 
       // then
-      assert.dom('section[data-test-empty-dashboard]').exists();
+      assert
+        .dom(screen.getByRole('heading', { name: 'Bravo vous avez terminé les compétences recommandées !' }))
+        .exists();
     });
 
     test('should not display Empty Dashboard Information on dashboard if user has competence to continue', async function (assert) {
@@ -521,10 +554,15 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
 
       // then
-      assert.dom('section[data-test-empty-dashboard]').doesNotExist();
+      assert
+        .dom(screen.queryByRole('heading', { name: 'Bravo vous avez terminé les compétences recommandées !' }))
+        .doesNotExist();
+      assert
+        .dom(screen.queryByRole('button', { name: this.intl.t('pages.dashboard.empty-dashboard.link-to-competences') }))
+        .doesNotExist();
     });
   });
 
@@ -551,11 +589,11 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
 
       // then
-      assert.dom('.dashboard-content__score').exists();
-      assert.ok(find('.hexagon-score-content__pix-score').textContent.includes(pixScore));
+      assert.dom(screen.getByText(pixScore)).exists();
+      assert.dom(screen.getByRole('button', { name: this.intl.t('pages.profile.total-score-helper.label') })).exists();
     });
   });
 
@@ -583,10 +621,10 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
 
       // then
-      assert.ok(contains(this.intl.t('pages.dashboard.campaigns.resume.action')));
+      assert.ok(screen.getByRole('link', { name: this.intl.t('pages.dashboard.campaigns.resume.action') }));
     });
 
     test('should not display the banner when there is no code', async function (assert) {
@@ -611,10 +649,10 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       });
 
       // when
-      await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
+      const screen = await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
 
       // then
-      assert.notOk(contains(this.intl.t('pages.dashboard.campaigns.resume.action')));
+      assert.notOk(screen.queryByRole('link', { name: this.intl.t('pages.dashboard.campaigns.resume.action') }));
     });
   });
 });

--- a/mon-pix/tests/integration/components/hexagon-score_test.js
+++ b/mon-pix/tests/integration/components/hexagon-score_test.js
@@ -7,14 +7,6 @@ module('Integration | Component | hexagon-score', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   module('Component rendering', function () {
-    test('should render component', async function (assert) {
-      // when
-      await render(hbs`<HexagonScore />`);
-      // then
-
-      assert.ok(this.element.querySelector('.hexagon-score'));
-    });
-
     test('should display two dashes, when no pixScore provided', async function (assert) {
       // when
       await render(hbs`<HexagonScore />`);

--- a/mon-pix/tests/integration/components/hexagon-score_test.js
+++ b/mon-pix/tests/integration/components/hexagon-score_test.js
@@ -1,32 +1,38 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { render } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | hexagon-score', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   module('Component rendering', function () {
     test('should display two dashes, when no pixScore provided', async function (assert) {
-      // when
-      await render(hbs`<HexagonScore />`);
+      // given & when
+      const screen = await render(hbs`<HexagonScore />`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(this.element.querySelector('.hexagon-score-content__pix-score').innerHTML, '–');
+      assert.ok(screen.getByText('–'));
     });
 
     test('should display provided score in hexagon', async function (assert) {
       // given
       const pixScore = '777';
       this.set('pixScore', pixScore);
+
       // when
-      await render(hbs`<HexagonScore @pixScore={{this.pixScore}} />`);
+      const screen = await render(hbs`<HexagonScore @pixScore={{this.pixScore}} />`);
+
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(this.element.querySelector('.hexagon-score-content__pix-score').innerHTML, pixScore);
+      assert.ok(screen.getByText(pixScore));
+    });
+
+    test('should display an information tooltip', async function (assert) {
+      // given & when
+      const screen = await render(hbs`<HexagonScore />`);
+
+      // then
+      assert.ok(screen.getByRole('button', { name: this.intl.t('pages.profile.total-score-helper.label') }));
     });
   });
 });

--- a/mon-pix/tests/integration/components/navbar-desktop-header_test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-header_test.js
@@ -1,53 +1,68 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import { setBreakpoint } from 'ember-responsive/test-support';
-
-import { contains } from '../../helpers/contains';
 
 module('Integration | Component | navbar-desktop-header', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   module('when user is not logged', function (hooks) {
-    hooks.beforeEach(async function () {
+    hooks.beforeEach(function () {
+      // given
       class sessionService extends Service {
         isAuthenticated = false;
       }
       this.owner.register('service:session', sessionService);
       setBreakpoint('desktop');
-      await render(hbs`<NavbarDesktopHeader/>`);
     });
 
-    test('should display the Pix logo', function (assert) {
+    test('should display the Pix logo', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
       // then
-      assert.dom('.navbar-desktop-header-logo').exists();
-      assert.dom('.pix-logo').exists();
+      assert.dom(screen.getByRole('img', { name: this.intl.t('navigation.homepage') })).exists();
+      assert.dom(screen.getByRole('link', { name: this.intl.t('navigation.homepage') })).exists();
     });
 
-    test('should not display the navigation menu', function (assert) {
+    test('should not display the navigation menu', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
       // then
-      assert.dom('.navbar-desktop-header-container__menu').doesNotExist();
+      assert.dom(screen.queryByRole('navigation', { name: this.intl.t('navigation.main.label') })).doesNotExist();
     });
 
-    test('should display link to signup page', function (assert) {
+    test('should display link to signup page', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
       // then
-      assert.dom('.navbar-menu-signup-link').exists();
+      assert.dom(screen.getByRole('link', { name: this.intl.t('navigation.not-logged.sign-up') })).exists();
     });
 
-    test('should display link to login page', function (assert) {
+    test('should display link to login page', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
       // then
-      assert.dom('.navbar-menu-signin-link').exists();
+      assert.dom(screen.getByRole('link', { name: this.intl.t('navigation.not-logged.sign-in') })).exists();
     });
 
-    test('should not display the link "J\'ai un code"', function (assert) {
-      assert.notOk(contains("J'ai un code"));
+    test('should not display the link "J\'ai un code"', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
+      // then
+      assert.notOk(screen.queryByRole('link', { name: this.intl.t('navigation.main.code') }));
     });
   });
 
   module('When user is logged', function (hooks) {
-    hooks.beforeEach(async function () {
+    hooks.beforeEach(function () {
+      // given
       class sessionService extends Service {
         isAuthenticated = true;
         data = {
@@ -60,53 +75,71 @@ module('Integration | Component | navbar-desktop-header', function (hooks) {
       }
       this.owner.register('service:session', sessionService);
       class currentUserService extends Service {
-        user = { isAnonymous: false };
+        user = { isAnonymous: false, firstName: 'Judy' };
       }
       this.owner.register('service:currentUser', currentUserService);
       setBreakpoint('desktop');
-      await render(hbs`<NavbarDesktopHeader/>}`);
     });
 
-    test('should display the link "J\'ai un code"', function (assert) {
-      assert.ok(contains("J'ai un code"));
-    });
+    test('should display the link "J\'ai un code"', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
 
-    test('should display the Pix logo', function (assert) {
       // then
-      assert.dom('.navbar-desktop-header-logo').exists();
-      assert.dom('.pix-logo').exists();
+      assert.dom(screen.getByRole('link', { name: this.intl.t('navigation.main.code') })).exists();
     });
 
-    test('should display logged user details informations', function (assert) {
+    test('should display the Pix logo', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
       // then
-      assert.dom('.logged-user-details').exists();
+      assert.dom(screen.getByRole('img', { name: this.intl.t('navigation.homepage') })).exists();
+      assert.dom(screen.getByRole('link', { name: this.intl.t('navigation.homepage') })).exists();
     });
 
-    test('should not display link to signup page', function (assert) {
+    test('should display logged user details informations', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
       // then
-      assert.dom('.navbar-menu-signup-link').doesNotExist();
+      assert.dom(screen.getByRole('button', { name: 'Judy Consulter mes informations' })).exists();
     });
 
-    test('should not display link to login page', function (assert) {
+    test('should not display link to signup page', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
       // then
-      assert.dom('.navbar-menu-signin-link').doesNotExist();
+      assert.dom(screen.queryByRole('link', { name: this.intl.t('navigation.not-logged.sign-up') })).doesNotExist();
     });
 
-    test('should display the navigation menu with expected elements', function (assert) {
+    test('should not display link to login page', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
       // then
-      assert.dom('.navbar-desktop-header-container__menu').exists();
-      assert.dom('.navbar-desktop-header-menu__item').exists({ count: 5 });
-      assert.ok(contains('Accueil'));
-      assert.ok(contains('Compétences'));
-      assert.ok(contains('Mes tutos'));
-      assert.ok(contains('Certification'));
-      assert.ok(contains("J'ai un code"));
-      assert.notOk(contains('Mes formations'));
+      assert.dom(screen.queryByRole('link', { name: this.intl.t('navigation.not-logged.sign-in') })).doesNotExist();
+    });
+
+    test('should display the navigation menu with expected elements', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
+      // then
+      assert.dom(screen.getByRole('navigation', { name: this.intl.t('navigation.main.label') })).exists();
+      assert.dom(screen.getByRole('link', { name: this.intl.t('navigation.main.dashboard') })).exists();
+      assert.dom(screen.getByRole('link', { name: this.intl.t('navigation.main.skills') })).exists();
+      assert.dom(screen.getByRole('link', { name: this.intl.t('navigation.main.start-certification') })).exists();
+      assert.dom(screen.getByRole('link', { name: this.intl.t('navigation.main.tutorials') })).exists();
+      assert.dom(screen.getByRole('link', { name: this.intl.t('navigation.main.code') })).exists();
+      assert.dom(screen.queryByRole('link', { name: this.intl.t('navigation.main.trainings') })).doesNotExist();
     });
   });
 
   module('when user has recommended trainings', function (hooks) {
-    hooks.beforeEach(async function () {
+    hooks.beforeEach(function () {
+      // given
       class sessionService extends Service {
         isAuthenticated = true;
         data = {
@@ -126,17 +159,20 @@ module('Integration | Component | navbar-desktop-header', function (hooks) {
       }
       this.owner.register('service:currentUser', currentUser);
       setBreakpoint('desktop');
-      await render(hbs`<NavbarDesktopHeader/>}`);
     });
 
     test('should display "My trainings" link', async function (assert) {
-      assert.dom('.navbar-desktop-header-menu__item').exists({ count: 6 });
-      assert.ok(contains('Mes formations'));
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
+      // then
+      assert.dom(screen.getByRole('link', { name: this.intl.t('navigation.main.trainings') })).exists();
     });
   });
 
   module('when user comes from external platform', function (hooks) {
-    hooks.beforeEach(async function () {
+    hooks.beforeEach(function () {
+      // given
       class sessionService extends Service {
         isAuthenticated = false;
         data = {
@@ -144,39 +180,54 @@ module('Integration | Component | navbar-desktop-header', function (hooks) {
         };
       }
       this.owner.register('service:session', sessionService);
-
       setBreakpoint('desktop');
-      await render(hbs`<NavbarDesktopHeader/>`);
     });
 
-    test('should display the Pix logo', function (assert) {
+    test('should display the Pix logo', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
       // then
-      assert.dom('.navbar-desktop-header-logo').exists();
-      assert.dom('.pix-logo').exists();
+      assert.dom(screen.getByRole('img', { name: this.intl.t('navigation.homepage') })).exists();
+      assert.dom(screen.getByRole('link', { name: this.intl.t('navigation.homepage') })).exists();
     });
 
-    test('should not display the navigation menu', function (assert) {
+    test('should not display the navigation menu', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
       // then
-      assert.dom('.navbar-desktop-header-container__menu').doesNotExist();
+      assert.dom(screen.queryByRole('navigation', { name: this.intl.t('navigation.main.label') })).doesNotExist();
     });
 
-    test('should not display link to signup page', function (assert) {
+    test('should not display link to signup page', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
       // then
-      assert.dom('.navbar-menu-signup-link').doesNotExist();
+      assert.dom(screen.queryByRole('link', { name: this.intl.t('navigation.not-logged.sign-up') })).doesNotExist();
     });
 
-    test('should not display link to login page', function (assert) {
+    test('should not display link to login page', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
       // then
-      assert.dom('.navbar-menu-signin-link').doesNotExist();
+      assert.dom(screen.queryByRole('link', { name: this.intl.t('navigation.not-logged.sign-in') })).doesNotExist();
     });
 
-    test('should not display the join campaign link', function (assert) {
-      assert.notOk(contains("J'ai un code"));
+    test('should not display the join campaign link', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
+      // then
+      assert.dom(screen.queryByRole('link', { name: this.intl.t('navigation.main.code') })).doesNotExist();
     });
   });
 
   module('when logged user is anonymous', function (hooks) {
     hooks.beforeEach(async function () {
+      // given
       class sessionService extends Service {
         isAuthenticated = true;
       }
@@ -187,32 +238,47 @@ module('Integration | Component | navbar-desktop-header', function (hooks) {
       this.owner.register('service:currentUser', currentUserService);
 
       setBreakpoint('desktop');
-      await render(hbs`<NavbarDesktopHeader/>`);
     });
 
-    test('should display the Pix logo', function (assert) {
+    test('should display the Pix logo', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
       // then
-      assert.dom('.navbar-desktop-header-logo').exists();
-      assert.dom('.pix-logo').exists();
+      assert.dom(screen.getByRole('img', { name: this.intl.t('navigation.homepage') })).exists();
+      assert.dom(screen.getByRole('link', { name: this.intl.t('navigation.homepage') })).exists();
     });
 
-    test('should not display the navigation menu', function (assert) {
+    test('should not display the navigation menu', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
       // then
-      assert.dom('.navbar-desktop-header-container__menu').doesNotExist();
+      assert.dom(screen.queryByRole('navigation', { name: this.intl.t('navigation.main.label') })).doesNotExist();
     });
 
-    test('should not display link to signup page', function (assert) {
+    test('should not display link to signup page', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
       // then
-      assert.dom('.navbar-menu-signup-link').doesNotExist();
+      assert.dom(screen.queryByRole('link', { name: this.intl.t('navigation.not-logged.sign-up') })).doesNotExist();
     });
 
-    test('should not display link to login page', function (assert) {
+    test('should not display link to login page', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
       // then
-      assert.dom('.navbar-menu-signin-link').doesNotExist();
+      assert.dom(screen.queryByRole('link', { name: this.intl.t('navigation.not-logged.sign-in') })).doesNotExist();
     });
 
-    test('should not display the join campaign link', function (assert) {
-      assert.notOk(contains("J'ai un code"));
+    test('should not display the join campaign link', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarDesktopHeader/>`);
+
+      // then
+      assert.dom(screen.queryByRole('link', { name: this.intl.t('navigation.main.code') })).doesNotExist();
     });
   });
 
@@ -221,10 +287,10 @@ module('Integration | Component | navbar-desktop-header', function (hooks) {
     this.set('isFrenchDomainUrl', false);
 
     // when
-    await render(hbs`<NavbarDesktopHeader @shouldShowTheMarianneLogo={{this.isFrenchDomainUrl}} />`);
+    const screen = await render(hbs`<NavbarDesktopHeader @shouldShowTheMarianneLogo={{this.isFrenchDomainUrl}} />`);
 
     // then
-    assert.dom('.navbar-desktop-header-logo__marianne').doesNotExist();
+    assert.dom(screen.queryByRole('img', { name: this.intl.t('common.french-republic') })).doesNotExist();
   });
 
   test('should display marianne logo when url does have frenchDomainExtension', async function (assert) {
@@ -232,9 +298,9 @@ module('Integration | Component | navbar-desktop-header', function (hooks) {
     this.set('isFrenchDomainUrl', true);
 
     // when
-    await render(hbs`<NavbarDesktopHeader @shouldShowTheMarianneLogo={{this.isFrenchDomainUrl}} />`);
+    const screen = await render(hbs`<NavbarDesktopHeader @shouldShowTheMarianneLogo={{this.isFrenchDomainUrl}} />`);
 
     // then
-    assert.dom('.navbar-desktop-header-logo__marianne').exists();
+    assert.dom(screen.getByRole('img', { name: this.intl.t('common.french-republic') })).exists();
   });
 });

--- a/mon-pix/tests/integration/components/navbar-desktop-header_test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-header_test.js
@@ -20,11 +20,6 @@ module('Integration | Component | navbar-desktop-header', function (hooks) {
       await render(hbs`<NavbarDesktopHeader/>`);
     });
 
-    test('should be rendered', function (assert) {
-      // then
-      assert.dom('.navbar-desktop-header__container').exists();
-    });
-
     test('should display the Pix logo', function (assert) {
       // then
       assert.dom('.navbar-desktop-header-logo').exists();
@@ -70,10 +65,6 @@ module('Integration | Component | navbar-desktop-header', function (hooks) {
       this.owner.register('service:currentUser', currentUserService);
       setBreakpoint('desktop');
       await render(hbs`<NavbarDesktopHeader/>}`);
-    });
-
-    test('should be rendered', function (assert) {
-      assert.dom('.navbar-desktop-header').exists();
     });
 
     test('should display the link "J\'ai un code"', function (assert) {
@@ -158,11 +149,6 @@ module('Integration | Component | navbar-desktop-header', function (hooks) {
       await render(hbs`<NavbarDesktopHeader/>`);
     });
 
-    test('should be rendered', function (assert) {
-      // then
-      assert.dom('.navbar-desktop-header__container').exists();
-    });
-
     test('should display the Pix logo', function (assert) {
       // then
       assert.dom('.navbar-desktop-header-logo').exists();
@@ -202,11 +188,6 @@ module('Integration | Component | navbar-desktop-header', function (hooks) {
 
       setBreakpoint('desktop');
       await render(hbs`<NavbarDesktopHeader/>`);
-    });
-
-    test('should be rendered', function (assert) {
-      // then
-      assert.dom('.navbar-desktop-header__container').exists();
     });
 
     test('should display the Pix logo', function (assert) {

--- a/mon-pix/tests/integration/components/navbar-desktop-nav-menu_test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-nav-menu_test.js
@@ -1,16 +1,30 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
+import { render } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | navbar desktop menu', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('should be rendered', async function (assert) {
+  test('should render links', async function (assert) {
+    // given
+    class SessionStub extends Service {
+      isAuthenticated = true;
+    }
+    this.owner.register('service:session', SessionStub);
+    this.set('menu', [
+      {
+        name: this.intl.t('navigation.not-logged.sign-in'),
+      },
+      { name: this.intl.t('navigation.not-logged.sign-up') },
+    ]);
+
     // when
-    await render(hbs`<NavbarDesktopMenu/>`);
+    const screen = await render(hbs`<NavbarDesktopMenu @menu={{this.menu}}  />`);
 
     // then
-    assert.dom('.navbar-desktop-menu').exists();
+    assert.dom(screen.getByRole('link', { name: this.intl.t('navigation.not-logged.sign-up') })).exists();
+    assert.dom(screen.getByRole('link', { name: this.intl.t('navigation.not-logged.sign-in') })).exists();
   });
 });

--- a/mon-pix/tests/integration/components/navbar-header_test.js
+++ b/mon-pix/tests/integration/components/navbar-header_test.js
@@ -1,12 +1,9 @@
-/* eslint ember/no-classic-classes: 0 */
-
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setBreakpoint } from 'ember-responsive/test-support';
-import { contains } from '../../helpers/contains';
+import { render } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | navbar-header', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -17,11 +14,11 @@ module('Integration | Component | navbar-header', function (hooks) {
       setBreakpoint('desktop');
 
       // when
-      await render(hbs`<NavbarHeader/>`);
+      const screen = await render(hbs`<NavbarHeader/>`);
 
       // then
-      assert.ok(contains(this.intl.t('common.skip-links.skip-to-content')));
-      assert.ok(contains(this.intl.t('common.skip-links.skip-to-footer')));
+      assert.ok(screen.getByRole('link', { name: this.intl.t('common.skip-links.skip-to-content') }));
+      assert.ok(screen.getByRole('link', { name: this.intl.t('common.skip-links.skip-to-footer') }));
     });
   });
 
@@ -29,47 +26,49 @@ module('Integration | Component | navbar-header', function (hooks) {
     test('should be rendered in mobile/tablet mode with a burger', async function (assert) {
       // given
       setBreakpoint('tablet');
-      this.owner.register('service:session', Service.extend({ isAuthenticated: true }));
-      this.owner.register('service:currentUser', Service.extend({ user: { fullName: 'John Doe' } }));
-      this.set('burger', {
-        state: {
-          actions: {
-            toggle: () => true,
-          },
-        },
-      });
+      class SessionStub extends Service {
+        isAuthenticated = true;
+      }
+      this.owner.register('service:session', SessionStub);
+      class CurrentUserStub extends Service {
+        user = { fullName: 'John Doe' };
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
 
       // when
-      await render(hbs`<NavbarHeader @burger={{this.burger}} />`);
+      const screen = await render(hbs`<NavbarHeader />`);
 
       // then
-      assert.dom('.navbar-mobile-header__container').exists();
-      assert.dom('.navbar-mobile-header__burger-icon').exists();
+      assert.ok(screen.getByRole('navigation', { name: this.intl.t('navigation.main.label') }));
+      assert.ok(screen.getByRole('button', { name: this.intl.t('navigation.mobile-button-title') }));
     });
 
     test('should be rendered in mobile/tablet mode without burger', async function (assert) {
       // given
       setBreakpoint('tablet');
+      class SessionStub extends Service {
+        isAuthenticated = false;
+      }
+      this.owner.register('service:session', SessionStub);
 
       // when
-      await render(hbs`<NavbarHeader/>`);
+      const screen = await render(hbs`<NavbarHeader/>`);
 
       // then
-      assert.dom('.navbar-mobile-header__container').exists();
-      assert.dom('.navbar-mobile-header__burger-icon').doesNotExist();
+      assert.dom(screen.queryByRole('navigation', { name: this.intl.t('navigation.main.label') })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: this.intl.t('navigation.mobile-button-title') })).doesNotExist();
     });
 
     test('should render skip links', async function (assert) {
       // given
       setBreakpoint('tablet');
-      this.owner.register('service:currentUser', Service.extend({ user: { fullName: 'John Doe' } }));
 
       // when
-      await render(hbs`<NavbarHeader/>`);
+      const screen = await render(hbs`<NavbarHeader/>`);
 
       // then
-      assert.ok(contains(this.intl.t('common.skip-links.skip-to-content')));
-      assert.ok(contains(this.intl.t('common.skip-links.skip-to-footer')));
+      assert.ok(screen.getByRole('link', { name: this.intl.t('common.skip-links.skip-to-content') }));
+      assert.ok(screen.getByRole('link', { name: this.intl.t('common.skip-links.skip-to-footer') }));
     });
   });
 });

--- a/mon-pix/tests/integration/components/navbar-header_test.js
+++ b/mon-pix/tests/integration/components/navbar-header_test.js
@@ -1,5 +1,4 @@
 /* eslint ember/no-classic-classes: 0 */
-/* eslint ember/require-tagless-components: 0 */
 
 import Service from '@ember/service';
 import { module, test } from 'qunit';
@@ -12,30 +11,24 @@ import { contains } from '../../helpers/contains';
 module('Integration | Component | navbar-header', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('when user is on desktop', function (hooks) {
-    hooks.beforeEach(async function () {
-      setBreakpoint('desktop');
-      await render(hbs`<NavbarHeader/>`);
-    });
-
-    test('should be rendered in desktop mode', function (assert) {
-      // then
-      assert.dom('.navbar-desktop-header__container').exists();
-    });
-
+  module('when user is on desktop', function () {
     test('should render skip links', async function (assert) {
+      // given
+      setBreakpoint('desktop');
+
+      // when
+      await render(hbs`<NavbarHeader/>`);
+
+      // then
       assert.ok(contains(this.intl.t('common.skip-links.skip-to-content')));
       assert.ok(contains(this.intl.t('common.skip-links.skip-to-footer')));
     });
   });
 
-  module('When user is not on desktop ', function (hooks) {
-    hooks.beforeEach(function () {
-      setBreakpoint('tablet');
-    });
-
+  module('When user is not on desktop ', function () {
     test('should be rendered in mobile/tablet mode with a burger', async function (assert) {
-      // when
+      // given
+      setBreakpoint('tablet');
       this.owner.register('service:session', Service.extend({ isAuthenticated: true }));
       this.owner.register('service:currentUser', Service.extend({ user: { fullName: 'John Doe' } }));
       this.set('burger', {
@@ -45,13 +38,19 @@ module('Integration | Component | navbar-header', function (hooks) {
           },
         },
       });
+
+      // when
       await render(hbs`<NavbarHeader @burger={{this.burger}} />`);
+
       // then
       assert.dom('.navbar-mobile-header__container').exists();
       assert.dom('.navbar-mobile-header__burger-icon').exists();
     });
 
     test('should be rendered in mobile/tablet mode without burger', async function (assert) {
+      // given
+      setBreakpoint('tablet');
+
       // when
       await render(hbs`<NavbarHeader/>`);
 
@@ -61,10 +60,14 @@ module('Integration | Component | navbar-header', function (hooks) {
     });
 
     test('should render skip links', async function (assert) {
+      // given
+      setBreakpoint('tablet');
       this.owner.register('service:currentUser', Service.extend({ user: { fullName: 'John Doe' } }));
 
+      // when
       await render(hbs`<NavbarHeader/>`);
 
+      // then
       assert.ok(contains(this.intl.t('common.skip-links.skip-to-content')));
       assert.ok(contains(this.intl.t('common.skip-links.skip-to-footer')));
     });

--- a/mon-pix/tests/integration/components/navbar-mobile-header_test.js
+++ b/mon-pix/tests/integration/components/navbar-mobile-header_test.js
@@ -1,6 +1,3 @@
-/* eslint ember/no-classic-classes: 0 */
-/* eslint ember/require-tagless-components: 0 */
-
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
@@ -14,9 +11,11 @@ module('Integration | Component | navbar-mobile-header', function (hooks) {
   module('when user is not logged', function (hooks) {
     hooks.beforeEach(async function () {
       // given & when
-      this.owner.register('service:session', Service.extend({ isAuthenticated: false }));
+      class SessionStub extends Service {
+        isAuthenticated = false;
+      }
+      this.owner.register('service:session', SessionStub);
       setBreakpoint('tablet');
-      await render(hbs`<NavbarMobileHeader />`);
     });
 
     test('should be rendered', function (assert) {
@@ -40,8 +39,14 @@ module('Integration | Component | navbar-mobile-header', function (hooks) {
 
   module('When user is logged', function (hooks) {
     hooks.beforeEach(function () {
-      this.owner.register('service:session', Service.extend({ isAuthenticated: true }));
-      this.owner.register('service:currentUser', Service.extend({ user: { fullName: 'John Doe' } }));
+      class SessionStub extends Service {
+        isAuthenticated = true;
+      }
+      this.owner.register('service:session', SessionStub);
+      class CurrentUserStub extends Service {
+        user = { fullName: 'John Doe' };
+      }
+      this.owner.register('service:currentUser', CurrentUserStub);
       setBreakpoint('tablet');
     });
 

--- a/mon-pix/tests/integration/components/navbar-mobile-header_test.js
+++ b/mon-pix/tests/integration/components/navbar-mobile-header_test.js
@@ -26,9 +26,13 @@ module('Integration | Component | navbar-mobile-header', function (hooks) {
       assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.homepage') }));
     });
 
-    test('should not display the burger menu', function (assert) {
+    test('should not display the burger menu', async function (assert) {
+      // when
+      const screen = await render(hbs`<NavbarMobileHeader />`);
+
       // then
-      assert.dom('.navbar-mobile-header__burger-icon').doesNotExist();
+      assert.dom(screen.queryByRole('navigation', { name: this.intl.t('navigation.main.label') })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: this.intl.t('navigation.mobile-button-title') })).doesNotExist();
     });
   });
 
@@ -47,18 +51,19 @@ module('Integration | Component | navbar-mobile-header', function (hooks) {
 
     test('should display the Pix logo', async function (assert) {
       // when
-      await render(hbs`<NavbarMobileHeader />`);
+      const screen = await render(hbs`<NavbarMobileHeader />`);
 
       // then
-      assert.dom('.navbar-mobile-header-logo__pix').exists();
+      assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.homepage') }));
     });
 
     test('should display the burger icon', async function (assert) {
       // when
-      await render(hbs`<NavbarMobileHeader />`);
+      const screen = await render(hbs`<NavbarMobileHeader />`);
 
       // then
-      assert.dom('.navbar-mobile-header__burger-icon').exists();
+      assert.ok(screen.getByRole('navigation', { name: this.intl.t('navigation.main.label') }));
+      assert.ok(screen.getByRole('button', { name: this.intl.t('navigation.mobile-button-title') }));
     });
   });
 
@@ -67,10 +72,10 @@ module('Integration | Component | navbar-mobile-header', function (hooks) {
     this.set('isFrenchDomainUrl', false);
 
     // when
-    await render(hbs`<NavbarMobileHeader @shouldShowTheMarianneLogo={{this.isFrenchDomainUrl}} />`);
+    const screen = await render(hbs`<NavbarMobileHeader @shouldShowTheMarianneLogo={{this.isFrenchDomainUrl}} />`);
 
     // then
-    assert.dom('.navbar-mobile-header-logo__marianne').doesNotExist();
+    assert.dom(screen.queryByRole('img', { name: this.intl.t('common.french-republic') })).doesNotExist();
   });
 
   test('should display marianne logo when url does have frenchDomainExtension', async function (assert) {

--- a/mon-pix/tests/integration/components/navbar-mobile-header_test.js
+++ b/mon-pix/tests/integration/components/navbar-mobile-header_test.js
@@ -18,11 +18,6 @@ module('Integration | Component | navbar-mobile-header', function (hooks) {
       setBreakpoint('tablet');
     });
 
-    test('should be rendered', function (assert) {
-      // then
-      assert.dom('.navbar-mobile-header__container').exists();
-    });
-
     test('should display the Pix logo', async function (assert) {
       // when
       const screen = await render(hbs`<NavbarMobileHeader />`);
@@ -48,14 +43,6 @@ module('Integration | Component | navbar-mobile-header', function (hooks) {
       }
       this.owner.register('service:currentUser', CurrentUserStub);
       setBreakpoint('tablet');
-    });
-
-    test('should be rendered', async function (assert) {
-      // when
-      await render(hbs`<NavbarMobileHeader />`);
-
-      // then
-      assert.dom('.navbar-mobile-header').exists();
     });
 
     test('should display the Pix logo', async function (assert) {

--- a/mon-pix/tests/integration/components/pix-logo_test.js
+++ b/mon-pix/tests/integration/components/pix-logo_test.js
@@ -10,10 +10,6 @@ module('Integration | Component | pix logo', function (hooks) {
     await render(hbs`{{pix-logo}}`);
   });
 
-  test('renders', function (assert) {
-    assert.dom('.pix-logo').exists();
-  });
-
   test('should display the logo', function (assert) {
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line qunit/no-assert-equal

--- a/mon-pix/tests/integration/components/pix-logo_test.js
+++ b/mon-pix/tests/integration/components/pix-logo_test.js
@@ -1,24 +1,19 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { render } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | pix logo', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  hooks.beforeEach(async function () {
-    await render(hbs`{{pix-logo}}`);
-  });
+  test('should display the logo', async function (assert) {
+    // given & when
+    const screen = await render(hbs`<PixLogo />`);
 
-  test('should display the logo', function (assert) {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.pix-logo__image').getAttribute('src'), '/images/pix-logo.svg');
-  });
-
-  test('should have a textual alternative', function (assert) {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.pix-logo__image').getAttribute('alt'), "Page d'accueil de Pix");
+    // then
+    assert.dom(screen.getByRole('link', { name: this.intl.t('navigation.homepage') })).exists();
+    assert.ok(
+      screen.getByRole('img', { name: this.intl.t('navigation.homepage') }).hasAttribute('src', '/images/pix-logo.svg')
+    );
   });
 });

--- a/mon-pix/tests/integration/components/signin-form_test.js
+++ b/mon-pix/tests/integration/components/signin-form_test.js
@@ -15,20 +15,30 @@ module('Integration | Component | signin form', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   module('Rendering', function () {
-    test('should display an input for identifiant field', async function (assert) {
+    test('[a11y] it should display a message that all inputs are required', async function (assert) {
       // given & when
       const screen = await render(hbs`<SigninForm />`);
 
       // then
-      assert.dom(screen.getByRole('textbox', { name: this.intl.t('pages.sign-in.fields.login.label') })).exists();
+      assert.dom(screen.getByText(this.intl.t('common.form.mandatory-all-fields'))).exists();
     });
 
-    test('should display an input for password field', async function (assert) {
+    test('should display a required input for username field', async function (assert) {
       // given & when
       const screen = await render(hbs`<SigninForm />`);
 
       // then
-      assert.dom(screen.getByLabelText(this.intl.t('pages.sign-in.fields.password.label'))).exists();
+      assert
+        .dom(screen.getByRole('textbox', { name: this.intl.t('pages.sign-in.fields.login.label') }))
+        .hasAttribute('required');
+    });
+
+    test('should display a required input for password field', async function (assert) {
+      // given & when
+      const screen = await render(hbs`<SigninForm />`);
+
+      // then
+      assert.dom(screen.getByLabelText(this.intl.t('pages.sign-in.fields.password.label'))).hasAttribute('required');
     });
 
     test('should display a submit button to authenticate', async function (assert) {

--- a/mon-pix/tests/integration/components/signin-form_test.js
+++ b/mon-pix/tests/integration/components/signin-form_test.js
@@ -1,13 +1,12 @@
 import sinon from 'sinon';
 import { module, test } from 'qunit';
-import { fillIn, find, render, triggerEvent } from '@ember/test-helpers';
+import { fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { render, clickByName } from '@1024pix/ember-testing-library';
 
 import Service from '@ember/service';
 
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { contains } from '../../helpers/contains';
-import { clickByLabel } from '../../helpers/click-by-label';
 
 import ENV from '../../../config/environment';
 const ApiErrorMessages = ENV.APP.API_ERROR_MESSAGES;
@@ -17,39 +16,39 @@ module('Integration | Component | signin form', function (hooks) {
 
   module('Rendering', function () {
     test('should display an input for identifiant field', async function (assert) {
-      // when
-      await render(hbs`<SigninForm />`);
+      // given & when
+      const screen = await render(hbs`<SigninForm />`);
 
       // then
-      assert.ok(document.querySelector('input#login'));
+      assert.dom(screen.getByRole('textbox', { name: this.intl.t('pages.sign-in.fields.login.label') })).exists();
     });
 
     test('should display an input for password field', async function (assert) {
-      // when
-      await render(hbs`<SigninForm />`);
+      // given & when
+      const screen = await render(hbs`<SigninForm />`);
 
       // then
-      assert.ok(document.querySelector('input#password'));
+      assert.dom(screen.getByLabelText(this.intl.t('pages.sign-in.fields.password.label'))).exists();
     });
 
     test('should display a submit button to authenticate', async function (assert) {
-      // when
-      await render(hbs`<SigninForm />`);
+      // given & when
+      const screen = await render(hbs`<SigninForm />`);
 
       // then
-      assert.ok(contains(this.intl.t('pages.sign-in.actions.submit')));
+      assert.dom(screen.getByRole('button', { name: this.intl.t('pages.sign-in.actions.submit') })).exists();
     });
 
     test('should display a link to password reset view', async function (assert) {
-      // when
-      await render(hbs`<SigninForm />`);
+      // given & when
+      const screen = await render(hbs`<SigninForm />`);
 
       // then
-      assert.ok(document.querySelector('a.sign-form-body__forgotten-password-link'));
+      assert.dom(screen.getByRole('link', { name: this.intl.t('pages.sign-in.forgotten-password') })).exists();
     });
 
     test('should not display any error by default', async function (assert) {
-      // when
+      // given & when
       await render(hbs`<SigninForm />`);
 
       // then
@@ -63,16 +62,18 @@ module('Integration | Component | signin form', function (hooks) {
           authenticateUser = sinon.stub().rejects({ status: 401 });
         }
         this.owner.register('service:session', sessionService);
-        await render(hbs`<SigninForm />`);
+        const screen = await render(hbs`<SigninForm />`);
 
         // when
-        await fillIn('input#login', 'usernotexist@example.net');
-        await fillIn('input#password', 'password');
-        await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
+        await fillIn(
+          screen.getByRole('textbox', { name: this.intl.t('pages.sign-in.fields.login.label') }),
+          'usernotexist@example.net'
+        );
+        await fillIn(screen.getByLabelText(this.intl.t('pages.sign-in.fields.password.label')), 'password');
+        await clickByName(this.intl.t('pages.sign-in.actions.submit'));
 
         // then
-        const expectedErrorMessage = this.intl.t(ApiErrorMessages.LOGIN_UNAUTHORIZED.I18N_KEY);
-        assert.strictEqual(find('div[id="sign-in-error-message"]').textContent.trim(), expectedErrorMessage);
+        assert.dom(screen.getByText(this.intl.t(ApiErrorMessages.LOGIN_UNAUTHORIZED.I18N_KEY))).exists();
       });
 
       test('should display related error message if bad request error', async function (assert) {
@@ -81,16 +82,18 @@ module('Integration | Component | signin form', function (hooks) {
           authenticateUser = sinon.stub().rejects({ status: 400 });
         }
         this.owner.register('service:session', sessionService);
-        await render(hbs`<SigninForm />`);
+        const screen = await render(hbs`<SigninForm />`);
 
         // when
-        await fillIn('input#login', 'usernotexist@example.net');
-        await fillIn('input#password', 'password');
-        await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
+        await fillIn(
+          screen.getByRole('textbox', { name: this.intl.t('pages.sign-in.fields.login.label') }),
+          'usernotexist@example.net'
+        );
+        await fillIn(screen.getByLabelText(this.intl.t('pages.sign-in.fields.password.label')), 'password');
+        await clickByName(this.intl.t('pages.sign-in.actions.submit'));
 
         // then
-        const expectedErrorMessage = this.intl.t(ApiErrorMessages.BAD_REQUEST.I18N_KEY);
-        assert.strictEqual(find('div[id="sign-in-error-message"]').textContent.trim(), expectedErrorMessage);
+        assert.ok(screen.getByText(this.intl.t(ApiErrorMessages.BAD_REQUEST.I18N_KEY)));
       });
 
       test('should display an error if api cannot be reached', async function (assert) {
@@ -100,19 +103,18 @@ module('Integration | Component | signin form', function (hooks) {
           authenticateUser = sinon.stub().rejects({ status: stubCatchedApiErrorInternetDisconnected });
         }
         this.owner.register('service:session', sessionService);
-        await render(hbs`<SigninForm />`);
+        const screen = await render(hbs`<SigninForm />`);
 
         // when
-        await fillIn('input#login', 'johnharry@example.net');
-        await fillIn('input#password', 'password123');
-        await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
+        await fillIn(
+          screen.getByRole('textbox', { name: this.intl.t('pages.sign-in.fields.login.label') }),
+          'johnharry@example.net'
+        );
+        await fillIn(screen.getByLabelText(this.intl.t('pages.sign-in.fields.password.label')), 'password123');
+        await clickByName(this.intl.t('pages.sign-in.actions.submit'));
 
         // then
-        assert.ok(document.querySelector('div.sign-form__notification-message--error'));
-        assert.strictEqual(
-          find('div[id="sign-in-error-message"]').textContent.trim(),
-          this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY)
-        );
+        assert.dom(screen.getByText(this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY))).exists();
       });
 
       module('blocking', function () {
@@ -125,22 +127,29 @@ module('Integration | Component | signin form', function (hooks) {
                 .rejects({ status: 403, responseJSON: { errors: [{ code: 'USER_IS_TEMPORARY_BLOCKED' }] } });
             }
             this.owner.register('service:session', sessionService);
-            await render(hbs`<SigninForm />`);
+            const screen = await render(hbs`<SigninForm />`);
 
             // when
-            await fillIn('input#login', 'user.temporary-blocked@example.net');
-            await fillIn('input#password', 'password');
-            await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
+            await fillIn(
+              screen.getByRole('textbox', { name: this.intl.t('pages.sign-in.fields.login.label') }),
+              'user.temporary-blocked@example.net'
+            );
+            await fillIn(screen.getByLabelText(this.intl.t('pages.sign-in.fields.password.label')), 'password123');
+            await clickByName(this.intl.t('pages.sign-in.actions.submit'));
 
             // then
-            const expectedErrorMessage = this.intl.t(ApiErrorMessages.USER_IS_TEMPORARY_BLOCKED.I18N_KEY, {
-              url: '/mot-de-passe-oublie',
-              htmlSafe: true,
-            });
-            assert.deepEqual(find('div[id="sign-in-error-message"]').innerHTML.trim(), expectedErrorMessage.string);
+            const errorMessage = screen.getByText(
+              (content) =>
+                content.startsWith(
+                  'Vous avez effectué trop de tentatives de connexion. Réessayez plus tard ou cliquez sur'
+                ) && content.endsWith('pour le réinitialiser.')
+            );
+            const errorMessageLink = screen.getByRole('link', { name: 'mot de passe oublié' });
+
+            assert.dom(errorMessage).exists();
+            assert.dom(errorMessageLink).hasAttribute('href', '/mot-de-passe-oublie');
           });
         });
-
         module('when is user blocked', function () {
           test('displays a specific error', async function (assert) {
             // given
@@ -150,19 +159,26 @@ module('Integration | Component | signin form', function (hooks) {
                 .rejects({ status: 403, responseJSON: { errors: [{ code: 'USER_IS_BLOCKED' }] } });
             }
             this.owner.register('service:session', sessionService);
-            await render(hbs`<SigninForm />`);
+            const screen = await render(hbs`<SigninForm />`);
 
             // when
-            await fillIn('input#login', 'user.blocked@example.net');
-            await fillIn('input#password', 'password');
-            await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
+            await fillIn(
+              screen.getByRole('textbox', { name: this.intl.t('pages.sign-in.fields.login.label') }),
+              'user.blocked@example.net'
+            );
+            await fillIn(screen.getByLabelText(this.intl.t('pages.sign-in.fields.password.label')), 'password123');
+            await clickByName(this.intl.t('pages.sign-in.actions.submit'));
 
             // then
-            const expectedErrorMessage = this.intl.t(ApiErrorMessages.USER_IS_BLOCKED.I18N_KEY, {
-              url: 'https://support.pix.org/support/tickets/new',
-              htmlSafe: true,
-            });
-            assert.deepEqual(find('div[id="sign-in-error-message"]').innerHTML.trim(), expectedErrorMessage.string);
+            const errorMessage = screen.getByText((content) =>
+              content.startsWith(
+                'Votre compte est bloqué car vous avez effectué trop de tentatives de connexion. Pour le débloquer,'
+              )
+            );
+            const errorMessageLink = screen.getByRole('link', { name: 'contactez-nous' });
+
+            assert.dom(errorMessage).exists();
+            assert.dom(errorMessageLink).hasAttribute('href', 'https://support.pix.org/support/tickets/new');
           });
         });
       });
@@ -171,8 +187,6 @@ module('Integration | Component | signin form', function (hooks) {
     module('when domain is pix.org', function () {
       test('should not display Pole Emploi button', async function (assert) {
         // given
-        const linkText = this.intl.t('pages.sign-in.pole-emploi.title');
-
         class UrlServiceStub extends Service {
           get isFrenchDomainExtension() {
             return false;
@@ -182,10 +196,18 @@ module('Integration | Component | signin form', function (hooks) {
         this.owner.register('service:url', UrlServiceStub);
 
         // when
-        await render(hbs`<SigninForm />`);
+        const screen = await render(hbs`<SigninForm />`);
 
         // then
-        assert.notOk(contains(linkText));
+        assert
+          .dom(
+            screen.queryByRole('link', {
+              name: `${this.intl.t('pages.sign-in.pole-emploi.link.img')} ${this.intl.t(
+                'pages.sign-in.pole-emploi.title'
+              )}`,
+            })
+          )
+          .doesNotExist();
       });
     });
 
@@ -199,13 +221,19 @@ module('Integration | Component | signin form', function (hooks) {
         }
         this.owner.register('service:url', UrlServiceStub);
 
-        const linkText = this.intl.t('pages.sign-in.pole-emploi.title');
-
         // when
-        await render(hbs`<SigninForm />`);
+        const screen = await render(hbs`<SigninForm />`);
 
         // then
-        assert.ok(contains(linkText));
+        assert
+          .dom(
+            screen.getByRole('link', {
+              name: `${this.intl.t('pages.sign-in.pole-emploi.link.img')} ${this.intl.t(
+                'pages.sign-in.pole-emploi.title'
+              )}`,
+            })
+          )
+          .exists();
       });
     });
   });
@@ -219,15 +247,16 @@ module('Integration | Component | signin form', function (hooks) {
       this.owner.register('service:session', sessionService);
       const session = this.owner.lookup('service:session', sessionService);
 
-      await render(hbs`<SigninForm />`);
+      const screen = await render(hbs`<SigninForm />`);
 
-      await fillIn('input#login', 'email@example.fr');
-      await triggerEvent('input#login', 'change');
-      await fillIn('input#password', 'azerty');
-      await triggerEvent('input#password', 'change');
+      await fillIn(
+        screen.getByRole('textbox', { name: this.intl.t('pages.sign-in.fields.login.label') }),
+        'johnharry@example.net'
+      );
+      await fillIn(screen.getByLabelText(this.intl.t('pages.sign-in.fields.password.label')), 'password123');
 
       // when
-      await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
+      await clickByName(this.intl.t('pages.sign-in.actions.submit'));
 
       // Then
       sinon.assert.calledOnce(session.authenticateUser);

--- a/mon-pix/tests/integration/components/signup-form_test.js
+++ b/mon-pix/tests/integration/components/signup-form_test.js
@@ -1,10 +1,9 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
-import { clickByLabel } from '../../helpers/click-by-label';
 import Service from '@ember/service';
 
 import { fillIn, find, findAll, triggerEvent } from '@ember/test-helpers';
-import { render } from '@1024pix/ember-testing-library';
+import { render, clickByName } from '@1024pix/ember-testing-library';
 
 import ArrayProxy from '@ember/array/proxy';
 import { resolve, reject } from 'rsvp';
@@ -15,8 +14,6 @@ import ENV from '../../../config/environment';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 const ApiErrorMessages = ENV.APP.API_ERROR_MESSAGES;
-
-const FORM_TITLE = '.sign-form-title';
 const INPUT_TEXT_FIELD_CLASS_DEFAULT = 'form-textfield__input-container--default';
 
 const userEmpty = EmberObject.create({});
@@ -41,10 +38,10 @@ module('Integration | Component | SignupForm', function (hooks) {
         this.intl.setLocale(testCase.locale);
 
         // when
-        await render(hbs`<SignupForm @user={{this.user}} />`);
+        const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
 
         // then
-        assert.strictEqual(find(FORM_TITLE).textContent, expectedTitle);
+        assert.dom(screen.getByRole('heading', { name: expectedTitle })).exists();
       });
     });
   });
@@ -63,6 +60,11 @@ module('Integration | Component | SignupForm', function (hooks) {
       assert.ok(screen.getByRole('link', { name: this.intl.t('pages.sign-up.subtitle.link') }));
       assert.ok(screen.getByRole('textbox', { name: this.intl.t('pages.sign-up.fields.firstname.label') }));
       assert.ok(screen.getByRole('textbox', { name: this.intl.t('pages.sign-up.fields.lastname.label') }));
+      assert.ok(
+        screen.getByLabelText(
+          `${this.intl.t('pages.sign-up.fields.password.label')} ${this.intl.t('pages.sign-up.fields.password.help')}`
+        )
+      );
       assert.ok(
         screen.getByRole('textbox', {
           name: `${this.intl.t('pages.sign-up.fields.email.label')} ${this.intl.t('pages.sign-up.fields.email.help')}`,
@@ -117,15 +119,13 @@ module('Integration | Component | SignupForm', function (hooks) {
       });
 
       this.set('user', user);
-      await render(hbs`<SignupForm @user={{this.user}} />`);
+      const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
 
       // when
-      await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
+      await clickByName(this.intl.t('pages.sign-up.actions.submit'));
 
       // then
-      assert.dom('div[id="sign-up-error-message"]').exists();
-      const expectedErrorMessage = this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY);
-      assert.strictEqual(find('div[id="sign-up-error-message"]').textContent.trim(), expectedErrorMessage);
+      assert.dom(screen.getByText(this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY))).exists();
     });
 
     test('should display related error message if internal server error', async function (assert) {
@@ -147,15 +147,13 @@ module('Integration | Component | SignupForm', function (hooks) {
       });
 
       this.set('user', user);
-      await render(hbs`<SignupForm @user={{this.user}} />`);
+      const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
 
       // when
-      await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
+      await clickByName(this.intl.t('pages.sign-up.actions.submit'));
 
       // then
-      assert.dom('div[id="sign-up-error-message"]').exists();
-      const expectedErrorMessage = this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY);
-      assert.strictEqual(find('div[id="sign-up-error-message"]').textContent.trim(), expectedErrorMessage);
+      assert.dom(screen.getByText(this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY))).exists();
     });
 
     test('should display related error message if bad gateway error', async function (assert) {
@@ -176,15 +174,13 @@ module('Integration | Component | SignupForm', function (hooks) {
       });
 
       this.set('user', user);
-      await render(hbs`<SignupForm @user={{this.user}} />`);
+      const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
 
       // when
-      await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
+      await clickByName(this.intl.t('pages.sign-up.actions.submit'));
 
       // then
-      assert.dom('div[id="sign-up-error-message"]').exists();
-      const expectedErrorMessage = this.intl.t(ApiErrorMessages.BAD_GATEWAY.I18N_KEY);
-      assert.strictEqual(find('div[id="sign-up-error-message"]').textContent.trim(), expectedErrorMessage);
+      assert.dom(screen.getByText(this.intl.t(ApiErrorMessages.BAD_GATEWAY.I18N_KEY))).exists();
     });
 
     test('should display related error message if gateway timeout error', async function (assert) {
@@ -205,15 +201,13 @@ module('Integration | Component | SignupForm', function (hooks) {
       });
 
       this.set('user', user);
-      await render(hbs`<SignupForm @user={{this.user}} />`);
+      const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
 
       // when
-      await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
+      await clickByName(this.intl.t('pages.sign-up.actions.submit'));
 
       // then
-      assert.dom('div[id="sign-up-error-message"]').exists();
-      const expectedErrorMessage = this.intl.t(ApiErrorMessages.GATEWAY_TIMEOUT.I18N_KEY);
-      assert.strictEqual(find('div[id="sign-up-error-message"]').textContent.trim(), expectedErrorMessage);
+      assert.dom(screen.getByText(this.intl.t(ApiErrorMessages.GATEWAY_TIMEOUT.I18N_KEY))).exists();
     });
 
     test('should display related error message if not implemented error', async function (assert) {
@@ -235,15 +229,13 @@ module('Integration | Component | SignupForm', function (hooks) {
       });
 
       this.set('user', user);
-      await render(hbs`<SignupForm @user={{this.user}} />`);
+      const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
 
       // when
-      await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
+      await clickByName(this.intl.t('pages.sign-up.actions.submit'));
 
       // then
-      assert.dom('div[id="sign-up-error-message"]').exists();
-      const expectedErrorMessage = this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY);
-      assert.strictEqual(find('div[id="sign-up-error-message"]').textContent.trim(), expectedErrorMessage);
+      assert.dom(screen.getByText(this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY))).exists();
     });
   });
 
@@ -279,7 +271,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         await render(hbs`<SignupForm @user={{this.user}} />`);
 
         // when
-        await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
+        await clickByName(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
         assert.true(isFormSubmitted);
@@ -305,7 +297,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         await render(hbs`<SignupForm @user={{this.user}} />`);
 
         // when
-        await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
+        await clickByName(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
         sinon.assert.calledOnce(session.authenticateUser);
@@ -318,76 +310,70 @@ module('Integration | Component | SignupForm', function (hooks) {
     module('Errors management', function () {
       test('should display an error message on first name field, when field is empty and focus-out', async function (assert) {
         // given
-        const emptyFirstnameErrorMessage = this.intl.t('pages.sign-up.fields.firstname.error');
         this.set('user', userEmpty);
-        await render(hbs`<SignupForm @user={{this.user}} />`);
+        const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
+
+        const firstNameInput = screen.getByRole('textbox', {
+          name: this.intl.t('pages.sign-up.fields.firstname.label'),
+        });
 
         // when
-        await fillIn('#firstName', '');
-        await triggerEvent('#firstName', 'focusout');
+        await fillIn(firstNameInput, '');
+        await triggerEvent(firstNameInput, 'focusout');
 
         // then
-        assert.ok(
-          find('#validationMessage-firstName').getAttribute('class').includes('form-textfield__message--error')
-        );
-        assert.strictEqual(find('.form-textfield__message--error').textContent.trim(), emptyFirstnameErrorMessage);
-        assert.ok(find('#firstName').getAttribute('class').includes('form-textfield__input--error'));
-        assert.dom('.form-textfield-icon__state--error').exists();
+        assert.dom(screen.getByText(this.intl.t('pages.sign-up.fields.firstname.error'))).exists();
       });
 
       test('should display an error message on last name field, when field is empty and focus-out', async function (assert) {
         // given
-        const emptyLastnameErrorMessage = this.intl.t('pages.sign-up.fields.lastname.error');
         this.set('user', userEmpty);
-        await render(hbs`<SignupForm @user={{this.user}} />`);
+        const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
+
+        const lastNameInput = screen.getByRole('textbox', {
+          name: this.intl.t('pages.sign-up.fields.lastname.label'),
+        });
 
         // when
-        await fillIn('#lastName', '');
-        await triggerEvent('#lastName', 'focusout');
+        await fillIn(lastNameInput, '');
+        await triggerEvent(lastNameInput, 'focusout');
 
         // then
-        assert.ok(find('#validationMessage-lastName').getAttribute('class').includes('form-textfield__message--error'));
-        assert.strictEqual(find('.form-textfield__message--error').textContent.trim(), emptyLastnameErrorMessage);
-        assert.ok(find('#lastName').getAttribute('class').includes('form-textfield__input--error'));
-        assert.dom('.form-textfield-icon__state--error').exists();
+        assert.dom(screen.getByText(this.intl.t('pages.sign-up.fields.lastname.error'))).exists();
       });
 
       test('should display an error message on email field, when field is empty and focus-out', async function (assert) {
         // given
-        const emptyEmailErrorMessage = this.intl.t('pages.sign-up.fields.email.error');
         this.set('user', userEmpty);
-        await render(hbs`<SignupForm @user={{this.user}} />`);
+        const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
+
+        const emailInput = screen.getByRole('textbox', {
+          name: `${this.intl.t('pages.sign-up.fields.email.label')} ${this.intl.t('pages.sign-up.fields.email.help')}`,
+        });
 
         // when
-        await fillIn('#email', '');
-        await triggerEvent('#email', 'focusout');
+        await fillIn(emailInput, '');
+        await triggerEvent(emailInput, 'focusout');
 
         // then
-        assert.ok(
-          find('.form-textfield__message-email').getAttribute('class').includes('form-textfield__message--error')
-        );
-        assert.strictEqual(find('.form-textfield__message--error').textContent.trim(), emptyEmailErrorMessage);
-        assert.ok(find('#email').getAttribute('class').includes('form-textfield__input--error'));
-        assert.dom('.form-textfield-icon__state--error').exists();
+        assert.dom(screen.getByText(this.intl.t('pages.sign-up.fields.email.error'))).exists();
       });
 
       test('should display an error message on password field, when field is empty and focus-out', async function (assert) {
         // given
-        const incorrectPasswordErrorMessage = this.intl.t('pages.sign-up.fields.password.error');
         this.set('user', userEmpty);
-        await render(hbs`<SignupForm @user={{this.user}} />`);
+        const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
+
+        const passwordInput = screen.getByLabelText(
+          `${this.intl.t('pages.sign-up.fields.password.label')} ${this.intl.t('pages.sign-up.fields.password.help')}`
+        );
 
         // when
-        await fillIn('#password', '');
-        await triggerEvent('#password', 'focusout');
+        await fillIn(passwordInput, '');
+        await triggerEvent(passwordInput, 'focusout');
 
         // then
-        assert.ok(
-          find('.form-textfield__message-password').getAttribute('class').includes('form-textfield__message--error')
-        );
-        assert.strictEqual(find('.form-textfield__message--error').textContent.trim(), incorrectPasswordErrorMessage);
-        assert.ok(find('#password').getAttribute('class').includes('form-textfield__input--error'));
-        assert.dom('.form-textfield-icon__state--error').exists();
+        assert.dom(screen.getByText(this.intl.t('pages.sign-up.fields.password.error'))).exists();
       });
 
       test("should display an error message on cgu field, when cgu isn't accepted and form is submitted", async function (assert) {
@@ -415,14 +401,13 @@ module('Integration | Component | SignupForm', function (hooks) {
         });
 
         this.set('user', userWithCguNotAccepted);
-        await render(hbs`<SignupForm @user={{this.user}} />`);
+        const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
 
         // when
-        await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
+        await clickByName(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
-        assert.dom('.sign-form__validation-error').exists();
-        assert.strictEqual(find('.sign-form__validation-error').textContent.trim(), uncheckedCheckboxCguErrorMessage);
+        assert.dom(screen.getByText(this.intl.t('common.cgu.error'))).exists();
       });
 
       test('should display an error message on email field, when email above a maximum length of 255 and focus-out', async function (assert) {
@@ -449,13 +434,13 @@ module('Integration | Component | SignupForm', function (hooks) {
         });
 
         this.set('user', userBackToSaveWithErrors);
-        await render(hbs`<SignupForm @user={{this.user}} />`);
+        const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
 
         // when
-        await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
+        await clickByName(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
-        assert.strictEqual(find('#validationMessage-email').textContent, expectedMaxLengthEmailError);
+        assert.dom(screen.getByText(expectedMaxLengthEmailError)).exists();
       });
 
       test('should not display success notification message when an error occurred during the form submission', async function (assert) {
@@ -477,7 +462,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         await render(hbs`<SignupForm @user={{this.user}} />`);
 
         // when
-        await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
+        await clickByName(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
         assert.dom('.signup-form__notification-message').doesNotExist();
@@ -488,73 +473,69 @@ module('Integration | Component | SignupForm', function (hooks) {
       test('should display first name field as validated without error message, when field is filled and focus-out', async function (assert) {
         // given
         this.set('user', userEmpty);
-        await render(hbs`<SignupForm @user={{this.user}} />`);
+        const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
+
+        const firstNameInput = screen.getByRole('textbox', {
+          name: this.intl.t('pages.sign-up.fields.firstname.label'),
+        });
 
         // when
-        await fillIn('#firstName', 'pix');
-        await triggerEvent('#firstName', 'focusout');
+        await fillIn(firstNameInput, 'pix');
+        await triggerEvent(firstNameInput, 'focusout');
 
         // then
-        assert.ok(
-          find('#validationMessage-firstName').getAttribute('class').includes('form-textfield__message--success')
-        );
-        assert.dom('.form-textfield__message--error').doesNotExist();
-        assert.ok(find('#firstName').getAttribute('class').includes('form-textfield__input--success'));
-        assert.dom('.form-textfield-icon__state--success').exists();
+        assert.dom(screen.queryByText(this.intl.t('pages.sign-up.fields.firstname.error'))).doesNotExist();
       });
 
       test('should display last name field as validated without error message, when field is filled and focus-out', async function (assert) {
         // given
         this.set('user', userEmpty);
-        await render(hbs`<SignupForm @user={{this.user}} />`);
+        const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
+
+        const lastNameInput = screen.getByRole('textbox', {
+          name: this.intl.t('pages.sign-up.fields.lastname.label'),
+        });
 
         // when
-        await fillIn('#lastName', 'pix');
-        await triggerEvent('#lastName', 'focusout');
+        await fillIn(lastNameInput, 'pix');
+        await triggerEvent(lastNameInput, 'focusout');
 
         // then
-        assert.ok(
-          find('#validationMessage-lastName').getAttribute('class').includes('form-textfield__message--success')
-        );
-        assert.dom('.form-textfield__message--error').doesNotExist();
-        assert.ok(find('#lastName').getAttribute('class').includes('form-textfield__input--success'));
-        assert.dom('.form-textfield-icon__state--success').exists();
+        assert.dom(screen.queryByText(this.intl.t('pages.sign-up.fields.lastname.error'))).doesNotExist();
       });
 
       test('should display email field as validated without error message, when field is filled and focus-out', async function (assert) {
         // given
         this.set('user', userEmpty);
-        await render(hbs`<SignupForm @user={{this.user}} />`);
+        const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
+
+        const emailInput = screen.getByRole('textbox', {
+          name: `${this.intl.t('pages.sign-up.fields.email.label')} ${this.intl.t('pages.sign-up.fields.email.help')}`,
+        });
 
         // when
-        await fillIn('#email', 'shi@fu.pix');
-        await triggerEvent('#email', 'focusout');
+        await fillIn(emailInput, 'shi@fu.pix');
+        await triggerEvent(emailInput, 'focusout');
 
         // then
-        assert.ok(
-          find('.form-textfield__message-email').getAttribute('class').includes('form-textfield__message--success')
-        );
-        assert.dom('.form-textfield__message--error').doesNotExist();
-        assert.ok(find('#email').getAttribute('class').includes('form-textfield__input--success'));
-        assert.dom('.form-textfield-icon__state--success').exists();
+        assert.dom(screen.queryByText(this.intl.t('pages.sign-up.fields.email.error'))).doesNotExist();
       });
 
       test('should display password field as validated without error message, when field is filled and focus-out', async function (assert) {
         // given
         this.set('user', userEmpty);
-        await render(hbs`<SignupForm @user={{this.user}} />`);
+        const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
+
+        const passwordInput = screen.getByLabelText(
+          `${this.intl.t('pages.sign-up.fields.password.label')} ${this.intl.t('pages.sign-up.fields.password.help')}`
+        );
 
         // when
-        await fillIn('#password', 'Mypassword1');
-        await triggerEvent('#password', 'focusout');
+        await fillIn(passwordInput, 'Mypassword1');
+        await triggerEvent(passwordInput, 'focusout');
 
         // then
-        assert.ok(
-          find('.form-textfield__message-password').getAttribute('class').includes('form-textfield__message--success')
-        );
-        assert.dom('.form-textfield__message--error').doesNotExist();
-        assert.ok(find('#password').getAttribute('class').includes('form-textfield__input--success'));
-        assert.dom('.form-textfield-icon__state--success').exists();
+        assert.dom(screen.queryByText(this.intl.t('pages.sign-up.fields.password.error'))).doesNotExist();
       });
 
       test('should not display an error message on cgu field, when cgu is accepted and form is submitted', async function (assert) {
@@ -568,13 +549,13 @@ module('Integration | Component | SignupForm', function (hooks) {
 
         this.set('user', userWithCguAccepted);
         this.set('authenticateUser', () => {});
-        await render(hbs`<SignupForm @user={{this.user}} />`);
+        const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
 
         // when
-        await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
+        await clickByName(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
-        assert.dom('.sign-form__validation-error').doesNotExist();
+        assert.dom(screen.queryByText(this.intl.t('common.cgu.error'))).doesNotExist();
       });
 
       test('should reset validation property, when all things are ok and form is submitted', async function (assert) {
@@ -595,7 +576,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         await render(hbs`<SignupForm @user={{this.user}} />`);
 
         // when
-        await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
+        await clickByName(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
         assert.ok(
@@ -641,7 +622,7 @@ module('Integration | Component | SignupForm', function (hooks) {
       await render(hbs`<SignupForm @user={{this.user}} />`);
 
       // when
-      await clickByLabel("Je m'inscris");
+      await clickByName(this.intl.t('pages.sign-up.actions.submit'));
 
       // then
       assert.ok(find('.loader-in-button'));

--- a/mon-pix/tests/integration/components/signup-form_test.js
+++ b/mon-pix/tests/integration/components/signup-form_test.js
@@ -49,24 +49,12 @@ module('Integration | Component | SignupForm', function (hooks) {
     });
   });
 
-  module('Rendering', function (hooks) {
-    hooks.beforeEach(async function () {
-      this.set('user', userEmpty);
-      this.intl.setLocale(['en', 'fr']);
-      await render(hbs`<SignupForm @user={{this.user}} />`);
-    });
-
-    test('renders', function (assert) {
-      assert.dom('.sign-form__container').exists();
-    });
-
-    test('should return correct form title', function (assert) {
-      const formTitle = this.intl.t('pages.sign-up.first-title');
-      assert.strictEqual(find(FORM_TITLE).textContent, formTitle);
-    });
-
+  module('Rendering', function () {
     test('should display form elements', async function (assert) {
-      // given & when
+      // given
+      this.set('user', userEmpty);
+
+      // when
       const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
 
       // then
@@ -85,7 +73,10 @@ module('Integration | Component | SignupForm', function (hooks) {
     });
 
     test("should have links to Pix's CGU and data protection policy ", async function (assert) {
-      // given & when
+      // given
+      this.set('user', userEmpty);
+
+      // when
       const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
 
       // then
@@ -94,7 +85,10 @@ module('Integration | Component | SignupForm', function (hooks) {
     });
 
     test('should render a submit button', async function (assert) {
-      // given & when
+      // given
+      this.set('user', userEmpty);
+
+      // when
       const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
 
       // then

--- a/mon-pix/tests/integration/components/signup-form_test.js
+++ b/mon-pix/tests/integration/components/signup-form_test.js
@@ -96,6 +96,36 @@ module('Integration | Component | SignupForm', function (hooks) {
       // then
       assert.ok(screen.getByRole('button', { name: this.intl.t('pages.sign-up.actions.submit') }));
     });
+
+    test('[a11y] it should display a message that all inputs are required', async function (assert) {
+      // given & when
+      const screen = await render(hbs`<SignupForm />`);
+
+      // then
+      assert.dom(screen.getByText(this.intl.t('common.form.mandatory-all-fields'))).exists();
+      assert
+        .dom(screen.getByRole('textbox', { name: this.intl.t('pages.sign-up.fields.firstname.label') }))
+        .hasAttribute('required');
+      assert
+        .dom(screen.getByRole('textbox', { name: this.intl.t('pages.sign-up.fields.lastname.label') }))
+        .hasAttribute('required');
+      assert
+        .dom(
+          screen.getByRole('textbox', {
+            name: `${this.intl.t('pages.sign-up.fields.email.label')} ${this.intl.t(
+              'pages.sign-up.fields.email.help'
+            )}`,
+          })
+        )
+        .hasAttribute('required');
+      assert
+        .dom(
+          screen.getByLabelText(
+            `${this.intl.t('pages.sign-up.fields.password.label')} ${this.intl.t('pages.sign-up.fields.password.help')}`
+          )
+        )
+        .hasAttribute('required');
+    });
   });
 
   module('When API returns errors', function () {

--- a/mon-pix/tests/integration/components/skiplink_test.js
+++ b/mon-pix/tests/integration/components/skiplink_test.js
@@ -1,18 +1,16 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
-import { contains } from '../../helpers/contains';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Skip Link', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   test('displays supplied label and links to the correct anchor', async function (assert) {
-    await render(hbs`<Skiplink @href="#anchor-link" @label="go-to-link" />`);
+    // given & when
+    const screen = await render(hbs`<Skiplink @href="#anchor-link" @label="go-to-link" />`);
 
-    assert.ok(contains('go-to-link'));
-
-    const skipLink = this.element.getElementsByClassName('skip-link')[0];
-    assert.ok(skipLink.href.includes('#anchor-link'));
+    // then
+    assert.ok(screen.getByRole('link', { name: 'go-to-link' }).hasAttribute('href', '#anchor-link'));
   });
 });

--- a/mon-pix/tests/integration/components/user-logged-menu_test.js
+++ b/mon-pix/tests/integration/components/user-logged-menu_test.js
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { click, find, triggerKeyEvent } from '@ember/test-helpers';
+import { click, triggerKeyEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { render } from '@1024pix/ember-testing-library';
 
@@ -14,7 +14,6 @@ module('Integration | Component | user logged menu', function (hooks) {
       class currentUserService extends Service {
         user = {
           firstName: 'Hermione',
-          email: 'hermione.granger@hogwarts.com',
           fullName: 'Hermione Granger',
         };
       }
@@ -22,101 +21,155 @@ module('Integration | Component | user logged menu', function (hooks) {
       this.owner.register('service:currentUser', currentUserService);
     });
 
-    test('should render component', async function (assert) {
-      // when
-      await render(hbs`<UserLoggedMenu/>`);
-
-      // then
-      assert.dom('.logged-user-details').exists();
-    });
-
     test('should display logged user name with a11y guidance', async function (assert) {
       // when
-      await render(hbs`<UserLoggedMenu/>`);
+      const screen = await render(hbs`<UserLoggedMenu/>`);
 
       // then
-      const nodes = find('.logged-user-name__link').childNodes;
+      const buttonMenu = screen.getByRole('button', {
+        name: `Hermione ${this.intl.t('navigation.user-logged-menu.details')}`,
+      });
+      const nodes = buttonMenu.childNodes;
       const buttonTextContent = nodes[1].textContent;
       const a11yText = nodes[3].textContent;
 
-      assert.dom('.logged-user-name').exists();
-      assert.dom('.logged-user-name__link').exists();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(a11yText, this.intl.t('navigation.user-logged-menu.details'));
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(buttonTextContent, 'Hermione');
+      assert.strictEqual(a11yText, this.intl.t('navigation.user-logged-menu.details'));
+      assert.strictEqual(buttonTextContent, 'Hermione');
     });
 
     test('should hide user menu, when no action on user-name', async function (assert) {
       // when
-      await render(hbs`<UserLoggedMenu/>`);
+      const screen = await render(hbs`<UserLoggedMenu/>`);
 
       // then
-      assert.dom('.logged-user-menu').doesNotExist();
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: `Hermione ${this.intl.t('navigation.user-logged-menu.details')}`,
+            expanded: false,
+          })
+        )
+        .exists();
+      assert.dom(screen.queryByRole('link', { name: this.intl.t('navigation.user.account') })).doesNotExist();
+      assert.dom(screen.queryByRole('link', { name: this.intl.t('navigation.user.certifications') })).doesNotExist();
+      assert.dom(screen.queryByRole('link', { name: this.intl.t('navigation.main.help') })).doesNotExist();
+      assert.dom(screen.queryByRole('link', { name: this.intl.t('navigation.user.sign-out') })).doesNotExist();
     });
 
     test('should display a user menu, when user-name is clicked', async function (assert) {
-      // given
-      const MENU_ITEMS_COUNT = 4;
-
       // when
       const screen = await render(hbs`<UserLoggedMenu/>`);
-      await click('.logged-user-name__link');
+      await click(
+        screen.getByRole('button', {
+          name: `Hermione ${this.intl.t('navigation.user-logged-menu.details')}`,
+        })
+      );
 
       // then
-      assert.dom('.logged-user-menu').exists();
-      assert.dom('.logged-user-menu__link').exists({ count: MENU_ITEMS_COUNT });
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: `Hermione ${this.intl.t('navigation.user-logged-menu.details')}`,
+            expanded: true,
+          })
+        )
+        .exists();
       assert.ok(screen.getByText('Hermione Granger'));
     });
 
     test('should display link to user certifications', async function (assert) {
       // when
       const screen = await render(hbs`<UserLoggedMenu/>`);
-      await click('.logged-user-name');
+      await click(
+        screen.getByRole('button', {
+          name: `Hermione ${this.intl.t('navigation.user-logged-menu.details')}`,
+        })
+      );
 
       // then
-      assert.ok(screen.getByRole('link', { name: 'Mes certifications' }));
+      assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.user.certifications') }));
     });
 
     test('should display link to help center', async function (assert) {
       // when
       const screen = await render(hbs`<UserLoggedMenu/>`);
-      await click('.logged-user-name');
+      await click(
+        screen.getByRole('button', {
+          name: `Hermione ${this.intl.t('navigation.user-logged-menu.details')}`,
+        })
+      );
 
       // then
-      assert.ok(screen.getByRole('link', { name: 'Aide' }));
+      assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.main.help') }));
     });
 
     test('should hide user menu, when it was previously open and user-name is clicked one more time', async function (assert) {
+      // given
+      const screen = await render(hbs`<UserLoggedMenu/>`);
+      const buttonMenu = screen.getByRole('button', {
+        name: `Hermione ${this.intl.t('navigation.user-logged-menu.details')}`,
+      });
+
       // when
-      await render(hbs`<UserLoggedMenu/>`);
-      await click('.logged-user-name');
-      await click('.logged-user-name');
+      await click(buttonMenu);
+      await click(buttonMenu);
 
       // then
-      assert.dom('.logged-user-menu').doesNotExist();
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: `Hermione ${this.intl.t('navigation.user-logged-menu.details')}`,
+            expanded: false,
+          })
+        )
+        .exists();
+      assert.dom(screen.queryByRole('link', { name: this.intl.t('navigation.user.account') })).doesNotExist();
     });
 
     test('should hide user menu, when it was previously open and user press key escape', async function (assert) {
+      // given
+      const screen = await render(hbs`<UserLoggedMenu/>`);
+      const buttonMenu = screen.getByRole('button', {
+        name: `Hermione ${this.intl.t('navigation.user-logged-menu.details')}`,
+      });
+
       // when
-      await render(hbs`<UserLoggedMenu/>`);
-      await click('.logged-user-name');
-      await triggerKeyEvent('.logged-user-name', 'keydown', 27);
+      await click(buttonMenu);
+      await triggerKeyEvent(buttonMenu, 'keydown', 27);
 
       // then
-      assert.dom('.logged-user-menu').doesNotExist();
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: `Hermione ${this.intl.t('navigation.user-logged-menu.details')}`,
+            expanded: false,
+          })
+        )
+        .exists();
+      assert.dom(screen.queryByRole('link', { name: this.intl.t('navigation.user.account') })).doesNotExist();
     });
 
     test('should hide user menu, when it was previously open and user press shift-tab key', async function (assert) {
+      // given
+      const screen = await render(hbs`<UserLoggedMenu/>`);
+      const buttonMenu = screen.getByRole('button', {
+        name: `Hermione ${this.intl.t('navigation.user-logged-menu.details')}`,
+      });
+
       // when
-      await render(hbs`<UserLoggedMenu/>`);
-      await click('.logged-user-name');
-      await triggerKeyEvent('.logged-user-name', 'keydown', 9, { shiftKey: true });
+      await click(buttonMenu);
+      await triggerKeyEvent(buttonMenu, 'keydown', 9, { shiftKey: true });
 
       // then
-      assert.dom('.logged-user-menu').doesNotExist();
+      assert
+        .dom(
+          screen.getByRole('button', {
+            name: `Hermione ${this.intl.t('navigation.user-logged-menu.details')}`,
+            expanded: false,
+          })
+        )
+        .exists();
+      assert.dom(screen.queryByRole('link', { name: this.intl.t('navigation.user.account') })).doesNotExist();
     });
 
     test('should hide user menu, when the menu is opened then closed', async function (assert) {
@@ -134,6 +187,7 @@ module('Integration | Component | user logged menu', function (hooks) {
         hooks.beforeEach(function () {
           class currentUserService extends Service {
             user = {
+              firstName: 'Hermione',
               hasAssessmentParticipations: true,
             };
           }
@@ -144,10 +198,14 @@ module('Integration | Component | user logged menu', function (hooks) {
         test('should display link to user tests', async function (assert) {
           // when
           const screen = await render(hbs`<UserLoggedMenu/>`);
-          await click('.logged-user-name');
+          await click(
+            screen.getByRole('button', {
+              name: `Hermione ${this.intl.t('navigation.user-logged-menu.details')}`,
+            })
+          );
 
           // then
-          assert.ok(screen.getByRole('link', { name: 'Mes parcours' }));
+          assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.user.tests') }));
         });
       });
 
@@ -155,10 +213,14 @@ module('Integration | Component | user logged menu', function (hooks) {
         test('should not display link to user tests', async function (assert) {
           // when
           const screen = await render(hbs`<UserLoggedMenu/>`);
-          await click('.logged-user-name');
+          await click(
+            screen.getByRole('button', {
+              name: `Hermione ${this.intl.t('navigation.user-logged-menu.details')}`,
+            })
+          );
 
           // then
-          assert.notOk(screen.queryByRole('link', { name: 'Mes parcours' }));
+          assert.notOk(screen.queryByRole('link', { name: this.intl.t('navigation.user.tests') }));
         });
       });
     });
@@ -174,10 +236,16 @@ module('Integration | Component | user logged menu', function (hooks) {
 
     test('should not display user information, for unlogged', async function (assert) {
       // when
-      await render(hbs`<UserLoggedMenu/>`);
+      const screen = await render(hbs`<UserLoggedMenu/>`);
 
       // then
-      assert.dom('.logged-user-name').doesNotExist();
+      assert
+        .dom(
+          screen.queryByRole('button', {
+            name: this.intl.t('navigation.user-logged-menu.details'),
+          })
+        )
+        .doesNotExist();
     });
   });
 });

--- a/mon-pix/tests/integration/components/user-logged-menu_test.js
+++ b/mon-pix/tests/integration/components/user-logged-menu_test.js
@@ -172,16 +172,6 @@ module('Integration | Component | user logged menu', function (hooks) {
       assert.dom(screen.queryByRole('link', { name: this.intl.t('navigation.user.account') })).doesNotExist();
     });
 
-    test('should hide user menu, when the menu is opened then closed', async function (assert) {
-      // when
-      await render(hbs`<UserLoggedMenu/>`);
-      await click('.logged-user-name');
-      await click('.logged-user-name');
-
-      // then
-      assert.dom('.logged-user-menu').doesNotExist();
-    });
-
     module('Link to "My tests"', function () {
       module('when user has at least one participation', function (hooks) {
         hooks.beforeEach(function () {


### PR DESCRIPTION
## :christmas_tree: Problème
C'est le grand retour du nettoyage de tests ! 

Nous avons désormais [un package Pix](https://www.npmjs.com/package/@1024pix/ember-testing-library) qui contient des [méthodes utilisant testing library](https://github.com/1024pix/ember-testing-library/blob/dev/addon/index.js). Il est importé dans la grande majorité de nos applis Pix mais encore peu utilisé dans nos tests front.

Nous avons également des tests se basant sur du html, du css. 
Or une bonne pratique pour les tests consiste à séparer les préoccupations entre le style et les tests. Les noms de classe et la structure DOM changent avec le temps.

## :gift: Proposition
Unifier nos tests sur Pix App en utilisants les méthodes du package et de testing library.

## :star2: Remarques
On supprime des tests inutiles qui vérifie la présence des containers (div), on privilégie de vérifier la présence des éléments à l'intérieur plutôt.

On ajoute aussi quelques tests a11y.

On avait bien clean Pix Admin déjà : 
- https://github.com/1024pix/pix/pull/4163
- https://github.com/1024pix/pix/pull/4259
- https://github.com/1024pix/pix/pull/4376

## :santa: Pour tester
Les tests passent au vert ✅
