### PR TITLE
Mettre à disposition un environnement de développement simplifié en utilisant docker-compose

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,7 @@
 
 2 environnements sont proposés :  
 - Environnement par défaut : build les container en mode "production". Les instances front sont build et servies par un nginx.
-- Dev : les images sont démarrées avec Node afin de permettre le développement local. 
+- Dev : les containers sont démarrées avec Node afin de permettre le développement local. 
 
 Les environnements sont disponible grace au multi-stage Dockerfile.
 https://docs.docker.com/develop/develop-images/multistage-build/
@@ -35,12 +35,41 @@ Pour coder sur pix-orga :
 
 ```sh
 
-docker-compose -f docker-compose.yaml -f docker-compose-dev.yaml build orga
-docker-compose -f docker-compose.yaml -f docker-compose-dev.yaml up -d orga
+docker-compose -f docker-compose.yaml -f docker-compose-dev-front.yaml build orga
+docker-compose -f docker-compose.yaml -f docker-compose-dev-front.yaml up -d orga
 ```
+
+## Dev API + frontend : 
+docker-compose -f docker-compose.yaml -f docker-compose-dev-api.yaml -f docker-compose-dev-front.yaml build api orga
+docker-compose -f docker-compose.yaml -f docker-compose-dev-api.yaml -f docker-compose-dev-front.yaml up -d api orga
+
 
 ## Réinitialisation de la DB : 
 
 ```sh
 docker-compose exec  api npm run db:reset 
 ```
+
+## Simplifier l'utilisation à l'aide d'un alias : 
+
+```sh
+alias dcapi="docker-compose -f docker-compose.yaml -f docker-compose-dev-api.yaml"
+alias dcfront="docker-compose -f docker-compose.yaml -f docker-compose-dev-front.yaml"
+alias dcall="docker-compose -f docker-compose.yaml -f docker-compose-dev-api.yaml -f docker-compose-dev-front.yaml"
+```
+
+## Node_modules : 
+
+Dans l'environnement de dev, les node_modules sont stockés dans un volumes dédiés et ne sont pas dans le dossier de travail afin d'ignorer les possibles modifications / différences entre l'environement local et docker.
+
+En cas de problème et afin de repartir à zéro sur les node_modules, supprimez le volume : 
+docker volume rm <VOLUME_NAME> (voir fichier docker-compose front dev)
+
+
+## Rappel des URLs en local: 
+
+API : http://localhost:3000
+mon-pix : http://localhost:4200
+Orga : http://localhost:4201
+Admin : http://localhost:4202
+Certif : http://localhost:4203

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,12 +21,22 @@ docker-compose up -d
 
 Copier le sample.env en .env et rajouter si besoin des valeurs nécessaires
 
-## exemple utilisation Dev : 
-> Le démarrage de tous les projets en simmultané utilise beaucoup de ressources réseau car les projets sont build au démarrage.
+## exemple utilisation Dev d'API : 
 
 ```sh
-docker-compose -f docker-compose.yaml -f docker-compose-dev.yaml build 
-docker-compose -f docker-compose.yaml -f docker-compose-dev.yaml up mon-pix
+docker-compose -f docker-compose.yaml -f docker-compose-dev-api.yaml build 
+docker-compose -f docker-compose.yaml -f docker-compose-dev-api.yaml up -d 
+```
+
+## exemple utilisation Dev Frontend : 
+> Le démarrage de tous les projets frontend en simmultané utilise beaucoup de ressources réseau car les projets sont build au démarrage.
+
+Pour coder sur pix-orga : 
+
+```sh
+
+docker-compose -f docker-compose.yaml -f docker-compose-dev.yaml build orga
+docker-compose -f docker-compose.yaml -f docker-compose-dev.yaml up -d orga
 ```
 
 ## Réinitialisation de la DB : 

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,7 @@
 
 2 environnements sont proposés :  
 - Environnement par défaut : build les container en mode "production". Les instances front sont build et servies par un nginx.
-- Dev : les containers sont démarrées avec Node afin de permettre le développement local. 
+- Dev : les containers sont démarrés avec Node afin de permettre le développement local. 
 
 Les environnements sont disponible grace au multi-stage Dockerfile.
 https://docs.docker.com/develop/develop-images/multistage-build/
@@ -60,10 +60,10 @@ alias dcall="docker-compose -f docker-compose.yaml -f docker-compose-dev-api.yam
 
 ## Node_modules : 
 
-Dans l'environnement de dev, les node_modules sont stockés dans un volumes dédiés et ne sont pas dans le dossier de travail afin d'ignorer les possibles modifications / différences entre l'environement local et docker.
+Dans l'environnement de dev, les node_modules sont stockés dans un volumes dédié et ne sont pas dans le dossier de travail afin d'ignorer les possibles modifications / différences entre l'environement local et docker.
 
 En cas de problème et afin de repartir à zéro sur les node_modules, supprimez le volume : 
-docker volume rm <VOLUME_NAME> (voir fichier docker-compose front dev)
+`docker volume rm <VOLUME_NAME>` (voir fichier docker-compose front dev)
 
 
 ## Rappel des URLs en local: 

--- a/docker/docker-compose-dev-api.yaml
+++ b/docker/docker-compose-dev-api.yaml
@@ -1,0 +1,18 @@
+
+version: '3'
+
+services:
+  api:
+    image: pix/api:dev
+    mem_limit: 1g
+    mem_reservation: 128M
+    cpus: 5
+    build: 
+      dockerfile: ../docker/dockerfiles/Dockerfile.hapi
+      context: ../api/
+      target: dev
+    volumes:
+      - ../api:/code 
+      - ./dev/api/node_modules/:/code/node_modules/  
+      - .env:/code/.env 
+    command: ["bash", "-c", "npm install && npm run start:watch"]

--- a/docker/docker-compose-dev-api.yaml
+++ b/docker/docker-compose-dev-api.yaml
@@ -13,6 +13,9 @@ services:
       target: dev
     volumes:
       - ../api:/code 
-      - ./dev/api/node_modules/:/code/node_modules/  
+      - api_node_modules:/code/node_modules/  
       - .env:/code/.env 
     command: ["bash", "-c", "npm install && npm run start:watch"]
+
+volumes:
+  api_node_modules:

--- a/docker/docker-compose-dev-front.yaml
+++ b/docker/docker-compose-dev-front.yaml
@@ -6,6 +6,9 @@ services:
       dockerfile: ../docker/dockerfiles/Dockerfile.ember
       context: ../orga
       target: dev
+    volumes: 
+      - ../orga/:/code
+      - orga_node_modules:/code/node_modules
     image: pix/orga:dev
     command: npx ember serve --port 80 --proxy http://api:3000
 
@@ -14,16 +17,22 @@ services:
       dockerfile: ../docker/dockerfiles/Dockerfile.ember
       context: ../admin/
       target: dev
+    volumes: 
+      - ../admin/:/code
+      - admin_node_modules:/code/node_modules
     image: pix/admin:dev
-    command: npx ember serve --proxy http://api:3000
+    command: npx ember serve --port 80 --proxy http://api:3000
 
   certif:
     build: 
       dockerfile: ../docker/dockerfiles/Dockerfile.ember
       context: ../certif/
       target: dev
+    volumes: 
+      - ../certif/:/code
+      - certif_node_modules:/code/node_modules
     image: pix/certif:dev
-    command: npx ember serve --proxy http://api:3000
+    command: npx ember serve --port 80 --proxy http://api:3000
 
   mon-pix:
     image: pix/mon-pix:dev
@@ -31,4 +40,13 @@ services:
       dockerfile: ../docker/dockerfiles/Dockerfile.ember
       context: ../mon-pix/
       target: dev
-    command: npx ember serve --proxy http://api:3000
+    volumes: 
+      - ../mon-pix/:/code
+      - mon-pix_node_modules:/code/node_modules
+    command: npx ember serve --port 80 --proxy http://api:3000
+
+volumes:
+  orga_node_modules:
+  admin_node_modules:
+  mon-pix_node_modules:
+  certif_node_modules:

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -9,6 +9,7 @@ services:
       context: ../api/
       target: dev
     volumes:
+      - ../api:/code
       - .env:/code/.env 
 
   orga:

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -1,24 +1,13 @@
 
 version: '3'
-
 services:
-  api:
-    image: pix/api:dev
-    build: 
-      dockerfile: ../docker/dockerfiles/Dockerfile.hapi
-      context: ../api/
-      target: dev
-    volumes:
-      - ../api:/code
-      - .env:/code/.env 
-
   orga:
     build: 
       dockerfile: ../docker/dockerfiles/Dockerfile.ember
       context: ../orga
       target: dev
     image: pix/orga:dev
-    command: npx ember serve --proxy http://api:3000
+    command: npx ember serve --port 80 --proxy http://api:3000
 
   admin:
     build: 

--- a/docker/dockerfiles/Dockerfile.ember
+++ b/docker/dockerfiles/Dockerfile.ember
@@ -4,6 +4,7 @@ WORKDIR /code
 COPY . .
 
 RUN npm ci
+RUN npm install -g ember-cli 
 
 CMD [ "npm", "run", "start:watch" ]
 

--- a/docker/dockerfiles/Dockerfile.hapi
+++ b/docker/dockerfiles/Dockerfile.hapi
@@ -7,4 +7,4 @@ COPY . .
 
 RUN npm ci
 
-CMD [ "npm", "run", "start:watch" ]
+CMD [ "npm", "run", "start" ]

--- a/docker/dockerfiles/Dockerfile.hapi
+++ b/docker/dockerfiles/Dockerfile.hapi
@@ -1,10 +1,12 @@
 FROM node:16.18.1 as dev
 
-WORKDIR /code
+
 EXPOSE 3000
 
-COPY . .
+USER node
+COPY --chown=node:node . /code 
 
+WORKDIR /code
 RUN npm ci
 
 CMD [ "npm", "run", "start" ]


### PR DESCRIPTION
## :christmas_tree: Problème
L'utilisation de docker-compose en local ne permet pas d'avoir un vrai environnement de développement.

## :gift: Proposition
Modifier la documentation ainsi que les fichiers de configuration docker-compose.

## :santa: Pour tester

Test Dev API + frontend : 

```sh
cd docker
cp sample.env  .env
docker-compose -f docker-compose.yaml -f docker-compose-dev-api.yaml -f docker-compose-dev-front.yaml build api orga
docker-compose -f docker-compose.yaml -f docker-compose-dev-api.yaml -f docker-compose-dev-front.yaml up -d api orga
docker-compose exec  api npm run db:reset 
```


