### PR TITLE
[TECH]: Ajouter dans les seeds un user qui est membre de plusieurs organisations de types différents (PIX-6496)

### DIFF
--- a/api/db/seeds/data/organizations-pro-builder.js
+++ b/api/db/seeds/data/organizations-pro-builder.js
@@ -1,7 +1,7 @@
 const Membership = require('../../../lib/domain/models/Membership');
 const OrganizationInvitation = require('../../../lib/domain/models/OrganizationInvitation');
 const { ROLES } = require('../../../lib/domain/constants').PIX_ADMIN;
-const { DEFAULT_PASSWORD } = require('./users-builder');
+const { DEFAULT_PASSWORD, PIX_ALL_ORGA_ID } = require('./users-builder');
 const OidcIdentityProviders = require('../../../lib/domain/constants/oidc-identity-providers');
 
 const PRO_COMPANY_ID = 1;
@@ -64,6 +64,12 @@ function organizationsProBuilder({ databaseBuilder }) {
 
   databaseBuilder.factory.buildMembership({
     userId: proUser1.id,
+    organizationId: PRO_COMPANY_ID,
+    organizationRole: Membership.roles.ADMIN,
+  });
+
+  databaseBuilder.factory.buildMembership({
+    userId: PIX_ALL_ORGA_ID,
     organizationId: PRO_COMPANY_ID,
     organizationRole: Membership.roles.ADMIN,
   });

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -1,5 +1,5 @@
 const Membership = require('../../../lib/domain/models/Membership');
-const { DEFAULT_PASSWORD } = require('./users-builder');
+const { DEFAULT_PASSWORD, PIX_ALL_ORGA_ID } = require('./users-builder');
 const { SamlIdentityProviders } = require('../../../lib/domain/constants/saml-identity-providers');
 const { ROLES } = require('../../../lib/domain/constants').PIX_ADMIN;
 
@@ -83,6 +83,11 @@ function _buildMiddleSchools({ databaseBuilder }) {
 
   databaseBuilder.factory.buildMembership({
     userId: SCO_ADMIN_ID,
+    organizationId: SCO_MIDDLE_SCHOOL_ID,
+    organizationRole: Membership.roles.ADMIN,
+  });
+  databaseBuilder.factory.buildMembership({
+    userId: PIX_ALL_ORGA_ID,
     organizationId: SCO_MIDDLE_SCHOOL_ID,
     organizationRole: Membership.roles.ADMIN,
   });
@@ -487,6 +492,12 @@ function _buildFarmingSchools({ databaseBuilder }) {
 
   databaseBuilder.factory.buildMembership({
     userId: SCO_ADMIN_ID,
+    organizationId: SCO_AGRI_ID,
+    organizationRole: Membership.roles.ADMIN,
+  });
+
+  databaseBuilder.factory.buildMembership({
+    userId: PIX_ALL_ORGA_ID,
     organizationId: SCO_AGRI_ID,
     organizationRole: Membership.roles.ADMIN,
   });

--- a/api/db/seeds/data/organizations-sup-builder.js
+++ b/api/db/seeds/data/organizations-sup-builder.js
@@ -1,6 +1,6 @@
 const Membership = require('../../../lib/domain/models/Membership');
 const { ROLES } = require('../../../lib/domain/constants').PIX_ADMIN;
-const { DEFAULT_PASSWORD } = require('./users-builder');
+const { DEFAULT_PASSWORD, PIX_ALL_ORGA_ID } = require('./users-builder');
 
 const SUP_UNIVERSITY_ID = 2;
 const SUP_STUDENT_ASSOCIATED_ID = 888;
@@ -49,6 +49,12 @@ function organizationsSupBuilder({ databaseBuilder }) {
 
   databaseBuilder.factory.buildMembership({
     userId: supUser1.id,
+    organizationId: SUP_UNIVERSITY_ID,
+    organizationRole: Membership.roles.ADMIN,
+  });
+
+  databaseBuilder.factory.buildMembership({
+    userId: PIX_ALL_ORGA_ID,
     organizationId: SUP_UNIVERSITY_ID,
     organizationRole: Membership.roles.ADMIN,
   });

--- a/api/db/seeds/data/users-builder.js
+++ b/api/db/seeds/data/users-builder.js
@@ -4,6 +4,7 @@ const PIX_SUPER_ADMIN_ID = 199;
 const PIX_SUPPORT_ID = 200;
 const PIX_METIER_ID = 201;
 const PIX_CERTIF_ID = 202;
+const PIX_ALL_ORGA_ID = 203;
 const DEFAULT_PASSWORD = 'pix123';
 
 function usersBuilder({ databaseBuilder }) {
@@ -58,6 +59,15 @@ function usersBuilder({ databaseBuilder }) {
     firstName: 'Pix',
     lastName: 'Certif',
     email: 'pixcertif@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+  });
+
+  databaseBuilder.factory.buildUser.withRawPassword({
+    id: PIX_ALL_ORGA_ID,
+    firstName: 'All',
+    lastName: 'Orga',
+    email: 'allorga@example.net',
+    pixOrgaTermsOfServiceAccepted: true,
     rawPassword: DEFAULT_PASSWORD,
   });
 
@@ -201,5 +211,6 @@ module.exports = {
   PIX_SUPPORT_ID,
   PIX_METIER_ID,
   PIX_CERTIF_ID,
+  PIX_ALL_ORGA_ID,
   DEFAULT_PASSWORD,
 };


### PR DESCRIPTION
## :christmas_tree: Problème
Lors de nos tests fonctionnels, on a parfois besoin d’aller voir dans plusieurs orga de différents type.
Pour se faire, on devait se déconnecter et se connecter avec le bon user. Ce qui est laborieux.

## :gift: Proposition
Créer un user qui a accès à toutes les organisations.

## :star2: Remarques
Je suis open pour changer le nom du user 

## :santa: Pour tester
Se connecter avec le mail `allorga@example.net`
