### PR TITLE
[FEATURE] Ajout d'une nouvelle route qui répond toujours OK à la question courante

### DIFF
--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -14,6 +14,9 @@ const {
   extractUserIdFromRequest,
 } = require('../../infrastructure/utils/request-response-utils');
 
+const Examiner = require('../../domain/models/Examiner');
+const ValidatorAlwaysOK = require('../../domain/models/ValidatorAlwaysOK');
+
 module.exports = {
   async save(request, h) {
     const assessment = assessmentSerializer.deserialize(request.payload);
@@ -113,6 +116,27 @@ module.exports = {
     const competenceEvaluations = await usecases.findCompetenceEvaluationsByAssessment({ userId, assessmentId });
 
     return competenceEvaluationSerializer.serialize(competenceEvaluations);
+  },
+
+  async autoValidateNextChallenge(request, h) {
+    const assessmentId = request.params.id;
+    const locale = extractLocaleFromRequest(request);
+    const assessment = await usecases.getAssessment({ assessmentId, locale });
+    const userId = assessment.userId;
+    const fakeAnswer = {
+      assessmentId,
+      challengeId: assessment.lastChallengeId,
+      value: 'fake_answer',
+    };
+    const validatorAlwaysOK = new ValidatorAlwaysOK();
+    const alwaysTrueExaminer = new Examiner({ validator: validatorAlwaysOK });
+    await usecases.correctAnswerThenUpdateAssessment({
+      answer: fakeAnswer,
+      userId,
+      locale,
+      examiner: alwaysTrueExaminer,
+    });
+    return h.response().code(204);
   },
 };
 

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -126,7 +126,7 @@ module.exports = {
     const fakeAnswer = {
       assessmentId,
       challengeId: assessment.lastChallengeId,
-      value: 'fake_answer',
+      value: 'FAKE_ANSWER_WITH_AUTO_VALIDATE_NEXT_CHALLENGE',
     };
     const validatorAlwaysOK = new ValidatorAlwaysOK();
     const alwaysTrueExaminer = new Examiner({ validator: validatorAlwaysOK });

--- a/api/lib/application/assessments/index.js
+++ b/api/lib/application/assessments/index.js
@@ -178,7 +178,7 @@ exports.register = async (server) => {
   if (featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled) {
     routes.push({
       method: 'POST',
-      path: '/api/admin/assessments/{id}/auto-validate-next-challenge',
+      path: '/api/admin/assessments/{id}/always-ok-validate-next-challenge',
       config: {
         pre: [
           {

--- a/api/lib/application/assessments/index.js
+++ b/api/lib/application/assessments/index.js
@@ -101,6 +101,31 @@ exports.register = async (server) => {
       },
     },
     {
+      method: 'POST',
+      path: '/api/admin/assessments/{id}/auto-validate-next-challenge',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.assessmentId,
+          }),
+        },
+        handler: assessmentController.autoValidateNextChallenge,
+        tags: ['api'],
+      },
+    },
+    {
       method: 'PATCH',
       path: '/api/assessments/{id}/complete-assessment',
       config: {

--- a/api/lib/application/assessments/index.js
+++ b/api/lib/application/assessments/index.js
@@ -1,11 +1,9 @@
 const Joi = require('joi');
+const { featureToggles } = require('../../config');
 const assessmentController = require('./assessment-controller');
 const securityPreHandlers = require('../security-pre-handlers');
 const assessmentAuthorization = require('../preHandlers/assessment-authorization');
 const identifiersType = require('../../domain/types/identifiers-type');
-
-// eslint-disable-next-line node/no-process-env
-const NOT_RUNNING_IN_PRODUCTION = process.env.NODE_ENV != 'production';
 
 exports.register = async (server) => {
   const routes = [
@@ -177,7 +175,7 @@ exports.register = async (server) => {
     },
   ];
 
-  if (NOT_RUNNING_IN_PRODUCTION) {
+  if (featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled) {
     routes.push({
       method: 'POST',
       path: '/api/admin/assessments/{id}/auto-validate-next-challenge',

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -202,6 +202,9 @@ module.exports = (function () {
         process.env.FT_CLEA_RESULTS_RETRIEVAL_BY_HABILITATED_CERTIFICATION_CENTERS
       ),
       isMassiveSessionManagementEnabled: isFeatureEnabled(process.env.FT_MASSIVE_SESSION_MANAGEMENT),
+      isAlwaysOkValidateNextChallengeEndpointEnabled: isFeatureEnabled(
+        process.env.FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT
+      ),
     },
 
     infra: {

--- a/api/lib/domain/models/ValidatorAlwaysOK.js
+++ b/api/lib/domain/models/ValidatorAlwaysOK.js
@@ -1,0 +1,14 @@
+const Validation = require('./Validation');
+const Validator = require('./Validator');
+const AnswerStatus = require('./AnswerStatus');
+
+class ValidatorAlwaysOK extends Validator {
+  assess() {
+    return new Validation({
+      result: AnswerStatus.OK,
+      resultDetails: null,
+    });
+  }
+}
+
+module.exports = ValidatorAlwaysOK;

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -25,6 +25,7 @@ module.exports = async function correctAnswerThenUpdateAssessment({
   flashAssessmentResultRepository,
   flashAlgorithmService,
   algorithmDataFetcherService,
+  examiner,
 } = {}) {
   const assessment = await assessmentRepository.get(answer.assessmentId);
   if (assessment.userId !== userId) {
@@ -41,7 +42,7 @@ module.exports = async function correctAnswerThenUpdateAssessment({
   }
 
   const challenge = await challengeRepository.get(answer.challengeId);
-  const correctedAnswer = _evaluateAnswer({ challenge, answer, assessment });
+  const correctedAnswer = _evaluateAnswer({ challenge, answer, assessment, examiner });
   const now = dateUtils.getNowDate();
   const lastQuestionDate = assessment.lastQuestionDate || now;
   correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
@@ -112,8 +113,8 @@ module.exports = async function correctAnswerThenUpdateAssessment({
   return answerSaved;
 };
 
-function _evaluateAnswer({ challenge, answer, assessment }) {
-  const examiner = new Examiner({ validator: challenge.validator });
+function _evaluateAnswer({ challenge, answer, assessment, examiner: injectedExaminer }) {
+  const examiner = injectedExaminer ?? new Examiner({ validator: challenge.validator });
   return examiner.evaluate({
     answer,
     challengeFormat: challenge.format,

--- a/api/lib/infrastructure/validate-environment-variables.js
+++ b/api/lib/infrastructure/validate-environment-variables.js
@@ -28,6 +28,7 @@ const schema = Joi.object({
   AUTH_SECRET: Joi.string().required(),
   SCO_ACCOUNT_RECOVERY_KEY_LIFETIME_MINUTES: Joi.number().integer().min(1).optional(),
   NODE_ENV: Joi.string().optional().valid('development', 'test', 'production'),
+  FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE: Joi.string().optional().valid('true', 'false'),
   POLE_EMPLOI_CLIENT_ID: Joi.string().optional(),
   POLE_EMPLOI_CLIENT_SECRET: Joi.string().optional(),
   POLE_EMPLOI_TOKEN_URL: Joi.string().uri().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -789,6 +789,13 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_MASSIVE_SESSION_MANAGEMENT=true
 
+# Enable the /api/admin/assessments/{id}/auto-validate-next-challenge' endpoint
+#
+# presence: optional
+# type: boolean
+# default: false
+# FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT=false
+
 # =====
 # CPF
 # =====

--- a/api/sample.env
+++ b/api/sample.env
@@ -789,7 +789,7 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_MASSIVE_SESSION_MANAGEMENT=true
 
-# Enable the /api/admin/assessments/{id}/auto-validate-next-challenge' endpoint
+# Enable the /api/admin/assessments/{id}/always-ok-validate-next-challenge' endpoint
 #
 # presence: optional
 # type: boolean

--- a/api/tests/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
@@ -7,6 +7,7 @@ const {
   insertUserWithRoleSuperAdmin,
   generateValidRequestAuthorizationHeader,
 } = require('../../../test-helper');
+const settings = require('../../../../lib/config');
 const createServer = require('../../../../server');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 
@@ -46,13 +47,21 @@ const learningContent = [
 ];
 
 describe('Acceptance | API | assessment-controller-auto-validate-next-challenge', function () {
+  let originalEnvValue;
   let server;
   let assessmentId;
 
   beforeEach(async function () {
+    originalEnvValue = settings.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled;
+    settings.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = true;
+
     server = await createServer();
     const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
     mockLearningContent(learningContentObjects);
+  });
+
+  afterEach(function () {
+    settings.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = originalEnvValue;
   });
 
   describe('POST /api/admin/assessments/:id/auto-validate-next-challenge', function () {

--- a/api/tests/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
@@ -98,7 +98,7 @@ describe('Acceptance | API | assessment-controller-auto-validate-next-challenge'
       const lastAnswer = await knex.select('*').from('answers').where({ assessmentId }).first();
       expect(lastAnswer).to.exist;
       expect(lastAnswer.result).to.eql('ok');
-      expect(lastAnswer.value).to.eql('fake_answer');
+      expect(lastAnswer.value).to.eql('FAKE_ANSWER_WITH_AUTO_VALIDATE_NEXT_CHALLENGE');
     });
   });
 });

--- a/api/tests/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
@@ -1,0 +1,95 @@
+const {
+  expect,
+  databaseBuilder,
+  knex,
+  mockLearningContent,
+  learningContentBuilder,
+  insertUserWithRoleSuperAdmin,
+  generateValidRequestAuthorizationHeader,
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
+const Assessment = require('../../../../lib/domain/models/Assessment');
+
+const lastChallengeAnswer = 'last challenge answer';
+const lastChallengeId = 'lastChallengeId';
+const learningContent = [
+  {
+    areas: [
+      {
+        id: 'recArea1',
+        titleFrFr: 'area1_Title',
+        color: 'someColor',
+        competences: [
+          {
+            id: 'competenceId',
+            nameFrFr: 'Mener une recherche et une veille d’information',
+            index: '1.1',
+            tubes: [
+              {
+                id: 'recTube0_0',
+                skills: [
+                  {
+                    id: 'skillWeb2Id',
+                    nom: '@web2',
+                    challenges: [
+                      { id: lastChallengeId, solution: lastChallengeAnswer, type: 'QROC', autoReply: false },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+describe('Acceptance | API | assessment-controller-auto-validate-next-challenge', function () {
+  let server;
+  let assessmentId;
+
+  beforeEach(async function () {
+    server = await createServer();
+    const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
+    mockLearningContent(learningContentObjects);
+  });
+
+  describe('POST /api/admin/assessments/:id/auto-validate-next-challenge', function () {
+    let userId;
+
+    beforeEach(async function () {
+      const user = await insertUserWithRoleSuperAdmin();
+      userId = user.id;
+      assessmentId = databaseBuilder.factory.buildAssessment({
+        state: Assessment.states.STARTED,
+        type: Assessment.types.PREVIEW,
+        lastChallengeId,
+        userId,
+      }).id;
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async function () {
+      await knex('answers').delete();
+    });
+
+    it('records an "ok" answer and returns 200 HTTP status code', async function () {
+      // when
+      const response = await server.inject({
+        method: 'POST',
+        url: `/api/admin/assessments/${assessmentId}/auto-validate-next-challenge`,
+        headers: {
+          authorization: `Bearer ${generateValidRequestAuthorizationHeader(userId)}`,
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(204);
+      const lastAnswer = await knex.select('*').from('answers').where({ assessmentId }).first();
+      expect(lastAnswer).to.exist;
+      expect(lastAnswer.result).to.eql('ok');
+      expect(lastAnswer.value).to.eql('fake_answer');
+    });
+  });
+});

--- a/api/tests/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-auto-validate-next-challenge_test.js
@@ -64,7 +64,7 @@ describe('Acceptance | API | assessment-controller-auto-validate-next-challenge'
     settings.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = originalEnvValue;
   });
 
-  describe('POST /api/admin/assessments/:id/auto-validate-next-challenge', function () {
+  describe('POST /api/admin/assessments/:id/always-ok-validate-next-challenge', function () {
     let userId;
 
     beforeEach(async function () {
@@ -87,7 +87,7 @@ describe('Acceptance | API | assessment-controller-auto-validate-next-challenge'
       // when
       const response = await server.inject({
         method: 'POST',
-        url: `/api/admin/assessments/${assessmentId}/auto-validate-next-challenge`,
+        url: `/api/admin/assessments/${assessmentId}/always-ok-validate-next-challenge`,
         headers: {
           authorization: `Bearer ${generateValidRequestAuthorizationHeader(userId)}`,
         },

--- a/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_tests.js
@@ -22,6 +22,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
           id: '0',
           type: 'feature-toggles',
           attributes: {
+            'is-always-ok-validate-next-challenge-endpoint-enabled': false,
             'is-clea-results-retrieval-by-habilitated-certification-centers-enabled': false,
             'is-massive-session-management-enabled': false,
           },

--- a/api/tests/unit/application/assessments/index_test.js
+++ b/api/tests/unit/application/assessments/index_test.js
@@ -1,4 +1,5 @@
 const { expect, HttpTestServer, sinon } = require('../../../test-helper');
+const settings = require('../../../../lib/config');
 const assessmentAuthorization = require('../../../../lib/application/preHandlers/assessment-authorization');
 const moduleUnderTest = require('../../../../lib/application/assessments');
 const assessmentController = require('../../../../lib/application/assessments/assessment-controller');
@@ -96,6 +97,17 @@ describe('Unit | Application | Router | assessment-router', function () {
   });
 
   describe('POST /api/admin/assessments/{id}/auto-validate-next-challenge', function () {
+    let originalEnvValue;
+
+    beforeEach(async function () {
+      originalEnvValue = settings.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled;
+      settings.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = true;
+    });
+
+    afterEach(function () {
+      settings.featureToggles.isAlwaysOkValidateNextChallengeEndpointEnabled = originalEnvValue;
+    });
+
     it('should return a response with an HTTP status code 403 if user does not have the rights', async function () {
       // given
       sinon.stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf').returns((request, h) =>

--- a/api/tests/unit/application/assessments/index_test.js
+++ b/api/tests/unit/application/assessments/index_test.js
@@ -96,7 +96,7 @@ describe('Unit | Application | Router | assessment-router', function () {
     });
   });
 
-  describe('POST /api/admin/assessments/{id}/auto-validate-next-challenge', function () {
+  describe('POST /api/admin/assessments/{id}/always-ok-validate-next-challenge', function () {
     let originalEnvValue;
 
     beforeEach(async function () {
@@ -123,7 +123,7 @@ describe('Unit | Application | Router | assessment-router', function () {
       // when
       const { statusCode } = await httpTestServer.request(
         'POST',
-        `/api/admin/assessments/123/auto-validate-next-challenge`
+        `/api/admin/assessments/123/always-ok-validate-next-challenge`
       );
 
       // then


### PR DESCRIPTION
## :jack_o_lantern: Problème

On cherche à remplacer la fonction `getChallengeForPixAutoAnswer`

## :bat: Solution

Mise à disposition d'une nouvelle route dans l'API qui répond toujours OK à la question courante

## :spider_web: Remarques

* Cette nouvelle route est à activer avec une variable d'env `FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT`.

* :warning: Ne pas activer en environnement de production.

* Il faudra supprimer la fonction `getChallengeForPixAutoAnswer` :
   * après que cette nouvelle route soit déployée
   * après qu'une nouvelle version d'auto-answer soit mise à disposition

## :ghost: Pour tester

### Vérification du feature toggle

L'efficacité du feature toggle protégeant la route peut se tester facilement en ligne de commande :

1. Vérifier que la commande suivante renvoie un `404` :
   ```shell
   curl -X POST http://app.dev.pix.fr/api/admin/assessments/55555/always-ok-validate-next-challenge
   ```
2. Ajouter la ligne `FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT=true` au fichier `.env`
3. Vérifier que la commande suivante renvoie un `401` :
   ```shell
   curl -X POST http://app.dev.pix.fr/api/admin/assessments/55555/always-ok-validate-next-challenge
   ```

### Vérification du fonctionnement

Cette nouvelle route se teste avec la nouvelle version d'auto-answer. Pour cette partie de test, se rapprocher d'un dev qui pourra vous expliquer comment utiliser cette fonctionnalité si vous ne la connaissez pas encore.
