### PR TITLE
[BUGFIX] Récupérer les details d'une certification dans admin (PIX-6502)

### DIFF
--- a/admin/app/routes/authenticated/certifications/certification/details.js
+++ b/admin/app/routes/authenticated/certifications/certification/details.js
@@ -1,7 +1,11 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 export default class CertificationDetailsRoute extends Route {
+  @service store;
+
   model() {
-    return this.modelFor('authenticated.certifications.certification');
+    const { certification_id } = this.paramsFor('authenticated.certifications.certification');
+    return this.store.findRecord('certification-details', certification_id);
   }
 
   setupController(controller, model) {


### PR DESCRIPTION
This commit removed the call for details of a certification course

This reverts from commit f0d8b2753451d95f13b40f529d90f1d7e41c9695 and 1fe3a2fc5371e7872220e6871e0f27c5bbcf8665

## :christmas_tree: Problème
Avant
![image](https://user-images.githubusercontent.com/3769147/206299247-ae47d4fe-17ba-48a3-bcb9-cf87e8563a95.png)

Apres
![image](https://user-images.githubusercontent.com/3769147/206299200-a14e8908-91dd-4972-9f88-4172ee528fa2.png)


## :gift: Proposition
Lors de la migration ember, la recuperation des details a ete supprimé. Let's get it back!

## :star2: Remarques


## :santa: Pour tester
Aller sur `certifications/106647/details` et s'assurer que les détails de la session s'affichent correctement
