### PR TITLE
[TECH] Tester la version 9 de npm

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -7,7 +7,7 @@
   "author": "GIP Pix",
   "engines": {
     "node": "16",
-    "npm": "8"
+    "npm": "9"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## :christmas_tree: Problème
La version 9 de npm est sortie

## :gift: Proposition
Le tester pour voir, elle n'est pas encore released avec node

## :star2: Remarques
Les tests passent sauf un
```
  2679 passing (1m)
  1 failing

  1) Integration | Infrastructure | TemporaryStorage | RedisTemporaryStorage
       #set
         should set new value:
     ReplyError: ERR syntax error
      at parseError (node_modules/redis-parser/lib/parser.js:179:12)
      at parseType (node_modules/redis-parser/lib/parser.js:302:14)

```

## :santa: Pour tester

#### Local
Installer npm
```
npm install --global npm@9 
```

Installer les packages
```
npm ci
```

Exécuter les test 
```
npm test
```
