### PR TITLE
[FEATURE] Rendre l'accès au compte d'un utilisateur qui a été bloqué définitivement sur Pix Admin (PIX-6388).

### DIFF
--- a/admin/app/adapters/user-login.js
+++ b/admin/app/adapters/user-login.js
@@ -1,0 +1,18 @@
+import ApplicationAdapter from './application';
+
+export default class UserLoginAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+
+  urlForUpdateRecord(id) {
+    return `${this.host}/${this.namespace}/users/${id}`;
+  }
+
+  updateRecord(store, type, snapshot) {
+    if (snapshot.adapterOptions && snapshot.adapterOptions.unblockUserAccount) {
+      const url = this.urlForUpdateRecord(snapshot.adapterOptions.userId) + '/unblock';
+      return this.ajax(url, 'PUT');
+    }
+
+    return super.updateRecord(...arguments);
+  }
+}

--- a/admin/app/components/users/user-overview.hbs
+++ b/admin/app/components/users/user-overview.hbs
@@ -174,6 +174,11 @@
         <PixButton @size="small" @backgroundColor="red" @triggerAction={{this.toggleDisplayAnonymizeModal}}>
           Anonymiser cet utilisateur
         </PixButton>
+        {{#if @user.userLogin.blockedAt}}
+          <PixButton @backgroundColor="yellow" @triggerAction={{this.unblockUserAccount}} @size="small">
+            Débloquer l'utilisateur
+          </PixButton>
+        {{/if}}
       {{/if}}
     </div>
   </form>

--- a/admin/app/components/users/user-overview.js
+++ b/admin/app/components/users/user-overview.js
@@ -195,4 +195,10 @@ export default class UserOverview extends Component {
 
     this.toggleDisplayAnonymizeModal();
   }
+
+  @action
+  async unblockUserAccount() {
+    const userLogin = await this.args.user.userLogin;
+    await userLogin.save({ adapterOptions: { unblockUserAccount: true, userId: this.args.user.id } });
+  }
 }

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -277,6 +277,17 @@ export default function () {
     });
   });
 
+  this.put('/admin/users/:id/unblock', (schema, request) => {
+    const userId = request.params.id;
+    const user = schema.users.findBy({ id: userId });
+    const userLogin = schema.userLogins.findBy({ id: user.userLoginId });
+    return userLogin.update({
+      blockedAt: null,
+      temporaryBlockedUntil: null,
+      failureCount: 0,
+    });
+  });
+
   this.post('/admin/users/:id/remove-authentication', (schema, request) => {
     const userId = request.params.id;
     const params = JSON.parse(request.requestBody);

--- a/admin/mirage/serializers/user.js
+++ b/admin/mirage/serializers/user.js
@@ -5,6 +5,7 @@ const _includes = [
   'authenticationMethods',
   'organizationMemberships',
   'certificationCenterMemberships',
+  'userLogin',
 ];
 
 export default ApplicationSerializer.extend({

--- a/admin/tests/acceptance/authenticated/users/get_test.js
+++ b/admin/tests/acceptance/authenticated/users/get_test.js
@@ -177,6 +177,37 @@ module('Acceptance | authenticated/users/get', function (hooks) {
     });
   });
 
+  module('when administrator click on unblock button', function () {
+    test('should unblock the user', async function (assert) {
+      // given
+      await buildAndAuthenticateUser(this.server, {
+        email: 'john.harry@example.net',
+        username: 'john.harry121297',
+      });
+      const userLogin = server.create('user-login', {
+        blockedAt: new Date('2021-02-01T03:00:00Z'),
+        temporaryBlockedUntil: null,
+        failureCount: 50,
+      });
+      const userToUnblock = server.create('user', {
+        firstName: 'Jane',
+        lastName: 'Harry',
+        email: 'jane.harry@example.net',
+        username: 'jane.harry050697',
+        userLogin,
+      });
+
+      const screen = await visit(`/users/${userToUnblock.id}`);
+
+      // when
+      await clickByName("Débloquer l'utilisateur");
+
+      // then
+      assert.dom(screen.queryByText('Bloqué à :')).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: "Débloquer l'utilisateur" })).doesNotExist();
+    });
+  });
+
   module('when administrator click on dissociate button', function () {
     test('should not display registration any more', async function (assert) {
       // given

--- a/admin/tests/unit/adapters/user-login_test.js
+++ b/admin/tests/unit/adapters/user-login_test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapter | user-login', function (hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:user-login');
+    sinon.stub(adapter, 'ajax');
+  });
+
+  hooks.afterEach(function () {
+    adapter.ajax.restore();
+  });
+
+  module('#urlForUpdateRecord', function () {
+    test('should add /admin inside the default update record url', function (assert) {
+      // when
+      const url = adapter.urlForUpdateRecord(123);
+
+      // then
+      assert.ok(url.endsWith('/admin/users/123'));
+    });
+  });
+
+  module('#updateRecord', function () {
+    module('when unblockUserAccount adapterOptions is passed', function () {
+      test('should send a PUT request to user unblock user account endpoint', async function (assert) {
+        // given
+        const adapterOptions = { unblockUserAccount: true, userId: 123 };
+
+        // when
+        await adapter.updateRecord(null, { modelName: 'user-login' }, { adapterOptions });
+
+        // then
+        sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/admin/users/123/unblock', 'PUT');
+        assert.ok(adapter);
+      });
+    });
+  });
+});

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -90,6 +90,29 @@ exports.register = async function (server) {
       },
     },
     {
+      method: 'PUT',
+      path: '/api/admin/users/{id}/unblock',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+              ])(request, h),
+          },
+        ],
+        handler: userController.unblockUserAccount,
+        notes: ["- Permet à un administrateur de débloquer le compte d'un utilisateur"],
+        tags: ['api', 'admin', 'user', 'unblock'],
+      },
+    },
+    {
       method: 'POST',
       path: '/api/admin/users/{id}/add-pix-authentication-method',
       config: {

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -18,6 +18,7 @@ const campaignParticipationForUserManagementSerializer = require('../../infrastr
 const userOrganizationForAdminSerializer = require('../../infrastructure/serializers/jsonapi/user-organization-for-admin-serializer');
 const certificationCenterMembershipSerializer = require('../../infrastructure/serializers/jsonapi/certification-center-membership-serializer');
 const trainingSerializer = require('../../infrastructure/serializers/jsonapi/training-serializer');
+const userLoginSerializer = require('../../infrastructure/serializers/jsonapi/user-login-serializer');
 
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 const requestResponseUtils = require('../../infrastructure/utils/request-response-utils');
@@ -270,6 +271,12 @@ module.exports = {
     const adminMemberId = request.auth.credentials.userId;
     const user = await usecases.anonymizeUser({ userId: userToAnonymizeId, updatedByUserId: adminMemberId });
     return h.response(userAnonymizedDetailsForAdminSerializer.serialize(user)).code(200);
+  },
+
+  async unblockUserAccount(request, h) {
+    const userId = request.params.id;
+    const userLogin = await usecases.unblockUserAccount({ userId });
+    return h.response(userLoginSerializer.serialize(userLogin)).code(200);
   },
 
   async removeAuthenticationMethod(request, h) {

--- a/api/lib/domain/models/UserLogin.js
+++ b/api/lib/domain/models/UserLogin.js
@@ -46,6 +46,12 @@ class UserLogin {
     this.blockedAt = new Date();
   }
 
+  unblockUser() {
+    this.failureCount = 0;
+    this.temporaryBlockedUntil = null;
+    this.blockedAt = null;
+  }
+
   isUserBlocked() {
     return !!this.blockedAt || this.failureCount >= settings.login.blockingLimitFailureCount;
   }

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -413,6 +413,7 @@ module.exports = injectDependencies(
     startWritingCampaignProfilesCollectionResultsToStream: require('./start-writing-campaign-profiles-collection-results-to-stream'),
     superviseSession: require('./supervise-session'),
     unarchiveCampaign: require('./unarchive-campaign'),
+    unblockUserAccount: require('./unblock-user-account'),
     unpublishSession: require('./unpublish-session'),
     reassignAuthenticationMethodToAnotherUser: require('./reassign-authentication-method-to-another-user'),
     updateAdminMember: require('./update-admin-member'),

--- a/api/lib/domain/usecases/unblock-user-account.js
+++ b/api/lib/domain/usecases/unblock-user-account.js
@@ -1,0 +1,6 @@
+module.exports = async function unblockUserAccount({ userId, userLoginRepository }) {
+  const userLogin = await userLoginRepository.findByUserId(userId);
+  userLogin.unblockUser();
+
+  return await userLoginRepository.update(userLogin);
+};

--- a/api/lib/infrastructure/serializers/jsonapi/user-login-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-login-serializer.js
@@ -1,0 +1,9 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(usersAnonymizedDetailsForAdmin) {
+    return new Serializer('user-login', {
+      attributes: ['userId', 'failureCount', 'temporaryBlockedUntil', 'blockedAt'],
+    }).serialize(usersAnonymizedDetailsForAdmin);
+  },
+};

--- a/api/tests/acceptance/application/users/users-route_test.js
+++ b/api/tests/acceptance/application/users/users-route_test.js
@@ -47,4 +47,33 @@ describe('Acceptance | Route | users', function () {
       expect(updatedUserRelationships['authentication-methods'].data).to.be.empty;
     });
   });
+
+  describe('PUT /admin/users/:id/unblock', function () {
+    it('should unblock user how has tried to many wrong password', async function () {
+      // given
+      const server = await createServer();
+      const userId = databaseBuilder.factory.buildUser.withRawPassword().id;
+      const userLoginId = databaseBuilder.factory.buildUserLogin({ userId }).id;
+      const superAdmin = await insertUserWithRoleSuperAdmin();
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject({
+        method: 'PUT',
+        url: `/api/admin/users/${userId}/unblock`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(superAdmin.id) },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+
+      expect(response.result.data.id).to.equal(`${userLoginId}`);
+      expect(response.result.data.type).to.equal('user-logins');
+
+      expect(response.result.data.attributes['user-id']).to.equal(userId);
+      expect(response.result.data.attributes['failure-count']).to.equal(0);
+      expect(response.result.data.attributes['temporary-blocked-until']).to.be.null;
+      expect(response.result.data.attributes['blocked-at']).to.be.null;
+    });
+  });
 });

--- a/api/tests/acceptance/application/users/users-route_test.js
+++ b/api/tests/acceptance/application/users/users-route_test.js
@@ -6,7 +6,7 @@ const {
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
 
-describe('Acceptance | Controller | users-controller-anonymize-user', function () {
+describe('Acceptance | Route | users', function () {
   describe('POST /admin/users/:id/anonymize', function () {
     it("anomymizes user, removes authentication methods and disables user's certification center and organisation memberships", async function () {
       // given

--- a/api/tests/integration/domain/usecases/unblock-user-account_test.js
+++ b/api/tests/integration/domain/usecases/unblock-user-account_test.js
@@ -1,0 +1,30 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+
+const usecases = require('../../../../lib/domain/usecases');
+const UserLogin = require('../../../../lib/domain/models/UserLogin');
+
+describe('Integration | UseCases | unblockUserAccount', function () {
+  it('should reset failure count, temporary blocked until date and blocked at date', async function () {
+    // given
+    const userId = databaseBuilder.factory.buildUser({ email: 'email@example.net' }).id;
+    databaseBuilder.factory.buildUser({ email: 'alreadyexist@example.net' });
+    const userLoginId = databaseBuilder.factory.buildUserLogin({
+      userId,
+      failureCount: 50,
+      blockedAt: new Date('2022-11-11'),
+      temporaryBlockedUntil: new Date('2022-11-10'),
+    }).id;
+    await databaseBuilder.commit();
+
+    // when
+    const result = await usecases.unblockUserAccount({ userId });
+
+    // then
+    expect(result).to.be.an.instanceOf(UserLogin);
+    expect(result.id).equal(userLoginId);
+    expect(result.userId).equal(userId);
+    expect(result.failureCount).equal(0);
+    expect(result.temporaryBlockedUntil).equal(null);
+    expect(result.blockedAt).equal(null);
+  });
+});

--- a/api/tests/unit/domain/models/UserLogin_test.js
+++ b/api/tests/unit/domain/models/UserLogin_test.js
@@ -262,4 +262,24 @@ describe('Unit | Domain | Models | UserLogin', function () {
       });
     });
   });
+
+  describe('#unblockUser', function () {
+    it('should reset failure count and reset temporary blocked until', function () {
+      // given
+      const userLogin = new UserLogin({
+        userId: 666,
+        failureCount: 50,
+        temporaryBlockedUntil: new Date('2022-11-25'),
+        blockedAt: new Date('2022-12-01'),
+      });
+
+      // when
+      userLogin.unblockUser();
+
+      // then
+      expect(userLogin.failureCount).to.equal(0);
+      expect(userLogin.temporaryBlockedUntil).to.be.null;
+      expect(userLogin.blockedAt).to.be.null;
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-login-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-login-serializer_test.js
@@ -1,0 +1,40 @@
+const { expect } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/user-login-serializer');
+const UserLogin = require('../../../../../lib/domain/models/UserLogin');
+
+describe('Unit | Serializer | JSONAPI | user-login-serializer', function () {
+  describe('#serialize', function () {
+    it('should serialize user details for Pix Admin', function () {
+      // given
+      const now = new Date();
+      const temporaryBlockedUntil = new Date('2020-01-02');
+      const createdAt = new Date('2020-01-01');
+      const userLogin = new UserLogin({
+        id: 8,
+        userId: 14,
+        failureCount: 50,
+        blockedAt: now,
+        temporaryBlockedUntil,
+        createdAt,
+        updatedAt: now,
+      });
+
+      // when
+      const json = serializer.serialize(userLogin);
+
+      // then
+      expect(json).to.be.deep.equal({
+        data: {
+          attributes: {
+            'user-id': 14,
+            'failure-count': 50,
+            'temporary-blocked-until': temporaryBlockedUntil,
+            'blocked-at': now,
+          },
+          id: '8',
+          type: 'user-logins',
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
Désormais lorsqu'un utilisateur Pix entre plusieurs fois un mot de passe erroné (50 tentatives), son compte est bloqué. 
Or actuellement si un utilisateur contacte le support pour lui débloquer le-dit compte, on doit passer sur la prod pour le faire.

## :gift: Proposition
Rendre l'accès au compte via Pix Admin.

## :santa: Pour tester
- Se connecter à Pix Admin avec un des deux rôles, super Admin ou support
- Aller dans la page d'un utilisateur 

Si local : ajouter une date dans la colonne "blockedAt", sur la table user-logins pour l'utilisateur que l'on veut débloquer
Si review : aller sur Adminer pour faire le changement
Sinon aller sur Pix App et faire les 50 tentatives (bon courage, c'est long)

- Cliquer sur le bouton "Débloquer l'utilisateur" sur la page de détails
- Constater que l'utilisateur n'est plus bloqué (faire une connexion sur Pix App)
- Constater que le bouton jaune n'apparaît plus et que les infos de blocage n’apparaissent plus aussi

