### PR TITLE
[TECH] Stocker le lien entre un certif-course et le dernier assessment-result (PIX-6527)

### DIFF
--- a/api/db/migrations/20221130143941_add-last-assessment-result-id-to-certif-course.js
+++ b/api/db/migrations/20221130143941_add-last-assessment-result-id-to-certif-course.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'certification-course-last-assessment-result';
+
+exports.up = function (knex) {
+  return knex.schema.createTable(TABLE_NAME, function (table) {
+    table
+      .integer('certificationCourseId')
+      .unique({ indexName: 'certification-course-last-assessment-id-unique' })
+      .references('certification-courses.id')
+      .notNullable();
+    table.integer('lastAssessmentResultId').references('assessment-results.id').notNullable();
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable(TABLE_NAME);
+};

--- a/api/db/migrations/20221130143941_add-last-assessment-result-id-to-certif-course.js
+++ b/api/db/migrations/20221130143941_add-last-assessment-result-id-to-certif-course.js
@@ -1,4 +1,4 @@
-const TABLE_NAME = 'certification-course-last-assessment-result';
+const TABLE_NAME = 'certification-courses-last-assessment-results';
 
 exports.up = function (knex) {
   return knex.schema.createTable(TABLE_NAME, function (table) {

--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -38,6 +38,11 @@ async function handleCertificationRescoring({
       assessmentResultRepository
     );
 
+    await certificationCourseRepository.saveLastAssessmentResultId({
+      certificationCourseId: certificationAssessment.certificationCourseId,
+      lastAssessmentResultId: assessmentResultId,
+    });
+
     await _saveCompetenceMarks(certificationAssessmentScore, assessmentResultId, competenceMarkRepository);
 
     await _cancelCertificationCourseIfHasNotEnoughNonNeutralizedChallengesToBeTrusted({
@@ -59,6 +64,7 @@ async function handleCertificationRescoring({
     await _saveResultAfterCertificationComputeError({
       certificationAssessment,
       assessmentResultRepository,
+      certificationCourseRepository,
       certificationComputeError: error,
       juryId: event.juryId,
       event,
@@ -85,6 +91,7 @@ async function _saveResultAfterCertificationComputeError({
   certificationAssessment,
   assessmentResultRepository,
   certificationComputeError,
+  certificationCourseRepository,
   juryId,
   event,
 }) {
@@ -95,7 +102,11 @@ async function _saveResultAfterCertificationComputeError({
     juryId,
     emitter,
   });
-  await assessmentResultRepository.save(assessmentResult);
+  const { id: assessmentResultId } = await assessmentResultRepository.save(assessmentResult);
+  await certificationCourseRepository.saveLastAssessmentResultId({
+    certificationCourseId: certificationAssessment.certificationCourseId,
+    lastAssessmentResultId: assessmentResultId,
+  });
 }
 
 async function _saveAssessmentResult(

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -85,6 +85,11 @@ async function _saveResult({
     assessmentResultRepository,
   });
 
+  await certificationCourseRepository.saveLastAssessmentResultId({
+    certificationCourseId: certificationAssessment.certificationCourseId,
+    lastAssessmentResultId: assessmentResult.id,
+  });
+
   await bluebird.mapSeries(certificationAssessmentScore.competenceMarks, (competenceMark) => {
     const competenceMarkDomain = new CompetenceMark({
       ...competenceMark,
@@ -123,7 +128,11 @@ async function _saveResultAfterCertificationComputeError({
     assessmentId: certificationAssessment.id,
     emitter: EMITTER,
   });
-  await assessmentResultRepository.save(assessmentResult);
+  const { id: assessmentResultId } = await assessmentResultRepository.save(assessmentResult);
+  await certificationCourseRepository.saveLastAssessmentResultId({
+    certificationCourseId: certificationAssessment.certificationCourseId,
+    lastAssessmentResultId: assessmentResultId,
+  });
   const certificationCourse = await certificationCourseRepository.get(certificationAssessment.certificationCourseId);
   certificationCourse.complete({ now: new Date() });
   return certificationCourseRepository.update(certificationCourse);

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -132,7 +132,7 @@ module.exports = {
   },
 
   async saveLastAssessmentResultId({ certificationCourseId, lastAssessmentResultId }) {
-    return knex('certification-course-last-assessment-result')
+    return knex('certification-courses-last-assessment-results')
       .insert({ certificationCourseId, lastAssessmentResultId })
       .onConflict('certificationCourseId')
       .merge(['lastAssessmentResultId']);

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -131,6 +131,13 @@ module.exports = {
     return bookshelfCertificationCourses.map(toDomain);
   },
 
+  async saveLastAssessmentResultId({ certificationCourseId, lastAssessmentResultId }) {
+    return knex('certification-course-last-assessment-result')
+      .insert({ certificationCourseId, lastAssessmentResultId })
+      .onConflict('certificationCourseId')
+      .merge(['lastAssessmentResultId']);
+  },
+
   toDomain,
 };
 

--- a/api/scripts/certification/fill-last-assessment-result-certification-course-table.js
+++ b/api/scripts/certification/fill-last-assessment-result-certification-course-table.js
@@ -8,7 +8,7 @@ const bluebird = require('bluebird');
 const DEFAULT_COUNT = 20000;
 const DEFAULT_CONCURRENCY = 2;
 
-const ASSOC_TABLE_NAME = 'certification-course-last-assessment-result';
+const ASSOC_TABLE_NAME = 'certification-courses-last-assessment-results';
 
 const addLastAssessmentResultCertificationCourse = async ({ count, concurrency }) => {
   logger.info('\tRécupération des certifications éligibles...');

--- a/api/scripts/certification/fill-last-assessment-result-certification-course-table.js
+++ b/api/scripts/certification/fill-last-assessment-result-certification-course-table.js
@@ -1,0 +1,153 @@
+require('dotenv').config();
+const { performance } = require('perf_hooks');
+const logger = require('../../lib/infrastructure/logger');
+const cache = require('../../lib/infrastructure/caches/learning-content-cache');
+const { knex, disconnect } = require('../../db/knex-database-connection');
+const yargs = require('yargs');
+const bluebird = require('bluebird');
+const DEFAULT_COUNT = 20000;
+const DEFAULT_CONCURRENCY = 2;
+
+const ASSOC_TABLE_NAME = 'certification-course-last-assessment-result';
+
+const addLastAssessmentResultCertificationCourse = async ({ count, concurrency }) => {
+  logger.info('\tRécupération des certifications éligibles...');
+  const eligibleCertificationIds = await _findEligibleCertifications(count);
+  logger.info(`\tOK : ${eligibleCertificationIds.length} certifications récupérées`);
+
+  logger.info('\tInscription du status dans la certification...');
+  let failedGenerations = 0;
+  const data = await bluebird
+    .mapSeries(
+      eligibleCertificationIds,
+      async (certificationCourseId) => {
+        try {
+          const lastAssessmentResultId = await _getLatestAssessmentResultId(certificationCourseId);
+          if (lastAssessmentResultId) return { certificationCourseId, lastAssessmentResultId };
+        } catch (err) {
+          ++failedGenerations;
+          logger.error(`Went wrong for certification ${certificationCourseId}`);
+        }
+      },
+      { concurrency }
+    )
+    .filter(Boolean);
+
+  try {
+    await knex(ASSOC_TABLE_NAME).insert(data);
+  } catch (e) {
+    logger.error(e);
+  }
+  logger.info(`\n\tOK, ${failedGenerations} générations de codes échouées pour cause de code en doublon`);
+};
+
+const isLaunchedFromCommandLine = require.main === module;
+
+async function main() {
+  const startTime = performance.now();
+  logger.info(`Script ${__filename} est lancé !`);
+  logger.info('Validation des arguments...');
+  const commandLineArgs = yargs
+    .option('count', {
+      description: 'Nombre de certificats pour lesquels on remplit la colonne',
+      type: 'number',
+      default: DEFAULT_COUNT,
+    })
+    .option('concurrency', {
+      description: 'Concurrence',
+      type: 'number',
+      default: DEFAULT_CONCURRENCY,
+    })
+    .help().argv;
+  const { count, concurrency } = _validateAndNormalizeArgs(commandLineArgs);
+  logger.info(`OK : Nombre de certificats - ${count} / Concurrence - ${concurrency}`);
+  await addLastAssessmentResultCertificationCourse({ count, concurrency });
+  const endTime = performance.now();
+  const duration = Math.round(endTime - startTime);
+  logger.info(`Script fini en ${duration * 1000} secondes.`);
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+      await cache.quit();
+    }
+  }
+})();
+
+function _validateAndNormalizeArgs({ count, concurrency }) {
+  const finalCount = _validateAndNormalizeCount(count);
+  const finalConcurrency = _validateAndNormalizeConcurrency(concurrency);
+
+  return {
+    count: finalCount,
+    concurrency: finalConcurrency,
+  };
+}
+
+function _validateAndNormalizeCount(count) {
+  if (isNaN(count)) {
+    count = DEFAULT_COUNT;
+  }
+  if (count <= 0 || count > 50000) {
+    throw new Error(`Nombre de certifications à traiter ${count} ne peut pas être inférieur à 1 ni supérieur à 50000.`);
+  }
+
+  return count;
+}
+
+function _validateAndNormalizeConcurrency(concurrency) {
+  if (isNaN(concurrency)) {
+    concurrency = DEFAULT_CONCURRENCY;
+  }
+  if (concurrency <= 0 || concurrency > 5) {
+    throw new Error(`La concurrence ${concurrency} ne peut pas être inférieure à 1 ni supérieure à 5.`);
+  }
+
+  return concurrency;
+}
+
+function _findEligibleCertifications(count) {
+  return knex
+    .pluck('id')
+    .from('certification-courses')
+    .whereNotExists(
+      knex
+        .select(1)
+        .from({ 'last-assessment-results': ASSOC_TABLE_NAME })
+        .whereRaw('"certification-courses".id = "certificationCourseId"')
+    )
+    .limit(count);
+}
+
+async function _getLatestAssessmentResultId(certificationCourseId) {
+  const certificationDTO = await knex('certification-courses')
+    .select({ lastAssessmentResultId: 'assessment-results.id' })
+    .where({ 'certification-courses.id': certificationCourseId })
+    .innerJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
+    .innerJoin('assessment-results', 'assessment-results.assessmentId', 'assessments.id')
+    .whereNotExists(
+      knex
+        .select(1)
+        .from({ 'last-assessment-results': 'assessment-results' })
+        .whereRaw('"last-assessment-results"."assessmentId" = assessments.id')
+        .whereRaw('"assessment-results"."createdAt" < "last-assessment-results"."createdAt"')
+    )
+    .whereNotExists(
+      knex
+        .select(1)
+        .from({ 'last-assessment-results': ASSOC_TABLE_NAME })
+        .whereRaw('"certification-courses".id = "last-assessment-results"."certificationCourseId"')
+    )
+    .first();
+
+  return certificationDTO?.lastAssessmentResultId;
+}
+
+module.exports = { addLastAssessmentResultCertificationCourse };

--- a/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -172,7 +172,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
   });
 
   afterEach(async function () {
-    await knex('certification-course-last-assessment-result').delete();
+    await knex('certification-courses-last-assessment-results').delete();
     return knex('assessment-results').delete();
   });
 
@@ -341,7 +341,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
       });
 
       afterEach(async function () {
-        await knex('certification-course-last-assessment-result').delete();
+        await knex('certification-courses-last-assessment-results').delete();
         await knex('competence-marks').delete();
         await knex('assessment-results').delete();
       });

--- a/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -172,6 +172,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
   });
 
   afterEach(async function () {
+    await knex('certification-course-last-assessment-result').delete();
     return knex('assessment-results').delete();
   });
 
@@ -340,7 +341,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
       });
 
       afterEach(async function () {
-        await knex('complementary-certification-course-results').delete();
+        await knex('certification-course-last-assessment-result').delete();
         await knex('competence-marks').delete();
         await knex('assessment-results').delete();
       });

--- a/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
+++ b/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
@@ -96,6 +96,7 @@ describe('Acceptance | Controller | sessions-controller', function () {
 
     describe('Success case', function () {
       afterEach(async function () {
+        await knex('certification-course-last-assessment-result').delete();
         await knex('certification-issue-reports').delete();
         await knex('finalized-sessions').delete();
         await knex('competence-marks').delete();

--- a/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
+++ b/api/tests/acceptance/application/session/session-controller-put-finalization_test.js
@@ -96,7 +96,7 @@ describe('Acceptance | Controller | sessions-controller', function () {
 
     describe('Success case', function () {
       afterEach(async function () {
-        await knex('certification-course-last-assessment-result').delete();
+        await knex('certification-courses-last-assessment-results').delete();
         await knex('certification-issue-reports').delete();
         await knex('finalized-sessions').delete();
         await knex('competence-marks').delete();

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -508,7 +508,7 @@ describe('Integration | Repository | Certification Course', function () {
 
     afterEach(function () {
       // given
-      return knex('certification-course-last-assessment-result').delete();
+      return knex('certification-courses-last-assessment-results').delete();
     });
 
     it('should insert certification course id and its last assessment result id', async function () {
@@ -523,7 +523,7 @@ describe('Integration | Repository | Certification Course', function () {
         lastAssessmentResultId: 6,
       });
       // then
-      const result = await knex('certification-course-last-assessment-result').select('*');
+      const result = await knex('certification-courses-last-assessment-results').select('*');
       expect(result).to.deep.equal([{ lastAssessmentResultId: 6, certificationCourseId }]);
     });
 
@@ -533,7 +533,7 @@ describe('Integration | Repository | Certification Course', function () {
       databaseBuilder.factory.buildAssessmentResult({ id: 6, assessmentId: 5 });
       databaseBuilder.factory.buildAssessmentResult({ id: 7, assessmentId: 5 });
       await databaseBuilder.commit();
-      await knex('certification-course-last-assessment-result').insert({
+      await knex('certification-courses-last-assessment-results').insert({
         lastAssessmentResultId: 6,
         certificationCourseId,
       });
@@ -545,7 +545,7 @@ describe('Integration | Repository | Certification Course', function () {
       });
 
       // then
-      const result = await knex('certification-course-last-assessment-result').select('*');
+      const result = await knex('certification-courses-last-assessment-results').select('*');
       expect(result).to.deep.equal([{ lastAssessmentResultId: 7, certificationCourseId }]);
     });
   });

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -494,4 +494,59 @@ describe('Integration | Repository | Certification Course', function () {
       expect(result).to.be.empty;
     });
   });
+
+  describe('#saveLastAssessmentResult', function () {
+    let sessionId;
+    let certificationCourseId;
+
+    beforeEach(function () {
+      // given
+      sessionId = databaseBuilder.factory.buildSession().id;
+      certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ sessionId }).id;
+      return databaseBuilder.commit();
+    });
+
+    afterEach(function () {
+      // given
+      return knex('certification-course-last-assessment-result').delete();
+    });
+
+    it('should insert certification course id and its last assessment result id', async function () {
+      // given
+      databaseBuilder.factory.buildAssessment({ id: 5, certificationCourseId });
+      databaseBuilder.factory.buildAssessmentResult({ id: 6, assessmentId: 5 });
+      await databaseBuilder.commit();
+
+      // when
+      await certificationCourseRepository.saveLastAssessmentResultId({
+        certificationCourseId,
+        lastAssessmentResultId: 6,
+      });
+      // then
+      const result = await knex('certification-course-last-assessment-result').select('*');
+      expect(result).to.deep.equal([{ lastAssessmentResultId: 6, certificationCourseId }]);
+    });
+
+    it('should update certification course id and its last assessment result id', async function () {
+      // given
+      databaseBuilder.factory.buildAssessment({ id: 5, certificationCourseId });
+      databaseBuilder.factory.buildAssessmentResult({ id: 6, assessmentId: 5 });
+      databaseBuilder.factory.buildAssessmentResult({ id: 7, assessmentId: 5 });
+      await databaseBuilder.commit();
+      await knex('certification-course-last-assessment-result').insert({
+        lastAssessmentResultId: 6,
+        certificationCourseId,
+      });
+
+      // when
+      await certificationCourseRepository.saveLastAssessmentResultId({
+        certificationCourseId,
+        lastAssessmentResultId: 7,
+      });
+
+      // then
+      const result = await knex('certification-course-last-assessment-result').select('*');
+      expect(result).to.deep.equal([{ lastAssessmentResultId: 7, certificationCourseId }]);
+    });
+  });
 });

--- a/api/tests/integration/scripts/certification/fill-last-assessment-result-certification-course-table_test.js
+++ b/api/tests/integration/scripts/certification/fill-last-assessment-result-certification-course-table_test.js
@@ -3,7 +3,7 @@ const {
   addLastAssessmentResultCertificationCourse,
 } = require('../../../../scripts/certification/fill-last-assessment-result-certification-course-table');
 
-const ASSOC_TABLE_NAME = 'certification-course-last-assessment-result';
+const ASSOC_TABLE_NAME = 'certification-courses-last-assessment-results';
 
 const OLD_UPDATED_AT = new Date('2020-01-01');
 const NEW_UPDATED_AT = new Date('2022-02-02');

--- a/api/tests/integration/scripts/certification/fill-last-assessment-result-certification-course-table_test.js
+++ b/api/tests/integration/scripts/certification/fill-last-assessment-result-certification-course-table_test.js
@@ -1,0 +1,110 @@
+const { expect, databaseBuilder, knex, sinon } = require('../../../test-helper');
+const {
+  addLastAssessmentResultCertificationCourse,
+} = require('../../../../scripts/certification/fill-last-assessment-result-certification-course-table');
+
+const ASSOC_TABLE_NAME = 'certification-course-last-assessment-result';
+
+const OLD_UPDATED_AT = new Date('2020-01-01');
+const NEW_UPDATED_AT = new Date('2022-02-02');
+
+describe('Integration | Scripts | Certification | fill-latest-assessment-result-certification-course-table', function () {
+  let clock;
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers(NEW_UPDATED_AT);
+  });
+
+  afterEach(function () {
+    clock.restore();
+    return knex(ASSOC_TABLE_NAME).delete();
+  });
+
+  describe('#addLastAssessmentResultCertificationCourse', function () {
+    describe('when there is assessment results', function () {
+      it('Update last assessment results id for certification courses with no data yet', async function () {
+        // given
+        _buildCertification(1);
+        _buildCertification(2);
+        _buildCertification(3);
+        _buildAssessmentResults({
+          certificationCourseId: 1,
+          latestAssessmentResultId: 10,
+          lastCreatedAt: new Date('2020-01-01'),
+        });
+        _buildAssessmentResults({
+          certificationCourseId: 1,
+          latestAssessmentResultId: 999,
+          lastCreatedAt: new Date('2020-01-03'),
+        });
+        _buildAssessmentResults({ certificationCourseId: 2, latestAssessmentResultId: 20 });
+        _buildAssessmentResults({ certificationCourseId: 3, latestAssessmentResultId: 30 });
+
+        await databaseBuilder.commit();
+        await knex(ASSOC_TABLE_NAME).insert({
+          certificationCourseId: 1,
+          lastAssessmentResultId: 10,
+        });
+
+        // when
+        await addLastAssessmentResultCertificationCourse({ count: 10, concurrency: 1 });
+
+        // then
+        const certificationDTOs = await knex(ASSOC_TABLE_NAME).orderBy('certificationCourseId');
+        expect(certificationDTOs).to.deep.equal([
+          {
+            certificationCourseId: 1,
+            lastAssessmentResultId: 10,
+          },
+          { certificationCourseId: 2, lastAssessmentResultId: 20 },
+          {
+            certificationCourseId: 3,
+            lastAssessmentResultId: 30,
+          },
+        ]);
+      });
+    });
+
+    describe('when there is no assessment results', function () {
+      it('do nothing', async function () {
+        // given
+        _buildCertification();
+        await databaseBuilder.commit();
+
+        // when
+        await addLastAssessmentResultCertificationCourse({ count: 10, concurrency: 1 });
+
+        // then
+        const certificationDTOs = await knex(ASSOC_TABLE_NAME).orderBy('certificationCourseId');
+        expect(certificationDTOs).to.be.empty;
+      });
+    });
+  });
+});
+
+function _buildCertification(id) {
+  databaseBuilder.factory.buildCertificationCourse({
+    id,
+    updatedAt: OLD_UPDATED_AT,
+  });
+}
+
+function _buildAssessmentResults({
+  certificationCourseId,
+  latestAssessmentResultId,
+  lastCreatedAt = new Date('2021-01-01'),
+}) {
+  const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
+  // not the latest
+  databaseBuilder.factory.buildAssessmentResult({
+    assessmentId,
+    createdAt: new Date('2020-01-01'),
+  });
+  // the latest
+  databaseBuilder.factory.buildAssessmentResult({
+    id: latestAssessmentResultId,
+    assessmentId,
+    createdAt: lastCreatedAt,
+  });
+  return assessmentId;
+}

--- a/api/tests/integration/scripts/certification/get-cpf-import-status-from-xml_test.js
+++ b/api/tests/integration/scripts/certification/get-cpf-import-status-from-xml_test.js
@@ -55,7 +55,8 @@ describe('Integration | Scripts | Certification | get-cpf-import-status-from-xml
         // then
         const [certificationCourse1, certificationCourse2, certificationCourse3] = await knex('certification-courses')
           .select('id', 'cpfImportStatus')
-          .whereIn('id', [1234, 4567, 891011]);
+          .whereIn('id', [1234, 4567, 891011])
+          .orderBy('id');
         expect(certificationCourse1).to.deep.equal({
           id: 1234,
           cpfImportStatus: null,

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -27,6 +27,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
       get: sinon.stub(),
       update: sinon.stub(),
       getCreationDate: sinon.stub(),
+      saveLastAssessmentResultId: sinon.stub(),
     };
     competenceMarkRepository = { save: sinon.stub() };
   });
@@ -94,6 +95,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
         // then
         expect(AssessmentResult.buildAlgoErrorResult).to.not.have.been.called;
         expect(assessmentResultRepository.save).to.not.have.been.called;
+        expect(certificationCourseRepository.saveLastAssessmentResultId).to.not.have.been.called;
         expect(certificationCourseRepository.update).to.not.have.been.called;
       });
     });
@@ -104,7 +106,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
       let certificationCourse;
 
       beforeEach(function () {
-        errorAssessmentResult = Symbol('ErrorAssessmentResult');
+        errorAssessmentResult = domainBuilder.buildAssessmentResult({ id: 98 });
         certificationCourse = domainBuilder.buildCertificationCourse({
           id: certificationCourseId,
           completedAt: null,
@@ -112,7 +114,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
 
         scoringCertificationService.calculateCertificationAssessmentScore.rejects(computeError);
         sinon.stub(AssessmentResult, 'buildAlgoErrorResult').returns(errorAssessmentResult);
-        assessmentResultRepository.save.resolves();
+        assessmentResultRepository.save.resolves(errorAssessmentResult);
         certificationCourseRepository.get
           .withArgs(certificationAssessment.certificationCourseId)
           .resolves(certificationCourse);
@@ -155,7 +157,10 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
           emitter: 'PIX-ALGO',
         });
         expect(assessmentResultRepository.save).to.have.been.calledWithExactly(errorAssessmentResult);
-
+        expect(certificationCourseRepository.saveLastAssessmentResultId).to.have.been.calledOnceWith({
+          certificationCourseId: 1234,
+          lastAssessmentResultId: 98,
+        });
         expect(certificationCourseRepository.update).to.have.been.calledWithExactly(
           new CertificationCourse({
             ...certificationCourse.toDTO(),
@@ -220,6 +225,10 @@ describe('Unit | Domain | Events | handle-certification-scoring', function () {
           emitter: 'PIX-ALGO',
         });
         expect(assessmentResultRepository.save).to.have.been.calledWithExactly(assessmentResult);
+        expect(certificationCourseRepository.saveLastAssessmentResultId).to.have.been.calledOnceWith({
+          certificationCourseId: 1234,
+          lastAssessmentResultId: 99,
+        });
         expect(certificationCourseRepository.update).to.have.been.calledWithExactly(
           new CertificationCourse({
             ...certificationCourse.toDTO(),


### PR DESCRIPTION
## :christmas_tree: Problème
On peut avoir plusieurs assessment-results pour un certif-course
`certification-courses 1-1 assessment 1-* assessment-results`
Dans les requetes c'est tres penible et couteux

 
## :gift: Proposition
Faire une table associative 'certification-course-last-assessment-results' entre le certification-course et le dernier assessment-result.
L'ajout/MAJ dans la table se fait apres la creation d'un assessment-result (scoring/rescoring)

## :star2: Remarques
Script de migration
On créé le script de migration. L'utilisation de cette table se fera une fois le script de migration passé.

Ajout d'un tri sur une requête dans un test pour éviter des flaky

## :santa: Pour tester
Passer une certification, s'assurer que la table 'certification-course-last-assessment-results' contient une entree pour le certification course.
Neutraliser une questions (coté admin). S'assurer que le nouvel assessment result est mis à jour dans la table associative