### PR TITLE
[FEATURE] Agrandir le champ d'invitation par email dans Pix Orga (PIX-3849)

### DIFF
--- a/high-level-tests/e2e/cypress/support/step_definitions/member.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/member.js
@@ -20,6 +20,6 @@ Then(`je vois {int} membre\(s\)`, (numberOfMembers) => {
 
 When(`j'invite {string} à rejoindre l'organisation`, (emailAddresses) => {
   cy.contains('Inviter un membre').click();
-  cy.contains('Adresse(s) e-mail').parent().within(() => cy.get('input').type(emailAddresses));
+  cy.contains('Adresse(s) e-mail').parent().within(() => cy.get('textarea').type(emailAddresses));
   cy.get('button').contains('Inviter').click();
 });

--- a/orga/app/components/team/invite-form.hbs
+++ b/orga/app/components/team/invite-form.hbs
@@ -2,14 +2,12 @@
 <form {{on "submit" @onSubmit}} class="form" ...attributes>
 
   <div class="form__field">
-    <label for="email" class="label">{{t "pages.team-new-item.input-label"}}</label>
-    <Input
-      id="email"
-      @type="email"
+    <PixTextarea
+      @id="email"
+      @label={{t "pages.team-new-item.input-label"}}
+      type="email"
       @value={{@email}}
-      name="email"
-      class="input"
-      multiple={{true}}
+      class="invite-form__email-field"
       aria-required="true"
       required="required"
     />

--- a/orga/app/styles/pages/authenticated/team/new.scss
+++ b/orga/app/styles/pages/authenticated/team/new.scss
@@ -4,3 +4,7 @@
     margin-top: 32px;
   }
 }
+
+.invite-form__email-field {
+  min-height: 70px;
+}


### PR DESCRIPTION
## :christmas_tree: Problème
Feedback reçu de la communauté Pix Orga : 
![image](https://user-images.githubusercontent.com/38167520/206713676-0d0df191-492e-4ecb-835c-5dae774064f1.png)

## :gift: Proposition
Agrandir le champ pour ajouter des emails.

## :star2: Remarques
RAS

## :santa: Pour tester
- Se connecter avec un admin sur Pix Orga 
- Aller sur `equipe/creation/` 
- Constater que le champ a grandis.
<img width="907" alt="image" src="https://user-images.githubusercontent.com/38167520/206714015-0320d4d0-5460-43da-960b-79aef52ac663.png">

