### PR TITLE
[BUGFIX] Tooltip "Copié !" dans la page détail d'une session n'apparait plus (PIX-6437)

### DIFF
--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -2,16 +2,21 @@
   <div class="session-details-row">
     <div class="session-details-content session-details-content--multiple session-details-content--copyable">
       <h3 class="label-text session-details-content__label">Numéro de session</h3>
-      <div class="session-details-content__clipboard" {{on "mouseout" this.removeSessionNumberTooltip}}>
+      <div class="session-details-content__clipboard">
         <span class="content-text content-text--bold session-details-content__text">{{this.session.id}}</span>
         {{#if (is-clipboard-supported)}}
-          <PixTooltip @id="tooltip-clipboard-button" @isInline={{true}} @hide={{this.isSessionNumberTooltipTextEmpty}}>
+          <PixTooltip
+            @id="tooltip-clipboard-button"
+            @manual={{true}}
+            @isInline={{true}}
+            @hide={{this.isSessionNumberTooltipTextEmpty}}
+          >
             <:triggerElement>
               <CopyButton
                 @clipboardText={{this.session.id}}
                 @success={{this.showSessionIdTooltip}}
                 @classNames="icon-button session-details-content__clipboard-button"
-                aria-label={{t "copy-session-number"}}
+                aria-label={{t "pages.sessions.detail.parameters.copy-access-code-number"}}
               >
                 <FaIcon @icon="copy" prefix="fas" />
               </CopyButton>
@@ -26,11 +31,16 @@
       <h3 class="label-text session-details-content__label">{{t "pages.sessions.detail.parameters.session-access-code"}}
         <div class="session-details-content__sub-label">{{t "pages.sessions.detail.parameters.session-candidate"}}</div>
       </h3>
-      <div class="session-details-content__clipboard" {{on "mouseout" this.removeAccessCodeTooltip}}>
+      <div class="session-details-content__clipboard">
         <span class="content-text content-text--bold session-details-content__text">{{this.session.accessCode}}</span>
         {{#if (is-clipboard-supported)}}
           {{! template-lint-disable no-duplicate-id }}
-          <PixTooltip @id="tooltip-clipboard-button" @isInline={{true}} @hide={{this.isAccessCodeTooltipTextEmpty}}>
+          <PixTooltip
+            @id="tooltip-clipboard-button"
+            @manual={{true}}
+            @isInline={{true}}
+            @hide={{this.isAccessCodeTooltipTextEmpty}}
+          >
             <:triggerElement>
               <CopyButton
                 @clipboardText={{this.session.accessCode}}
@@ -53,7 +63,7 @@
           {{t "pages.sessions.detail.parameters.session-password"}}
           <div class="session-details-content__sub-label">{{t "pages.session-supervising.header.supervisor"}}</div>
         </h3>
-        <div class="session-details-content__clipboard" {{on "mouseout" this.removeSupervisorPasswordTooltip}}>
+        <div class="session-details-content__clipboard">
           <span class="content-text content-text--bold session-details-content__text">
             C-{{this.session.supervisorPassword}}
           </span>
@@ -61,6 +71,7 @@
           {{#if (is-clipboard-supported)}}
             <PixTooltip
               @id="tooltip-clipboard-button"
+              @manual={{true}}
               @isInline={{true}}
               @hide={{this.isSupervisorPasswordTooltipTextEmpty}}
             >


### PR DESCRIPTION
## :christmas_tree: Problème
Suite à la montée de version de pix-ui sur Certif la tooltip n'apparait plus sur les copy button dans le detail d'une session.

## :gift: Proposition
Ajout d'un parametre sur PixTooltip pour gérer manuellement le comportement de la tooltip

## :star2: Remarques
Cette PR est bloquée tant que celle sur Pix Ui n'est pas mergé : https://github.com/1024pix/pix-ui/pull/306

## :santa: Pour tester
- Pour tester en local avec la bonne version de pix-ui lancer cette commande : `npm i -D @1024pix/pix-ui@github:1024pix/pix-ui#pix-6437-fix-tooltip`
- Se connecter à Pix Certif depuis n'importe quel compte
- Aller sur le détail d'une session et cliquer sur l'icone du numéro de session ou de code d'acces
- Voir que la tooltip s'affiche bien au clic et reste pendant 2 sec