### PR TITLE
[FEATURE] Sauvegarde des infos de l'éditeur dans la table des contenus formatifs (PIX-6138)

### DIFF
--- a/api/db/database-builder/factory/build-training.js
+++ b/api/db/database-builder/factory/build-training.js
@@ -7,6 +7,8 @@ function buildTraining({
   type = 'webinaire',
   duration = '06:00:00',
   locale = 'fr-fr',
+  editorName = "Ministère de l'Éducation nationale et de la Jeunesse",
+  editorLogoUrl = 'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
   createdAt = new Date(),
   updatedAt = new Date(),
 } = {}) {
@@ -17,6 +19,8 @@ function buildTraining({
     type,
     duration,
     locale,
+    editorName,
+    editorLogoUrl,
     createdAt,
     updatedAt,
   };

--- a/api/db/migrations/20221212100331_add-training-editor-name-logo-column.js
+++ b/api/db/migrations/20221212100331_add-training-editor-name-logo-column.js
@@ -1,0 +1,28 @@
+const TABLE_NAME = 'trainings';
+const EDITOR_NAME_COLUMN = 'editorName';
+const EDITOR_LOGO_URL_COLUMN = 'editorLogoUrl';
+const editorName = "Ministère de l'Éducation nationale et de la Jeunesse";
+const editorLogoUrl =
+  'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.string(EDITOR_NAME_COLUMN).default(editorName).notNullable();
+    table.string(EDITOR_LOGO_URL_COLUMN).default(editorLogoUrl).notNullable();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(EDITOR_NAME_COLUMN);
+    table.dropColumn(EDITOR_LOGO_URL_COLUMN);
+  });
+};

--- a/api/db/seeds/data/trainings-builder.js
+++ b/api/db/seeds/data/trainings-builder.js
@@ -14,6 +14,8 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'autoformation',
     duration: '00:00:05',
     locale: 'fr-fr',
+    editorName: 'Autre ministère',
+    editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/autre_logo_url.svg',
   });
   const training3 = databaseBuilder.factory.buildTraining({
     title: 'Comment toiletter son chien',

--- a/api/lib/application/trainings/index.js
+++ b/api/lib/application/trainings/index.js
@@ -64,6 +64,8 @@ exports.register = async (server) => {
                 duration: Joi.string().allow(null),
                 type: Joi.string().valid('autoformation', 'webinaire').allow(null),
                 locale: Joi.string().valid('fr-fr', 'fr', 'en-gb').allow(null),
+                editorName: Joi.string().allow(null),
+                editorLogoUrl: Joi.string().allow(null),
               }),
               type: Joi.string().valid('trainings'),
             }).required(),

--- a/api/lib/domain/models/Training.js
+++ b/api/lib/domain/models/Training.js
@@ -1,5 +1,5 @@
 class Training {
-  constructor({ id, title, link, type, duration, locale, targetProfileIds } = {}) {
+  constructor({ id, title, link, type, duration, locale, targetProfileIds, editorName, editorLogoUrl } = {}) {
     this.id = id;
     this.title = title;
     this.link = link;
@@ -7,6 +7,8 @@ class Training {
     this.duration = { ...duration }; // Prevent use of PostgresInterval object
     this.locale = locale;
     this.targetProfileIds = targetProfileIds;
+    this.editorName = editorName;
+    this.editorLogoUrl = editorLogoUrl;
   }
 }
 

--- a/api/lib/domain/read-models/UserRecommendedTraining.js
+++ b/api/lib/domain/read-models/UserRecommendedTraining.js
@@ -1,11 +1,13 @@
 class UserRecommendedTraining {
-  constructor({ id, title, link, type, duration, locale } = {}) {
+  constructor({ id, title, link, type, duration, locale, editorName, editorLogoUrl } = {}) {
     this.id = id;
     this.title = title;
     this.link = link;
     this.type = type;
     this.duration = { ...duration }; // Prevent use of PostgresInterval object
     this.locale = locale;
+    this.editorName = editorName;
+    this.editorLogoUrl = editorLogoUrl;
   }
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
@@ -3,7 +3,7 @@ const { Serializer, Deserializer } = require('jsonapi-serializer');
 module.exports = {
   serialize(training = {}, meta) {
     return new Serializer('trainings', {
-      attributes: ['duration', 'link', 'locale', 'title', 'type'],
+      attributes: ['duration', 'link', 'locale', 'title', 'type', 'editorName', 'editorLogoUrl'],
       meta,
     }).serialize(training);
   },

--- a/api/scripts/create-trainings.js
+++ b/api/scripts/create-trainings.js
@@ -1,9 +1,9 @@
 const { knex, disconnect } = require('../db/knex-database-connection');
 const { parseCsvWithHeaderAndRequiredFields } = require('./helpers/csvHelpers');
-const REQUIRED_FIELD_NAMES = ['title', 'link', 'type', 'duration', 'locale'];
+const REQUIRED_FIELD_NAMES = ['title', 'link', 'type', 'duration', 'locale', 'editorName', 'editorLogoUrl'];
 
 function prepareDataForInsert(rawTrainings) {
-  return rawTrainings.map(({ title, link, type, duration, locale }) => {
+  return rawTrainings.map(({ title, link, type, duration, locale, editorName, editorLogoUrl }) => {
     const trimmedType = type.trim();
     if (['webinaire', 'autoformation'].includes(trimmedType)) {
       return {
@@ -12,6 +12,8 @@ function prepareDataForInsert(rawTrainings) {
         type: type.trim(),
         duration: duration.trim(),
         locale: locale.trim(),
+        editorName: editorName.trim(),
+        editorLogoUrl: editorLogoUrl.trim(),
       };
     }
 

--- a/api/tests/acceptance/application/campaign-participations/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participations/campaign-participation-controller_test.js
@@ -396,6 +396,8 @@ describe('Acceptance | API | Campaign Participations', function () {
         locale: training.locale,
         title: training.title,
         type: training.type,
+        'editor-name': training.editorName,
+        'editor-logo-url': training.editorLogoUrl,
       });
     });
   });

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -22,7 +22,11 @@ describe('Acceptance | Controller | training-controller', function () {
         const superAdmin = await insertUserWithRoleSuperAdmin();
         const training = databaseBuilder.factory.buildTraining();
         await databaseBuilder.commit();
-        const updatedTraining = { title: 'new title' };
+        const updatedTraining = {
+          title: 'new title',
+          editorName: 'editor name',
+          editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/logo.svg',
+        };
 
         options = {
           method: 'PATCH',
@@ -35,6 +39,8 @@ describe('Acceptance | Controller | training-controller', function () {
               type: 'trainings',
               attributes: {
                 title: updatedTraining.title,
+                editorName: updatedTraining.editorName,
+                editorLogoUrl: updatedTraining.editorLogoUrl,
               },
             },
           },
@@ -48,6 +54,8 @@ describe('Acceptance | Controller | training-controller', function () {
               title: updatedTraining.title,
               link: training.link,
               duration: training.duration,
+              editorName: updatedTraining.editorName,
+              editorLogoUrl: updatedTraining.editorLogoUrl,
             },
           },
         };
@@ -61,6 +69,12 @@ describe('Acceptance | Controller | training-controller', function () {
         expect(response.result.data.id).to.exist;
         expect(response.result.data.attributes.title).to.deep.equal(expectedResponse.data.attributes.title);
         expect(response.result.data.attributes.link).to.deep.equal(expectedResponse.data.attributes.link);
+        expect(response.result.data.attributes['editor-name']).to.deep.equal(
+          expectedResponse.data.attributes.editorName
+        );
+        expect(response.result.data.attributes['editor-logo-url']).to.deep.equal(
+          expectedResponse.data.attributes.editorLogoUrl
+        );
       });
     });
   });

--- a/api/tests/acceptance/application/users/users-controller-find-paginated-user-recommended-trainings_test.js
+++ b/api/tests/acceptance/application/users/users-controller-find-paginated-user-recommended-trainings_test.js
@@ -44,6 +44,9 @@ describe('Acceptance | Controller | users-controller-find-paginated-user-recomme
             locale: 'fr-fr',
             title: 'title',
             type: 'webinaire',
+            'editor-name': "Ministère de l'Éducation nationale et de la Jeunesse",
+            'editor-logo-url':
+              'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
           },
         },
       ]);

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -282,6 +282,8 @@ describe('Integration | Repository | training-repository', function () {
       const attributesToUpdate = {
         title: 'Mon nouveau titre',
         link: 'https://example.net/mon-nouveau-lien',
+        editorName: 'Mon nouvel editeur',
+        editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/nouveau-logo.svg',
       };
 
       // when
@@ -293,6 +295,8 @@ describe('Integration | Repository | training-repository', function () {
       expect(updatedTraining.link).to.equal(attributesToUpdate.link);
       expect(updatedTraining.locale).to.equal(training.locale);
       expect(updatedTraining.type).to.equal(training.type);
+      expect(updatedTraining.editorName).to.be.equal(attributesToUpdate.editorName);
+      expect(updatedTraining.editorLogoUrl).to.be.equal(attributesToUpdate.editorLogoUrl);
       expect(updatedTraining.updatedAt).to.be.above(currentTraining.updatedAt);
     });
 
@@ -309,6 +313,8 @@ describe('Integration | Repository | training-repository', function () {
       const attributesToUpdate = {
         title: 'Mon nouveau titre',
         link: 'https://example.net/mon-nouveau-lien',
+        editorName: 'Mon nouvel editeur',
+        editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/nouveau-logo.svg',
       };
 
       // when
@@ -318,6 +324,8 @@ describe('Integration | Repository | training-repository', function () {
       expect(updatedTraining).to.be.instanceOf(Training);
       expect(updatedTraining.title).to.equal(attributesToUpdate.title);
       expect(updatedTraining.link).to.equal(attributesToUpdate.link);
+      expect(updatedTraining.editorName).to.be.equal(attributesToUpdate.editorName);
+      expect(updatedTraining.editorLogoUrl).to.be.equal(attributesToUpdate.editorLogoUrl);
       expect(updatedTraining.targetProfileIds).to.deep.equal([targetProfile.id]);
     });
 
@@ -330,6 +338,8 @@ describe('Integration | Repository | training-repository', function () {
       const attributesToUpdate = {
         title: 'Mon nouveau titre',
         link: 'https://example.net/mon-nouveau-lien',
+        editorName: 'Mon nouvel editeur',
+        editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/nouveau-logo.svg',
       };
 
       // when
@@ -337,11 +347,13 @@ describe('Integration | Repository | training-repository', function () {
 
       // then
       const trainingNotUpdated = await knex('trainings')
-        .select('title', 'link')
+        .select('title', 'link', 'editorName', 'editorLogoUrl')
         .where({ id: trainingNotToBeUpdated.id })
         .first();
       expect(trainingNotUpdated.title).to.equal(trainingNotToBeUpdated.title);
       expect(trainingNotUpdated.link).to.equal(trainingNotToBeUpdated.link);
+      expect(trainingNotUpdated.editorName).to.equal(trainingNotToBeUpdated.editorName);
+      expect(trainingNotUpdated.editorLogoUrl).to.equal(trainingNotToBeUpdated.editorLogoUrl);
     });
   });
 

--- a/api/tests/tooling/domain-builder/factory/build-training.js
+++ b/api/tests/tooling/domain-builder/factory/build-training.js
@@ -10,6 +10,8 @@ module.exports = function buildTraining({
   },
   locale = 'fr-fr',
   targetProfileIds = [1],
+  editorName = 'Ministère education nationale',
+  editorLogoUrl = 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
 } = {}) {
   return new Training({
     id,
@@ -19,5 +21,7 @@ module.exports = function buildTraining({
     duration,
     locale,
     targetProfileIds,
+    editorName,
+    editorLogoUrl,
   });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -17,6 +17,8 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
               hours: 5,
             },
             locale: 'fr-fr',
+            'editor-name': 'Ministère education nationale',
+            'editor-logo-url': 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
           },
           id: training.id.toString(),
           type: 'trainings',
@@ -51,6 +53,8 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
               hours: 5,
             },
             locale: 'fr-fr',
+            'editor-name': 'Ministère education nationale',
+            'editor-logo-url': 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
           },
           id: training.id.toString(),
           type: 'trainings',
@@ -78,6 +82,8 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
             duration: '6h',
             type: 'webinaire',
             locale: 'fr-fr',
+            'editor-name': 'Ministère education nationale',
+            'editor-logo-url': 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
           },
         },
       };
@@ -92,6 +98,8 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
         locale: 'fr-fr',
         duration: '6h',
         type: 'webinaire',
+        editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
+        editorName: 'Ministère education nationale',
       });
     });
   });

--- a/api/tests/unit/scripts/create-trainings_test.js
+++ b/api/tests/unit/scripts/create-trainings_test.js
@@ -4,7 +4,7 @@ const { prepareDataForInsert } = require('../../../scripts/create-trainings');
 
 describe('Unit | Scripts | create-trainings.js', function () {
   describe('#prepareDataForInsert', function () {
-    it('should trim title, link, type, duration and locale', function () {
+    it('should trim all properties', function () {
       // given
       const data = [
         {
@@ -13,6 +13,8 @@ describe('Unit | Scripts | create-trainings.js', function () {
           type: '   autoformation   ',
           duration: '   06:00:00   ',
           locale: '  fr-fr',
+          editorName: "     Ministère de l'intérieur    ",
+          editorLogoUrl: '   https://images.pix.fr/contenu-formatif/editeur/logo.svg  ',
         },
         {
           title: '   Moodle : Partager et échanger ses ressources',
@@ -20,6 +22,8 @@ describe('Unit | Scripts | create-trainings.js', function () {
           type: '   webinaire ',
           duration: '01:00:00  ',
           locale: 'fr-fr ',
+          editorName: "     Ministère de l'éducation    ",
+          editorLogoUrl: '   https://images.pix.fr/contenu-formatif/editeur/logo2.svg  ',
         },
       ];
 
@@ -34,6 +38,8 @@ describe('Unit | Scripts | create-trainings.js', function () {
           type: 'autoformation',
           duration: '06:00:00',
           locale: 'fr-fr',
+          editorName: "Ministère de l'intérieur",
+          editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/logo.svg',
         },
         {
           title: 'Moodle : Partager et échanger ses ressources',
@@ -41,6 +47,8 @@ describe('Unit | Scripts | create-trainings.js', function () {
           type: 'webinaire',
           duration: '01:00:00',
           locale: 'fr-fr',
+          editorName: "Ministère de l'éducation",
+          editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/logo2.svg',
         },
       ]);
     });
@@ -54,6 +62,8 @@ describe('Unit | Scripts | create-trainings.js', function () {
           type: 'autoformation',
           duration: '06:00:00',
           locale: 'fr-fr',
+          editorName: "Ministère de l'éducation",
+          editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/logo.svg',
         },
         {
           title: 'Moodle : Partager et échanger ses ressources',
@@ -61,6 +71,8 @@ describe('Unit | Scripts | create-trainings.js', function () {
           type: 'test',
           duration: '01:00:00',
           locale: 'fr-fr',
+          editorName: "Ministère de l'éducation",
+          editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/logo.svg',
         },
       ];
 

--- a/high-level-tests/e2e/cypress/fixtures/trainings.json
+++ b/high-level-tests/e2e/cypress/fixtures/trainings.json
@@ -5,6 +5,8 @@
     "link": "https://test.fr/",
     "type": "autoformation",
     "duration": "0 years 0 mons 0 days 6 hours 0 mins 0.0 secs",
-    "locale": "fr"
+    "locale": "fr",
+    "editorName": "Ministère de l'éducation nationale",
+    "editorLogoUrl": "https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg"
   }
 ]


### PR DESCRIPTION
## :christmas_tree: Problème

Aucune info éditeur de contenu formatif n'était stockée en base.

## :gift: Proposition

On stocke maintenant le nom et l'URL du logo de l'éditeur en base de donnée.

## :santa: Pour tester

- Aller sur la [RA de Pix-App](https://app-pr5358.review.pix.fr/)
- Se connecter en tant que `userpix1@example.net`
- Aller dans la page `Mes formations` via le menu principal
- Vérifier que les propriétés `editorName` et `editorLogoUrl` sont bien présentes dans les données de la requête `/api/users/1/trainings`

Possibilité de vérifier aussi dans la DB directement, table `trainings`.

En local, lancer le script et la migration en local et vérifier que les nouvelles colonnes soient bien sauvegardées sur la table.
