### PR TITLE
[FEATURE] Générer les acquis de campagne à la création de celle-ci en fonction du profil cible choisi (PIX-5582).

### DIFF
--- a/api/lib/domain/models/CampaignCreator.js
+++ b/api/lib/domain/models/CampaignCreator.js
@@ -11,14 +11,14 @@ class CampaignCreator {
     const { type, targetProfileId } = campaignAttributes;
 
     if (type === CampaignTypes.ASSESSMENT) {
-      _checkAssessmentCampaignCreatationAllowed(targetProfileId, this.availableTargetProfileIds);
+      _checkAssessmentCampaignCreationAllowed(targetProfileId, this.availableTargetProfileIds);
     }
 
     return new CampaignForCreation(campaignAttributes);
   }
 }
 
-function _checkAssessmentCampaignCreatationAllowed(targetProfileId, availableTargetProfileIds) {
+function _checkAssessmentCampaignCreationAllowed(targetProfileId, availableTargetProfileIds) {
   if (targetProfileId && !availableTargetProfileIds.includes(targetProfileId)) {
     throw new UserNotAuthorizedToCreateCampaignError(
       `Organization does not have an access to the profile ${targetProfileId}`

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -8,6 +8,8 @@ const targetProfileRepository = require('./target-profile-repository');
 const skillRepository = require('./skill-repository');
 const Stage = require('../../domain/models/Stage');
 
+const CAMPAIGNS_TABLE = 'campaigns';
+
 module.exports = {
   isCodeAvailable(code) {
     return BookshelfCampaign.where({ code })
@@ -57,8 +59,8 @@ module.exports = {
       'multipleSendings',
     ]);
 
-    const createdCampaign = await new BookshelfCampaign(campaignAttributes).save();
-    return bookshelfToDomainConverter.buildDomainObject(BookshelfCampaign, createdCampaign);
+    const [createdCampaign] = await knex(CAMPAIGNS_TABLE).insert(campaignAttributes).returning('*');
+    return new Campaign(createdCampaign);
   },
 
   async update(campaign) {

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -45,6 +45,7 @@ module.exports = {
   },
 
   async save(campaign) {
+    const trx = await knex.transaction();
     const campaignAttributes = _.pick(campaign, [
       'name',
       'code',
@@ -58,9 +59,27 @@ module.exports = {
       'targetProfileId',
       'multipleSendings',
     ]);
-
-    const [createdCampaign] = await knex(CAMPAIGNS_TABLE).insert(campaignAttributes).returning('*');
-    return new Campaign(createdCampaign);
+    try {
+      const [createdCampaignDTO] = await trx(CAMPAIGNS_TABLE).insert(campaignAttributes).returning('*');
+      const createdCampaign = new Campaign(createdCampaignDTO);
+      if (createdCampaign.isAssessment()) {
+        const cappedTubes = await trx('target-profile_tubes')
+          .select('tubeId', 'level')
+          .where('targetProfileId', campaignAttributes.targetProfileId);
+        const skillData = [];
+        for (const cappedTube of cappedTubes) {
+          const allLevelSkills = await skillRepository.findActiveByTubeId(cappedTube.tubeId);
+          const rightLevelSkills = allLevelSkills.filter((skill) => skill.difficulty <= cappedTube.level);
+          skillData.push(...rightLevelSkills.map((skill) => ({ skillId: skill.id, campaignId: createdCampaign.id })));
+        }
+        await trx.batchInsert('campaign_skills', skillData);
+      }
+      await trx.commit();
+      return createdCampaign;
+    } catch (err) {
+      await trx.rollback();
+      throw err;
+    }
   },
 
   async update(campaign) {

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -1,5 +1,14 @@
-const { expect, domainBuilder, databaseBuilder, knex, mockLearningContent } = require('../../../test-helper');
+const {
+  expect,
+  domainBuilder,
+  databaseBuilder,
+  knex,
+  mockLearningContent,
+  sinon,
+  catchErr,
+} = require('../../../test-helper');
 const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
+const skillRepository = require('../../../../lib/infrastructure/repositories/skill-repository');
 const Campaign = require('../../../../lib/domain/models/Campaign');
 const CampaignTypes = require('../../../../lib/domain/models/CampaignTypes');
 const { NotFoundError } = require('../../../../lib/domain/errors');
@@ -63,66 +72,268 @@ describe('Integration | Repository | Campaign', function () {
       expect(_.pick(actualCampaign, checkedAttributes)).to.deep.equal(_.pick(campaign, checkedAttributes));
     });
 
-    it('should resolve null if the code do not correspond to any campaign ', function () {
+    it('should resolve null if the code do not correspond to any campaign ', async function () {
       // when
-      const promise = campaignRepository.getByCode('BIDULEFAUX');
+      const result = await campaignRepository.getByCode('BIDULEFAUX');
 
       // then
-      return promise.then((result) => {
-        expect(result).to.be.null;
-      });
+      expect(result).to.be.null;
     });
   });
 
   describe('#save', function () {
-    afterEach(function () {
+    afterEach(async function () {
+      await knex('campaign_skills').delete();
       return knex('campaigns').delete();
     });
 
-    it('should save the given campaign with type ASSESSMENT', async function () {
-      // given
-      const user = databaseBuilder.factory.buildUser();
-      const creatorId = user.id;
-      const ownerId = databaseBuilder.factory.buildUser().id;
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      databaseBuilder.factory.buildMembership({ userId: creatorId, organizationId });
-      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      await databaseBuilder.commit();
+    context('when campaign is of type ASSESSMENT', function () {
+      it('should save the given campaign with type ASSESSMENT', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser();
+        const creatorId = user.id;
+        const ownerId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        databaseBuilder.factory.buildMembership({ userId: creatorId, organizationId });
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+        await databaseBuilder.commit();
 
-      const campaignToSave = {
-        name: 'Evaluation niveau 1 recherche internet',
-        code: 'BCTERD153',
-        customLandingPageText: 'Parcours évaluatif concernant la recherche internet',
-        creatorId,
-        ownerId,
-        organizationId,
-        multipleSendings: true,
-        type: CampaignTypes.ASSESSMENT,
-        targetProfileId,
-        title: 'Parcours recherche internet',
-      };
+        const campaignToSave = {
+          name: 'Evaluation niveau 1 recherche internet',
+          code: 'BCTERD153',
+          customLandingPageText: 'Parcours évaluatif concernant la recherche internet',
+          creatorId,
+          ownerId,
+          organizationId,
+          multipleSendings: true,
+          type: CampaignTypes.ASSESSMENT,
+          targetProfileId,
+          title: 'Parcours recherche internet',
+        };
 
-      // when
-      const savedCampaign = await campaignRepository.save(campaignToSave);
+        // when
+        const savedCampaign = await campaignRepository.save(campaignToSave);
 
-      // then
-      expect(savedCampaign).to.be.instanceof(Campaign);
-      expect(savedCampaign.id).to.exist;
+        // then
+        expect(savedCampaign).to.be.instanceof(Campaign);
+        expect(savedCampaign.id).to.exist;
 
-      expect(savedCampaign).to.deep.include(
-        _.pick(campaignToSave, [
-          'name',
-          'code',
-          'title',
-          'type',
-          'customLandingPageText',
-          'creator',
-          'organization',
-          'targetProfile',
-          'multipleSendings',
-          'ownerId',
-        ])
-      );
+        expect(savedCampaign).to.deep.include(
+          _.pick(campaignToSave, [
+            'name',
+            'code',
+            'title',
+            'type',
+            'customLandingPageText',
+            'creator',
+            'organization',
+            'targetProfile',
+            'multipleSendings',
+            'ownerId',
+          ])
+        );
+      });
+
+      it('should save the active skills of the target profile as campaign skills', async function () {
+        // given
+        const learningContent = {
+          areas: [{ id: 'recArea1', competenceIds: ['recCompetence1'] }],
+          competences: [
+            {
+              id: 'recCompetence1',
+              areaId: 'recArea1',
+              tubeIds: ['recTube1', 'recTube2', 'recTube3'],
+            },
+          ],
+          tubes: [
+            {
+              id: 'recTube1',
+              skillIds: ['recArchivedSkill1Tube1', 'recActiveSkill2Tube1', 'recActiveSkill3Tube1'],
+            },
+            {
+              id: 'recTube2',
+              skillIds: ['recActiveSkill2Tube2', 'recArchivedSkill4Tube2', 'recActiveSkill6Tube2'],
+            },
+            {
+              id: 'recTube3',
+              skillIds: ['recArchivedSkill1Tube3', 'recArchivedSkill3Tube3', 'recActiveSkill8Tube3'],
+            },
+            {
+              id: 'recTube4',
+              skillIds: ['recSkillTube4'],
+            },
+          ],
+          skills: [
+            {
+              id: 'recArchivedSkill1Tube1',
+              name: 'archivedSkill1Tube1_1',
+              status: 'archivé',
+              level: 1,
+              tubeId: 'recTube1',
+            },
+            {
+              id: 'recActiveSkill2Tube1',
+              name: 'activeSkill2Tube1_2',
+              status: 'actif',
+              level: 2,
+              tubeId: 'recTube1',
+            },
+            {
+              id: 'recActiveSkill3Tube1',
+              name: 'activeSkill3Tube1_3',
+              status: 'actif',
+              level: 3,
+              tubeId: 'recTube1',
+            },
+            {
+              id: 'recActiveSkill2Tube2',
+              name: 'activeSkill2Tube2_2',
+              status: 'actif',
+              level: 2,
+              tubeId: 'recTube2',
+            },
+            {
+              id: 'recArchivedSkill4Tube2',
+              name: 'archivedSkill4Tube2_4',
+              status: 'archivé',
+              level: 4,
+              tubeId: 'recTube2',
+            },
+            {
+              id: 'recActiveSkill6Tube2',
+              name: 'activeSkill6Tube2_6',
+              status: 'actif',
+              level: 6,
+              tubeId: 'recTube2',
+            },
+            {
+              id: 'recArchivedSkill1Tube3',
+              name: 'archivedSkill1Tube3_1',
+              status: 'archivé',
+              level: 1,
+              tubeId: 'recTube3',
+            },
+            {
+              id: 'recArchivedSkill3Tube3',
+              name: 'archivedSkill3Tube3_3',
+              status: 'archivé',
+              level: 3,
+              tubeId: 'recTube3',
+            },
+            {
+              id: 'recActiveSkill8Tube3',
+              name: 'activeSkill8Tube3_8',
+              status: 'actif',
+              level: 8,
+              tubeId: 'recTube3',
+            },
+            {
+              id: 'recSkillTube4',
+              name: 'skillTube4_1',
+              status: 'actif',
+              level: 1,
+              tubeId: 'recTube4',
+            },
+          ],
+        };
+        mockLearningContent(learningContent);
+        const user = databaseBuilder.factory.buildUser();
+        const creatorId = user.id;
+        const ownerId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        databaseBuilder.factory.buildMembership({ userId: creatorId, organizationId });
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+        databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube1', level: 2 });
+        databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube2', level: 8 });
+        databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube3', level: 3 });
+        // random tube
+        databaseBuilder.factory.buildTargetProfileTube({ tubeId: 'recTube4' });
+        await databaseBuilder.commit();
+
+        const campaignToSave = {
+          name: 'Evaluation niveau 1 recherche internet',
+          code: 'BCTERD153',
+          customLandingPageText: 'Parcours évaluatif concernant la recherche internet',
+          creatorId,
+          ownerId,
+          organizationId,
+          multipleSendings: true,
+          type: CampaignTypes.ASSESSMENT,
+          targetProfileId,
+          title: 'Parcours recherche internet',
+        };
+
+        // when
+        const savedCampaign = await campaignRepository.save(campaignToSave);
+
+        // then
+        const skillIds = await knex('campaign_skills')
+          .pluck('skillId')
+          .where('campaignId', savedCampaign.id)
+          .orderBy('skillId', 'ASC');
+        expect(skillIds).to.deepEqualArray(['recActiveSkill2Tube1', 'recActiveSkill2Tube2', 'recActiveSkill6Tube2']);
+      });
+
+      it('should not save anything if something goes wrong between campaign creation and skills computation', async function () {
+        // given
+        const findActiveStub = sinon.stub(skillRepository, 'findActiveByTubeId');
+        findActiveStub.rejects(new Error('Forcing rollback'));
+        const learningContent = {
+          areas: [{ id: 'recArea1', competenceIds: ['recCompetence1'] }],
+          competences: [
+            {
+              id: 'recCompetence1',
+              areaId: 'recArea1',
+              tubeIds: ['recTube1', 'recTube2', 'recTube3'],
+            },
+          ],
+          tubes: [
+            {
+              id: 'recTube1',
+              skillIds: ['recSkill1'],
+            },
+          ],
+          skills: [
+            {
+              id: 'recSkill1',
+              name: 'recSkill1',
+              status: 'actif',
+              level: 1,
+              tubeId: 'recTube1',
+            },
+          ],
+        };
+        mockLearningContent(learningContent);
+        const user = databaseBuilder.factory.buildUser();
+        const creatorId = user.id;
+        const ownerId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        databaseBuilder.factory.buildMembership({ userId: creatorId, organizationId });
+        const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+        databaseBuilder.factory.buildTargetProfileTube({ targetProfileId, tubeId: 'recTube1', level: 2 });
+        await databaseBuilder.commit();
+        const campaignToSave = {
+          name: 'Evaluation niveau 1 recherche internet',
+          code: 'BCTERD153',
+          customLandingPageText: 'Parcours évaluatif concernant la recherche internet',
+          creatorId,
+          ownerId,
+          organizationId,
+          multipleSendings: true,
+          type: CampaignTypes.ASSESSMENT,
+          targetProfileId,
+          title: 'Parcours recherche internet',
+        };
+
+        // when
+        await catchErr(campaignRepository.save)(campaignToSave);
+
+        // then
+        const skillIds = await knex('campaign_skills').pluck('skillId');
+        const campaignIds = await knex('campaigns').pluck('id');
+        expect(skillIds).to.be.empty;
+        expect(campaignIds).to.be.empty;
+      });
     });
 
     it('should save the given campaign with type PROFILES_COLLECTION', async function () {
@@ -166,6 +377,8 @@ describe('Integration | Repository | Campaign', function () {
           'ownerId',
         ])
       );
+      const skillIds = await knex('campaign_skills').pluck('skillId').where('campaignId', savedCampaign.id);
+      expect(skillIds).to.be.empty;
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la grosse Epix de refonte de fonctionnement des profil-cibles, il a été décidé que les profil-cibles seraient maintenant définis par des sujets cappés en niveau (et non plus par des acquis). En revanche, on a toujours besoin d'avoir une liste d'acquis définie et commune à tous les participants d'une campagne.

## :robot: Solution
Au moment de la création de campagne, faire une "capture" des acquis actifs correspondant aux critères de sujets cappés en niveau du profil cible choisi.

## :rainbow: Remarques

## :100: Pour tester
Créer des campagnes et vérifier en base de données que les acquis sont bien capturés dans la table "campaign_skills"
