### PR TITLE
[TECH] Exclusion des certifications déjà prises en comptes (PIX-6523)

### DIFF
--- a/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
@@ -3,7 +3,6 @@ const logger = require('../../../logger');
 const dayjs = require('dayjs');
 const utc = require('dayjs/plugin/utc');
 const timezone = require('dayjs/plugin/timezone');
-const { cpfImportStatus } = require('../../../../domain/models/CertificationCourse');
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
@@ -41,7 +40,6 @@ module.exports = async function createAndUpload({
   await cpfCertificationResultRepository.markCertificationCoursesAsExported({
     certificationCourseIds,
     filename,
-    cpfImportStatus: cpfImportStatus.READY_TO_SEND,
   });
 
   logger.info(`${filename} generated in ${_getTimeInSec(start)}s.`);

--- a/api/lib/infrastructure/jobs/cpf-export/handlers/planner.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/planner.js
@@ -1,7 +1,6 @@
 const dayjs = require('dayjs');
 const { plannerJob } = require('../../../../config').cpf;
 const logger = require('../../../logger');
-const { cpfImportStatus } = require('../../../../domain/models/CertificationCourse');
 const _ = require('lodash');
 
 module.exports = async function planner({ pgBoss, cpfCertificationResultRepository, jobId }) {
@@ -22,7 +21,6 @@ module.exports = async function planner({ pgBoss, cpfCertificationResultReposito
     await cpfCertificationResultRepository.markCertificationToExport({
       certificationCourseIds,
       batchId,
-      cpfImportStatus: cpfImportStatus.PENDING,
     });
 
     pgBoss.send('CpfExportBuilderJob', {

--- a/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
@@ -14,12 +14,12 @@ module.exports = {
       )
       .where('certification-courses.isPublished', true)
       .where('certification-courses.isCancelled', false)
-      .whereNull('certification-courses.cpfFilename')
       .whereNotNull('certification-courses.sex')
       .where('assessment-results.status', AssessmentResult.status.VALIDATED)
       .where('competence-marks.level', '>', -1)
       .where('sessions.publishedAt', '>=', startDate)
       .where('sessions.publishedAt', '<=', endDate)
+      .whereNull('certification-courses.cpfImportStatus')
       .pluck('certification-courses.id')
       .orderBy('certification-courses.id');
     return ids;

--- a/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
+++ b/api/lib/infrastructure/repositories/cpf-certification-result-repository.js
@@ -1,6 +1,7 @@
 const { knex } = require('../../../db/knex-database-connection');
 const CpfCertificationResult = require('../../domain/read-models/CpfCertificationResult');
 const AssessmentResult = require('../../domain/models/AssessmentResult');
+const { cpfImportStatus } = require('../../domain/models/CertificationCourse');
 
 module.exports = {
   async getIdsByTimeRange({ startDate, endDate }) {
@@ -33,19 +34,19 @@ module.exports = {
     return cpfCertificationResults.map((certificationCourse) => new CpfCertificationResult(certificationCourse));
   },
 
-  async markCertificationCoursesAsExported({ certificationCourseIds, filename, cpfImportStatus }) {
+  async markCertificationCoursesAsExported({ certificationCourseIds, filename }) {
     const now = new Date();
 
     return knex('certification-courses')
-      .update({ cpfFilename: filename, cpfImportStatus, updatedAt: now })
+      .update({ cpfFilename: filename, cpfImportStatus: cpfImportStatus.READY_TO_SEND, updatedAt: now })
       .whereIn('id', certificationCourseIds);
   },
 
-  async markCertificationToExport({ certificationCourseIds, batchId, cpfImportStatus }) {
+  async markCertificationToExport({ certificationCourseIds, batchId }) {
     const now = new Date();
 
     return knex('certification-courses')
-      .update({ cpfFilename: batchId, cpfImportStatus, updatedAt: now })
+      .update({ cpfFilename: batchId, cpfImportStatus: cpfImportStatus.PENDING, updatedAt: now })
       .whereIn('id', certificationCourseIds);
   },
 

--- a/api/tests/integration/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
+++ b/api/tests/integration/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
@@ -1,6 +1,5 @@
 const { domainBuilder, expect, sinon } = require('../../../../../test-helper');
 const createAndUpload = require('../../../../../../lib/infrastructure/jobs/cpf-export/handlers/create-and-upload');
-const { cpfImportStatus } = require('../../../../../../lib/domain/models/CertificationCourse');
 const { createUnzip } = require('node:zlib');
 const fs = require('fs');
 const proxyquire = require('proxyquire');
@@ -80,7 +79,6 @@ describe('Integration | Infrastructure | jobs | cpf-export | create-and-upload',
     expect(cpfCertificationResultRepository.markCertificationCoursesAsExported).to.have.been.calledWith({
       certificationCourseIds: [12, 20],
       filename: expectedFileName,
-      cpfImportStatus: cpfImportStatus.READY_TO_SEND,
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -469,7 +469,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
 
       // when
       await cpfCertificationResultRepository.markCertificationCoursesAsExported({
-        certificationCourseIds: [456, 789]
+        certificationCourseIds: [456, 789],
       });
 
       // then
@@ -497,9 +497,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
       });
 
       // then
-      const certificationCourses = await knex('certification-courses')
-        .select('id', 'cpfImportStatus')
-        .orderBy('id');
+      const certificationCourses = await knex('certification-courses').select('id', 'cpfImportStatus').orderBy('id');
       expect(certificationCourses).to.deep.equal([
         { id: 123, cpfImportStatus: null },
         { id: 456, cpfImportStatus: 'PENDING' },

--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -231,7 +231,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
         const startDate = new Date('2022-01-01');
         const endDate = new Date('2022-01-10');
 
-        createCertificationCourseWithCompetenceMarks({ sessionDate: '2022-01-08', cpfFilename: 'file.xml' });
+        createCertificationCourseWithCompetenceMarks({ sessionDate: '2022-01-08', cpfImportStatus: 'SUCCESS' });
         await databaseBuilder.commit();
 
         // when
@@ -462,24 +462,22 @@ describe('Integration | Repository | CpfCertificationResult', function () {
   describe('#markCertificationCoursesAsExported', function () {
     it('should save filename in cpfFilename', async function () {
       // given
-      databaseBuilder.factory.buildCertificationCourse({ id: 123, cpfFilename: null });
-      databaseBuilder.factory.buildCertificationCourse({ id: 456, cpfFilename: null });
-      databaseBuilder.factory.buildCertificationCourse({ id: 789, cpfFilename: null });
+      databaseBuilder.factory.buildCertificationCourse({ id: 123 });
+      databaseBuilder.factory.buildCertificationCourse({ id: 456 });
+      databaseBuilder.factory.buildCertificationCourse({ id: 789 });
       await databaseBuilder.commit();
 
       // when
       await cpfCertificationResultRepository.markCertificationCoursesAsExported({
-        certificationCourseIds: [456, 789],
-        filename: 'filename.xml',
-        cpfImportStatus: 'GENERATED',
+        certificationCourseIds: [456, 789]
       });
 
       // then
-      const certificationCourses = await knex('certification-courses').select('id', 'cpfFilename', 'cpfImportStatus');
+      const certificationCourses = await knex('certification-courses').select('id', 'cpfImportStatus');
       expect(certificationCourses).to.deep.equal([
-        { id: 123, cpfImportStatus: null, cpfFilename: null },
-        { id: 456, cpfImportStatus: 'GENERATED', cpfFilename: 'filename.xml' },
-        { id: 789, cpfImportStatus: 'GENERATED', cpfFilename: 'filename.xml' },
+        { id: 123, cpfImportStatus: null },
+        { id: 456, cpfImportStatus: 'READY_TO_SEND' },
+        { id: 789, cpfImportStatus: 'READY_TO_SEND' },
       ]);
     });
   });
@@ -487,26 +485,25 @@ describe('Integration | Repository | CpfCertificationResult', function () {
   describe('#markCertificationToExport', function () {
     it('should save batchId in cpfFilename', async function () {
       // given
-      databaseBuilder.factory.buildCertificationCourse({ id: 123, cpfFilename: null });
-      databaseBuilder.factory.buildCertificationCourse({ id: 456, cpfFilename: null });
-      databaseBuilder.factory.buildCertificationCourse({ id: 789, cpfFilename: null });
+      databaseBuilder.factory.buildCertificationCourse({ id: 123 });
+      databaseBuilder.factory.buildCertificationCourse({ id: 456 });
+      databaseBuilder.factory.buildCertificationCourse({ id: 789 });
       await databaseBuilder.commit();
 
       // when
       await cpfCertificationResultRepository.markCertificationToExport({
         certificationCourseIds: [456, 789],
         batchId: '1234-75834#0',
-        cpfImportStatus: 'PENDING',
       });
 
       // then
       const certificationCourses = await knex('certification-courses')
-        .select('id', 'cpfFilename', 'cpfImportStatus')
+        .select('id', 'cpfImportStatus')
         .orderBy('id');
       expect(certificationCourses).to.deep.equal([
-        { id: 123, cpfImportStatus: null, cpfFilename: null },
-        { id: 456, cpfImportStatus: 'PENDING', cpfFilename: '1234-75834#0' },
-        { id: 789, cpfImportStatus: 'PENDING', cpfFilename: '1234-75834#0' },
+        { id: 123, cpfImportStatus: null },
+        { id: 456, cpfImportStatus: 'PENDING' },
+        { id: 789, cpfImportStatus: 'PENDING' },
       ]);
     });
   });
@@ -544,6 +541,7 @@ function createCertificationCourseWithCompetenceMarks({
   isPublished = true,
   sessionDate = '2022-01-08',
   cpfFilename = null,
+  cpfImportStatus = null,
 }) {
   const publishedSessionId = databaseBuilder.factory.buildSession({ publishedAt: new Date(sessionDate) }).id;
   databaseBuilder.factory.buildCertificationCourse({
@@ -560,6 +558,7 @@ function createCertificationCourseWithCompetenceMarks({
     sessionId: publishedSessionId,
     isCancelled: certificationCourseCancelled,
     cpfFilename,
+    cpfImportStatus,
   }).id;
   databaseBuilder.factory.buildAssessmentResult({
     id: 2244,

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/create-and-upload_test.js
@@ -1,6 +1,5 @@
 const { domainBuilder, expect, sinon } = require('../../../../../test-helper');
 const createAndUpload = require('../../../../../../lib/infrastructure/jobs/cpf-export/handlers/create-and-upload');
-const { cpfImportStatus } = require('../../../../../../lib/domain/models/CertificationCourse');
 const { PassThrough, Readable } = require('stream');
 const dayjs = require('dayjs');
 const utc = require('dayjs/plugin/utc');
@@ -73,7 +72,6 @@ describe('Unit | Infrastructure | jobs | cpf-export | create-and-upload', functi
       expect(cpfCertificationResultRepository.markCertificationCoursesAsExported).to.have.been.calledWith({
         certificationCourseIds: [12, 20, 33, 98, 114],
         filename: 'pix-cpf-export-20220101-114327.xml.gz',
-        cpfImportStatus: cpfImportStatus.READY_TO_SEND,
       });
 
       expect(loggerSpy).to.not.have.been.called;

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/planner_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/planner_test.js
@@ -1,6 +1,5 @@
 const { expect, sinon } = require('../../../../../test-helper');
 const planner = require('../../../../../../lib/infrastructure/jobs/cpf-export/handlers/planner');
-const { cpfImportStatus } = require('../../../../../../lib/domain/models/CertificationCourse');
 const dayjs = require('dayjs');
 const { cpf } = require('../../../../../../lib/config');
 const utc = require('dayjs/plugin/utc');
@@ -41,17 +40,14 @@ describe('Unit | Infrastructure | jobs | cpf-export | planner', function () {
     expect(cpfCertificationResultRepository.markCertificationToExport.getCall(0)).to.have.been.calledWithExactly({
       certificationCourseIds: ['1', '2'],
       batchId: '237584-7648#0',
-      cpfImportStatus: cpfImportStatus.PENDING,
     });
     expect(cpfCertificationResultRepository.markCertificationToExport.getCall(1)).to.have.been.calledWithExactly({
       certificationCourseIds: ['3', '4'],
       batchId: '237584-7648#1',
-      cpfImportStatus: cpfImportStatus.PENDING,
     });
     expect(cpfCertificationResultRepository.markCertificationToExport.getCall(2)).to.have.been.calledWithExactly({
       certificationCourseIds: ['5'],
       batchId: '237584-7648#2',
-      cpfImportStatus: cpfImportStatus.PENDING,
     });
     expect(cpfCertificationResultRepository.getIdsByTimeRange).to.have.been.calledWith({ startDate, endDate });
     expect(pgBoss.send.firstCall).to.have.been.calledWith('CpfExportBuilderJob', {


### PR DESCRIPTION
## :christmas_tree: Problème
L’export des données de certification Pix au CPF existe déjà.
Il permet aux utilisateurs de retrouver leur certification Pix dans leur espace CPF parmi leurs autres certifications.
Lors de la creation des fichiers pour l'export au CPF on s'appuie sur le nom du fichiers d'export pour filtrer

## :gift: Proposition
Ne pas utiliser le champs cpfFilename mais le statut cpf pour filtrer les certifications

## :santa: Pour tester
Lancer 2 fois le batch CPF et s'assurer que les certifications ne sont traitées qu'une seule fois
