### PR TITLE
[TECH] Correction d'un test flaky dans le repo cpf-certification-result.

### DIFF
--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -500,7 +500,9 @@ describe('Integration | Repository | CpfCertificationResult', function () {
       });
 
       // then
-      const certificationCourses = await knex('certification-courses').select('id', 'cpfFilename', 'cpfImportStatus');
+      const certificationCourses = await knex('certification-courses')
+        .select('id', 'cpfFilename', 'cpfImportStatus')
+        .orderBy('id');
       expect(certificationCourses).to.deep.equal([
         { id: 123, cpfImportStatus: null, cpfFilename: null },
         { id: 456, cpfImportStatus: 'PENDING', cpfFilename: '1234-75834#0' },
@@ -533,6 +535,7 @@ describe('Integration | Repository | CpfCertificationResult', function () {
     });
   });
 });
+
 function createCertificationCourseWithCompetenceMarks({
   certificationCourseId = 145,
   sex = 'M',


### PR DESCRIPTION
## :christmas_tree: Problème

Un run des tests en local a donné le résultat de l'image suivante.

<img width="883" alt="Capture d’écran 2022-12-13 à 14 42 22" src="https://user-images.githubusercontent.com/36371437/207345530-06ea44fe-c4e6-4554-ac3d-ee1675642608.png">

On remarque que les résultats ne sont pas triés.

## :gift: Proposition

Ajout d'un `orderBy` dans la requête du test.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

CI verte
