### PR TITLE
[TECH] Utiliser la table associative des dernier assessment results  pour eviter des requetes complexes (PIX-6537)

### DIFF
--- a/api/db/database-builder/factory/build-assessment-result.js
+++ b/api/db/database-builder/factory/build-assessment-result.js
@@ -1,10 +1,11 @@
 const buildAssessment = require('./build-assessment');
+const buildCertificationCourseLastAssessmentResult = require('./build-certification-course-last-assessment-result');
 const buildUser = require('./build-user');
 const databaseBuffer = require('../database-buffer');
 const AssessmentResult = require('../../../lib/domain/models/AssessmentResult');
 const _ = require('lodash');
 
-module.exports = function buildAssessmentResult({
+function buildAssessmentResult({
   id = databaseBuffer.getNextId(),
   pixScore = 456,
   reproducibilityRate = null,
@@ -17,8 +18,9 @@ module.exports = function buildAssessmentResult({
   juryId,
   assessmentId,
   createdAt = new Date('2020-01-01'),
+  certificationCourseId,
 } = {}) {
-  assessmentId = _.isUndefined(assessmentId) ? buildAssessment().id : assessmentId;
+  assessmentId = _.isUndefined(assessmentId) ? buildAssessment({ certificationCourseId }).id : assessmentId;
   juryId = _.isUndefined(juryId) ? buildUser().id : juryId;
 
   const values = {
@@ -39,4 +41,45 @@ module.exports = function buildAssessmentResult({
     tableName: 'assessment-results',
     values,
   });
+}
+
+module.exports = buildAssessmentResult;
+
+buildAssessmentResult.last = function ({
+  certificationCourseId,
+  id,
+  pixScore,
+  reproducibilityRate,
+  level,
+  status,
+  emitter,
+  commentForJury,
+  commentForCandidate,
+  commentForOrganization,
+  juryId,
+  assessmentId,
+  createdAt,
+}) {
+  const assessmentResult = buildAssessmentResult({
+    id,
+    pixScore,
+    reproducibilityRate,
+    level,
+    status,
+    emitter,
+    commentForJury,
+    commentForCandidate,
+    commentForOrganization,
+    juryId,
+    assessmentId,
+    createdAt,
+    certificationCourseId,
+  });
+
+  buildCertificationCourseLastAssessmentResult({
+    certificationCourseId,
+    lastAssessmentResultId: assessmentResult.id,
+  });
+
+  return assessmentResult;
 };

--- a/api/db/database-builder/factory/build-certification-course-last-assessment-result.js
+++ b/api/db/database-builder/factory/build-certification-course-last-assessment-result.js
@@ -1,0 +1,15 @@
+const databaseBuffer = require('../database-buffer');
+
+module.exports = function buildCertificationCourseLastAssessmentResult({
+  certificationCourseId,
+  lastAssessmentResultId,
+} = {}) {
+  const values = {
+    certificationCourseId,
+    lastAssessmentResultId,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'certification-courses-last-assessment-results',
+    values,
+  });
+};

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -26,6 +26,7 @@ module.exports = {
   buildCertificationChallenge: require('./build-certification-challenge'),
   buildComplementaryCertificationCourseResult: require('./build-complementary-certification-course-result'),
   buildCertificationCourse: require('./build-certification-course'),
+  buildCertificationCourseLastAssessmentResult: require('./build-certification-course-last-assessment-result'),
   buildCertificationCpfCity: require('./build-certification-cpf-city'),
   buildCertificationIssueReport: require('./build-certification-issue-report'),
   buildCertificationReport: require('./build-certification-report'),

--- a/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -27,9 +27,18 @@ module.exports = {
       })
       .from('certification-courses')
       .innerJoin('organization-learners', 'organization-learners.userId', 'certification-courses.userId')
-      .innerJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
-      .innerJoin('assessment-results', 'assessment-results.assessmentId', 'assessments.id')
       .innerJoin('sessions', 'sessions.id', 'certification-courses.sessionId')
+      .innerJoin(
+        'certification-courses-last-assessment-results',
+        'certification-courses.id',
+        'certification-courses-last-assessment-results.certificationCourseId'
+      )
+      .innerJoin(
+        'assessment-results',
+        'assessment-results.id',
+        'certification-courses-last-assessment-results.lastAssessmentResultId'
+      )
+      .innerJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
       .innerJoin('competence-marks', 'competence-marks.assessmentResultId', 'assessment-results.id')
       .whereNotExists(
         knex
@@ -38,13 +47,6 @@ module.exports = {
           .whereRaw('"last-certification-courses"."userId" = "certification-courses"."userId"')
           .whereRaw('"last-certification-courses"."isCancelled"= false')
           .whereRaw('"certification-courses"."createdAt" < "last-certification-courses"."createdAt"')
-      )
-      .whereNotExists(
-        knex
-          .select(1)
-          .from({ 'last-assessment-results': 'assessment-results' })
-          .whereRaw('"last-assessment-results"."assessmentId" = assessments.id')
-          .whereRaw('"assessment-results"."createdAt" < "last-assessment-results"."createdAt"')
       )
 
       .where({ 'certification-courses.isCancelled': false })

--- a/api/lib/infrastructure/repositories/certification-repository.js
+++ b/api/lib/infrastructure/repositories/certification-repository.js
@@ -12,13 +12,15 @@ module.exports = {
       })
       .where('certification-courses.sessionId', sessionId)
       .join('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
-      .leftJoin('assessment-results', 'assessment-results.assessmentId', 'assessments.id')
-      .whereNotExists(
-        knex
-          .select(1)
-          .from({ 'last-assessment-results': 'assessment-results' })
-          .whereRaw('"last-assessment-results"."assessmentId" = assessments.id')
-          .whereRaw('"assessment-results"."createdAt" < "last-assessment-results"."createdAt"')
+      .leftJoin(
+        'certification-courses-last-assessment-results',
+        'certification-courses.id',
+        'certification-courses-last-assessment-results.certificationCourseId'
+      )
+      .leftJoin(
+        'assessment-results',
+        'assessment-results.id',
+        'certification-courses-last-assessment-results.lastAssessmentResultId'
       );
 
     const hasCertificationInError = _hasCertificationInError(certificationDTOs);

--- a/api/lib/infrastructure/repositories/jury-certification-repository.js
+++ b/api/lib/infrastructure/repositories/jury-certification-repository.js
@@ -91,19 +91,17 @@ function _selectJuryCertifications() {
     })
     .from('certification-courses')
     .join('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
-    .leftJoin('assessment-results', 'assessment-results.assessmentId', 'assessments.id')
-    .modify(_filterMostRecentAssessmentResult)
+    .leftJoin(
+      'certification-courses-last-assessment-results',
+      'certification-courses.id',
+      'certification-courses-last-assessment-results.certificationCourseId'
+    )
+    .leftJoin(
+      'assessment-results',
+      'assessment-results.id',
+      'certification-courses-last-assessment-results.lastAssessmentResultId'
+    )
     .groupBy('certification-courses.id', 'assessments.id', 'assessment-results.id');
-}
-
-function _filterMostRecentAssessmentResult(qb) {
-  return qb.whereNotExists(
-    knex
-      .select(1)
-      .from({ 'last-assessment-results': 'assessment-results' })
-      .whereRaw('"last-assessment-results"."assessmentId" = assessments.id')
-      .whereRaw('"assessment-results"."createdAt" < "last-assessment-results"."createdAt"')
-  );
 }
 
 async function _toDomainWithComplementaryCertifications({

--- a/api/lib/infrastructure/repositories/jury-certification-summary-repository.js
+++ b/api/lib/infrastructure/repositories/jury-certification-summary-repository.js
@@ -66,8 +66,16 @@ async function _getByCertificationCourseIds(orderedCertificationCourseIds) {
     )
     .from('certification-courses')
     .leftJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
-    .leftJoin('assessment-results', 'assessment-results.assessmentId', 'assessments.id')
-    .modify(_filterMostRecentAssessmentResult)
+    .leftJoin(
+      'certification-courses-last-assessment-results',
+      'certification-courses.id',
+      'certification-courses-last-assessment-results.certificationCourseId'
+    )
+    .leftJoin(
+      'assessment-results',
+      'assessment-results.id',
+      'certification-courses-last-assessment-results.lastAssessmentResultId'
+    )
     .leftJoin(
       'complementary-certification-courses',
       'complementary-certification-courses.certificationCourseId',
@@ -112,16 +120,6 @@ function _getCertificationCoursesIdBySessionIdQuery(sessionId) {
     .orderBy('lastName', 'ASC')
     .orderBy('firstName', 'ASC')
     .orderBy('id', 'ASC');
-}
-
-function _filterMostRecentAssessmentResult(qb) {
-  return qb.whereNotExists(
-    knex
-      .select(1)
-      .from({ 'last-assessment-results': 'assessment-results' })
-      .whereRaw('"last-assessment-results"."assessmentId" = assessments.id')
-      .whereRaw('"assessment-results"."createdAt" < "last-assessment-results"."createdAt"')
-  );
 }
 
 function _buildJuryCertificationSummaryDTOs(juryCertificationSummaryRows, certificationIssueReportRows) {

--- a/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -67,6 +67,10 @@ describe('Acceptance | API | Certification Course', function () {
           competenceId: 'competence_id',
         }).id;
         const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({ assessmentId }).id;
+        databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+          certificationCourseId: 1234,
+          lastAssessmentResultId: assessmentResultId,
+        });
         databaseBuilder.factory.buildCompetenceMark({ assessmentResultId, competenceId: 'competence_id' });
 
         databaseBuilder.factory.buildCertificationChallenge({
@@ -288,6 +292,10 @@ describe('Acceptance | API | Certification Course', function () {
         commentForOrganization: 'comment organization',
         commentForJury: 'comment jury',
         status: 'rejected',
+      });
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId: 123,
+        lastAssessmentResultId: 456,
       });
       databaseBuilder.factory.buildCompetenceMark({
         id: 125,

--- a/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-courses/certification-course-controller_test.js
@@ -66,11 +66,10 @@ describe('Acceptance | API | Certification Course', function () {
           certificationCourseId: 1234,
           competenceId: 'competence_id',
         }).id;
-        const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({ assessmentId }).id;
-        databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
+          assessmentId,
           certificationCourseId: 1234,
-          lastAssessmentResultId: assessmentResultId,
-        });
+        }).id;
         databaseBuilder.factory.buildCompetenceMark({ assessmentResultId, competenceId: 'competence_id' });
 
         databaseBuilder.factory.buildCertificationChallenge({
@@ -283,7 +282,8 @@ describe('Acceptance | API | Certification Course', function () {
       });
       databaseBuilder.factory.buildAssessment({ id: 159, certificationCourseId: 123 });
       databaseBuilder.factory.buildUser({ id: 66 });
-      databaseBuilder.factory.buildAssessmentResult({
+      databaseBuilder.factory.buildAssessmentResult.last({
+        certificationCourseId: 123,
         id: 456,
         assessmentId: 159,
         pixScore: 55,
@@ -292,10 +292,6 @@ describe('Acceptance | API | Certification Course', function () {
         commentForOrganization: 'comment organization',
         commentForJury: 'comment jury',
         status: 'rejected',
-      });
-      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-        certificationCourseId: 123,
-        lastAssessmentResultId: 456,
       });
       databaseBuilder.factory.buildCompetenceMark({
         id: 125,

--- a/api/tests/acceptance/application/certifications/index_test.js
+++ b/api/tests/acceptance/application/certifications/index_test.js
@@ -37,16 +37,13 @@ describe('Acceptance | API | Certifications', function () {
       type: Assessment.types.CERTIFICATION,
       state: 'completed',
     });
-    assessmentResult = databaseBuilder.factory.buildAssessmentResult({
+    assessmentResult = databaseBuilder.factory.buildAssessmentResult.last({
+      certificationCourseId: certificationCourse.id,
       assessmentId: assessment.id,
       level: 1,
       pixScore: 23,
       emitter: 'PIX-ALGO',
       status: 'validated',
-    });
-    databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-      certificationCourseId: certificationCourse.id,
-      lastAssessmentResultId: assessmentResult.id,
     });
     const { id } = databaseBuilder.factory.buildComplementaryCertificationCourse({
       certificationCourseId: certificationCourse.id,

--- a/api/tests/acceptance/application/certifications/index_test.js
+++ b/api/tests/acceptance/application/certifications/index_test.js
@@ -44,6 +44,10 @@ describe('Acceptance | API | Certifications', function () {
       emitter: 'PIX-ALGO',
       status: 'validated',
     });
+    databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+      certificationCourseId: certificationCourse.id,
+      lastAssessmentResultId: assessmentResult.id,
+    });
     const { id } = databaseBuilder.factory.buildComplementaryCertificationCourse({
       certificationCourseId: certificationCourse.id,
       name: 'patisseries au fruits',

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -2006,13 +2006,8 @@ describe('Acceptance | Application | organization-controller', function () {
         isPublished: true,
       });
 
-      const assessment = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationCourse.id });
-      const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
-        assessmentId: assessment.id,
-      });
-      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+      databaseBuilder.factory.buildAssessmentResult.last({
         certificationCourseId: certificationCourse.id,
-        lastAssessmentResultId: lastAssessmentResultId,
       });
       await databaseBuilder.commit();
 
@@ -2089,13 +2084,10 @@ describe('Acceptance | Application | organization-controller', function () {
         state: 'completed',
       });
 
-      const assessmentResult = databaseBuilder.factory.buildAssessmentResult({
+      const assessmentResult = databaseBuilder.factory.buildAssessmentResult.last({
+        certificationCourseId: certificationCourse.id,
         assessmentId: assessment.id,
         status: AssessmentResult.status.VALIDATED,
-      });
-      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-        certificationCourseId: certificationCourse.id,
-        lastAssessmentResultId: assessmentResult.id,
       });
       databaseBuilder.factory.buildCompetenceMark({
         level: 3,

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -2007,8 +2007,13 @@ describe('Acceptance | Application | organization-controller', function () {
       });
 
       const assessment = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationCourse.id });
-      databaseBuilder.factory.buildAssessmentResult({ assessmentId: assessment.id });
-
+      const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
+        assessmentId: assessment.id,
+      });
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId: certificationCourse.id,
+        lastAssessmentResultId: lastAssessmentResultId,
+      });
       await databaseBuilder.commit();
 
       const options = {
@@ -2087,6 +2092,10 @@ describe('Acceptance | Application | organization-controller', function () {
       const assessmentResult = databaseBuilder.factory.buildAssessmentResult({
         assessmentId: assessment.id,
         status: AssessmentResult.status.VALIDATED,
+      });
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId: certificationCourse.id,
+        lastAssessmentResultId: assessmentResult.id,
       });
       databaseBuilder.factory.buildCompetenceMark({
         level: 3,

--- a/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
@@ -77,12 +77,11 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
           partnerKey: badge.key,
           acquired: true,
         });
-        const assessmentId1 = dbf.buildAssessment({ certificationCourseId: certif1.id }).id;
-        asr1 = dbf.buildAssessmentResult({ assessmentId: assessmentId1, createdAt: new Date('2018-04-15T00:00:00Z') });
-        dbf.buildCertificationCourseLastAssessmentResult({
+        asr1 = dbf.buildAssessmentResult.last({
           certificationCourseId: certif1.id,
-          lastAssessmentResultId: asr1.id,
+          createdAt: new Date('2018-04-15T00:00:00Z'),
         });
+
         certif2 = dbf.buildCertificationCourse({ sessionId, lastName: 'CCC' });
         dbf.buildAssessment({ certificationCourseId: certif2.id });
 

--- a/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
@@ -79,7 +79,10 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
         });
         const assessmentId1 = dbf.buildAssessment({ certificationCourseId: certif1.id }).id;
         asr1 = dbf.buildAssessmentResult({ assessmentId: assessmentId1, createdAt: new Date('2018-04-15T00:00:00Z') });
-
+        dbf.buildCertificationCourseLastAssessmentResult({
+          certificationCourseId: certif1.id,
+          lastAssessmentResultId: asr1.id,
+        });
         certif2 = dbf.buildCertificationCourse({ sessionId, lastName: 'CCC' });
         dbf.buildAssessment({ certificationCourseId: certif2.id });
 
@@ -137,10 +140,10 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
         const response = await server.inject(request);
 
         // then
-        expect(response.result.data[0].attributes).to.deep.equal(expectedJuryCertifSumm1);
-        expect(response.result.data[0].id).to.deep.equal(certif1.id.toString());
-        expect(response.result.data[1].attributes).to.deep.equal(expectedJuryCertifSumm2);
-        expect(response.result.data[1].id).to.deep.equal(certif2.id.toString());
+        expect(response.result.data).to.deep.equal([
+          { type: 'jury-certification-summaries', id: certif1.id.toString(), attributes: expectedJuryCertifSumm1 },
+          { type: 'jury-certification-summaries', id: certif2.id.toString(), attributes: expectedJuryCertifSumm2 },
+        ]);
       });
     });
   });

--- a/api/tests/acceptance/application/session/session-controller-patch-publish-session_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch-publish-session_test.js
@@ -76,9 +76,14 @@ describe('PATCH /api/admin/sessions/:id/publish', function () {
           options.url = `/api/admin/sessions/${sessionId}/publish`;
           certificationId = databaseBuilder.factory.buildCertificationCourse({ sessionId, isPublished: false }).id;
           databaseBuilder.factory.buildAssessment({ id: 123, certificationCourseId: certificationId });
-          databaseBuilder.factory.buildAssessmentResult({
+          const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
             status: status.VALIDATED,
             assessmentId: 123,
+          });
+
+          databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+            certificationCourseId: certificationId,
+            lastAssessmentResultId,
           });
           return databaseBuilder.commit();
         });

--- a/api/tests/acceptance/application/session/session-controller-patch-publish-session_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch-publish-session_test.js
@@ -75,16 +75,11 @@ describe('PATCH /api/admin/sessions/:id/publish', function () {
           databaseBuilder.factory.buildFinalizedSession({ sessionId });
           options.url = `/api/admin/sessions/${sessionId}/publish`;
           certificationId = databaseBuilder.factory.buildCertificationCourse({ sessionId, isPublished: false }).id;
-          databaseBuilder.factory.buildAssessment({ id: 123, certificationCourseId: certificationId });
-          const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
+          databaseBuilder.factory.buildAssessmentResult.last({
+            certificationCourseId: certificationId,
             status: status.VALIDATED,
-            assessmentId: 123,
           });
 
-          databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-            certificationCourseId: certificationId,
-            lastAssessmentResultId,
-          });
           return databaseBuilder.commit();
         });
 

--- a/api/tests/integration/infrastructure/repositories/certificate-repository_attestation_test.js
+++ b/api/tests/integration/infrastructure/repositories/certificate-repository_attestation_test.js
@@ -7,8 +7,6 @@ const {
   mockLearningContent,
 } = require('../../../test-helper');
 const { NotFoundError } = require('../../../../lib/domain/errors');
-const CertificationAttestation = require('../../../../lib/domain/models/CertificationAttestation');
-const _ = require('lodash');
 const certificationRepository = require('../../../../lib/infrastructure/repositories/certificate-repository');
 
 describe('Integration | Infrastructure | Repository | Certification Attestation', function () {
@@ -191,10 +189,9 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       // then
       const expectedCertificationAttestation =
         domainBuilder.buildCertificationAttestation(certificationAttestationData);
-      expect(certificationAttestation).to.be.instanceOf(CertificationAttestation);
-      expect(_.omit(certificationAttestation, ['resultCompetenceTree'])).to.deep.equal(
-        _.omit(expectedCertificationAttestation, ['resultCompetenceTree'])
-      );
+      expect(certificationAttestation).to.deepEqualInstanceOmitting(expectedCertificationAttestation, [
+        'resultCompetenceTree',
+      ]);
     });
 
     it('should return a CertificationAttestation with appropriate result competence tree', async function () {
@@ -275,7 +272,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         competenceMarks: [competenceMarks1, competenceMarks2],
         competenceTree: domainBuilder.buildCompetenceTree({ areas: [area1] }),
       });
-      expect(certificationAttestation.resultCompetenceTree).to.deep.equal(expectedResultCompetenceTree);
+      expect(certificationAttestation.resultCompetenceTree).to.deepEqualInstance(expectedResultCompetenceTree);
     });
 
     it('should take into account the latest validated assessment result of a student', async function () {
@@ -310,7 +307,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       // then
       const expectedCertificationAttestation =
         domainBuilder.buildCertificationAttestation(certificationAttestationData);
-      expect(certificationAttestation).to.be.instanceOf(CertificationAttestation);
       expect(certificationAttestation).to.deepEqualInstanceOmitting(expectedCertificationAttestation, [
         'resultCompetenceTree',
       ]);
@@ -415,10 +411,9 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         // then
         const expectedCertificationAttestation =
           domainBuilder.buildCertificationAttestation(certificationAttestationData);
-        expect(certificationAttestation).to.be.instanceOf(CertificationAttestation);
-        expect(_.omit(certificationAttestation, ['resultCompetenceTree'])).to.deep.equal(
-          _.omit(expectedCertificationAttestation, ['resultCompetenceTree'])
-        );
+        expect(certificationAttestation).deepEqualInstanceOmitting(expectedCertificationAttestation, [
+          'resultCompetenceTree',
+        ]);
       });
     });
   });
@@ -771,18 +766,16 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       const expectedCertificationAttestationC =
         domainBuilder.buildCertificationAttestation(certificationAttestationDataC);
       expect(certificationAttestations).to.have.length(3);
-      expect(certificationAttestations[0]).to.be.instanceOf(CertificationAttestation);
-      expect(_.omit(certificationAttestations[0], ['resultCompetenceTree'])).to.deep.equal(
-        _.omit(expectedCertificationAttestationB, ['resultCompetenceTree'])
-      );
-      expect(certificationAttestations[1]).to.be.instanceOf(CertificationAttestation);
-      expect(_.omit(certificationAttestations[1], ['resultCompetenceTree'])).to.deep.equal(
-        _.omit(expectedCertificationAttestationC, ['resultCompetenceTree'])
-      );
-      expect(certificationAttestations[2]).to.be.instanceOf(CertificationAttestation);
-      expect(_.omit(certificationAttestations[2], ['resultCompetenceTree'])).to.deep.equal(
-        _.omit(expectedCertificationAttestationA, ['resultCompetenceTree'])
-      );
+
+      expect(certificationAttestations[0]).deepEqualInstanceOmitting(expectedCertificationAttestationB, [
+        'resultCompetenceTree',
+      ]);
+      expect(certificationAttestations[1]).deepEqualInstanceOmitting(expectedCertificationAttestationC, [
+        'resultCompetenceTree',
+      ]);
+      expect(certificationAttestations[2]).deepEqualInstanceOmitting(expectedCertificationAttestationA, [
+        'resultCompetenceTree',
+      ]);
     });
 
     it('should ignore disabled shooling-registrations', async function () {
@@ -883,7 +876,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         'resultCompetenceTree',
       ]);
 
-      expect(certificationAttestations[1]).to.be.instanceOf(CertificationAttestation);
       expect(certificationAttestations[1]).to.deepEqualInstanceOmitting(expectedCertificationAttestationA, [
         'resultCompetenceTree',
       ]);
@@ -931,7 +923,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       const expectedCertificationAttestation =
         domainBuilder.buildCertificationAttestation(certificationAttestationData);
       expect(certificationAttestations).to.have.length(1);
-      expect(certificationAttestations[0]).to.be.instanceOf(CertificationAttestation);
       expect(certificationAttestations[0]).to.deepEqualInstanceOmitting(expectedCertificationAttestation, [
         'resultCompetenceTree',
       ]);
@@ -1008,10 +999,9 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         certificationAttestationDataNewest
       );
       expect(certificationAttestations).to.have.length(1);
-      expect(certificationAttestations[0]).to.be.instanceOf(CertificationAttestation);
-      expect(_.omit(certificationAttestations[0], ['resultCompetenceTree'])).to.deep.equal(
-        _.omit(expectedCertificationAttestation, ['resultCompetenceTree'])
-      );
+      expect(certificationAttestations[0]).to.deepEqualInstanceOmitting(expectedCertificationAttestation, [
+        'resultCompetenceTree',
+      ]);
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/certificate-repository_attestation_test.js
+++ b/api/tests/integration/infrastructure/repositories/certificate-repository_attestation_test.js
@@ -1217,10 +1217,14 @@ function _buildRejected(certificationAttestationData) {
   const assessmentId = databaseBuilder.factory.buildAssessment({
     certificationCourseId: certificationAttestationData.id,
   }).id;
-  databaseBuilder.factory.buildAssessmentResult({
+  const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
     assessmentId,
     pixScore: certificationAttestationData.pixScore,
     status: 'rejected',
+  });
+  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+    certificationCourseId: certificationAttestationData.id,
+    lastAssessmentResultId,
   });
 }
 
@@ -1242,10 +1246,14 @@ function _buildCancelled(certificationAttestationData) {
   const assessmentId = databaseBuilder.factory.buildAssessment({
     certificationCourseId: certificationAttestationData.id,
   }).id;
-  databaseBuilder.factory.buildAssessmentResult({
+  const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
     assessmentId,
     pixScore: certificationAttestationData.pixScore,
     status: 'validated',
+  });
+  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+    certificationCourseId: certificationAttestationData.id,
+    lastAssessmentResultId,
   });
 }
 
@@ -1273,6 +1281,10 @@ function _buildValidCertificationAttestation(certificationAttestationData, build
     status: 'validated',
     createdAt: new Date('2020-01-02'),
   }).id;
+  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+    certificationCourseId: certificationAttestationData.id,
+    lastAssessmentResultId: assessmentResultId,
+  });
 
   if (buildCompetenceMark) {
     databaseBuilder.factory.buildCompetenceMark({
@@ -1324,6 +1336,12 @@ function _buildCertificationAttestationWithSeveralResults(certificationAttestati
     status,
     createdAt: new Date('2019-01-02'),
   }).id;
+
+  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+    certificationCourseId: certificationAttestationData.id,
+    lastAssessmentResultId: assessmentResultId2,
+  });
+
   databaseBuilder.factory.buildCompetenceMark({
     assessmentResultId: assessmentResultId1,
   });

--- a/api/tests/integration/infrastructure/repositories/certificate-repository_attestation_test.js
+++ b/api/tests/integration/infrastructure/repositories/certificate-repository_attestation_test.js
@@ -53,7 +53,14 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         certifiedBadges: [],
         sessionId: 789,
       };
-      await _buildIncomplete(certificationAttestationData);
+      _buildSession({
+        userId: certificationAttestationData.userId,
+        sessionId: certificationAttestationData.sessionId,
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+      });
+      _buildIncomplete(certificationAttestationData);
+      await databaseBuilder.commit();
 
       // when
       const error = await catchErr(certificationRepository.getCertificationAttestation)(
@@ -84,7 +91,14 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         certifiedBadges: [],
         sessionId: 789,
       };
-      await _buildCancelled(certificationAttestationData);
+      _buildSession({
+        userId: certificationAttestationData.userId,
+        sessionId: certificationAttestationData.sessionId,
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+      });
+      _buildCancelled(certificationAttestationData);
+      await databaseBuilder.commit();
 
       // when
       const error = await catchErr(certificationRepository.getCertificationAttestation)(
@@ -115,7 +129,14 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         certifiedBadges: [],
         sessionId: 789,
       };
-      await _buildValidCertificationAttestation(certificationAttestationData);
+      _buildSession({
+        userId: certificationAttestationData.userId,
+        sessionId: certificationAttestationData.sessionId,
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+      });
+      _buildValidCertificationAttestation(certificationAttestationData);
+      await databaseBuilder.commit();
 
       // when
       const error = await catchErr(certificationRepository.getCertificationAttestation)(
@@ -146,7 +167,13 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         certifiedBadges: [],
         sessionId: 789,
       };
-      await _buildRejected(certificationAttestationData);
+      _buildSession({
+        userId: certificationAttestationData.userId,
+        sessionId: certificationAttestationData.sessionId,
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+      });
+      _buildRejected(certificationAttestationData);
       await databaseBuilder.commit();
 
       // when
@@ -181,7 +208,14 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         certifiedBadges: [],
         sessionId: 789,
       };
-      await _buildValidCertificationAttestation(certificationAttestationData);
+      _buildSession({
+        userId: certificationAttestationData.userId,
+        sessionId: certificationAttestationData.sessionId,
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+      });
+      _buildValidCertificationAttestation(certificationAttestationData);
+      await databaseBuilder.commit();
 
       // when
       const certificationAttestation = await certificationRepository.getCertificationAttestation(123);
@@ -213,8 +247,13 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         certifiedBadges: [],
         sessionId: 789,
       };
-
-      const assessmentResultId = await _buildValidCertificationAttestation(certificationAttestationData, false);
+      _buildSession({
+        userId: certificationAttestationData.userId,
+        sessionId: certificationAttestationData.sessionId,
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+      });
+      const assessmentResultId = _buildValidCertificationAttestation(certificationAttestationData, false);
 
       const competenceMarks1 = domainBuilder.buildCompetenceMark({
         id: 1234,
@@ -296,7 +335,14 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         certifiedBadges: [],
         sessionId: 789,
       };
-      await _buildValidCertificationAttestationWithSeveralResults(certificationAttestationData);
+
+      _buildSession({
+        userId: certificationAttestationData.userId,
+        sessionId: certificationAttestationData.sessionId,
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+      });
+      _buildValidCertificationAttestationWithSeveralResults(certificationAttestationData);
       await databaseBuilder.commit();
 
       // when
@@ -351,7 +397,14 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
           ],
           sessionId: 789,
         };
-        await _buildValidCertificationAttestation(certificationAttestationData);
+
+        _buildSession({
+          userId: certificationAttestationData.userId,
+          sessionId: certificationAttestationData.sessionId,
+          publishedAt: certificationAttestationData.deliveredAt,
+          certificationCenter: certificationAttestationData.certificationCenter,
+        });
+        _buildValidCertificationAttestation(certificationAttestationData);
         const badge1Id = databaseBuilder.factory.buildBadge({ key: 'PIX_TEST_1' }).id;
         const badge2Id = databaseBuilder.factory.buildBadge({ key: 'PIX_TEST_2' }).id;
         const complementaryCertification1Id = databaseBuilder.factory.buildComplementaryCertification({
@@ -425,7 +478,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       mockLearningContent(learningContentObjects);
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
       databaseBuilder.factory.buildOrganization({ id: 456, type: 'SCO', isManagingStudents: true });
-      await databaseBuilder.commit();
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -444,12 +496,19 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixPlusDroitCertificationImagePath: null,
         sessionId: 789,
       };
-      await _buildValidCertificationAttestation(certificationAttestationData);
-      await _linkCertificationAttestationToOrganization({
+      _buildSession({
+        userId: certificationAttestationData.userId,
+        sessionId: certificationAttestationData.sessionId,
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+      });
+      _buildValidCertificationAttestation(certificationAttestationData);
+      _linkCertificationAttestationToOrganization({
         certificationAttestationData,
         organizationId: 456,
         division: '3emeB',
       });
+      await databaseBuilder.commit();
 
       // when
       const certificationAttestations =
@@ -467,7 +526,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       const learningContentObjects = learningContentBuilder.buildLearningContent.fromAreas(minimalLearningContent);
       mockLearningContent(learningContentObjects);
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SUP', isManagingStudents: false });
-      await databaseBuilder.commit();
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -486,12 +544,19 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixPlusDroitCertificationImagePath: null,
         sessionId: 789,
       };
-      await _buildValidCertificationAttestation(certificationAttestationData);
-      await _linkCertificationAttestationToOrganization({
+      _buildSession({
+        userId: 456,
+        sessionId: 789,
+        publishedAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+      });
+      _buildValidCertificationAttestation(certificationAttestationData);
+      _linkCertificationAttestationToOrganization({
         certificationAttestationData,
         organizationId: 123,
         division: '3emeB',
       });
+      await databaseBuilder.commit();
 
       // when
       const certificationAttestations =
@@ -509,7 +574,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       const learningContentObjects = learningContentBuilder.buildLearningContent.fromAreas(minimalLearningContent);
       mockLearningContent(learningContentObjects);
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
-      await databaseBuilder.commit();
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -528,12 +592,19 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixPlusDroitCertificationImagePath: null,
         sessionId: 789,
       };
-      await _buildValidCertificationAttestation(certificationAttestationData);
-      await _linkCertificationAttestationToOrganization({
+      _buildSession({
+        userId: certificationAttestationData.userId,
+        sessionId: certificationAttestationData.sessionId,
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+      });
+      _buildValidCertificationAttestation(certificationAttestationData);
+      _linkCertificationAttestationToOrganization({
         certificationAttestationData,
         organizationId: 123,
         division: '5emeG',
       });
+      await databaseBuilder.commit();
 
       // when
       const certificationAttestations =
@@ -551,7 +622,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       const learningContentObjects = learningContentBuilder.buildLearningContent.fromAreas(minimalLearningContent);
       mockLearningContent(learningContentObjects);
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
-      await databaseBuilder.commit();
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -570,12 +640,19 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixPlusDroitCertificationImagePath: null,
         sessionId: 789,
       };
-      await _buildRejected(certificationAttestationData);
-      await _linkCertificationAttestationToOrganization({
+      _buildSession({
+        userId: certificationAttestationData.userId,
+        sessionId: certificationAttestationData.sessionId,
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+      });
+      _buildRejected(certificationAttestationData);
+      _linkCertificationAttestationToOrganization({
         certificationAttestationData,
         organizationId: 123,
         division: '3emeB',
       });
+      await databaseBuilder.commit();
 
       // when
       const certificationAttestations =
@@ -593,7 +670,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       const learningContentObjects = learningContentBuilder.buildLearningContent.fromAreas(minimalLearningContent);
       mockLearningContent(learningContentObjects);
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
-      await databaseBuilder.commit();
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -612,12 +688,19 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixPlusDroitCertificationImagePath: null,
         sessionId: 789,
       };
-      await _buildCancelled(certificationAttestationData);
-      await _linkCertificationAttestationToOrganization({
+      _buildSession({
+        userId: certificationAttestationData.userId,
+        sessionId: certificationAttestationData.sessionId,
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+      });
+      _buildCancelled(certificationAttestationData);
+      _linkCertificationAttestationToOrganization({
         certificationAttestationData,
         organizationId: 123,
         division: '3emeB',
       });
+      await databaseBuilder.commit();
 
       // when
       const certificationAttestations =
@@ -635,7 +718,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       const learningContentObjects = learningContentBuilder.buildLearningContent.fromAreas(minimalLearningContent);
       mockLearningContent(learningContentObjects);
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
-      await databaseBuilder.commit();
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -654,12 +736,19 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixPlusDroitCertificationImagePath: null,
         sessionId: 789,
       };
-      await _buildValidCertificationAttestation(certificationAttestationData);
-      await _linkCertificationAttestationToOrganization({
+      _buildSession({
+        userId: certificationAttestationData.userId,
+        sessionId: certificationAttestationData.sessionId,
+        publishedAt: certificationAttestationData.deliveredAt,
+        certificationCenter: certificationAttestationData.certificationCenter,
+      });
+      _buildValidCertificationAttestation(certificationAttestationData);
+      _linkCertificationAttestationToOrganization({
         certificationAttestationData,
         organizationId: 123,
         division: '3emeB',
       });
+      await databaseBuilder.commit();
 
       // when
       const certificationAttestations =
@@ -677,7 +766,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       const learningContentObjects = learningContentBuilder.buildLearningContent.fromAreas(minimalLearningContent);
       mockLearningContent(learningContentObjects);
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
-      await databaseBuilder.commit();
       const certificationAttestationDataA = {
         id: 456,
         firstName: 'James',
@@ -732,24 +820,43 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixPlusDroitCertificationImagePath: null,
         sessionId: 888,
       };
-      await _buildValidCertificationAttestation(certificationAttestationDataA);
-      await _buildValidCertificationAttestation(certificationAttestationDataB);
-      await _buildValidCertificationAttestation(certificationAttestationDataC);
-      await _linkCertificationAttestationToOrganization({
+      _buildSession({
+        userId: certificationAttestationDataA.userId,
+        sessionId: certificationAttestationDataA.sessionId,
+        publishedAt: certificationAttestationDataA.deliveredAt,
+        certificationCenter: certificationAttestationDataA.certificationCenter,
+      });
+      _buildSession({
+        userId: certificationAttestationDataC.userId,
+        sessionId: certificationAttestationDataC.sessionId,
+        publishedAt: certificationAttestationDataC.deliveredAt,
+        certificationCenter: certificationAttestationDataC.certificationCenter,
+      });
+      _buildSession({
+        userId: certificationAttestationDataB.userId,
+        sessionId: certificationAttestationDataB.sessionId,
+        publishedAt: certificationAttestationDataB.deliveredAt,
+        certificationCenter: certificationAttestationDataB.certificationCenter,
+      });
+      _buildValidCertificationAttestation(certificationAttestationDataA);
+      _buildValidCertificationAttestation(certificationAttestationDataB);
+      _buildValidCertificationAttestation(certificationAttestationDataC);
+      _linkCertificationAttestationToOrganization({
         certificationAttestationData: certificationAttestationDataA,
         organizationId: 123,
         division: '3emeB',
       });
-      await _linkCertificationAttestationToOrganization({
+      _linkCertificationAttestationToOrganization({
         certificationAttestationData: certificationAttestationDataB,
         organizationId: 123,
         division: '3emeB',
       });
-      await _linkCertificationAttestationToOrganization({
+      _linkCertificationAttestationToOrganization({
         certificationAttestationData: certificationAttestationDataC,
         organizationId: 123,
         division: '3emeB',
       });
+      await databaseBuilder.commit();
 
       // when
       const certificationAttestations =
@@ -783,7 +890,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       const learningContentObjects = learningContentBuilder.buildLearningContent.fromAreas(minimalLearningContent);
       mockLearningContent(learningContentObjects);
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
-      await databaseBuilder.commit();
       const certificationAttestationDataA = {
         id: 456,
         firstName: 'James',
@@ -838,25 +944,44 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixPlusDroitCertificationImagePath: null,
         sessionId: 888,
       };
-      await _buildValidCertificationAttestation(certificationAttestationDataA);
-      await _buildValidCertificationAttestation(certificationAttestationDataB);
-      await _buildValidCertificationAttestation(certificationAttestationDataC);
-      await _linkCertificationAttestationToOrganization({
+      _buildSession({
+        userId: certificationAttestationDataA.userId,
+        sessionId: certificationAttestationDataA.sessionId,
+        publishedAt: certificationAttestationDataA.deliveredAt,
+        certificationCenter: certificationAttestationDataA.certificationCenter,
+      });
+      _buildSession({
+        userId: certificationAttestationDataC.userId,
+        sessionId: certificationAttestationDataC.sessionId,
+        publishedAt: certificationAttestationDataC.deliveredAt,
+        certificationCenter: certificationAttestationDataC.certificationCenter,
+      });
+      _buildSession({
+        userId: certificationAttestationDataB.userId,
+        sessionId: certificationAttestationDataB.sessionId,
+        publishedAt: certificationAttestationDataB.deliveredAt,
+        certificationCenter: certificationAttestationDataB.certificationCenter,
+      });
+      _buildValidCertificationAttestation(certificationAttestationDataA);
+      _buildValidCertificationAttestation(certificationAttestationDataB);
+      _buildValidCertificationAttestation(certificationAttestationDataC);
+      _linkCertificationAttestationToOrganization({
         certificationAttestationData: certificationAttestationDataA,
         organizationId: 123,
         division: '3emeB',
       });
-      await _linkCertificationAttestationToOrganization({
+      _linkCertificationAttestationToOrganization({
         certificationAttestationData: certificationAttestationDataB,
         organizationId: 123,
         division: '3emeB',
       });
-      await _linkCertificationAttestationToOrganization({
+      _linkCertificationAttestationToOrganization({
         certificationAttestationData: certificationAttestationDataC,
         organizationId: 123,
         division: '3emeB',
         isDisabled: true,
       });
+      await databaseBuilder.commit();
 
       // when
       const certificationAttestations =
@@ -886,7 +1011,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
       const learningContentObjects = learningContentBuilder.buildLearningContent.fromAreas(minimalLearningContent);
       mockLearningContent(learningContentObjects);
       databaseBuilder.factory.buildOrganization({ id: 123, type: 'SCO', isManagingStudents: true });
-      await databaseBuilder.commit();
       const certificationAttestationData = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -905,12 +1029,20 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixPlusDroitCertificationImagePath: null,
         sessionId: 789,
       };
-      await _buildValidCertificationAttestationWithSeveralResults(certificationAttestationData);
-      await _linkCertificationAttestationToOrganization({
+      _buildSession({
+        userId: 456,
+        sessionId: 789,
+        publishedAt: new Date('2021-05-05'),
+        certificationCenter: 'Centre des poules bien dodues',
+      });
+      _buildValidCertificationAttestationWithSeveralResults(certificationAttestationData);
+      _linkCertificationAttestationToOrganization({
         certificationAttestationData,
         organizationId: 123,
         division: '3emeB',
       });
+
+      await databaseBuilder.commit();
 
       // when
       const certificationAttestations =
@@ -937,7 +1069,6 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         organizationId: 123,
         division: '3emeb',
       }).id;
-      await databaseBuilder.commit();
       const certificationAttestationDataOldest = {
         id: 123,
         firstName: 'Sarah Michelle',
@@ -974,18 +1105,31 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
         pixPlusDroitCertificationImagePath: null,
         sessionId: 999,
       };
-      await _buildValidCertificationAttestation(certificationAttestationDataOldest);
-      await _buildValidCertificationAttestation(certificationAttestationDataNewest);
-      await _linkCertificationAttestationToOrganization({
+      _buildSession({
+        userId: certificationAttestationDataOldest.userId,
+        sessionId: certificationAttestationDataOldest.sessionId,
+        publishedAt: certificationAttestationDataOldest.deliveredAt,
+        certificationCenter: certificationAttestationDataOldest.certificationCenter,
+      });
+      _buildSession({
+        userId: certificationAttestationDataNewest.userId,
+        sessionId: certificationAttestationDataNewest.sessionId,
+        publishedAt: certificationAttestationDataNewest.deliveredAt,
+        certificationCenter: certificationAttestationDataNewest.certificationCenter,
+      });
+      _buildValidCertificationAttestation(certificationAttestationDataOldest);
+      _buildValidCertificationAttestation(certificationAttestationDataNewest);
+      _linkCertificationAttestationToOrganization({
         certificationAttestationData: certificationAttestationDataOldest,
         organizationId: 123,
         organizationLearnerId,
       });
-      await _linkCertificationAttestationToOrganization({
+      _linkCertificationAttestationToOrganization({
         certificationAttestationData: certificationAttestationDataNewest,
         organizationId: 123,
         organizationLearnerId,
       });
+      await databaseBuilder.commit();
 
       // when
       const certificationAttestations =
@@ -1006,15 +1150,7 @@ describe('Integration | Infrastructure | Repository | Certification Attestation'
   });
 });
 
-async function _buildIncomplete(certificationAttestationData) {
-  databaseBuilder.factory.buildUser({ id: certificationAttestationData.userId });
-  const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-  databaseBuilder.factory.buildSession({
-    id: certificationAttestationData.sessionId,
-    publishedAt: certificationAttestationData.deliveredAt,
-    certificationCenter: certificationAttestationData.certificationCenter,
-    certificationCenterId,
-  });
+function _buildIncomplete(certificationAttestationData) {
   databaseBuilder.factory.buildCertificationCourse({
     id: certificationAttestationData.id,
     firstName: certificationAttestationData.firstName,
@@ -1030,18 +1166,9 @@ async function _buildIncomplete(certificationAttestationData) {
     userId: certificationAttestationData.userId,
   });
   databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationAttestationData.id });
-  await databaseBuilder.commit();
 }
 
-async function _buildRejected(certificationAttestationData) {
-  databaseBuilder.factory.buildUser({ id: certificationAttestationData.userId });
-  const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-  databaseBuilder.factory.buildSession({
-    id: certificationAttestationData.sessionId,
-    publishedAt: certificationAttestationData.deliveredAt,
-    certificationCenter: certificationAttestationData.certificationCenter,
-    certificationCenterId,
-  });
+function _buildRejected(certificationAttestationData) {
   databaseBuilder.factory.buildCertificationCourse({
     id: certificationAttestationData.id,
     firstName: certificationAttestationData.firstName,
@@ -1064,18 +1191,9 @@ async function _buildRejected(certificationAttestationData) {
     pixScore: certificationAttestationData.pixScore,
     status: 'rejected',
   });
-  await databaseBuilder.commit();
 }
 
-async function _buildCancelled(certificationAttestationData) {
-  databaseBuilder.factory.buildUser({ id: certificationAttestationData.userId });
-  const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-  databaseBuilder.factory.buildSession({
-    id: certificationAttestationData.sessionId,
-    publishedAt: certificationAttestationData.deliveredAt,
-    certificationCenter: certificationAttestationData.certificationCenter,
-    certificationCenterId,
-  });
+function _buildCancelled(certificationAttestationData) {
   databaseBuilder.factory.buildCertificationCourse({
     id: certificationAttestationData.id,
     firstName: certificationAttestationData.firstName,
@@ -1098,18 +1216,9 @@ async function _buildCancelled(certificationAttestationData) {
     pixScore: certificationAttestationData.pixScore,
     status: 'validated',
   });
-  await databaseBuilder.commit();
 }
 
-async function _buildValidCertificationAttestation(certificationAttestationData, buildCompetenceMark = true) {
-  databaseBuilder.factory.buildUser({ id: certificationAttestationData.userId });
-  const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-  databaseBuilder.factory.buildSession({
-    id: certificationAttestationData.sessionId,
-    publishedAt: certificationAttestationData.deliveredAt,
-    certificationCenter: certificationAttestationData.certificationCenter,
-    certificationCenterId,
-  });
+function _buildValidCertificationAttestation(certificationAttestationData, buildCompetenceMark = true) {
   databaseBuilder.factory.buildCertificationCourse({
     id: certificationAttestationData.id,
     firstName: certificationAttestationData.firstName,
@@ -1140,26 +1249,22 @@ async function _buildValidCertificationAttestation(certificationAttestationData,
     });
   }
 
-  await databaseBuilder.commit();
-
   return assessmentResultId;
 }
 
-async function _buildValidCertificationAttestationWithSeveralResults(certificationAttestationData) {
-  databaseBuilder.factory.buildUser({ id: certificationAttestationData.userId });
+function _buildSession({ userId, sessionId, publishedAt, certificationCenter }) {
+  databaseBuilder.factory.buildUser({ id: userId });
   const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
   databaseBuilder.factory.buildSession({
-    id: certificationAttestationData.sessionId,
-    publishedAt: certificationAttestationData.deliveredAt,
-    certificationCenter: certificationAttestationData.certificationCenter,
+    id: sessionId,
+    publishedAt,
+    certificationCenter: certificationCenter,
     certificationCenterId,
   });
-  const mostRecentSessionId = databaseBuilder.factory.buildSession({
-    publishedAt: certificationAttestationData.deliveredAt,
-    certificationCenter: certificationAttestationData.certificationCenter,
-    certificationCenterId,
-  }).id;
-  const mostRecentCertificationCourseId = databaseBuilder.factory.buildCertificationCourse({
+}
+
+function _buildValidCertificationAttestationWithSeveralResults(certificationAttestationData) {
+  databaseBuilder.factory.buildCertificationCourse({
     id: certificationAttestationData.id,
     firstName: certificationAttestationData.firstName,
     lastName: certificationAttestationData.lastName,
@@ -1173,7 +1278,6 @@ async function _buildValidCertificationAttestationWithSeveralResults(certificati
     sessionId: certificationAttestationData.sessionId,
     userId: certificationAttestationData.userId,
   }).id;
-  databaseBuilder.factory.buildCertificationCourse({ sessionId: mostRecentSessionId });
   const assessmentId = databaseBuilder.factory.buildAssessment({
     certificationCourseId: certificationAttestationData.id,
   }).id;
@@ -1195,42 +1299,9 @@ async function _buildValidCertificationAttestationWithSeveralResults(certificati
   databaseBuilder.factory.buildCompetenceMark({
     assessmentResultId: assessmentResultId2,
   });
-
-  const mostRecentAssessmentId = databaseBuilder.factory.buildAssessment({
-    certificationCourseId: mostRecentCertificationCourseId,
-  }).id;
-  const mostRecentAssessmentResultId1 = databaseBuilder.factory.buildAssessmentResult({
-    assessmentId: mostRecentAssessmentId,
-    pixScore: certificationAttestationData.pixScore,
-    status: 'validated',
-    createdAt: new Date('2020-01-02'),
-  }).id;
-  const mostRecentAssessmentResultId2 = databaseBuilder.factory.buildAssessmentResult({
-    assessmentId: mostRecentAssessmentId,
-    pixScore: certificationAttestationData.pixScore + 20,
-    status: 'validated',
-    createdAt: new Date('2020-01-01'),
-  }).id;
-  const mostRecentAssessmentResultId3 = databaseBuilder.factory.buildAssessmentResult({
-    assessmentId: mostRecentAssessmentId,
-    pixScore: 0,
-    status: 'rejected',
-    createdAt: new Date('2020-01-03'),
-  }).id;
-  databaseBuilder.factory.buildCompetenceMark({
-    assessmentResultId: mostRecentAssessmentResultId1,
-  });
-  databaseBuilder.factory.buildCompetenceMark({
-    assessmentResultId: mostRecentAssessmentResultId2,
-  });
-  databaseBuilder.factory.buildCompetenceMark({
-    assessmentResultId: mostRecentAssessmentResultId3,
-  });
-
-  await databaseBuilder.commit();
 }
 
-async function _linkCertificationAttestationToOrganization({
+function _linkCertificationAttestationToOrganization({
   certificationAttestationData,
   organizationId,
   division,
@@ -1250,5 +1321,4 @@ async function _linkCertificationAttestationToOrganization({
     sessionId: certificationAttestationData.sessionId,
     organizationLearnerId: srId,
   });
-  await databaseBuilder.commit();
 }

--- a/api/tests/integration/infrastructure/repositories/certificate-repository_attestation_test.js
+++ b/api/tests/integration/infrastructure/repositories/certificate-repository_attestation_test.js
@@ -1214,17 +1214,11 @@ function _buildRejected(certificationAttestationData) {
     sessionId: certificationAttestationData.sessionId,
     userId: certificationAttestationData.userId,
   });
-  const assessmentId = databaseBuilder.factory.buildAssessment({
+
+  databaseBuilder.factory.buildAssessmentResult.last({
     certificationCourseId: certificationAttestationData.id,
-  }).id;
-  const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
-    assessmentId,
     pixScore: certificationAttestationData.pixScore,
     status: 'rejected',
-  });
-  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-    certificationCourseId: certificationAttestationData.id,
-    lastAssessmentResultId,
   });
 }
 
@@ -1243,17 +1237,10 @@ function _buildCancelled(certificationAttestationData) {
     sessionId: certificationAttestationData.sessionId,
     userId: certificationAttestationData.userId,
   });
-  const assessmentId = databaseBuilder.factory.buildAssessment({
+  databaseBuilder.factory.buildAssessmentResult.last({
     certificationCourseId: certificationAttestationData.id,
-  }).id;
-  const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
-    assessmentId,
     pixScore: certificationAttestationData.pixScore,
     status: 'validated',
-  });
-  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-    certificationCourseId: certificationAttestationData.id,
-    lastAssessmentResultId,
   });
 }
 
@@ -1272,19 +1259,12 @@ function _buildValidCertificationAttestation(certificationAttestationData, build
     sessionId: certificationAttestationData.sessionId,
     userId: certificationAttestationData.userId,
   });
-  const assessmentId = databaseBuilder.factory.buildAssessment({
+  const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
     certificationCourseId: certificationAttestationData.id,
-  }).id;
-  const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
-    assessmentId,
     pixScore: certificationAttestationData.pixScore,
     status: 'validated',
     createdAt: new Date('2020-01-02'),
   }).id;
-  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-    certificationCourseId: certificationAttestationData.id,
-    lastAssessmentResultId: assessmentResultId,
-  });
 
   if (buildCompetenceMark) {
     databaseBuilder.factory.buildCompetenceMark({
@@ -1330,17 +1310,13 @@ function _buildCertificationAttestationWithSeveralResults(certificationAttestati
     status: 'rejected',
     createdAt: new Date('2019-01-01'),
   }).id;
-  const assessmentResultId2 = databaseBuilder.factory.buildAssessmentResult({
+  const assessmentResultId2 = databaseBuilder.factory.buildAssessmentResult.last({
+    certificationCourseId: certificationAttestationData.id,
     assessmentId,
     pixScore: certificationAttestationData.pixScore,
     status,
     createdAt: new Date('2019-01-02'),
   }).id;
-
-  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-    certificationCourseId: certificationAttestationData.id,
-    lastAssessmentResultId: assessmentResultId2,
-  });
 
   databaseBuilder.factory.buildCompetenceMark({
     assessmentResultId: assessmentResultId1,

--- a/api/tests/integration/infrastructure/repositories/certificate-repository_private_test.js
+++ b/api/tests/integration/infrastructure/repositories/certificate-repository_private_test.js
@@ -8,7 +8,6 @@ const {
 } = require('../../../test-helper');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const certificateRepository = require('../../../../lib/infrastructure/repositories/certificate-repository');
-const PrivateCertificate = require('../../../../lib/domain/models/PrivateCertificate');
 
 describe('Integration | Infrastructure | Repository | Certificate_private', function () {
   const minimalLearningContent = [
@@ -59,7 +58,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         certificationCenter: privateCertificateData.certificationCenter,
         certificationCenterId,
       }).id;
-      const certificateId = databaseBuilder.factory.buildCertificationCourse({
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
         firstName: privateCertificateData.firstName,
         lastName: privateCertificateData.lastName,
         birthdate: privateCertificateData.birthdate,
@@ -72,15 +71,17 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         sessionId,
         userId,
       }).id;
-      databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId });
+      databaseBuilder.factory.buildAssessment({ certificationCourseId });
       await databaseBuilder.commit();
 
       // when
-      const error = await catchErr(certificateRepository.getPrivateCertificate)(certificateId, { locale: 'fr' });
+      const error = await catchErr(certificateRepository.getPrivateCertificate)(certificationCourseId, {
+        locale: 'fr',
+      });
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);
-      expect(error.message).to.equal(`Certificate not found for ID ${certificateId}`);
+      expect(error.message).to.equal(`Certificate not found for ID ${certificationCourseId}`);
     });
 
     it('should throw a NotFoundError when the certificate is cancelled', async function () {
@@ -107,7 +108,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         certificationCenter: privateCertificateData.certificationCenter,
         certificationCenterId,
       }).id;
-      const certificateId = databaseBuilder.factory.buildCertificationCourse({
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
         firstName: privateCertificateData.firstName,
         lastName: privateCertificateData.lastName,
         birthdate: privateCertificateData.birthdate,
@@ -120,7 +121,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         sessionId,
         userId,
       }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
       databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: privateCertificateData.pixScore,
@@ -129,11 +130,13 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
       await databaseBuilder.commit();
 
       // when
-      const error = await catchErr(certificateRepository.getPrivateCertificate)(certificateId, { locale: 'fr' });
+      const error = await catchErr(certificateRepository.getPrivateCertificate)(certificationCourseId, {
+        locale: 'fr',
+      });
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);
-      expect(error.message).to.equal(`Certificate not found for ID ${certificateId}`);
+      expect(error.message).to.equal(`Certificate not found for ID ${certificationCourseId}`);
     });
 
     it('should throw a NotFoundError when the certificate is not published', async function () {
@@ -159,7 +162,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         certificationCenter: privateCertificateData.certificationCenter,
         certificationCenterId,
       }).id;
-      const certificateId = databaseBuilder.factory.buildCertificationCourse({
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
         firstName: privateCertificateData.firstName,
         lastName: privateCertificateData.lastName,
         birthdate: privateCertificateData.birthdate,
@@ -172,7 +175,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         sessionId,
         userId,
       }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
       databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: privateCertificateData.pixScore,
@@ -181,11 +184,13 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
       await databaseBuilder.commit();
 
       // when
-      const error = await catchErr(certificateRepository.getPrivateCertificate)(certificateId, { locale: 'fr' });
+      const error = await catchErr(certificateRepository.getPrivateCertificate)(certificationCourseId, {
+        locale: 'fr',
+      });
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);
-      expect(error.message).to.equal(`Certificate not found for ID ${certificateId}`);
+      expect(error.message).to.equal(`Certificate not found for ID ${certificationCourseId}`);
     });
 
     it('should throw a NotFoundError when the certificate is rejected', async function () {
@@ -212,7 +217,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         certificationCenter: privateCertificateData.certificationCenter,
         certificationCenterId,
       }).id;
-      const certificateId = databaseBuilder.factory.buildCertificationCourse({
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
         firstName: privateCertificateData.firstName,
         lastName: privateCertificateData.lastName,
         birthdate: privateCertificateData.birthdate,
@@ -225,7 +230,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         sessionId,
         userId,
       }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
       databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: privateCertificateData.pixScore,
@@ -234,11 +239,13 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
       await databaseBuilder.commit();
 
       // when
-      const error = await catchErr(certificateRepository.getPrivateCertificate)(certificateId, { locale: 'fr' });
+      const error = await catchErr(certificateRepository.getPrivateCertificate)(certificationCourseId, {
+        locale: 'fr',
+      });
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);
-      expect(error.message).to.equal(`Certificate not found for ID ${certificateId}`);
+      expect(error.message).to.equal(`Certificate not found for ID ${certificationCourseId}`);
     });
 
     it('should return a PrivateCertificate', async function () {
@@ -264,14 +271,14 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         commentForCandidate: 'Il aime beaucoup les mangues, et ça se voit !',
       };
 
-      const { certificateId } = await _buildValidPrivateCertificate(privateCertificateData);
+      const { certificationCourseId } = await _buildValidPrivateCertificate(privateCertificateData);
 
       // when
-      const privateCertificate = await certificateRepository.getPrivateCertificate(certificateId);
+      const privateCertificate = await certificateRepository.getPrivateCertificate(certificationCourseId);
 
       // then
       const expectedPrivateCertificate = domainBuilder.buildPrivateCertificate.validated({
-        id: certificateId,
+        id: certificationCourseId,
         ...privateCertificateData,
       });
       expect(privateCertificate).to.deepEqualInstanceOmitting(expectedPrivateCertificate, ['resultCompetenceTree']);
@@ -298,7 +305,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
           commentForCandidate: 'Il aime beaucoup les mangues, et ça se voit !',
         };
 
-        const { certificateId, assessmentResultId } = await _buildValidPrivateCertificate(
+        const { certificationCourseId, assessmentResultId } = await _buildValidPrivateCertificate(
           privateCertificateData,
           false
         );
@@ -373,21 +380,22 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         mockLearningContent(learningContentObjects);
 
         // when
-        const privateCertificate = await certificateRepository.getPrivateCertificate(certificateId, { locale: 'fr' });
+        const privateCertificate = await certificateRepository.getPrivateCertificate(certificationCourseId, {
+          locale: 'fr',
+        });
 
         // then
         const resultCompetenceTree = domainBuilder.buildResultCompetenceTree({
-          id: `${certificateId}-${assessmentResultId}`,
+          id: `${certificationCourseId}-${assessmentResultId}`,
           competenceMarks: [competenceMarks1, competenceMarks2],
           competenceTree: domainBuilder.buildCompetenceTree({ areas: [area1] }),
         });
         const expectedPrivateCertificate = domainBuilder.buildPrivateCertificate.validated({
-          id: certificateId,
+          id: certificationCourseId,
           resultCompetenceTree,
           ...privateCertificateData,
         });
-        expect(privateCertificate).to.be.instanceOf(PrivateCertificate);
-        expect(privateCertificate).to.deep.equal(expectedPrivateCertificate);
+        expect(privateCertificate).to.deepEqualInstance(expectedPrivateCertificate);
       });
     });
 
@@ -413,7 +421,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
           commentForCandidate: 'Il aime beaucoup les mangues, et ça se voit !',
         };
 
-        const { certificateId, assessmentResultId } = await _buildValidPrivateCertificate(
+        const { certificationCourseId, assessmentResultId } = await _buildValidPrivateCertificate(
           privateCertificateData,
           false
         );
@@ -488,11 +496,13 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         mockLearningContent(learningContentObjects);
 
         // when
-        const privateCertificate = await certificateRepository.getPrivateCertificate(certificateId, { locale: 'en' });
+        const privateCertificate = await certificateRepository.getPrivateCertificate(certificationCourseId, {
+          locale: 'en',
+        });
 
         // then
         const resultCompetenceTree = domainBuilder.buildResultCompetenceTree({
-          id: `${certificateId}-${assessmentResultId}`,
+          id: `${certificationCourseId}-${assessmentResultId}`,
           competenceMarks: [competenceMarks1, competenceMarks2],
           competenceTree: domainBuilder.buildCompetenceTree({
             areas: [
@@ -508,7 +518,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
           }),
         });
         const expectedPrivateCertificate = domainBuilder.buildPrivateCertificate.validated({
-          id: certificateId,
+          id: certificationCourseId,
           resultCompetenceTree,
           ...privateCertificateData,
         });
@@ -567,7 +577,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
           ],
         };
 
-        const { certificateId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
+        const { certificationCourseId } = await _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
           privateCertificateData,
           acquiredBadges: [
             {
@@ -592,11 +602,11 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         await databaseBuilder.commit();
 
         // when
-        const privateCertificate = await certificateRepository.getPrivateCertificate(certificateId);
+        const privateCertificate = await certificateRepository.getPrivateCertificate(certificationCourseId);
 
         // then
         const expectedPrivateCertificate = domainBuilder.buildPrivateCertificate.validated({
-          id: certificateId,
+          id: certificationCourseId,
           ...privateCertificateData,
         });
 
@@ -639,7 +649,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         certificationCenter: privateCertificateData.certificationCenter,
         certificationCenterId,
       }).id;
-      const certificateId = databaseBuilder.factory.buildCertificationCourse({
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
         firstName: privateCertificateData.firstName,
         lastName: privateCertificateData.lastName,
         birthdate: privateCertificateData.birthdate,
@@ -652,7 +662,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         sessionId,
         userId,
       }).id;
-      databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId });
+      databaseBuilder.factory.buildAssessment({ certificationCourseId });
       await databaseBuilder.commit();
 
       // when
@@ -686,7 +696,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         certificationCenter: privateCertificateData.certificationCenter,
         certificationCenterId,
       }).id;
-      const certificateId = databaseBuilder.factory.buildCertificationCourse({
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
         firstName: privateCertificateData.firstName,
         lastName: privateCertificateData.lastName,
         birthdate: privateCertificateData.birthdate,
@@ -699,7 +709,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         sessionId,
         userId,
       }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
       databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: privateCertificateData.pixScore,
@@ -738,7 +748,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         certificationCenter: privateCertificateData.certificationCenter,
         certificationCenterId,
       }).id;
-      const certificateId = databaseBuilder.factory.buildCertificationCourse({
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
         firstName: privateCertificateData.firstName,
         lastName: privateCertificateData.lastName,
         birthdate: privateCertificateData.birthdate,
@@ -751,7 +761,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         sessionId,
         userId,
       }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
       databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: privateCertificateData.pixScore,
@@ -790,7 +800,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         certificationCenter: privateCertificateData.certificationCenter,
         certificationCenterId,
       }).id;
-      const certificateId = databaseBuilder.factory.buildCertificationCourse({
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
         firstName: privateCertificateData.firstName,
         lastName: privateCertificateData.lastName,
         birthdate: privateCertificateData.birthdate,
@@ -803,7 +813,7 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         sessionId,
         userId,
       }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
       databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: privateCertificateData.pixScore,
@@ -838,26 +848,31 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         commentForCandidate: 'Il aime beaucoup les mangues, et ça se voit !',
       };
 
-      const { certificateId } = await _buildValidPrivateCertificate(privateCertificateData);
+      const { certificationCourseId } = await _buildValidPrivateCertificate(privateCertificateData);
       // when
       const privateCertificates = await certificateRepository.findPrivateCertificatesByUserId({ userId });
 
       // then
       const expectedPrivateCertificate = domainBuilder.buildPrivateCertificate.validated({
-        id: certificateId,
+        id: certificationCourseId,
         ...privateCertificateData,
       });
       expect(privateCertificates).to.have.length(1);
-      expect(privateCertificates[0]).to.be.instanceOf(PrivateCertificate);
-      expect(privateCertificates[0]).to.deep.equal(expectedPrivateCertificate);
+      expect(privateCertificates[0]).to.deepEqualInstance(expectedPrivateCertificate);
     });
 
     it('should return all the certificates of the user if he has many ordered by creation date DESC', async function () {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
-      const { certificateId } = await _buildValidPrivateCertificate({ userId, date: '2021-05-02' });
-      const { certificateId: certificateId2 } = await _buildValidPrivateCertificate({ userId, date: '2021-06-02' });
-      const { certificateId: certificateId3 } = await _buildValidPrivateCertificate({ userId, date: '2021-07-02' });
+      const { certificationCourseId } = await _buildValidPrivateCertificate({ userId, date: '2021-05-02' });
+      const { certificationCourseId: certificationCourseId2 } = await _buildValidPrivateCertificate({
+        userId,
+        date: '2021-06-02',
+      });
+      const { certificationCourseId: certificationCourseId3 } = await _buildValidPrivateCertificate({
+        userId,
+        date: '2021-07-02',
+      });
       await databaseBuilder.commit();
 
       // when
@@ -865,9 +880,9 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
 
       // then
       expect(privateCertificates).to.have.length(3);
-      expect(privateCertificates[0].id).to.equal(certificateId3);
-      expect(privateCertificates[1].id).to.equal(certificateId2);
-      expect(privateCertificates[2].id).to.equal(certificateId);
+      expect(privateCertificates[0].id).to.equal(certificationCourseId3);
+      expect(privateCertificates[1].id).to.equal(certificationCourseId2);
+      expect(privateCertificates[2].id).to.equal(certificationCourseId);
     });
 
     it('should build from the latest assessment result if validated', async function () {
@@ -889,17 +904,17 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         commentForCandidate: 'Il aime beaucoup les mangues, et ça se voit !',
       };
 
-      const { certificateId } = await _buildValidPrivateCertificateWithSeveralResults(privateCertificateData);
+      const { certificationCourseId } = await _buildValidPrivateCertificateWithSeveralResults(privateCertificateData);
 
       // when
       const privateCertificates = await certificateRepository.findPrivateCertificatesByUserId({ userId });
 
       // then
       const expectedPrivateCertificate = domainBuilder.buildPrivateCertificate.validated({
-        id: certificateId,
+        id: certificationCourseId,
         ...privateCertificateData,
       });
-      expect(privateCertificates[0]).to.deep.equal(expectedPrivateCertificate);
+      expect(privateCertificates[0]).to.deepEqualInstance(expectedPrivateCertificate);
     });
   });
 });
@@ -911,7 +926,7 @@ async function _buildValidPrivateCertificate(privateCertificateData, buildCompet
     certificationCenter: privateCertificateData.certificationCenter,
     certificationCenterId,
   }).id;
-  const certificateId = databaseBuilder.factory.buildCertificationCourse({
+  const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
     firstName: privateCertificateData.firstName,
     lastName: privateCertificateData.lastName,
     birthdate: privateCertificateData.birthdate,
@@ -924,7 +939,7 @@ async function _buildValidPrivateCertificate(privateCertificateData, buildCompet
     sessionId,
     userId: privateCertificateData.userId,
   }).id;
-  const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId }).id;
+  const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
   const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
     assessmentId,
     pixScore: privateCertificateData.pixScore,
@@ -941,7 +956,7 @@ async function _buildValidPrivateCertificate(privateCertificateData, buildCompet
 
   await databaseBuilder.commit();
 
-  return { certificateId, assessmentResultId, assessmentId };
+  return { certificationCourseId, assessmentResultId, assessmentId };
 }
 
 async function _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
@@ -954,7 +969,7 @@ async function _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
     certificationCenter: privateCertificateData.certificationCenter,
     certificationCenterId,
   }).id;
-  const certificateId = databaseBuilder.factory.buildCertificationCourse({
+  const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
     firstName: privateCertificateData.firstName,
     lastName: privateCertificateData.lastName,
     birthdate: privateCertificateData.birthdate,
@@ -967,7 +982,7 @@ async function _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
     sessionId,
     userId: privateCertificateData.userId,
   }).id;
-  const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId }).id;
+  const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
   databaseBuilder.factory.buildAssessmentResult({
     assessmentId,
     pixScore: privateCertificateData.pixScore,
@@ -997,7 +1012,7 @@ async function _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
         temporaryCertificateMessage,
       }).id;
       const { id: complementaryCertificationCourseId } = databaseBuilder.factory.buildComplementaryCertificationCourse({
-        certificationCourseId: certificateId,
+        certificationCourseId,
         complementaryCertificationId,
         complementaryCertificationBadgeId: acquiredComplementaryBadgeId,
       });
@@ -1009,7 +1024,7 @@ async function _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
     }
   );
   await databaseBuilder.commit();
-  return { certificateId };
+  return { certificationCourseId };
 }
 
 async function _buildValidPrivateCertificateWithSeveralResults(privateCertificateData) {
@@ -1019,7 +1034,7 @@ async function _buildValidPrivateCertificateWithSeveralResults(privateCertificat
     certificationCenter: privateCertificateData.certificationCenter,
     certificationCenterId,
   }).id;
-  const certificateId = databaseBuilder.factory.buildCertificationCourse({
+  const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
     firstName: privateCertificateData.firstName,
     lastName: privateCertificateData.lastName,
     birthdate: privateCertificateData.birthdate,
@@ -1032,7 +1047,7 @@ async function _buildValidPrivateCertificateWithSeveralResults(privateCertificat
     sessionId,
     userId: privateCertificateData.userId,
   }).id;
-  const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId }).id;
+  const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
   const assessmentResult1Id = databaseBuilder.factory.buildAssessmentResult({
     assessmentId,
     pixScore: privateCertificateData.pixScore,
@@ -1055,5 +1070,5 @@ async function _buildValidPrivateCertificateWithSeveralResults(privateCertificat
 
   await databaseBuilder.commit();
 
-  return { certificateId };
+  return { certificationCourseId };
 }

--- a/api/tests/integration/infrastructure/repositories/certificate-repository_private_test.js
+++ b/api/tests/integration/infrastructure/repositories/certificate-repository_private_test.js
@@ -121,15 +121,10 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         sessionId,
         userId,
       }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-      const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
+      databaseBuilder.factory.buildAssessmentResult({
+        certificationCourseId,
         pixScore: privateCertificateData.pixScore,
         status: 'validated',
-      });
-      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-        certificationCourseId,
-        lastAssessmentResultId,
       });
       await databaseBuilder.commit();
 
@@ -179,15 +174,10 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         sessionId,
         userId,
       }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-      const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
+      databaseBuilder.factory.buildAssessmentResult.last({
+        certificationCourseId,
         pixScore: privateCertificateData.pixScore,
         status: 'validated',
-      });
-      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-        certificationCourseId,
-        lastAssessmentResultId,
       });
       await databaseBuilder.commit();
 
@@ -238,15 +228,10 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         sessionId,
         userId,
       }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-      const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
+      databaseBuilder.factory.buildAssessmentResult.last({
+        certificationCourseId,
         pixScore: privateCertificateData.pixScore,
         status: 'rejected',
-      });
-      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-        certificationCourseId,
-        lastAssessmentResultId,
       });
       await databaseBuilder.commit();
 
@@ -721,15 +706,10 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         sessionId,
         userId,
       }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-      const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
+      databaseBuilder.factory.buildAssessmentResult.last({
+        certificationCourseId,
         pixScore: privateCertificateData.pixScore,
         status: 'validated',
-      });
-      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-        certificationCourseId,
-        lastAssessmentResultId,
       });
 
       await databaseBuilder.commit();
@@ -778,16 +758,12 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         sessionId,
         userId,
       }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-      const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
+      databaseBuilder.factory.buildAssessmentResult.last({
+        certificationCourseId,
         pixScore: privateCertificateData.pixScore,
         status: 'validated',
       });
-      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-        certificationCourseId,
-        lastAssessmentResultId,
-      });
+
       await databaseBuilder.commit();
 
       // when
@@ -834,15 +810,11 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         sessionId,
         userId,
       }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-      const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
+
+      databaseBuilder.factory.buildAssessmentResult.last({
+        certificationCourseId,
         pixScore: privateCertificateData.pixScore,
         status: 'rejected',
-      });
-      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-        certificationCourseId,
-        lastAssessmentResultId,
       });
       await databaseBuilder.commit();
 
@@ -964,18 +936,13 @@ async function _buildValidPrivateCertificate(privateCertificateData, buildCompet
     sessionId,
     userId: privateCertificateData.userId,
   }).id;
-  const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-  const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
-    assessmentId,
+  const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
+    certificationCourseId,
     pixScore: privateCertificateData.pixScore,
     status: 'validated',
     commentForCandidate: privateCertificateData.commentForCandidate,
     createdAt: new Date('2021-01-01'),
   }).id;
-  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-    certificationCourseId,
-    lastAssessmentResultId: assessmentResultId,
-  });
 
   if (buildCompetenceMark) {
     databaseBuilder.factory.buildCompetenceMark({
@@ -985,7 +952,7 @@ async function _buildValidPrivateCertificate(privateCertificateData, buildCompet
 
   await databaseBuilder.commit();
 
-  return { certificationCourseId, assessmentResultId, assessmentId };
+  return { certificationCourseId, assessmentResultId };
 }
 
 async function _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
@@ -1011,17 +978,12 @@ async function _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
     sessionId,
     userId: privateCertificateData.userId,
   }).id;
-  const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-  const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
-    assessmentId,
+  databaseBuilder.factory.buildAssessmentResult.last({
+    certificationCourseId,
     pixScore: privateCertificateData.pixScore,
     status: 'validated',
     commentForCandidate: privateCertificateData.commentForCandidate,
     createdAt: new Date('2021-01-01'),
-  });
-  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-    certificationCourseId,
-    lastAssessmentResultId,
   });
 
   acquiredBadges?.forEach(
@@ -1080,17 +1042,12 @@ async function _buildValidPrivateCertificateWithSeveralResults(privateCertificat
     sessionId,
     userId: privateCertificateData.userId,
   }).id;
-  const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-  const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
-    assessmentId,
+  const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult.last({
+    certificationCourseId,
     pixScore: privateCertificateData.pixScore,
     status: 'validated',
     commentForCandidate: privateCertificateData.commentForCandidate,
     createdAt: new Date('2021-03-01'),
-  });
-  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-    certificationCourseId,
-    lastAssessmentResultId,
   });
 
   databaseBuilder.factory.buildCompetenceMark({

--- a/api/tests/integration/infrastructure/repositories/certificate-repository_private_test.js
+++ b/api/tests/integration/infrastructure/repositories/certificate-repository_private_test.js
@@ -122,10 +122,14 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         userId,
       }).id;
       const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-      databaseBuilder.factory.buildAssessmentResult({
+      const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: privateCertificateData.pixScore,
         status: 'validated',
+      });
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId,
+        lastAssessmentResultId,
       });
       await databaseBuilder.commit();
 
@@ -176,10 +180,14 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         userId,
       }).id;
       const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-      databaseBuilder.factory.buildAssessmentResult({
+      const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: privateCertificateData.pixScore,
         status: 'validated',
+      });
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId,
+        lastAssessmentResultId,
       });
       await databaseBuilder.commit();
 
@@ -231,10 +239,14 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         userId,
       }).id;
       const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-      databaseBuilder.factory.buildAssessmentResult({
+      const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: privateCertificateData.pixScore,
         status: 'rejected',
+      });
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId,
+        lastAssessmentResultId,
       });
       await databaseBuilder.commit();
 
@@ -710,11 +722,16 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         userId,
       }).id;
       const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-      databaseBuilder.factory.buildAssessmentResult({
+      const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: privateCertificateData.pixScore,
         status: 'validated',
       });
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId,
+        lastAssessmentResultId,
+      });
+
       await databaseBuilder.commit();
 
       // when
@@ -762,10 +779,14 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         userId,
       }).id;
       const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-      databaseBuilder.factory.buildAssessmentResult({
+      const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: privateCertificateData.pixScore,
         status: 'validated',
+      });
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId,
+        lastAssessmentResultId,
       });
       await databaseBuilder.commit();
 
@@ -814,10 +835,14 @@ describe('Integration | Infrastructure | Repository | Certificate_private', func
         userId,
       }).id;
       const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-      databaseBuilder.factory.buildAssessmentResult({
+      const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: privateCertificateData.pixScore,
         status: 'rejected',
+      });
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId,
+        lastAssessmentResultId,
       });
       await databaseBuilder.commit();
 
@@ -947,6 +972,10 @@ async function _buildValidPrivateCertificate(privateCertificateData, buildCompet
     commentForCandidate: privateCertificateData.commentForCandidate,
     createdAt: new Date('2021-01-01'),
   }).id;
+  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+    certificationCourseId,
+    lastAssessmentResultId: assessmentResultId,
+  });
 
   if (buildCompetenceMark) {
     databaseBuilder.factory.buildCompetenceMark({
@@ -983,12 +1012,16 @@ async function _buildValidPrivateCertificateWithAcquiredAndNotAcquiredBadges({
     userId: privateCertificateData.userId,
   }).id;
   const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-  databaseBuilder.factory.buildAssessmentResult({
+  const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
     assessmentId,
     pixScore: privateCertificateData.pixScore,
     status: 'validated',
     commentForCandidate: privateCertificateData.commentForCandidate,
     createdAt: new Date('2021-01-01'),
+  });
+  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+    certificationCourseId,
+    lastAssessmentResultId,
   });
 
   acquiredBadges?.forEach(
@@ -1048,24 +1081,20 @@ async function _buildValidPrivateCertificateWithSeveralResults(privateCertificat
     userId: privateCertificateData.userId,
   }).id;
   const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-  const assessmentResult1Id = databaseBuilder.factory.buildAssessmentResult({
-    assessmentId,
-    pixScore: privateCertificateData.pixScore,
-    status: 'validated',
-    commentForCandidate: privateCertificateData.commentForCandidate,
-    createdAt: new Date('2021-01-01'),
-  }).id;
-
-  databaseBuilder.factory.buildAssessmentResult({
+  const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
     assessmentId,
     pixScore: privateCertificateData.pixScore,
     status: 'validated',
     commentForCandidate: privateCertificateData.commentForCandidate,
     createdAt: new Date('2021-03-01'),
   });
+  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+    certificationCourseId,
+    lastAssessmentResultId,
+  });
 
   databaseBuilder.factory.buildCompetenceMark({
-    assessmentResultId: assessmentResult1Id,
+    assessmentResultId: lastAssessmentResultId,
   });
 
   await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/certificate-repository_shareable_test.js
+++ b/api/tests/integration/infrastructure/repositories/certificate-repository_shareable_test.js
@@ -604,6 +604,10 @@ async function _buildValidShareableCertificate(shareableCertificateData, buildCo
     status: 'validated',
     createdAt: new Date('2020-01-02'),
   }).id;
+  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+    certificationCourseId,
+    lastAssessmentResultId: assessmentResultId,
+  });
 
   if (buildCompetenceMark) {
     databaseBuilder.factory.buildCompetenceMark({
@@ -643,6 +647,10 @@ async function _buildValidShareableCertificateWithAcquiredBadges({ shareableCert
     pixScore: shareableCertificateData.pixScore,
     status: 'validated',
   }).id;
+  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+    certificationCourseId,
+    lastAssessmentResultId: assessmentResultId,
+  });
 
   acquiredBadges?.forEach(
     ({

--- a/api/tests/integration/infrastructure/repositories/certificate-repository_shareable_test.js
+++ b/api/tests/integration/infrastructure/repositories/certificate-repository_shareable_test.js
@@ -57,7 +57,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
         certificationCenter: shareableCertificateData.certificationCenter,
         certificationCenterId,
       }).id;
-      const certificateId = databaseBuilder.factory.buildCertificationCourse({
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
         firstName: shareableCertificateData.firstName,
         lastName: shareableCertificateData.lastName,
         birthdate: shareableCertificateData.birthdate,
@@ -70,7 +70,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
         sessionId,
         userId,
       }).id;
-      databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId });
+      databaseBuilder.factory.buildAssessment({ certificationCourseId });
       await databaseBuilder.commit();
 
       // when
@@ -104,7 +104,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
         certificationCenter: shareableCertificateData.certificationCenter,
         certificationCenterId,
       }).id;
-      const certificateId = databaseBuilder.factory.buildCertificationCourse({
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
         firstName: shareableCertificateData.firstName,
         lastName: shareableCertificateData.lastName,
         birthdate: shareableCertificateData.birthdate,
@@ -117,7 +117,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
         sessionId,
         userId,
       }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
       databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: shareableCertificateData.pixScore,
@@ -156,7 +156,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
         certificationCenter: shareableCertificateData.certificationCenter,
         certificationCenterId,
       }).id;
-      const certificateId = databaseBuilder.factory.buildCertificationCourse({
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
         firstName: shareableCertificateData.firstName,
         lastName: shareableCertificateData.lastName,
         birthdate: shareableCertificateData.birthdate,
@@ -169,7 +169,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
         sessionId,
         userId,
       }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
       databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: shareableCertificateData.pixScore,
@@ -208,7 +208,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
         certificationCenter: shareableCertificateData.certificationCenter,
         certificationCenterId,
       }).id;
-      const certificateId = databaseBuilder.factory.buildCertificationCourse({
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
         firstName: shareableCertificateData.firstName,
         lastName: shareableCertificateData.lastName,
         birthdate: shareableCertificateData.birthdate,
@@ -221,7 +221,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
         sessionId,
         userId,
       }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId }).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
       databaseBuilder.factory.buildAssessmentResult({
         assessmentId,
         pixScore: shareableCertificateData.pixScore,
@@ -257,7 +257,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
           pixScore: 51,
         };
 
-        const { certificateId, assessmentResultId } = await _buildValidShareableCertificate(
+        const { certificationCourseId, assessmentResultId } = await _buildValidShareableCertificate(
           shareableCertificateData,
           false
         );
@@ -341,12 +341,12 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
 
         // then
         const resultCompetenceTree = domainBuilder.buildResultCompetenceTree({
-          id: `${certificateId}-${assessmentResultId}`,
+          id: `${certificationCourseId}-${assessmentResultId}`,
           competenceMarks: [competenceMarks1, competenceMarks2],
           competenceTree: domainBuilder.buildCompetenceTree({ areas: [area1] }),
         });
         const expectedShareableCertificate = domainBuilder.buildShareableCertificate({
-          id: certificateId,
+          id: certificationCourseId,
           ...shareableCertificateData,
           resultCompetenceTree,
         });
@@ -374,7 +374,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
           pixScore: 51,
         };
 
-        const { certificateId, assessmentResultId } = await _buildValidShareableCertificate(
+        const { certificationCourseId, assessmentResultId } = await _buildValidShareableCertificate(
           shareableCertificateData,
           false
         );
@@ -458,7 +458,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
 
         // then
         const resultCompetenceTree = domainBuilder.buildResultCompetenceTree({
-          id: `${certificateId}-${assessmentResultId}`,
+          id: `${certificationCourseId}-${assessmentResultId}`,
           competenceMarks: [competenceMarks1, competenceMarks2],
           competenceTree: domainBuilder.buildCompetenceTree({
             areas: [
@@ -474,7 +474,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
           }),
         });
         const expectedShareableCertificate = domainBuilder.buildShareableCertificate({
-          id: certificateId,
+          id: certificationCourseId,
           ...shareableCertificateData,
           resultCompetenceTree,
         });
@@ -531,7 +531,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
           ],
         };
 
-        const { certificateId } = await _buildValidShareableCertificateWithAcquiredBadges({
+        const { certificationCourseId } = await _buildValidShareableCertificateWithAcquiredBadges({
           shareableCertificateData,
           acquiredBadges: [
             {
@@ -562,7 +562,7 @@ describe('Integration | Infrastructure | Repository | Shareable Certificate', fu
 
         // then
         const expectedShareableCertificate = domainBuilder.buildShareableCertificate({
-          id: certificateId,
+          id: certificationCourseId,
           ...shareableCertificateData,
         });
         expect(shareableCertificate).to.deepEqualInstanceOmitting(expectedShareableCertificate, [
@@ -581,7 +581,7 @@ async function _buildValidShareableCertificate(shareableCertificateData, buildCo
     certificationCenter: shareableCertificateData.certificationCenter,
     certificationCenterId,
   }).id;
-  const certificateId = databaseBuilder.factory.buildCertificationCourse({
+  const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
     id: shareableCertificateData.id,
     firstName: shareableCertificateData.firstName,
     lastName: shareableCertificateData.lastName,
@@ -613,7 +613,7 @@ async function _buildValidShareableCertificate(shareableCertificateData, buildCo
 
   await databaseBuilder.commit();
 
-  return { certificateId, assessmentResultId };
+  return { certificationCourseId, assessmentResultId };
 }
 
 async function _buildValidShareableCertificateWithAcquiredBadges({ shareableCertificateData, acquiredBadges }) {
@@ -623,7 +623,7 @@ async function _buildValidShareableCertificateWithAcquiredBadges({ shareableCert
     certificationCenter: shareableCertificateData.certificationCenter,
     certificationCenterId,
   }).id;
-  const certificateId = databaseBuilder.factory.buildCertificationCourse({
+  const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
     id: shareableCertificateData.id,
     firstName: shareableCertificateData.firstName,
     lastName: shareableCertificateData.lastName,
@@ -637,7 +637,7 @@ async function _buildValidShareableCertificateWithAcquiredBadges({ shareableCert
     sessionId,
     userId: shareableCertificateData.userId,
   }).id;
-  const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificateId }).id;
+  const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
   const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
     assessmentId,
     pixScore: shareableCertificateData.pixScore,
@@ -666,7 +666,7 @@ async function _buildValidShareableCertificateWithAcquiredBadges({ shareableCert
         temporaryCertificateMessage,
       }).id;
       const { id: complementaryCertificationCourseId } = databaseBuilder.factory.buildComplementaryCertificationCourse({
-        certificationCourseId: certificateId,
+        certificationCourseId,
         complementaryCertificationId,
         complementaryCertificationBadgeId,
       });
@@ -682,5 +682,5 @@ async function _buildValidShareableCertificateWithAcquiredBadges({ shareableCert
     assessmentResultId,
   });
   await databaseBuilder.commit();
-  return { certificateId };
+  return { certificationCourseId };
 }

--- a/api/tests/integration/infrastructure/repositories/certificate-repository_shareable_test.js
+++ b/api/tests/integration/infrastructure/repositories/certificate-repository_shareable_test.js
@@ -595,19 +595,13 @@ async function _buildValidShareableCertificate(shareableCertificateData, buildCo
     sessionId,
     userId: shareableCertificateData.userId,
   }).id;
-  const assessmentId = databaseBuilder.factory.buildAssessment({
+
+  const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
     certificationCourseId: shareableCertificateData.id,
-  }).id;
-  const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
-    assessmentId,
     pixScore: shareableCertificateData.pixScore,
     status: 'validated',
     createdAt: new Date('2020-01-02'),
   }).id;
-  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-    certificationCourseId,
-    lastAssessmentResultId: assessmentResultId,
-  });
 
   if (buildCompetenceMark) {
     databaseBuilder.factory.buildCompetenceMark({
@@ -641,16 +635,11 @@ async function _buildValidShareableCertificateWithAcquiredBadges({ shareableCert
     sessionId,
     userId: shareableCertificateData.userId,
   }).id;
-  const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
-  const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
-    assessmentId,
+  const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
+    certificationCourseId,
     pixScore: shareableCertificateData.pixScore,
     status: 'validated',
   }).id;
-  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-    certificationCourseId,
-    lastAssessmentResultId: assessmentResultId,
-  });
 
   acquiredBadges?.forEach(
     ({

--- a/api/tests/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
@@ -32,6 +32,7 @@ describe('Integration | Repository | Certification-ls ', function () {
   afterEach(async function () {
     await knex('competence-marks').delete();
     await knex('certification-candidates').delete();
+    await knex('certification-courses-last-assessment-results').delete();
     await knex('complementary-certification-course-results').delete();
     await knex('assessment-results').delete();
     await knex('assessments').delete();

--- a/api/tests/integration/infrastructure/repositories/certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-repository_test.js
@@ -141,6 +141,14 @@ function _buildCertification({
       status: status.VALIDATED,
     });
     // the latest
-    databaseBuilder.factory.buildAssessmentResult({ assessmentId: id, createdAt: new Date('2021-01-01'), status });
+    const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
+      assessmentId: id,
+      createdAt: new Date('2021-01-01'),
+      status,
+    });
+    databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+      certificationCourseId: id,
+      lastAssessmentResultId,
+    });
   }
 }

--- a/api/tests/integration/infrastructure/repositories/certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-repository_test.js
@@ -141,14 +141,11 @@ function _buildCertification({
       status: status.VALIDATED,
     });
     // the latest
-    const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
+    databaseBuilder.factory.buildAssessmentResult.last({
+      certificationCourseId: id,
       assessmentId: id,
       createdAt: new Date('2021-01-01'),
       status,
-    });
-    databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-      certificationCourseId: id,
-      lastAssessmentResultId,
     });
   }
 }

--- a/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
@@ -42,38 +42,21 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         sessionId,
       }).id;
       const certificationCourseIdNotInSession = databaseBuilder.factory.buildCertificationCourse().id;
-      const assessmentId1 = databaseBuilder.factory.buildAssessment({
-        certificationCourseId: certificationCourseId1,
-      }).id;
-      const assessmentId2 = databaseBuilder.factory.buildAssessment({
-        certificationCourseId: certificationCourseId2,
-      }).id;
-      databaseBuilder.factory.buildAssessment({
-        certificationCourseId: certificationCourseId3,
-      });
       databaseBuilder.factory.buildAssessment({
         certificationCourseId: certificationCourseIdNotInSession,
       });
-      const assessmentResultId1 = databaseBuilder.factory.buildAssessmentResult({
-        assessmentId: assessmentId1,
+      const assessmentResultId1 = databaseBuilder.factory.buildAssessmentResult.last({
+        certificationCourseId: certificationCourseId1,
         pixScore: 123,
         status: CertificationResult.status.VALIDATED,
         commentForOrganization: 'Un commentaire orga 1',
       }).id;
-      const assessmentResultId2 = databaseBuilder.factory.buildAssessmentResult({
-        assessmentId: assessmentId2,
+      databaseBuilder.factory.buildAssessmentResult.last({
+        certificationCourseId: certificationCourseId2,
         pixScore: 0,
         status: CertificationResult.status.REJECTED,
         commentForOrganization: 'Un commentaire orga 2',
       }).id;
-      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-        certificationCourseId: certificationCourseId1,
-        lastAssessmentResultId: assessmentResultId1,
-      });
-      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-        certificationCourseId: certificationCourseId2,
-        lastAssessmentResultId: assessmentResultId2,
-      });
       databaseBuilder.factory.buildCompetenceMark({
         id: 123,
         score: 10,
@@ -581,35 +564,20 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         sessionId,
         userId: userId3,
       }).id;
-      const assessmentId1 = databaseBuilder.factory.buildAssessment({
+
+      const assessmentResultId1 = databaseBuilder.factory.buildAssessmentResult.last({
         certificationCourseId: certificationCourseId1,
-      }).id;
-      const assessmentId2 = databaseBuilder.factory.buildAssessment({
-        certificationCourseId: certificationCourseId2,
-      }).id;
-      databaseBuilder.factory.buildAssessment({
-        certificationCourseId: certificationCourseId3,
-      });
-      const assessmentResultId1 = databaseBuilder.factory.buildAssessmentResult({
-        assessmentId: assessmentId1,
         pixScore: 123,
         status: CertificationResult.status.VALIDATED,
         commentForOrganization: 'Un commentaire orga 1',
       }).id;
-      const assessmentResultId2 = databaseBuilder.factory.buildAssessmentResult({
-        assessmentId: assessmentId2,
+      databaseBuilder.factory.buildAssessmentResult.last({
+        certificationCourseId: certificationCourseId2,
         pixScore: 0,
         status: CertificationResult.status.REJECTED,
         commentForOrganization: 'Un commentaire orga 2',
       }).id;
-      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-        certificationCourseId: certificationCourseId1,
-        lastAssessmentResultId: assessmentResultId1,
-      });
-      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-        certificationCourseId: certificationCourseId2,
-        lastAssessmentResultId: assessmentResultId2,
-      });
+
       databaseBuilder.factory.buildCompetenceMark({
         id: 123,
         score: 10,
@@ -774,19 +742,12 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         sessionId,
         userId,
       }).id;
-      const assessmentId = databaseBuilder.factory.buildAssessment({
+      const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
         certificationCourseId,
-      }).id;
-      const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
-        assessmentId,
         pixScore: 123,
         status: CertificationResult.status.VALIDATED,
         commentForOrganization: 'Un commentaire orga 1',
       }).id;
-      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-        certificationCourseId,
-        lastAssessmentResultId: assessmentResultId,
-      });
 
       databaseBuilder.factory.buildCompetenceMark({
         id: 123,
@@ -952,16 +913,10 @@ async function _buildCertificationResultInSession(sessionId) {
     sessionId,
     isPublished: true,
   }).id;
-  const assessmentId = databaseBuilder.factory.buildAssessment({
+  const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
     certificationCourseId,
   }).id;
-  const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
-    assessmentId,
-  }).id;
-  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-    certificationCourseId,
-    lastAssessmentResultId: assessmentResultId,
-  });
+
   const competenceMarkId = databaseBuilder.factory.buildCompetenceMark({
     assessmentResultId,
   }).id;
@@ -976,16 +931,10 @@ async function _buildCertificationResultWithCandidate(sessionId) {
     userId,
     isPublished: true,
   }).id;
-  const assessmentId = databaseBuilder.factory.buildAssessment({
+
+  const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
     certificationCourseId,
   }).id;
-  const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
-    assessmentId,
-  }).id;
-  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-    certificationCourseId,
-    lastAssessmentResultId: assessmentResultId,
-  });
   const competenceMarkId = databaseBuilder.factory.buildCompetenceMark({
     assessmentResultId,
   }).id;

--- a/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-result-repository_test.js
@@ -60,11 +60,19 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         status: CertificationResult.status.VALIDATED,
         commentForOrganization: 'Un commentaire orga 1',
       }).id;
-      databaseBuilder.factory.buildAssessmentResult({
+      const assessmentResultId2 = databaseBuilder.factory.buildAssessmentResult({
         assessmentId: assessmentId2,
         pixScore: 0,
         status: CertificationResult.status.REJECTED,
         commentForOrganization: 'Un commentaire orga 2',
+      }).id;
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId: certificationCourseId1,
+        lastAssessmentResultId: assessmentResultId1,
+      });
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId: certificationCourseId2,
+        lastAssessmentResultId: assessmentResultId2,
       });
       databaseBuilder.factory.buildCompetenceMark({
         id: 123,
@@ -588,11 +596,19 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         status: CertificationResult.status.VALIDATED,
         commentForOrganization: 'Un commentaire orga 1',
       }).id;
-      databaseBuilder.factory.buildAssessmentResult({
+      const assessmentResultId2 = databaseBuilder.factory.buildAssessmentResult({
         assessmentId: assessmentId2,
         pixScore: 0,
         status: CertificationResult.status.REJECTED,
         commentForOrganization: 'Un commentaire orga 2',
+      }).id;
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId: certificationCourseId1,
+        lastAssessmentResultId: assessmentResultId1,
+      });
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId: certificationCourseId2,
+        lastAssessmentResultId: assessmentResultId2,
       });
       databaseBuilder.factory.buildCompetenceMark({
         id: 123,
@@ -767,6 +783,11 @@ describe('Integration | Infrastructure | Repository | Certification Result', fun
         status: CertificationResult.status.VALIDATED,
         commentForOrganization: 'Un commentaire orga 1',
       }).id;
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId,
+        lastAssessmentResultId: assessmentResultId,
+      });
+
       databaseBuilder.factory.buildCompetenceMark({
         id: 123,
         score: 10,
@@ -937,6 +958,10 @@ async function _buildCertificationResultInSession(sessionId) {
   const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
     assessmentId,
   }).id;
+  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+    certificationCourseId,
+    lastAssessmentResultId: assessmentResultId,
+  });
   const competenceMarkId = databaseBuilder.factory.buildCompetenceMark({
     assessmentResultId,
   }).id;
@@ -957,6 +982,10 @@ async function _buildCertificationResultWithCandidate(sessionId) {
   const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
     assessmentId,
   }).id;
+  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+    certificationCourseId,
+    lastAssessmentResultId: assessmentResultId,
+  });
   const competenceMarkId = databaseBuilder.factory.buildCompetenceMark({
     assessmentResultId,
   }).id;

--- a/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/cpf-certification-result-repository_test.js
@@ -364,12 +364,10 @@ function createCertificationCourseWithCompetenceMarks({
     cpfFilename,
     cpfImportStatus,
   }).id;
-  const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult({
+  const { id: lastAssessmentResultId } = databaseBuilder.factory.buildAssessmentResult.last({
+    certificationCourseId,
     pixScore: 132,
     status: assessmentResultStatus,
-    assessmentId: databaseBuilder.factory.buildAssessment({
-      certificationCourseId,
-    }).id,
   });
   competenceMarks.forEach((competenceMark) =>
     databaseBuilder.factory.buildCompetenceMark({
@@ -379,9 +377,4 @@ function createCertificationCourseWithCompetenceMarks({
       competence_code: competenceMark.competenceCode,
     })
   );
-
-  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-    certificationCourseId,
-    lastAssessmentResultId,
-  });
 }

--- a/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
@@ -117,6 +117,10 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
         commentForJury: 'Un commentaire jury',
         juryId: 22,
       }).id;
+      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+        certificationCourseId: 1,
+        lastAssessmentResultId: assessmentResultId,
+      });
       databaseBuilder.factory.buildCompetenceMark({
         id: 123,
         score: 10,

--- a/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
@@ -108,7 +108,8 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
 
       databaseBuilder.factory.buildAssessment({ id: 159, certificationCourseId: 1 });
       databaseBuilder.factory.buildUser({ id: 22 });
-      const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({
+      const assessmentResultId = databaseBuilder.factory.buildAssessmentResult.last({
+        certificationCourseId: 1,
         assessmentId: 159,
         pixScore: 123,
         status: 'validated',
@@ -117,10 +118,6 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
         commentForJury: 'Un commentaire jury',
         juryId: 22,
       }).id;
-      databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
-        certificationCourseId: 1,
-        lastAssessmentResultId: assessmentResultId,
-      });
       databaseBuilder.factory.buildCompetenceMark({
         id: 123,
         score: 10,

--- a/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -64,14 +64,11 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
 
         dbf.buildAssessmentResult({ assessmentId: manyAsrAssessmentId, createdAt: new Date('2018-02-15T00:00:00Z') });
         dbf.buildAssessmentResult({ assessmentId: manyAsrAssessmentId, createdAt: new Date('2018-03-15T00:00:00Z') });
-        latestAssessmentResult = dbf.buildAssessmentResult({
+        latestAssessmentResult = dbf.buildAssessmentResult.last({
+          certificationCourseId: manyAsrCertification.id,
           assessmentId: manyAsrAssessmentId,
           createdAt: new Date('2018-04-15T00:00:00Z'),
           status: assessmentResultStatuses.VALIDATED,
-        });
-        dbf.buildCertificationCourseLastAssessmentResult({
-          certificationCourseId: manyAsrCertification.id,
-          lastAssessmentResultId: latestAssessmentResult.id,
         });
 
         return databaseBuilder.commit();
@@ -335,14 +332,11 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
 
         dbf.buildAssessmentResult({ assessmentId: manyAsrAssessmentId, createdAt: new Date('2018-02-15T00:00:00Z') });
         dbf.buildAssessmentResult({ assessmentId: manyAsrAssessmentId, createdAt: new Date('2018-03-15T00:00:00Z') });
-        const latestAssessmentResult = dbf.buildAssessmentResult({
+        const latestAssessmentResult = dbf.buildAssessmentResult.last({
+          certificationCourseId: manyAsrCertification.id,
           assessmentId: manyAsrAssessmentId,
           createdAt: new Date('2018-04-15T00:00:00Z'),
           status: assessmentResultStatuses.VALIDATED,
-        });
-        dbf.buildCertificationCourseLastAssessmentResult({
-          certificationCourseId: manyAsrCertification.id,
-          lastAssessmentResultId: latestAssessmentResult.id,
         });
 
         const categoryId = dbf.buildIssueReportCategory({

--- a/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -69,6 +69,10 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           createdAt: new Date('2018-04-15T00:00:00Z'),
           status: assessmentResultStatuses.VALIDATED,
         });
+        dbf.buildCertificationCourseLastAssessmentResult({
+          certificationCourseId: manyAsrCertification.id,
+          lastAssessmentResultId: latestAssessmentResult.id,
+        });
 
         return databaseBuilder.commit();
       });
@@ -335,6 +339,10 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           assessmentId: manyAsrAssessmentId,
           createdAt: new Date('2018-04-15T00:00:00Z'),
           status: assessmentResultStatuses.VALIDATED,
+        });
+        dbf.buildCertificationCourseLastAssessmentResult({
+          certificationCourseId: manyAsrCertification.id,
+          lastAssessmentResultId: latestAssessmentResult.id,
         });
 
         const categoryId = dbf.buildIssueReportCategory({

--- a/api/tests/tooling/domain-builder/factory/build-certifications-results-for-ls.js
+++ b/api/tests/tooling/domain-builder/factory/build-certifications-results-for-ls.js
@@ -103,6 +103,8 @@ function _createAssessmentResultWithCompetenceMarks({
       level: cm.level,
     });
   });
+
+  return assessmentResult;
 }
 
 function buildOrganization(uai) {
@@ -189,16 +191,23 @@ function _buildValidatedCertificationData({
     certificationCreatedDate,
   });
 
-  _createAssessmentResultWithCompetenceMarks({
+  const { id: lastAssessmentResultId } = _createAssessmentResultWithCompetenceMarks({
     assessmentId,
+    certificationCourseId: certificationCourse.id,
     pixScore,
     status: certificationStatus,
     createdAt: assessmentCreatedDate,
     competenceMarks,
   });
 
+  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+    certificationCourseId: certificationCourse.id,
+    lastAssessmentResultId,
+  });
+
   _createAssessmentResultWithCompetenceMarks({
     assessmentId,
+    certificationCourseId: certificationCourse.id,
     pixScore,
     status: certificationStatus,
     createdAt: assessmentBeforeCreatedDate,
@@ -224,40 +233,50 @@ function buildRejectedPublishedCertificationData({
   certificationCreationDate,
 }) {
   const certificationStatus = status.REJECTED;
-  const { assessmentId } = _buildCertificationData({
+  const { assessmentId, certificationCourse } = _buildCertificationData({
     user,
     organizationLearner,
     isPublished: true,
     createdAt: certificationCreationDate,
   });
 
-  _createAssessmentResultWithCompetenceMarks({
+  const { id: lastAssessmentResultId } = _createAssessmentResultWithCompetenceMarks({
     assessmentId,
     status: certificationStatus,
     createdAt: assessmentCreatedDate,
     competenceMarks,
+  });
+
+  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+    certificationCourseId: certificationCourse.id,
+    lastAssessmentResultId,
   });
 }
 
 function buildErrorUnpublishedCertificationData({ user, organizationLearner, competenceMarks }) {
   const certificationStatus = status.REJECTED;
-  const { assessmentId } = _buildCertificationData({
+  const { assessmentId, certificationCourse } = _buildCertificationData({
     user,
     organizationLearner,
     isPublished: false,
   });
 
-  _createAssessmentResultWithCompetenceMarks({
+  const { id: lastAssessmentResultId } = _createAssessmentResultWithCompetenceMarks({
     assessmentId,
     status: certificationStatus,
     createdAt: assessmentCreatedDate,
     competenceMarks,
   });
+
+  databaseBuilder.factory.buildCertificationCourseLastAssessmentResult({
+    certificationCourseId: certificationCourse.id,
+    lastAssessmentResultId,
+  });
 }
 
 function buildCertificationDataWithNoCompetenceMarks({ user, organizationLearner }) {
   const certificationStatus = status.REJECTED;
-  const { assessmentId } = _buildCertificationData({
+  const { assessmentId, certificationCourse } = _buildCertificationData({
     user,
     organizationLearner,
     publicationDate: null,
@@ -265,6 +284,7 @@ function buildCertificationDataWithNoCompetenceMarks({ user, organizationLearner
 
   databaseBuilder.factory.buildAssessmentResult({
     assessmentId,
+    certificationCourseId: certificationCourse.id,
     status: certificationStatus,
     createdAt: assessmentBeforeBeforeCreatedDate,
   });


### PR DESCRIPTION
## :christmas_tree: Problème
La PR pix-6527, a permis de renseigner dans une table associative le lien entre un certif course et son dernier assessment-results mais cette table n'est pas utilisée

## :gift: Proposition
Remplacer les lourdes sous requetes par une jointure sur cette table.

## :star2: Remarques


## :santa: Pour tester
Verifier qu'on recupère bien les dernier resultats pour un certificats apres un scoring et rescoring
(modifier le nbr de pix certifié via neutralisation et verifier que le nombre de pix sur les certificats est bien à jour)
