### PR TITLE
[TECH] Ajouter un categoryId au certification issue report (PIX-6542)

### DIFF
--- a/api/db/database-builder/factory/build-certification-issue-report.js
+++ b/api/db/database-builder/factory/build-certification-issue-report.js
@@ -1,12 +1,13 @@
 const buildCertificationCourse = require('./build-certification-course');
+const buildIssueReportCategory = require('./build-issue-report-category');
 const _ = require('lodash');
 const databaseBuffer = require('../database-buffer');
-const { CertificationIssueReportCategories } = require('../../../lib/domain/models/CertificationIssueReportCategory');
 
 module.exports = function buildCertificationIssueReport({
   id = databaseBuffer.getNextId(),
   certificationCourseId,
-  category = CertificationIssueReportCategories.OTHER,
+  categoryId,
+  category,
   description = 'Une super description',
   subcategory = null,
   hasBeenAutomaticallyResolved = null,
@@ -15,10 +16,12 @@ module.exports = function buildCertificationIssueReport({
   resolution = null,
 } = {}) {
   certificationCourseId = _.isUndefined(certificationCourseId) ? buildCertificationCourse().id : certificationCourseId;
+  categoryId = _.isUndefined(categoryId) ? buildIssueReportCategory().id : categoryId;
 
   const values = {
     id,
     certificationCourseId,
+    categoryId,
     category,
     description,
     subcategory,

--- a/api/db/database-builder/factory/build-issue-report-category.js
+++ b/api/db/database-builder/factory/build-issue-report-category.js
@@ -1,0 +1,21 @@
+const databaseBuffer = require('../database-buffer');
+
+module.exports = function buildIssueReportCategory({
+  id = databaseBuffer.getNextId(),
+  name = 'Some problem',
+  isDeprecated = false,
+  isImpactful = false,
+  issueReportCategoryId = null,
+} = {}) {
+  const values = {
+    id,
+    name,
+    isDeprecated,
+    isImpactful,
+    issueReportCategoryId,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'issue-report-categories',
+    values,
+  });
+};

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -42,6 +42,7 @@ module.exports = {
   buildDataProtectionOfficer: require('./build-data-protection-officer'),
   buildFinalizedSession: require('./build-finalized-session'),
   buildFlashAssessmentResult: require('./build-flash-assessment-result'),
+  buildIssueReportCategory: require('./build-issue-report-category'),
   buildKnowledgeElement: require('./build-knowledge-element'),
   buildKnowledgeElementSnapshot: require('./build-knowledge-element-snapshot'),
   buildMembership: require('./build-membership'),

--- a/api/db/migrations/20221130100911_add-issue-report-categories.js
+++ b/api/db/migrations/20221130100911_add-issue-report-categories.js
@@ -1,0 +1,163 @@
+const TABLE_NAME = 'issue-report-categories';
+
+exports.up = async (knex) => {
+  await knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments().primary();
+    t.string('name').notNullable();
+    t.boolean('isDeprecated').notNullable().defaultTo(false);
+    t.boolean('isImpactful').notNullable().defaultTo(false);
+    t.integer('issueReportCategoryId');
+  });
+
+  await knex.batchInsert(TABLE_NAME, [
+    {
+      name: 'OTHER',
+      isDeprecated: true,
+      isImpactful: true,
+    },
+    {
+      name: 'CANDIDATE_INFORMATIONS_CHANGES',
+      isDeprecated: false,
+      isImpactful: false,
+    },
+    {
+      name: 'SIGNATURE_ISSUE',
+      isDeprecated: false,
+      isImpactful: false,
+    },
+    {
+      name: 'CONNECTION_OR_END_SCREEN',
+      isDeprecated: false,
+      isImpactful: false,
+    },
+    {
+      name: 'IN_CHALLENGE',
+      isDeprecated: false,
+      isImpactful: false,
+    },
+    {
+      name: 'FRAUD',
+      isDeprecated: false,
+      isImpactful: true,
+    },
+    {
+      name: 'TECHNICAL_PROBLEM',
+      isDeprecated: true,
+      isImpactful: true,
+    },
+    {
+      name: 'NON_BLOCKING_CANDIDATE_ISSUE',
+      isDeprecated: false,
+      isImpactful: false,
+    },
+    {
+      name: 'NON_BLOCKING_TECHNICAL_ISSUE',
+      isDeprecated: false,
+      isImpactful: false,
+    },
+    {
+      name: 'LATE_OR_LEAVING',
+      isDeprecated: true,
+      isImpactful: false,
+    },
+  ]);
+
+  const categories = await knex('issue-report-categories').select('name', 'id');
+  const getCategoryId = (lookupName) => categories.find(({ name }) => lookupName === name).id;
+  await knex.batchInsert(TABLE_NAME, [
+    {
+      name: 'LEFT_EXAM_ROOM',
+      isDeprecated: true,
+      isImpactful: false,
+      issueReportCategoryId: getCategoryId('OTHER'),
+    },
+    {
+      name: 'NAME_OR_BIRTHDATE',
+      isDeprecated: false,
+      isImpactful: true,
+      issueReportCategoryId: getCategoryId('CANDIDATE_INFORMATIONS_CHANGES'),
+    },
+    {
+      name: 'EXTRA_TIME_PERCENTAGE',
+      isDeprecated: false,
+      isImpactful: false,
+      issueReportCategoryId: getCategoryId('CANDIDATE_INFORMATIONS_CHANGES'),
+    },
+    {
+      name: 'IMAGE_NOT_DISPLAYING',
+      isDeprecated: false,
+      isImpactful: true,
+      issueReportCategoryId: getCategoryId('IN_CHALLENGE'),
+    },
+    {
+      name: 'LINK_NOT_WORKING',
+      isDeprecated: true,
+      isImpactful: true,
+      issueReportCategoryId: getCategoryId('IN_CHALLENGE'),
+    },
+    {
+      name: 'EMBED_NOT_WORKING',
+      isDeprecated: false,
+      isImpactful: true,
+      issueReportCategoryId: getCategoryId('IN_CHALLENGE'),
+    },
+    {
+      name: 'FILE_NOT_OPENING',
+      isDeprecated: false,
+      isImpactful: true,
+      issueReportCategoryId: getCategoryId('IN_CHALLENGE'),
+    },
+    {
+      name: 'WEBSITE_UNAVAILABLE',
+      isDeprecated: false,
+      isImpactful: true,
+      issueReportCategoryId: getCategoryId('IN_CHALLENGE'),
+    },
+    {
+      name: 'WEBSITE_BLOCKED',
+      isDeprecated: false,
+      isImpactful: true,
+      issueReportCategoryId: getCategoryId('IN_CHALLENGE'),
+    },
+    {
+      name: 'EXTRA_TIME_EXCEEDED',
+      isDeprecated: false,
+      isImpactful: true,
+      issueReportCategoryId: getCategoryId('IN_CHALLENGE'),
+    },
+    {
+      name: 'SOFTWARE_NOT_WORKING',
+      isDeprecated: false,
+      isImpactful: true,
+      issueReportCategoryId: getCategoryId('IN_CHALLENGE'),
+    },
+    {
+      name: 'UNINTENTIONAL_FOCUS_OUT',
+      isDeprecated: false,
+      isImpactful: true,
+      issueReportCategoryId: getCategoryId('IN_CHALLENGE'),
+    },
+    {
+      name: 'OTHER',
+      isDeprecated: true,
+      isImpactful: true,
+      issueReportCategoryId: getCategoryId('OTHER'),
+    },
+    {
+      name: 'SKIP_ON_OOPS',
+      isDeprecated: false,
+      isImpactful: true,
+      issueReportCategoryId: getCategoryId('IN_CHALLENGE'),
+    },
+    {
+      name: 'ACCESSIBILITY_ISSUE',
+      isDeprecated: false,
+      isImpactful: true,
+      issueReportCategoryId: getCategoryId('IN_CHALLENGE'),
+    },
+  ]);
+};
+
+exports.down = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};

--- a/api/db/migrations/20221208141139_update-certification-issue-report.js
+++ b/api/db/migrations/20221208141139_update-certification-issue-report.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'certification-issue-reports';
+
+exports.up = async function (knex) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
+    table.integer('categoryId').references('issue-report-categories.id');
+  });
+};
+
+exports.down = async function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn('categoryId');
+  });
+};

--- a/api/db/seeds/data/certification/issue-report-categories-builder.js
+++ b/api/db/seeds/data/certification/issue-report-categories-builder.js
@@ -1,10 +1,10 @@
 function issueReportCategoriesBuilder({ databaseBuilder }) {
-
   const otherCategoryId = databaseBuilder.factory.buildIssueReportCategory({
     name: 'OTHER',
     isDeprecated: true,
     isImpactful: true,
   }).id;
+
   const candidateInformationChangeId = databaseBuilder.factory.buildIssueReportCategory({
     name: 'CANDIDATE_INFORMATIONS_CHANGES',
     isDeprecated: false,

--- a/api/db/seeds/data/certification/issue-report-categories-builder.js
+++ b/api/db/seeds/data/certification/issue-report-categories-builder.js
@@ -1,0 +1,140 @@
+function issueReportCategoriesBuilder({ databaseBuilder }) {
+
+  const otherCategoryId = databaseBuilder.factory.buildIssueReportCategory({
+    name: 'OTHER',
+    isDeprecated: true,
+    isImpactful: true,
+  }).id;
+  const candidateInformationChangeId = databaseBuilder.factory.buildIssueReportCategory({
+    name: 'CANDIDATE_INFORMATIONS_CHANGES',
+    isDeprecated: false,
+    isImpactful: false,
+  }).id;
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'SIGNATURE_ISSUE',
+    isDeprecated: false,
+    isImpactful: false,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'CONNECTION_OR_END_SCREEN',
+    isDeprecated: false,
+    isImpactful: false,
+  });
+  const inChallengeId = databaseBuilder.factory.buildIssueReportCategory({
+    name: 'IN_CHALLENGE',
+    isDeprecated: false,
+    isImpactful: false,
+  }).id;
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'FRAUD',
+    isDeprecated: false,
+    isImpactful: true,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'TECHNICAL_PROBLEM',
+    isDeprecated: true,
+    isImpactful: true,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'NON_BLOCKING_CANDIDATE_ISSUE',
+    isDeprecated: false,
+    isImpactful: false,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'NON_BLOCKING_TECHNICAL_ISSUE',
+    isDeprecated: false,
+    isImpactful: false,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'LATE_OR_LEAVING',
+    isDeprecated: true,
+    isImpactful: false,
+  });
+
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'LEFT_EXAM_ROOM',
+    isDeprecated: true,
+    isImpactful: false,
+    issueReportCategoryId: otherCategoryId,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'NAME_OR_BIRTHDATE',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: candidateInformationChangeId,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'EXTRA_TIME_PERCENTAGE',
+    isDeprecated: false,
+    isImpactful: false,
+    issueReportCategoryId: candidateInformationChangeId,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'IMAGE_NOT_DISPLAYING',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'LINK_NOT_WORKING',
+    isDeprecated: true,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'EMBED_NOT_WORKING',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'FILE_NOT_OPENING',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'WEBSITE_UNAVAILABLE',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'WEBSITE_BLOCKED',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'EXTRA_TIME_EXCEEDED',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'SOFTWARE_NOT_WORKING',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'OTHER',
+    isDeprecated: true,
+    isImpactful: true,
+    issueReportCategoryId: otherCategoryId,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'SKIP_ON_OOPS',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+  databaseBuilder.factory.buildIssueReportCategory({
+    name: 'ACCESSIBILITY_ISSUE',
+    isDeprecated: false,
+    isImpactful: true,
+    issueReportCategoryId: inChallengeId,
+  });
+}
+
+module.exports = { issueReportCategoriesBuilder };

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -34,6 +34,7 @@ const pixAdminRolesBuilder = require('./data/pix-admin-roles-builder');
 const stagesBuilder = require('./data/stages-builder');
 const { certificationCpfCountryBuilder } = require('./data/certification/certification-cpf-country-builder');
 const { certificationCpfCityBuilder } = require('./data/certification/certification-cpf-city-builder');
+const { issueReportCategoriesBuilder } = require('./data/certification/issue-report-categories-builder');
 const {
   getEligibleCampaignParticipations,
   generateKnowledgeElementSnapshots,
@@ -84,6 +85,7 @@ exports.seed = async (knex) => {
   complementaryCertificationCourseResultsBuilder({ databaseBuilder });
   certificationCpfCountryBuilder({ databaseBuilder });
   certificationCpfCityBuilder({ databaseBuilder });
+  issueReportCategoriesBuilder({ databaseBuilder });
 
   // Éléments de parcours
   campaignsProBuilder({ databaseBuilder });

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -131,11 +131,12 @@ class CertificationIssueReport {
     }
   }
 
-  static create({ id, certificationCourseId, category, description, subcategory, questionNumber }) {
+  static create({ id, certificationCourseId, category, categoryId, description, subcategory, questionNumber }) {
     const certificationIssueReport = new CertificationIssueReport({
       id,
       certificationCourseId,
       category,
+      categoryId,
       description,
       subcategory,
       questionNumber,

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -91,6 +91,7 @@ class CertificationIssueReport {
     id,
     certificationCourseId,
     category,
+    categoryId,
     description,
     subcategory,
     questionNumber,
@@ -101,6 +102,7 @@ class CertificationIssueReport {
     this.id = id;
     this.certificationCourseId = certificationCourseId;
     this.category = category;
+    this.categoryId = categoryId;
     this.subcategory = subcategory;
     this.description = description;
     this.questionNumber = questionNumber;

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -87,6 +87,7 @@ const dependencies = {
   finalizedSessionRepository: require('../../infrastructure/repositories/sessions/finalized-session-repository'),
   supOrganizationLearnerRepository: require('../../infrastructure/repositories/sup-organization-learner-repository'),
   improvementService: require('../../domain/services/improvement-service'),
+  issueReportCategoryRepository: require('../../infrastructure/repositories/issue-report-category-repository'),
   juryCertificationRepository: require('../../infrastructure/repositories/jury-certification-repository'),
   juryCertificationSummaryRepository: require('../../infrastructure/repositories/jury-certification-summary-repository'),
   jurySessionRepository: require('../../infrastructure/repositories/sessions/jury-session-repository'),

--- a/api/lib/domain/usecases/save-certification-issue-report.js
+++ b/api/lib/domain/usecases/save-certification-issue-report.js
@@ -3,7 +3,16 @@ const CertificationIssueReport = require('../models/CertificationIssueReport');
 module.exports = async function saveCertificationIssueReport({
   certificationIssueReportDTO,
   certificationIssueReportRepository,
+  issueReportCategoryRepository,
 }) {
-  const certificationIssueReport = CertificationIssueReport.create(certificationIssueReportDTO);
+  const issueReportCategoryName = certificationIssueReportDTO.subcategory ?? certificationIssueReportDTO.category;
+
+  const issueReportCategory = await issueReportCategoryRepository.get({ name: issueReportCategoryName });
+
+  const certificationIssueReport = CertificationIssueReport.create({
+    ...certificationIssueReportDTO,
+    categoryId: issueReportCategory.id,
+  });
+
   return certificationIssueReportRepository.save(certificationIssueReport);
 };

--- a/api/lib/infrastructure/repositories/issue-report-category-repository.js
+++ b/api/lib/infrastructure/repositories/issue-report-category-repository.js
@@ -1,0 +1,7 @@
+const { knex } = require('../../../db/knex-database-connection');
+
+module.exports = {
+  async get({ name }) {
+    return knex('issue-report-categories').where({ name }).first();
+  },
+};

--- a/api/lib/infrastructure/repositories/jury-certification-repository.js
+++ b/api/lib/infrastructure/repositories/jury-certification-repository.js
@@ -114,18 +114,7 @@ async function _toDomainWithComplementaryCertifications({
   badgeKeyAndLabelsGroupedByTargetProfile,
 }) {
   const certificationIssueReports = certificationIssueReportDTOs.map(
-    (certificationIssueReport) =>
-      new CertificationIssueReport({
-        id: certificationIssueReport.id,
-        certificationCourseId: certificationIssueReport.certificationCourseId,
-        category: certificationIssueReport.category,
-        description: certificationIssueReport.description,
-        subcategory: certificationIssueReport.subcategory,
-        questionNumber: certificationIssueReport.questionNumber,
-        resolvedAt: certificationIssueReport.resolvedAt,
-        resolution: certificationIssueReport.resolution,
-        hasBeenAutomaticallyResolved: certificationIssueReport.hasBeenAutomaticallyResolved,
-      })
+    (certificationIssueReport) => new CertificationIssueReport({ ...certificationIssueReport })
   );
 
   const [complementaryCertificationCourseResultsWithExternal, commonComplementaryCertificationCourseResults] =

--- a/api/scripts/certification/fill-issue-report-category-id.js
+++ b/api/scripts/certification/fill-issue-report-category-id.js
@@ -1,0 +1,59 @@
+const logger = require('../../lib/infrastructure/logger');
+const { knex, disconnect } = require('../../db/knex-database-connection');
+const bluebird = require('bluebird');
+
+const isLaunchedFromCommandLine = require.main === module;
+
+async function _getIdCategorySubcategoryFromCertificationIssueReport() {
+  return knex('certification-issue-reports').select('id', 'category', 'subcategory');
+}
+
+async function main() {
+  logger.info(`Script ${__filename} est lancé !`);
+
+  const certificationIssueReports = await _getIdCategorySubcategoryFromCertificationIssueReport();
+
+  logger.info(`Nb de certification issue reports à modifier : ${certificationIssueReports.length}`);
+
+  const categories = await knex('issue-report-categories').select('name', 'id');
+
+  await _updateIssueReportsWithCategoryId(certificationIssueReports, categories);
+
+  const { count: reportsNotUpdated } = await knex('certification-issue-reports').count('*').whereNull('categoryId');
+
+  if (reportsNotUpdated > 0) {
+    logger.info(
+      `Nb de certification issue reports non mis à jour : ${reportsNotUpdated.length} / ${certificationIssueReports.length}`
+    );
+  } else {
+    logger.info(`${certificationIssueReports.length} certification issue reports mis à jour`);
+  }
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();
+
+module.exports = { main };
+
+async function _updateIssueReportsWithCategoryId(certificationIssueReports, categories) {
+  await bluebird.map(certificationIssueReports, async (certificationIssueReport) => {
+    const getCategoryId = (lookupName) => categories.find(({ name }) => lookupName === name).id;
+    const category = certificationIssueReport.subcategory ?? certificationIssueReport.category;
+    certificationIssueReport.categoryId = getCategoryId(category);
+
+    await knex('certification-issue-reports').where({ id: certificationIssueReport.id }).update({
+      categoryId: certificationIssueReport.categoryId,
+      updatedAt: new Date(),
+    });
+  });
+}

--- a/api/tests/acceptance/application/certification-reports/certification-report-controller_test.js
+++ b/api/tests/acceptance/application/certification-reports/certification-report-controller_test.js
@@ -7,6 +7,7 @@ describe('Acceptance | Controller | certification-report-controller', function (
   beforeEach(async function () {
     server = await createServer();
     userId = databaseBuilder.factory.buildUser().id;
+    databaseBuilder.factory.buildIssueReportCategory({ name: 'FRAUD' });
     ({ id: sessionId, certificationCenterId } = databaseBuilder.factory.buildSession());
     databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
     certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
@@ -19,8 +20,9 @@ describe('Acceptance | Controller | certification-report-controller', function (
   });
 
   describe('POST /api/certification-reports/{id}/certification-issue-reports', function () {
-    afterEach(function () {
-      return knex('certification-issue-reports').delete();
+    afterEach(async function () {
+      await knex('certification-issue-reports').delete();
+      await knex('issue-report-categories').delete();
     });
 
     it('should return 201 HTTP status code', async function () {

--- a/api/tests/integration/infrastructure/repositories/certification-issue-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-issue-report-repository_test.js
@@ -17,12 +17,14 @@ describe('Integration | Repository | Certification Issue Report', function () {
       it('should persist the certif issue report in db', async function () {
         // given
         const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+
         await databaseBuilder.commit();
 
         const certificationIssueReport = domainBuilder.buildCertificationIssueReport({
           id: undefined,
           certificationCourseId,
           category: CertificationIssueReportCategories.IN_CHALLENGE,
+          categoryId: null,
           description: 'Un gros problème',
           subcategory: CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
           questionNumber: 5,
@@ -37,6 +39,7 @@ describe('Integration | Repository | Certification Issue Report', function () {
         const expectedSavedCertificationIssueReport = domainBuilder.buildCertificationIssueReport({
           certificationCourseId,
           category: CertificationIssueReportCategories.IN_CHALLENGE,
+          categoryId: null,
           description: 'Un gros problème',
           isActionRequired: true,
           subcategory: CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
@@ -56,10 +59,19 @@ describe('Integration | Repository | Certification Issue Report', function () {
       it('should persist the updated certif issue report in db', async function () {
         // given
         const certificationCourseId = databaseBuilder.factory.buildCertificationCourse().id;
+        databaseBuilder.factory.buildIssueReportCategory({
+          id: 123,
+          name: CertificationIssueReportCategories.IN_CHALLENGE,
+        });
+        const categoryId = databaseBuilder.factory.buildIssueReportCategory({
+          issueReportCategoryId: 2,
+          name: CertificationIssueReportCategories.IMAGE_NOT_DISPLAYING,
+        }).id;
         const certificationIssueReport = databaseBuilder.factory.buildCertificationIssueReport({
           id: 1234,
           certificationCourseId,
           category: CertificationIssueReportCategories.IN_CHALLENGE,
+          categoryId,
           description: 'Un gros problème',
           subcategory: CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
           questionNumber: 5,
@@ -83,6 +95,7 @@ describe('Integration | Repository | Certification Issue Report', function () {
           id: 1234,
           certificationCourseId,
           category: CertificationIssueReportCategories.IN_CHALLENGE,
+          categoryId,
           description: 'Un gros problème',
           isActionRequired: true,
           subcategory: CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
@@ -137,14 +150,25 @@ describe('Integration | Repository | Certification Issue Report', function () {
     it('should return certification issue reports for a certification course id', async function () {
       // given
       const targetCertificationCourse = databaseBuilder.factory.buildCertificationCourse();
+      const categoryId = databaseBuilder.factory.buildIssueReportCategory({
+        name: CertificationIssueReportCategories.OTHER,
+      }).id;
       const otherCertificationCourse = databaseBuilder.factory.buildCertificationCourse();
       const issueReportForTargetCourse1 = databaseBuilder.factory.buildCertificationIssueReport({
         certificationCourseId: targetCertificationCourse.id,
+        category: CertificationIssueReportCategories.OTHER,
+        categoryId,
       });
       const issueReportForTargetCourse2 = databaseBuilder.factory.buildCertificationIssueReport({
         certificationCourseId: targetCertificationCourse.id,
+        category: CertificationIssueReportCategories.OTHER,
+        categoryId,
       });
-      databaseBuilder.factory.buildCertificationIssueReport({ certificationCourseId: otherCertificationCourse.id });
+      databaseBuilder.factory.buildCertificationIssueReport({
+        certificationCourseId: otherCertificationCourse.id,
+        category: CertificationIssueReportCategories.OTHER,
+        categoryId,
+      });
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/integration/infrastructure/repositories/issue-report-categories-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/issue-report-categories-repository_test.js
@@ -1,0 +1,22 @@
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const issueReportCategoryRepository = require('../../../../lib/infrastructure/repositories/issue-report-category-repository');
+
+describe('Integration | Repository | Issue Report Categories', function () {
+  afterEach(async function () {
+    await knex('issue-report-categories').delete();
+  });
+
+  describe('#get', function () {
+    it('should return a certification issue report', async function () {
+      // given
+      const issueReportCategory = databaseBuilder.factory.buildIssueReportCategory({ category: 'OTHER' });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await issueReportCategoryRepository.get({ name: issueReportCategory.name });
+
+      // then
+      expect(result).to.deep.equal({ ...issueReportCategory });
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-repository_test.js
@@ -207,9 +207,12 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
       databaseBuilder.factory.buildCertificationCourse({ id: 1 });
       databaseBuilder.factory.buildCertificationCourse({ id: 2 });
       databaseBuilder.factory.buildAssessment({ id: 159, certificationCourseId: 1 });
+      const issueReportCategoryId1 = databaseBuilder.factory.buildIssueReportCategory({ name: 'first_category' }).id;
+      const issueReportCategoryId2 = databaseBuilder.factory.buildIssueReportCategory({ name: 'second_category' }).id;
       const expectedCertificationIssueReportA = domainBuilder.buildCertificationIssueReport.impactful({
         id: 456,
         certificationCourseId: 1,
+        categoryId: issueReportCategoryId1,
         description: 'une description 1',
         questionNumber: 1,
         resolvedAt: new Date('2022-05-05'),
@@ -219,6 +222,7 @@ describe('Integration | Infrastructure | Repository | Jury Certification', funct
       const expectedCertificationIssueReportB = domainBuilder.buildCertificationIssueReport.notImpactful({
         id: 123,
         certificationCourseId: 1,
+        categoryId: issueReportCategoryId2,
         description: 'une description 2',
         questionNumber: 12,
         resolvedAt: new Date('2021-12-25'),

--- a/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-certification-summary-repository_test.js
@@ -38,6 +38,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
       let otherStartedCertification;
       const description = 'Super candidat !';
       let certificationIssueReport;
+      let issueReportCategoryId;
 
       beforeEach(function () {
         const dbf = databaseBuilder.factory;
@@ -46,12 +47,15 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
         startedCertification = dbf.buildCertificationCourse({ sessionId, lastName: 'CCC' });
         otherStartedCertification = dbf.buildCertificationCourse({ sessionId, lastName: 'DDD' });
 
+        issueReportCategoryId = dbf.buildIssueReportCategory({ name: CertificationIssueReportCategories.OTHER }).id;
+
         const manyAsrAssessmentId = dbf.buildAssessment({ certificationCourseId: manyAsrCertification.id }).id;
         dbf.buildAssessment({ certificationCourseId: startedCertification.id });
 
         certificationIssueReport = dbf.buildCertificationIssueReport({
           certificationCourseId: manyAsrCertification.id,
           category: CertificationIssueReportCategories.OTHER,
+          categoryId: issueReportCategoryId,
           description,
         });
 
@@ -89,6 +93,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
               subcategory: null,
               questionNumber: null,
               category: CertificationIssueReportCategories.OTHER,
+              categoryId: issueReportCategoryId,
               hasBeenAutomaticallyResolved: null,
               resolvedAt: null,
               resolution: null,
@@ -197,15 +202,19 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
 
         const manyAsrAssessmentId = dbf.buildAssessment({ certificationCourseId: manyAsrCertification.id }).id;
 
+        const categoryId = dbf.buildIssueReportCategory({ name: CertificationIssueReportCategories.OTHER }).id;
+
         const issueReport1 = dbf.buildCertificationIssueReport({
           certificationCourseId: manyAsrCertification.id,
           category: CertificationIssueReportCategories.OTHER,
+          categoryId,
           description: 'first certification issue report',
           hasBeenAutomaticallyResolved: false,
         });
         const issueReport2 = dbf.buildCertificationIssueReport({
           certificationCourseId: manyAsrCertification.id,
           category: CertificationIssueReportCategories.OTHER,
+          categoryId,
           description: 'second certification issue report',
           hasBeenAutomaticallyResolved: false,
         });
@@ -229,6 +238,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           new CertificationIssueReport({
             id: issueReport1.id,
             category: issueReport1.category,
+            categoryId: issueReport1.categoryId,
             certificationCourseId: manyAsrCertification.id,
             description: 'first certification issue report',
             hasBeenAutomaticallyResolved: false,
@@ -240,6 +250,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           new CertificationIssueReport({
             id: issueReport2.id,
             category: issueReport2.category,
+            categoryId: issueReport2.categoryId,
             certificationCourseId: manyAsrCertification.id,
             description: 'second certification issue report',
             hasBeenAutomaticallyResolved: false,
@@ -320,15 +331,19 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           status: assessmentResultStatuses.VALIDATED,
         });
 
+        const categoryId = dbf.buildIssueReportCategory({ name: CertificationIssueReportCategories.OTHER }).id;
+
         const issueReport1 = dbf.buildCertificationIssueReport({
           certificationCourseId: manyAsrCertification.id,
           category: CertificationIssueReportCategories.OTHER,
+          categoryId,
           description: 'first certification issue report',
           hasBeenAutomaticallyResolved: false,
         });
         const issueReport2 = dbf.buildCertificationIssueReport({
           certificationCourseId: manyAsrCertification.id,
           category: CertificationIssueReportCategories.OTHER,
+          categoryId,
           description: 'second certification issue report',
           hasBeenAutomaticallyResolved: false,
         });
@@ -369,6 +384,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           new CertificationIssueReport({
             id: issueReport1.id,
             category: issueReport1.category,
+            categoryId,
             certificationCourseId: manyAsrCertification.id,
             description: 'first certification issue report',
             hasBeenAutomaticallyResolved: false,
@@ -380,6 +396,7 @@ describe('Integration | Repository | JuryCertificationSummary', function () {
           new CertificationIssueReport({
             id: issueReport2.id,
             category: issueReport2.category,
+            categoryId,
             certificationCourseId: manyAsrCertification.id,
             description: 'second certification issue report',
             hasBeenAutomaticallyResolved: false,

--- a/api/tests/integration/scripts/certification/fill-issue-report-category-id_test.js
+++ b/api/tests/integration/scripts/certification/fill-issue-report-category-id_test.js
@@ -1,0 +1,70 @@
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const { main } = require('../../../../scripts/certification/fill-issue-report-category-id');
+
+describe('Integration | Scripts | Certification | fill-issue-report-category-id', function () {
+  describe('#updateCertificationIssueReport', function () {
+    context('when there is no subcategory', function () {
+      it('returns a certification issue report updated with a categoryId', async function () {
+        // given
+        const candidateFraudId = databaseBuilder.factory.buildIssueReportCategory({
+          name: 'FRAUD',
+          isDeprecated: false,
+          isImpactful: true,
+        }).id;
+
+        databaseBuilder.factory.buildCertificationIssueReport({
+          id: 1,
+          category: 'FRAUD',
+          categoryId: null,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        await main();
+
+        // then
+        const certificationIssueReport = await knex('certification-issue-reports')
+          .select('id', 'category', 'subcategory', 'categoryId')
+          .where('id', 1)
+          .first();
+        expect(certificationIssueReport.categoryId).to.equal(candidateFraudId);
+      });
+    });
+
+    context('when there is a subcategory', function () {
+      it('returns a certification issue report updated with a categoryId from a subcategory', async function () {
+        // given
+        const issueReportCategoryId = databaseBuilder.factory.buildIssueReportCategory({
+          name: 'OTHER',
+          isDeprecated: true,
+          isImpactful: true,
+        }).id;
+        const subCategoryId = databaseBuilder.factory.buildIssueReportCategory({
+          name: 'LEFT_EXAM_ROOM',
+          isDeprecated: true,
+          isImpactful: false,
+          issueReportCategoryId,
+        }).id;
+
+        databaseBuilder.factory.buildCertificationIssueReport({
+          id: 1,
+          category: 'LEFT_EXAM_ROOM',
+          categoryId: null,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        await main();
+
+        // then
+        const certificationIssueReport = await knex('certification-issue-reports')
+          .select('id', 'category', 'subcategory', 'categoryId')
+          .where('id', 1)
+          .first();
+        expect(certificationIssueReport.categoryId).to.equal(subCategoryId);
+      });
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-certification-issue-report.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-issue-report.js
@@ -7,6 +7,7 @@ const {
 const buildCertificationIssueReport = function ({
   id = 123,
   certificationCourseId,
+  categoryId = null,
   category = CertificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES,
   subcategory = CertificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
   description = 'Une super description',
@@ -18,6 +19,7 @@ const buildCertificationIssueReport = function ({
   return new CertificationIssueReport({
     id,
     certificationCourseId,
+    categoryId,
     category,
     subcategory,
     description,
@@ -36,6 +38,8 @@ buildCertificationIssueReport.impactful = function ({
   resolvedAt,
   resolution,
   hasBeenAutomaticallyResolved,
+  category = CertificationIssueReportCategories.FRAUD,
+  categoryId,
 } = {}) {
   return buildCertificationIssueReport({
     id,
@@ -44,7 +48,8 @@ buildCertificationIssueReport.impactful = function ({
     questionNumber,
     resolvedAt,
     resolution,
-    category: CertificationIssueReportCategories.FRAUD,
+    categoryId,
+    category,
     subcategory: null,
     hasBeenAutomaticallyResolved,
   });
@@ -58,6 +63,8 @@ buildCertificationIssueReport.notImpactful = function ({
   resolvedAt,
   resolution,
   hasBeenAutomaticallyResolved,
+  category = CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN,
+  categoryId,
 } = {}) {
   return buildCertificationIssueReport({
     id,
@@ -66,7 +73,8 @@ buildCertificationIssueReport.notImpactful = function ({
     questionNumber,
     resolvedAt,
     resolution,
-    category: CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN,
+    categoryId,
+    category,
     subcategory: null,
     hasBeenAutomaticallyResolved,
   });

--- a/api/tests/unit/domain/usecases/save-certification-issue-report_test.js
+++ b/api/tests/unit/domain/usecases/save-certification-issue-report_test.js
@@ -1,33 +1,69 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const saveCertificationIssueReport = require('../../../../lib/domain/usecases/save-certification-issue-report');
-const {
-  CertificationIssueReportCategories,
-} = require('../../../../lib/domain/models/CertificationIssueReportCategory');
 const CertificationIssueReport = require('../../../../lib/domain/models/CertificationIssueReport');
 
 describe('Unit | UseCase | save-certification-issue-report', function () {
   describe('#saveCertificationIssueReport', function () {
-    it('should save the certification issue report', async function () {
-      // given
-      const certificationIssueReportRepository = { save: sinon.stub() };
-      const sessionId = 1;
-      const aCertificationCourse = domainBuilder.buildCertificationCourse({ sessionId });
-      const certificationIssueReportDTO = {
-        certificationCourseId: aCertificationCourse.getId(),
-        category: CertificationIssueReportCategories.FRAUD,
-        description: 'une description',
-      };
-      const expectedCertificationIssueReport = new CertificationIssueReport(certificationIssueReportDTO);
-      certificationIssueReportRepository.save.resolves(expectedCertificationIssueReport);
+    describe('when there is a category of issue report', function () {
+      it('should save the certification issue report', async function () {
+        // given
+        const certificationIssueReportRepository = { save: sinon.stub() };
+        const issueReportCategoryRepository = { get: sinon.stub() };
+        const sessionId = 1;
+        const aCertificationCourse = domainBuilder.buildCertificationCourse({ sessionId });
+        const certificationIssueReportDTO = {
+          certificationCourseId: aCertificationCourse.getId(),
+          category: 'FRAUD',
+          description: 'une description',
+        };
+        const expectedCertificationIssueReport = new CertificationIssueReport(certificationIssueReportDTO);
+        issueReportCategoryRepository.get
+          .withArgs({ name: certificationIssueReportDTO.category })
+          .resolves({ id: 1234, name: certificationIssueReportDTO.category });
+        certificationIssueReportRepository.save.resolves(expectedCertificationIssueReport);
 
-      // when
-      const certifIssueReportResult = await saveCertificationIssueReport({
-        certificationIssueReportDTO,
-        certificationIssueReportRepository,
+        // when
+        const certifIssueReportResult = await saveCertificationIssueReport({
+          certificationIssueReportDTO,
+          certificationIssueReportRepository,
+          issueReportCategoryRepository,
+        });
+
+        // then
+        expect(certifIssueReportResult).to.deep.equal(expectedCertificationIssueReport);
       });
+    });
 
-      // then
-      expect(certifIssueReportResult).to.deep.equal(expectedCertificationIssueReport);
+    describe('when there is a subcategory of issue report', function () {
+      it('should save the certification issue report', async function () {
+        // given
+        const certificationIssueReportRepository = { save: sinon.stub() };
+        const issueReportCategoryRepository = { get: sinon.stub() };
+        const sessionId = 1;
+        const aCertificationCourse = domainBuilder.buildCertificationCourse({ sessionId });
+        const certificationIssueReportDTO = {
+          certificationCourseId: aCertificationCourse.getId(),
+          category: 'IN_CHALLENGE',
+          subcategory: 'EMBED_NOT_WORKING',
+          description: 'une description',
+          questionNumber: 1,
+        };
+        const expectedCertificationIssueReport = new CertificationIssueReport(certificationIssueReportDTO);
+        issueReportCategoryRepository.get
+          .withArgs({ name: certificationIssueReportDTO.subcategory })
+          .resolves({ id: 1234, name: certificationIssueReportDTO.subcategory });
+        certificationIssueReportRepository.save.resolves(expectedCertificationIssueReport);
+
+        // when
+        const certifIssueReportResult = await saveCertificationIssueReport({
+          certificationIssueReportDTO,
+          certificationIssueReportRepository,
+          issueReportCategoryRepository,
+        });
+
+        // then
+        expect(certifIssueReportResult).to.deep.equal(expectedCertificationIssueReport);
+      });
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Préparation au  #5311 

## :gift: Proposition
- Stocker les catégories de signalement dans ```issue-report-categories```
- Stocker le categoryId dans ```certification-issue-reports``` à la sauvegarde d'un issue report (finalisation)
- Créer un script pour renseigner le categoryId pour les issue reports antérieurs
## :star2: Remarques
TODO:
- [x] Test func sur finalization avec signalement
- [x] Test func sur pix-admin lectures signlement
## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
