### PR TITLE
[TECH] Déplacer le contenu de la table "target-profiles_skills" vers "campaign_skills" (PIX-5696)

### DIFF
--- a/api/db/database-builder/factory/campaign-participation-overview-factory.js
+++ b/api/db/database-builder/factory/campaign-participation-overview-factory.js
@@ -1,8 +1,7 @@
 const buildAssessment = require('./build-assessment');
 const buildCampaign = require('./build-campaign');
 const buildCampaignParticipation = require('./build-campaign-participation');
-const buildTargetProfileSkill = require('./build-target-profile-skill');
-const buildTargetProfile = require('./build-target-profile');
+const buildCampaignSkill = require('./build-campaign-skill');
 const buildUser = require('./build-user');
 const Assessment = require('../../../lib/domain/models/Assessment');
 const CampaignParticipationStatuses = require('../../../lib/domain/models/CampaignParticipationStatuses');
@@ -44,12 +43,9 @@ module.exports = {
     return campaignParticipation;
   },
 
-  buildOnGoing({ userId, createdAt, assessmentCreatedAt, targetProfileSkills } = {}) {
-    const targetProfile = buildTargetProfile();
-    targetProfileSkills.forEach((skill) =>
-      buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill })
-    );
-    const campaign = buildCampaign({ targetProfileId: targetProfile.id });
+  buildOnGoing({ userId, createdAt, assessmentCreatedAt, campaignSkills } = {}) {
+    const campaign = buildCampaign();
+    campaignSkills.forEach((skill) => buildCampaignSkill({ campaignId: campaign.id, skillId: skill }));
 
     const campaignParticipation = buildCampaignParticipation({
       userId,
@@ -69,12 +65,9 @@ module.exports = {
     return campaignParticipation;
   },
 
-  buildToShare({ userId, createdAt, assessmentCreatedAt, targetProfileSkills } = {}) {
-    const targetProfile = buildTargetProfile();
-    targetProfileSkills.forEach((skill) =>
-      buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill })
-    );
-    const campaign = buildCampaign({ targetProfileId: targetProfile.id });
+  buildToShare({ userId, createdAt, assessmentCreatedAt, campaignSkills } = {}) {
+    const campaign = buildCampaign();
+    campaignSkills.forEach((skill) => buildCampaignSkill({ campaignId: campaign.id, skillId: skill }));
 
     const campaignParticipation = buildCampaignParticipation({
       userId,
@@ -94,12 +87,9 @@ module.exports = {
     return campaignParticipation;
   },
 
-  buildEnded({ userId, createdAt, sharedAt, assessmentCreatedAt, targetProfileSkills } = {}) {
-    const targetProfile = buildTargetProfile();
-    targetProfileSkills.forEach((skill) =>
-      buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill })
-    );
-    const campaign = buildCampaign({ targetProfileId: targetProfile.id });
+  buildEnded({ userId, createdAt, sharedAt, assessmentCreatedAt, campaignSkills } = {}) {
+    const campaign = buildCampaign();
+    campaignSkills.forEach((skill) => buildCampaignSkill({ campaignId: campaign.id, skillId: skill }));
 
     const campaignParticipation = buildCampaignParticipation({
       userId,
@@ -124,13 +114,10 @@ module.exports = {
     sharedAt,
     assessmentCreatedAt,
     campaignArchivedAt = new Date('1998-07-01'),
-    targetProfileSkills,
+    campaignSkills,
   } = {}) {
-    const targetProfile = buildTargetProfile();
-    targetProfileSkills.forEach((skill) =>
-      buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill })
-    );
-    const campaign = buildCampaign({ targetProfileId: targetProfile.id, archivedAt: campaignArchivedAt });
+    const campaign = buildCampaign({ archivedAt: campaignArchivedAt });
+    campaignSkills.forEach((skill) => buildCampaignSkill({ campaignId: campaign.id, skillId: skill }));
 
     const campaignParticipation = buildCampaignParticipation({
       userId,
@@ -156,13 +143,10 @@ module.exports = {
     assessmentCreatedAt,
     deletedAt = new Date('1998-07-01'),
     deletedBy = buildUser().id,
-    targetProfileSkills,
+    campaignSkills,
   } = {}) {
-    const targetProfile = buildTargetProfile();
-    targetProfileSkills.forEach((skill) =>
-      buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill })
-    );
-    const campaign = buildCampaign({ targetProfileId: targetProfile.id });
+    const campaign = buildCampaign();
+    campaignSkills.forEach((skill) => buildCampaignSkill({ campaignId: campaign.id, skillId: skill }));
 
     const campaignParticipation = buildCampaignParticipation({
       userId,

--- a/api/db/seeds/data/fill-campaign-skills.js
+++ b/api/db/seeds/data/fill-campaign-skills.js
@@ -1,0 +1,40 @@
+const { knex } = require('../../../db/knex-database-connection');
+const skillRepository = require('../../../lib/infrastructure/repositories/skill-repository');
+
+async function fillCampaignSkills() {
+  const campaigns = await knex('campaigns')
+    .select({
+      campaignId: 'campaigns.id',
+      targetProfileId: 'campaigns.targetProfileId',
+    })
+    .leftJoin('campaign_skills', 'campaign_skills.campaignId', 'campaigns.id')
+    .whereNull('campaign_skills.campaignId')
+    .where('campaigns.type', 'ASSESSMENT')
+    .orderBy('campaigns.id');
+
+  for (const { campaignId, targetProfileId } of campaigns) {
+    const cappedTubes = await knex('target-profile_tubes')
+      .select('tubeId', 'level')
+      .where('targetProfileId', targetProfileId);
+
+    const skillData = [];
+    if (cappedTubes.length > 0) {
+      for (const cappedTube of cappedTubes) {
+        const allLevelSkills = await skillRepository.findActiveByTubeId(cappedTube.tubeId);
+        const rightLevelSkills = allLevelSkills.filter((skill) => skill.difficulty <= cappedTube.level);
+        skillData.push(...rightLevelSkills.map((skill) => ({ skillId: skill.id, campaignId })));
+      }
+    } else {
+      const skillIds = await knex('target-profiles_skills')
+        .pluck('skillId')
+        .distinct()
+        .where('targetProfileId', targetProfileId);
+      skillData.push(...skillIds.map((skillId) => ({ skillId, campaignId })));
+    }
+    await knex.batchInsert('campaign_skills', skillData);
+  }
+}
+
+module.exports = {
+  fillCampaignSkills,
+};

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -43,6 +43,7 @@ const computeParticipationsResults = require('../../scripts/prod/compute-partici
 const poleEmploiSendingsBuilder = require('./data/pole-emploi-sendings-builder');
 const { trainingBuilder } = require('./data/trainings-builder');
 const { richTargetProfilesBuilder } = require('./data/learning-content/target-profiles-builder');
+const { fillCampaignSkills } = require('./data/fill-campaign-skills');
 
 exports.seed = async (knex) => {
   const databaseBuilder = new DatabaseBuilder({ knex });
@@ -101,6 +102,7 @@ exports.seed = async (knex) => {
 
   await databaseBuilder.commit();
   await databaseBuilder.fixSequences();
+  await fillCampaignSkills();
   const campaignParticipationData = await getEligibleCampaignParticipations(50000);
   await generateKnowledgeElementSnapshots(campaignParticipationData, 1);
   await computeParticipationsResults(10, false);

--- a/api/scripts/prod/target-profile-migrations/convert-target-profiles-into-new-format.js
+++ b/api/scripts/prod/target-profile-migrations/convert-target-profiles-into-new-format.js
@@ -1,15 +1,15 @@
 require('dotenv').config();
 const _ = require('lodash');
-const { knex, disconnect } = require('../../db/knex-database-connection');
-const logger = require('../../lib/infrastructure/logger');
-const cache = require('../../lib/infrastructure/caches/learning-content-cache');
+const { knex, disconnect } = require('../../../db/knex-database-connection');
+const logger = require('../../../lib/infrastructure/logger');
+const cache = require('../../../lib/infrastructure/caches/learning-content-cache');
 
 let allSkills;
 let allTubes;
 async function _cacheLearningContentData() {
-  const skillRepository = require('../../lib/infrastructure/repositories/skill-repository');
+  const skillRepository = require('../../../lib/infrastructure/repositories/skill-repository');
   allSkills = await skillRepository.list();
-  const tubeRepository = require('../../lib/infrastructure/repositories/tube-repository');
+  const tubeRepository = require('../../../lib/infrastructure/repositories/tube-repository');
   allTubes = await tubeRepository.list();
 }
 

--- a/api/scripts/prod/target-profile-migrations/copy-target-profile-skills-into-campaign-skills.js
+++ b/api/scripts/prod/target-profile-migrations/copy-target-profile-skills-into-campaign-skills.js
@@ -1,0 +1,136 @@
+require('dotenv').config();
+const { performance } = require('perf_hooks');
+const yargs = require('yargs');
+const bluebird = require('bluebird');
+const _ = require('lodash');
+const logger = require('../../../lib/infrastructure/logger');
+const cache = require('../../../lib/infrastructure/caches/learning-content-cache');
+const { knex, disconnect } = require('../../../db/knex-database-connection');
+
+const DEFAULT_MAX_CAMPAIGNS_COUNT = 50000;
+const DEFAULT_CONCURRENCY = 3;
+
+const MEMO = {};
+
+let progression = 0;
+function _logProgression(totalCount) {
+  ++progression;
+  process.stdout.cursorTo(0);
+  process.stdout.write(`${Math.round((progression * 100) / totalCount, 2)} %`);
+}
+
+const copySkills = async ({ maxCampaignCount, concurrency }) => {
+  const campaignDatas = await getEligibleCampaigns(maxCampaignCount);
+
+  logger.info(`Found ${campaignDatas.length} to handle.`);
+  return bluebird.map(
+    campaignDatas,
+    async (campaignData) => {
+      const { campaignId, targetProfileId } = campaignData;
+      const skillIds = await getTargetProfileSkills(targetProfileId);
+      await createCampaignSkills(campaignId, skillIds);
+      _logProgression(campaignDatas.length);
+    },
+    { concurrency }
+  );
+};
+
+async function createCampaignSkills(campaignId, skillIds) {
+  const data = skillIds.map((skillId) => ({ campaignId, skillId }));
+  return knex.batchInsert('campaign_skills', data);
+}
+
+async function getTargetProfileSkills(targetProfileId) {
+  const key = targetProfileId.toString();
+  if (!MEMO[key]) {
+    const skillIds = await knex('target-profiles_skills').pluck('skillId').where({ targetProfileId });
+    MEMO[key] = _.uniq(skillIds);
+  }
+  return MEMO[key];
+}
+
+async function getEligibleCampaigns(maxCampaignCount) {
+  return knex('campaigns')
+    .select({
+      campaignId: 'campaigns.id',
+      targetProfileId: 'campaigns.targetProfileId',
+    })
+    .leftJoin('campaign_skills', 'campaign_skills.campaignId', 'campaigns.id')
+    .whereNull('campaign_skills.campaignId')
+    .where('campaigns.type', 'ASSESSMENT')
+    .whereNot('campaigns.assessmentMethod', 'FLASH')
+    .orderBy('campaigns.id')
+    .limit(maxCampaignCount);
+}
+
+const isLaunchedFromCommandLine = require.main === module;
+
+async function main() {
+  const startTime = performance.now();
+  logger.info(`Script ${__filename} has started`);
+  const commandLineArgs = yargs
+    .option('maxCampaignCount', {
+      description: 'Nombre de campagnes max. à traiter.',
+      type: 'number',
+      default: DEFAULT_MAX_CAMPAIGNS_COUNT,
+    })
+    .option('concurrency', {
+      description: 'Concurrence',
+      type: 'number',
+      default: DEFAULT_CONCURRENCY,
+    })
+    .help().argv;
+  const { maxCampaignCount, concurrency } = _validateAndNormalizeArgs(commandLineArgs);
+  await copySkills({ maxCampaignCount, concurrency });
+  const endTime = performance.now();
+  const duration = Math.round(endTime - startTime);
+  logger.info(`Script has ended: took ${duration} milliseconds`);
+}
+
+function _validateAndNormalizeArgs({ concurrency, maxCampaignCount }) {
+  const finalMaxCampaignCount = _validateAndNormalizeMaxCampaignCount(maxCampaignCount);
+  const finalConcurrency = _validateAndNormalizeConcurrency(concurrency);
+
+  return {
+    maxCampaignCount: finalMaxCampaignCount,
+    concurrency: finalConcurrency,
+  };
+}
+
+function _validateAndNormalizeConcurrency(concurrency) {
+  if (isNaN(concurrency)) {
+    concurrency = DEFAULT_CONCURRENCY;
+  }
+  if (concurrency <= 0 || concurrency > 5) {
+    throw new Error(`Concurrent ${concurrency} ne peut pas être inférieur à 1 ni supérieur à 5.`);
+  }
+
+  return concurrency;
+}
+
+function _validateAndNormalizeMaxCampaignCount(maxCampaignCount) {
+  if (isNaN(maxCampaignCount)) {
+    maxCampaignCount = DEFAULT_MAX_CAMPAIGNS_COUNT;
+  }
+  if (maxCampaignCount <= 0) {
+    throw new Error(`Nombre max de campagnes ${maxCampaignCount} ne peut pas être inférieur à 1.`);
+  }
+
+  return maxCampaignCount;
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+      await cache.quit();
+    }
+  }
+})();
+
+module.exports = { copySkills };

--- a/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -226,6 +226,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
         const campaign = databaseBuilder.factory.buildCampaign({
           targetProfileId: targetProfile.id,
         });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'recSkill0_0' });
 
         // when
         await _createAndCompleteCampaignParticipation({
@@ -249,9 +250,11 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
         const firstCampaign = databaseBuilder.factory.buildCampaign({
           targetProfileId: targetProfile.id,
         });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: firstCampaign.id, skillId: 'recSkill0_0' });
         const secondCampaign = databaseBuilder.factory.buildCampaign({
           targetProfileId: targetProfile.id,
         });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: secondCampaign.id, skillId: 'recSkill0_0' });
 
         await _createAndCompleteCampaignParticipation({
           user,
@@ -284,6 +287,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
         const campaign = databaseBuilder.factory.buildCampaign({
           targetProfileId: targetProfile.id,
         });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'recSkill0_0' });
 
         // when
         await _createAndCompleteCampaignParticipation({
@@ -368,11 +372,6 @@ async function _createAndCompleteCampaignParticipation({ user, campaign, badge, 
     campaignParticipationId: campaignParticipation.id,
   });
   const anyDateBeforeCampaignParticipation = new Date(campaignParticipation.sharedAt.getTime() - 60 * 1000);
-
-  databaseBuilder.factory.buildTargetProfileSkill({
-    targetProfileId: campaign.targetProfileId,
-    skillId: 'recSkill0_0',
-  });
   databaseBuilder.factory.buildKnowledgeElement({
     skillId: 'recSkill0_0',
     assessmentId: campaignAssessment.id,

--- a/api/tests/acceptance/application/campaign-participations/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participations/campaign-participation-controller_test.js
@@ -64,9 +64,8 @@ describe('Acceptance | API | Campaign Participations', function () {
 
     it('shares the campaign participation', async function () {
       // given
-      const targetProfile = databaseBuilder.factory.buildTargetProfile();
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'recAcquisWeb1' });
-      const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+      const campaign = databaseBuilder.factory.buildCampaign();
+      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'recAcquisWeb1' });
       const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
         id: campaignParticipationId,
         userId: user.id,
@@ -98,9 +97,6 @@ describe('Acceptance | API | Campaign Participations', function () {
     const options = {
       method: 'POST',
       url: '/api/campaign-participations',
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      headers: { authorization: generateValidRequestAuthorizationHeader() },
       payload: {
         data: {
           type: 'campaign-participations',

--- a/api/tests/acceptance/application/campaigns/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaigns/campaign-controller_test.js
@@ -20,7 +20,6 @@ const createServer = require('../../../../server');
 describe('Acceptance | API | Campaign Controller', function () {
   let campaign;
   let organization;
-  let targetProfile;
   let server;
 
   beforeEach(async function () {
@@ -59,17 +58,12 @@ describe('Acceptance | API | Campaign Controller', function () {
     beforeEach(async function () {
       userId = databaseBuilder.factory.buildUser({ firstName: 'Jean', lastName: 'Bono' }).id;
       organization = databaseBuilder.factory.buildOrganization();
-      targetProfile = databaseBuilder.factory.buildTargetProfile({
-        organizationId: organization.id,
-        name: 'Profile 2',
-      });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'recSkillId1' });
       campaign = databaseBuilder.factory.buildCampaign({
         name: 'Campagne de Test N°2',
         organizationId: organization.id,
-        targetProfileId: targetProfile.id,
         idPixLabel: 'Identifiant entreprise',
       });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'recSkillId1' });
 
       databaseBuilder.factory.buildMembership({
         userId,
@@ -77,17 +71,12 @@ describe('Acceptance | API | Campaign Controller', function () {
         organizationRole: Membership.roles.MEMBER,
       });
 
-      targetProfile = databaseBuilder.factory.buildTargetProfile({
-        organizationId: organization.id,
-        name: 'Profile 3',
-      });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'recSkillId1' });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'recSkillId2' });
       campaign = databaseBuilder.factory.buildCampaign({
         name: 'Campagne de Test N°3',
         organizationId: organization.id,
-        targetProfileId: targetProfile.id,
       });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'recSkillId1' });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'recSkillId2' });
 
       const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
         campaignId: campaign.id,
@@ -218,12 +207,10 @@ describe('Acceptance | API | Campaign Controller', function () {
       const skillId = 'rec123';
       const userId = databaseBuilder.factory.buildUser().id;
       organization = databaseBuilder.factory.buildOrganization();
-      targetProfile = databaseBuilder.factory.buildTargetProfile();
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skillId });
       campaign = databaseBuilder.factory.buildCampaign({
         organizationId: organization.id,
-        targetProfileId: targetProfile.id,
       });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: skillId });
       accessToken = _createTokenWithAccessId({ userId, campaignId: campaign.id });
 
       databaseBuilder.factory.buildMembership({
@@ -541,17 +528,8 @@ describe('Acceptance | API | Campaign Controller', function () {
           name: 'Campagne de Test N°3',
           organizationId: organization.id,
         });
-        targetProfile = databaseBuilder.factory.buildTargetProfile({
-          organizationId: organization.id,
-          name: 'Profile 3',
-        });
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'recSkillId1' });
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'recSkillId2' });
-        campaign = databaseBuilder.factory.buildCampaign({
-          name: 'Campagne de Test N°3',
-          organizationId: organization.id,
-          targetProfileId: targetProfile.id,
-        });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'recSkillId1' });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'recSkillId2' });
         databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id });
 
         await databaseBuilder.commit();
@@ -689,7 +667,7 @@ describe('Acceptance | API | Campaign Controller', function () {
       const userId = databaseBuilder.factory.buildUser().id;
       organization = databaseBuilder.factory.buildOrganization();
       databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId });
-      targetProfile = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organization.id });
+      const targetProfile = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organization.id });
       databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'recSkill1' });
       await databaseBuilder.commit();
 
@@ -764,33 +742,7 @@ describe('Acceptance | API | Campaign Controller', function () {
       const userId = databaseBuilder.factory.buildUser().id;
       organization = databaseBuilder.factory.buildOrganization();
       databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId });
-      targetProfile = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organization.id });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'recSkill1' });
       await databaseBuilder.commit();
-
-      const learningContent = [
-        {
-          id: 'recArea1',
-          competences: [
-            {
-              id: 'recCompetence1',
-              tubes: [
-                {
-                  id: 'recTube1',
-                  skills: [
-                    {
-                      id: 'recSkill1',
-                      challenges: [],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ];
-      const learningContentObjects = learningContentBuilder.buildLearningContent.fromAreas(learningContent);
-      mockLearningContent(learningContentObjects);
 
       // when
       const payload = {
@@ -839,7 +791,7 @@ describe('Acceptance | API | Campaign Controller', function () {
       const userId = databaseBuilder.factory.buildUser().id;
       organization = databaseBuilder.factory.buildOrganization();
       databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId });
-      targetProfile = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organization.id });
+      const targetProfile = databaseBuilder.factory.buildTargetProfile({ ownerOrganizationId: organization.id });
       databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'recSkill1' });
       const anotherUserId = databaseBuilder.factory.buildUser().id;
       await databaseBuilder.commit();
@@ -948,14 +900,9 @@ describe('Acceptance | API | Campaign Controller', function () {
             organizationId: organization.id,
             organizationRole: Membership.roles.MEMBER,
           });
-          const targetProfile = databaseBuilder.factory.buildTargetProfile({
-            ownerOrganizationId: organization.id,
-            name: 'Profile 3',
-          });
           const campaign = databaseBuilder.factory.buildCampaign({
             name: 'Campagne de Test N°3',
             organizationId: organization.id,
-            targetProfileId: targetProfile.id,
           });
 
           databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -1011,14 +958,9 @@ describe('Acceptance | API | Campaign Controller', function () {
             organizationId: organization.id,
             organizationRole: Membership.roles.MEMBER,
           });
-          const targetProfile = databaseBuilder.factory.buildTargetProfile({
-            ownerOrganizationId: organization.id,
-            name: 'Profile 3',
-          });
           const campaign = databaseBuilder.factory.buildCampaign({
             name: 'Campagne de Test N°3',
             organizationId: organization.id,
-            targetProfileId: targetProfile.id,
           });
 
           databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -1089,14 +1031,9 @@ describe('Acceptance | API | Campaign Controller', function () {
             organizationId: organization.id,
             organizationRole: Membership.roles.MEMBER,
           });
-          const targetProfile = databaseBuilder.factory.buildTargetProfile({
-            ownerOrganizationId: organization.id,
-            name: 'Profile 3',
-          });
           const campaign = databaseBuilder.factory.buildCampaign({
             name: 'Campagne de Test N°3',
             organizationId: organization.id,
-            targetProfileId: targetProfile.id,
           });
 
           databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -1152,14 +1089,9 @@ describe('Acceptance | API | Campaign Controller', function () {
             organizationId: organization.id,
             organizationRole: Membership.roles.MEMBER,
           });
-          const targetProfile = databaseBuilder.factory.buildTargetProfile({
-            ownerOrganizationId: organization.id,
-            name: 'Profile 3',
-          });
           const campaign = databaseBuilder.factory.buildCampaign({
             name: 'Campagne de Test N°3',
             organizationId: organization.id,
-            targetProfileId: targetProfile.id,
           });
 
           databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -1229,14 +1161,9 @@ describe('Acceptance | API | Campaign Controller', function () {
           organizationId: organization.id,
           organizationRole: Membership.roles.MEMBER,
         });
-        const targetProfile = databaseBuilder.factory.buildTargetProfile({
-          ownerOrganizationId: organization.id,
-          name: 'Profile 3',
-        });
         const campaign = databaseBuilder.factory.buildCampaign({
           name: 'Campagne de Test N°3',
           organizationId: organization.id,
-          targetProfileId: targetProfile.id,
         });
 
         databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
@@ -1343,12 +1270,12 @@ describe('Acceptance | API | Campaign Controller', function () {
     beforeEach(async function () {
       const skillId = 'recSkillId1';
       campaign = databaseBuilder.factory.buildCampaign();
+      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: skillId });
       userId = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildMembership({
         organizationId: campaign.organizationId,
         userId,
       });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: campaign.targetProfileId, skillId: skillId });
 
       options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
       options.url = `/api/campaigns/${campaign.id}`;

--- a/api/tests/acceptance/application/campaigns/campaign-stats-controller_test.js
+++ b/api/tests/acceptance/application/campaigns/campaign-stats-controller_test.js
@@ -46,8 +46,6 @@ describe('Acceptance | API | Campaign Stats Controller', function () {
       mockLearningContent(learningContentObjects);
 
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recSkillId1' });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recSkillId2' });
       const stage1 = databaseBuilder.factory.buildStage({
         targetProfileId,
         threshold: 0,
@@ -57,6 +55,8 @@ describe('Acceptance | API | Campaign Stats Controller', function () {
       const stage2 = databaseBuilder.factory.buildStage({ targetProfileId, threshold: 30 });
 
       const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'recSkillId1' });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'recSkillId2' });
       const userId = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildMembership({ organizationId: campaign.organizationId, userId });
       await databaseBuilder.commit();

--- a/api/tests/acceptance/application/progressions/progression-controller_test.js
+++ b/api/tests/acceptance/application/progressions/progression-controller_test.js
@@ -45,12 +45,8 @@ describe('Acceptance | API | Progressions', function () {
       mockLearningContent(learningContentObjects);
 
       userId = databaseBuilder.factory.buildUser({}).id;
-      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId });
-      const campaignId = databaseBuilder.factory.buildCampaign({
-        name: 'Campaign',
-        targetProfileId,
-      }).id;
+      const campaignId = databaseBuilder.factory.buildCampaign({ name: 'Campaign' }).id;
+      databaseBuilder.factory.buildCampaignSkill({ campaignId });
       const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ campaignId }).id;
       assessmentId = databaseBuilder.factory.buildAssessment({
         userId: userId,

--- a/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
+++ b/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
@@ -14,7 +14,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
   const EMERALD_COLOR = 'emerald';
   const WILD_STRAWBERRY_COLOR = 'wild-strawberry';
 
-  let user, campaign, assessment, campaignParticipation, targetProfile, targetProfileSkills;
+  let user, campaign, assessment, campaignParticipation, targetProfile, campaignSkills;
 
   let server, badge, skillSet, stage;
 
@@ -24,11 +24,27 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
     const oldDate = new Date('2018-02-03');
     const recentDate = new Date('2018-05-06');
     const futureDate = new Date('2018-07-10');
+    const skillIds = [
+      'recSkill1',
+      'recSkill2',
+      'recSkill3',
+      'recSkill4',
+      'recSkill5',
+      'recSkill6',
+      'recSkill7',
+      'recSkill8',
+    ];
 
     user = databaseBuilder.factory.buildUser();
     targetProfile = databaseBuilder.factory.buildTargetProfile();
     campaign = databaseBuilder.factory.buildCampaign({
       targetProfileId: targetProfile.id,
+    });
+    campaignSkills = _.times(8, (index) => {
+      return databaseBuilder.factory.buildCampaignSkill({
+        campaignId: campaign.id,
+        skillId: skillIds[index],
+      });
     });
     campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
       campaignId: campaign.id,
@@ -41,24 +57,6 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
       userId: user.id,
       type: 'CAMPAIGN',
       state: 'completed',
-    });
-
-    const skillIds = [
-      'recSkill1',
-      'recSkill2',
-      'recSkill3',
-      'recSkill4',
-      'recSkill5',
-      'recSkill6',
-      'recSkill7',
-      'recSkill8',
-    ];
-
-    targetProfileSkills = _.times(8, (index) => {
-      return databaseBuilder.factory.buildTargetProfileSkill({
-        targetProfileId: targetProfile.id,
-        skillId: skillIds[index],
-      });
     });
 
     badge = databaseBuilder.factory.buildBadge({
@@ -100,11 +98,11 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
       targetProfileId: targetProfile.id,
     });
 
-    targetProfileSkills.slice(2).forEach((targetProfileSkill, index) => {
+    campaignSkills.slice(2).forEach((campaignSkill, index) => {
       databaseBuilder.factory.buildKnowledgeElement({
         userId: user.id,
         assessmentId: assessment.id,
-        skillId: targetProfileSkill.skillId,
+        skillId: campaignSkill.skillId,
         status: index < 3 ? 'validated' : 'invalidated',
         createdAt: index < 5 ? oldDate : futureDate,
       });

--- a/api/tests/acceptance/application/users/users-controller-get-campaign-participation-overviews_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-campaign-participation-overviews_test.js
@@ -56,15 +56,15 @@ describe('Acceptance | Controller | users-controller-get-campaign-participation-
       // given
       const startedCampaignParticipation = databaseBuilder.factory.campaignParticipationOverviewFactory.buildOnGoing({
         userId,
-        targetProfileSkills: ['recSkillId1'],
+        campaignSkills: ['recSkillId1'],
       });
       const sharableCampaignParticipation = databaseBuilder.factory.campaignParticipationOverviewFactory.buildToShare({
         userId,
-        targetProfileSkills: ['recSkillId1'],
+        campaignSkills: ['recSkillId1'],
       });
       databaseBuilder.factory.campaignParticipationOverviewFactory.buildEnded({
         userId,
-        targetProfileSkills: ['recSkillId1'],
+        campaignSkills: ['recSkillId1'],
       });
 
       await databaseBuilder.commit();

--- a/api/tests/acceptance/application/users/users-controller-is-certifiable_test.js
+++ b/api/tests/acceptance/application/users/users-controller-is-certifiable_test.js
@@ -176,13 +176,6 @@ describe('Acceptance | users-controller-is-certifiable', function () {
     });
 
     const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-    learningContent.skills.forEach(({ id: skillId }) => {
-      databaseBuilder.factory.buildTargetProfileSkill({
-        targetProfileId,
-        skillId,
-      });
-    });
-
     const cleaBadgeId = databaseBuilder.factory.buildBadge({
       key: 'PARTNER_KEY',
       isCertifiable: true,
@@ -200,6 +193,12 @@ describe('Acceptance | users-controller-is-certifiable', function () {
     });
 
     const campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
+    learningContent.skills.forEach(({ id: skillId }) => {
+      databaseBuilder.factory.buildCampaignSkill({
+        campaignId,
+        skillId,
+      });
+    });
     const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ campaignId }).id;
 
     databaseBuilder.factory.buildBadgeAcquisition({

--- a/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
@@ -182,9 +182,8 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', function 
           toFake: ['Date'],
         });
 
-        const targetProfile = databaseBuilder.factory.buildTargetProfile();
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'url1' });
-        const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        const campaign = databaseBuilder.factory.buildCampaign();
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'url1' });
 
         _.each(
           [

--- a/api/tests/acceptance/scripts/target-profile-migrations/convert-target-profiles-into-new-format_test.js
+++ b/api/tests/acceptance/scripts/target-profile-migrations/convert-target-profiles-into-new-format_test.js
@@ -1,8 +1,8 @@
-const { expect, databaseBuilder, sinon, mockLearningContent } = require('../../test-helper');
-const { knex } = require('../../../db/knex-database-connection');
-const logger = require('../../../lib/infrastructure/logger');
+const { expect, databaseBuilder, sinon, mockLearningContent } = require('../../../test-helper');
+const { knex } = require('../../../../db/knex-database-connection');
+const logger = require('../../../../lib/infrastructure/logger');
 
-const { doJob } = require('../../../scripts/prod/convert-target-profiles-into-new-format');
+const { doJob } = require('../../../../scripts/prod/target-profile-migrations/convert-target-profiles-into-new-format');
 
 describe('Acceptance | Scripts | convert-target-profiles-into-new-format', function () {
   it('should execute the script as expected', async function () {

--- a/api/tests/acceptance/scripts/target-profile-migrations/copy-target-profile-skills-into-campaign-skills_test.js
+++ b/api/tests/acceptance/scripts/target-profile-migrations/copy-target-profile-skills-into-campaign-skills_test.js
@@ -1,0 +1,58 @@
+const { expect, databaseBuilder, sinon } = require('../../../test-helper');
+const { knex } = require('../../../../db/knex-database-connection');
+const logger = require('../../../../lib/infrastructure/logger');
+const CampaignTypes = require('../../../../lib/domain/models/CampaignTypes');
+const {
+  copySkills,
+} = require('../../../../scripts/prod/target-profile-migrations/copy-target-profile-skills-into-campaign-skills');
+
+describe('Acceptance | Scripts | copy-target-profile-skills-into-campaign-skills', function () {
+  afterEach(function () {
+    return knex('campaign_skills').delete();
+  });
+
+  it('should execute the script as expected', async function () {
+    // given
+    sinon.stub(logger, 'info');
+    sinon.stub(logger, 'error');
+    databaseBuilder.factory.buildTargetProfile({ id: 1 });
+    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: 1, skillId: 'skillA' });
+    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: 1, skillId: 'skillB' });
+    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: 1, skillId: 'skillC' });
+    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: 1, skillId: 'skillC' });
+    databaseBuilder.factory.buildTargetProfile({ id: 2 });
+    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: 2, skillId: 'skillA' });
+    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: 2, skillId: 'skillD' });
+    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: 2, skillId: 'skillE' });
+    databaseBuilder.factory.buildCampaign({ id: 10, type: CampaignTypes.ASSESSMENT, targetProfileId: 1 });
+    databaseBuilder.factory.buildCampaign({ id: 11, type: CampaignTypes.ASSESSMENT, targetProfileId: 1 });
+    databaseBuilder.factory.buildCampaign({ id: 12, type: CampaignTypes.ASSESSMENT, targetProfileId: 2 });
+    databaseBuilder.factory.buildCampaign({ id: 13, type: CampaignTypes.PROFILES_COLLECTION, targetProfileId: 2 });
+    await databaseBuilder.commit();
+
+    // when
+    await copySkills({ maxCampaignCount: 100, concurrency: 1 });
+
+    // then
+    const skillIdsForCampaign10 = await knex('campaign_skills')
+      .pluck('skillId')
+      .where('campaignId', 10)
+      .orderBy('skillId');
+    const skillIdsForCampaign11 = await knex('campaign_skills')
+      .pluck('skillId')
+      .where('campaignId', 11)
+      .orderBy('skillId');
+    const skillIdsForCampaign12 = await knex('campaign_skills')
+      .pluck('skillId')
+      .where('campaignId', 12)
+      .orderBy('skillId');
+    const skillIdsForCampaign13 = await knex('campaign_skills')
+      .pluck('skillId')
+      .where('campaignId', 13)
+      .orderBy('skillId');
+    expect(skillIdsForCampaign10).to.deep.equal(['skillA', 'skillB', 'skillC']);
+    expect(skillIdsForCampaign11).to.deep.equal(['skillA', 'skillB', 'skillC']);
+    expect(skillIdsForCampaign12).to.deep.equal(['skillA', 'skillD', 'skillE']);
+    expect(skillIdsForCampaign13).to.be.empty;
+  });
+});

--- a/api/tests/integration/domain/services/certification-badges-service_test.js
+++ b/api/tests/integration/domain/services/certification-badges-service_test.js
@@ -62,11 +62,10 @@ describe('Integration | Service | Certification-Badges Service', function () {
 
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
 
-      listSkill.forEach((skillId) => databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId }));
-
       const badge = databaseBuilder.factory.buildBadge.certifiable({ targetProfileId: targetProfileId });
 
       const campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
+      listSkill.forEach((skillId) => databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId }));
       const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ campaignId }).id;
 
       databaseBuilder.factory.buildBadgeAcquisition({ userId, badgeId: badge.id, campaignParticipationId });

--- a/api/tests/integration/domain/usecases/find-assessment-participation-result-list_test.js
+++ b/api/tests/integration/domain/usecases/find-assessment-participation-result-list_test.js
@@ -7,15 +7,11 @@ describe('Integration | UseCase | find-assessment-participation-result-list', fu
   const page = { number: 1 };
 
   beforeEach(async function () {
-    const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
     const skill = { id: 'recSkill', status: 'actif' };
-    databaseBuilder.factory.buildTargetProfileSkill({
-      targetProfileId: targetProfileId,
-      skillId: skill.id,
-    });
 
     organizationId = databaseBuilder.factory.buildOrganization().id;
-    campaignId = databaseBuilder.factory.buildCampaign({ organizationId, targetProfileId }).id;
+    campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+    databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: skill.id });
 
     const participation1 = { participantExternalId: 'Yubaba', campaignId, status: 'SHARED' };
     const participant1 = { firstName: 'Chihiro', lastName: 'Ogino' };

--- a/api/tests/integration/domain/usecases/get-campaign-participations-counts-by-stage_test.js
+++ b/api/tests/integration/domain/usecases/get-campaign-participations-counts-by-stage_test.js
@@ -45,10 +45,6 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-stage', 
     mockLearningContent(learningContentObjects);
 
     const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recSkillId1' });
-    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recSkillId2' });
-    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recSkillId3' });
-    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recSkillId4' });
     organizationId = databaseBuilder.factory.buildOrganization().id;
     userId = databaseBuilder.factory.buildUser().id;
     databaseBuilder.factory.buildMembership({ organizationId, userId });
@@ -61,6 +57,10 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-stage', 
     stage2 = databaseBuilder.factory.buildStage({ targetProfileId, threshold: 30 });
     stage3 = databaseBuilder.factory.buildStage({ targetProfileId, threshold: 70 });
     campaignId = databaseBuilder.factory.buildCampaign({ organizationId, targetProfileId }).id;
+    databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'recSkillId1' });
+    databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'recSkillId2' });
+    databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'recSkillId3' });
+    databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'recSkillId4' });
   });
 
   context('when requesting user is not allowed to access campaign informations', function () {
@@ -82,9 +82,8 @@ describe('Integration | UseCase | get-campaign-participations-counts-by-stage', 
 
   context('when the campaign doesnt manage stages', function () {
     it('should throw a NoStagesForCampaign error', async function () {
-      const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recSkillId1' });
-      const campaign2 = databaseBuilder.factory.buildCampaign({ organizationId, targetProfileId });
+      const campaign2 = databaseBuilder.factory.buildCampaign({ organizationId });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign2.id, skillId: 'recSkillId1' });
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/integration/domain/usecases/handle-badge-acquisition_test.js
+++ b/api/tests/integration/domain/usecases/handle-badge-acquisition_test.js
@@ -68,13 +68,13 @@ describe('Integration | Usecase | Handle Badge Acquisition', function () {
 
       userId = databaseBuilder.factory.buildUser().id;
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      listSkill.forEach((skillId) => databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId }));
       databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web1', status: 'validated' });
       databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web2', status: 'validated' });
       databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web3', status: 'validated' });
       databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web4', status: 'invalidated' });
 
       const campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
+      listSkill.forEach((skillId) => databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId }));
       const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ campaignId, userId }).id;
 
       badgeCompleted = databaseBuilder.factory.buildBadge({

--- a/api/tests/integration/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
+++ b/api/tests/integration/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
@@ -19,13 +19,12 @@ describe('Integration | Domain | UseCases | send-shared-participation-results-to
 
     userId = databaseBuilder.factory.buildUser().id;
     databaseBuilder.factory.buildAuthenticationMethod.withPoleEmploiAsIdentityProvider({ userId });
-    const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId });
 
     const organizationId = databaseBuilder.factory.buildOrganization().id;
     const tagId = databaseBuilder.factory.buildTag({ name: 'POLE EMPLOI' }).id;
     databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
-    const campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId, organizationId }).id;
+    const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+    databaseBuilder.factory.buildCampaignSkill({ campaignId });
     campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ campaignId, userId }).id;
     databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId });
 

--- a/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -56,12 +56,6 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
       });
 
       targetProfile = databaseBuilder.factory.buildTargetProfile({ name: '+Profile 1' });
-      ['recSkillWeb1', 'recSkillWeb2', 'recSkillWeb3'].forEach((skillId) => {
-        databaseBuilder.factory.buildTargetProfileSkill({
-          targetProfileId: targetProfile.id,
-          skillId: skillId,
-        });
-      });
 
       campaign = databaseBuilder.factory.buildCampaign({
         name: '@Campagne de Test N°1',
@@ -70,6 +64,12 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         idPixLabel: 'Mail Pro',
         type: 'ASSESSMENT',
         targetProfileId: targetProfile.id,
+      });
+      ['recSkillWeb1', 'recSkillWeb2', 'recSkillWeb3'].forEach((skillId) => {
+        databaseBuilder.factory.buildCampaignSkill({
+          campaignId: campaign.id,
+          skillId: skillId,
+        });
       });
 
       organizationLearner = { firstName: '@Jean', lastName: '=Bono' };

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-repository_test.js
@@ -7,268 +7,9 @@ const { NotFoundError } = require('../../../../lib/domain/errors');
 describe('Integration | Repository | Campaign Assessment Participation Result', function () {
   describe('#getByCampaignIdAndCampaignParticipationId', function () {
     context('when learning content is defined by target profile skills', function () {
-      let campaignId, campaignParticipationId, targetProfileId;
-
-      beforeEach(function () {
-        targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'skill1' });
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'skill2' });
-
-        const learningContent = {
-          frameworks: [{ id: 'frameworkId', name: 'frameworkName' }],
-          areas: [
-            {
-              id: 'recArea0',
-              competenceIds: ['rec1', 'rec2'],
-              color: 'orange',
-              frameworkId: 'frameworkId',
-            },
-          ],
-          competences: [
-            {
-              id: 'rec1',
-              index: '1.1',
-              areaId: 'recArea0',
-              skillIds: ['skill1'],
-              origin: 'Pix',
-              name_i18n: {
-                fr: 'Compétence 1',
-                en: 'English competence 1',
-              },
-            },
-            {
-              id: 'rec2',
-              index: '1.2',
-              areaId: 'recArea0',
-              skillIds: ['skill2'],
-              origin: 'Pix',
-              name_i18n: {
-                fr: 'Compétence 2',
-                en: 'English competence 2',
-              },
-            },
-          ],
-          thematics: [],
-          tubes: [
-            {
-              id: 'recTube1',
-              competenceId: 'rec1',
-            },
-            {
-              id: 'recTube2',
-              competenceId: 'rec2',
-            },
-          ],
-          skills: [
-            {
-              id: 'skill1',
-              name: '@acquis1',
-              status: 'actif',
-              tubeId: 'recTube1',
-              competenceId: 'rec1',
-            },
-            {
-              id: 'skill2',
-              name: '@acquis2',
-              status: 'actif',
-              tubeId: 'recTube2',
-              competenceId: 'rec1',
-            },
-          ],
-          challenges: [],
-        };
-
-        mockLearningContent(learningContent);
-        return databaseBuilder.commit();
-      });
-
-      afterEach(function () {
-        return knex('knowledge-element-snapshots').delete();
-      });
-
-      context('When campaign participation is shared', function () {
-        beforeEach(function () {
-          campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT', targetProfileId }).id;
-          const userId = databaseBuilder.factory.buildUser().id;
-          campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
-            campaignId,
-            userId,
-            sharedAt: new Date('2020-01-02'),
-          }).id;
-
-          databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId });
-
-          databaseBuilder.factory.buildKnowledgeElement({
-            userId,
-            skillId: 'skill1',
-            competenceId: 'rec1',
-            createdAt: new Date('2020-01-01'),
-            status: KnowledgeElement.StatusType.VALIDATED,
-          });
-          databaseBuilder.factory.buildKnowledgeElement({
-            userId,
-            skillId: 'skill2',
-            competenceId: 'rec2',
-            createdAt: new Date('2020-01-01'),
-            status: KnowledgeElement.StatusType.INVALIDATED,
-          });
-          databaseBuilder.factory.buildKnowledgeElement({
-            userId,
-            skillId: 'skill3',
-            competenceId: 'rec2',
-            createdAt: new Date('2020-01-01'),
-            status: KnowledgeElement.StatusType.VALIDATED,
-          });
-          return databaseBuilder.commit();
-        });
-
-        it('fills competenceResults', async function () {
-          const expectedResult = [
-            {
-              areaColor: 'orange',
-              id: `${campaignParticipationId}-rec1`,
-              index: '1.1',
-              name: 'Compétence 1',
-              competenceMasteryRate: 1,
-            },
-            {
-              areaColor: 'orange',
-              id: `${campaignParticipationId}-rec2`,
-              index: '1.2',
-              name: 'Compétence 2',
-              competenceMasteryRate: 0,
-            },
-          ];
-
-          const campaignAssessmentParticipationResult =
-            await campaignAssessmentParticipationResultRepository.getByCampaignIdAndCampaignParticipationId({
-              campaignId,
-              campaignParticipationId,
-            });
-
-          expect(campaignAssessmentParticipationResult.isShared).to.equal(true);
-          expect(campaignAssessmentParticipationResult.competenceResults.length).to.equal(2);
-          expect(campaignAssessmentParticipationResult.competenceResults).to.deep.equal(expectedResult);
-        });
-      });
-
-      context('When given locale is fr', function () {
-        const locale = FRENCH_SPOKEN;
-        beforeEach(function () {
-          campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT', targetProfileId }).id;
-          const userId = databaseBuilder.factory.buildUser().id;
-          campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
-            campaignId,
-            userId,
-            sharedAt: new Date('2020-01-02'),
-          }).id;
-          databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId });
-          return databaseBuilder.commit();
-        });
-
-        it('returns french', async function () {
-          const campaignAssessmentParticipationResult =
-            await campaignAssessmentParticipationResultRepository.getByCampaignIdAndCampaignParticipationId({
-              campaignId,
-              campaignParticipationId,
-              locale,
-            });
-
-          expect(campaignAssessmentParticipationResult.competenceResults[0].name).to.equal('Compétence 1');
-        });
-      });
-
-      context('When given locale is en', function () {
-        const locale = ENGLISH_SPOKEN;
-        beforeEach(function () {
-          campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT', targetProfileId }).id;
-          const userId = databaseBuilder.factory.buildUser().id;
-          campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
-            campaignId,
-            userId,
-            sharedAt: new Date('2020-01-02'),
-          }).id;
-          databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId });
-          return databaseBuilder.commit();
-        });
-
-        it('returns english', async function () {
-          const campaignAssessmentParticipationResult =
-            await campaignAssessmentParticipationResultRepository.getByCampaignIdAndCampaignParticipationId({
-              campaignId,
-              campaignParticipationId,
-              locale,
-            });
-
-          expect(campaignAssessmentParticipationResult.competenceResults[0].name).to.equal('English competence 1');
-        });
-      });
-
-      context('When no given locale', function () {
-        beforeEach(function () {
-          campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT', targetProfileId }).id;
-          const userId = databaseBuilder.factory.buildUser().id;
-          campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
-            campaignId,
-            userId,
-            sharedAt: new Date('2020-01-02'),
-          }).id;
-          databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId });
-          return databaseBuilder.commit();
-        });
-
-        it('returns french', async function () {
-          const campaignAssessmentParticipationResult =
-            await campaignAssessmentParticipationResultRepository.getByCampaignIdAndCampaignParticipationId({
-              campaignId,
-              campaignParticipationId,
-            });
-
-          expect(campaignAssessmentParticipationResult.competenceResults[0].name).to.equal('Compétence 1');
-        });
-      });
-
-      context('When something is wrong with a campaign participations', function () {
-        it('throws a NotFoundError when no existing campaign participation', async function () {
-          campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT', targetProfileId }).id;
-
-          await databaseBuilder.commit();
-
-          const error = await catchErr(
-            campaignAssessmentParticipationResultRepository.getByCampaignIdAndCampaignParticipationId
-          )({ campaignId, campaignParticipationId: 77777 });
-
-          //then
-          expect(error).to.be.instanceof(NotFoundError);
-        });
-
-        it('throws a NotFoundError when campaign participation is deleted', async function () {
-          campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT', targetProfileId }).id;
-          campaignParticipationId = databaseBuilder.factory.buildAssessmentFromParticipation({
-            sharedAt: null,
-            deletedAt: new Date('2022-01-01'),
-            campaignId,
-          }).campaignParticipationId;
-
-          await databaseBuilder.commit();
-
-          const error = await catchErr(
-            campaignAssessmentParticipationResultRepository.getByCampaignIdAndCampaignParticipationId
-          )({ campaignId, campaignParticipationId });
-
-          //then
-          expect(error).to.be.instanceof(NotFoundError);
-        });
-      });
-    });
-    context('when learning content is defined by campaign skills', function () {
       let campaignId, campaignParticipationId;
 
       beforeEach(function () {
-        campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT' }).id;
-        databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skill1' });
-        databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skill2' });
-
         const learningContent = {
           frameworks: [{ id: 'frameworkId', name: 'frameworkName' }],
           areas: [
@@ -343,6 +84,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
 
       context('When campaign participation is shared', function () {
         beforeEach(function () {
+          campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT' }).id;
+          _buildCampaignSkills(campaignId);
           const userId = databaseBuilder.factory.buildUser().id;
           campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
@@ -409,6 +152,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
       context('When given locale is fr', function () {
         const locale = FRENCH_SPOKEN;
         beforeEach(function () {
+          campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT' }).id;
+          _buildCampaignSkills(campaignId);
           const userId = databaseBuilder.factory.buildUser().id;
           campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
@@ -434,6 +179,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
       context('When given locale is en', function () {
         const locale = ENGLISH_SPOKEN;
         beforeEach(function () {
+          campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT' }).id;
+          _buildCampaignSkills(campaignId);
           const userId = databaseBuilder.factory.buildUser().id;
           campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
@@ -458,6 +205,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
 
       context('When no given locale', function () {
         beforeEach(function () {
+          campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT' }).id;
+          _buildCampaignSkills(campaignId);
           const userId = databaseBuilder.factory.buildUser().id;
           campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
             campaignId,
@@ -481,6 +230,11 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
 
       context('When something is wrong with a campaign participations', function () {
         it('throws a NotFoundError when no existing campaign participation', async function () {
+          campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT' }).id;
+          _buildCampaignSkills(campaignId);
+
+          await databaseBuilder.commit();
+
           const error = await catchErr(
             campaignAssessmentParticipationResultRepository.getByCampaignIdAndCampaignParticipationId
           )({ campaignId, campaignParticipationId: 77777 });
@@ -490,6 +244,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
         });
 
         it('throws a NotFoundError when campaign participation is deleted', async function () {
+          campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT' }).id;
+          _buildCampaignSkills(campaignId);
           campaignParticipationId = databaseBuilder.factory.buildAssessmentFromParticipation({
             sharedAt: null,
             deletedAt: new Date('2022-01-01'),
@@ -509,3 +265,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
     });
   });
 });
+
+function _buildCampaignSkills(campaignId) {
+  databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skill1' });
+  databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skill2' });
+}

--- a/api/tests/integration/infrastructure/repositories/campaign-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participant-repository_test.js
@@ -521,7 +521,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
       mockLearningContent(learningContent);
     });
     it('set the userId', async function () {
-      const campaign = buildCampaignWithCompleteTargetProfile({});
+      const campaign = buildCampaignWithSkills({});
       const { id: userId } = databaseBuilder.factory.buildUser();
 
       await databaseBuilder.commit();
@@ -539,7 +539,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
     context('when there is a previous campaign participation', function () {
       it('find the most recent campaign participation', async function () {
-        const campaignToStartParticipation = buildCampaignWithCompleteTargetProfile({
+        const campaignToStartParticipation = buildCampaignWithSkills({
           organizationId,
           multipleSendings: true,
           idPixLabel: 'externalId',
@@ -586,7 +586,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
     context('when there is no previous campaign participation', function () {
       it('return null', async function () {
-        const campaignToStartParticipation = buildCampaignWithCompleteTargetProfile({
+        const campaignToStartParticipation = buildCampaignWithSkills({
           organizationId,
           idPixLabel: 'externalId',
         });
@@ -608,7 +608,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
     context('when there is one organization learner', function () {
       it('find the organization learner', async function () {
-        const campaignToStartParticipation = buildCampaignWithCompleteTargetProfile({ organizationId });
+        const campaignToStartParticipation = buildCampaignWithSkills({ organizationId });
         const { id: userId } = databaseBuilder.factory.buildUser();
         const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
           userId,
@@ -630,7 +630,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
       });
 
       it('find only organization learner which is not disabled', async function () {
-        const campaignToStartParticipation = buildCampaignWithCompleteTargetProfile({ organizationId });
+        const campaignToStartParticipation = buildCampaignWithSkills({ organizationId });
         const { id: userId } = databaseBuilder.factory.buildUser();
         databaseBuilder.factory.buildOrganizationLearner({
           userId,
@@ -654,7 +654,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
       context('when the organization learner has already participated', function () {
         context('when the participation associated to the same user', function () {
           it('returns false for organizationLearnerHasParticipatedForAnotherUser', async function () {
-            const campaignToStartParticipation = buildCampaignWithCompleteTargetProfile({
+            const campaignToStartParticipation = buildCampaignWithSkills({
               organizationId,
             });
             const { id: userId } = databaseBuilder.factory.buildUser();
@@ -685,7 +685,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
           context('when there is participation for another campaign', function () {
             it('returns organization learner id', async function () {
-              const campaignToStartParticipation = buildCampaignWithCompleteTargetProfile({ organizationId });
+              const campaignToStartParticipation = buildCampaignWithSkills({ organizationId });
               const { id: userId } = databaseBuilder.factory.buildUser();
               const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
                 userId,
@@ -714,7 +714,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
         context('when the participation associated to another user', function () {
           it('takes into account the participation', async function () {
-            const campaignToStartParticipation = buildCampaignWithCompleteTargetProfile({ organizationId });
+            const campaignToStartParticipation = buildCampaignWithSkills({ organizationId });
             const { id: userId } = databaseBuilder.factory.buildUser();
             const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
               userId,
@@ -742,7 +742,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
           context('when the participation is deleted', function () {
             it('does not take into account the participation', async function () {
-              const campaignToStartParticipation = buildCampaignWithCompleteTargetProfile({ organizationId });
+              const campaignToStartParticipation = buildCampaignWithSkills({ organizationId });
               const { id: userId } = databaseBuilder.factory.buildUser();
               const { id: organizationLearnerId } = databaseBuilder.factory.buildOrganizationLearner({
                 userId,
@@ -772,7 +772,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
             context('when there are several previous participations', function () {
               it('does not take into account participations', async function () {
-                const campaignToStartParticipation = buildCampaignWithCompleteTargetProfile({
+                const campaignToStartParticipation = buildCampaignWithSkills({
                   multipleSendings: true,
                   organizationId,
                 });
@@ -821,7 +821,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
     context('when there are several organization learners', function () {
       context('when there are several organization Learners for the same user', function () {
         it('find the organizationLearnerId for the correct organization', async function () {
-          const campaignToStartParticipation = buildCampaignWithCompleteTargetProfile({ organizationId });
+          const campaignToStartParticipation = buildCampaignWithSkills({ organizationId });
           const { id: userId } = databaseBuilder.factory.buildUser();
           databaseBuilder.factory.buildOrganizationLearner({
             userId,
@@ -847,7 +847,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
       context('when there are several organization learners for the same organization', function () {
         it('find the organizationLearnerId for the correct user', async function () {
-          const campaignToStartParticipation = buildCampaignWithCompleteTargetProfile({ organizationId });
+          const campaignToStartParticipation = buildCampaignWithSkills({ organizationId });
           const { id: userId } = databaseBuilder.factory.buildUser();
           databaseBuilder.factory.buildOrganizationLearner({
             organizationId,
@@ -883,7 +883,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
         };
 
         mockLearningContent(learningContent);
-        const campaignToStartParticipation = buildCampaignWithCompleteTargetProfile(
+        const campaignToStartParticipation = buildCampaignWithSkills(
           {
             idPixLabel: 'email',
             type: 'ASSESSMENT',
@@ -921,7 +921,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
 
         mockLearningContent(learningContent);
 
-        const campaignToStartParticipation = buildCampaignWithCompleteTargetProfile(
+        const campaignToStartParticipation = buildCampaignWithSkills(
           {
             idPixLabel: 'email',
             type: 'ASSESSMENT',
@@ -932,7 +932,7 @@ describe('Integration | Infrastructure | Repository | CampaignParticipant', func
           },
           ['skill1']
         );
-        buildCampaignWithCompleteTargetProfile(
+        buildCampaignWithSkills(
           {
             idPixLabel: 'id',
             type: 'ASSESSMENT',
@@ -1028,19 +1028,17 @@ async function makeCampaignParticipant({
   return campaignParticipant;
 }
 
-function buildCampaignWithCompleteTargetProfile(attributes, skills = ['skill1']) {
+function buildCampaignWithSkills(attributes, skills = ['skill1']) {
   const { id: organizationId } = databaseBuilder.factory.buildOrganization({
     isManagingStudents: attributes.isRestricted,
     id: attributes.organizationId,
   });
-  const { id: targetProfileId } = databaseBuilder.factory.buildTargetProfile();
-  skills.forEach((skillId) => {
-    databaseBuilder.factory.buildTargetProfileSkill({ skillId, targetProfileId });
-  });
   const campaign = databaseBuilder.factory.buildCampaign({
     ...attributes,
     organizationId,
-    targetProfileId,
+  });
+  skills.forEach((skillId) => {
+    databaseBuilder.factory.buildCampaignSkill({ skillId, campaignId: campaign.id });
   });
 
   return new CampaignToStartParticipation({ ...campaign, ...attributes });

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -36,7 +36,6 @@ describe('Integration | Repository | Campaign Participation Overview', function 
     const learningContentObjects = learningContentBuilder.buildLearningContent.fromAreas(learningContent);
     mockLearningContent(learningContentObjects);
     targetProfile = databaseBuilder.factory.buildTargetProfile();
-    databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'recSkillId1' });
     databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id });
     await databaseBuilder.commit();
   });
@@ -51,6 +50,7 @@ describe('Integration | Repository | Campaign Participation Overview', function 
           organizationId,
           targetProfileId: targetProfile.id,
         });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'recSkillId1' });
         const { id: participationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -87,7 +87,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
 
       it('should retrieve all campaign participation of the user', async function () {
         const { id: campaign1Id } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign1Id, skillId: 'recSkillId1' });
         const { id: campaign2Id } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign2Id, skillId: 'recSkillId1' });
         const { id: participation1Id } = campaignParticipationOverviewFactory.build({
           userId,
           campaignId: campaign1Id,
@@ -108,7 +110,9 @@ describe('Integration | Repository | Campaign Participation Overview', function 
 
       it('should retrieve only campaign participation linked to ASSESSMENT', async function () {
         const { id: campaign1Id } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign1Id, skillId: 'recSkillId1' });
         const { id: campaign2Id } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign2Id, skillId: 'recSkillId1' });
         const { id: campaign3Id } = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.PROFILES_COLLECTION });
         const { id: participation1Id } = campaignParticipationOverviewFactory.build({
           userId,
@@ -134,6 +138,7 @@ describe('Integration | Repository | Campaign Participation Overview', function 
           targetProfileId: targetProfile.id,
           multipleSendings: true,
         });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'recSkillId1' });
         const { id: oldParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -161,6 +166,7 @@ describe('Integration | Repository | Campaign Participation Overview', function 
 
       it('retrieves information about the most recent assessment of campaign participation', async function () {
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'recSkillId1' });
         const { id: participationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -195,6 +201,7 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({
           targetProfileId: targetProfile.id,
         });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'recSkillId1' });
         const { id: participationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -220,6 +227,7 @@ describe('Integration | Repository | Campaign Participation Overview', function 
           targetProfileId: targetProfile.id,
           archivedAt,
         });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'recSkillId1' });
         const { id: participationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -242,12 +250,12 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         const { id: oldestParticipation } = campaignParticipationOverviewFactory.buildOnGoing({
           userId,
           createdAt: new Date('2020-01-01'),
-          targetProfileSkills: ['recSkillId1'],
+          campaignSkills: ['recSkillId1'],
         });
         campaignParticipationOverviewFactory.buildOnGoing({
           userId,
           createdAt: new Date('2020-01-02'),
-          targetProfileSkills: ['recSkillId1'],
+          campaignSkills: ['recSkillId1'],
         });
         await databaseBuilder.commit();
         const page = { number: 2, size: 1 };
@@ -379,19 +387,19 @@ describe('Integration | Repository | Campaign Participation Overview', function 
         it('orders all campaign participation by status', async function () {
           const { id: participationArchived } = campaignParticipationOverviewFactory.buildArchived({
             userId,
-            targetProfileSkills: ['recSkillId1'],
+            campaignSkills: ['recSkillId1'],
           });
           const { id: participationEndedId } = campaignParticipationOverviewFactory.buildEnded({
             userId,
-            targetProfileSkills: ['recSkillId1'],
+            campaignSkills: ['recSkillId1'],
           });
           const { id: participationOnGoingId } = campaignParticipationOverviewFactory.buildOnGoing({
             userId,
-            targetProfileSkills: ['recSkillId1'],
+            campaignSkills: ['recSkillId1'],
           });
           const { id: participationToShareId } = campaignParticipationOverviewFactory.buildToShare({
             userId,
-            targetProfileSkills: ['recSkillId1'],
+            campaignSkills: ['recSkillId1'],
           });
           await databaseBuilder.commit();
 
@@ -413,12 +421,12 @@ describe('Integration | Repository | Campaign Participation Overview', function 
           const { id: oldestParticipation } = campaignParticipationOverviewFactory.buildOnGoing({
             userId,
             createdAt: new Date('2020-01-01'),
-            targetProfileSkills: ['recSkillId1'],
+            campaignSkills: ['recSkillId1'],
           });
           const { id: newestParticipation } = campaignParticipationOverviewFactory.buildOnGoing({
             userId,
             createdAt: new Date('2020-01-02'),
-            targetProfileSkills: ['recSkillId1'],
+            campaignSkills: ['recSkillId1'],
           });
           await databaseBuilder.commit();
 
@@ -436,19 +444,19 @@ describe('Integration | Repository | Campaign Participation Overview', function 
             userId,
             sharedAt: new Date('2020-01-01'),
             createdAt: new Date('2020-01-04'),
-            targetProfileSkills: ['recSkillId1'],
+            campaignSkills: ['recSkillId1'],
           });
           const { id: secondParticipation } = campaignParticipationOverviewFactory.buildEnded({
             userId,
             sharedAt: new Date('2020-01-02'),
             createdAt: new Date('2020-01-02'),
-            targetProfileSkills: ['recSkillId1'],
+            campaignSkills: ['recSkillId1'],
           });
           const { id: lastParticipation } = campaignParticipationOverviewFactory.buildEnded({
             userId,
             sharedAt: new Date('2020-01-02'),
             createdAt: new Date('2020-01-03'),
-            targetProfileSkills: ['recSkillId1'],
+            campaignSkills: ['recSkillId1'],
           });
 
           await databaseBuilder.commit();
@@ -471,19 +479,19 @@ describe('Integration | Repository | Campaign Participation Overview', function 
             userId,
             sharedAt: new Date('2020-01-01'),
             createdAt: new Date('2020-01-04'),
-            targetProfileSkills: ['recSkillId1'],
+            campaignSkills: ['recSkillId1'],
           });
           const { id: lastParticipation } = campaignParticipationOverviewFactory.buildArchived({
             userId,
             sharedAt: new Date('2020-01-02'),
             createdAt: new Date('2020-01-02'),
-            targetProfileSkills: ['recSkillId1'],
+            campaignSkills: ['recSkillId1'],
           });
           const { id: secondParticipation } = campaignParticipationOverviewFactory.buildArchived({
             userId,
             sharedAt: null,
             createdAt: new Date('2020-01-03'),
-            targetProfileSkills: ['recSkillId1'],
+            campaignSkills: ['recSkillId1'],
           });
 
           await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-result-repository_test.js
@@ -11,10 +11,6 @@ describe('Integration | Repository | Campaign Participation Result', function ()
 
     beforeEach(function () {
       targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'skill1' });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'skill2' });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'skill3' });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'skill4' });
 
       const learningContent = {
         areas: [
@@ -65,6 +61,7 @@ describe('Integration | Repository | Campaign Participation Result', function ()
     it('use the most recent assessment to define if the participation is completed', async function () {
       const { id: userId } = databaseBuilder.factory.buildUser();
       const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+      _buildCampaignSkills(campaignId);
       const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -97,6 +94,7 @@ describe('Integration | Repository | Campaign Participation Result', function ()
     it('compute the number of skills, the number of skill tested and the number of skill validated', async function () {
       const { id: userId } = databaseBuilder.factory.buildUser();
       const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+      _buildCampaignSkills(campaignId);
       const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -155,6 +153,7 @@ describe('Integration | Repository | Campaign Participation Result', function ()
     it('computes the results for each competence assessed', async function () {
       const { id: userId } = databaseBuilder.factory.buildUser();
       const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+      _buildCampaignSkills(campaignId);
       const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -232,6 +231,7 @@ describe('Integration | Repository | Campaign Participation Result', function ()
       it('compute results by using knowledge elements', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+        _buildCampaignSkills(campaignId);
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -289,6 +289,7 @@ describe('Integration | Repository | Campaign Participation Result', function ()
       it('returns the stage reached', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+        _buildCampaignSkills(campaignId);
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -377,3 +378,10 @@ describe('Integration | Repository | Campaign Participation Result', function ()
     });
   });
 });
+
+function _buildCampaignSkills(campaignId) {
+  databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skill1' });
+  databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skill2' });
+  databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skill3' });
+  databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skill4' });
+}

--- a/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -45,10 +45,10 @@ describe('Integration | Repository | Campaign-Report', function () {
       beforeEach(function () {
         const learningContent = {
           skills: [
-            { id: 'skill1', tubeId: 1 },
-            { id: 'skill2', tubeId: 1 },
-            { id: 'skill3', tubeId: 2 },
-            { id: 'skill4', tubeId: 3 },
+            { id: 'skill1', tubeId: 'tube1' },
+            { id: 'skill2', tubeId: 'tube1' },
+            { id: 'skill3', tubeId: 'tube2' },
+            { id: 'skill4', tubeId: 'tube3' },
           ],
         };
 
@@ -63,9 +63,9 @@ describe('Integration | Repository | Campaign-Report', function () {
         });
         const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
 
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill1' });
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill2' });
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill3' });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'skill1' });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'skill2' });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'skill3' });
 
         await databaseBuilder.commit();
         const result = await campaignReportRepository.get(campaign.id);
@@ -92,7 +92,7 @@ describe('Integration | Repository | Campaign-Report', function () {
             multipleSendings: false,
           });
 
-          databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill1' });
+          databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'skill1' });
           databaseBuilder.factory.buildBadge({ targetProfileId: targetProfile.id, key: 1 });
           databaseBuilder.factory.buildBadge({ targetProfileId: targetProfile.id, key: 2 });
           databaseBuilder.factory.buildBadge({ key: 3 });
@@ -110,7 +110,7 @@ describe('Integration | Repository | Campaign-Report', function () {
             const targetProfile = databaseBuilder.factory.buildTargetProfile();
             const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
 
-            databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill1' });
+            databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'skill1' });
             databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id });
 
             await databaseBuilder.commit();
@@ -124,10 +124,7 @@ describe('Integration | Repository | Campaign-Report', function () {
             const { id: otherTargetProfilId } = databaseBuilder.factory.buildTargetProfile();
             const campaign = databaseBuilder.factory.buildCampaign();
 
-            databaseBuilder.factory.buildTargetProfileSkill({
-              targetProfileId: campaign.targetProfileId,
-              skillId: 'skill1',
-            });
+            databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'skill1' });
             databaseBuilder.factory.buildStage({ targetProfileId: otherTargetProfilId });
 
             await databaseBuilder.commit();
@@ -143,11 +140,7 @@ describe('Integration | Repository | Campaign-Report', function () {
       let campaign;
       beforeEach(function () {
         campaign = databaseBuilder.factory.buildCampaign();
-
-        databaseBuilder.factory.buildTargetProfileSkill({
-          targetProfileId: campaign.targetProfileId,
-          skillId: 'skill1',
-        });
+        databaseBuilder.factory.buildCampaignSkill({ campaignId: campaign.id, skillId: 'skill1' });
 
         const learningContent = { skills: [{ id: 'skill1' }] };
 

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -285,17 +285,16 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
   });
 
   describe('findByCampaignIdForSharedCampaignParticipation', function () {
-    let userId, targetProfileId, campaignId;
+    let userId, campaignId;
 
     beforeEach(function () {
-      targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       userId = databaseBuilder.factory.buildUser().id;
-      campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
+      campaignId = databaseBuilder.factory.buildCampaign().id;
     });
 
     it('should have the skill Id', async function () {
       // given
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 12 });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 12 });
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -322,7 +321,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
     it('should return nothing when there is no shared campaign participations', async function () {
       // given
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 1 });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 1 });
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -348,9 +347,9 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
     it('should return a list of knowledge elements when there are shared campaign participations', async function () {
       // given
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 1 });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 2 });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 3 });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 1 });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 2 });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 3 });
       const otherUserId = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
@@ -396,8 +395,8 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
     it('should return a list of knowledge elements when there are validated knowledge elements', async function () {
       // given
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recSkill1' });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recSkill2' });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'recSkill1' });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'recSkill2' });
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -430,7 +429,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
     it('should return a list of knowledge elements whose its skillId is included in the campaign target profile', async function () {
       // given
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recSkill1' });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'recSkill1' });
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -463,7 +462,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
     it('should return only knowledge elements before shared date', async function () {
       // given
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 1 });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 1 });
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -496,7 +495,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
     it('should return only last knowledge element for a skill', async function () {
       // given
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 1 });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 1 });
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -530,8 +529,8 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
     it('should return latest knowledge elements by skill for each user in the campaign', async function () {
       // given
       const userId2 = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 12 });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 13 });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 12 });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 13 });
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -575,7 +574,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
     it('should return only last knowledge element if validated for a skill within sharedAt date', async function () {
       // given
       const userId2 = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 12 });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 12 });
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -621,19 +620,18 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
   });
 
   describe('findByCampaignIdAndUserIdForSharedCampaignParticipation', function () {
-    let userId, targetProfileId, campaignId;
+    let userId, campaignId;
 
     beforeEach(function () {
-      targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       userId = databaseBuilder.factory.buildUser().id;
-      campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
+      campaignId = databaseBuilder.factory.buildCampaign().id;
     });
 
     it('should return a list of knowledge elements for a given user', async function () {
       // given
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 1 });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 2 });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 3 });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 1 });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 2 });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 3 });
       const otherUserId = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
@@ -681,7 +679,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
     it('should return only knowledge elements before shared date', async function () {
       // given
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 1 });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 1 });
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -716,7 +714,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
     it('should return only last knowledge element if validated for a skill within sharedAt date', async function () {
       // given
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 1 });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 1 });
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -758,7 +756,7 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
     it('should not return any knowledge element if latest by skill is not validated', async function () {
       // given
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 1 });
+      databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 1 });
       databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -793,13 +791,10 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
   });
 
   describe('#findSnapshotGroupedByCompetencesForUsers', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const sandbox = sinon.createSandbox();
-    let userId1;
-    let userId2;
+    let userId1, userId2, sandbox;
 
     beforeEach(function () {
+      sandbox = sinon.createSandbox();
       userId1 = databaseBuilder.factory.buildUser().id;
       userId2 = databaseBuilder.factory.buildUser().id;
       return databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
@@ -15,11 +15,6 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
       domainBuilder.buildAssessment();
       targetProfile = domainBuilder.buildTargetProfile({ ownerOrganizationId: null });
       databaseBuilder.factory.buildTargetProfile(targetProfile);
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill1' });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill2' });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill3' });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill4' });
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: 'skill6' });
 
       const learningContent = {
         areas: [
@@ -71,6 +66,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
     it('use the most recent assessment to define if the participation is completed', async function () {
       const { id: userId } = databaseBuilder.factory.buildUser();
       const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+      _buildCampaignSkills(campaignId);
       const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -111,6 +107,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
           tagetProfileId: targetProfile.id,
           multipleSendings: true,
         });
+        _buildCampaignSkills(campaignId);
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -140,6 +137,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
           targetProfileId: targetProfile.id,
           multipleSendings: true,
         });
+        _buildCampaignSkills(campaignId);
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -166,6 +164,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
           tagetProfileId: targetProfile.id,
           multipleSendings: false,
         });
+        _buildCampaignSkills(campaignId);
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -192,6 +191,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
           targetProfileId: targetProfile.id,
           multipleSendings: true,
         });
+        _buildCampaignSkills(campaignId);
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -218,6 +218,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
           targetProfileId: targetProfile.id,
           multipleSendings: true,
         }).id;
+        _buildCampaignSkills(campaignId);
         const userId = databaseBuilder.factory.buildUser().id;
         databaseBuilder.factory.buildOrganizationLearner({ userId, organizationId, isDisabled: true });
         const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
@@ -256,6 +257,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
           targetProfileId: targetProfile.id,
           multipleSendings: true,
         }).id;
+        _buildCampaignSkills(campaignId);
         const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -300,6 +302,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({
           archivedAt: new Date(),
         });
+        _buildCampaignSkills(campaignId);
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -325,6 +328,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         // given
         const { id: userId } = databaseBuilder.factory.buildUser();
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({ archivedAt: null });
+        _buildCampaignSkills(campaignId);
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -350,6 +354,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         // given
         const { id: userId } = databaseBuilder.factory.buildUser();
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({ archivedAt: null });
+        _buildCampaignSkills(campaignId);
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -375,6 +380,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
     it('compute the number of skills, the number of skill tested and the number of skill validated', async function () {
       const { id: userId } = databaseBuilder.factory.buildUser();
       const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+      _buildCampaignSkills(campaignId);
       const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -427,6 +433,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
     it('compute the number of skills, the number of skill tested and the number of skill validated using operative skills', async function () {
       const { id: userId } = databaseBuilder.factory.buildUser();
       const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+      _buildCampaignSkills(campaignId);
       const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -471,6 +478,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
     it('computes the results for each competence assessed', async function () {
       const { id: userId } = databaseBuilder.factory.buildUser();
       const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+      _buildCampaignSkills(campaignId);
       const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
         userId,
         campaignId,
@@ -551,6 +559,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const { id: otherTargetProfileId } = databaseBuilder.factory.buildTargetProfile();
         const { id: userId } = databaseBuilder.factory.buildUser();
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        _buildCampaignSkills(campaignId);
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -644,6 +653,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
       it('computes the results for each badge', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        _buildCampaignSkills(campaignId);
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -714,6 +724,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
       it('computes the results for each badge earned during the current campaign participation', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        _buildCampaignSkills(campaignId);
         const { id: otherCampaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
@@ -801,6 +812,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         it('computes the buildSkillSet for each competence of badge', async function () {
           const { id: userId } = databaseBuilder.factory.buildUser();
           const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+          _buildCampaignSkills(campaignId);
           const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
             userId,
             campaignId,
@@ -901,6 +913,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
       it('should throw a not found error', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        _buildCampaignSkills(campaignId);
         await databaseBuilder.commit();
 
         const error = await catchErr(participantResultRepository.getByUserIdAndCampaignId)({
@@ -919,6 +932,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
       it('returns the mastery rate for the participation using the mastery rate stocked', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        _buildCampaignSkills(campaignId);
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -944,6 +958,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
       it('returns the mastery rate for the participation using knowledge elements', async function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+        _buildCampaignSkills(campaignId);
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -972,6 +987,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
           tagetProfileId: targetProfile.id,
           multipleSendings: true,
         });
+        _buildCampaignSkills(campaignId);
         const { id: oldCampaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -1017,6 +1033,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({
           assessmentMethod: Assessment.methods.FLASH,
         });
+        _buildCampaignSkills(campaignId);
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -1048,3 +1065,11 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
     });
   });
 });
+
+function _buildCampaignSkills(campaignId) {
+  databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skill1' });
+  databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skill2' });
+  databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skill3' });
+  databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skill4' });
+  databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: 'skill6' });
+}

--- a/api/tests/integration/infrastructure/repositories/participant-results-shared-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/participant-results-shared-repository_test.js
@@ -350,13 +350,12 @@ describe('Integration | Repository | Campaign Participant Result Shared Reposito
 });
 
 function _buildCampaignForSkills(skillIds) {
-  const { id: targetProfileId } = databaseBuilder.factory.buildTargetProfile();
+  const campaign = databaseBuilder.factory.buildCampaign({ type: CampaignTypes.ASSESSMENT });
 
   skillIds.forEach((skillId) => {
-    databaseBuilder.factory.buildTargetProfileSkill({ skillId, targetProfileId });
+    databaseBuilder.factory.buildCampaignSkill({ skillId, campaignId: campaign.id });
   });
-
-  return databaseBuilder.factory.buildCampaign({ targetProfileId, type: CampaignTypes.ASSESSMENT });
+  return campaign;
 }
 
 function _buildParticipationWithSnapshot(participationAttributes, knowledgeElementsAttributes) {

--- a/api/tests/integration/scripts/data-generation/generate-certif-cli_test.js
+++ b/api/tests/integration/scripts/data-generation/generate-certif-cli_test.js
@@ -8,7 +8,7 @@ const skillRepository = require('../../../../lib/infrastructure/repositories/ski
 const competenceRepository = require('../../../../lib/infrastructure/repositories/competence-repository');
 const challengeRepository = require('../../../../lib/infrastructure/repositories/challenge-repository');
 const databaseBuffer = require('../../../../db/database-builder/database-buffer');
-
+// FIXME Too hard to edit \o/
 describe('Integration | Scripts | generate-certif-cli.js', function () {
   const certificationCenterSup = { id: 3, type: 'SUP' };
   const certificationCenterPro = { id: 2, type: 'PRO' };

--- a/api/tests/integration/scripts/prod/compute-badge-acquisitions_test.js
+++ b/api/tests/integration/scripts/prod/compute-badge-acquisitions_test.js
@@ -130,7 +130,6 @@ describe('Script | Prod | Compute Badge Acquisitions', function () {
       userId1 = databaseBuilder.factory.buildUser().id;
       userId2 = databaseBuilder.factory.buildUser().id;
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      listSkill.forEach((skillId) => databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId }));
       databaseBuilder.factory.buildKnowledgeElement({ userId: userId1, skillId: 'web1', status: 'validated' });
       databaseBuilder.factory.buildKnowledgeElement({ userId: userId1, skillId: 'web2', status: 'validated' });
       databaseBuilder.factory.buildKnowledgeElement({ userId: userId1, skillId: 'web3', status: 'validated' });
@@ -142,6 +141,7 @@ describe('Script | Prod | Compute Badge Acquisitions', function () {
       databaseBuilder.factory.buildKnowledgeElement({ userId: userId2, skillId: 'web4', status: 'invalidated' });
 
       const campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
+      listSkill.forEach((skillId) => databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId }));
       campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({ campaignId, userId: userId1 });
       campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({ campaignId, userId: userId2 });
 
@@ -269,13 +269,13 @@ describe('Script | Prod | Compute Badge Acquisitions', function () {
 
       userId = databaseBuilder.factory.buildUser().id;
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      listSkill.forEach((skillId) => databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId }));
       databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web1', status: 'validated' });
       databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web2', status: 'validated' });
       databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web3', status: 'validated' });
       databaseBuilder.factory.buildKnowledgeElement({ userId, skillId: 'web4', status: 'invalidated' });
 
       const campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
+      listSkill.forEach((skillId) => databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId }));
       campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId, userId });
 
       badgeCompleted = databaseBuilder.factory.buildBadge({

--- a/api/tests/integration/scripts/prod/compute-participation-results_test.js
+++ b/api/tests/integration/scripts/prod/compute-participation-results_test.js
@@ -239,12 +239,12 @@ describe('computeParticipationResults', function () {
 
 function _buildCampaignForSkills(skillIds) {
   const { id: targetProfileId } = databaseBuilder.factory.buildTargetProfile();
+  const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId });
 
   skillIds.forEach((skillId) => {
-    databaseBuilder.factory.buildTargetProfileSkill({ skillId, targetProfileId });
+    databaseBuilder.factory.buildCampaignSkill({ skillId, campaignId: campaign.id });
   });
-
-  return databaseBuilder.factory.buildCampaign({ targetProfileId });
+  return campaign;
 }
 
 function _buildParticipationWithSnapshot(participationAttributes, knowledgeElementsAttributes) {

--- a/api/tests/integration/scripts/prod/compute-pole-emploi-sendings_test.js
+++ b/api/tests/integration/scripts/prod/compute-pole-emploi-sendings_test.js
@@ -43,7 +43,7 @@ describe('computePoleEmploiSendings', function () {
             tubes: [
               {
                 id: 'tube1Id',
-                skills: [{ id: skill1.id, nom: '@web1' }],
+                skills: [{ id: skill1.id, nom: '@web1', difficulty: 1 }],
               },
             ],
           },
@@ -53,7 +53,7 @@ describe('computePoleEmploiSendings', function () {
             tubes: [
               {
                 id: 'tube2Id',
-                skills: [{ id: skill2.id, nom: '@file1' }],
+                skills: [{ id: skill2.id, nom: '@file1', difficulty: 1 }],
               },
             ],
           },
@@ -66,9 +66,6 @@ describe('computePoleEmploiSendings', function () {
     const tagId = databaseBuilder.factory.buildTag({ name: 'POLE EMPLOI' }).id;
     databaseBuilder.factory.buildOrganizationTag({ tagId, organizationId });
     const targetProfileId = databaseBuilder.factory.buildTargetProfile({ name: 'Diagnostic initial' }).id;
-    [skill1, skill2].forEach((skill) =>
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: skill.id })
-    );
     campaignId = databaseBuilder.factory.buildCampaign({
       name: 'Campagne Pôle Emploi',
       code,
@@ -76,6 +73,7 @@ describe('computePoleEmploiSendings', function () {
       organizationId,
       targetProfileId,
     }).id;
+    [skill1, skill2].forEach((skill) => databaseBuilder.factory.buildCampaignSkill({ campaignId, skillId: skill.id }));
     userId = databaseBuilder.factory.buildUser({ firstName: 'Martin', lastName: 'Tamare' }).id;
     return databaseBuilder.commit();
   });


### PR DESCRIPTION
## :christmas_tree: Problème
Poursuite de l'epic, maintenant les acquis de la campagne sont associés à la campagne. Il faut rétroactivement associer les acquis à toutes les campagnes.

## :gift: Proposition
Déplacer le contenu de target-profile-skills vers campaign_skills

## :star2: Remarques
⚠️ Script à exécuter sur chaque environnement -> Integ / recette / prod

📖 **TODO** Modifier les seeds pour que les campagnes créées aient aussi la création de leur **campaign-skills** (#mortDuFun)

## :santa: Pour tester
On peut exécuter le script sur la RA et vérifier que les campagnes en cours sont ISO (page d'analyse / de résulats par ex)
