### PR TITLE
[FEATURE] Utiliser les informations de l'éditeur de contenus formatifs (PIX-6139)

### DIFF
--- a/mon-pix/app/components/training/card.hbs
+++ b/mon-pix/app/components/training/card.hbs
@@ -14,8 +14,8 @@
     <div class="training-card-content__illustration">
       <img
         class="training-card-content-illustration__logo"
-        src="/images/logo/logo-ministere-education-nationale-et-jeunesse.svg"
-        alt="{{t 'common.french-education-ministry'}}"
+        src={{@training.editorLogoUrl}}
+        alt="{{@training.editorName}}"
       />
       {{! template-lint-disable require-valid-alt-text }}
       <img class="training-card-content-illustration__image" src={{this.imageSrc}} alt="" />

--- a/mon-pix/app/models/training.js
+++ b/mon-pix/app/models/training.js
@@ -6,6 +6,8 @@ export default class Training extends Model {
   @attr('string') link;
   @attr('string') type;
   @attr('string') locale;
+  @attr('string') editorName;
+  @attr('string') editorLogoUrl;
   @attr() duration;
 
   @belongsTo('campaign-participation') campaignParticpation;

--- a/mon-pix/mirage/factories/user.js
+++ b/mon-pix/mirage/factories/user.js
@@ -252,6 +252,8 @@ export default Factory.extend({
         type: 'autoformation',
         duration: '10:00:00',
         locale: 'fr-fr',
+        editorName: "Ministère de l'éducation nationale et de la jeunesse",
+        editorLogoUrl: 'https://mon-logo.svg',
       });
       const anotherTraining = server.create('training', {
         title: 'Apprendre à piloter des chauves-souris',
@@ -259,6 +261,8 @@ export default Factory.extend({
         type: 'webinaire',
         duration: '10:00:00',
         locale: 'fr-fr',
+        editorName: "Ministère de l'éducation nationale et de la jeunesse",
+        editorLogoUrl: 'https://mon-logo.svg',
       });
       const trainings = [training, anotherTraining];
       user.update({ trainings });

--- a/mon-pix/tests/integration/components/training/card_test.js
+++ b/mon-pix/tests/integration/components/training/card_test.js
@@ -14,6 +14,9 @@ module('Integration | Component | Training | Card', function (hooks) {
       type: 'webinaire',
       locale: 'fr-fr',
       duration: { hours: 6 },
+      editorName: "Ministère de l'éducation nationale et de la jeunesse",
+      editorLogoUrl:
+        'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
     });
 
     // when
@@ -21,25 +24,19 @@ module('Integration | Component | Training | Card', function (hooks) {
 
     // then
     assert.dom('.training-card').exists();
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.training-card__content').href, 'https://training.net/');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.training-card-content__title').textContent.trim(), 'Mon super training');
+    assert.strictEqual(find('.training-card__content').href, 'https://training.net/');
+    assert.strictEqual(find('.training-card-content__title').textContent.trim(), 'Mon super training');
     assert.dom('.training-card-content__infos').exists();
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.training-card-content-infos-list__type').textContent.trim(), 'Webinaire');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.training-card-content-infos-list__duration').textContent.trim(), '6h');
+    assert.strictEqual(find('.training-card-content-infos-list__type').textContent.trim(), 'Webinaire');
+    assert.strictEqual(find('.training-card-content-infos-list__duration').textContent.trim(), '6h');
     assert.notOk(find('.training-card-content-illustration__image').alt);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(
+    assert.strictEqual(
       find('.training-card-content-illustration__logo').alt,
-      this.intl.t('common.french-education-ministry')
+      "Ministère de l'éducation nationale et de la jeunesse"
+    );
+    assert.strictEqual(
+      find('.training-card-content-illustration__logo').src,
+      'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg'
     );
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, le logo du ministère de l'éducation nationale et de la jeunesse et son attribut alternatif sont en dur.

## :gift: Proposition
Utiliser les informations ramenées de la base de données.

## :star2: Remarques
Un seed avec un lien cassé permet de constater l'apparition de l'attribut `alt`.

## :santa: Pour tester
- Se connecter à Pix app
- Aller sur la page /mes-formations
- Constater la présence du logo de l'éducation nationale sur les différentes formations sauf sur la deuxième qui affiche `"Autre ministère"`.