### PR TITLE
[TECH] Vérifier qu'aucun acquis n'est enregistré lors de la création d'une campagne flash (PIX-6547).

### DIFF
--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -379,6 +379,37 @@ describe('Integration | Repository | Campaign', function () {
       });
     });
 
+    context('when assessment method is `flash`', function () {
+      it('should not save any skills', async function () {
+        const user = databaseBuilder.factory.buildUser();
+        const creatorId = user.id;
+        const ownerId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        databaseBuilder.factory.buildMembership({ userId: creatorId, organizationId });
+
+        await databaseBuilder.commit();
+
+        const campaignToSave = {
+          name: 'Evaluation niveau 1 recherche internet',
+          code: 'BCTERD153',
+          customLandingPageText: 'Parcours évaluatif concernant la recherche internet',
+          creatorId,
+          ownerId,
+          organizationId,
+          multipleSendings: true,
+          type: CampaignTypes.ASSESSMENT,
+          assessmentMethod: 'FLASH',
+          targetProfileId: null,
+          title: 'Parcours recherche internet',
+        };
+
+        const savedCampaign = await campaignRepository.save(campaignToSave);
+
+        const skillIds = await knex('campaign_skills').pluck('skillId').where('campaignId', savedCampaign.id);
+        expect(skillIds).to.deepEqualArray([]);
+      });
+    });
+
     it('should save the given campaign with type PROFILES_COLLECTION', async function () {
       // given
       const user = databaseBuilder.factory.buildUser();


### PR DESCRIPTION
## :christmas_tree: Problème
Les campagnes flash ne sont liées à aucun profil cible, donc nous ne devons enregistrer aucun acquis lors de leur création.

## :gift: Proposition
Ajouter un test qui vérifie ce comportement.

## :star2: Remarques
RAS

## :santa: Pour tester
Lancer une campagne flash et vérifier que tout se passe bien.
