### PR TITLE
[BUGFIX] Corriger la réinitialisation du formulaire et le chargement infini de la création de compte SCO sur pix App (PIX-6107).

### DIFF
--- a/mon-pix/app/components/routes/register-form.hbs
+++ b/mon-pix/app/components/routes/register-form.hbs
@@ -142,16 +142,15 @@
         {{/if}}
       </div>
 
-      <LinkTo
-        @route="campaigns.access"
-        @model={{@campaignCode}}
-        class="link link--underline register-form__return-button"
+      <PixButton
+        @triggerAction={{this.resetForm}}
+        @isBorderVisible={{true}}
+        @backgroundColor="transparent-light"
+        class="register-form__reset-form-button"
       >
-        <span class="icon-button register-form-return-button__icon">
-          <FaIcon @icon="arrow-left" />
-        </span>
+        <FaIcon @icon="arrow-left" />
         {{t "pages.login-or-register.register-form.not-me"}}
-      </LinkTo>
+      </PixButton>
 
       <p class="legal-notice">
         {{t "pages.login-or-register.register-form.rgpd-legal-notice"}}

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -82,16 +82,16 @@ export default class RegisterForm extends Component {
 
   dependentUser = null;
   scoOrganizationLearner = null;
-  validation = new FormValidation();
+  @tracked validation = new FormValidation();
 
-  username = '';
-  email = '';
-  password = '';
-  firstName = '';
-  lastName = '';
-  dayOfBirth = '';
-  monthOfBirth = '';
-  yearOfBirth = '';
+  @tracked username = '';
+  @tracked email = '';
+  @tracked password = '';
+  @tracked firstName = '';
+  @tracked lastName = '';
+  @tracked dayOfBirth = '';
+  @tracked monthOfBirth = '';
+  @tracked yearOfBirth = '';
 
   get birthdate() {
     const dayOfBirth = standardizeNumberInTwoDigitFormat(this.dayOfBirth.trim());
@@ -248,7 +248,7 @@ export default class RegisterForm extends Component {
   @action
   triggerInputYearValidation(key, value) {
     value = value.trim();
-    this.yearOfBirth = value;
+    this._standardizeNumberInInput('yearOfBirth', value);
     this._validateInputYear(key, value);
   }
 
@@ -260,6 +260,23 @@ export default class RegisterForm extends Component {
   @action
   triggerInputPasswordValidation(key, value) {
     this._validateInputPassword(key, value);
+  }
+
+  @action
+  resetForm() {
+    if (this.scoOrganizationLearner) this.scoOrganizationLearner.unloadRecord();
+    if (this.dependentUser) this.dependentUser.unloadRecord();
+    this.firstName = null;
+    this.lastName = null;
+    this.dayOfBirth = null;
+    this.monthOfBirth = null;
+    this.yearOfBirth = null;
+    this.password = null;
+    this.email = null;
+    this.username = null;
+    this.matchingStudentFound = false;
+    this.loginWithUsername = true;
+    this.validation = new FormValidation();
   }
 
   _executeFieldValidation(key, value, isValid) {

--- a/mon-pix/app/styles/components/_pix-toggle.scss
+++ b/mon-pix/app/styles/components/_pix-toggle.scss
@@ -1,6 +1,5 @@
 .pix-toggle {
   display: flex;
-  width: 359px;
   height: 44px;
   color: $pix-neutral-60;
   font-weight: $font-medium;

--- a/mon-pix/app/styles/components/_register-form.scss
+++ b/mon-pix/app/styles/components/_register-form.scss
@@ -59,19 +59,11 @@
     border: none;
   }
 
-  &__return-button {
-    display: inline-flex;
-    align-items: center;
-    margin: 4px 0;
-    font-size: 0.875rem;
-    font-family: $font-roboto;
-  }
-
-  &__return-button:hover {
-
-    > .register-form-return-button__icon {
-      background-color: $pix-neutral-20;
-    }
+  &__reset-form-button {
+    display: flex;
+    gap: 6px;
+    width: 100%;
+    margin-top: 10px;
   }
 
   &__error {

--- a/mon-pix/tests/unit/components/register-form_test.js
+++ b/mon-pix/tests/unit/components/register-form_test.js
@@ -1,0 +1,45 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+import { setupTest } from 'ember-qunit';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+
+module('Unit | Component | register-form', function (hooks) {
+  setupTest(hooks);
+
+  module('#resetForm', function () {
+    module('when click on "It\'s not me"', function () {
+      test('should reset register form', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const unloadRecordStub = sinon.stub();
+        store.createRecord('sco-organization-learner', { unloadRecord: unloadRecordStub });
+        store.createRecord('dependent-user', { unloadRecord: unloadRecordStub });
+        const component = createGlimmerComponent('component:routes/register-form');
+        component.firstName = 'Lili';
+        component.lastName = 'Coptère';
+        component.monthOfBirth = '05';
+        component.yearOfBirth = '2002';
+        component.dayOfBirth = '02';
+        component.email = 'lili.coptere@ciel.clair';
+        component.username = 'lilicoptere0205';
+        component.matchingStudentFound = true;
+        component.loginWithUsername = false;
+
+        // when
+        await component.resetForm();
+
+        // then
+        assert.strictEqual(component.firstName, null);
+        assert.strictEqual(component.lastName, null);
+        assert.strictEqual(component.monthOfBirth, null);
+        assert.strictEqual(component.yearOfBirth, null);
+        assert.strictEqual(component.dayOfBirth, null);
+        assert.strictEqual(component.email, null);
+        assert.strictEqual(component.username, null);
+        assert.strictEqual(component.password, null);
+        assert.false(component.matchingStudentFound);
+        assert.true(component.loginWithUsername);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
Sur Pix App, lorsqu'un élève déconnecté entre une campagne SCO (/campagnes), il accède à la double mire lui permettant de se connecter ou de créer un compte Pix. Dans la partie création, si l'élève entre un nom, prénom et date de naissance valides, on lui propose un identifiant et un mot de passe à saisir.

L'erreur initiale était que si l'élève clique sur le lien "Ce n'est pas moi" à la fin du formulaire et le remplissait à nouveau nom, prénom et date de naissance , le bouton "Je m'inscris" charge à l'infini et il ne se passe plus rien.

Or en voulant reproduire le bug, on a constaté une autre erreur, le lien "Ce n'est pas moi" ne réinitialisait plus le formulaire.

## :gift: Proposition
Remplacer le lien "Ce n'est pas moi" par un bouton qui réinitialise le formulaire.
Ce bouton fixe l'autre erreur de chargement infini en supprimant des entrées Ember.

## :star2: Remarques
Initialement ce lien était un composant linkTo Ember qui depuis la montée de version d'Ember en 3.28, ne permettait plus le rafraîchissement du formulaire. On a donc opté pour un bouton dont l'action réinitialise le formulaire en question.

Le chargement infini était causé par une erreur Ember. 
<img width="530" alt="Capture d’écran 2022-12-13 à 15 39 53" src="https://user-images.githubusercontent.com/58915422/207647217-3d5133e0-a342-494c-bc2c-3c7b1f9603bc.png">

Lorsque l'élève remplit la première fois le formulaire, on enregistre 2 entrées : `dependant-user` et `sco-organization-learner`. Ces entrées n'étaient plus supprimés lorsque l'élève cliquait sur "Ce n'est pas moi". La suppression avait été retiré du code lors d'une montée de version également.

Changement du lien en bouton :
AVANT
<img width="399" alt="Capture d’écran 2022-12-14 à 17 25 42" src="https://user-images.githubusercontent.com/58915422/207651815-0c687b86-f9c4-4cd0-893d-117a63db542c.png">


APRÈS
<img width="416" alt="Capture d’écran 2022-12-14 à 16 55 32" src="https://user-images.githubusercontent.com/58915422/207651634-59e1a053-78ad-4cba-bd5a-f45e302468ae.png">


## :santa: Pour tester

- Aller sur Pix App
- Entrer `/campagnes`
- Entrer le code SCOBADGE1
- Dans la double mire entrer le seed suivant : first last 10 10 2010
- Cliquer sur le bouton "Ce n'est pas moi"
- Constater que les champs (nom, prénom et date de naissance, email ou username) ont été réinitialisé, la deuxième partie du formulaire de nouveau masqué.
- Entrer un autre seed : prenom nom 09 09 2009
- Constater que le bouton ne load pas à l'infini :))))))

