### PR TITLE
[FEATURE] Ajout d'une route dans l'API pour créer des contenus formatifs (PIX-6416)

### DIFF
--- a/api/lib/application/trainings/index.js
+++ b/api/lib/application/trainings/index.js
@@ -39,6 +39,43 @@ exports.register = async (server) => {
       },
     },
     {
+      method: 'POST',
+      path: '/api/admin/trainings',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+          },
+        ],
+        handler: trainingsController.create,
+        validate: {
+          payload: Joi.object({
+            data: Joi.object({
+              attributes: Joi.object({
+                link: Joi.string().required(),
+                title: Joi.string().required(),
+                duration: Joi.string().required(),
+                type: Joi.string().valid('autoformation', 'webinaire').required(),
+                locale: Joi.string().valid('fr-fr', 'fr', 'en-gb').required(),
+                editorName: Joi.string().required(),
+                editorLogoUrl: Joi.string().required(),
+              }),
+              type: Joi.string().valid('trainings'),
+            }).required(),
+          }).required(),
+          options: {
+            allowUnknown: true,
+          },
+        },
+        tags: ['api', 'admin', 'trainings'],
+        notes: ['- Permet à un administrateur de créer un nouveau contenu formatif'],
+      },
+    },
+    {
       method: 'PATCH',
       path: '/api/admin/trainings/{trainingId}',
       config: {

--- a/api/lib/application/trainings/training-controller.js
+++ b/api/lib/application/trainings/training-controller.js
@@ -9,6 +9,11 @@ module.exports = {
     const { trainings, meta } = await usecases.findPaginatedTrainingSummaries({ page });
     return trainingSummarySerializer.serialize(trainings, meta);
   },
+  async create(request, h) {
+    const deserializedTraining = await trainingSerializer.deserialize(request.payload);
+    const createdTraining = await usecases.createTraining({ training: deserializedTraining });
+    return h.response(trainingSerializer.serialize(createdTraining)).created();
+  },
   async update(request) {
     const { trainingId } = request.params;
     const training = await trainingSerializer.deserialize(request.payload);

--- a/api/lib/domain/usecases/create-training.js
+++ b/api/lib/domain/usecases/create-training.js
@@ -1,0 +1,3 @@
+module.exports = function createTraining({ training, domainTransaction, trainingRepository }) {
+  return trainingRepository.create({ training, domainTransaction });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -230,6 +230,7 @@ module.exports = injectDependencies(
     createStage: require('./create-stage'),
     createTag: require('./create-tag'),
     createTargetProfile: require('./create-target-profile'),
+    createTraining: require('./create-training'),
     createUser: require('./create-user'),
     createUserAndReconcileToOrganizationLearnerFromExternalUser: require('./create-user-and-reconcile-to-organization-learner-from-external-user'),
     createOidcUser: require('./create-oidc-user'),

--- a/api/lib/infrastructure/repositories/training-repository.js
+++ b/api/lib/infrastructure/repositories/training-repository.js
@@ -67,6 +67,12 @@ module.exports = {
     return trainingsDTO.map((training) => _toDomain(training, targetProfileTrainings));
   },
 
+  async create({ training, domainTransaction = DomainTransaction.emptyTransaction() }) {
+    const knexConn = domainTransaction?.knexTransaction || knex;
+    const [createdTraining] = await knexConn(TABLE_NAME).insert(training).returning('*');
+    return new Training(createdTraining);
+  },
+
   async update({ id, attributesToUpdate, domainTransaction = DomainTransaction.emptyTransaction() }) {
     const knexConn = domainTransaction?.knexTransaction || knex;
     const [updatedTraining] = await knexConn(TABLE_NAME)

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -13,6 +13,56 @@ describe('Acceptance | Controller | training-controller', function () {
     server = await createServer();
   });
 
+  describe('POST /api/admin/trainings', function () {
+    it('should create a new training and response with a 201', async function () {
+      // given
+      const superAdmin = await insertUserWithRoleSuperAdmin();
+
+      const expectedResponse = {
+        type: 'trainings',
+        id: '101064',
+        attributes: {
+          title: 'Titre du training',
+          link: 'https://training-link.org',
+          type: 'webinaire',
+          duration: {
+            hours: 6,
+          },
+          locale: 'fr',
+          'editor-name': 'Un ministère',
+          'editor-logo-url': 'https://mon-logo.svg',
+        },
+      };
+
+      // when
+      const response = await server.inject({
+        method: 'POST',
+        url: '/api/admin/trainings',
+        payload: {
+          data: {
+            type: 'trainings',
+            attributes: {
+              title: 'Titre du training',
+              link: 'https://training-link.org',
+              type: 'webinaire',
+              duration: '6h',
+              locale: 'fr',
+              editorLogoUrl: 'https://mon-logo.svg',
+              editorName: 'Un ministère',
+            },
+          },
+        },
+        headers: { authorization: generateValidRequestAuthorizationHeader(superAdmin.id) },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(201);
+      expect(response.result.data.type).to.equal(expectedResponse.type);
+      expect(response.result.data.id).to.exist;
+      expect(response.result.data.attributes).to.deep.equal(expectedResponse.attributes);
+    });
+  });
+
   describe('PATCH /api/admin/trainings/{trainingId}', function () {
     let options;
 

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -272,6 +272,29 @@ describe('Integration | Repository | training-repository', function () {
     });
   });
 
+  describe('#create', function () {
+    it('should create a training', async function () {
+      // given
+      const training = {
+        title: 'Titre du training',
+        link: 'https://training-link.org',
+        type: 'webinaire',
+        duration: '6h',
+        locale: 'fr',
+        editorName: 'Un ministère',
+        editorLogoUrl: 'https://mon-logo.svg',
+      };
+
+      // when
+      const createdTraining = await trainingRepository.create({ training });
+
+      // then
+      expect(createdTraining).to.be.instanceOf(Training);
+      expect(createdTraining.id).to.exist;
+      expect(createdTraining).to.deep.include({ ...training, duration: { hours: 6 } });
+    });
+  });
+
   describe('#update', function () {
     it('should update given attributes', async function () {
       // given

--- a/api/tests/unit/application/trainings/training-controller_test.js
+++ b/api/tests/unit/application/trainings/training-controller_test.js
@@ -37,6 +37,67 @@ describe('Unit | Controller | training-controller', function () {
     });
   });
 
+  describe('#create', function () {
+    const deserializedTraining = { title: 'Training title' };
+    const createdTraining = { title: 'Training title' };
+
+    beforeEach(function () {
+      sinon.stub(trainingSerializer, 'deserialize').returns(deserializedTraining);
+      sinon.stub(trainingSerializer, 'serialize');
+      sinon.stub(usecases, 'createTraining').resolves(createdTraining);
+    });
+
+    it('should call the training create use-case', async function () {
+      // given
+      const payload = {
+        data: {
+          attributes: {
+            title: 'A new training',
+            locale: 'fr',
+          },
+        },
+      };
+
+      // when
+      await trainingController.create({ payload }, hFake);
+
+      // then
+      expect(trainingSerializer.deserialize).to.have.been.calledWith(payload);
+      expect(usecases.createTraining).to.have.been.calledOnceWithExactly({
+        training: deserializedTraining,
+      });
+    });
+
+    it('should return a serialized training', async function () {
+      // given
+      const expectedSerializedTraining = {
+        title: 'A new training',
+        duration: {
+          hours: 5,
+        },
+      };
+
+      trainingSerializer.serialize.returns(expectedSerializedTraining);
+
+      // when
+      const response = await trainingController.create(
+        {
+          data: {
+            attributes: {
+              title: 'A new training',
+              duration: '5h',
+            },
+          },
+        },
+        hFake
+      );
+
+      // then
+      expect(trainingSerializer.serialize).to.have.been.calledWith(deserializedTraining);
+      expect(response.source).to.deep.equal(expectedSerializedTraining);
+    });
+  });
+
   describe('#update', function () {
     const deserializedTraining = { title: 'new title' };
     const updatedTraining = { title: 'new title' };

--- a/api/tests/unit/domain/usecases/create-training_test.js
+++ b/api/tests/unit/domain/usecases/create-training_test.js
@@ -1,0 +1,25 @@
+const { expect, sinon } = require('../../../test-helper');
+const createTraining = require('../../../../lib/domain/usecases/create-training');
+
+describe('Unit | UseCase | create-training', function () {
+  it('should call training repository to create the training', async function () {
+    // given
+    const training = Symbol('training');
+    const domainTransaction = Symbol('domain-transaction');
+    const repositoryResult = Symbol('repository-result');
+
+    const trainingRepositoryStub = {
+      create: sinon.stub().resolves(repositoryResult),
+    };
+
+    // when
+    const result = await createTraining({ training, domainTransaction, trainingRepository: trainingRepositoryStub });
+
+    // then
+    expect(trainingRepositoryStub.create).to.have.been.calledWithExactly({
+      training,
+      domainTransaction,
+    });
+    expect(result).to.equal(repositoryResult);
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème

L'API ne permettait pas encore de créer des contenus formatifs.

## :gift: Proposition

Ajout d'une route POST pour les contenus formatifs.
Seuls les rôles SuperAdmin et Métier ont les droits de création.

## :star2: Remarques

Les doublons ne sont pas gérés (checker les liens ?)

## :santa: Pour tester

- Se connecter sur Pix Admin, avec un compte METIER ou SUPER_ADMIN
- Récupérer le Bearer dans le local storage
- Lancer une requête
```bash
curl -X POST https://api-pr5374.review.pix.fr/api/admin/trainings -H 'Authorization: Bearer <token>' -H 'Content-Type: application/json' -H 'Accept: application/json' --data-raw '{ "data": { "attributes": { "title": "Nouveau training", "link": "https://training-link.org", "type": "webinaire", "duration": "6h", "locale": "fr", "editorName": "Ministère de l'éducation", "editorLogoUrl": "https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg", }, "type": "trainings" } }'
```
- Vérifier sur Metabase que le training existe
