### PR TITLE
[BUGFIX] Corriger l'affichage de tooltip du bouton d'annulation d'une invitation sur Pix Orga (PIX-3912). 

### DIFF
--- a/certif/app/styles/globals/tables.scss
+++ b/certif/app/styles/globals/tables.scss
@@ -53,7 +53,7 @@
     tr:focus-within,
     tr:active {
       color: $pix-neutral-80;
-      background-color: $pix-neutral-10;
+      background-color: $pix-neutral-15;
       transition: 0.25s ease;
     }
 

--- a/orga/app/components/team/invitations-list.hbs
+++ b/orga/app/components/team/invitations-list.hbs
@@ -16,7 +16,6 @@
         <tr aria-label="{{t 'pages.team-invitations.table.row.aria-label'}}">
           <td>{{invitation.email}}</td>
           <td class="hide-on-mobile">
-            {{t "pages.team-invitations.table.row.message"}}
             {{dayjs-format invitation.updatedAt "DD/MM/YYYY [-] HH:mm" locale="fr"}}
           </td>
           <td>

--- a/orga/app/components/team/invitations-list.hbs
+++ b/orga/app/components/team/invitations-list.hbs
@@ -19,19 +19,21 @@
             {{dayjs-format invitation.updatedAt "DD/MM/YYYY [-] HH:mm" locale="fr"}}
           </td>
           <td>
-            <PixTooltip @isInline={{true}}>
-              <:triggerElement>
-                <PixIconButton
-                  @ariaLabel={{t "pages.team-invitations.cancel-invitation"}}
-                  @icon="trash-can"
-                  @triggerAction={{fn this.cancelInvitation invitation}}
-                  @withBackground={{true}}
-                />
-              </:triggerElement>
-              <:tooltip>
-                {{t "pages.team-invitations.cancel-invitation"}}
-              </:tooltip>
-            </PixTooltip>
+            <div class="invitations-list__action">
+              <PixTooltip @isInline={{true}}>
+                <:triggerElement>
+                  <PixIconButton
+                    @ariaLabel={{t "pages.team-invitations.cancel-invitation"}}
+                    @icon="trash-can"
+                    @triggerAction={{fn this.cancelInvitation invitation}}
+                    @withBackground={{true}}
+                  />
+                </:triggerElement>
+                <:tooltip>
+                  {{t "pages.team-invitations.cancel-invitation"}}
+                </:tooltip>
+              </PixTooltip>
+            </div>
           </td>
         </tr>
       {{/each}}

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -74,6 +74,7 @@
 @import 'pages/authenticated/preselect-target-profile';
 @import 'pages/authenticated/team';
 @import 'pages/authenticated/team/list';
+@import 'pages/authenticated/team/invitations-list';
 @import 'pages/authenticated/team/new';
 @import 'pages/authenticated/terms-of-service';
 

--- a/orga/app/styles/pages/authenticated/team/invitations-list.scss
+++ b/orga/app/styles/pages/authenticated/team/invitations-list.scss
@@ -1,0 +1,5 @@
+.invitations-list {
+  &__action {
+    width: 38px;
+  }
+}

--- a/orga/tests/integration/components/team/invitations-list_test.js
+++ b/orga/tests/integration/components/team/invitations-list_test.js
@@ -45,11 +45,7 @@ module('Integration | Component | Team::InvitationsList', function (hooks) {
 
     // then
     assert.contains('gigi@example.net');
-    assert.contains(
-      `${this.intl.t('pages.team-invitations.table.row.message')} ${this.dayjs
-        .self(pendingInvitationDate)
-        .format('DD/MM/YYYY - HH:mm')}`
-    );
+    assert.contains(this.dayjs.self(pendingInvitationDate).format('DD/MM/YYYY - HH:mm'));
   });
 
   test('it should show success notification when cancelling an invitation succeeds', async function (assert) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -989,8 +989,7 @@
           "pending-invitation": "Pending invitation"
         },
         "row": {
-          "aria-label": "Pending invitation",
-          "message": "Sent on"
+          "aria-label": "Pending invitation"
         }
       }
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -989,8 +989,7 @@
           "pending-invitation": "Date de dernier envoi"
         },
         "row": {
-          "aria-label": "Invitation en attente",
-          "message": "Dernière invitation envoyée le"
+          "aria-label": "Invitation en attente"
         }
       }
     },


### PR DESCRIPTION
## :christmas_tree: Problème
Sur Pix Orga, la bulle d'information liée au bouton de suppression d'une invitation n'apparaît plus au dessus de ce dernier.
<img width="526" alt="Capture d’écran 2022-12-15 à 15 07 03" src="https://user-images.githubusercontent.com/58915422/207881726-229d2582-c02c-429b-98c1-d672d5716672.png">


## :gift: Proposition
Fixer le bouton.

D'autres demandes inclut dans ce ticket : 
- Fond de couleur des tables iso en Pix Orga et Pix Certif (`$pix-neutral-15`)
- Dans la colonne ‘Date de dernier envoi’, retirer le texte ‘Dernière invitation envoyée le’ de chaque ligne. Le titre de la colonne suffit.

## :star2: Remarques
[une mise à jour de Pix UI](https://github.com/1024pix/pix-ui/pull/276) à introduit un changement de comportement sur le composant Pix Tooltip ce qui a causé ce décalage. 
Le tooltip prend la taille du parent, la bulle reste centré tandis que le bouton passe à gauche. (détails dans le ticket JIRA)
Choix d'ajouter une div qui impose une taille dans la cellule qui rectifie le comportement.

## :santa: Pour tester
Aller sur Pix Orga (sco.admin@example.net)
Aller dans Équipe
Aller dans l'onglet Invitations
Inviter un membre
Dans le tableau, constater : 
- Que seul la date et l'heure s'affiche, plus de texte ‘Dernière invitation envoyée le’
- survoler le bouton, la bulle s'affiche bien au dessus
