### PR TITLE
[BUGFIX] Evite de couper le titre de la carte tutos (PIX-6573)

### DIFF
--- a/mon-pix/app/styles/components/_tutorial-card.scss
+++ b/mon-pix/app/styles/components/_tutorial-card.scss
@@ -25,6 +25,7 @@
     font-weight: $font-semi-bold;
     font-size: 1.25rem;
     font-family: $font-open-sans;
+    line-height: 1.25;
     text-overflow: ellipsis;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;


### PR DESCRIPTION
## :christmas_tree: Problème
Les caractères du titre de la carte tuto peuvent être coupé en bas dans la page de checkpoint. C'est dû au [`line-height` qu'on applique à la tout le `content` de la PixModal](https://github.com/1024pix/pix-ui/blob/e479981fe8a00c152ecb85f60ab7388ce55563a0/addon/styles/_pix-modal.scss#L88).

![image](https://user-images.githubusercontent.com/5855339/208110246-008d733f-25ad-496a-a5af-ca515c6def09.png)

## :gift: Proposition
Forcer le `line-height` du titre de la carte.

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que les titres de cartes avec les caractères `p` ou `q` ne sont plus coupés.
