### PR TITLE
[FEATURE] Utiliser le composant PixFilterableAndSearchableSelect pour la création de campagne d'évaluation de participants (PIX-6054)

### DIFF
--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -111,58 +111,37 @@
 
   {{#if this.isCampaignGoalAssessment}}
     <div class="form__field-with-info form__field-with-info--small">
-      <label class="label" for="campaign-target-profile">
-        <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-        {{t "pages.campaign-creation.target-profiles-list-label"}}
-      </label>
-      {{#if this.categories}}
-        <fieldset class="form__field-filters">
-          <legend class="form__field-filters-title">{{t "pages.campaign-creation.tags-title"}}</legend>
-          {{#each this.categories as |category|}}
-            <PixSelectableTag
-              @label={{category.translation}}
-              @id={{category.name}}
-              @onChange={{fn this.toggleCategory category.name}}
-            />
-          {{/each}}
-        </fieldset>
-      {{/if}}
-      <div class="form__field-with-info form__field--wide">
-        <PixSelect
-          @id="campaign-target-profile"
-          @onChange={{this.selectTargetProfile}}
-          @options={{this.targetProfilesOptions}}
-          @hideDefaultOption={{true}}
-          @value={{this.targetProfile.id}}
-          @errorMessage="{{if
-            @errors.targetProfile
-            (t 'api-errors-messages.campaign-creation.target-profile-required')
-          }}"
-          @emptySearchMessage=""
-          @placeholder={{t "pages.campaign-creation.target-profiles-search-placeholder"}}
-          @isSearchable={{true}}
-          class="campaign-target-profile"
-          aria-describedby="target-profile-info"
-          aria-required={{true}}
-        />
-        {{#if this.targetProfile}}
-          <div class="form__field-info" id="target-profile-info">
-            <span class="form__field-info-title">
-              <FaIcon @icon="circle-info" class="form__field-info-icon" />
-              <span>{{this.targetProfile.name}}</span>
-            </span>
+      <PixFilterableAndSearchableSelect
+        @label={{t "pages.campaign-creation.target-profiles-list-label"}}
+        @placeholder={{t "pages.campaign-creation.target-profiles-label"}}
+        @options={{this.targetProfilesOptions}}
+        @hideDefaultOption={{true}}
+        @onChange={{this.selectTargetProfile}}
+        @categoriesLabel={{t "pages.campaign-creation.target-profiles-category-label"}}
+        @categoriesPlaceholder={{t "pages.campaign-creation.target-profiles-category-placeholder"}}
+        @value={{this.targetProfile.id}}
+        @requiredText={{t "common.form.mandatory-fields-title"}}
+        @errorMessage={{if @errors.targetProfile (t "api-errors-messages.campaign-creation.target-profile-required")}}
+        @isSearchable={{true}}
+        @searchLabel={{t "pages.campaign-creation.target-profiles-search-placeholder"}}
+      />
+      {{#if this.targetProfile}}
+        <div class="form__field-info" id="target-profile-info">
+          <span class="form__field-info-title">
+            <FaIcon @icon="circle-info" class="form__field-info-icon" />
+            <span>{{this.targetProfile.name}}</span>
+          </span>
 
-            <Campaign::TargetProfileDetails
-              class="form__field-info-message"
-              @targetProfileDescription={{this.targetProfile.description}}
-              @hasStages={{this.targetProfile.hasStage}}
-              @hasBadges={{gt this.targetProfile.thematicResultCount 0}}
-              @targetProfileTubesCount={{this.targetProfile.tubeCount}}
-              @targetProfileThematicResultCount={{this.targetProfile.thematicResultCount}}
-            />
-          </div>
-        {{/if}}
-      </div>
+          <Campaign::TargetProfileDetails
+            class="form__field-info-message"
+            @targetProfileDescription={{this.targetProfile.description}}
+            @hasStages={{this.targetProfile.hasStage}}
+            @hasBadges={{gt this.targetProfile.thematicResultCount 0}}
+            @targetProfileTubesCount={{this.targetProfile.tubeCount}}
+            @targetProfileThematicResultCount={{this.targetProfile.thematicResultCount}}
+          />
+        </div>
+      {{/if}}
     </div>
   {{/if}}
 

--- a/orga/app/styles/pages/authenticated/campaigns/create-form.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/create-form.scss
@@ -16,15 +16,24 @@
     width: auto;
   }
 }
+.pix-filterable-and-searchable-select {
+  @include device-is('desktop') {
+    width: 500px;
+  }
+}
 
+.pix-multi-select {
+  @include device-is('desktop') {
+    width: 140px;
+  }
+}
 
-.target-profile-option {
-  position: absolute;
-  height: 20px;
-  width: 14px;
-  top: 2px;
-  bottom: 0;
-  right: 10px;
-  margin: auto;
-  color :$pix-neutral-30;
+.pix-select {
+  @include device-is('desktop') {
+    width: 360px !important;
+  }
+
+  &__dropdown {
+    overflow-x: hidden;
+  }
 }

--- a/orga/config/icons.js
+++ b/orga/config/icons.js
@@ -9,6 +9,7 @@ module.exports = function () {
       'award',
       'book',
       'bullhorn',
+      'check',
       'chevron-down',
       'chevron-up',
       'crown',

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.0",
-        "@1024pix/pix-ui": "^23.0.1",
+        "@1024pix/pix-ui": "^23.2.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
         "@ember/optional-features": "^2.0.0",
@@ -1049,9 +1049,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-23.0.1.tgz",
-      "integrity": "sha512-B84qHzNT0HIBuK5L8LLpNdLB8NpdLnUbvuYqgBck/ARK+ULynxZtOqIWxpHrg83/M774P3ApYW2wPW1egPW+PQ==",
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-23.2.0.tgz",
+      "integrity": "sha512-pkTY2H1CX5Md196QtEtbR3RCIuo7bP1eYP00C6h8bQeXzjIjOPfXJZvx7rz8ZK/ugRs65ADjAdT8Ud5+CZizFw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -34916,9 +34916,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-23.0.1.tgz",
-      "integrity": "sha512-B84qHzNT0HIBuK5L8LLpNdLB8NpdLnUbvuYqgBck/ARK+ULynxZtOqIWxpHrg83/M774P3ApYW2wPW1egPW+PQ==",
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-23.2.0.tgz",
+      "integrity": "sha512-pkTY2H1CX5Md196QtEtbR3RCIuo7bP1eYP00C6h8bQeXzjIjOPfXJZvx7rz8ZK/ugRs65ADjAdT8Ud5+CZizFw==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.8",

--- a/orga/package.json
+++ b/orga/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.0",
-    "@1024pix/pix-ui": "^23.0.1",
+    "@1024pix/pix-ui": "^23.2.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",
     "@ember/optional-features": "^2.0.0",

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -26,6 +26,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     }
     this.owner.register('service:current-user', CurrentUserStub);
     this.set('defaultMembers', defaultMembers);
+    this.targetProfiles = [];
   });
 
   test('it should contain inputs, attributes and validation button', async function (assert) {
@@ -35,6 +36,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         @onSubmit={{this.createCampaignSpy}}
         @onCancel={{this.cancelSpy}}
         @errors={{this.errors}}
+        @targetProfiles={{this.targetProfiles}}
         @membersSortedByFullName={{this.defaultMembers}} />`
     );
 
@@ -52,6 +54,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         @onSubmit={{this.createCampaignSpy}}
         @onCancel={{this.cancelSpy}}
         @errors={{this.errors}}
+        @targetProfiles={{this.targetProfiles}}
         @membersSortedByFullName={{this.defaultMembers}} />`
     );
 
@@ -67,6 +70,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         @onSubmit={{this.createCampaignSpy}}
         @onCancel={{this.cancelSpy}}
         @errors={{this.errors}}
+        @targetProfiles={{this.targetProfiles}}
         @membersSortedByFullName={{this.defaultMembers}} />`
     );
 
@@ -81,6 +85,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         @onSubmit={{this.createCampaignSpy}}
         @onCancel={{this.cancelSpy}}
         @errors={{this.errors}}
+        @targetProfiles={{this.targetProfiles}}
         @membersSortedByFullName={{this.defaultMembers}} />`
     );
 
@@ -96,6 +101,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{this.createCampaignSpy}}
           @onCancel={{this.cancelSpy}}
           @errors={{this.errors}}
+          @targetProfiles={{this.targetProfiles}}
           @membersSortedByFullName={{this.defaultMembers}}/>`
       );
       await clickByName(t('pages.campaign-creation.purpose.assessment'));
@@ -116,6 +122,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{this.createCampaignSpy}}
           @onCancel={{this.cancelSpy}}
           @errors={{this.errors}}
+          @targetProfiles={{this.targetProfiles}}
           @membersSortedByFullName={{this.defaultMembers}} />`
       );
       await clickByName(t('pages.campaign-creation.purpose.assessment'));
@@ -132,142 +139,13 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{this.createCampaignSpy}}
           @onCancel={{this.cancelSpy}}
           @errors={{this.errors}}
+          @targetProfiles={{this.targetProfiles}}
           @membersSortedByFullName={{this.defaultMembers}} />`
       );
 
       // then
       assert.notContains(t('pages.campaign-creation.multiple-sendings.question-label'));
       assert.notContains(t('pages.campaign-creation.multiple-sendings.info'));
-    });
-
-    module('when there are several target profiles associated to the organization', function () {
-      test('it should display the all category tags', async function (assert) {
-        // given
-        this.targetProfiles = [
-          EmberObject.create({
-            id: '4',
-            name: 'targetProfile4',
-            description: 'description4',
-            category: 'SUBJECT',
-          }),
-          EmberObject.create({
-            id: '5',
-            name: 'targetProfile5',
-            description: 'description7',
-            category: 'OTHER',
-          }),
-        ];
-        // when
-        await render(
-          hbs`<Campaign::CreateForm
-            @targetProfiles={{this.targetProfiles}}
-            @onSubmit={{this.createCampaignSpy}}
-            @onCancel={{this.cancelSpy}} 
-            @errors={{this.errors}}
-            @membersSortedByFullName={{this.defaultMembers}} />`
-        );
-        await clickByName(t('pages.campaign-creation.purpose.assessment'));
-
-        // then
-        assert.contains(t('pages.campaign-creation.tags-title'));
-        assert.contains(t('pages.campaign-creation.tags.SUBJECT'));
-        assert.contains(t('pages.campaign-creation.tags.OTHER'));
-      });
-
-      test('it should display each category tags once', async function (assert) {
-        // given
-        this.targetProfiles = [
-          EmberObject.create({
-            id: '4',
-            name: 'targetProfile4',
-            description: 'description4',
-            category: 'SUBJECT',
-          }),
-          EmberObject.create({
-            id: '4',
-            name: 'targetProfile6',
-            description: 'description6',
-            category: 'SUBJECT',
-          }),
-          EmberObject.create({
-            id: '5',
-            name: 'targetProfile5',
-            description: 'description7',
-            category: 'OTHER',
-          }),
-        ];
-
-        // when
-        await render(
-          hbs`<Campaign::CreateForm
-            @targetProfiles={{this.targetProfiles}}
-            @onSubmit={{this.createCampaignSpy}}
-            @onCancel={{this.cancelSpy}} 
-            @errors={{this.errors}}
-            @membersSortedByFullName={{this.defaultMembers}} />`
-        );
-        await clickByName(t('pages.campaign-creation.purpose.assessment'));
-        // then
-        assert.contains(t('pages.campaign-creation.tags-title'));
-        assert.dom('label[for="SUBJECT"]').exists({ count: 1 });
-        assert.contains(t('pages.campaign-creation.tags.OTHER'));
-      });
-
-      test('it should display only the target profiles associated to the tag selected', async function (assert) {
-        // given
-        this.targetProfiles = [
-          EmberObject.create({
-            id: '4',
-            name: 'targetProfile4',
-            description: 'description4',
-            category: 'SUBJECT',
-          }),
-          EmberObject.create({
-            id: '5',
-            name: 'targetProfile5',
-            description: 'description7',
-            category: 'OTHER',
-          }),
-        ];
-        // when
-        const screen = await render(
-          hbs`<Campaign::CreateForm
-            @targetProfiles={{this.targetProfiles}}
-            @onSubmit={{this.createCampaignSpy}}
-            @onCancel={{this.cancelSpy}} 
-            @errors={{this.errors}}
-            @membersSortedByFullName={{this.defaultMembers}} />`
-        );
-        await click(screen.getByLabelText(t('pages.campaign-creation.purpose.assessment')));
-        await click(screen.getByLabelText(t('pages.campaign-creation.tags.SUBJECT')));
-        // then
-        await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
-        const option = await screen.findAllByRole('option');
-
-        assert.strictEqual(option.length, 1);
-        assert.dom(option[0]).hasText('targetProfile4');
-      });
-    });
-
-    module('when there is no target profiles associated to the organization', function () {
-      test('it should not display the category tags', async function (assert) {
-        // given
-        this.targetProfiles = [];
-
-        // when
-        await render(
-          hbs`<Campaign::CreateForm
-            @targetProfiles={{this.targetProfiles}}
-            @onSubmit={{this.createCampaignSpy}}
-            @onCancel={{this.cancelSpy}}
-            @errors={{this.errors}}
-            @membersSortedByFullName={{this.defaultMembers}} />`
-        );
-        await clickByName(t('pages.campaign-creation.purpose.assessment'));
-
-        // then
-        assert.notContains(t('pages.campaign-creation.tags-title'));
-      });
     });
 
     module('when the user chose a target profile', function () {
@@ -350,6 +228,123 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         // then
         assert.contains(t('common.target-profile-details.results.common'));
       });
+      module('Displaying options and categories', function () {
+        test('it should display options in alphapetical order', async function (assert) {
+          // given
+          this.targetProfiles = [
+            EmberObject.create({
+              id: '1',
+              name: 'targetProfile4',
+              description: 'description4',
+              tubeCount: 11,
+              thematicResultCount: 12,
+              hasStage: true,
+              category: 'B',
+            }),
+            EmberObject.create({
+              id: '2',
+              name: 'targetProfile3',
+              description: 'description3',
+              tubeCount: 21,
+              thematicResultCount: 22,
+              hasStage: false,
+              category: 'B',
+            }),
+            EmberObject.create({
+              id: '3',
+              name: 'targetProfile2',
+              description: 'description2',
+              tubeCount: 33,
+              thematicResultCount: 12,
+              hasStage: true,
+              category: 'A',
+            }),
+            EmberObject.create({
+              id: '4',
+              name: 'targetProfile1',
+              description: 'description1',
+              tubeCount: 44,
+              thematicResultCount: 12,
+              hasStage: true,
+              category: 'A',
+            }),
+          ];
+
+          // when
+          const screen = await render(
+            hbs`<Campaign::CreateForm
+              @targetProfiles={{this.targetProfiles}}
+              @onSubmit={{this.createCampaignSpy}}
+              @onCancel={{this.cancelSpy}}
+              @errors={{this.errors}}
+              @membersSortedByFullName={{this.defaultMembers}} />`
+          );
+          await clickByName(t('pages.campaign-creation.purpose.assessment'));
+
+          await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
+          let options = await screen.findAllByRole('option');
+
+          // then
+          options = options.map((option) => {
+            return option.innerText;
+          });
+          assert.deepEqual(options, [
+            t('pages.campaign-creation.target-profiles-label'),
+            'targetProfile1',
+            'targetProfile2',
+            'targetProfile3',
+            'targetProfile4',
+          ]);
+        });
+
+        test('it should display options with OTHER category at last position', async function (assert) {
+          // given
+          this.targetProfiles = [
+            EmberObject.create({
+              id: '2',
+              name: 'targetProfile3',
+              description: 'description3',
+              tubeCount: 21,
+              thematicResultCount: 22,
+              hasStage: false,
+              category: 'OTHER',
+            }),
+            EmberObject.create({
+              id: '1',
+              name: 'targetProfile4',
+              description: 'description4',
+              tubeCount: 11,
+              thematicResultCount: 12,
+              hasStage: true,
+              category: 'A',
+            }),
+          ];
+
+          // when
+          const screen = await render(
+            hbs`<Campaign::CreateForm
+              @targetProfiles={{this.targetProfiles}}
+              @onSubmit={{this.createCampaignSpy}}
+              @onCancel={{this.cancelSpy}}
+              @errors={{this.errors}}
+              @membersSortedByFullName={{this.defaultMembers}} />`
+          );
+          await clickByName(t('pages.campaign-creation.purpose.assessment'));
+
+          await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
+          let options = await screen.findAllByRole('option');
+
+          // then
+          options = options.map((option) => {
+            return option.innerText;
+          });
+          assert.deepEqual(options, [
+            t('pages.campaign-creation.target-profiles-label'),
+            'targetProfile4',
+            'targetProfile3',
+          ]);
+        });
+      });
     });
 
     module('when the user wants to clear the content of the target profile input', function (hooks) {
@@ -373,6 +368,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{this.createCampaignSpy}}
           @onCancel={{this.cancelSpy}}
           @errors={{this.errors}}
+          @targetProfiles={{this.targetProfiles}}
           @membersSortedByFullName={{this.defaultMembers}} />`
       );
       await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
@@ -389,6 +385,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{this.createCampaignSpy}}
           @onCancel={{this.cancelSpy}}
           @errors={{this.errors}}
+          @targetProfiles={{this.targetProfiles}}
           @membersSortedByFullName={{this.defaultMembers}} />`
       );
       await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
@@ -409,6 +406,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{this.createCampaignSpy}}
           @onCancel={{this.cancelSpy}}
           @errors={{this.errors}}
+          @targetProfiles={{this.targetProfiles}}
           @membersSortedByFullName={{this.defaultMembers}} />`
       );
       await clickByName(t('pages.campaign-creation.purpose.profiles-collection'));
@@ -427,6 +425,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{this.createCampaignSpy}}
           @onCancel={{this.cancelSpy}}
           @errors={{this.errors}}
+          @targetProfiles={{this.targetProfiles}}
           @membersSortedByFullName={{this.defaultMembers}} />`
       );
 
@@ -443,6 +442,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{this.createCampaignSpy}}
           @onCancel={{this.cancelSpy}}
           @errors={{this.errors}}
+          @targetProfiles={{this.targetProfiles}}
           @membersSortedByFullName={{this.defaultMembers}} />`
       );
       await clickByName(t('pages.campaign-creation.no'));
@@ -460,6 +460,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{this.createCampaignSpy}}
           @onCancel={{this.cancelSpy}}
           @errors={{this.errors}}
+          @targetProfiles={{this.targetProfiles}}
           @membersSortedByFullName={{this.defaultMembers}} />`
       );
       await clickByName(t('pages.campaign-creation.yes'));
@@ -471,7 +472,8 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
 
   test('it should send campaign creation action when submitted', async function (assert) {
     // given
-    this.targetProfiles = [{ name: 'targetProfile1' }];
+    const targetProfile = { name: 'targetProfile1', id: 123 };
+    this.targetProfiles = [targetProfile];
     this.createCampaignSpy = sinon.stub();
 
     const screen = await render(
@@ -485,12 +487,12 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
     await fillByLabel(`* ${t('pages.campaign-creation.name.label')}`, 'Ma campagne');
     await clickByName(t('pages.campaign-creation.purpose.assessment'));
     await click(screen.getByLabelText(t('pages.campaign-creation.target-profiles-list-label'), { exact: false }));
-    await click(await screen.findByRole('option', { name: this.targetProfiles[0].name }));
+    await click(await screen.findByRole('option', { name: targetProfile.name }));
 
     // when
     await clickByName(t('pages.campaign-creation.actions.create'));
 
-    sinon.assert.calledWithMatch(this.createCampaignSpy, { name: 'Ma campagne' });
+    sinon.assert.calledWithMatch(this.createCampaignSpy, { name: 'Ma campagne', targetProfile });
     // then
     assert.ok(true);
   });
@@ -526,6 +528,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{this.createCampaignSpy}}
           @onCancel={{this.cancelSpy}}
           @errors={{this.errors}}
+          @targetProfiles={{this.targetProfiles}}
           @membersSortedByFullName={{this.defaultMembers}} />`
       );
       await clickByName(t('pages.campaign-creation.yes'));
@@ -555,6 +558,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
           @onSubmit={{this.createCampaignSpy}}
           @onCancel={{this.cancelSpy}}
           @errors={{this.errors}}
+          @targetProfiles={{this.targetProfiles}}
           @membersSortedByFullName={{this.defaultMembers}} />`
       );
       await clickByName(t('pages.campaign-creation.purpose.assessment'));

--- a/orga/tests/integration/components/campaign/results/profile-list_test.js
+++ b/orga/tests/integration/components/campaign/results/profile-list_test.js
@@ -208,7 +208,6 @@ module('Integration | Component | Campaign::Results::ProfileList', function (hoo
 
     module('when user set a search filter', function () {
       test('that in the fullname search input we will have the value that we put', async function (assert) {
-        console.log('hi');
         const campaign = store.createRecord('campaign', {
           id: 1,
           name: 'campagne 1',

--- a/orga/tests/unit/components/campaign/create-form_test.js
+++ b/orga/tests/unit/components/campaign/create-form_test.js
@@ -2,117 +2,11 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 import Service from '@ember/service';
-import { setupIntl, t } from 'ember-intl/test-support';
+import { setupIntl } from 'ember-intl/test-support';
 
 module('Unit | Component | Campaign::CreateForm', (hooks) => {
   setupTest(hooks);
   setupIntl(hooks);
-
-  module('#categories', function () {
-    module('when this a target profile without OTHER category', function () {
-      test('should sort categories in alphabetic order', async function (assert) {
-        // given
-        const targetProfiles = [
-          {
-            category: 'SUBJECT',
-            name: 'Accès simplifié',
-          },
-          {
-            category: 'CUSTOM',
-            name: 'PC sur mesure',
-          },
-          {
-            category: 'PREDEFINED',
-            name: 'PC prédéfini',
-          },
-        ];
-        class CurrentUserStub extends Service {
-          prescriber = { id: 1 };
-        }
-        this.owner.lookup('service:intl').setLocale('fr');
-        this.owner.register('service:current-user', CurrentUserStub);
-        const component = await createGlimmerComponent('component:campaign/create-form', {
-          targetProfiles,
-        });
-        //when
-        const allCategories = await component.categories;
-
-        //then
-        const expectedOrder = [
-          {
-            name: 'PREDEFINED',
-            translation: t('pages.campaign-creation.tags.PREDEFINED'),
-          },
-          {
-            name: 'CUSTOM',
-            translation: t('pages.campaign-creation.tags.CUSTOM'),
-          },
-          {
-            name: 'SUBJECT',
-            translation: t('pages.campaign-creation.tags.SUBJECT'),
-          },
-        ];
-        assert.deepEqual(allCategories, expectedOrder);
-      });
-    });
-
-    module('when this a target profile with OTHER category', function () {
-      test('should sort categories in alphabetic order and put the other category at the end.', async function (assert) {
-        // given
-        class CurrentUserStub extends Service {
-          prescriber = { id: 1 };
-        }
-        this.owner.lookup('service:intl').setLocale('fr');
-        this.owner.register('service:current-user', CurrentUserStub);
-        const targetProfiles = [
-          {
-            category: 'SUBJECT',
-            name: 'Accès simplifié',
-          },
-          {
-            category: 'CUSTOM',
-            name: 'PC sur mesure',
-          },
-          {
-            category: 'PREDEFINED',
-            name: 'PC prédéfini',
-          },
-          {
-            category: 'OTHER',
-            name: 'PC autre',
-          },
-        ];
-
-        const component = await createGlimmerComponent('component:campaign/create-form', {
-          targetProfiles,
-        });
-
-        //when
-        const allCategories = await component.categories;
-
-        //then
-        const expectedOrder = [
-          {
-            name: 'PREDEFINED',
-            translation: t('pages.campaign-creation.tags.PREDEFINED'),
-          },
-          {
-            name: 'CUSTOM',
-            translation: t('pages.campaign-creation.tags.CUSTOM'),
-          },
-          {
-            name: 'SUBJECT',
-            translation: t('pages.campaign-creation.tags.SUBJECT'),
-          },
-          {
-            name: 'OTHER',
-            translation: t('pages.campaign-creation.tags.OTHER'),
-          },
-        ];
-        assert.deepEqual(allCategories, expectedOrder);
-      });
-    });
-  });
 
   module('#onChangeCampaignOwner', function () {
     test('should set new owner id', async function (assert) {
@@ -125,7 +19,10 @@ module('Unit | Component | Campaign::CreateForm', (hooks) => {
         { id: 1, fullName: 'Remy Fasol' },
         { id: 7, fullName: 'Thierry Golo' },
       ];
-      const component = await createGlimmerComponent('component:campaign/create-form', { membersSortedByFullName });
+      const component = await createGlimmerComponent('component:campaign/create-form', {
+        membersSortedByFullName,
+        targetProfiles: [],
+      });
       const newOwnerId = 7;
 
       //when

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -361,6 +361,9 @@
         "SUBJECT": "Subject"
       },
       "tags-title": "Filter:",
+      "target-profiles-category-label": "Filter customised test by category",
+      "target-profiles-category-placeholder": "Categories",
+      "target-profiles-label": "Select a customised test",
       "target-profiles-list-label": "What would you like to test?",
       "target-profiles-search-placeholder": "Search by name",
       "test-title": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -361,6 +361,9 @@
         "SUBJECT": "Thématiques"
       },
       "tags-title": "Filtrer la recherche :",
+      "target-profiles-category-label": "Filtrer les parcours par catégories",
+      "target-profiles-category-placeholder": "Catégories",
+      "target-profiles-label": "Sélectionner un parcours",
       "target-profiles-list-label": "Que souhaitez-vous tester ?",
       "target-profiles-search-placeholder": "Rechercher par nom",
       "test-title": {


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, le choix du profil cible lors de la création d’une campagne dans Pix Orga pose plusieurs problèmes (compréhension, filtre, recherche, affichage).

## :gift: Proposition
Maintenant que le composant PixFilterableAndSearchableSelect a été créé et mis à jour depuis Pix UI dans Pix Orga, on peut l'utiliser le dans la page de création de campagne dans Pix Orga

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
- se connecter à pix orga
- campagnes => créer une campagne
- cocher "Évaluer les participants"
- voir apparaître et tester le composant PixFilterableAndSearchableSelect