### PR TITLE
[TECH] Utilise ILIKE dans les requêtes SQL plutôt que d'utiliser LOWER(column) LIKE %inputlowercase%

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-assessment-participation-result-list-repository.js
@@ -81,8 +81,8 @@ function _filterBySearch(queryBuilder, filters) {
         '<=',
         0.8
       )
-        .orWhereRaw('LOWER("organization-learners"."lastName") LIKE ?', `%${search}%`)
-        .orWhereRaw('LOWER("organization-learners"."firstName") LIKE ?', `%${search}%`);
+        .orWhereILike('organization-learners.lastName', `%${search}%`)
+        .orWhereILike('organization-learners.firstName', `%${search}%`);
     });
   }
 }

--- a/api/lib/infrastructure/repositories/campaign-report-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-report-repository.js
@@ -13,7 +13,7 @@ const { SHARED } = CampaignParticipationStatuses;
 
 function _setSearchFiltersForQueryBuilder(qb, { name, ongoing = true, ownerName, isOwnedByMe }, userId) {
   if (name) {
-    qb.whereRaw('LOWER("name") LIKE ?', `%${name.toLowerCase()}%`);
+    qb.whereILike('name', `%${name}%`);
   }
   if (ongoing) {
     qb.whereNull('campaigns.archivedAt');

--- a/api/lib/infrastructure/repositories/certification-center-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-repository.js
@@ -35,13 +35,13 @@ function _setSearchFiltersForQueryBuilder(filters, qb) {
     qb.whereRaw('CAST(id as TEXT) LIKE ?', `%${id.toString().toLowerCase()}%`);
   }
   if (name) {
-    qb.whereRaw('LOWER("name") LIKE ?', `%${name.toLowerCase()}%`);
+    qb.whereILike('name', `%${name}%`);
   }
   if (type) {
-    qb.whereRaw('LOWER("type") LIKE ?', `%${type.toLowerCase()}%`);
+    qb.whereILike('type', `%${type}%`);
   }
   if (externalId) {
-    qb.whereRaw('LOWER("externalId") LIKE ?', `%${externalId.toLowerCase()}%`);
+    qb.whereILike('externalId', `%${externalId}%`);
   }
 }
 

--- a/api/lib/infrastructure/repositories/membership-repository.js
+++ b/api/lib/infrastructure/repositories/membership-repository.js
@@ -27,13 +27,13 @@ function _toDomain(bookshelfMembership) {
 function _setSearchFiltersForQueryBuilder(filter, qb) {
   const { firstName, lastName, email, organizationRole } = filter;
   if (firstName) {
-    qb.whereRaw('LOWER(users."firstName") LIKE ?', `%${firstName.toLowerCase()}%`);
+    qb.whereILike('users.firstName', `%${firstName}%`);
   }
   if (lastName) {
-    qb.whereRaw('LOWER(users."lastName") LIKE ?', `%${lastName.toLowerCase()}%`);
+    qb.whereILike('users.lastName', `%${lastName}%`);
   }
   if (email) {
-    qb.whereRaw('LOWER(users."email") LIKE ?', `%${email.toLowerCase()}%`);
+    qb.whereILike('users.email', `%${email}%`);
   }
   if (organizationRole) {
     qb.where('memberships.organizationRole', organizationRole);

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -38,13 +38,13 @@ function _setSearchFiltersForQueryBuilder(qb, filter) {
     qb.where('organizations.id', id);
   }
   if (name) {
-    qb.whereRaw('LOWER("name") LIKE ?', `%${name.toLowerCase()}%`);
+    qb.whereILike('name', `%${name}%`);
   }
   if (type) {
-    qb.whereRaw('LOWER("type") LIKE ?', `%${type.toLowerCase()}%`);
+    qb.whereILike('type', `%${type}%`);
   }
   if (externalId) {
-    qb.whereRaw('LOWER("externalId") LIKE ?', `%${externalId.toLowerCase()}%`);
+    qb.whereILike('externalId', `%${externalId}%`);
   }
 }
 

--- a/api/lib/infrastructure/repositories/sessions/jury-session-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/jury-session-repository.js
@@ -116,7 +116,7 @@ function _setupFilters(query, filters) {
   }
 
   if (certificationCenterName) {
-    query.whereRaw('LOWER(??) LIKE ?', ['certificationCenter', '%' + certificationCenterName.toLowerCase() + '%']);
+    query.whereILike('certificationCenter', `%${certificationCenterName}%`);
   }
 
   if (certificationCenterType) {

--- a/api/lib/infrastructure/repositories/sup-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sup-organization-participant-repository.js
@@ -10,7 +10,7 @@ function _setFilters(qb, { search, studentNumber, groups, certificability } = {}
     filterByFullName(qb, search, 'organization-learners.firstName', 'organization-learners.lastName');
   }
   if (studentNumber) {
-    qb.whereRaw('LOWER("organization-learners"."studentNumber") LIKE ?', `%${studentNumber.toLowerCase()}%`);
+    qb.whereILike('organization-learners.studentNumber', `%${studentNumber}%`);
   }
   if (groups) {
     qb.whereIn(

--- a/api/lib/infrastructure/repositories/target-profile-summary-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-summary-for-admin-repository.js
@@ -45,7 +45,7 @@ module.exports = {
 function _applyFilters(qb, filter) {
   const { name, id } = filter;
   if (name) {
-    qb.whereRaw('LOWER("name") LIKE ?', `%${name.toLowerCase()}%`);
+    qb.whereILike('name', `%${name}%`);
   }
   if (id) {
     qb.where({ id });

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -598,15 +598,15 @@ function _setSearchFiltersForQueryBuilder(filter, qb) {
   const { firstName, lastName, email, username } = filter;
 
   if (firstName) {
-    qb.whereRaw('LOWER("firstName") LIKE ?', `%${firstName.toLowerCase()}%`);
+    qb.whereILike('firstName', `%${firstName}%`);
   }
   if (lastName) {
-    qb.whereRaw('LOWER("lastName") LIKE ?', `%${lastName.toLowerCase()}%`);
+    qb.whereILike('lastName', `%${lastName}%`);
   }
   if (email) {
-    qb.whereRaw('LOWER("email") LIKE ?', `%${email.toLowerCase()}%`);
+    qb.whereILike('email', `%${email}%`);
   }
   if (username) {
-    qb.whereRaw('LOWER("username") LIKE ?', `%${username.toLowerCase()}%`);
+    qb.whereILike('username', `%${username}%`);
   }
 }


### PR DESCRIPTION
## :christmas_tree: Problème
La forme `LOWER(column) LIKE %inputlowercase%` est similaire a `column ILIKE %input%`.

## :gift: Proposition
Utiliser la forme "native" postgres et utiliser la fonction dédié par knex.

## :santa: Pour tester
:green_circle: 
