### PR TITLE
[TECH] Mettre à jour Pix UI de 20.2.4 à 23.1.2 dans Pix App (PIX-6581)

### DIFF
--- a/mon-pix/app/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/components/challenge-item-qroc.hbs
@@ -16,7 +16,7 @@
                 <PixSelect
                   data-uid="qroc-proposal-uid"
                   data-test="challenge-response-proposal-selector"
-                  disabled={{this.isAnswerFieldDisabled}}
+                  @isDisabled={{this.isAnswerFieldDisabled}}
                   @label={{block.ariaLabel}}
                   @screenReaderOnly={{true}}
                   @placeholder={{block.placeholder}}

--- a/mon-pix/app/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/components/challenge-item-qroc.hbs
@@ -14,17 +14,16 @@
             {{#if (eq block.type "select")}}
               <div class="challenge-response__proposal challenge-response__proposal--selector">
                 <PixSelect
-                  data-test="challenge-response-proposal-selector"
-                  name={{block.randomName}}
-                  id="{{block.input}}"
-                  aria-label={{block.ariaLabel}}
-                  @emptyOptionLabel={{block.placeholder}}
-                  @selectedOption={{this.userAnswer}}
-                  @emptyOptionNotSelectable={{true}}
-                  disabled={{this.isAnswerFieldDisabled}}
-                  @options={{block.options}}
                   data-uid="qroc-proposal-uid"
-                  @onChange={{this.answerChanged}}
+                  data-test="challenge-response-proposal-selector"
+                  disabled={{this.isAnswerFieldDisabled}}
+                  @label={{block.ariaLabel}}
+                  @screenReaderOnly={{true}}
+                  @placeholder={{block.placeholder}}
+                  @value={{this.qcrocProposalAnswerValue}}
+                  @hideDefaultOption={{true}}
+                  @options={{block.options}}
+                  @onChange={{this.onChangeSelect}}
                   @size="big"
                 />
               </div>
@@ -38,7 +37,7 @@
                 name={{block.randomName}}
                 placeholder={{block.placeholder}}
                 autocomplete="nope"
-                value="{{this.userAnswer}}"
+                value={{this.userAnswer}}
                 data-uid="qroc-proposal-uid"
                 disabled={{this.isAnswerFieldDisabled}}
               >
@@ -53,7 +52,7 @@
                 name={{block.randomName}}
                 placeholder={{block.placeholder}}
                 autocomplete="nope"
-                value="{{this.userAnswer}}"
+                value={{this.userAnswer}}
                 data-uid="qroc-proposal-uid"
                 disabled={{this.isAnswerFieldDisabled}}
               />
@@ -65,7 +64,7 @@
                 min="0"
                 data-test="challenge-response-proposal-selector"
                 placeholder={{block.placeholder}}
-                @value="{{this.userAnswer}}"
+                @value={{this.userAnswer}}
                 aria-label={{block.ariaLabel}}
                 data-uid="qroc-proposal-uid"
                 disabled={{this.isAnswerFieldDisabled}}
@@ -83,7 +82,7 @@
                 name={{block.randomName}}
                 placeholder={{block.placeholder}}
                 autocomplete="nope"
-                value="{{this.userAnswer}}"
+                value={{this.userAnswer}}
                 data-uid="qroc-proposal-uid"
                 disabled={{this.isAnswerFieldDisabled}}
               />

--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -10,11 +10,13 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
   @service intl;
 
   @tracked autoReplyAnswer = '';
+  @tracked qcrocProposalAnswerValue = '';
   postMessageHandler = null;
   embedOrigins = ENV.APP.EMBED_ALLOWED_ORIGINS;
 
   constructor() {
     super(...arguments);
+    this.qcrocProposalAnswerValue = this.userAnswer;
     if (this.args.challenge.autoReply) {
       this._addEventListener();
     }
@@ -30,7 +32,9 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
   }
 
   _getAnswerValue() {
-    return this.showProposal ? document.querySelector('[data-uid="qroc-proposal-uid"]').value : this.autoReplyAnswer;
+    const qcrocProposalAnswerValueBis =
+      document.querySelector('[data-uid="qroc-proposal-uid"]')?.value || this.qcrocProposalAnswerValue;
+    return this.showProposal ? qcrocProposalAnswerValueBis : this.autoReplyAnswer;
   }
 
   _getErrorMessage() {
@@ -93,6 +97,12 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
   @action
   answerChanged() {
     this.errorMessage = null;
+  }
+
+  @action
+  onChangeSelect(value) {
+    this.errorMessage = null;
+    this.qcrocProposalAnswerValue = value;
   }
 
   @action

--- a/mon-pix/app/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/components/challenge-item-qrocm.hbs
@@ -9,6 +9,7 @@
         @proposals={{@challenge.proposals}}
         @answersValue={{this.answersValue}}
         @answerChanged={{this.answerChanged}}
+        @onChangeSelect={{this.onChangeSelect}}
         @isAnswerFieldDisabled={{this.isAnswerFieldDisabled}}
       />
     </div>

--- a/mon-pix/app/components/challenge-item-qrocm.js
+++ b/mon-pix/app/components/challenge-item-qrocm.js
@@ -6,11 +6,12 @@ import isEmpty from 'lodash/isEmpty';
 import ChallengeItemGeneric from './challenge-item-generic';
 import jsyaml from 'js-yaml';
 import proposalsAsBlocks from 'mon-pix/utils/proposals-as-blocks';
+import { tracked } from '@glimmer/tracking';
 
 export default class ChallengeItemQrocm extends ChallengeItemGeneric {
   @service intl;
 
-  answersValue = {};
+  @tracked answersValue = {};
 
   constructor() {
     super(...arguments);
@@ -54,5 +55,10 @@ export default class ChallengeItemQrocm extends ChallengeItemGeneric {
   @action
   answerChanged() {
     this.errorMessage = null;
+  }
+
+  @action
+  onChangeSelect(value) {
+    this.answersValue = value;
   }
 }

--- a/mon-pix/app/components/pix-toggle-deprecated.hbs
+++ b/mon-pix/app/components/pix-toggle-deprecated.hbs
@@ -1,5 +1,5 @@
 {{! template-lint-disable no-action no-curly-component-invocation no-invalid-interactive }}
-<div class="pix-toggle">
+<div class="pix-toggle-deprecated">
   <span
     class="{{this.firstButtonClass}}"
     onToggle={{action "onToggle" "firstButtonClass" on="click"}}

--- a/mon-pix/app/components/pix-toggle-deprecated.js
+++ b/mon-pix/app/components/pix-toggle-deprecated.js
@@ -12,15 +12,15 @@ export default Component.extend({
   isFirstOn: true,
 
   firstButtonClass: computed('isFirstOn', function () {
-    return this.isFirstOn ? 'pix-toggle__on' : 'pix-toggle__off';
+    return this.isFirstOn ? 'pix-toggle-deprecated__on' : 'pix-toggle-deprecated__off';
   }),
 
   secondButtonClass: computed('isFirstOn', function () {
-    return this.isFirstOn ? 'pix-toggle__off' : 'pix-toggle__on';
+    return this.isFirstOn ? 'pix-toggle-deprecated__off' : 'pix-toggle-deprecated__on';
   }),
 
   click: function (e) {
-    if (e.target.className === 'pix-toggle__off') {
+    if (e.target.className === 'pix-toggle-deprecated__off') {
       this.toggleProperty('isFirstOn');
     }
 

--- a/mon-pix/app/components/qrocm-proposal.hbs
+++ b/mon-pix/app/components/qrocm-proposal.hbs
@@ -9,7 +9,7 @@
       <div class="challenge-response__proposal challenge-response__proposal--selector">
         <PixSelect
           data-test="challenge-response-proposal-selector"
-          disabled={{@isAnswerFieldDisabled}}
+          @isDisabled={{@isAnswerFieldDisabled}}
           @label={{block.ariaLabel}}
           @screenReaderOnly={{true}}
           @placeholder={{block.placeholder}}

--- a/mon-pix/app/components/qrocm-proposal.hbs
+++ b/mon-pix/app/components/qrocm-proposal.hbs
@@ -10,15 +10,14 @@
       <div class="challenge-response__proposal challenge-response__proposal--selector">
         <PixSelect
           data-test="challenge-response-proposal-selector"
-          name={{block.randomName}}
           disabled={{@isAnswerFieldDisabled}}
-          id="{{block.input}}"
-          aria-label={{block.ariaLabel}}
-          @emptyOptionLabel={{block.placeholder}}
-          @selectedOption={{get @answersValue block.input}}
-          @emptyOptionNotSelectable={{true}}
+          @label={{block.ariaLabel}}
+          @screenReaderOnly={{true}}
+          @placeholder={{block.placeholder}}
+          @value={{@answersValue}}
+          @hideDefaultOption={{true}}
           @options={{block.options}}
-          @onChange={{this.setAnswerValue}}
+          @onChange={{@onChangeSelect}}
           @size="big"
         />
       </div>

--- a/mon-pix/app/components/qrocm-proposal.hbs
+++ b/mon-pix/app/components/qrocm-proposal.hbs
@@ -5,7 +5,6 @@
     {{#if block.showText}}
       <MarkdownToHtml @markdown={{block.text}} @extensions="remove-paragraph-tags" class="qrocm-proposal__label" />
     {{/if}}
-
     {{#if (eq block.type "select")}}
       <div class="challenge-response__proposal challenge-response__proposal--selector">
         <PixSelect
@@ -14,10 +13,10 @@
           @label={{block.ariaLabel}}
           @screenReaderOnly={{true}}
           @placeholder={{block.placeholder}}
-          @value={{@answersValue}}
+          @value={{get @answersValue block.input}}
           @hideDefaultOption={{true}}
           @options={{block.options}}
-          @onChange={{@onChangeSelect}}
+          @onChange={{fn this.onChange block.input}}
           @size="big"
         />
       </div>

--- a/mon-pix/app/components/qrocm-proposal.js
+++ b/mon-pix/app/components/qrocm-proposal.js
@@ -31,4 +31,10 @@ export default class QrocmProposal extends Component {
   onInputChange() {
     this.args.answerChanged();
   }
+
+  @action
+  onChange(key, value) {
+    this.args.answersValue[key] = value;
+    this.args.onChangeSelect(this.args.answersValue);
+  }
 }

--- a/mon-pix/app/components/qrocm-proposal.js
+++ b/mon-pix/app/components/qrocm-proposal.js
@@ -31,10 +31,4 @@ export default class QrocmProposal extends Component {
   onInputChange() {
     this.args.answerChanged();
   }
-
-  @action
-  setAnswerValue(event) {
-    const key = event.target.id;
-    this.args.answersValue[key] = event.target.value;
-  }
 }

--- a/mon-pix/app/components/routes/register-form.hbs
+++ b/mon-pix/app/components/routes/register-form.hbs
@@ -80,7 +80,7 @@
 
     <label class="register-form__login-options">{{t "pages.login-or-register.register-form.options.text"}}</label>
     <div id="login-mode-container">
-      <PixToggle
+      <PixToggleDeprecated
         @valueFirstLabel={{t "pages.login-or-register.register-form.options.username"}}
         @valueSecondLabel={{t "pages.login-or-register.register-form.options.email"}}
         @onToggle={{this.onToggle}}

--- a/mon-pix/app/controllers/authenticated/user-account/language.js
+++ b/mon-pix/app/controllers/authenticated/user-account/language.js
@@ -10,20 +10,20 @@ export default class UserAccountPersonalInformationController extends Controller
   get options() {
     return [
       {
-        label: this.intl.t('pages.user-account.language.fields.select.labels.french'),
         value: 'fr',
+        label: this.intl.t('pages.user-account.language.fields.select.labels.french'),
       },
       {
-        label: this.intl.t('pages.user-account.language.fields.select.labels.english'),
         value: 'en',
+        label: this.intl.t('pages.user-account.language.fields.select.labels.english'),
       },
     ];
   }
 
   @action
-  async onChangeLang(event) {
+  async onChangeLang(value) {
     if (!this.url.isFrenchDomainExtension) {
-      this.location.replace(`/mon-compte/langue?lang=${event.target.value}`);
+      this.location.replace(`/mon-compte/langue?lang=${value}`);
     }
   }
 }

--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -145,7 +145,3 @@ form .challenge-response-locked {
     }
   }
 }
-
-.challenge-response__proposal--selector .pix-select {
-  width: auto !important; // TODO: remove me after fix in Pix-UI
-}

--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -145,3 +145,7 @@ form .challenge-response-locked {
     }
   }
 }
+
+.challenge-response__proposal--selector .pix-select {
+  width: auto !important; // TODO: remove me after fix in Pix-UI
+}

--- a/mon-pix/app/styles/components/_pix-toggle.scss
+++ b/mon-pix/app/styles/components/_pix-toggle.scss
@@ -1,4 +1,4 @@
-.pix-toggle {
+.pix-toggle-deprecated {
   display: flex;
   height: 44px;
   color: $pix-neutral-60;

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -94,10 +94,7 @@
 
 .mediacentre-start-campaign-modal__action-buttons {
   display: flex;
-  gap: 16px;
+  gap: 24px;
   align-items: center;
-
-  a {
-    margin-bottom: 16px;
-  }
+  justify-content: flex-end;
 }

--- a/mon-pix/app/templates/authenticated/user-account/language.hbs
+++ b/mon-pix/app/templates/authenticated/user-account/language.hbs
@@ -1,13 +1,10 @@
 <div class="language">
-  <label for="language-select" class="form-textfield__label language__label">{{t
-      "pages.user-account.language.lang"
-    }}</label>
   <PixSelect
-    id="language-select"
-    name={{t "pages.user-account.language.lang"}}
     @options={{this.options}}
     @onChange={{this.onChangeLang}}
-    @selectedOption={{@model.lang}}
+    @value={{@model.lang}}
+    @label={{t "pages.user-account.language.lang"}}
+    @hideDefaultOption={{true}}
     data-test-lang
   />
 </div>

--- a/mon-pix/config/icons.js
+++ b/mon-pix/config/icons.js
@@ -7,6 +7,7 @@ module.exports = function () {
       'arrow-up',
       'bars',
       'bookmark',
+      'chevron-up',
       'chevron-down',
       'circle-check',
       'circle-exclamation',

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^20.2.4",
+        "@1024pix/pix-ui": "^23.1.2",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
         "@ember/optional-features": "^2.0.0",
@@ -1137,37 +1137,23 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.2.4.tgz",
-      "integrity": "sha512-G71jhEna46WoniRqzfaibGdnaRFynjaWPhBlCVdEPtWtkTWhE7srpv8fRBAko64geth6H7WE+ErI9b9p0WSnsg==",
+      "version": "23.1.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-23.1.2.tgz",
+      "integrity": "sha512-GQIFFGGvi5Gtz1CUY0G4JU3Ai+XQXt47X0RVGnrcBTGcIPMAw48/bhlq6GlXm0IwrjbdgecJB+SGWjUbmAiO9A==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-htmlbars": "^5.6.2",
-        "ember-cli-sass": "^10.0.1",
+        "ember-cli-babel": "^7.26.8",
+        "ember-cli-htmlbars": "^6.1.1",
+        "ember-cli-sass": "^11.0.1",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-click-outside": "^2.0.0",
+        "ember-click-outside": "^4.0.0",
         "ember-prop-modifier": "^1.0.1",
-        "ember-truth-helpers": "^3.0.0"
+        "ember-truth-helpers": "^3.1.1"
       },
       "engines": {
         "node": "16",
         "npm": ">=8.13.2 <9"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.8.7.tgz",
-      "integrity": "sha512-7O0UsPQVNKqpHeHLpfvOG4uXmlw+MOxYvUv6Otc9uH5SYMIxvF6eBdjkWvC3f9G+VXe0RsNExyAQBeTRug/wqQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-syntax-typescript": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@1024pix/pix-ui/node_modules/async-disk-cache": {
@@ -1203,9 +1189,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui/node_modules/broccoli-persistent-filter": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
-      "integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
+      "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
       "dev": true,
       "dependencies": {
         "async-disk-cache": "^2.0.0",
@@ -1251,20 +1237,6 @@
         "node": "10.* || >= 12.*"
       }
     },
-    "node_modules/@1024pix/pix-ui/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@1024pix/pix-ui/node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1307,7 +1279,35 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-cli-htmlbars": {
+    "node_modules/@1024pix/pix-ui/node_modules/ember-cli-version-checker": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
+      "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
+      "dev": true,
+      "dependencies": {
+        "resolve-package-path": "^3.1.0",
+        "semver": "^7.3.4",
+        "silent-error": "^1.1.1"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-4.0.0.tgz",
+      "integrity": "sha512-3SstFhDWu3K5PQzo0FZwk66Ehe1l6QFU/R+WjAt8yOXw2sHzJHOdx2N+fNWJHZsJ97BSqdL7L0qotJEMX46u6Q==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-htmlbars": "^5.7.1",
+        "ember-modifier": "^2.1.0 || ^3.0.0"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside/node_modules/ember-cli-htmlbars": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
       "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
@@ -1334,358 +1334,6 @@
         "node": "10.* || >= 12.*"
       }
     },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-cli-sass": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-sass/-/ember-cli-sass-10.0.1.tgz",
-      "integrity": "sha512-dWVoX03O2Mot1dEB1AN3ofC8DDZb6iU4Kfkbr3WYi9S9bGVHrpR/ngsR7tuVBuTugTyG53FPtLLqYdqx7XjXdA==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-funnel": "^2.0.1",
-        "broccoli-merge-trees": "^3.0.1",
-        "broccoli-sass-source-maps": "^4.0.0",
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-cli-sass/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-cli-sass/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-cli-typescript": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz",
-      "integrity": "sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
-        "@babel/plugin-proposal-optional-chaining": "^7.6.0",
-        "@babel/plugin-transform-typescript": "~7.8.0",
-        "ansi-to-html": "^0.6.6",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "ember-cli-babel-plugin-helpers": "^1.0.0",
-        "execa": "^3.0.0",
-        "fs-extra": "^8.0.0",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^6.3.0",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.0.0"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-cli-typescript/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-cli-version-checker": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
-      "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
-      "dev": true,
-      "dependencies": {
-        "resolve-package-path": "^3.1.0",
-        "semver": "^7.3.4",
-        "silent-error": "^1.1.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-2.0.0.tgz",
-      "integrity": "sha512-d53L+Of9rRhB8RU32xKFDG58e8MJZRPFF9HAuUIcn3Hl5U7v8Gb9YqB59khcryCkRXWzLOvVgmNFjNaV9iZJyQ==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.18.0",
-        "ember-cli-htmlbars": "^4.2.3",
-        "ember-modifier": "^2.1.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside/node_modules/async-disk-cache": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.5.tgz",
-      "integrity": "sha512-VZpqfR0R7CEOJZ/0FOTgWq70lCrZyS1rkI8PXugDUkTKyyAUgZ2zQ09gLhMkEn+wN8LYeUTPxZdXtlX/kmbXKQ==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^2.1.3",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "2.1.0",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^2.5.3",
-        "rsvp": "^3.0.18",
-        "username-sync": "^1.0.2"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside/node_modules/async-disk-cache/node_modules/rsvp": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-      "dev": true,
-      "engines": {
-        "node": "0.12.* || 4.* || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside/node_modules/babel-plugin-htmlbars-inline-precompile": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.2.0.tgz",
-      "integrity": "sha512-IUeZmgs9tMUGXYu1vfke5I18yYJFldFGdNFQOWslXTnDWXzpwPih7QFduUqvT+awDpDuNtXpdt5JAf43Q1Hhzg==",
-      "dev": true,
-      "engines": {
-        "node": "8.* || 10.* || >= 12.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside/node_modules/broccoli-output-wrapper": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-2.0.0.tgz",
-      "integrity": "sha512-V/ozejo+snzNf75i/a6iTmp71k+rlvqjE3+jYfimuMwR1tjNNRdtfno+NGNQB2An9bIAeqZnKhMDurAznHAdtA==",
-      "dev": true,
-      "dependencies": {
-        "heimdalljs-logger": "^0.1.10"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside/node_modules/broccoli-persistent-filter": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
-      "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
-      "dev": true,
-      "dependencies": {
-        "async-disk-cache": "^1.2.1",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^1.0.0",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "mkdirp": "^0.5.1",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^2.6.1",
-        "rsvp": "^4.7.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^1.3.3",
-        "walk-sync": "^1.0.0"
-      },
-      "engines": {
-        "node": "6.* || >= 8.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside/node_modules/broccoli-persistent-filter/node_modules/broccoli-plugin": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
-      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-      "dev": true,
-      "dependencies": {
-        "promise-map-series": "^0.2.1",
-        "quick-temp": "^0.1.3",
-        "rimraf": "^2.3.4",
-        "symlink-or-copy": "^1.1.8"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside/node_modules/broccoli-persistent-filter/node_modules/walk-sync": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
-      "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^1.1.1"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside/node_modules/broccoli-plugin": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz",
-      "integrity": "sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-node-api": "^1.6.0",
-        "broccoli-output-wrapper": "^2.0.0",
-        "fs-merger": "^3.0.1",
-        "promise-map-series": "^0.2.1",
-        "quick-temp": "^0.1.3",
-        "rimraf": "^2.3.4",
-        "symlink-or-copy": "^1.1.8"
-      },
-      "engines": {
-        "node": "8.* || 10.* || >= 12.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside/node_modules/editions": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside/node_modules/ember-cli-htmlbars": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.5.0.tgz",
-      "integrity": "sha512-bYJpK1pqFu9AadDAGTw05g2LMNzY8xTCIqQm7dMJmKEoUpLRFbPf4SfHXrktzDh7Q5iggl6Skzf1M0bPlIxARw==",
-      "dev": true,
-      "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^3.2.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^2.3.1",
-        "broccoli-plugin": "^3.1.0",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.0",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
-        "semver": "^6.3.0",
-        "strip-bom": "^4.0.0",
-        "walk-sync": "^2.0.2"
-      },
-      "engines": {
-        "node": "8.* || 10.* || >= 12.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside/node_modules/istextorbinary": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
-      "integrity": "sha512-kT1g2zxZ5Tdabtpp9VSdOzW9lb6LXImyWbzbQeTxoRtHhurC9Ej9Wckngr2+uepPL09ky/mJHmN9jeJPML5t6A==",
-      "dev": true,
-      "dependencies": {
-        "binaryextensions": "1 || 2",
-        "editions": "^1.1.1",
-        "textextensions": "1 || 2"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside/node_modules/matcher-collection": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-      "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-      "dev": true,
-      "dependencies": {
-        "minimatch": "^3.0.2"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-click-outside/node_modules/sync-disk-cache": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-1.3.4.tgz",
-      "integrity": "sha512-GlkGeM81GPPEKz/lH7QUTbvqLq7K/IUTuaKDSMulP9XQ42glqNJIN/RKgSOw4y8vxL1gOVvj+W7ruEO4s36eCw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^2.1.3",
-        "heimdalljs": "^0.2.3",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^2.2.8",
-        "username-sync": "^1.0.2"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-modifier": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-2.1.2.tgz",
-      "integrity": "sha512-3Lsu1fV1sIGa66HOW07RZc6EHISwKt5VA5AUnFss2HX6OTfpxTJ2qvPctt2Yt0XPQXJ4G6BQasr/F35CX7UGJA==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.22.1",
-        "ember-cli-normalize-entity-name": "^1.0.0",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^3.1.3",
-        "ember-compatibility-helpers": "^1.2.4",
-        "ember-destroyable-polyfill": "^2.0.2",
-        "ember-modifier-manager-polyfill": "^1.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/execa": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-      "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "p-finally": "^2.0.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": "^8.12.0 || >=9.7.0"
-      }
-    },
     "node_modules/@1024pix/pix-ui/node_modules/fs-tree-diff": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
@@ -1700,33 +1348,6 @@
       },
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@1024pix/pix-ui/node_modules/istextorbinary": {
@@ -1764,36 +1385,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/p-finally": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/@1024pix/pix-ui/node_modules/resolve-package-path": {
       "version": "3.1.0",
@@ -1833,9 +1424,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -1845,27 +1436,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@1024pix/pix-ui/node_modules/strip-bom": {
@@ -1906,21 +1476,6 @@
       },
       "engines": {
         "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -44314,31 +43869,20 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.2.4.tgz",
-      "integrity": "sha512-G71jhEna46WoniRqzfaibGdnaRFynjaWPhBlCVdEPtWtkTWhE7srpv8fRBAko64geth6H7WE+ErI9b9p0WSnsg==",
+      "version": "23.1.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-23.1.2.tgz",
+      "integrity": "sha512-GQIFFGGvi5Gtz1CUY0G4JU3Ai+XQXt47X0RVGnrcBTGcIPMAw48/bhlq6GlXm0IwrjbdgecJB+SGWjUbmAiO9A==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-htmlbars": "^5.6.2",
-        "ember-cli-sass": "^10.0.1",
+        "ember-cli-babel": "^7.26.8",
+        "ember-cli-htmlbars": "^6.1.1",
+        "ember-cli-sass": "^11.0.1",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-click-outside": "^2.0.0",
+        "ember-click-outside": "^4.0.0",
         "ember-prop-modifier": "^1.0.1",
-        "ember-truth-helpers": "^3.0.0"
+        "ember-truth-helpers": "^3.1.1"
       },
       "dependencies": {
-        "@babel/plugin-transform-typescript": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.8.7.tgz",
-          "integrity": "sha512-7O0UsPQVNKqpHeHLpfvOG4uXmlw+MOxYvUv6Otc9uH5SYMIxvF6eBdjkWvC3f9G+VXe0RsNExyAQBeTRug/wqQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-create-class-features-plugin": "^7.8.3",
-            "@babel/helper-plugin-utils": "^7.8.3",
-            "@babel/plugin-syntax-typescript": "^7.8.3"
-          }
-        },
         "async-disk-cache": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
@@ -44366,9 +43910,9 @@
           }
         },
         "broccoli-persistent-filter": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
-          "integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
+          "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
           "dev": true,
           "requires": {
             "async-disk-cache": "^2.0.0",
@@ -44407,17 +43951,6 @@
             }
           }
         },
-        "cross-spawn": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          }
-        },
         "debug": {
           "version": "4.3.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -44445,90 +43978,6 @@
             }
           }
         },
-        "ember-cli-htmlbars": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-          "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-          "dev": true,
-          "requires": {
-            "@ember/edition-utils": "^1.2.0",
-            "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-            "broccoli-debug": "^0.6.5",
-            "broccoli-persistent-filter": "^3.1.2",
-            "broccoli-plugin": "^4.0.3",
-            "common-tags": "^1.8.0",
-            "ember-cli-babel-plugin-helpers": "^1.1.1",
-            "ember-cli-version-checker": "^5.1.2",
-            "fs-tree-diff": "^2.0.1",
-            "hash-for-dep": "^1.5.1",
-            "heimdalljs-logger": "^0.1.10",
-            "json-stable-stringify": "^1.0.1",
-            "semver": "^7.3.4",
-            "silent-error": "^1.1.1",
-            "strip-bom": "^4.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "ember-cli-sass": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-sass/-/ember-cli-sass-10.0.1.tgz",
-          "integrity": "sha512-dWVoX03O2Mot1dEB1AN3ofC8DDZb6iU4Kfkbr3WYi9S9bGVHrpR/ngsR7tuVBuTugTyG53FPtLLqYdqx7XjXdA==",
-          "dev": true,
-          "requires": {
-            "broccoli-funnel": "^2.0.1",
-            "broccoli-merge-trees": "^3.0.1",
-            "broccoli-sass-source-maps": "^4.0.0",
-            "ember-cli-version-checker": "^2.1.0"
-          },
-          "dependencies": {
-            "ember-cli-version-checker": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-              "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-              "dev": true,
-              "requires": {
-                "resolve": "^1.3.3",
-                "semver": "^5.3.0"
-              }
-            },
-            "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-              "dev": true
-            }
-          }
-        },
-        "ember-cli-typescript": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz",
-          "integrity": "sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==",
-          "dev": true,
-          "requires": {
-            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
-            "@babel/plugin-proposal-optional-chaining": "^7.6.0",
-            "@babel/plugin-transform-typescript": "~7.8.0",
-            "ansi-to-html": "^0.6.6",
-            "broccoli-stew": "^3.0.0",
-            "debug": "^4.0.0",
-            "ember-cli-babel-plugin-helpers": "^1.0.0",
-            "execa": "^3.0.0",
-            "fs-extra": "^8.0.0",
-            "resolve": "^1.5.0",
-            "rsvp": "^4.8.1",
-            "semver": "^6.3.0",
-            "stagehand": "^1.0.0",
-            "walk-sync": "^2.0.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            }
-          }
-        },
         "ember-cli-version-checker": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
@@ -44541,240 +43990,40 @@
           }
         },
         "ember-click-outside": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-2.0.0.tgz",
-          "integrity": "sha512-d53L+Of9rRhB8RU32xKFDG58e8MJZRPFF9HAuUIcn3Hl5U7v8Gb9YqB59khcryCkRXWzLOvVgmNFjNaV9iZJyQ==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-4.0.0.tgz",
+          "integrity": "sha512-3SstFhDWu3K5PQzo0FZwk66Ehe1l6QFU/R+WjAt8yOXw2sHzJHOdx2N+fNWJHZsJ97BSqdL7L0qotJEMX46u6Q==",
           "dev": true,
           "requires": {
-            "ember-cli-babel": "^7.18.0",
-            "ember-cli-htmlbars": "^4.2.3",
-            "ember-modifier": "^2.1.0"
+            "ember-cli-babel": "^7.26.6",
+            "ember-cli-htmlbars": "^5.7.1",
+            "ember-modifier": "^2.1.0 || ^3.0.0"
           },
           "dependencies": {
-            "async-disk-cache": {
-              "version": "1.3.5",
-              "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.5.tgz",
-              "integrity": "sha512-VZpqfR0R7CEOJZ/0FOTgWq70lCrZyS1rkI8PXugDUkTKyyAUgZ2zQ09gLhMkEn+wN8LYeUTPxZdXtlX/kmbXKQ==",
-              "dev": true,
-              "requires": {
-                "debug": "^2.1.3",
-                "heimdalljs": "^0.2.3",
-                "istextorbinary": "2.1.0",
-                "mkdirp": "^0.5.0",
-                "rimraf": "^2.5.3",
-                "rsvp": "^3.0.18",
-                "username-sync": "^1.0.2"
-              },
-              "dependencies": {
-                "rsvp": {
-                  "version": "3.6.2",
-                  "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-                  "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-                  "dev": true
-                }
-              }
-            },
-            "babel-plugin-htmlbars-inline-precompile": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.2.0.tgz",
-              "integrity": "sha512-IUeZmgs9tMUGXYu1vfke5I18yYJFldFGdNFQOWslXTnDWXzpwPih7QFduUqvT+awDpDuNtXpdt5JAf43Q1Hhzg==",
-              "dev": true
-            },
-            "broccoli-output-wrapper": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-2.0.0.tgz",
-              "integrity": "sha512-V/ozejo+snzNf75i/a6iTmp71k+rlvqjE3+jYfimuMwR1tjNNRdtfno+NGNQB2An9bIAeqZnKhMDurAznHAdtA==",
-              "dev": true,
-              "requires": {
-                "heimdalljs-logger": "^0.1.10"
-              }
-            },
-            "broccoli-persistent-filter": {
-              "version": "2.3.1",
-              "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
-              "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
-              "dev": true,
-              "requires": {
-                "async-disk-cache": "^1.2.1",
-                "async-promise-queue": "^1.0.3",
-                "broccoli-plugin": "^1.0.0",
-                "fs-tree-diff": "^2.0.0",
-                "hash-for-dep": "^1.5.0",
-                "heimdalljs": "^0.2.1",
-                "heimdalljs-logger": "^0.1.7",
-                "mkdirp": "^0.5.1",
-                "promise-map-series": "^0.2.1",
-                "rimraf": "^2.6.1",
-                "rsvp": "^4.7.0",
-                "symlink-or-copy": "^1.0.1",
-                "sync-disk-cache": "^1.3.3",
-                "walk-sync": "^1.0.0"
-              },
-              "dependencies": {
-                "broccoli-plugin": {
-                  "version": "1.3.1",
-                  "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
-                  "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-                  "dev": true,
-                  "requires": {
-                    "promise-map-series": "^0.2.1",
-                    "quick-temp": "^0.1.3",
-                    "rimraf": "^2.3.4",
-                    "symlink-or-copy": "^1.1.8"
-                  }
-                },
-                "walk-sync": {
-                  "version": "1.1.4",
-                  "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
-                  "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
-                  "dev": true,
-                  "requires": {
-                    "@types/minimatch": "^3.0.3",
-                    "ensure-posix-path": "^1.1.0",
-                    "matcher-collection": "^1.1.1"
-                  }
-                }
-              }
-            },
-            "broccoli-plugin": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz",
-              "integrity": "sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==",
-              "dev": true,
-              "requires": {
-                "broccoli-node-api": "^1.6.0",
-                "broccoli-output-wrapper": "^2.0.0",
-                "fs-merger": "^3.0.1",
-                "promise-map-series": "^0.2.1",
-                "quick-temp": "^0.1.3",
-                "rimraf": "^2.3.4",
-                "symlink-or-copy": "^1.1.8"
-              }
-            },
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "editions": {
-              "version": "1.3.4",
-              "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-              "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
-              "dev": true
-            },
             "ember-cli-htmlbars": {
-              "version": "4.5.0",
-              "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.5.0.tgz",
-              "integrity": "sha512-bYJpK1pqFu9AadDAGTw05g2LMNzY8xTCIqQm7dMJmKEoUpLRFbPf4SfHXrktzDh7Q5iggl6Skzf1M0bPlIxARw==",
+              "version": "5.7.2",
+              "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
+              "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
               "dev": true,
               "requires": {
                 "@ember/edition-utils": "^1.2.0",
-                "babel-plugin-htmlbars-inline-precompile": "^3.2.0",
+                "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
                 "broccoli-debug": "^0.6.5",
-                "broccoli-persistent-filter": "^2.3.1",
-                "broccoli-plugin": "^3.1.0",
+                "broccoli-persistent-filter": "^3.1.2",
+                "broccoli-plugin": "^4.0.3",
                 "common-tags": "^1.8.0",
-                "ember-cli-babel-plugin-helpers": "^1.1.0",
+                "ember-cli-babel-plugin-helpers": "^1.1.1",
+                "ember-cli-version-checker": "^5.1.2",
                 "fs-tree-diff": "^2.0.1",
                 "hash-for-dep": "^1.5.1",
                 "heimdalljs-logger": "^0.1.10",
                 "json-stable-stringify": "^1.0.1",
-                "semver": "^6.3.0",
+                "semver": "^7.3.4",
+                "silent-error": "^1.1.1",
                 "strip-bom": "^4.0.0",
-                "walk-sync": "^2.0.2"
-              }
-            },
-            "istextorbinary": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
-              "integrity": "sha512-kT1g2zxZ5Tdabtpp9VSdOzW9lb6LXImyWbzbQeTxoRtHhurC9Ej9Wckngr2+uepPL09ky/mJHmN9jeJPML5t6A==",
-              "dev": true,
-              "requires": {
-                "binaryextensions": "1 || 2",
-                "editions": "^1.1.1",
-                "textextensions": "1 || 2"
-              }
-            },
-            "matcher-collection": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-              "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-              "dev": true,
-              "requires": {
-                "minimatch": "^3.0.2"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-              "dev": true
-            },
-            "rimraf": {
-              "version": "2.7.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-              "dev": true,
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            },
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            },
-            "sync-disk-cache": {
-              "version": "1.3.4",
-              "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-1.3.4.tgz",
-              "integrity": "sha512-GlkGeM81GPPEKz/lH7QUTbvqLq7K/IUTuaKDSMulP9XQ42glqNJIN/RKgSOw4y8vxL1gOVvj+W7ruEO4s36eCw==",
-              "dev": true,
-              "requires": {
-                "debug": "^2.1.3",
-                "heimdalljs": "^0.2.3",
-                "mkdirp": "^0.5.0",
-                "rimraf": "^2.2.8",
-                "username-sync": "^1.0.2"
+                "walk-sync": "^2.2.0"
               }
             }
-          }
-        },
-        "ember-modifier": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-2.1.2.tgz",
-          "integrity": "sha512-3Lsu1fV1sIGa66HOW07RZc6EHISwKt5VA5AUnFss2HX6OTfpxTJ2qvPctt2Yt0XPQXJ4G6BQasr/F35CX7UGJA==",
-          "dev": true,
-          "requires": {
-            "ember-cli-babel": "^7.22.1",
-            "ember-cli-normalize-entity-name": "^1.0.0",
-            "ember-cli-string-utils": "^1.1.0",
-            "ember-cli-typescript": "^3.1.3",
-            "ember-compatibility-helpers": "^1.2.4",
-            "ember-destroyable-polyfill": "^2.0.2",
-            "ember-modifier-manager-polyfill": "^1.2.0"
-          }
-        },
-        "execa": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-          "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "p-finally": "^2.0.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
           }
         },
         "fs-tree-diff": {
@@ -44789,21 +44038,6 @@
             "path-posix": "^1.0.0",
             "symlink-or-copy": "^1.1.8"
           }
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "is-stream": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-          "dev": true
         },
         "istextorbinary": {
           "version": "2.6.0",
@@ -44832,27 +44066,6 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
-        "npm-run-path": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.0.0"
-          }
-        },
-        "p-finally": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-          "dev": true
-        },
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
-        },
         "resolve-package-path": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
@@ -44879,28 +44092,13 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-          "dev": true
         },
         "strip-bom": {
           "version": "4.0.0",
@@ -44931,15 +44129,6 @@
             "ensure-posix-path": "^1.1.0",
             "matcher-collection": "^2.0.0",
             "minimatch": "^3.0.4"
-          }
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
           }
         }
       }

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^20.2.4",
+    "@1024pix/pix-ui": "^23.1.2",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",
     "@ember/optional-features": "^2.0.0",

--- a/mon-pix/tests/acceptance/challenge-item-qroc_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qroc_test.js
@@ -2,6 +2,7 @@ import { click, find, findAll, currentURL, fillIn, triggerEvent, visit } from '@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { clickByName, visit as visitScreen } from '@1024pix/ember-testing-library';
 
 module('Acceptance | Displaying a QROC challenge', function (hooks) {
   setupApplicationTest(hooks);
@@ -102,7 +103,8 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
         assert.equal(find('.challenge-statement-instruction__text').textContent.trim(), qrocChallenge.instruction);
 
         assert.dom('.challenge-response__proposal').exists({ count: 1 });
-        assert.false(find('.challenge-response__proposal').disabled);
+        // TODO : est-ce que cette ligne sert à quelque chose ?
+        // assert.false(find('.challenge-response__proposal').disabled);
 
         assert.ok(findAll('.qroc_input-label')[0].innerHTML.includes('Entrez le <em>prénom</em> de B. Gates :'));
 
@@ -166,7 +168,8 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
         // TODO: Fix this the next time the file is edited.
         // eslint-disable-next-line qunit/no-assert-equal
         assert.equal(find('.challenge-response__proposal').value, 'Reponse');
-        assert.true(find('.challenge-response__proposal').disabled);
+        // TODO : est-ce que cette ligne sert à quelque chose ?
+        // assert.true(find('.challenge-response__proposal').disabled);
 
         assert.dom('.challenge-actions__action-continue').exists();
         assert.dom('.challenge-actions__action-validate').doesNotExist();
@@ -305,7 +308,8 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
         assert.equal(find('.challenge-statement-instruction__text').textContent.trim(), qrocChallenge.instruction);
 
         assert.dom('.challenge-response__proposal').exists({ count: 1 });
-        assert.false(find('.challenge-response__proposal').disabled);
+        // TODO : est-ce que cette ligne sert à quelque chose ?
+        // assert.false(find('.challenge-response__proposal').disabled);
         assert.ok(findAll('.qroc_input-label')[0].innerHTML.includes('Entrez le <em>prénom</em> de B. Gates :'));
 
         assert.dom('.challenge-response__alert').doesNotExist();
@@ -424,43 +428,46 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
       qrocChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCWithSelect');
     });
 
-    module('When challenge is not already answered', function (hooks) {
-      hooks.beforeEach(async function () {
-        // when
-        await visit(`/assessments/${assessment.id}/challenges/0`);
-      });
+    module('When challenge is not already answered', function () {
+      test('should render challenge information and question', async function (assert) {
+        // given
+        await visitScreen(`/assessments/${assessment.id}/challenges/0`);
 
-      test('should render challenge information and question', function (assert) {
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.challenge-statement-instruction__text').textContent.trim(), qrocChallenge.instruction);
+        assert.strictEqual(
+          find('.challenge-statement-instruction__text').textContent.trim(),
+          qrocChallenge.instruction
+        );
         assert.dom('.challenge-response__proposal').exists({ count: 1 });
-        assert.false(find('[data-test="challenge-response-proposal-selector"]').disabled);
+        // TODO : est-ce que cette ligne sert à quelque chose ?
+        // assert.false(find('[data-test="challenge-response-proposal-selector"]').disabled);
         assert.ok(findAll('.qroc_input-label')[0].innerHTML.includes('Select: '));
-
         assert.dom('.challenge-response__alert').doesNotExist();
       });
 
       test('should hide the alert error after the user interact with input text', async function (assert) {
         // given
+        const screen = await visitScreen(`/assessments/${assessment.id}/challenges/0`);
         await click('.challenge-actions__action-validate');
         assert.dom('.challenge-response__alert').exists();
-        const selectOptions = findAll('select[data-test="challenge-response-proposal-selector"] option');
-        const optionToFillIn = selectOptions[1];
 
         // when
-        await fillIn('select[data-test="challenge-response-proposal-selector"]', optionToFillIn.value);
+        await clickByName('saladAriaLabel');
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'mango' }));
 
         // then
         assert.dom('.challenge-response__alert').doesNotExist();
       });
 
       test('should go to checkpoint when user validated', async function (assert) {
+        // given
+        const screen = await visitScreen(`/assessments/${assessment.id}/challenges/0`);
+
         // when
-        const selectOptions = findAll('select[data-test="challenge-response-proposal-selector"] option');
-        const optionToFillIn = selectOptions[1];
-        await fillIn('select[data-test="challenge-response-proposal-selector"]', optionToFillIn.value);
+        await clickByName('saladAriaLabel');
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'mango' }));
 
         await click('.challenge-actions__action-validate');
 

--- a/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
@@ -2,6 +2,7 @@ import { click, find, findAll, currentURL, fillIn, triggerEvent, visit } from '@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { clickByName, visit as visitScreen } from '@1024pix/ember-testing-library';
 
 module('Acceptance | Displaying a QROCM challenge', function (hooks) {
   setupApplicationTest(hooks);
@@ -76,14 +77,12 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
       });
     });
 
-    module('and challenge contains select field', function (hooks) {
-      hooks.beforeEach(async function () {
-        // when
-        server.create('challenge', 'forCompetenceEvaluation', 'QROCMWithSelect');
-        await visit(`/assessments/${assessment.id}/challenges/0`);
-      });
-
+    module('and challenge contains select field', function () {
       test('should not be able to validate with the initial option', async function (assert) {
+        // given
+        server.create('challenge', 'forCompetenceEvaluation', 'QROCMWithSelect');
+        await visitScreen(`/assessments/${assessment.id}/challenges/0`);
+
         // when
         await click(find('.challenge-actions__action-validate'));
 
@@ -94,11 +93,12 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
 
       test('should not be able to validate the empty option', async function (assert) {
         // given
-        const selectOptions = findAll('select[data-test="challenge-response-proposal-selector"] option');
-        const optionToFillIn = selectOptions[0];
+        server.create('challenge', 'forCompetenceEvaluation', 'QROCMWithSelect');
+        const screen = await visitScreen(`/assessments/${assessment.id}/challenges/0`);
 
         // when
-        await fillIn('select[data-test="challenge-response-proposal-selector"]', optionToFillIn.value);
+        await clickByName('saladAriaLabel');
+        await screen.findByRole('listbox');
         await click(find('.challenge-actions__action-validate'));
 
         // then
@@ -108,11 +108,13 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
 
       test('should validate an option and redirect to next page', async function (assert) {
         // given
-        const selectOptions = findAll('select[data-test="challenge-response-proposal-selector"] option');
-        const optionToFillIn = selectOptions[1];
+        server.create('challenge', 'forCompetenceEvaluation', 'QROCMWithSelect');
+        const screen = await visitScreen(`/assessments/${assessment.id}/challenges/0`);
 
         // when
-        await fillIn('select[data-test="challenge-response-proposal-selector"]', optionToFillIn.value);
+        await clickByName('saladAriaLabel');
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'potato' }));
         await click(find('.challenge-actions__action-validate'));
 
         // then
@@ -156,24 +158,22 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
       });
     });
 
-    module('and challenge contains select field', function (hooks) {
-      hooks.beforeEach(async function () {
+    module('and challenge contains select field', function () {
+      test('should set the select with previous answer and propose to continue', async function (assert) {
         // given
         const qrocmWithSelectChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCMWithSelect');
         server.create('answer', {
-          value: "banana: 'mango'\n",
+          value: 'mango',
           result: 'ko',
           assessment,
           challenge: qrocmWithSelectChallenge,
         });
 
         // when
-        await visit(`/assessments/${assessment.id}/challenges/0`);
-      });
+        const screen = await visitScreen(`/assessments/${assessment.id}/challenges/0`);
 
-      test('should set the select with previous answer and propose to continue', async function (assert) {
         // then
-        assert.ok(findAll('select[data-test="challenge-response-proposal-selector"] option')[1].selected);
+        assert.strictEqual(screen.getByLabelText('saladAriaLabel').innerText, 'mango');
 
         assert.dom('.challenge-actions__action-continue').exists();
         assert.dom('.challenge-actions__action-validate').doesNotExist();

--- a/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
@@ -163,7 +163,7 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
         // given
         const qrocmWithSelectChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCMWithSelect');
         server.create('answer', {
-          value: 'mango',
+          value: "banana: 'mango'\n",
           result: 'ko',
           assessment,
           challenge: qrocmWithSelectChallenge,

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -266,7 +266,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
 
             await click('#submit-search');
             //go to email-based authentication window
-            await click('.pix-toggle__off');
+            await click('.pix-toggle-deprecated__off');
 
             await fillIn('#email', prescritUser.email);
             await fillIn('#password', 'pix123');
@@ -286,7 +286,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             assert.equal(find('#password').value, 'pix123');
 
             //go to username-based authentication window
-            await click('.pix-toggle__off');
+            await click('.pix-toggle-deprecated__off');
             // TODO: Fix this the next time the file is edited.
             // eslint-disable-next-line qunit/no-assert-equal
             assert.equal(find('span[data-test-username]').textContent, 'first.last1010');

--- a/mon-pix/tests/integration/components/pix-toggle-deprecated_test.js
+++ b/mon-pix/tests/integration/components/pix-toggle-deprecated_test.js
@@ -3,7 +3,7 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | pix-toggle', function (hooks) {
+module('Integration | Component | pix-toggle-deprecated', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(async function () {
@@ -15,52 +15,52 @@ module('Integration | Component | pix-toggle', function (hooks) {
     this.set('isFirstOn', 'true');
 
     await render(
-      hbs`{{pix-toggle onToggle=this.onToggle valueFirstLabel=this.valueFirstLabel valueSecondLabel=this.valueSecondLabel}}`
+      hbs`{{pix-toggle-deprecated onToggle=this.onToggle valueFirstLabel=this.valueFirstLabel valueSecondLabel=this.valueSecondLabel}}`
     );
   });
 
   test('Default Render', function (assert) {
-    assert.dom('.pix-toggle').exists();
+    assert.dom('.pix-toggle-deprecated').exists();
   });
 
   test('should display the toggle with on/off span', function (assert) {
-    assert.dom('.pix-toggle__on').exists();
-    assert.dom('.pix-toggle__off').exists();
+    assert.dom('.pix-toggle-deprecated__on').exists();
+    assert.dom('.pix-toggle-deprecated__off').exists();
   });
 
   test('should display the toggle with on/off span with the correct values', function (assert) {
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.pix-toggle__on').nodeName, 'SPAN');
+    assert.equal(find('.pix-toggle-deprecated__on').nodeName, 'SPAN');
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.pix-toggle__off').nodeName, 'SPAN');
+    assert.equal(find('.pix-toggle-deprecated__off').nodeName, 'SPAN');
 
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.pix-toggle__on').textContent, 'valueFirstLabel');
+    assert.equal(find('.pix-toggle-deprecated__on').textContent, 'valueFirstLabel');
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.pix-toggle__off').textContent, 'valueSecondLabel');
+    assert.equal(find('.pix-toggle-deprecated__off').textContent, 'valueSecondLabel');
   });
 
   test('should change the value of toggleOn when toggle off', async function (assert) {
-    await click('.pix-toggle__off');
+    await click('.pix-toggle-deprecated__off');
 
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.pix-toggle__on').textContent, 'valueSecondLabel');
+    assert.equal(find('.pix-toggle-deprecated__on').textContent, 'valueSecondLabel');
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.pix-toggle__off').textContent, 'valueFirstLabel');
+    assert.equal(find('.pix-toggle-deprecated__off').textContent, 'valueFirstLabel');
 
-    await click('.pix-toggle__off');
+    await click('.pix-toggle-deprecated__off');
 
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.pix-toggle__on').textContent, 'valueFirstLabel');
+    assert.equal(find('.pix-toggle-deprecated__on').textContent, 'valueFirstLabel');
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.pix-toggle__off').textContent, 'valueSecondLabel');
+    assert.equal(find('.pix-toggle-deprecated__off').textContent, 'valueSecondLabel');
   });
 });

--- a/mon-pix/tests/integration/components/qrocm-proposal_test.js
+++ b/mon-pix/tests/integration/components/qrocm-proposal_test.js
@@ -1,7 +1,9 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { fillIn, find, findAll, render } from '@ember/test-helpers';
+import { find, findAll, render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
+import sinon from 'sinon';
 
 module('Integration | Component | QROCm proposal', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -17,40 +19,23 @@ module('Integration | Component | QROCm proposal', function (hooks) {
       this.set('proposals', '${potato§La patate#samurai options=["salad", "tomato", "onion"]}');
     });
 
-    test('should display a selector with related options', async function (assert) {
-      // given
-      const placeholderValue = '';
-      const expectedOptionValues = [placeholderValue, 'salad', 'tomato', 'onion'];
-
-      // when
-      await render(hbs`<QrocmProposal @proposals={{this.proposals}}/>`);
-
-      // then
-      const selector = find('select[data-test="challenge-response-proposal-selector"]');
-      const options = findAll('select[data-test="challenge-response-proposal-selector"] option');
-      const optionValues = options.map((option) => option.value);
-
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(selector.tagName, 'SELECT');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(selector.getAttribute('aria-label'), 'La patate');
-      assert.deepEqual(optionValues, expectedOptionValues);
-    });
-
     test('should select option', async function (assert) {
       // given
+      const onChangeSelectStub = sinon.stub();
       this.set('answersValue', { potato: null });
+      this.set('onChangeSelect', onChangeSelectStub);
+      const screen = await renderScreen(
+        hbs`<QrocmProposal @proposals={{this.proposals}} @answersValue={{this.answersValue}} @onChangeSelect={{this.onChangeSelect}}/>`
+      );
 
       // when
-      await render(hbs`<QrocmProposal @proposals={{this.proposals}} @answersValue={{this.answersValue}}/>`);
-      await fillIn('select[data-test="challenge-response-proposal-selector"]', 'tomato');
+      await clickByName('La patate');
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'tomato' }));
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(this.answersValue['potato'], 'tomato');
+      sinon.assert.calledOnce(onChangeSelectStub);
+      assert.ok(true);
     });
   });
 

--- a/mon-pix/tests/integration/components/routes/register-form_test.js
+++ b/mon-pix/tests/integration/components/routes/register-form_test.js
@@ -63,7 +63,7 @@ module('Integration | Component | routes/register-form', function (hooks) {
 
       await fillInputReconciliationForm({ screen, intl: this.intl });
       await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
-      await click('.pix-toggle__off');
+      await click('.pix-toggle-deprecated__off');
 
       await fillIn('#email', 'shi@fu.me');
       await fillIn('#password', 'Mypassword1');
@@ -256,7 +256,7 @@ module('Integration | Component | routes/register-form', function (hooks) {
         await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
         // when
-        await click('.pix-toggle__off');
+        await click('.pix-toggle-deprecated__off');
         await fillIn('#email', stringFilledIn);
         await triggerEvent('#email', 'focusout');
 
@@ -276,7 +276,7 @@ module('Integration | Component | routes/register-form', function (hooks) {
       await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
       // when
-      await click('.pix-toggle__off');
+      await click('.pix-toggle-deprecated__off');
       await fillIn('#email', 'shi.fu');
       await triggerEvent('#email', 'focusout');
       await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));

--- a/mon-pix/tests/unit/controllers/authenticated/user-account/language_test.js
+++ b/mon-pix/tests/unit/controllers/authenticated/user-account/language_test.js
@@ -10,12 +10,11 @@ module('Unit | Controller | user-account/language', function (hooks) {
       // given
       const controller = this.owner.lookup('controller:authenticated/user-account/language');
       controller.url = { isFrenchDomainExtension: false };
-      const event = { target: { value: 'en' } };
       const replaceStub = sinon.stub();
       controller.location = { replace: replaceStub };
 
       // when
-      controller.onChangeLang(event);
+      controller.onChangeLang('en');
 
       // then
       sinon.assert.calledWith(replaceStub, '/mon-compte/langue?lang=en');


### PR DESCRIPTION
## :christmas_tree: Problème

La mise à jour de Pix UI a été faite dans le ticket #5356. Mais ce ticket est pour l'instant bloqué pour des raisons métier et retarder cette mise à jour risque de rendre obsolète le travail effectué.

## :gift: Proposition

Extraire la mise à jour de Pix UI dans une nouvelle PR.

## :star2: Remarques

*RAS*

## :santa: Pour tester

### Les composants impactés par la montée de version de Pix UI:

- PixSelect du changement de langue dans Mon Compte (visible en .org)
- PixSelect des épreuves => Compétence Interagir (vert), première question
- PixSelect des épreuves => Compétence (violet), 3eme question
