### PR TITLE
[TECH] Dissocier les prescriptions d'un étudiant lors de son anonymisation sur Pix Admin (PIX-5441)

### DIFF
--- a/admin/app/components/users/user-overview.js
+++ b/admin/app/components/users/user-overview.js
@@ -192,6 +192,7 @@ export default class UserOverview extends Component {
     await this.args.user.save({ adapterOptions: { anonymizeUser: true } });
     this.args.user.organizationMemberships = [];
     this.args.user.certificationCenterMemberships = [];
+    this.args.user.organizationLearners = [];
 
     this.toggleDisplayAnonymizeModal();
   }

--- a/admin/tests/unit/components/users/user-overview_test.js
+++ b/admin/tests/unit/components/users/user-overview_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 import ENV from 'pix-admin/config/environment';
+import sinon from 'sinon';
 
 module('Unit | Component | users | user-overview', function (hooks) {
   setupTest(hooks);
@@ -120,6 +121,21 @@ module('Unit | Component | users | user-overview', function (hooks) {
         // when && then
         assert.false(component.shouldDisplayTemporaryBlockedDate);
       });
+    });
+  });
+
+  module('#anonymizeUser', function () {
+    test('should empty organization learners', async function (assert) {
+      // given
+      const organizationLearners = [{ firstName: 'fanny', lastName: 'epi' }];
+      const user = { organizationLearners, save: sinon.stub().resolves() };
+      const component = createGlimmerComponent('component:users/user-overview', { user });
+
+      // when
+      await component.anonymizeUser();
+
+      // then
+      assert.deepEqual(user.organizationLearners, []);
     });
   });
 });

--- a/api/lib/domain/usecases/add-pix-authentication-method-by-email.js
+++ b/api/lib/domain/usecases/add-pix-authentication-method-by-email.js
@@ -29,6 +29,6 @@ module.exports = async function addPixAuthenticationMethodByEmail({
     });
     await authenticationMethodRepository.create({ authenticationMethod: authenticationMethodFromPix });
 
-    return userRepository.updateUserDetailsForAdministration(userId, { email });
+    return userRepository.updateUserDetailsForAdministration({ id: userId, userAttributes: { email } });
   }
 };

--- a/api/lib/domain/usecases/add-pix-authentication-method-by-email.js
+++ b/api/lib/domain/usecases/add-pix-authentication-method-by-email.js
@@ -28,7 +28,7 @@ module.exports = async function addPixAuthenticationMethodByEmail({
       }),
     });
     await authenticationMethodRepository.create({ authenticationMethod: authenticationMethodFromPix });
-
-    return userRepository.updateUserDetailsForAdministration({ id: userId, userAttributes: { email } });
+    await userRepository.updateUserDetailsForAdministration({ id: userId, userAttributes: { email } });
+    return userRepository.getUserDetailsForAdmin(userId);
   }
 };

--- a/api/lib/domain/usecases/anonymize-user.js
+++ b/api/lib/domain/usecases/anonymize-user.js
@@ -18,5 +18,5 @@ module.exports = async function anonymizeUser({
   await refreshTokenService.revokeRefreshTokensForUserId({ userId });
   await membershipRepository.disableMembershipsByUserId({ userId, updatedByUserId });
   await certificationCenterMembershipRepository.disableMembershipsByUserId({ updatedByUserId, userId });
-  return userRepository.updateUserDetailsForAdministration(userId, anonymizedUser);
+  return userRepository.updateUserDetailsForAdministration({ id: userId, userAttributes: anonymizedUser });
 };

--- a/api/lib/domain/usecases/anonymize-user.js
+++ b/api/lib/domain/usecases/anonymize-user.js
@@ -1,3 +1,5 @@
+const DomainTransaction = require('../../infrastructure/DomainTransaction');
+
 module.exports = async function anonymizeUser({
   updatedByUserId,
   userId,
@@ -14,16 +16,20 @@ module.exports = async function anonymizeUser({
     username: null,
   };
 
-  await authenticationMethodRepository.removeAllAuthenticationMethodsByUserId({ userId });
-  await refreshTokenService.revokeRefreshTokensForUserId({ userId });
-  await membershipRepository.disableMembershipsByUserId({ userId, updatedByUserId });
-  await certificationCenterMembershipRepository.disableMembershipsByUserId({
-    updatedByUserId,
-    userId,
-  });
-  await userRepository.updateUserDetailsForAdministration({
-    id: userId,
-    userAttributes: anonymizedUser,
+  await DomainTransaction.execute(async (domainTransaction) => {
+    await authenticationMethodRepository.removeAllAuthenticationMethodsByUserId({ userId, domainTransaction });
+    await refreshTokenService.revokeRefreshTokensForUserId({ userId });
+    await membershipRepository.disableMembershipsByUserId({ userId, updatedByUserId, domainTransaction });
+    await certificationCenterMembershipRepository.disableMembershipsByUserId({
+      updatedByUserId,
+      userId,
+      domainTransaction,
+    });
+    await userRepository.updateUserDetailsForAdministration({
+      id: userId,
+      userAttributes: anonymizedUser,
+      domainTransaction,
+    });
   });
   return userRepository.getUserDetailsForAdmin(userId);
 };

--- a/api/lib/domain/usecases/anonymize-user.js
+++ b/api/lib/domain/usecases/anonymize-user.js
@@ -17,6 +17,13 @@ module.exports = async function anonymizeUser({
   await authenticationMethodRepository.removeAllAuthenticationMethodsByUserId({ userId });
   await refreshTokenService.revokeRefreshTokensForUserId({ userId });
   await membershipRepository.disableMembershipsByUserId({ userId, updatedByUserId });
-  await certificationCenterMembershipRepository.disableMembershipsByUserId({ updatedByUserId, userId });
-  return userRepository.updateUserDetailsForAdministration({ id: userId, userAttributes: anonymizedUser });
+  await certificationCenterMembershipRepository.disableMembershipsByUserId({
+    updatedByUserId,
+    userId,
+  });
+  await userRepository.updateUserDetailsForAdministration({
+    id: userId,
+    userAttributes: anonymizedUser,
+  });
+  return userRepository.getUserDetailsForAdmin(userId);
 };

--- a/api/lib/domain/usecases/anonymize-user.js
+++ b/api/lib/domain/usecases/anonymize-user.js
@@ -7,6 +7,7 @@ module.exports = async function anonymizeUser({
   authenticationMethodRepository,
   membershipRepository,
   certificationCenterMembershipRepository,
+  organizationLearnerRepository,
   refreshTokenService,
 }) {
   const anonymizedUser = {
@@ -25,6 +26,7 @@ module.exports = async function anonymizeUser({
       userId,
       domainTransaction,
     });
+    await organizationLearnerRepository.dissociateAllStudentsByUserId({ userId, domainTransaction });
     await userRepository.updateUserDetailsForAdministration({
       id: userId,
       userAttributes: anonymizedUser,

--- a/api/lib/domain/usecases/update-user-details-for-administration.js
+++ b/api/lib/domain/usecases/update-user-details-for-administration.js
@@ -26,7 +26,7 @@ module.exports = async function updateUserDetailsForAdministration({
     userDetailsForAdministration.mustValidateTermsOfService = true;
   }
 
-  await userRepository.updateUserDetailsForAdministration(userId, userDetailsForAdministration);
+  await userRepository.updateUserDetailsForAdministration({ id: userId, userAttributes: userDetailsForAdministration });
 
   return userRepository.getUserDetailsForAdmin(userId);
 };

--- a/api/lib/infrastructure/repositories/authentication-method-repository.js
+++ b/api/lib/infrastructure/repositories/authentication-method-repository.js
@@ -166,8 +166,9 @@ module.exports = {
     return knex(AUTHENTICATION_METHODS_TABLE).where({ userId, identityProvider }).del();
   },
 
-  async removeAllAuthenticationMethodsByUserId({ userId }) {
-    return knex(AUTHENTICATION_METHODS_TABLE).where({ userId }).del();
+  async removeAllAuthenticationMethodsByUserId({ userId, domainTransaction = DomainTransaction.emptyTransaction() }) {
+    const knexConn = domainTransaction.knexTransaction ?? knex;
+    return knexConn(AUTHENTICATION_METHODS_TABLE).where({ userId }).del();
   },
 
   async updateChangedPassword({ userId, hashedPassword }, domainTransaction = DomainTransaction.emptyTransaction()) {

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -10,6 +10,7 @@ const { knex } = require('../../../db/knex-database-connection');
 const CertificationCenter = require('../../domain/models/CertificationCenter');
 const User = require('../../domain/models/User');
 const CertificationCenterMembership = require('../../domain/models/CertificationCenterMembership');
+const DomainTransaction = require('../DomainTransaction');
 
 function _toDomain(certificationCenterMembershipDTO) {
   let user, certificationCenter;
@@ -154,8 +155,13 @@ module.exports = {
     return _toDomain(refererCertificationCenterMembership);
   },
 
-  async disableMembershipsByUserId({ userId, updatedByUserId }) {
-    await knex('certification-center-memberships')
+  async disableMembershipsByUserId({
+    userId,
+    updatedByUserId,
+    domainTransaction = DomainTransaction.emptyTransaction(),
+  }) {
+    const knexConn = domainTransaction.knexTransaction ?? knex;
+    await knexConn('certification-center-memberships')
       .whereNull('disabledAt')
       .andWhere({ userId })
       .update({ disabledAt: new Date(), updatedByUserId });

--- a/api/lib/infrastructure/repositories/membership-repository.js
+++ b/api/lib/infrastructure/repositories/membership-repository.js
@@ -6,6 +6,7 @@ const Organization = require('../../domain/models/Organization');
 const bookshelfUtils = require('../utils/knex-utils');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
 const { knex } = require('../../../db/knex-database-connection');
+const DomainTransaction = require('../DomainTransaction');
 
 const DEFAULT_PAGE_SIZE = 10;
 const DEFAULT_PAGE_NUMBER = 1;
@@ -129,7 +130,12 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObject(BookshelfMembership, updatedMembershipWithUserAndOrganization);
   },
 
-  async disableMembershipsByUserId({ userId, updatedByUserId }) {
-    await knex('memberships').where({ userId }).update({ disabledAt: new Date(), updatedByUserId });
+  async disableMembershipsByUserId({
+    userId,
+    updatedByUserId,
+    domainTransaction = DomainTransaction.emptyTransaction(),
+  }) {
+    const knexConn = domainTransaction.knexTransaction ?? knex;
+    await knexConn('memberships').where({ userId }).update({ disabledAt: new Date(), updatedByUserId });
   },
 };

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -244,6 +244,16 @@ module.exports = {
     await knex('organization-learners').where({ id: organizationLearnerId }).update({ userId: null });
   },
 
+  async dissociateAllStudentsByUserId({ userId }) {
+    await knex('organization-learners')
+      .update({ userId: null })
+      .where({ userId })
+      .whereIn(
+        'organization-learners.organizationId',
+        knex.select('id').from('organizations').where({ isManagingStudents: true })
+      );
+  },
+
   async findOneByUserIdAndOrganizationId({
     userId,
     organizationId,

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -244,8 +244,9 @@ module.exports = {
     await knex('organization-learners').where({ id: organizationLearnerId }).update({ userId: null });
   },
 
-  async dissociateAllStudentsByUserId({ userId }) {
-    await knex('organization-learners')
+  async dissociateAllStudentsByUserId({ userId, domainTransaction = DomainTransaction.emptyTransaction() }) {
+    const knexConn = domainTransaction.knexTransaction ?? knex;
+    await knexConn('organization-learners')
       .update({ userId: null })
       .where({ userId })
       .whereIn(

--- a/api/lib/infrastructure/repositories/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-repository.js
@@ -241,12 +241,7 @@ module.exports = {
   },
 
   async dissociateUserFromOrganizationLearner(organizationLearnerId) {
-    await BookshelfOrganizationLearner.where({ id: organizationLearnerId }).save(
-      { userId: null },
-      {
-        patch: true,
-      }
-    );
+    await knex('organization-learners').where({ id: organizationLearnerId }).update({ userId: null });
   },
 
   async findOneByUserIdAndOrganizationId({

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -246,11 +246,6 @@ module.exports = {
       if (!userDTO) {
         throw new UserNotFoundError(`User not found for ID ${id}`);
       }
-
-      const organizationLearnersDTO = await knex('organization-learners').where({ userId: userDTO.id });
-      const authenticationMethodsDTO = await knex('authentication-methods').where({ userId: userDTO.id });
-
-      return _toUserDetailsForAdminDomain({ userDTO, organizationLearnersDTO, authenticationMethodsDTO });
     } catch (err) {
       if (isUniqConstraintViolated(err)) {
         throw new AlreadyExistingEntityError('Cette adresse e-mail ou cet identifiant est déjà utilisé(e).');
@@ -443,33 +438,6 @@ function _fromKnexDTOToUserDetailsForAdmin({ userDTO, organizationLearnersDTO, a
     organizationLearners,
     authenticationMethods: authenticationMethodsDTO,
     userLogin,
-  });
-}
-
-function _toUserDetailsForAdminDomain({ userDTO, organizationLearnersDTO, authenticationMethodsDTO }) {
-  const organizationLearners = organizationLearnersDTO?.map(
-    (organizationLearnerDTO) => new OrganizationLearner(organizationLearnerDTO)
-  );
-  return new UserDetailsForAdmin({
-    id: userDTO.id,
-    firstName: userDTO.firstName,
-    lastName: userDTO.lastName,
-    birthdate: userDTO.birthdate,
-    organizationId: userDTO.organizationId,
-    username: userDTO.username,
-    email: userDTO.email,
-    cgu: userDTO.cgu,
-    pixOrgaTermsOfServiceAccepted: userDTO.pixOrgaTermsOfServiceAccepted,
-    pixCertifTermsOfServiceAccepted: userDTO.pixCertifTermsOfServiceAccepted,
-    createdAt: userDTO.createdAt,
-    lang: userDTO.lang,
-    lastTermsOfServiceValidatedAt: userDTO.lastTermsOfServiceValidatedAt,
-    lastPixOrgaTermsOfServiceValidatedAt: userDTO.lastPixOrgaTermsOfServiceValidatedAt,
-    lastPixCertifTermsOfServiceValidatedAt: userDTO.lastPixCertifTermsOfServiceValidatedAt,
-    lastLoggedAt: userDTO.lastLoggedAt,
-    emailConfirmedAt: userDTO.emailConfirmedAt,
-    organizationLearners,
-    authenticationMethods: authenticationMethodsDTO,
   });
 }
 

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -234,7 +234,7 @@ module.exports = {
       });
   },
 
-  async updateUserDetailsForAdministration(id, userAttributes) {
+  async updateUserDetailsForAdministration({ id, userAttributes }) {
     try {
       const updatedUser = await BookshelfUser.where({ id }).save(userAttributes, { patch: true, method: 'update' });
       await updatedUser.related('authenticationMethods').fetch({ require: false });

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -234,9 +234,14 @@ module.exports = {
       });
   },
 
-  async updateUserDetailsForAdministration({ id, userAttributes }) {
+  async updateUserDetailsForAdministration({
+    id,
+    userAttributes,
+    domainTransaction = DomainTransaction.emptyTransaction(),
+  }) {
     try {
-      const [userDTO] = await knex('users').where({ id }).update(userAttributes).returning('*');
+      const knexConn = domainTransaction.knexTransaction ?? knex;
+      const [userDTO] = await knexConn('users').where({ id }).update(userAttributes).returning('*');
 
       if (!userDTO) {
         throw new UserNotFoundError(`User not found for ID ${id}`);

--- a/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-repository_test.js
@@ -1454,21 +1454,31 @@ describe('Integration | Infrastructure | Repository | organization-learner-repos
   });
 
   describe('#dissociateUserFromOrganizationLearner', function () {
-    let organizationLearner;
-
-    beforeEach(async function () {
-      const user = databaseBuilder.factory.buildUser();
-      organizationLearner = databaseBuilder.factory.buildOrganizationLearner({ userId: user.id });
-      await databaseBuilder.commit();
-    });
-
     it('should delete association between user and organizationLearner', async function () {
+      // given
+      const userToNotDissociate = databaseBuilder.factory.buildUser();
+      const organizationLearnerToNotDissociate = databaseBuilder.factory.buildOrganizationLearner({
+        userId: userToNotDissociate.id,
+      });
+      const userToDissociate = databaseBuilder.factory.buildUser();
+      const organizationLearnerToDissociate = databaseBuilder.factory.buildOrganizationLearner({
+        userId: userToDissociate.id,
+      });
+      await databaseBuilder.commit();
+
       // when
-      await organizationLearnerRepository.dissociateUserFromOrganizationLearner(organizationLearner.id);
+      await organizationLearnerRepository.dissociateUserFromOrganizationLearner(organizationLearnerToDissociate.id);
 
       // then
-      const organizationLearnerPatched = await organizationLearnerRepository.get(organizationLearner.id);
+      const organizationLearnerPatched = await knex('organization-learners')
+        .where({ id: organizationLearnerToDissociate.id })
+        .first();
       expect(organizationLearnerPatched.userId).to.equal(null);
+
+      const robotInBDD = await knex('organization-learners')
+        .where({ id: organizationLearnerToNotDissociate.id })
+        .first();
+      expect(robotInBDD.userId).to.equal(userToNotDissociate.id);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -1304,13 +1304,13 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
           email: 'email_123@example.net',
           username: 'username_123',
         };
-        const updatedUser = await userRepository.updateUserDetailsForAdministration({
+        await userRepository.updateUserDetailsForAdministration({
           id: userInDb.id,
           userAttributes: userPropertiesToUpdate,
         });
 
         // then
-        expect(updatedUser).to.be.an.instanceOf(UserDetailsForAdmin);
+        const updatedUser = await knex('users').where({ id: userInDb.id }).first();
         expect(updatedUser.firstName).to.equal('prenom_123');
         expect(updatedUser.lastName).to.equal('nom_123');
         expect(updatedUser.email).to.equal('email_123@example.net');

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -1304,10 +1304,10 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
           email: 'email_123@example.net',
           username: 'username_123',
         };
-        const updatedUser = await userRepository.updateUserDetailsForAdministration(
-          userInDb.id,
-          userPropertiesToUpdate
-        );
+        const updatedUser = await userRepository.updateUserDetailsForAdministration({
+          id: userInDb.id,
+          userAttributes: userPropertiesToUpdate,
+        });
 
         // then
         expect(updatedUser).to.be.an.instanceOf(UserDetailsForAdmin);
@@ -1333,7 +1333,10 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
         const userPropertiesToUpdate = {
           username: 'already.exist.username',
         };
-        const error = await catchErr(userRepository.updateUserDetailsForAdministration)(userId, userPropertiesToUpdate);
+        const error = await catchErr(userRepository.updateUserDetailsForAdministration)({
+          id: userId,
+          userAttributes: userPropertiesToUpdate,
+        });
 
         // then
         expect(error).to.be.instanceOf(AlreadyExistingEntityError);
@@ -1348,10 +1351,10 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
         const userPropertiesToUpdate = {
           email: 'partielupdate@hotmail.com',
         };
-        const error = await catchErr(userRepository.updateUserDetailsForAdministration)(
-          wrongUserId,
-          userPropertiesToUpdate
-        );
+        const error = await catchErr(userRepository.updateUserDetailsForAdministration)({
+          id: wrongUserId,
+          userAttributes: userPropertiesToUpdate,
+        });
 
         // then
         expect(error).to.be.instanceOf(UserNotFoundError);

--- a/api/tests/unit/domain/usecases/add-pix-authentication-method-by-email_test.js
+++ b/api/tests/unit/domain/usecases/add-pix-authentication-method-by-email_test.js
@@ -11,6 +11,7 @@ describe('Unit | UseCase | add-pix-authentication-method-by-email', function () 
     userRepository = {
       checkIfEmailIsAvailable: sinon.stub(),
       updateUserDetailsForAdministration: sinon.stub(),
+      getUserDetailsForAdmin: sinon.stub(),
     };
     authenticationMethodRepository = {
       hasIdentityProviderPIX: sinon.stub(),

--- a/api/tests/unit/domain/usecases/add-pix-authentication-method-by-email_test.js
+++ b/api/tests/unit/domain/usecases/add-pix-authentication-method-by-email_test.js
@@ -108,6 +108,9 @@ describe('Unit | UseCase | add-pix-authentication-method-by-email', function () 
     });
 
     // then
-    expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWith(user.id, { email });
+    expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWith({
+      id: user.id,
+      userAttributes: { email },
+    });
   });
 });

--- a/api/tests/unit/domain/usecases/anonymize-user_test.js
+++ b/api/tests/unit/domain/usecases/anonymize-user_test.js
@@ -17,21 +17,23 @@ describe('Unit | UseCase | anonymize-user', function () {
     // given
     const userId = 1;
     const updatedByUserId = 2;
-    const expectedAnonymizedUser = {
+    const anonymizedUser = {
       firstName: `prenom_${userId}`,
       lastName: `nom_${userId}`,
       email: `email_${userId}@example.net`,
       username: null,
     };
+    const expectedAnonymizedUser = Symbol('anonymized user');
 
-    const userRepository = { updateUserDetailsForAdministration: sinon.stub() };
+    const userRepository = { updateUserDetailsForAdministration: sinon.stub(), getUserDetailsForAdmin: sinon.stub() };
     const authenticationMethodRepository = { removeAllAuthenticationMethodsByUserId: sinon.stub() };
     const refreshTokenService = { revokeRefreshTokensForUserId: sinon.stub() };
     const membershipRepository = { disableMembershipsByUserId: sinon.stub() };
     const certificationCenterMembershipRepository = { disableMembershipsByUserId: sinon.stub() };
+    userRepository.getUserDetailsForAdmin.withArgs(userId).resolves(expectedAnonymizedUser);
 
     // when
-    await anonymizeUser({
+    const result = await anonymizeUser({
       userId,
       userRepository,
       authenticationMethodRepository,
@@ -42,6 +44,8 @@ describe('Unit | UseCase | anonymize-user', function () {
     });
 
     // then
+    expect(result).to.be.equal(expectedAnonymizedUser);
+
     expect(authenticationMethodRepository.removeAllAuthenticationMethodsByUserId).to.have.been.calledWithExactly({
       userId,
     });
@@ -56,7 +60,7 @@ describe('Unit | UseCase | anonymize-user', function () {
     });
     expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWithExactly({
       id: userId,
-      userAttributes: expectedAnonymizedUser,
+      userAttributes: anonymizedUser,
     });
   });
 });

--- a/api/tests/unit/domain/usecases/anonymize-user_test.js
+++ b/api/tests/unit/domain/usecases/anonymize-user_test.js
@@ -54,9 +54,9 @@ describe('Unit | UseCase | anonymize-user', function () {
       updatedByUserId,
       userId,
     });
-    expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWithExactly(
-      userId,
-      expectedAnonymizedUser
-    );
+    expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWithExactly({
+      id: userId,
+      userAttributes: expectedAnonymizedUser,
+    });
   });
 });

--- a/api/tests/unit/domain/usecases/anonymize-user_test.js
+++ b/api/tests/unit/domain/usecases/anonymize-user_test.js
@@ -14,7 +14,12 @@ describe('Unit | UseCase | anonymize-user', function () {
     clock.restore();
   });
 
-  it("deletes all authentication methods, revokes all user's refresh tokens, disables all user's organisation memberships, disables all user's certification center memberships and anonymize user", async function () {
+  it(`deletes all authentication methods,
+      revokes all user's refresh tokens,
+      disables all user's organisation memberships,
+      disables all user's certification center memberships,
+      disables all user's student prescriptions,
+      and anonymize user`, async function () {
     // given
     const userId = 1;
     const updatedByUserId = 2;
@@ -40,16 +45,18 @@ describe('Unit | UseCase | anonymize-user', function () {
     const refreshTokenService = { revokeRefreshTokensForUserId: sinon.stub() };
     const membershipRepository = { disableMembershipsByUserId: sinon.stub() };
     const certificationCenterMembershipRepository = { disableMembershipsByUserId: sinon.stub() };
+    const organizationLearnerRepository = { dissociateAllStudentsByUserId: sinon.stub() };
 
     // when
     const result = await anonymizeUser({
+      updatedByUserId,
       userId,
       userRepository,
       authenticationMethodRepository,
       refreshTokenService,
       membershipRepository,
       certificationCenterMembershipRepository,
-      updatedByUserId,
+      organizationLearnerRepository,
     });
 
     // then
@@ -73,6 +80,10 @@ describe('Unit | UseCase | anonymize-user', function () {
     expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWithExactly({
       id: userId,
       userAttributes: anonymizedUser,
+      domainTransaction,
+    });
+    expect(organizationLearnerRepository.dissociateAllStudentsByUserId).to.have.been.calledWithExactly({
+      userId,
       domainTransaction,
     });
   });

--- a/api/tests/unit/domain/usecases/update-user-details-for-administration_test.js
+++ b/api/tests/unit/domain/usecases/update-user-details-for-administration_test.js
@@ -109,7 +109,10 @@ describe('Unit | UseCase | update-user-details-for-administration', function () 
     });
 
     // then
-    expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWith(userId, attributesToUpdate);
+    expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWith({
+      id: userId,
+      userAttributes: attributesToUpdate,
+    });
   });
 
   context('when adding a new email for user', function () {
@@ -133,7 +136,10 @@ describe('Unit | UseCase | update-user-details-for-administration', function () 
 
       // then
       const expectedAttributes = { email, mustValidateTermsOfService: true };
-      expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWith(userId, expectedAttributes);
+      expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWith({
+        id: userId,
+        userAttributes: expectedAttributes,
+      });
     });
 
     it('should not update mustValidateTermsOfService if user has email', async function () {
@@ -156,7 +162,10 @@ describe('Unit | UseCase | update-user-details-for-administration', function () 
 
       // then
       const expectedAttributes = { email };
-      expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWith(userId, expectedAttributes);
+      expect(userRepository.updateUserDetailsForAdministration).to.have.been.calledWith({
+        id: userId,
+        userAttributes: expectedAttributes,
+      });
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Le but de l'anonymisation est que l'on efface toutes les traces d'un utilisateur. Pour l'instant on change ses informations personnelles (anonymisation du nom, prénom, adresse e-mail) et on lui coupe les accès à toutes les applications Pix. 
Cependant, lorsqu'on anonymise un utilisateur, on se rend compte que les prescrits sont toujours présents dans les organisations auxquelles il a été inscrit. On veut également le dissocier des organisations auxquelles il appartient.

## :gift: Proposition
Lors de l'anonymisation, dissocier de l'utilisateur toutes ses prescriptions à des orga.
Note : on ne dissocie que les prescriptions reliées à des organizations qui sont isManagingStudents. (Car c'est de la responsabilité de Pix de dissocier ces étudiants, par contre ce n'est pas la responsabilité de Pix de dissocier les prescriptions des organisations qui ne sont pas isManagingStudent, ces informations là sont la propriété des organisations).

## :star2: Remarques
Une domain transaction a été ajoutée pour l'action d'anoymisation : soit toutes les actions de l'anonymisation réussissent ensemble, soit tout rate (sauf peut être la révocation de token qui est indépendante).

## :santa: Pour tester
- Lancer Pix Admin 
- Aller sur la page d'un utilisateur ayant des prescriptions (voir tableau "prescrits" en bas de page de détail d'un utilisateur)
- Anonymiser l'utilisateur
- Constater que le tableau prescrits a été vidé
- Vérifier la non régression (nom / prénom / email / username anonymisé + accès Pix Orga + accès Pix Certif coupés ...)