### PR TITLE
[BUGFIX] Changer la méthode d'import des candidats pour réafficher les messages d'erreur (PIX-6587)

### DIFF
--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -219,8 +219,7 @@ exports.register = async (server) => {
           }),
         },
         payload: {
-          multipart: true,
-          allow: 'multipart/form-data',
+          parse: 'gunzip',
           maxBytes: 1048576 * 10, // 10MB
         },
         pre: [

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -207,7 +207,7 @@ module.exports = {
 
   async importCertificationCandidatesFromCandidatesImportSheet(request) {
     const sessionId = request.params.id;
-    const odsBuffer = request.payload.file;
+    const odsBuffer = request.payload;
 
     try {
       await usecases.importCertificationCandidatesFromCandidatesImportSheet({ sessionId, odsBuffer });

--- a/api/tests/acceptance/application/session/session-controller-import-certification-candidates-from-attendance-sheet_reports_categorization_test.js
+++ b/api/tests/acceptance/application/session/session-controller-import-certification-candidates-from-attendance-sheet_reports_categorization_test.js
@@ -62,12 +62,7 @@ describe('Acceptance | Controller | session-controller-import-certification-cand
             // given
             const odsFileName = 'files/1.5/import-certification-candidates-reports-categorization-test-ok.ods';
             const odsFilePath = `${__dirname}/${odsFileName}`;
-            const options = {
-              method: 'POST',
-              url: `/api/sessions/${sessionIdAllowed}/certification-candidates/import`,
-              headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
-              payload: fs.createReadStream(odsFilePath),
-            };
+            const options = generateOptions({ odsFilePath, userId: user.id, sessionId: sessionIdAllowed });
 
             // when
             const response = await server.inject(options);
@@ -83,12 +78,7 @@ describe('Acceptance | Controller | session-controller-import-certification-cand
             const odsFileName =
               'files/1.5/import-certification-candidates-reports-categorization-test-special-birthdate-ok.ods';
             const odsFilePath = `${__dirname}/${odsFileName}`;
-            const options = {
-              method: 'POST',
-              url: `/api/sessions/${sessionIdAllowed}/certification-candidates/import`,
-              headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
-              payload: fs.createReadStream(odsFilePath),
-            };
+            const options = generateOptions({ odsFilePath, userId: user.id, sessionId: sessionIdAllowed });
 
             // when
             const response = await server.inject(options);
@@ -105,12 +95,7 @@ describe('Acceptance | Controller | session-controller-import-certification-cand
           const odsFileName =
             'files/1.5/import-certification-candidates-reports-categorization-test-ko-invalid-file.ods';
           const odsFilePath = `${__dirname}/${odsFileName}`;
-          const options = {
-            method: 'POST',
-            url: `/api/sessions/${sessionIdAllowed}/certification-candidates/import`,
-            headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
-            payload: fs.createReadStream(odsFilePath),
-          };
+          const options = generateOptions({ odsFilePath, userId: user.id, sessionId: sessionIdAllowed });
 
           // when
           const response = await server.inject(options);
@@ -126,12 +111,7 @@ describe('Acceptance | Controller | session-controller-import-certification-cand
         // given
         const odsFileName = 'files/1.5/import-certification-candidates-reports-categorization-test-ko-invalid-data.ods';
         const odsFilePath = `${__dirname}/${odsFileName}`;
-        const options = {
-          method: 'POST',
-          url: `/api/sessions/${sessionIdAllowed}/certification-candidates/import`,
-          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
-          payload: fs.createReadStream(odsFilePath),
-        };
+        const options = generateOptions({ odsFilePath, userId: user.id, sessionId: sessionIdAllowed });
 
         // when
         const response = await server.inject(options);
@@ -146,12 +126,7 @@ describe('Acceptance | Controller | session-controller-import-certification-cand
         // given
         const odsFileName = 'files/1.5/import-certification-candidates-reports-categorization-test-ok.ods';
         const odsFilePath = `${__dirname}/${odsFileName}`;
-        const options = {
-          method: 'POST',
-          url: `/api/sessions/${sessionIdAllowed}/certification-candidates/import`,
-          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
-          payload: fs.createReadStream(odsFilePath),
-        };
+        const options = generateOptions({ odsFilePath, userId: user.id, sessionId: sessionIdAllowed });
 
         const userId = databaseBuilder.factory.buildUser().id;
         databaseBuilder.factory.buildCertificationCandidate({ sessionId: sessionIdAllowed, userId });
@@ -166,3 +141,12 @@ describe('Acceptance | Controller | session-controller-import-certification-cand
     });
   });
 });
+
+function generateOptions({ odsFilePath, userId, sessionId }) {
+  return {
+    method: 'POST',
+    url: `/api/sessions/${sessionId}/certification-candidates/import`,
+    headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+    payload: fs.createReadStream(odsFilePath),
+  };
+}

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -174,7 +174,7 @@ describe('Unit | Controller | sessionController', function () {
       // given
       request = {
         params: { id: sessionId },
-        payload: { file: odsBuffer },
+        payload: odsBuffer,
       };
 
       sinon.stub(usecases, 'importCertificationCandidatesFromCandidatesImportSheet').resolves();

--- a/certif/app/adapters/certification-candidates-import.js
+++ b/certif/app/adapters/certification-candidates-import.js
@@ -1,0 +1,11 @@
+import ApplicationAdapter from './application';
+
+export default class CertificationCandidatesImport extends ApplicationAdapter {
+  async addCertificationCandidatesFromOds(sessionId, files) {
+    const file = files?.[0];
+    if (!file) return;
+
+    const url = `${this.host}/${this.namespace}/sessions/${sessionId}/certification-candidates/import`;
+    return this.ajax(url, 'POST', { data: file });
+  }
+}

--- a/certif/app/components/import-candidates.hbs
+++ b/certif/app/components/import-candidates.hbs
@@ -47,15 +47,9 @@
           </p>
         </div>
         <div class="panel-actions__button">
-          {{! template-lint-disable require-presentational-children }}
-          {{#let (file-queue name="file-upload" onFileAdded=this.importCertificationCandidates) as |queue|}}
-            <label class="file-upload" for="upload-attendance-sheet">
-              <PixButtonLink role="button" tabindex="0">
-                Importer (.ods)&nbsp;<FaIcon @icon="cloud-upload-alt" />
-              </PixButtonLink>
-            </label>
-            <input id="upload-attendance-sheet" type="file" accept=".ods" hidden {{queue.selectFile}} />
-          {{/let}}
+          <PixButtonUpload @id="upload-attendance-sheet" @onChange={{this.importCertificationCandidates}} accept=".ods">
+            Importer (.ods)&nbsp;<FaIcon @icon="cloud-upload-alt" />
+          </PixButtonUpload>
         </div>
       {{else}}
         <div class="panel-actions__action-icon">

--- a/certif/app/components/import-candidates.js
+++ b/certif/app/components/import-candidates.js
@@ -1,49 +1,57 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { htmlSafe } from '@ember/template';
 import { action } from '@ember/object';
+import { htmlSafe } from '@ember/template';
 
 export default class ImportCandidates extends Component {
   @service session;
   @service notifications;
+  @service store;
 
   @action
-  async importCertificationCandidates(file) {
-    const { access_token } = this.session.data.authenticated;
+  async importCertificationCandidates(files) {
+    const adapter = this.store.adapterFor('certification-candidates-import');
+    const sessionId = this.args.session.id;
 
+    this.isLoading = true;
     this.notifications.clearAll();
-
     try {
-      await file.upload(this.args.session.urlToUpload, {
-        headers: { Authorization: `Bearer ${access_token}` },
-      });
-      this.args.reloadCertificationCandidate();
+      await adapter.addCertificationCandidatesFromOds(sessionId, files);
       this.notifications.success('La liste des candidats a été importée avec succès.');
-    } catch (err) {
-      const errorPrefix = 'Aucun candidat n’a été importé. <br>';
-      let errorMessage = `${errorPrefix} Veuillez réessayer ou nous contacter via le formulaire du centre d'aide`;
-      if (err.body.errors) {
-        err.body.errors.forEach((error) => {
-          if (error.status === '422') {
-            if (error.code === 'INVALID_DOCUMENT') {
-              errorMessage = htmlSafe(`
+      this.args.reloadCertificationCandidate();
+    } catch (errorResponse) {
+      const errorMessage = this._handleErrorMessage(errorResponse);
+      this.notifications.error(htmlSafe(errorMessage), { cssClasses: 'certification-candidates-notification' });
+    } finally {
+      this.isLoading = false;
+    }
+  }
+
+  _handleErrorMessage(errorResponse) {
+    const errorPrefix = 'Aucun candidat n’a été importé. <br>';
+    let errorMessage = `${errorPrefix} Veuillez réessayer ou nous contacter via le formulaire du centre d'aide`;
+
+    if (errorResponse.errors) {
+      errorResponse.errors.forEach((error) => {
+        if (error.status === '422') {
+          if (error.code === 'INVALID_DOCUMENT') {
+            errorMessage = htmlSafe(`
               <p>
                 ${errorPrefix}<b>${error.detail}</b><br>
                 Veuillez télécharger à nouveau le modèle de liste des candidats et l'importer à nouveau.
               </p>`);
-            } else {
-              errorMessage = htmlSafe(`
+          } else {
+            errorMessage = htmlSafe(`
               <p>
                 ${errorPrefix}<b>${error.detail}</b>
               </p>`);
-            }
           }
-          if (error.status === '403' && error.detail === 'At least one candidate is already linked to a user') {
-            errorMessage = "La session a débuté, il n'est plus possible de modifier la liste des candidats.";
-          }
-        });
-      }
-      this.notifications.error(htmlSafe(errorMessage), { cssClasses: 'certification-candidates-notification' });
+        }
+        if (error.status === '403' && error.detail === 'At least one candidate is already linked to a user') {
+          errorMessage = "La session a débuté, il n'est plus possible de modifier la liste des candidats.";
+        }
+      });
     }
+    return errorMessage;
   }
 }

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -1,5 +1,4 @@
 import { Response } from 'miragejs';
-import { uploadHandler } from 'ember-file-upload';
 import { findPaginatedStudents } from './handlers/find-paginated-students';
 import { findPaginatedSessionSummaries } from './handlers/find-paginated-session-summaries';
 
@@ -114,65 +113,62 @@ export default function () {
     return { data: null };
   });
 
-  this.post(
-    '/sessions/:id/certification-candidates/import',
-    uploadHandler(function (schema, request) {
-      const { name } = request.requestBody.file;
-      if (name === 'invalid-file') {
-        return new Response(
-          422,
-          { some: 'header' },
-          {
-            errors: [
-              {
-                code: 'INVALID_DOCUMENT',
-                status: '422',
-                title: 'Unprocessable Entity',
-                detail: 'Une erreur personnalisée.',
-              },
-            ],
-          }
-        );
-      }
-      if (name === 'validation-error') {
-        return new Response(
-          422,
-          { some: 'header' },
-          {
-            errors: [
-              {
-                status: '422',
-                title: 'Unprocessable Entity',
-                detail: 'Une erreur personnalisée.',
-              },
-            ],
-          }
-        );
-      }
-      if (name === 'forbidden-import') {
-        return new Response(
-          403,
-          { some: 'header' },
-          {
-            errors: [
-              {
-                status: '403',
-                title: 'Forbidden',
-                detail: 'At least one candidate is already linked to a user',
-              },
-            ],
-          }
-        );
-      }
-      if (name.endsWith('addTwoCandidates')) {
-        const sessionId = name.split('.')[0];
-        const certificationCandidates = schema.certificationCandidates.where({ sessionId });
-        certificationCandidates.destroy();
-        server.createList('certification-candidate', 2, { isLinked: false, sessionId });
-      }
-      return new Response(204);
-    })
-  );
+  this.post('/sessions/:id/certification-candidates/import', function (schema, request) {
+    const { type } = request.requestBody;
+    if (type === 'invalid-file') {
+      return new Response(
+        422,
+        { some: 'header' },
+        {
+          errors: [
+            {
+              code: 'INVALID_DOCUMENT',
+              status: '422',
+              title: 'Unprocessable Entity',
+              detail: 'Une erreur personnalisée.',
+            },
+          ],
+        }
+      );
+    }
+    if (type === 'validation-error') {
+      return new Response(
+        422,
+        { some: 'header' },
+        {
+          errors: [
+            {
+              status: '422',
+              title: 'Unprocessable Entity',
+              detail: 'Une erreur personnalisée.',
+            },
+          ],
+        }
+      );
+    }
+    if (type === 'forbidden-import') {
+      return new Response(
+        403,
+        { some: 'header' },
+        {
+          errors: [
+            {
+              status: '403',
+              title: 'Forbidden',
+              detail: 'At least one candidate is already linked to a user',
+            },
+          ],
+        }
+      );
+    }
+    if (type.endsWith('add-two-candidates')) {
+      const sessionId = type.split('.')[0];
+      const certificationCandidates = schema.certificationCandidates.where({ sessionId });
+      certificationCandidates.destroy();
+      server.createList('certification-candidate', 2, { isLinked: false, sessionId });
+    }
+    return new Response(204);
+  });
 
   this.put('/sessions/:id/enroll-students-to-session', (schema, request) => {
     const requestBody = JSON.parse(request.requestBody);


### PR DESCRIPTION
## :christmas_tree: Problème
Les messages d'erreurs ne remontent plus lorsque l'on importe des candidats avec un fichier ods.

## :gift: Proposition
Changement de l'input d'import avec PixButtonUpload

## :star2: Remarques
Changement des tests égalements

## :santa: Pour tester
- se connecter à Pix Certif
- aller sur une session qui n'a pas encore commencé
- télécharger le template ods et le remplir avec des données erronées
- voir un message d'erreur remonter dans le toaster qui correspond à la donnée erronée

- aller sur une certif qui est déjà commencé par un candidat, voir le message d'erreur : "La session a débuté, il n'est plus possible de modifier la liste des candidats."