### PR TITLE
[FEATURE] Permettre à un admin de Pix Orga de renvoyer une invitation (PIX-463)

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -592,6 +592,39 @@ exports.register = async (server) => {
       },
     },
     {
+      method: 'PATCH',
+      path: '/api/organizations/{id}/resend-invitation',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsAdminInOrganization,
+            assign: 'isAdminInOrganization',
+          },
+        ],
+        handler: organizationController.resendInvitation,
+        validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
+          options: {
+            allowUnknown: true,
+          },
+          payload: Joi.object({
+            data: {
+              attributes: {
+                email: Joi.string().email().required(),
+              },
+            },
+          }),
+        },
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés en tant que responsables de l'organisation**\n" +
+            "- Elle permet de renvoyer une invitation à une personne, déjà utilisateur de Pix ou non, à être membre d'une organisation, via leur **adresse e-mail**",
+        ],
+        tags: ['api', 'invitations'],
+      },
+    },
+    {
       method: 'DELETE',
       path: '/api/organizations/{id}/invitations/{organizationInvitationId}',
       config: {

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -317,6 +317,19 @@ module.exports = {
     return h.response(organizationInvitationSerializer.serialize(organizationInvitations)).created();
   },
 
+  async resendInvitation(request, h) {
+    const organizationId = request.params.id;
+    const email = request.payload.data.attributes.email;
+    const locale = extractLocaleFromRequest(request);
+
+    const organizationInvitation = await usecases.resendOrganizationInvitation({
+      organizationId,
+      email,
+      locale,
+    });
+    return h.response(organizationInvitationSerializer.serialize(organizationInvitation));
+  },
+
   async cancelOrganizationInvitation(request, h) {
     const organizationInvitationId = request.params.organizationInvitationId;
     await usecases.cancelOrganizationInvitation({ organizationInvitationId });

--- a/api/lib/domain/services/organization-invitation-service.js
+++ b/api/lib/domain/services/organization-invitation-service.js
@@ -7,7 +7,7 @@ const _generateCode = () => {
   return randomString.generate({ length: 10, capitalization: 'uppercase' });
 };
 
-const createOrganizationInvitation = async ({
+const createOrUpdateOrganizationInvitation = async ({
   organizationRepository,
   organizationInvitationRepository,
   organizationId,
@@ -125,7 +125,7 @@ const createScoOrganizationInvitation = async ({
 };
 
 module.exports = {
-  createOrganizationInvitation,
+  createOrUpdateOrganizationInvitation,
   createScoOrganizationInvitation,
   createProOrganizationInvitation,
 };

--- a/api/lib/domain/usecases/create-organization-invitation-by-admin.js
+++ b/api/lib/domain/usecases/create-organization-invitation-by-admin.js
@@ -15,7 +15,7 @@ module.exports = async function createOrganizationInvitationByAdmin({
     throw new OrganizationArchivedError();
   }
 
-  return organizationInvitationService.createOrganizationInvitation({
+  return organizationInvitationService.createOrUpdateOrganizationInvitation({
     organizationId,
     email,
     locale,

--- a/api/lib/domain/usecases/create-organization-invitations.js
+++ b/api/lib/domain/usecases/create-organization-invitations.js
@@ -20,7 +20,7 @@ module.exports = async function createOrganizationInvitations({
   const uniqueEmails = [...new Set(trimmedEmails)];
 
   return bluebird.mapSeries(uniqueEmails, (email) => {
-    return organizationInvitationService.createOrganizationInvitation({
+    return organizationInvitationService.createOrUpdateOrganizationInvitation({
       organizationRepository,
       organizationInvitationRepository,
       organizationId,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -224,6 +224,7 @@ module.exports = injectDependencies(
     createOrganization: require('./create-organization'),
     createOrganizationInvitationByAdmin: require('./create-organization-invitation-by-admin'),
     createOrganizationInvitations: require('./create-organization-invitations'),
+    resendOrganizationInvitation: require('./resend-organization-invitation'),
     createOrganizationPlacesLot: require('./create-organization-places-lot'),
     createPasswordResetDemand: require('./create-password-reset-demand'),
     createSession: require('./create-session'),

--- a/api/lib/domain/usecases/resend-organization-invitation.js
+++ b/api/lib/domain/usecases/resend-organization-invitation.js
@@ -1,0 +1,17 @@
+const organizationInvitationService = require('../../domain/services/organization-invitation-service');
+
+module.exports = async function resendOrganizationInvitation({
+  organizationId,
+  email,
+  locale,
+  organizationRepository,
+  organizationInvitationRepository,
+}) {
+  return organizationInvitationService.createOrUpdateOrganizationInvitation({
+    organizationRepository,
+    organizationInvitationRepository,
+    organizationId,
+    email,
+    locale,
+  });
+};

--- a/api/scripts/send-invitations-to-sco-organizations.js
+++ b/api/scripts/send-invitations-to-sco-organizations.js
@@ -44,7 +44,7 @@ async function sendJoinOrganizationInvitations(invitations, tags) {
       process.stdout.write(`${index}/${invitations.length}\r`);
     }
 
-    return organizationInvitationService.createOrganizationInvitation({
+    return organizationInvitationService.createOrUpdateOrganizationInvitation({
       organizationRepository,
       organizationInvitationRepository,
       organizationId,

--- a/api/tests/integration/domain/services/organization-invitation-service_test.js
+++ b/api/tests/integration/domain/services/organization-invitation-service_test.js
@@ -8,12 +8,14 @@ const mailService = require('../../../../lib/domain/services/mail-service');
 const OrganizationInvitation = require('../../../../lib/domain/models/OrganizationInvitation');
 const Membership = require('../../../../lib/domain/models/Membership');
 
-const { createOrganizationInvitation } = require('../../../../lib/domain/services/organization-invitation-service');
+const {
+  createOrUpdateOrganizationInvitation,
+} = require('../../../../lib/domain/services/organization-invitation-service');
 const EmailingAttempt = require('../../../../lib/domain/models/EmailingAttempt');
 const { SendingEmailError } = require('../../../../lib/domain/errors');
 
 describe('Integration | Service | Organization-Invitation Service', function () {
-  describe('#createOrganizationInvitation', function () {
+  describe('#createOrUpdateOrganizationInvitation', function () {
     let clock;
     const now = new Date('2021-01-02');
 
@@ -41,7 +43,7 @@ describe('Integration | Service | Organization-Invitation Service', function () 
       };
 
       // when
-      const result = await createOrganizationInvitation({
+      const result = await createOrUpdateOrganizationInvitation({
         organizationId,
         email,
         role,
@@ -64,7 +66,7 @@ describe('Integration | Service | Organization-Invitation Service', function () 
       await databaseBuilder.commit();
 
       // when
-      const result = await createOrganizationInvitation({
+      const result = await createOrUpdateOrganizationInvitation({
         organizationId: organizationInvitation.organizationId,
         email: organizationInvitation.email,
         organizationRepository,
@@ -93,7 +95,7 @@ describe('Integration | Service | Organization-Invitation Service', function () 
       mailService.sendOrganizationInvitationEmail.resolves(mailerResponse);
 
       // when
-      const result = await catchErr(createOrganizationInvitation)({
+      const result = await catchErr(createOrUpdateOrganizationInvitation)({
         organizationId: organizationInvitation.organizationId,
         email,
         organizationRepository,

--- a/api/tests/unit/domain/services/organization-invitation-service_test.js
+++ b/api/tests/unit/domain/services/organization-invitation-service_test.js
@@ -3,7 +3,7 @@ const Membership = require('../../../../lib/domain/models/Membership');
 const OrganizationInvitation = require('../../../../lib/domain/models/OrganizationInvitation');
 const mailService = require('../../../../lib/domain/services/mail-service');
 const {
-  createOrganizationInvitation,
+  createOrUpdateOrganizationInvitation,
   createScoOrganizationInvitation,
   createProOrganizationInvitation,
 } = require('../../../../lib/domain/services/organization-invitation-service');
@@ -29,7 +29,7 @@ describe('Unit | Service | Organization-Invitation Service', function () {
     sinon.stub(mailService, 'sendScoOrganizationInvitationEmail').resolves();
   });
 
-  describe('#createOrganizationInvitation', function () {
+  describe('#createOrUpdateOrganizationInvitation', function () {
     context('when organization-invitation does not exist', function () {
       it('should create a new organization-invitation and send an email with organizationId, email, code and locale', async function () {
         // given
@@ -50,7 +50,7 @@ describe('Unit | Service | Organization-Invitation Service', function () {
         organizationRepository.get.resolves(organization);
 
         // when
-        await createOrganizationInvitation({
+        await createOrUpdateOrganizationInvitation({
           organizationRepository,
           organizationInvitationRepository,
           organizationId: organization.id,
@@ -98,7 +98,7 @@ describe('Unit | Service | Organization-Invitation Service', function () {
           );
 
           // when
-          const error = await catchErr(createOrganizationInvitation)({
+          const error = await catchErr(createOrUpdateOrganizationInvitation)({
             organizationRepository,
             organizationInvitationRepository,
             organizationId: organization.id,
@@ -132,7 +132,7 @@ describe('Unit | Service | Organization-Invitation Service', function () {
         organizationRepository.get.resolves(organization);
 
         // when
-        await createOrganizationInvitation({
+        await createOrUpdateOrganizationInvitation({
           organizationRepository,
           organizationInvitationRepository,
           organizationId: organization.id,
@@ -167,7 +167,7 @@ describe('Unit | Service | Organization-Invitation Service', function () {
         organizationRepository.get.resolves(organization);
 
         // when
-        await createOrganizationInvitation({
+        await createOrUpdateOrganizationInvitation({
           organizationRepository,
           organizationInvitationRepository,
           organizationId: organization.id,

--- a/api/tests/unit/domain/usecases/create-organization-invitation-by-admin_test.js
+++ b/api/tests/unit/domain/usecases/create-organization-invitation-by-admin_test.js
@@ -17,7 +17,7 @@ describe('Unit | UseCase | create-organization-invitation-by-admin', function ()
 
       const organizationInvitationRepository = sinon.stub();
       const organizationRepository = { get: sinon.stub().resolves(organization) };
-      sinon.stub(organizationInvitationService, 'createOrganizationInvitation').resolves();
+      sinon.stub(organizationInvitationService, 'createOrUpdateOrganizationInvitation').resolves();
 
       // when
       await createOrganizationInvitationByAdmin({
@@ -30,8 +30,8 @@ describe('Unit | UseCase | create-organization-invitation-by-admin', function ()
       });
 
       // then
-      expect(organizationInvitationService.createOrganizationInvitation).to.has.been.calledOnce;
-      expect(organizationInvitationService.createOrganizationInvitation).to.has.been.calledWith({
+      expect(organizationInvitationService.createOrUpdateOrganizationInvitation).to.has.been.calledOnce;
+      expect(organizationInvitationService.createOrUpdateOrganizationInvitation).to.has.been.calledWith({
         organizationId: organization.id,
         email,
         locale,
@@ -52,7 +52,7 @@ describe('Unit | UseCase | create-organization-invitation-by-admin', function ()
       const organizationRepository = {
         get: sinon.stub().resolves(archivedOrganization),
       };
-      sinon.stub(organizationInvitationService, 'createOrganizationInvitation').resolves();
+      sinon.stub(organizationInvitationService, 'createOrUpdateOrganizationInvitation').resolves();
 
       // when
       const error = await catchErr(createOrganizationInvitationByAdmin)({
@@ -67,7 +67,7 @@ describe('Unit | UseCase | create-organization-invitation-by-admin', function ()
       // then
       expect(error).to.be.instanceOf(OrganizationArchivedError);
       expect(error.message).to.be.equal("L'organisation est archivée.");
-      expect(organizationInvitationService.createOrganizationInvitation).to.not.have.been.called;
+      expect(organizationInvitationService.createOrUpdateOrganizationInvitation).to.not.have.been.called;
     });
   });
 });

--- a/api/tests/unit/domain/usecases/create-organization-invitations_test.js
+++ b/api/tests/unit/domain/usecases/create-organization-invitations_test.js
@@ -13,7 +13,7 @@ describe('Unit | UseCase | create-organization-invitations', function () {
     organizationRepository = {
       get: sinon.stub().resolves(organization),
     };
-    sinon.stub(organizationInvitationService, 'createOrganizationInvitation').resolves();
+    sinon.stub(organizationInvitationService, 'createOrUpdateOrganizationInvitation').resolves();
   });
 
   describe('#createOrganizationInvitations', function () {
@@ -33,8 +33,8 @@ describe('Unit | UseCase | create-organization-invitations', function () {
       });
 
       // then
-      expect(organizationInvitationService.createOrganizationInvitation).to.has.been.calledOnce;
-      expect(organizationInvitationService.createOrganizationInvitation).to.has.been.calledWith({
+      expect(organizationInvitationService.createOrUpdateOrganizationInvitation).to.has.been.calledOnce;
+      expect(organizationInvitationService.createOrUpdateOrganizationInvitation).to.has.been.calledWith({
         organizationId,
         email: emails[0],
         locale,
@@ -57,7 +57,7 @@ describe('Unit | UseCase | create-organization-invitations', function () {
       });
 
       // then
-      expect(organizationInvitationService.createOrganizationInvitation).to.has.been.calledTwice;
+      expect(organizationInvitationService.createOrUpdateOrganizationInvitation).to.has.been.calledTwice;
     });
 
     it('should throw an organization archived error when it is archived', async function () {
@@ -77,7 +77,7 @@ describe('Unit | UseCase | create-organization-invitations', function () {
       // then
       expect(error).to.be.instanceOf(OrganizationArchivedError);
       expect(error.message).to.be.equal("L'organisation est archivée.");
-      expect(organizationInvitationService.createOrganizationInvitation).to.not.have.been.called;
+      expect(organizationInvitationService.createOrUpdateOrganizationInvitation).to.not.have.been.called;
     });
   });
 });

--- a/api/tests/unit/domain/usecases/resend-organization-invitation_test.js
+++ b/api/tests/unit/domain/usecases/resend-organization-invitation_test.js
@@ -1,0 +1,37 @@
+const { expect, sinon } = require('../../../test-helper');
+
+const organizationInvitationService = require('../../../../lib/domain/services/organization-invitation-service');
+const resendOrganizationInvitation = require('../../../../lib/domain/usecases/resend-organization-invitation');
+
+describe('Unit | UseCase | resend-organization-invitation', function () {
+  describe('#resendOrganizationInvitation', function () {
+    it('should update the organization-invitation according organizationId and email', async function () {
+      // given
+      const organizationId = 1;
+      const email = 'member@organization.org';
+      const locale = 'fr-fr';
+
+      const organizationRepository = Symbol('organization repository');
+      const organizationInvitationRepository = Symbol('organization invitation repository');
+      sinon.stub(organizationInvitationService, 'createOrUpdateOrganizationInvitation').resolves();
+
+      // when
+      await resendOrganizationInvitation({
+        organizationId,
+        email,
+        locale,
+        organizationRepository,
+        organizationInvitationRepository,
+      });
+
+      // then
+      expect(organizationInvitationService.createOrUpdateOrganizationInvitation).to.has.been.calledOnceWith({
+        organizationId,
+        email,
+        locale,
+        organizationRepository,
+        organizationInvitationRepository,
+      });
+    });
+  });
+});

--- a/orga/app/adapters/organization-invitation.js
+++ b/orga/app/adapters/organization-invitation.js
@@ -21,6 +21,14 @@ export default class OrganizationInvitationAdapter extends ApplicationAdapter {
     return super.urlForQueryRecord(...arguments);
   }
 
+  urlForUpdateRecord(id, modelName, { adapterOptions }) {
+    if (adapterOptions && adapterOptions.resendInvitation) {
+      const { organizationId } = adapterOptions;
+      return `${this.host}/${this.namespace}/organizations/${organizationId}/resend-invitation`;
+    }
+    return super.urlForUpdateRecord(...arguments);
+  }
+
   createRecord() {
     return super.createRecord(...arguments).then((response) => {
       response.data = response.data[0];

--- a/orga/app/components/team/invitations-list-item.hbs
+++ b/orga/app/components/team/invitations-list-item.hbs
@@ -1,0 +1,43 @@
+<tr aria-label="{{t 'pages.team-invitations.table.row.aria-label'}}">
+  <td>{{@invitation.email}}</td>
+  <td class="hide-on-mobile">
+    {{dayjs-format @invitation.updatedAt "DD/MM/YYYY [-] HH:mm" locale="fr"}}
+  </td>
+  <td>
+    <div class="invitations-list__action">
+      <PixTooltip @isInline={{true}}>
+        <:triggerElement>
+          <PixIconButton
+            @ariaLabel={{t "pages.team-invitations.resend-invitation"}}
+            @icon="redo"
+            @triggerAction={{fn this.resendInvitation @invitation}}
+            @withBackground={{true}}
+            disabled={{this.isResending}}
+            aria-disabled={{this.isResending}}
+          />
+        </:triggerElement>
+        <:tooltip>
+          {{#if this.isResending}}
+            {{t "pages.team-invitations.invitation-resent-succeed-message"}}
+          {{else}}
+            {{t "pages.team-invitations.resend-invitation"}}
+          {{/if}}
+        </:tooltip>
+      </PixTooltip>
+
+      <PixTooltip @isInline={{true}}>
+        <:triggerElement>
+          <PixIconButton
+            @ariaLabel={{t "pages.team-invitations.cancel-invitation"}}
+            @icon="trash-can"
+            @triggerAction={{fn @cancelInvitation @invitation}}
+            @withBackground={{true}}
+          />
+        </:triggerElement>
+        <:tooltip>
+          {{t "pages.team-invitations.cancel-invitation"}}
+        </:tooltip>
+      </PixTooltip>
+    </div>
+  </td>
+</tr>

--- a/orga/app/components/team/invitations-list-item.js
+++ b/orga/app/components/team/invitations-list-item.js
@@ -1,0 +1,39 @@
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import ENV from 'pix-orga/config/environment';
+
+export default class InvitationsListItem extends Component {
+  @service store;
+  @service notifications;
+  @service currentUser;
+  @service intl;
+
+  @tracked isResending = false;
+
+  @action
+  async resendInvitation(organizationInvitation) {
+    this.isResending = true;
+    try {
+      const organizationId = this.currentUser.organization.id;
+      await organizationInvitation.save({
+        adapterOptions: {
+          resendInvitation: true,
+          email: organizationInvitation.email,
+          organizationId,
+        },
+      });
+
+      this.notifications.success(
+        this.intl.t('pages.team-new.success.invitation', { email: organizationInvitation.email })
+      );
+    } catch (e) {
+      this.notifications.error(this.intl.t('api-errors-messages.global'));
+    } finally {
+      setTimeout(() => {
+        this.isResending = false;
+      }, ENV.APP.MILLISECONDS_BEFORE_MAIL_RESEND);
+    }
+  }
+}

--- a/orga/app/components/team/invitations-list.hbs
+++ b/orga/app/components/team/invitations-list.hbs
@@ -13,29 +13,7 @@
     </thead>
     <tbody>
       {{#each @invitations as |invitation|}}
-        <tr aria-label="{{t 'pages.team-invitations.table.row.aria-label'}}">
-          <td>{{invitation.email}}</td>
-          <td class="hide-on-mobile">
-            {{dayjs-format invitation.updatedAt "DD/MM/YYYY [-] HH:mm" locale="fr"}}
-          </td>
-          <td>
-            <div class="invitations-list__action">
-              <PixTooltip @isInline={{true}}>
-                <:triggerElement>
-                  <PixIconButton
-                    @ariaLabel={{t "pages.team-invitations.cancel-invitation"}}
-                    @icon="trash-can"
-                    @triggerAction={{fn this.cancelInvitation invitation}}
-                    @withBackground={{true}}
-                  />
-                </:triggerElement>
-                <:tooltip>
-                  {{t "pages.team-invitations.cancel-invitation"}}
-                </:tooltip>
-              </PixTooltip>
-            </div>
-          </td>
-        </tr>
+        <Team::InvitationsListItem @invitation={{invitation}} @cancelInvitation={{this.cancelInvitation}} />
       {{/each}}
     </tbody>
   </table>

--- a/orga/app/components/team/invitations-list.js
+++ b/orga/app/components/team/invitations-list.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 
 export default class TeamInvitationsListComponent extends Component {
   @service store;

--- a/orga/app/styles/pages/authenticated/team/invitations-list.scss
+++ b/orga/app/styles/pages/authenticated/team/invitations-list.scss
@@ -1,5 +1,5 @@
-.invitations-list {
-  &__action {
-    width: 38px;
-  }
+.invitations-list__action {
+  width: 38px;
+  display: flex;
+  gap: 24px;
 }

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -43,6 +43,11 @@ module.exports = function (environment) {
         defaultValue: 8,
         minValue: 1,
       }),
+      MILLISECONDS_BEFORE_MAIL_RESEND: _getEnvironmentVariableAsNumber({
+        environmentVariableName: 'MILLISECONDS_BEFORE_MAIL_RESEND',
+        defaultValue: 5000,
+        minValue: 0,
+      }),
       PIX_APP_URL_WITHOUT_EXTENSION: process.env.PIX_APP_URL_WITHOUT_EXTENSION || 'https://app.pix.',
     },
 

--- a/orga/config/icons.js
+++ b/orga/config/icons.js
@@ -35,6 +35,7 @@ module.exports = function () {
       'xmark',
       'users',
       'trash-can',
+      'redo',
     ],
     'free-regular-svg-icons': ['circle-check', 'copy', 'trash-can'],
   };

--- a/orga/tests/integration/components/team/invitations-list-item_test.js
+++ b/orga/tests/integration/components/team/invitations-list-item_test.js
@@ -1,0 +1,52 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import Service from '@ember/service';
+import sinon from 'sinon';
+import { clickByName, render } from '@1024pix/ember-testing-library';
+import hbs from 'htmlbars-inline-precompile';
+
+class CurrentUserStub extends Service {
+  organization = { id: 1 };
+}
+
+module('Integration | Component | Team::InvitationsListItem', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should show success notification when resending an invitation succeeds', async function (assert) {
+    // given
+    const notifications = this.owner.lookup('service:notifications');
+    this.owner.register('service:current-user', CurrentUserStub);
+    sinon.stub(notifications, 'success');
+
+    const saveStub = sinon.stub();
+    const cancelInvitationStub = sinon.stub();
+    this.set('invitation', {
+      id: 777,
+      email: 'fifi@example.net',
+      isPending: true,
+      updatedAt: '2019-10-08T10:50:00Z',
+      save: saveStub,
+    });
+    this.set('cancelInvitation', cancelInvitationStub);
+
+    // when
+    await render(
+      hbs`<Team::InvitationsListItem @invitation={{this.invitation}} @cancelInvitation={{this.cancelInvitation}}/>`
+    );
+    await clickByName(this.intl.t('pages.team-invitations.resend-invitation'));
+
+    // then
+    sinon.assert.calledWith(saveStub, {
+      adapterOptions: {
+        resendInvitation: true,
+        email: 'fifi@example.net',
+        organizationId: 1,
+      },
+    });
+    sinon.assert.calledWith(
+      notifications.success,
+      this.intl.t('pages.team-new.success.invitation', { email: 'fifi@example.net' })
+    );
+    assert.ok(true);
+  });
+});

--- a/orga/tests/integration/components/team/invitations-list_test.js
+++ b/orga/tests/integration/components/team/invitations-list_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { render, clickByName } from '@1024pix/ember-testing-library';
+import { clickByName, render } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
 import Service from '@ember/service';
 

--- a/orga/tests/unit/adapters/organization-invitation_test.js
+++ b/orga/tests/unit/adapters/organization-invitation_test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapters | organization-invitation', function (hooks) {
+  setupTest(hooks);
+
+  module('#urlForUpdateRecord', function () {
+    test('should build update url from organization-invitation id', async function (assert) {
+      // given
+      const adapter = this.owner.lookup('adapter:organization-invitation');
+
+      const organizationId = 666;
+
+      // when
+      const url = await adapter.urlForUpdateRecord(777, 'organization-invitation', {
+        adapterOptions: { resendInvitation: true, organizationId },
+      });
+
+      // then
+      assert.true(url.endsWith(`/organizations/${organizationId}/resend-invitation`));
+    });
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1015,7 +1015,9 @@
     "team-invitations": {
       "title": "Team invitations",
       "cancel-invitation": "Delete this invitation",
+      "resend-invitation": "Resend the invitation",
       "invitation-cancelled-succeed-message": "The invitation has been deleted.",
+      "invitation-resent-succeed-message": "The invitation has been resent.",
       "table": {
         "column": {
           "email-address": "Email address",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1015,7 +1015,9 @@
     "team-invitations": {
       "title": "Invitations",
       "cancel-invitation": "Supprimer l’invitation",
+      "resend-invitation": "Renvoyer l'invitation",
       "invitation-cancelled-succeed-message": "L’invitation a bien été supprimée.",
+      "invitation-resent-succeed-message": "L'invitation a bien été renvoyée.",
       "table": {
         "column": {
           "email-address": "Adresse e-mail",


### PR DESCRIPTION
## :christmas_tree: Problème
Quand un admin de PixOrga invite un membre à rejoindre à leur espace PixOrga, il spécifie une adresse email, clique sur ‘Inviter’, puis est redirigé vers la page ‘Equipe’. C’est ici qu’il voit la ligne avec l’adresse email de la personne invitée.

Mais si l’admin souhaite relancer la personne, il doit suivre le même process à nouveau en retapant l’adresse email.

## :gift: Proposition
Ajouter un bouton permettant un raccourci : sur le tableau des invitations on rajoute un bouton "Renvoyer l'invitation", au clic cela renvoie un mail d'invitation à la personne concernée.

## :star2: Remarques
Pour ne pas faire exploser les quota sendinblue en cas de mauvaise utilisation du bouton, on limite les clics : il n'est possible de cliquer dessus qu'une fois toutes les 5 seconds (= durée d'affichage de la notif verte qui indique que le mail s'est bien envoyé).

## :santa: Pour tester

🔑 _Prérequis:  les variables d'environnement suivantes doivent être renseignée pour tester l'envoi d'email : `MAILING_ENABLED`, `MAILING_PROVIDER`, `SENDINBLUE_API_KEY`, `SENDINBLUE_ORGANIZATION_INVITATION_TEMPLATE_ID`_

**Fonctionnement normal**
- Se connecter à Pix Orga avec un admin 
- Aller sur l'onglet "Equipe"
- Cliquer sur "Inviter un membre" et remplir une adresse email à laquelle vous avez accès
- Quand vous arrivez sur la liste des invitations, constatez que vous avez un bouton d'action en plus "Renvoyer l'invitation"
<img width="1371" alt="image" src="https://user-images.githubusercontent.com/38167520/209350288-0f7ea99e-f184-4487-aaff-989035d8fb11.png">

- Cliquez sur ce bouton
- Constatez la popup de notification verte et vérifier que vous avez reçu le nouveau mail

- Essayez à nouveau de cliquer sur ce bouton
- Constatez que vous ne pouvez pas, la tooltip indique qu'il faut attendre
<img width="1371" alt="image" src="https://user-images.githubusercontent.com/38167520/209350457-c868f6ff-8b7e-46a2-8869-e6a989b78ee9.png">

- Attendez 5 secondes
- Constatez que vous pouvez à nouveau cliquer sur le bouton 🎉 

**Erreur côté API**
- Dans le fichier `organization-controller.js` remplacer la méthode `resendInvitation` par quelque chose qui plante. Ex : 
```  async resendInvitation(request, h) {
    throw new Error('ça casse hihi');
  },
```
- Cliquez à nouveau sur le bouton "Renvoyer l'invitation" côté front
- Constater que vous avez une pop up de notification rouge qui dit qu'il y a eu un soucis.