### PR TITLE
[TECH] Remplacer moment par dayjs dans les tests de l'API

### DIFF
--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -25,7 +25,8 @@ const {
   extractLocaleFromRequest,
   extractUserIdFromRequest,
 } = require('../../infrastructure/utils/request-response-utils');
-const moment = require('moment');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 const certificationResultUtils = require('../../infrastructure/utils/csv/certification-results');
 const certificationAttestationPdf = require('../../infrastructure/utils/pdf/certification-attestation-pdf');
 const organizationForAdminSerializer = require('../../infrastructure/serializers/jsonapi/organization-for-admin-serializer');
@@ -178,7 +179,7 @@ module.exports = {
       isFrenchDomainExtension,
     });
 
-    const now = moment();
+    const now = dayjs();
     const fileName = `${now.format('YYYYMMDD')}_attestations_${division}.pdf`;
 
     return h
@@ -195,7 +196,7 @@ module.exports = {
 
     const csvResult = await certificationResultUtils.getDivisionCertificationResultsCsv({ certificationResults });
 
-    const now = moment();
+    const now = dayjs();
     const fileName = `${now.format('YYYYMMDD')}_resultats_${division}.csv`;
 
     return h

--- a/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -1,4 +1,3 @@
-const moment = require('moment');
 const {
   databaseBuilder,
   expect,
@@ -316,6 +315,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
 
       beforeEach(function () {
         const limitDate = new Date('2020-01-01T00:00:00Z');
+        const dateAfterLimitDate = new Date('2020-01-02T00:00:00Z');
         certifiableUserId = databaseBuilder.factory.buildUser().id;
 
         const competenceIdSkillIdPairs =
@@ -329,7 +329,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
         certificationAssessmentId = databaseBuilder.factory.buildAnsweredNotCompletedCertificationAssessment({
           certifiableUserId,
           competenceIdSkillIdPairs,
-          limitDate: moment(limitDate).add(1, 'day').toDate(),
+          limitDate: dateAfterLimitDate,
         }).id;
         const badgeId = databaseBuilder.factory.buildBadge().id;
         databaseBuilder.factory.buildSkillSet({

--- a/api/tests/integration/domain/services/pick-certification-challenge_test.js
+++ b/api/tests/integration/domain/services/pick-certification-challenge_test.js
@@ -1,14 +1,11 @@
 const { expect, databaseBuilder, mockLearningContent } = require('../../../test-helper');
 const placementProfileService = require('../../../../lib/domain/services/placement-profile-service');
 const certificationChallengesService = require('../../../../lib/domain/services/certification-challenges-service');
-const moment = require('moment');
 const { PIX_COUNT_BY_LEVEL } = require('../../../../lib/domain/constants');
 
 describe('Integration | CertificationChallengeService | pickCertificationChallenge', function () {
-  const placementDate = new Date('2020-01-01T00:00:00Z');
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  const certificationDate = _addOneDayToDate(placementDate);
+  const placementDate = new Date('2020-01-01');
+  const certificationDate = new Date('2020-01-02');
   const sufficientPixValueToBeCertifiableOnCompetence = PIX_COUNT_BY_LEVEL;
   const unsufficientPixValueToBeCertifiableOnCompetence = 1;
   const locale = 'fr-fr';
@@ -705,8 +702,4 @@ async function _buildCorrectAnswerAndKnowledgeElement({
     skillId,
   });
   await databaseBuilder.commit();
-}
-
-function _addOneDayToDate(date) {
-  return moment(date).add(1, 'day').toDate();
 }

--- a/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
@@ -1,6 +1,5 @@
 const { expect, knex, databaseBuilder, domainBuilder, catchErr } = require('../../../test-helper');
 const _ = require('lodash');
-const moment = require('moment');
 const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
@@ -30,11 +29,10 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
 
       it('should return the assessment with the answers sorted by creation date', async function () {
         //given
-        const dateOfFirstAnswer = moment.utc().subtract(3, 'minute').toDate();
-        const dateOfSecondAnswer = moment.utc().subtract(2, 'minute').toDate();
-        const dateOfThirdAnswer = moment.utc().subtract(1, 'minute').toDate();
-        moment.utc().toDate();
-        const dateOfFourthAnswer = moment.utc().toDate();
+        const dateOfFirstAnswer = new Date('2022-01-01T10:00:00Z');
+        const dateOfSecondAnswer = new Date('2022-01-01T10:01:00Z');
+        const dateOfThirdAnswer = new Date('2022-01-01T10:02:00Z');
+        const dateOfFourthAnswer = new Date('2022-01-01T10:03:00Z');
 
         _.each(
           [
@@ -180,24 +178,25 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
     // - completed assessments without an AssessmentResult
 
     before(async function () {
-      limitDate = moment.utc().toDate();
+      limitDate = new Date('2022-01-01');
 
-      const afterLimiteDate = moment(limitDate).add(1, 'day').toDate();
-      const johnAssessmentResultDateToRemember = moment(limitDate).subtract(1, 'month').toDate();
-      const johnAssessmentDateToRemember = moment(limitDate).subtract(2, 'month').toDate();
-      const dateAssessmentBefore1 = moment(johnAssessmentDateToRemember).subtract(1, 'month').toDate();
-      const dateAssessmentBefore2 = moment(johnAssessmentDateToRemember).subtract(2, 'month').toDate();
-      const dateAssessmentBefore3 = moment(johnAssessmentDateToRemember).subtract(3, 'month').toDate();
+      const afterLimiteDate = new Date('2022-01-02');
+      const johnAssessmentResultDateToRemember = new Date('2021-12-01');
+      const johnAssessmentDateToRemember = new Date('2021-11-01');
+      const dateAssessmentBefore1 = new Date('2021-10-01');
+      const dateAssessmentBefore2 = new Date('2021-09-01');
+      const dateAssessmentBefore3 = new Date('2021-08-01');
+
       const dateAssessmentAfter = afterLimiteDate;
 
-      const dateAssessmentResultBefore1 = moment(johnAssessmentResultDateToRemember).subtract(1, 'month').toDate();
-      const dateAssessmentResultBefore2 = moment(johnAssessmentResultDateToRemember).subtract(2, 'month').toDate();
-      const dateAssessmentResultBefore3 = moment(johnAssessmentResultDateToRemember).subtract(3, 'month').toDate();
+      const dateAssessmentResultBefore1 = new Date('2021-11-01');
+      const dateAssessmentResultBefore2 = new Date('2021-10-01');
+      const dateAssessmentResultBefore3 = new Date('2021-09-01');
 
-      const dateAssessmentResultAfter1 = moment(afterLimiteDate).add(1, 'month').toDate();
-      const dateAssessmentResultAfter2 = moment(afterLimiteDate).add(2, 'month').toDate();
+      const dateAssessmentResultAfter1 = new Date('2022-02-02');
+      const dateAssessmentResultAfter2 = new Date('2022-03-02');
 
-      lastQuestionDate = moment('2021-03-10').toDate();
+      lastQuestionDate = new Date('2021-12-31');
 
       johnUserId = databaseBuilder.factory.buildUser().id;
       laylaUserId = databaseBuilder.factory.buildUser().id;

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const moment = require('moment');
 const { expect, knex, domainBuilder, databaseBuilder, sinon } = require('../../../test-helper');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
 const knowledgeElementRepository = require('../../../../lib/infrastructure/repositories/knowledge-element-repository');
@@ -46,15 +45,15 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
   });
 
   describe('#findUniqByUserId', function () {
-    const today = new Date('2018-08-01T12:34:56Z');
+    const today = new Date('2018-08-03');
     let knowledgeElementsWanted, knowledgeElementsWantedWithLimitDate;
     let userId;
 
     beforeEach(async function () {
       // given
-      const yesterday = moment(today).subtract(1, 'days').toDate();
-      const tomorrow = moment(today).add(1, 'days').toDate();
-      const dayBeforeYesterday = moment(today).subtract(2, 'days').toDate();
+      const yesterday = new Date('2018-08-02');
+      const tomorrow = new Date('2018-08-04');
+      const dayBeforeYesterday = new Date('2018-08-01');
 
       userId = databaseBuilder.factory.buildUser().id;
 
@@ -1021,13 +1020,13 @@ describe('Integration | Repository | knowledgeElementRepository', function () {
 
     context('when user does not have a snapshot for this date', function () {
       context('when no date is provided along with the user', function () {
-        it('should take into account all the knowledge elements with a createdAt anterior as now', async function () {
+        it('should take into account all the knowledge elements with a createdAt date prior to today', async function () {
           // given
           const learningContent = domainBuilder.buildCampaignLearningContent.withSimpleContent();
           const userId = databaseBuilder.factory.buildUser().id;
           databaseBuilder.factory.buildKnowledgeElement({
             userId,
-            createdAt: moment.utc().subtract(1, 'minute').toDate(),
+            createdAt: new Date('2019-04-28'),
             competenceId: learningContent.competences[0].id,
             skillId: learningContent.skills[0].id,
           });

--- a/api/tests/integration/infrastructure/utils/ods/read-ods-utils_test.js
+++ b/api/tests/integration/infrastructure/utils/ods/read-ods-utils_test.js
@@ -1,7 +1,5 @@
 const { readFile } = require('fs').promises;
 const _ = require('lodash');
-const moment = require('moment');
-moment.suppressDeprecationWarnings = true;
 
 const { expect, catchErr } = require('../../../../test-helper');
 const { UnprocessableEntityError } = require('../../../../../lib/application/http-errors');

--- a/api/tests/integration/infrastructure/utils/ods/write-ods-utils_test.js
+++ b/api/tests/integration/infrastructure/utils/ods/write-ods-utils_test.js
@@ -1,6 +1,4 @@
 const { writeFile, unlink } = require('fs').promises;
-const moment = require('moment');
-moment.suppressDeprecationWarnings = true;
 
 const { expect } = require('../../../../test-helper');
 

--- a/api/tests/integration/infrastructure/utils/pdf/certification-attestation-pdf_test.js
+++ b/api/tests/integration/infrastructure/utils/pdf/certification-attestation-pdf_test.js
@@ -1,5 +1,5 @@
 const { domainBuilder, expect, nock, catchErr } = require('../../../../test-helper');
-const moment = require('moment');
+const dayjs = require('dayjs');
 const { isSameBinary } = require('../../../../tooling/binary-comparator');
 const {
   getCertificationAttestationsPdfBuffer,
@@ -137,8 +137,8 @@ describe('Integration | Infrastructure | Utils | Pdf | Certification Attestation
   it('should generate a page per certificate', async function () {
     // given
     const professionalizingValidityStartDate = new Date('2022-01-01');
-    const deliveredBeforeStartDate = moment(professionalizingValidityStartDate).subtract(1, 'days').toDate();
-    const deliveredAfterStartDate = moment(professionalizingValidityStartDate).add(1, 'days').toDate();
+    const deliveredBeforeStartDate = dayjs(professionalizingValidityStartDate).subtract(1, 'days').toDate();
+    const deliveredAfterStartDate = dayjs(professionalizingValidityStartDate).add(1, 'days').toDate();
 
     const resultCompetenceTree = domainBuilder.buildResultCompetenceTree();
     const certificateWithComplementaryCertificationsAndWithoutProfessionalizingMessage =

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -1,4 +1,3 @@
-const { fn: momentProto } = require('moment');
 const {
   domainBuilder,
   expect,
@@ -1064,6 +1063,14 @@ describe('Unit | Application | Organizations | organization-controller', functio
   });
 
   describe('#downloadCertificationResults', function () {
+    const now = new Date('2019-01-01T05:06:07Z');
+    let clock;
+    beforeEach(function () {
+      clock = sinon.useFakeTimers(now);
+    });
+    afterEach(function () {
+      clock.restore();
+    });
     it('should return a response with CSV results', async function () {
       // given
       const request = {
@@ -1081,9 +1088,6 @@ describe('Unit | Application | Organizations | organization-controller', functio
         domainBuilder.buildCertificationResult({ isPublished: true }),
       ];
 
-      sinon.stub(momentProto, 'format');
-      momentProto.format.withArgs('YYYYMMDD').returns('20210101');
-
       sinon
         .stub(usecases, 'getScoCertificationResultsByDivision')
         .withArgs({ organizationId: 1, division: '3èmeA' })
@@ -1100,11 +1104,19 @@ describe('Unit | Application | Organizations | organization-controller', functio
       // then
       expect(response.source).to.equal('csv-string');
       expect(response.headers['Content-Type']).to.equal('text/csv;charset=utf-8');
-      expect(response.headers['Content-Disposition']).to.equal('attachment; filename="20210101_resultats_3èmeA.csv"');
+      expect(response.headers['Content-Disposition']).to.equal('attachment; filename="20190101_resultats_3èmeA.csv"');
     });
   });
 
   describe('#downloadCertificationAttestationsForDivision', function () {
+    const now = new Date('2019-01-01T05:06:07Z');
+    let clock;
+    beforeEach(function () {
+      clock = sinon.useFakeTimers(now);
+    });
+    afterEach(function () {
+      clock.restore();
+    });
     it('should return binary attestations', async function () {
       // given
       const certifications = [
@@ -1114,11 +1126,6 @@ describe('Unit | Application | Organizations | organization-controller', functio
       const organizationId = domainBuilder.buildOrganization().id;
       const division = '3b';
       const attestationsPDF = 'binary string';
-
-      sinon.stub(momentProto, 'format');
-      momentProto.format.withArgs('YYYYMMDD').returns('20210101');
-
-      const fileName = '20210101_attestations_3b.pdf';
       const userId = 1;
 
       const request = {
@@ -1137,14 +1144,14 @@ describe('Unit | Application | Organizations | organization-controller', functio
       sinon
         .stub(certificationAttestationPdf, 'getCertificationAttestationsPdfBuffer')
         .withArgs({ certificates: certifications, isFrenchDomainExtension: true })
-        .resolves({ buffer: attestationsPDF, fileName });
+        .resolves({ buffer: attestationsPDF });
 
       // when
       const response = await organizationController.downloadCertificationAttestationsForDivision(request, hFake);
 
       // then
       expect(response.source).to.deep.equal(attestationsPDF);
-      expect(response.headers['Content-Disposition']).to.contains('attachment; filename=20210101_attestations_3b.pdf');
+      expect(response.headers['Content-Disposition']).to.contains('attachment; filename=20190101_attestations_3b.pdf');
     });
   });
 

--- a/api/tests/unit/domain/models/KnowledgeElement_test.js
+++ b/api/tests/unit/domain/models/KnowledgeElement_test.js
@@ -1,7 +1,7 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
-const moment = require('moment');
+const dayjs = require('dayjs');
 
 describe('Unit | Domain | Models | KnowledgeElement', function () {
   describe('#isValidated', function () {
@@ -349,11 +349,11 @@ describe('Unit | Domain | Models | KnowledgeElement', function () {
       { daysBefore: 10, hoursBefore: 0, expectedDaysSinceLastKnowledgeElement: 10 },
     ].forEach(({ daysBefore, hoursBefore, expectedDaysSinceLastKnowledgeElement }) => {
       it(`should return ${expectedDaysSinceLastKnowledgeElement} days when the last knowledge element is ${daysBefore} days and ${hoursBefore} hours old`, function () {
-        const knowledgeElementCreationDate = moment(testCurrentDate)
+        const knowledgeElementCreationDate = dayjs(testCurrentDate)
           .subtract(daysBefore, 'day')
           .subtract(hoursBefore, 'hour')
           .toDate();
-        const oldDate = moment(testCurrentDate).subtract(100, 'day').toDate();
+        const oldDate = dayjs(testCurrentDate).subtract(100, 'day').toDate();
 
         knowledgeElements = [{ createdAt: oldDate }, { createdAt: knowledgeElementCreationDate }];
 

--- a/api/tests/unit/domain/models/Scorecard_test.js
+++ b/api/tests/unit/domain/models/Scorecard_test.js
@@ -1,4 +1,3 @@
-const moment = require('moment');
 const { expect, sinon } = require('../../../test-helper');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
 const Scorecard = require('../../../../lib/domain/models/Scorecard');
@@ -294,8 +293,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
       { daysSinceLastKnowledgeElement: 10, expectedDaysBeforeReset: 0 },
     ].forEach(({ daysSinceLastKnowledgeElement, expectedDaysBeforeReset }) => {
       it(`should return ${expectedDaysBeforeReset} days when ${daysSinceLastKnowledgeElement} days passed since last knowledge element`, function () {
-        const date = moment(testCurrentDate).toDate();
-        const knowledgeElements = [{ createdAt: date }];
+        const knowledgeElements = [{ createdAt: new Date(testCurrentDate) }];
 
         computeDaysSinceLastKnowledgeElementStub.returns(daysSinceLastKnowledgeElement);
 
@@ -339,8 +337,7 @@ describe('Unit | Domain | Models | Scorecard', function () {
       { daysSinceLastKnowledgeElement: 10, expectedDaysBeforeImproving: 0 },
     ].forEach(({ daysSinceLastKnowledgeElement, expectedDaysBeforeImproving }) => {
       it(`should return ${expectedDaysBeforeImproving} days when ${daysSinceLastKnowledgeElement} days passed since last knowledge element`, function () {
-        const date = moment(testCurrentDate).toDate();
-        const knowledgeElements = [{ createdAt: date }];
+        const knowledgeElements = [{ createdAt: new Date(testCurrentDate) }];
 
         computeDaysSinceLastKnowledgeElementStub.returns(daysSinceLastKnowledgeElement);
 

--- a/api/tests/unit/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
@@ -3,7 +3,6 @@ const UserToCreate = require('../../../../../lib/domain/models/UserToCreate');
 const DomainTransaction = require('../../../../../lib/infrastructure/DomainTransaction');
 const AuthenticationMethod = require('../../../../../lib/domain/models/AuthenticationMethod');
 const OidcIdentityProviders = require('../../../../../lib/domain/constants/oidc-identity-providers');
-const moment = require('moment');
 const PoleEmploiOidcAuthenticationService = require('../../../../../lib/domain/services/authentication/pole-emploi-oidc-authentication-service');
 const logoutUrlTemporaryStorage = require('../../../../../lib/infrastructure/temporary-storage').withPrefix(
   'logout-url:'
@@ -58,7 +57,7 @@ describe('Unit | Domain | Services | pole-emploi-oidc-authentication-service', f
         authenticationComplement: new AuthenticationMethod.OidcAuthenticationComplement({
           accessToken: sessionContent.accessToken,
           refreshToken: sessionContent.refreshToken,
-          expiredDate: moment().add(sessionContent.expiresIn, 's').toDate(),
+          expiredDate: new Date('2021-01-02T00:00:10Z'),
         }),
         userId,
       });

--- a/api/tests/unit/domain/services/sco-account-recovery-service_test.js
+++ b/api/tests/unit/domain/services/sco-account-recovery-service_test.js
@@ -11,7 +11,7 @@ const {
   UserHasAlreadyLeftSCO,
 } = require('../../../../lib/domain/errors');
 const { features } = require('../../../../lib/config');
-const moment = require('moment');
+const dayjs = require('dayjs');
 
 describe('Unit | Service | sco-account-recovery-service', function () {
   describe('#retrieveOrganizationLearner', function () {
@@ -563,7 +563,7 @@ describe('Unit | Service | sco-account-recovery-service', function () {
         // given
         features.scoAccountRecoveryKeyLifetimeMinutes = 1;
         const userId = '1234';
-        const createdTwoMinutesAgo = moment().subtract(2, 'minutes').toDate();
+        const createdTwoMinutesAgo = dayjs().subtract(2, 'minutes').toDate();
         accountRecoveryDemandRepository.findByTemporaryKey.resolves({ userId, createdAt: createdTwoMinutesAgo });
         userRepository.checkIfEmailIsAvailable.resolves();
         accountRecoveryDemandRepository.findByUserId.withArgs(userId).resolves([{ used: false }]);

--- a/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
@@ -5,7 +5,6 @@ const logger = require('../../../../../lib/infrastructure/logger');
 const authenticateOidcUser = require('../../../../../lib/domain/usecases/authentication/authenticate-oidc-user');
 const AuthenticationSessionContent = require('../../../../../lib/domain/models/AuthenticationSessionContent');
 const AuthenticationMethod = require('../../../../../lib/domain/models/AuthenticationMethod');
-const moment = require('moment');
 const OidcIdentityProviders = require('../../../../../lib/domain/constants/oidc-identity-providers');
 
 describe('Unit | UseCase | authenticate-oidc-user', function () {
@@ -205,7 +204,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
         const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement({
           accessToken: sessionContent.accessToken,
           refreshToken: sessionContent.refreshToken,
-          expiredDate: moment().add(sessionContent.expiresIn, 's').toDate(),
+          expiredDate: new Date(),
         });
         oidcAuthenticationService.createAuthenticationComplement.returns(authenticationComplement);
 
@@ -273,7 +272,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
       const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement({
         accessToken: sessionContent.accessToken,
         refreshToken: sessionContent.refreshToken,
-        expiredDate: moment().add(sessionContent.expiresIn, 's').toDate(),
+        expiredDate: new Date(),
       });
       oidcAuthenticationService.createAuthenticationComplement.returns(authenticationComplement);
 

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -1,5 +1,5 @@
 const querystring = require('querystring');
-const moment = require('moment');
+const dayjs = require('dayjs');
 const { expect, sinon, catchErr, domainBuilder } = require('../../../../test-helper');
 const settings = require('../../../../../lib/config');
 const { UnexpectedUserAccountError } = require('../../../../../lib/domain/errors');
@@ -79,7 +79,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
     context('when access token is valid', function () {
       it('should send the notification to Pole Emploi', async function () {
         // given
-        const expiredDate = moment().add(10, 'm').toDate();
+        const expiredDate = dayjs().add(10, 'm').toDate();
         const authenticationMethod = { authenticationComplement: { accessToken, expiredDate, refreshToken } };
 
         const expectedHearders = {
@@ -108,7 +108,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
       it('should log the notification to Pole Emploi', async function () {
         // given
         payload = { test: { progression: 100 } };
-        const expiredDate = moment().add(10, 'm').toDate();
+        const expiredDate = dayjs().add(10, 'm').toDate();
         const authenticationMethod = { authenticationComplement: { accessToken, expiredDate, refreshToken } };
 
         authenticationMethodRepository.findOneByUserIdAndIdentityProvider
@@ -182,7 +182,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
           const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement({
             accessToken: data['access_token'],
             refreshToken: data['refresh_token'],
-            expiredDate: moment().add(data['expires_in'], 's').toDate(),
+            expiredDate: dayjs().add(data['expires_in'], 's').toDate(),
           });
 
           // when
@@ -203,7 +203,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
           const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement({
             accessToken: data['access_token'],
             refreshToken: data['refresh_token'],
-            expiredDate: moment().add(data['expires_in'], 's').toDate(),
+            expiredDate: dayjs().add(data['expires_in'], 's').toDate(),
           });
 
           const expectedHeaders = {

--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/send-email_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/send-email_test.js
@@ -1,7 +1,13 @@
 const { expect, sinon } = require('../../../../../test-helper');
 const sendEmail = require('../../../../../../lib/infrastructure/jobs/cpf-export/handlers/send-email');
 const { cpf } = require('../../../../../../lib/config');
-const moment = require('moment-timezone');
+const dayjs = require('dayjs');
+const timezone = require('dayjs/plugin/timezone');
+const utc = require('dayjs/plugin/utc');
+const customParseFormat = require('dayjs/plugin/customParseFormat');
+dayjs.extend(timezone);
+dayjs.extend(utc);
+dayjs.extend(customParseFormat);
 
 describe('Unit | Infrastructure | jobs | cpf-export | send-email', function () {
   let cpfExternalStorage;
@@ -25,7 +31,7 @@ describe('Unit | Infrastructure | jobs | cpf-export | send-email', function () {
     await sendEmail({ cpfExternalStorage, mailService });
 
     // then
-    const expectedDate = moment.tz('01-15', 'MM-DD', 'Europe/Paris').toDate();
+    const expectedDate = dayjs.tz('01-15', 'MM-DD', 'Europe/Paris').toDate();
     expect(cpfExternalStorage.getPreSignUrlsOfFilesModifiedAfter).to.have.been.calledWith({ date: expectedDate });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème

La librairie `moment` est dépréciée et n'est plus maintenue.

## :gift: Proposition

- Utiliser des dates explicites quand l'utilisation d'une librairie est superflue
- Remplacer `moment` par `dayjs` quand c'est pertinent

## :star2: Remarques

- [Implémentation de l'ADR 0030](https://github.com/1024pix/pix/blob/dev/docs/adr/0030-revoir-le-choix-d-une-librairie-de-gestion-des-dates.md)
- Une autre PR remplacera moment par dayjs dans les implémentations
- Seule une implémentation a été modifiée (dans `organization-controller`) car il y avait un stub de la librairie dans le test associé

## :santa: Pour tester

Vérifier que les tests de la CI passent.