### PR TITLE
[TECH] Remplacer moment par dayjs dans l'API

### DIFF
--- a/api/lib/application/certifications/certification-controller.js
+++ b/api/lib/application/certifications/certification-controller.js
@@ -5,7 +5,8 @@ const shareableCertificateSerializer = require('../../infrastructure/serializers
 const certificationAttestationPdf = require('../../infrastructure/utils/pdf/certification-attestation-pdf.js');
 const requestResponseUtils = require('../../infrastructure/utils/request-response-utils.js');
 
-const moment = require('moment');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 
 module.exports = {
   async findUserCertifications(request) {
@@ -50,7 +51,7 @@ module.exports = {
       isFrenchDomainExtension,
     });
 
-    const fileName = `attestation-pix-${moment(attestation.deliveredAt).format('YYYYMMDD')}.pdf`;
+    const fileName = `attestation-pix-${dayjs(attestation.deliveredAt).format('YYYYMMDD')}.pdf`;
     return h
       .response(buffer)
       .header('Content-Disposition', `attachment; filename=${fileName}`)

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -1,4 +1,5 @@
-const moment = require('moment');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 const { BadRequestError, SessionPublicationBatchError } = require('../http-errors.js');
 const usecases = require('../../domain/usecases/index.js');
 const tokenService = require('../../domain/services/token-service.js');
@@ -165,7 +166,7 @@ module.exports = {
       certificationResults,
     });
 
-    const dateWithTime = moment(session.date + ' ' + session.time, 'YYYY-MM-DD HH:mm');
+    const dateWithTime = dayjs(session.date + ' ' + session.time, 'YYYY-MM-DD HH:mm');
     const fileName = `${dateWithTime.format('YYYYMMDD_HHmm')}_resultats_session_${sessionId}.csv`;
 
     return h
@@ -186,7 +187,7 @@ module.exports = {
       certificationResults,
     });
 
-    const dateWithTime = moment(session.date + ' ' + session.time, 'YYYY-MM-DD HH:mm');
+    const dateWithTime = dayjs(session.date + ' ' + session.time, 'YYYY-MM-DD HH:mm');
     const fileName = `${dateWithTime.format('YYYYMMDD_HHmm')}_resultats_session_${sessionId}.csv`;
 
     return h

--- a/api/lib/application/sessions/session-with-clea-certified-candidate-controller.js
+++ b/api/lib/application/sessions/session-with-clea-certified-candidate-controller.js
@@ -1,6 +1,7 @@
 const usecases = require('../../domain/usecases/index.js');
 const certificationResultUtils = require('../../infrastructure/utils/csv/certification-results.js');
 const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 
 module.exports = {
   async getCleaCertifiedCandidateDataCsv(request, h) {

--- a/api/lib/application/target-profiles/presenter/pdf/drawer/LegalMentionText.js
+++ b/api/lib/application/target-profiles/presenter/pdf/drawer/LegalMentionText.js
@@ -1,4 +1,5 @@
 const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 const Text = require('./Text.js');
 const ColorManager = require('../manager/color-manager.js');
 const FontManager = require('../manager/font-manager.js');

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -1,6 +1,6 @@
 /* eslint-disable node/no-process-env*/
 const path = require('path');
-const moment = require('moment');
+const dayjs = require('dayjs');
 const ms = require('ms');
 
 const { getArrayOfStrings } = require('../lib/infrastructure/utils/string-utils.js');
@@ -29,12 +29,12 @@ function _getDate(dateAsString) {
   if (!dateAsString) {
     return null;
   }
-  const dateAsMoment = moment(dateAsString);
-  if (!dateAsMoment.isValid()) {
+  const dateAsdayjs = dayjs(dateAsString);
+  if (!dateAsdayjs.isValid()) {
     return null;
   }
 
-  return dateAsMoment.toDate();
+  return dateAsdayjs.toDate();
 }
 
 function _removeTrailingSlashFromUrl(url) {

--- a/api/lib/domain/models/KnowledgeElement.js
+++ b/api/lib/domain/models/KnowledgeElement.js
@@ -1,6 +1,7 @@
 const Skill = require('../models/Skill.js');
 const _ = require('lodash');
-const moment = require('moment');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 
 const statuses = {
   VALIDATED: 'validated',
@@ -84,7 +85,7 @@ class KnowledgeElement {
   static computeDaysSinceLastKnowledgeElement(knowledgeElements) {
     const lastCreatedAt = _(knowledgeElements).map('createdAt').max();
     const precise = true;
-    return moment().diff(lastCreatedAt, 'days', precise);
+    return dayjs().diff(lastCreatedAt, 'days', precise);
   }
 
   static findDirectlyValidatedFromGroups(knowledgeElementsByCompetence) {

--- a/api/lib/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/lib/domain/read-models/participant-results/AssessmentResult.js
@@ -1,7 +1,8 @@
 const BadgeResult = require('./BadgeResult.js');
 const CompetenceResult = require('./CompetenceResult.js');
 const constants = require('../../constants.js');
-const moment = require('moment');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 
 class AssessmentResult {
   constructor({
@@ -79,7 +80,7 @@ class AssessmentResult {
     const isImprovementPossible =
       knowledgeElements.filter((knowledgeElement) => {
         const isOldEnoughToBeImproved =
-          moment(assessmentCreatedAt).diff(knowledgeElement.createdAt, 'days', true) >=
+          dayjs(assessmentCreatedAt).diff(knowledgeElement.createdAt, 'days', true) >=
           constants.MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING;
         return knowledgeElement.isInvalidated && isOldEnoughToBeImproved;
       }).length > 0;
@@ -103,7 +104,7 @@ class AssessmentResult {
   _timeBeforeRetryingPassed(sharedAt) {
     const isShared = Boolean(sharedAt);
     if (!isShared) return false;
-    return sharedAt && moment().diff(sharedAt, 'days', true) >= constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
+    return sharedAt && dayjs().diff(sharedAt, 'days', true) >= constants.MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING;
   }
 }
 

--- a/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
@@ -2,7 +2,8 @@ const settings = require('../../../config.js');
 const OidcAuthenticationService = require('./oidc-authentication-service.js');
 const DomainTransaction = require('../../../infrastructure/DomainTransaction.js');
 const AuthenticationMethod = require('../../models/AuthenticationMethod.js');
-const moment = require('moment');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 const { v4: uuidv4 } = require('uuid');
 const { temporaryStorage } = require('../../../infrastructure/temporary-storage/index.js');
 const logoutUrlTemporaryStorage = temporaryStorage.withPrefix('logout-url:');
@@ -100,7 +101,7 @@ class PoleEmploiOidcAuthenticationService extends OidcAuthenticationService {
     return new AuthenticationMethod.OidcAuthenticationComplement({
       accessToken: sessionContent.accessToken,
       refreshToken: sessionContent.refreshToken,
-      expiredDate: moment().add(sessionContent.expiresIn, 's').toDate(),
+      expiredDate: dayjs().add(sessionContent.expiresIn, 's').toDate(),
     });
   }
 }

--- a/api/lib/domain/services/cpf-certification-xml-export-service.js
+++ b/api/lib/domain/services/cpf-certification-xml-export-service.js
@@ -2,6 +2,7 @@ const { cpf } = require('../../config.js');
 const { create, fragment } = require('xmlbuilder2');
 const { v4: uuidv4 } = require('uuid');
 const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 const utc = require('dayjs/plugin/utc');
 const timezone = require('dayjs/plugin/timezone');
 dayjs.extend(utc);
@@ -10,7 +11,7 @@ dayjs.extend(timezone);
 const schemaVersion = '1.0.0';
 
 // prettier-ignore
-async function buildXmlExport({ cpfCertificationResults, writableStream, opts = {}}) {
+async function buildXmlExport({ cpfCertificationResults, writableStream, opts = {} }) {
   const overrideOpts = { allowEmptyTags: true, };
   const PLACEHOLDER = 'PLACEHOLDER';
   const formatedDate = dayjs().tz('Europe/Paris').format('YYYY-MM-DDThh:mm:ss') + '+01:00';
@@ -19,25 +20,25 @@ async function buildXmlExport({ cpfCertificationResults, writableStream, opts = 
       'xmlns:cpf': `urn:cdc:cpf:pc5:schema:${schemaVersion}`,
       'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
     })
-      .ele('cpf:idFlux').txt(uuidv4()).up()
-      .ele('cpf:horodatage').txt(formatedDate).up()
-      .ele('cpf:emetteur')
-        .ele('cpf:idClient').txt(cpf.idClient).up()
-        .ele('cpf:certificateurs')
-          .ele('cpf:certificateur')
-            .ele('cpf:idClient').txt(cpf.idClient).up()
-            .ele('cpf:idContrat').txt(cpf.idContrat).up()
-            .ele('cpf:certifications')
-              .ele('cpf:certification')
-                .ele('cpf:type').txt('RS').up()
-                .ele('cpf:code').txt(cpf.codeFranceConnect).up()
-                .ele('cpf:natureDeposant').txt('CERTIFICATEUR').up()
-                .ele('cpf:passageCertifications').txt(PLACEHOLDER);
-  const [headerOpeningTag, headerClosingTag] = root.end( {...opts, ...overrideOpts}).split(PLACEHOLDER);
+    .ele('cpf:idFlux').txt(uuidv4()).up()
+    .ele('cpf:horodatage').txt(formatedDate).up()
+    .ele('cpf:emetteur')
+    .ele('cpf:idClient').txt(cpf.idClient).up()
+    .ele('cpf:certificateurs')
+    .ele('cpf:certificateur')
+    .ele('cpf:idClient').txt(cpf.idClient).up()
+    .ele('cpf:idContrat').txt(cpf.idContrat).up()
+    .ele('cpf:certifications')
+    .ele('cpf:certification')
+    .ele('cpf:type').txt('RS').up()
+    .ele('cpf:code').txt(cpf.codeFranceConnect).up()
+    .ele('cpf:natureDeposant').txt('CERTIFICATEUR').up()
+    .ele('cpf:passageCertifications').txt(PLACEHOLDER);
+  const [headerOpeningTag, headerClosingTag] = root.end({ ...opts, ...overrideOpts }).split(PLACEHOLDER);
 
   await _write(writableStream, headerOpeningTag);
 
-  for(const {
+  for (const {
     id,
     publishedAt,
     pixScore,
@@ -51,117 +52,117 @@ async function buildXmlExport({ cpfCertificationResults, writableStream, opts = 
     countryCode,
     birthCountry,
     europeanNumericLevels,
-  } of  cpfCertificationResults) {
+  } of cpfCertificationResults) {
     const [yearOfBirth, monthOfBirth, dayOfBirth] = birthdate.split('-');
     const line = fragment()
       .ele('cpf:passageCertification')
-        .ele('cpf:idTechnique').txt(id)
-        .up()
-        .ele('cpf:obtentionCertification').txt('PAR_SCORING')
-        .up()
-        .ele('cpf:donneeCertifiee').txt(true)
-        .up()
-        .ele('cpf:dateDebutValidite').txt(dayjs(publishedAt).format('YYYY-MM-DD'))
-        .up()
-        .ele('cpf:dateFinValidite', { 'xsi:nil': true })
-        .up()
-        .ele('cpf:presenceNiveauLangueEuro').txt(false)
-        .up()
-        .ele('cpf:presenceNiveauNumeriqueEuro').txt(true)
-        .up();
+      .ele('cpf:idTechnique').txt(id)
+      .up()
+      .ele('cpf:obtentionCertification').txt('PAR_SCORING')
+      .up()
+      .ele('cpf:donneeCertifiee').txt(true)
+      .up()
+      .ele('cpf:dateDebutValidite').txt(dayjs(publishedAt).format('YYYY-MM-DD'))
+      .up()
+      .ele('cpf:dateFinValidite', { 'xsi:nil': true })
+      .up()
+      .ele('cpf:presenceNiveauLangueEuro').txt(false)
+      .up()
+      .ele('cpf:presenceNiveauNumeriqueEuro').txt(true)
+      .up();
     const niveauNumeriqueEuropeen = line
-        .ele('cpf:niveauNumeriqueEuropeen')
-          .ele('cpf:scoreGeneral').txt(pixScore)
-          .up();
+      .ele('cpf:niveauNumeriqueEuropeen')
+      .ele('cpf:scoreGeneral').txt(pixScore)
+      .up();
     const resultats = niveauNumeriqueEuropeen
-          .ele('cpf:resultats');
+      .ele('cpf:resultats');
 
     europeanNumericLevels.forEach(({ domainCompetenceId, competenceId, level }) => {
       resultats
-            .ele('cpf:resultat')
-              .ele('cpf:niveau').txt(level)
-              .up()
-              .ele('cpf:domaineCompetenceId').txt(domainCompetenceId)
-              .up()
-              .ele('cpf:competenceId').txt(competenceId)
-              .up()
-            .up();
+        .ele('cpf:resultat')
+        .ele('cpf:niveau').txt(level)
+        .up()
+        .ele('cpf:domaineCompetenceId').txt(domainCompetenceId)
+        .up()
+        .ele('cpf:competenceId').txt(competenceId)
+        .up()
+        .up();
     });
 
     resultats
-          .up();
+      .up();
     niveauNumeriqueEuropeen
-        .up();
+      .up();
 
     const details = line
-        .ele('cpf:scoring').txt(pixScore)
-        .up()
-        .ele('cpf:mentionValidee', { 'xsi:nil': true })
-        .up()
-        .ele('cpf:modalitesInscription')
-          .ele('cpf:modaliteAcces', { 'xsi:nil': true })
-          .up()
-        .up()
-        .ele('cpf:identificationTitulaire')
-          .ele('cpf:titulaire')
-            .ele('cpf:nomNaissance').txt(lastName)
-            .up()
-            .ele('cpf:nomUsage', { 'xsi:nil': true })
-            .up()
-            .ele('cpf:prenom1').txt(firstName)
-            .up()
-            .ele('cpf:anneeNaissance').txt(yearOfBirth)
-            .up()
-            .ele('cpf:moisNaissance').txt(monthOfBirth)
-            .up()
-            .ele('cpf:jourNaissance').txt(dayOfBirth)
-            .up()
-            .ele('cpf:sexe').txt(sex)
-            .up()
+      .ele('cpf:scoring').txt(pixScore)
+      .up()
+      .ele('cpf:mentionValidee', { 'xsi:nil': true })
+      .up()
+      .ele('cpf:modalitesInscription')
+      .ele('cpf:modaliteAcces', { 'xsi:nil': true })
+      .up()
+      .up()
+      .ele('cpf:identificationTitulaire')
+      .ele('cpf:titulaire')
+      .ele('cpf:nomNaissance').txt(lastName)
+      .up()
+      .ele('cpf:nomUsage', { 'xsi:nil': true })
+      .up()
+      .ele('cpf:prenom1').txt(firstName)
+      .up()
+      .ele('cpf:anneeNaissance').txt(yearOfBirth)
+      .up()
+      .ele('cpf:moisNaissance').txt(monthOfBirth)
+      .up()
+      .ele('cpf:jourNaissance').txt(dayOfBirth)
+      .up()
+      .ele('cpf:sexe').txt(sex)
+      .up()
 
     const communeNaissance = details
-            .ele('cpf:codeCommuneNaissance');
+      .ele('cpf:codeCommuneNaissance');
 
     if (inseeCode) {
       communeNaissance
-              .ele('cpf:codeInseeNaissance')
-                .ele('cpf:codeInsee').txt(inseeCode)
-                .up()
-              .up();
+        .ele('cpf:codeInseeNaissance')
+        .ele('cpf:codeInsee').txt(inseeCode)
+        .up()
+        .up();
     } else if (postalCode) {
       communeNaissance
-              .ele('cpf:codePostalNaissance')
-                .ele('cpf:codePostal').txt(postalCode)
-                .up()
-              .up();
+        .ele('cpf:codePostalNaissance')
+        .ele('cpf:codePostal').txt(postalCode)
+        .up()
+        .up();
     } else {
       communeNaissance
-              .ele('cpf:codePostalNaissance')
-                .ele('cpf:codePostal', { 'xsi:nil': true })
-                .up()
-              .up();
+        .ele('cpf:codePostalNaissance')
+        .ele('cpf:codePostal', { 'xsi:nil': true })
+        .up()
+        .up();
     }
     communeNaissance
-            .up()
-    
+      .up()
+
     details
-          .ele('cpf:libelleCommuneNaissance').txt(birthplace)
-          .up()
-        .up()
+      .ele('cpf:libelleCommuneNaissance').txt(birthplace)
+      .up()
+      .up()
     if (countryCode) {
       details
         .ele('cpf:codePaysNaissance').txt(countryCode)
         .up();
     }
     details
-        .ele('cpf:libellePaysNaissance').txt(birthCountry)
-        .up();
+      .ele('cpf:libellePaysNaissance').txt(birthCountry)
+      .up();
 
     line
       .up();
-    await _write(writableStream, line.end({ ...opts, ...overrideOpts,  }));
+    await _write(writableStream, line.end({ ...opts, ...overrideOpts, }));
   }
-  
+
   await _write(writableStream, headerClosingTag);
   writableStream.end();
 }

--- a/api/lib/domain/services/improvement-service.js
+++ b/api/lib/domain/services/improvement-service.js
@@ -1,12 +1,13 @@
 const constants = require('../constants.js');
-const moment = require('moment');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 
 function _keepKnowledgeElementsRecentOrValidated({ currentUserKnowledgeElements, assessment, minimumDelayInDays }) {
   const startedDateOfAssessment = assessment.createdAt;
 
   return currentUserKnowledgeElements.filter((knowledgeElement) => {
     const isNotOldEnoughToBeImproved =
-      moment(startedDateOfAssessment).diff(knowledgeElement.createdAt, 'days', true) < minimumDelayInDays;
+      dayjs(startedDateOfAssessment).diff(knowledgeElement.createdAt, 'days', true) < minimumDelayInDays;
     return knowledgeElement.isValidated || isNotOldEnoughToBeImproved;
   });
 }

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -1,4 +1,5 @@
 const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 
 const tokenService = require('./token-service.js');
 const { mailer } = require('../../infrastructure/mailers/mailer.js');

--- a/api/lib/domain/usecases/get-attendance-sheet.js
+++ b/api/lib/domain/usecases/get-attendance-sheet.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
-const moment = require('moment');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 const writeOdsUtils = require('../../infrastructure/utils/ods/write-ods-utils.js');
 const readOdsUtils = require('../../infrastructure/utils/ods/read-ods-utils.js');
 const sessionXmlService = require('../services/session-xml-service.js');
@@ -82,11 +83,11 @@ function _attendanceSheetWithCertificationCandidates(stringifiedXml, session) {
 function _transformSessionIntoAttendanceSheetSessionData(attendanceSheetData, value, prop) {
   switch (prop) {
     case 'time':
-      attendanceSheetData.startTime = moment(value, 'HH:mm').format('HH:mm');
-      attendanceSheetData.endTime = moment(value, 'HH:mm').add(moment.duration(2, 'hours')).format('HH:mm');
+      attendanceSheetData.startTime = dayjs(value, 'HH:mm').format('HH:mm');
+      attendanceSheetData.endTime = dayjs(value, 'HH:mm').add(2, 'hours').format('HH:mm');
       break;
     case 'date':
-      attendanceSheetData.date = moment(value, 'YYYY-MM-DD').format('DD/MM/YYYY');
+      attendanceSheetData.date = dayjs(value, 'YYYY-MM-DD').format('DD/MM/YYYY');
       break;
     case 'certificationCandidates':
       break;
@@ -105,7 +106,7 @@ function _transformCandidateIntoAttendanceSheetCandidateData(attendanceSheetData
       }
       break;
     case 'birthdate':
-      attendanceSheetData[prop] = value === null ? '' : moment(value, 'YYYY-MM-DD').format('YYYY-MM-DD');
+      attendanceSheetData[prop] = value === null ? '' : dayjs(value, 'YYYY-MM-DD').format('YYYY-MM-DD');
       break;
     default:
       attendanceSheetData[prop] = value === null ? '' : value;

--- a/api/lib/domain/usecases/get-target-profile-content-as-json.js
+++ b/api/lib/domain/usecases/get-target-profile-content-as-json.js
@@ -1,5 +1,6 @@
 const { ForbiddenAccess } = require('../../domain/errors.js');
 const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 const learningContentConversionService = require('../services/learning-content/learning-content-conversion-service.js');
 
 module.exports = async function getTargetProfileContentAsJson({

--- a/api/lib/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
+++ b/api/lib/infrastructure/exports/campaigns/campaign-profiles-collection-result-line.js
@@ -1,5 +1,6 @@
 const csvSerializer = require('../../serializers/csv/csv-serializer.js');
-const moment = require('moment');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 
 const EMPTY_ARRAY = [];
 
@@ -71,7 +72,7 @@ class CampaignProfilesCollectionResultLine {
 
   _getSharedAtColumn() {
     return this.campaignParticipationResult.isShared
-      ? moment.utc(this.campaignParticipationResult.sharedAt).format('YYYY-MM-DD')
+      ? dayjs.utc(this.campaignParticipationResult.sharedAt).format('YYYY-MM-DD')
       : this.notShared;
   }
 

--- a/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
+++ b/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
@@ -1,5 +1,6 @@
 const get = require('lodash/get');
-const moment = require('moment');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 const querystring = require('querystring');
 const monitoringTools = require('../../monitoring-tools.js');
 const authenticationMethodRepository = require('../../repositories/authentication-method-repository.js');
@@ -69,7 +70,7 @@ module.exports = {
       const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement({
         accessToken,
         refreshToken: tokenResponse.data['refresh_token'],
-        expiredDate: moment().add(tokenResponse.data['expires_in'], 's').toDate(),
+        expiredDate: dayjs().add(tokenResponse.data['expires_in'], 's').toDate(),
       });
       await authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider({
         authenticationComplement,

--- a/api/lib/infrastructure/files/candidates-import/CandidateData.js
+++ b/api/lib/infrastructure/files/candidates-import/CandidateData.js
@@ -1,4 +1,5 @@
-const moment = require('moment');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 const _ = require('lodash');
 const FRANCE_COUNTRY_CODE = '99100';
 const CertificationCandidate = require('../../../domain/models/CertificationCandidate.js');
@@ -46,7 +47,7 @@ module.exports = class CandidateData {
     this.email = this._emptyStringIfNull(email);
     this.resultRecipientEmail = this._emptyStringIfNull(resultRecipientEmail);
     this.externalId = this._emptyStringIfNull(externalId);
-    this.birthdate = birthdate === null ? '' : moment(birthdate, 'YYYY-MM-DD').format('YYYY-MM-DD');
+    this.birthdate = birthdate === null ? '' : dayjs(birthdate, 'YYYY-MM-DD').format('YYYY-MM-DD');
     if (!_.isFinite(extraTimePercentage) || extraTimePercentage <= 0) {
       this.extraTimePercentage = '';
     } else {

--- a/api/lib/infrastructure/files/candidates-import/SessionData.js
+++ b/api/lib/infrastructure/files/candidates-import/SessionData.js
@@ -1,4 +1,5 @@
-const moment = require('moment');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 
 module.exports = class SessionData {
   constructor({
@@ -33,9 +34,9 @@ module.exports = class SessionData {
     this.publishedAt = publishedAt;
     this.certificationCenterId = certificationCenterId;
     this.assignedCertificationOfficerId = assignedCertificationOfficerId;
-    this.startTime = moment(time, 'HH:mm').format('HH:mm');
-    this.endTime = moment(time, 'HH:mm').add(moment.duration(2, 'hours')).format('HH:mm');
-    this.date = moment(date, 'YYYY-MM-DD').format('DD/MM/YYYY');
+    this.startTime = dayjs(time, 'HH:mm').format('HH:mm');
+    this.endTime = dayjs(time, 'HH:mm').add(2, 'hours').format('HH:mm');
+    this.date = dayjs(date, 'YYYY-MM-DD').format('DD/MM/YYYY');
   }
 
   static fromSession(session) {

--- a/api/lib/infrastructure/files/candidates-import/candidates-import-transformation-structures.js
+++ b/api/lib/infrastructure/files/candidates-import/candidates-import-transformation-structures.js
@@ -1,4 +1,6 @@
 const _ = require('lodash');
+const dayjs = require('dayjs');
+
 const { convertDateValue } = require('../../utils/date-utils.js');
 const {
   CLEA,
@@ -40,6 +42,10 @@ const _TRANSFORMATION_STRUCT_FOR_PIX_CERTIF_CANDIDATES_IMPORT = [
     header: '* Date de naissance (format : jj/mm/aaaa)',
     property: 'birthdate',
     transformFn: (cellVal) => {
+      if (cellVal instanceof Date) {
+        return dayjs(cellVal).format('YYYY-MM-DD');
+      }
+
       return convertDateValue({ dateString: cellVal, inputFormat: 'DD/MM/YYYY', outputFormat: 'YYYY-MM-DD' });
     },
   },

--- a/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/create-and-upload.js
@@ -1,5 +1,6 @@
 const { createGzip } = require('node:zlib');
 const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 const utc = require('dayjs/plugin/utc');
 const timezone = require('dayjs/plugin/timezone');
 dayjs.extend(utc);

--- a/api/lib/infrastructure/jobs/cpf-export/handlers/planner.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/planner.js
@@ -1,4 +1,5 @@
 const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 const { plannerJob } = require('../../../../config.js').cpf;
 const _ = require('lodash');
 

--- a/api/lib/infrastructure/jobs/monitoring/MonitoringJobExecutionTimeHandler.js
+++ b/api/lib/infrastructure/jobs/monitoring/MonitoringJobExecutionTimeHandler.js
@@ -1,4 +1,5 @@
 const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 
 class MonitoringJobExecutionTimeHandler {
   constructor({ logger }) {

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -1,4 +1,5 @@
-const moment = require('moment');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 
 const { knex } = require('../../../db/knex-database-connection.js');
 const DomainTransaction = require('../DomainTransaction.js');
@@ -289,7 +290,7 @@ module.exports = {
     const user = await BookshelfUser.where({ id }).fetch({ require: false });
     await user.save(
       {
-        lastTermsOfServiceValidatedAt: moment().toDate(),
+        lastTermsOfServiceValidatedAt: dayjs().toDate(),
         mustValidateTermsOfService: false,
       },
       { patch: true, method: 'update' }

--- a/api/lib/infrastructure/serializers/xml/xml-organization-learner-set.js
+++ b/api/lib/infrastructure/serializers/xml/xml-organization-learner-set.js
@@ -1,4 +1,5 @@
-const moment = require('moment');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 const { isEmpty, isNil, each } = require('lodash');
 const { SiecleXmlImportError } = require('../../../domain/errors.js');
 
@@ -75,7 +76,7 @@ function _mapStudentInformationToOrganizationLearner(studentNode) {
     middleName: _getValueFromParsedElement(studentNode.PRENOM2),
     thirdName: _getValueFromParsedElement(studentNode.PRENOM3),
     sex: _convertSexCode(studentNode.CODE_SEXE),
-    birthdate: moment(studentNode.DATE_NAISS, 'DD/MM/YYYY').format('YYYY-MM-DD') || null,
+    birthdate: dayjs(studentNode.DATE_NAISS, 'DD/MM/YYYY').format('YYYY-MM-DD') || null,
     birthCountryCode: _getValueFromParsedElement(studentNode.CODE_PAYS),
     birthProvinceCode: _getValueFromParsedElement(studentNode.CODE_DEPARTEMENT_NAISS),
     birthCityCode: _getValueFromParsedElement(studentNode.CODE_COMMUNE_INSEE_NAISS),

--- a/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
+++ b/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
@@ -1,4 +1,5 @@
-const moment = require('moment');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 const _ = require('lodash');
 
 const STATS_COLUMNS_COUNT = 3;
@@ -105,10 +106,10 @@ class CampaignAssessmentCsvLine {
         this.targetedKnowledgeElementsCount,
         this.learningContent.skills.length
       ),
-      moment.utc(this.campaignParticipationInfo.createdAt).format('YYYY-MM-DD'),
+      dayjs.utc(this.campaignParticipationInfo.createdAt).format('YYYY-MM-DD'),
       this._makeYesNoColumns(this.campaignParticipationInfo.isShared),
       this.campaignParticipationInfo.isShared
-        ? moment.utc(this.campaignParticipationInfo.sharedAt).format('YYYY-MM-DD')
+        ? dayjs.utc(this.campaignParticipationInfo.sharedAt).format('YYYY-MM-DD')
         : this.emptyContent,
       ...(this.campaignStages.hasReachableStages ? [this._getReachedStage()] : []),
       ...(this.campaignParticipationInfo.isShared

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
-const moment = require('moment');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 const { getCsvContent } = require('./write-csv-utils.js');
 
 const REJECTED_AUTOMATICALLY_COMMENT =
@@ -223,7 +224,7 @@ function _formatPixScore(certificationResult) {
 }
 
 function _formatDate(date) {
-  return moment(date).format('DD/MM/YYYY');
+  return dayjs(date).format('DD/MM/YYYY');
 }
 
 function _formatStatus(certificationResult) {

--- a/api/lib/infrastructure/utils/date-utils.js
+++ b/api/lib/infrastructure/utils/date-utils.js
@@ -9,6 +9,10 @@ dayjs.parseTwoDigitYear = function (yearString) {
 };
 
 function isValidDate(dateValue, format) {
+  if (dateValue instanceof Date) {
+    return true;
+  }
+
   return dayjs.utc(dateValue, format, true).isValid();
 }
 

--- a/api/lib/infrastructure/utils/date-utils.js
+++ b/api/lib/infrastructure/utils/date-utils.js
@@ -1,20 +1,22 @@
-const moment = require('moment-timezone');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/utc'));
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 
-moment.parseTwoDigitYear = function (yearString) {
+dayjs.parseTwoDigitYear = function (yearString) {
   const year = parseInt(yearString);
   const currentYear = new Date().getFullYear();
   return 2000 + year < currentYear ? 2000 + year : 1900 + year;
 };
 
 function isValidDate(dateValue, format) {
-  return moment.utc(dateValue, format, true).isValid();
+  return dayjs.utc(dateValue, format, true).isValid();
 }
 
 function convertDateValue({ dateString, inputFormat, alternativeInputFormat = null, outputFormat }) {
   if (isValidDate(dateString, inputFormat)) {
-    return moment(dateString, inputFormat, true).format(outputFormat);
+    return dayjs(dateString, inputFormat, true).format(outputFormat);
   } else if (alternativeInputFormat && isValidDate(dateString, alternativeInputFormat)) {
-    return moment(dateString, alternativeInputFormat, true).format(outputFormat);
+    return dayjs(dateString, alternativeInputFormat, true).format(outputFormat);
   }
   return null;
 }

--- a/api/lib/infrastructure/utils/pdf/AttestationViewModel.js
+++ b/api/lib/infrastructure/utils/pdf/AttestationViewModel.js
@@ -1,5 +1,6 @@
 const sortBy = require('lodash/sortBy');
-const moment = require('moment');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 const { toArrayOfFixedLengthStringsConservingWords } = require('../string-utils.js');
 
 const PROFESSIONALIZING_VALIDITY_START_DATE = new Date('2022-01-01');
@@ -132,7 +133,7 @@ class CompetenceDetailViewModel {
 }
 
 function _formatDate(date) {
-  return moment(date).locale('fr').format('LL');
+  return dayjs(date).locale('fr').format('LL');
 }
 
 module.exports = AttestationViewModel;

--- a/api/lib/infrastructure/utils/pdf/certification-attestation-pdf.js
+++ b/api/lib/infrastructure/utils/pdf/certification-attestation-pdf.js
@@ -1,7 +1,8 @@
 const { PDFDocument, rgb } = require('pdf-lib');
 const { readFile } = require('fs/promises');
 const pdfLibFontkit = require('@pdf-lib/fontkit');
-const moment = require('moment');
+const dayjs = require('dayjs');
+dayjs.extend(require('dayjs/plugin/customParseFormat'));
 const _ = require('lodash');
 const bluebird = require('bluebird');
 // eslint-disable-next-line no-restricted-modules
@@ -48,7 +49,7 @@ async function getCertificationAttestationsPdfBuffer({
 
   const buffer = await _finalizeDocument(generatedPdfDoc);
 
-  const fileName = `attestation-pix-${moment(certificates[0].deliveredAt).format('YYYYMMDD')}.pdf`;
+  const fileName = `attestation-pix-${dayjs(certificates[0].deliveredAt).format('YYYYMMDD')}.pdf`;
 
   return {
     buffer,

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -295,6 +295,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
             isSuccessful: true,
             data: {
               access_token: 'TOKEN',
+              expires_in: new Date(),
             },
           };
           const httpResponse = {


### PR DESCRIPTION
## :christmas_tree: Problème
Suite de https://github.com/1024pix/pix/pull/5392

## :gift: Proposition
Modifier l'implémentation.

TODO :
- [ ] corriger la méthode `convertDate` qui n'a plus le même comportement pour les dates avec une année à deux chiffres(`YY`)
- [ ] puis voir si le quickfix du commit "fix(api): handle date object in ods import" est toujours nécessaire

## :star2: Remarques
Ou pourrait mettre à disposition par défaut `dayjs` avec les plugins.

## :santa: Pour tester
Vérifier que la CI passe.
