### PR TITLE
[TECH] Test de reproduction du bug des modales avec input suite montée en version Pix UI (PIX-6492)

### DIFF
--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -277,6 +277,59 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
         assert.contains('Inscrire le candidat');
       });
 
+      module('when the addCandidate button is clicked a second time', function (hooks) {
+        hooks.beforeEach(async function () {
+          server.createList('country', 2, { code: '99100' });
+        });
+
+        test('it should open the new Certification Candidate Modal with empty input', async function (assert) {
+          // given
+          const sessionWithoutCandidates = server.create('session', {
+            certificationCenterId: allowedCertificationCenterAccess.id,
+          });
+          const screen = await visit(`/sessions/${sessionWithoutCandidates.id}/candidats`);
+
+          await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
+          await fillIn(screen.getByLabelText('* Nom de famille'), 'BackStreet');
+          await fillIn(screen.getByLabelText('* Prénom'), 'Boys');
+          await click(screen.getByLabelText('Homme'));
+          await fillIn(screen.getByLabelText('* Date de naissance'), '01/01/2000');
+          await fillIn(screen.getByLabelText('* Pays de naissance'), '99100');
+          await click(screen.getByLabelText('Code INSEE'));
+          await fillIn(screen.getByLabelText('Identifiant externe'), '44AA3355');
+          await fillIn(screen.getByLabelText('* Code INSEE de naissance'), '75100');
+          await fillIn(screen.getByLabelText('Temps majoré (%)'), '20');
+          await fillIn(screen.getByLabelText('* Tarification part Pix'), 'PREPAID');
+          await fillIn(screen.getByLabelText('Code de prépaiement'), '12345');
+          await fillIn(
+            screen.getByLabelText('E-mail du destinataire des résultats (formateur, enseignant...)'),
+            'guybrush.threepwood@example.net'
+          );
+          await fillIn(screen.getByLabelText('E-mail de convocation'), 'roooooar@example.net');
+
+          await click(screen.getByRole('button', { name: 'Fermer' }));
+
+          // when
+          await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
+
+          // then
+          assert.strictEqual(screen.getByLabelText('* Nom de famille').value, '');
+          assert.strictEqual(screen.getByLabelText('* Prénom').value, '');
+          assert.false(screen.getByLabelText('Homme').checked);
+          assert.strictEqual(screen.getByLabelText('* Date de naissance').value, '');
+          assert.strictEqual(screen.getByLabelText('Identifiant externe').value, '');
+          assert.strictEqual(screen.getByLabelText('* Code INSEE de naissance').value, '');
+          assert.strictEqual(screen.getByLabelText('Temps majoré (%)').value, '');
+          assert.strictEqual(screen.getByLabelText('* Tarification part Pix').value, '');
+          assert.strictEqual(screen.getByLabelText('Code de prépaiement').value, '');
+          assert.strictEqual(
+            screen.getByLabelText('E-mail du destinataire des résultats (formateur, enseignant...)').value,
+            ''
+          );
+          assert.strictEqual(screen.getByLabelText('E-mail de convocation').value, '');
+        });
+      });
+
       module('when the new candidate form is submitted', function () {
         test('it should display the error message when the submitted form data is incorrect', async function (assert) {
           // given

--- a/certif/tests/acceptance/session-finalization_test.js
+++ b/certif/tests/acceptance/session-finalization_test.js
@@ -402,6 +402,79 @@ module('Acceptance | Session Finalization', function (hooks) {
           });
         });
       });
+
+      module('when there are completed reports and uncompleted reports', function () {
+        module('when we add a certification issue report on a completed report', function () {
+          test('it should add the issue report correctly', async function (assert) {
+            // given
+            const certificationReportUncompleted = server.create('certification-report', {
+              isCompleted: false,
+              abortReason: null,
+              certificationCourseId: 1,
+            });
+            const certificationReportCompleted = server.create('certification-report', {
+              isCompleted: true,
+              certificationCourseId: 2,
+            });
+            const certificationIssueReportUncompleted = server.create('certification-issue-report', {
+              certificationReportId: 1,
+            });
+            const certificationIssueReportUncompleted2 = server.create('certification-issue-report', {
+              certificationReportId: 1,
+            });
+            const certificationIssueReports = [
+              certificationIssueReportUncompleted,
+              certificationIssueReportUncompleted2,
+            ];
+            certificationReportUncompleted.update({ certificationIssueReports });
+            session.update({ certificationReports: [certificationReportUncompleted, certificationReportCompleted] });
+
+            // when
+            const screen = await visitScreen(`/sessions/${session.id}/finalisation`);
+            await click(screen.getByRole('button', { name: 'Ajouter' }));
+            await screen.findByRole('dialog');
+            await click(screen.getByLabelText('C6 Suspicion de fraude'));
+            await click(screen.getByRole('button', { name: 'Ajouter le signalement' }));
+
+            // then
+            assert.dom(screen.getByText('1 signalement')).exists();
+          });
+        });
+
+        module('when we add a certification issue report on an uncompleted report', function () {
+          test('it should add the issue report correctly', async function (assert) {
+            // given
+            const certificationReportCompleted = server.create('certification-report', {
+              isCompleted: true,
+              certificationCourseId: 1,
+            });
+            const certificationReportUncompleted = server.create('certification-report', {
+              isCompleted: false,
+              abortReason: null,
+              certificationCourseId: 2,
+            });
+            const certificationIssueReportCompleted = server.create('certification-issue-report', {
+              certificationReportId: 1,
+            });
+            const certificationIssueReportCompleted2 = server.create('certification-issue-report', {
+              certificationReportId: 1,
+            });
+            const certificationIssueReports = [certificationIssueReportCompleted, certificationIssueReportCompleted2];
+            certificationReportCompleted.update({ certificationIssueReports });
+            session.update({ certificationReports: [certificationReportUncompleted, certificationReportCompleted] });
+
+            // when
+            const screen = await visitScreen(`/sessions/${session.id}/finalisation`);
+            await click(screen.getByRole('button', { name: 'Ajouter' }));
+            await screen.findByRole('dialog');
+            await click(screen.getByLabelText('C6 Suspicion de fraude'));
+            await click(screen.getByRole('button', { name: 'Ajouter le signalement' }));
+
+            // then
+            assert.dom(screen.getByText('1 signalement')).exists();
+          });
+        });
+      });
     });
 
     module('When certificationPointOfContact tries to finalize a session that has not started yet', function () {


### PR DESCRIPTION
## :christmas_tree: Problème
Suite à la montée de version de Pix Ui sur Certif, un bug c'est produit sur nos modales avec formulaire. Les formulaires ne se rafraichissait plus, les inputs gardaient les valeurs entrées lors de la précédente ouverture de la modale.
Un fix a été fait suite au soucis en prod mais pas les tests pour reproduire le problème.

## :gift: Proposition
Ajouter ces tests pour éviter toute régression

## :star2: Remarques
Il faudrait aussi checker cette PR sur Pix UI qui corrigerait le problème autrement qu'en mettant des `if` autour de nos modales : https://github.com/1024pix/pix-ui/pull/299

## :santa: Pour tester
Supprimer les `if` ajoutés dans cette PR https://github.com/1024pix/pix/pull/5316 qui entourent les modales `IssueReportsModal` `AddIssueReportModal` `NewCertificationCandidateModal` et voir que les tests ne passent pas.