### PR TITLE
[BUGFIX] Corriger l'affichage du PixSelect lors du changement de rôle dans Pix Orga (PIX-6617)

### DIFF
--- a/orga/app/components/team/members-list-item.hbs
+++ b/orga/app/components/team/members-list-item.hbs
@@ -13,7 +13,7 @@
             @dropdownContentClass="zone-edit-role__dropdown-content"
             @ariaLabel={{t "pages.team-members.actions.manage"}}
           >
-            <Dropdown::Item @onClick={{fn this.editRoleOfMember @membership}}>
+            <Dropdown::Item @onClick={{this.toggleEditionMode}}>
               {{t "pages.team-members.actions.edit-organization-membership-role"}}
             </Dropdown::Item>
             <Dropdown::Item @onClick={{fn this.displayRemoveMembershipModal @membership}}>

--- a/orga/app/components/team/members-list-item.js
+++ b/orga/app/components/team/members-list-item.js
@@ -13,8 +13,6 @@ export default class MembersListItem extends Component {
 
   @tracked organizationRoles = null;
   @tracked isEditionMode = false;
-  @tracked selectedNewRole = null;
-  @tracked currentRole = null;
   @tracked isRemoveMembershipModalDisplayed = false;
 
   adminOption = {
@@ -49,14 +47,11 @@ export default class MembersListItem extends Component {
 
   @action
   setRoleSelection(value) {
-    this.selectedNewRole = value;
-    this.isEditionMode = true;
+    this.args.membership.organizationRole = value;
   }
 
   @action
-  editRoleOfMember(membership) {
-    this.selectedNewRole = null;
-    this.currentRole = membership.displayRole;
+  toggleEditionMode() {
     this.isEditionMode = true;
   }
 
@@ -64,15 +59,13 @@ export default class MembersListItem extends Component {
   async updateRoleOfMember(membership) {
     this.isEditionMode = false;
 
-    if (!this.selectedNewRole) return false;
-
-    membership.organizationRole = this.selectedNewRole;
     membership.organization = this.currentUser.organization;
 
     try {
       await membership.save();
       this.notifications.success(this.intl.t('pages.team-members.notifications.change-member-role.success'));
     } catch (e) {
+      membership.rollbackAttributes();
       this.notifications.error(this.intl.t('pages.team-members.notifications.change-member-role.error'));
     }
   }
@@ -80,7 +73,7 @@ export default class MembersListItem extends Component {
   @action
   cancelUpdateRoleOfMember() {
     this.isEditionMode = false;
-    this._clearState();
+    this.args.membership.rollbackAttributes();
   }
 
   @action
@@ -109,10 +102,5 @@ export default class MembersListItem extends Component {
     } finally {
       this.closeRemoveMembershipModal();
     }
-  }
-
-  _clearState() {
-    this.selectedNewRole = null;
-    this.currentRole = null;
   }
 }

--- a/orga/tests/integration/components/team/members-list-item_test.js
+++ b/orga/tests/integration/components/team/members-list-item_test.js
@@ -149,10 +149,10 @@ module('Integration | Component | Team::MembersListItem', function (hooks) {
         // when
         await click(screen.getByLabelText('Sélectionner un rôle'));
         await click(await screen.findByRole('option', { name: 'Administrateur' }));
-        await clickByText('Enregistrer');
 
         // then
-
+        assert.dom(screen.getByRole('option', { selected: true, name: 'Administrateur' })).exists();
+        await clickByText('Enregistrer');
         assert.strictEqual(memberMembership.organizationRole, 'ADMIN');
         sinon.assert.called(memberMembership.save);
       });


### PR DESCRIPTION
## :christmas_tree: Problème
[La montée de version de Pix-UI](https://github.com/1024pix/pix/pull/5333) (#5333) a entrainé une régression sur le Pix Select : 

Aller sur la liste des membres dans Pix Orga, cliquer sur les 3 points sur la ligne, cliquer sur “modifier un role”, selectionner un autre role.
Résultat: le role selectionné n’est pas gardé selectionné , on affiche toujours l'ancien rôle de cet utilisateur là.

Ceci pose d'autant de confusion que si on valide le changement de rôle, cela marche comme prévu (le rôle a été changé par la valeur que nous voulions sélectionner). 

## :gift: Proposition
Corriger le PixSelect + faire un peu de nettoyage 🧹 

## :star2: Remarques
RAS

## :santa: Pour tester
- Aller sur la liste des membres dans Pix Orga
- Cliquer sur les 3 points sur la ligne
- Cliquer sur “modifier un role”
- Selectionner un autre role
- Constater que le rôle selectionné est affiché

Vérifier la non régression sur ce changement de rôle. 
