### PR TITLE
[TECH] Modifier le script de mise à jour des certification issue reports (PIX-6635)

### DIFF
--- a/api/scripts/certification/fill-issue-report-category-id.js
+++ b/api/scripts/certification/fill-issue-report-category-id.js
@@ -46,8 +46,9 @@ async function main() {
 module.exports = { main };
 
 async function _updateIssueReportsWithCategoryId(certificationIssueReports, categories) {
-  await bluebird.map(certificationIssueReports, async (certificationIssueReport) => {
-    const getCategoryId = (lookupName) => categories.find(({ name }) => lookupName === name).id;
+  let count = 0;
+  await bluebird.mapSeries(certificationIssueReports, async (certificationIssueReport) => {
+    const getCategoryId = (lookupName) => categories.find(({ name }) => lookupName === name)?.id;
     const category = certificationIssueReport.subcategory ?? certificationIssueReport.category;
     certificationIssueReport.categoryId = getCategoryId(category);
 
@@ -55,5 +56,7 @@ async function _updateIssueReportsWithCategoryId(certificationIssueReports, cate
       categoryId: certificationIssueReport.categoryId,
       updatedAt: new Date(),
     });
+    count++;
+    if (count % 1000 === 0) logger.info('Nombre de certification issue report mis à jour : ', count);
   });
 }


### PR DESCRIPTION
## :christmas_tree: Problème
On a remarqué que le script créé dans le [ticket 6542](https://github.com/1024pix/pix/pull/5365) traitait les données en parallèle et ne fournissait pas d'état d'avancement.

## :gift: Proposition
Utiliser un mapSeries pour traiter les données de manière séquentielle puis logger l'état d'avancement du script. 

## :santa: Pour tester
