### PR TITLE
[BUGFIX] Corriger taille input (PIX-6639)

### DIFF
--- a/orga/app/styles/pages/authenticated/campaigns/create-form.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/create-form.scss
@@ -16,24 +16,27 @@
     width: auto;
   }
 }
-.pix-filterable-and-searchable-select {
-  @include device-is('desktop') {
-    width: 500px;
+.form__field-with-info {
+  .pix-filterable-and-searchable-select {
+    @include device-is('desktop') {
+      width: 500px;
+    }
   }
-}
-
-.pix-multi-select {
-  @include device-is('desktop') {
-    width: 140px;
+  
+  .pix-multi-select {
+    @include device-is('desktop') {
+      width: 140px;
+    }
   }
-}
-
-.pix-select {
-  @include device-is('desktop') {
-    width: 360px !important;
-  }
-
-  &__dropdown {
-    overflow-x: hidden;
+  
+  
+  .pix-select {
+    @include device-is('desktop') {
+      width: 360px !important;
+    }
+  
+    &__dropdown {
+      overflow-x: hidden;
+    }
   }
 }


### PR DESCRIPTION
## :christmas_tree: Problème
On a fait des correction sur pix select mais ca s'est impacté sur tous les pix select de l'appli

## :gift: Proposition
Faire en sorte que le fix soit que sur la page de création des campagnes

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
aller voir les select de l'appli et check qu'ils ont la bonne taille
