### PR TITLE
[FEATURE] Logguer les emails en erreur lors de la publication.

### DIFF
--- a/api/lib/domain/services/session-publication-service.js
+++ b/api/lib/domain/services/session-publication-service.js
@@ -44,7 +44,7 @@ async function publishSession({
     }
 
     if (_someHaveFailed(refererEmailingAttempts)) {
-      const failedEmailsReferer = _failedAttemptsReferer(refererEmailingAttempts);
+      const failedEmailsReferer = _failedAttemptsEmail(refererEmailingAttempts);
       throw new SendingEmailToRefererError(failedEmailsReferer);
     }
   }
@@ -57,7 +57,7 @@ async function publishSession({
     });
   }
   if (_someHaveFailed(emailingAttempts)) {
-    const failedEmailsRecipients = _failedAttemptsRecipients(emailingAttempts);
+    const failedEmailsRecipients = _failedAttemptsEmail(emailingAttempts);
     throw new SendingEmailToResultRecipientError(failedEmailsRecipients);
   }
 }
@@ -98,13 +98,7 @@ function _someHaveFailed(emailingAttempts) {
   return some(emailingAttempts, (emailAttempt) => emailAttempt.hasFailed());
 }
 
-function _failedAttemptsRecipients(emailingAttempts) {
-  return emailingAttempts
-    .filter((emailAttempt) => emailAttempt.hasFailed())
-    .map((emailAttempt) => emailAttempt.recipientEmail);
-}
-
-function _failedAttemptsReferer(emailingAttempts) {
+function _failedAttemptsEmail(emailingAttempts) {
   return emailingAttempts.filter((emailAttempt) => emailAttempt.hasFailed()).map((emailAttempt) => emailAttempt.email);
 }
 


### PR DESCRIPTION
## :christmas_tree: Problème
Lors de l'envoi d'email suite à la publication nous n'avons plus l'affichage des emails en erreurs

## :gift: Proposition
Logguer les emails

## :star2: Remarques
Fonctionnait il y a quelques mois!

## :santa: Pour tester
Publier une session avec un email et un domain qui n'existe pas. Verifier que l'email est bien loggué
