### PR TITLE
[BUGFIX] Améliorer la gestion des erreurs lors de l'envoi d'une invitation à rejoindre une organisation (PIX-6420)

### DIFF
--- a/admin/app/services/error-response-handler.js
+++ b/admin/app/services/error-response-handler.js
@@ -4,53 +4,54 @@ import isEmpty from 'lodash/isEmpty';
 import { inject as service } from '@ember/service';
 import Service from '@ember/service';
 
+const ERROR_MESSAGES_BY_STATUS = {
+  DEFAULT: 'Une erreur est survenue.',
+  STATUS_422: 'Cette opération est impossible.',
+  STATUS_412: 'Les préconditions ne sont pas réunies.',
+  STATUS_404: 'Non trouvé.',
+  STATUS_400: 'Mauvaise requête.',
+  STATUS_503: 'Service momentanément indisponible',
+};
+
 export default class ErrorResponseHandlerService extends Service {
   @service notifications;
 
-  ERROR_MESSAGES_BY_STATUS = {
-    DEFAULT: 'Une erreur est survenue.',
-    STATUS_422: 'Cette opération est impossible.',
-    STATUS_412: 'Les préconditions ne sont pas réunies.',
-    STATUS_404: 'Non trouvé.',
-    STATUS_400: 'Mauvaise requête.',
-    STATUS_503: 'Service momentanément indisponible',
-  };
-
   notify(errorResponse, customErrorMessageByStatus) {
     if (!_isJSONAPIError(errorResponse)) {
-      return this.notifications.error(errorResponse);
+      this.notifications.error(errorResponse);
+      return;
     }
 
     const { errors } = errorResponse;
     if (!errors) {
-      return this.notifications.error(this.ERROR_MESSAGES_BY_STATUS.DEFAULT);
+      this.notifications.error(ERROR_MESSAGES_BY_STATUS.DEFAULT);
+      return;
     }
 
-    errors.map((error) => {
-      switch (error.status) {
-        case '422':
-          this.notifications.error(customErrorMessageByStatus?.STATUS_422 || this.ERROR_MESSAGES_BY_STATUS.STATUS_422);
-          break;
-        case '412':
-          this.notifications.error(customErrorMessageByStatus?.STATUS_412 || this.ERROR_MESSAGES_BY_STATUS.STATUS_412);
-          break;
-        case '404':
-          this.notifications.error(customErrorMessageByStatus?.STATUS_404 || this.ERROR_MESSAGES_BY_STATUS.STATUS_404);
-          break;
-        case '400':
-          this.notifications.error(customErrorMessageByStatus?.STATUS_400 || this.ERROR_MESSAGES_BY_STATUS.STATUS_400);
-          break;
-        case '503':
-          this.notifications.error(customErrorMessageByStatus?.STATUS_503 || this.ERROR_MESSAGES_BY_STATUS.STATUS_503);
-          break;
-        default:
-          this.notifications.error(customErrorMessageByStatus?.DEFAULT || this.ERROR_MESSAGES_BY_STATUS.DEFAULT);
-          break;
-      }
+    errors.forEach((error) => {
+      const message = _getErrorMessageForHttpStatus(error.status, customErrorMessageByStatus);
+      this.notifications.error(message);
     });
   }
 }
 
 function _isJSONAPIError(errorResponse) {
   return !isEmpty(errorResponse.errors) && every(errorResponse.errors, (error) => error.title);
+}
+
+function _getErrorMessageForHttpStatus(errorStatus, customErrorMessageByStatus) {
+  switch (errorStatus) {
+    case '422':
+      return customErrorMessageByStatus?.STATUS_422 || ERROR_MESSAGES_BY_STATUS.STATUS_422;
+    case '412':
+      return customErrorMessageByStatus?.STATUS_412 || ERROR_MESSAGES_BY_STATUS.STATUS_412;
+    case '404':
+      return customErrorMessageByStatus?.STATUS_404 || ERROR_MESSAGES_BY_STATUS.STATUS_404;
+    case '400':
+      return customErrorMessageByStatus?.STATUS_400 || ERROR_MESSAGES_BY_STATUS.STATUS_400;
+    case '503':
+      return customErrorMessageByStatus?.STATUS_503 || ERROR_MESSAGES_BY_STATUS.STATUS_503;
+    default:
+      return customErrorMessageByStatus?.DEFAULT || ERROR_MESSAGES_BY_STATUS.DEFAULT;
+  }
 }

--- a/admin/app/services/error-response-handler.js
+++ b/admin/app/services/error-response-handler.js
@@ -13,6 +13,10 @@ const ERROR_MESSAGES_BY_STATUS = {
   STATUS_503: 'Service momentanément indisponible',
 };
 
+const ERROR_MESSAGES_BY_CODE = {
+  SENDING_EMAIL_TO_INVALID_DOMAIN: "Échec lors de l'envoi d'un e-mail car le domaine semble invalide.",
+};
+
 export default class ErrorResponseHandlerService extends Service {
   @service notifications;
 
@@ -29,6 +33,12 @@ export default class ErrorResponseHandlerService extends Service {
     }
 
     errors.forEach((error) => {
+      const messageForCode = _getErrorMessageForErrorCode(error.code);
+      if (messageForCode) {
+        this.notifications.error(messageForCode);
+        return;
+      }
+
       const message = _getErrorMessageForHttpStatus(error.status, customErrorMessageByStatus);
       this.notifications.error(message);
     });
@@ -37,6 +47,14 @@ export default class ErrorResponseHandlerService extends Service {
 
 function _isJSONAPIError(errorResponse) {
   return !isEmpty(errorResponse.errors) && every(errorResponse.errors, (error) => error.title);
+}
+
+function _getErrorMessageForErrorCode(errorCode) {
+  if (errorCode === 'SENDING_EMAIL_TO_INVALID_DOMAIN') {
+    return ERROR_MESSAGES_BY_CODE.SENDING_EMAIL_TO_INVALID_DOMAIN;
+  }
+
+  return null;
 }
 
 function _getErrorMessageForHttpStatus(errorStatus, customErrorMessageByStatus) {

--- a/admin/tests/acceptance/organization-invitations-management_test.js
+++ b/admin/tests/acceptance/organization-invitations-management_test.js
@@ -57,7 +57,8 @@ module('Acceptance | organization invitations management', function (hooks) {
 
       this.server.post(
         '/admin/organizations/:id/invitations',
-        () => new Response({}, 500, { errors: [{ status: '500' }] })
+        () => ({ errors: [{ status: '500', title: 'An error occurred' }] }),
+        500
       );
 
       // when

--- a/admin/tests/unit/controllers/authenticated/organizations/get/invitations_test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/invitations_test.js
@@ -47,9 +47,7 @@ module('Unit | Controller | authenticated/organizations/get/invitations', functi
       controller.createOrganizationInvitation();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.userEmailToInviteError, 'Ce champ est requis.');
+      assert.strictEqual(controller.userEmailToInviteError, 'Ce champ est requis.');
     });
 
     test('it should fail if userEmailToInvite is empty', function (assert) {
@@ -60,9 +58,7 @@ module('Unit | Controller | authenticated/organizations/get/invitations', functi
       controller.createOrganizationInvitation();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.userEmailToInviteError, 'Ce champ est requis.');
+      assert.strictEqual(controller.userEmailToInviteError, 'Ce champ est requis.');
     });
 
     test('it should fail if userEmailToInvite is not a valid email address', function (assert) {
@@ -73,9 +69,7 @@ module('Unit | Controller | authenticated/organizations/get/invitations', functi
       controller.createOrganizationInvitation();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.userEmailToInviteError, "L'adresse e-mail saisie n'est pas valide.");
+      assert.strictEqual(controller.userEmailToInviteError, "L'adresse e-mail saisie n'est pas valide.");
     });
 
     test('it should send a notification error if an error occured', async function (assert) {

--- a/admin/tests/unit/services/error-response-handler_test.js
+++ b/admin/tests/unit/services/error-response-handler_test.js
@@ -41,6 +41,11 @@ module('Unit | Service | error-response-handler', function (hooks) {
             title: 'Something else went wrong too !',
           },
           {
+            status: '400',
+            title: 'Sending email to an invalid domain',
+            code: 'SENDING_EMAIL_TO_INVALID_DOMAIN',
+          },
+          {
             title: 'Something went wrong',
             detail: 'the provided id is invalid',
           },
@@ -53,6 +58,7 @@ module('Unit | Service | error-response-handler', function (hooks) {
       // then
       sinon.assert.calledWith(errorMock, 'Cette opération est impossible.');
       sinon.assert.calledWith(errorMock, 'Non trouvé.');
+      sinon.assert.calledWith(errorMock, "Échec lors de l'envoi d'un e-mail car le domaine semble invalide.");
       sinon.assert.calledWith(errorMock, 'Une erreur est survenue.');
       assert.ok(true);
     });
@@ -97,6 +103,29 @@ module('Unit | Service | error-response-handler', function (hooks) {
       sinon.assert.calledWith(errorMock, customErrorMessagesByStatus.DEFAULT);
       sinon.assert.calledWith(errorMock, customErrorMessagesByStatus.STATUS_422);
       sinon.assert.calledWith(errorMock, customErrorMessagesByStatus.STATUS_404);
+      assert.ok(true);
+    });
+  });
+
+  module('with error codes', function () {
+    test('it notifies correct error for SENDING_EMAIL_TO_INVALID_DOMAIN error', function (assert) {
+      // given
+      const service = this.owner.lookup('service:error-response-handler');
+      service.notifications.error = sinon.stub();
+      const invalidDomainError = {
+        status: '400',
+        title: 'Sending email to an invalid domain',
+        code: 'SENDING_EMAIL_TO_INVALID_DOMAIN',
+      };
+
+      // when
+      service.notify({ errors: [invalidDomainError] });
+
+      // then
+      sinon.assert.calledWith(
+        service.notifications.error,
+        "Échec lors de l'envoi d'un e-mail car le domaine semble invalide."
+      );
       assert.ok(true);
     });
   });

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -476,6 +476,11 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.InvalidJuryLevelError) {
     return new HttpErrors.BadRequestError(error.message);
   }
+
+  if (error instanceof DomainErrors.SendingEmailToInvalidDomainError) {
+    return new HttpErrors.BadRequestError(error.message, 'SENDING_EMAIL_TO_INVALID_DOMAIN');
+  }
+
   return new HttpErrors.BaseHttpError(error.message);
 }
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -389,6 +389,12 @@ class SendingEmailError extends DomainError {
   }
 }
 
+class SendingEmailToInvalidDomainError extends DomainError {
+  constructor(emailAddress) {
+    super(`Failed to send email to ${emailAddress} because domain seems to be invalid.`);
+  }
+}
+
 class SendingEmailToRefererError extends DomainError {
   constructor(failedEmailReferers) {
     super(
@@ -1356,6 +1362,7 @@ module.exports = {
   OrganizationLearnerNotFound,
   OrganizationLearnersCouldNotBeSavedError,
   SendingEmailError,
+  SendingEmailToInvalidDomainError,
   SendingEmailToRefererError,
   SendingEmailToResultRecipientError,
   SessionAlreadyFinalizedError,

--- a/api/lib/domain/models/EmailingAttempt.js
+++ b/api/lib/domain/models/EmailingAttempt.js
@@ -14,6 +14,10 @@ module.exports = class EmailingAttempt {
     return this.status === AttemptStatus.FAILURE;
   }
 
+  hasFailedBecauseDomainWasInvalid() {
+    return this.status === AttemptStatus.FAILURE && this.errorCode === EmailingAttempt.errorCode.INVALID_DOMAIN;
+  }
+
   hasSucceeded() {
     return this.status === AttemptStatus.SUCCESS;
   }

--- a/api/lib/domain/models/EmailingAttempt.js
+++ b/api/lib/domain/models/EmailingAttempt.js
@@ -1,7 +1,13 @@
 module.exports = class EmailingAttempt {
-  constructor(email, status) {
+  static errorCode = {
+    PROVIDER_ERROR: 'PROVIDER_ERROR',
+    INVALID_DOMAIN: 'INVALID_DOMAIN',
+  };
+
+  constructor(email, status, errorCode) {
     this.email = email;
     this.status = status;
+    this.errorCode = errorCode;
   }
 
   hasFailed() {
@@ -16,8 +22,8 @@ module.exports = class EmailingAttempt {
     return new EmailingAttempt(email, AttemptStatus.SUCCESS);
   }
 
-  static failure(email) {
-    return new EmailingAttempt(email, AttemptStatus.FAILURE);
+  static failure(email, errorCode = EmailingAttempt.errorCode.PROVIDER_ERROR) {
+    return new EmailingAttempt(email, AttemptStatus.FAILURE, errorCode);
   }
 };
 

--- a/api/lib/domain/services/organization-invitation-service.js
+++ b/api/lib/domain/services/organization-invitation-service.js
@@ -1,7 +1,7 @@
 const randomString = require('randomstring');
 const Membership = require('../models/Membership');
 const mailService = require('../../domain/services/mail-service');
-const { SendingEmailError } = require('../errors');
+const { SendingEmailError, SendingEmailToInvalidDomainError } = require('../errors');
 
 const _generateCode = () => {
   return randomString.generate({ length: 10, capitalization: 'uppercase' });
@@ -42,6 +42,10 @@ const createOrganizationInvitation = async ({
     tags,
   });
   if (mailerResponse?.status === 'FAILURE') {
+    if (mailerResponse.hasFailedBecauseDomainWasInvalid()) {
+      throw new SendingEmailToInvalidDomainError(email);
+    }
+
     throw new SendingEmailError();
   }
 

--- a/api/lib/infrastructure/mail-check.js
+++ b/api/lib/infrastructure/mail-check.js
@@ -2,7 +2,7 @@ const { promisify } = require('util');
 const resolveMx = promisify(require('dns').resolveMx);
 
 module.exports = {
-  checkMail(address) {
+  checkDomainIsValid(address) {
     const domain = address.replace(/.*@/g, '');
     return resolveMx(domain).then(() => true);
   },

--- a/api/lib/infrastructure/mailers/mailer.js
+++ b/api/lib/infrastructure/mailers/mailer.js
@@ -26,7 +26,7 @@ class Mailer {
       await mailCheck.checkDomainIsValid(options.to);
     } catch (err) {
       logger.warn({ err }, `Email is not valid '${options.to}'`);
-      return EmailingAttempt.failure(options.to);
+      return EmailingAttempt.failure(options.to, EmailingAttempt.errorCode.INVALID_DOMAIN);
     }
 
     try {

--- a/api/lib/infrastructure/mailers/mailer.js
+++ b/api/lib/infrastructure/mailers/mailer.js
@@ -18,15 +18,15 @@ class Mailer {
   }
 
   async sendEmail(options) {
-    if (!mailing.enabled) {
-      return EmailingAttempt.success(options.to);
-    }
-
     try {
       await mailCheck.checkDomainIsValid(options.to);
     } catch (err) {
       logger.warn({ err }, `Email is not valid '${options.to}'`);
       return EmailingAttempt.failure(options.to, EmailingAttempt.errorCode.INVALID_DOMAIN);
+    }
+
+    if (!mailing.enabled) {
+      return EmailingAttempt.success(options.to);
     }
 
     try {

--- a/api/lib/infrastructure/mailers/mailer.js
+++ b/api/lib/infrastructure/mailers/mailer.js
@@ -23,7 +23,7 @@ class Mailer {
     }
 
     try {
-      await mailCheck.checkMail(options.to);
+      await mailCheck.checkDomainIsValid(options.to);
     } catch (err) {
       logger.warn({ err }, `Email is not valid '${options.to}'`);
       return EmailingAttempt.failure(options.to);

--- a/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
+++ b/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
@@ -106,12 +106,15 @@ describe('Integration | Scripts | send-invitations-to-sco-organizations.js', fun
 
     it('should add organization invitations into database', async function () {
       // given
-      const objectsForInvitations = ['user1@example', 'user2@example', 'user3@example', 'user4@example'].map(
-        (email) => {
-          const organizationId = databaseBuilder.factory.buildOrganization().id;
-          return { organizationId, email };
-        }
-      );
+      const objectsForInvitations = [
+        'user1@example.net',
+        'user2@example.net',
+        'user3@example.net',
+        'user4@example.net',
+      ].map((email) => {
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        return { organizationId, email };
+      });
 
       const numberBefore = await getNumberOfOrganizationInvitations();
       const tags = ['TEST'];

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -32,6 +32,7 @@ const {
   InvalidJuryLevelError,
   UnexpectedOidcStateError,
   InvalidIdentityProviderError,
+  SendingEmailToInvalidDomainError,
 } = require('../../../lib/domain/errors');
 const HttpErrors = require('../../../lib/application/http-errors.js');
 
@@ -509,6 +510,22 @@ describe('Unit | Application | ErrorManager', function () {
 
       // then
       expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(error.message);
+    });
+
+    it('should instantiate BadRequestError when SendingEmailToInvalidDomainError', async function () {
+      // given
+      const error = new SendingEmailToInvalidDomainError('Email domain was invalid.');
+      sinon.stub(HttpErrors, 'BadRequestError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(
+        error.message,
+        'SENDING_EMAIL_TO_INVALID_DOMAIN'
+      );
     });
 
     describe('SSO specific errors', function () {

--- a/api/tests/unit/domain/models/EmailingAttempt_test.js
+++ b/api/tests/unit/domain/models/EmailingAttempt_test.js
@@ -63,12 +63,21 @@ describe('Unit | Domain | Models | EmailingAttempt', function () {
   });
 
   describe('#failure', function () {
-    it('should create an emailAttempt with failure status', function () {
+    it('should create an emailAttempt with default error code', function () {
       // when
       const result = EmailingAttempt.failure('example@example.net');
 
       // then
-      const expectedEmailAttempt = new EmailingAttempt('example@example.net', 'FAILURE');
+      const expectedEmailAttempt = new EmailingAttempt('example@example.net', 'FAILURE', 'PROVIDER_ERROR');
+      expect(result).to.deepEqualInstance(expectedEmailAttempt);
+    });
+
+    it('should create an emailAttempt with given error code', function () {
+      // when
+      const result = EmailingAttempt.failure('example@example.net', EmailingAttempt.errorCode.INVALID_DOMAIN);
+
+      // then
+      const expectedEmailAttempt = new EmailingAttempt('example@example.net', 'FAILURE', 'INVALID_DOMAIN');
       expect(result).to.deepEqualInstance(expectedEmailAttempt);
     });
   });

--- a/api/tests/unit/domain/models/EmailingAttempt_test.js
+++ b/api/tests/unit/domain/models/EmailingAttempt_test.js
@@ -1,0 +1,75 @@
+const { expect } = require('../../../test-helper');
+
+const EmailingAttempt = require('../../../../lib/domain/models/EmailingAttempt');
+
+describe('Unit | Domain | Models | EmailingAttempt', function () {
+  describe('#hasFailed', function () {
+    it('should return true if status is failure', function () {
+      // given
+      const attempt = new EmailingAttempt('example@example.net', 'FAILURE');
+
+      // when
+      const result = attempt.hasFailed();
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('should return false if status is success', function () {
+      // given
+      const attempt = new EmailingAttempt('example@example.net', 'SUCCESS');
+
+      // when
+      const result = attempt.hasFailed();
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('#hasSucceeded', function () {
+    it('should return true if status is success', function () {
+      // given
+      const attempt = new EmailingAttempt('example@example.net', 'SUCCESS');
+
+      // when
+      const result = attempt.hasSucceeded();
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('should return false if status is failure', function () {
+      // given
+      const attempt = new EmailingAttempt('example@example.net', 'FAILURE');
+
+      // when
+      const result = attempt.hasSucceeded();
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('#success', function () {
+    it('should create an emailAttempt with success status', function () {
+      // when
+      const result = EmailingAttempt.success('example@example.net');
+
+      // then
+      const expectedEmailAttempt = new EmailingAttempt('example@example.net', 'SUCCESS');
+      expect(result).to.deepEqualInstance(expectedEmailAttempt);
+    });
+  });
+
+  describe('#failure', function () {
+    it('should create an emailAttempt with failure status', function () {
+      // when
+      const result = EmailingAttempt.failure('example@example.net');
+
+      // then
+      const expectedEmailAttempt = new EmailingAttempt('example@example.net', 'FAILURE');
+      expect(result).to.deepEqualInstance(expectedEmailAttempt);
+    });
+  });
+});

--- a/api/tests/unit/domain/models/EmailingAttempt_test.js
+++ b/api/tests/unit/domain/models/EmailingAttempt_test.js
@@ -27,6 +27,41 @@ describe('Unit | Domain | Models | EmailingAttempt', function () {
     });
   });
 
+  describe('#hasFailedBecauseDomainWasInvalid', function () {
+    it('returns true if status is failure because domain was invalid', function () {
+      // given
+      const attempt = new EmailingAttempt('example@example.net', 'FAILURE', 'INVALID_DOMAIN');
+
+      // when
+      const result = attempt.hasFailedBecauseDomainWasInvalid();
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('returns false if status is failure with another reason', function () {
+      // given
+      const attempt = new EmailingAttempt('example@example.net', 'FAILURE');
+
+      // when
+      const result = attempt.hasFailedBecauseDomainWasInvalid();
+
+      // then
+      expect(result).to.be.false;
+    });
+
+    it('returns false if status is success', function () {
+      // given
+      const attempt = new EmailingAttempt('example@example.net', 'SUCCESS');
+
+      // when
+      const result = attempt.hasFailedBecauseDomainWasInvalid();
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+
   describe('#hasSucceeded', function () {
     it('should return true if status is success', function () {
       // given

--- a/api/tests/unit/infrastructure/mailers/SendinblueProvider_test.js
+++ b/api/tests/unit/infrastructure/mailers/SendinblueProvider_test.js
@@ -24,7 +24,7 @@ describe('Unit | Class | SendinblueProvider', function () {
         sinon.stub(mailing, 'provider').value('sendinblue');
 
         sinon.stub(SendinblueProvider, 'createSendinblueSMTPApi');
-        sinon.stub(mailCheck, 'checkMail').withArgs(userEmailAddress).resolves();
+        sinon.stub(mailCheck, 'checkDomainIsValid').withArgs(userEmailAddress).resolves();
 
         stubbedSendinblueSMTPApi = { sendTransacEmail: sinon.stub() };
         SendinblueProvider.createSendinblueSMTPApi.returns(stubbedSendinblueSMTPApi);

--- a/api/tests/unit/infrastructure/mailers/mailer_test.js
+++ b/api/tests/unit/infrastructure/mailers/mailer_test.js
@@ -79,7 +79,9 @@ describe('Unit | Infrastructure | Mailers | mailer', function () {
 
           // then
           expect(logger.warn).to.have.been.calledWith({ err: expectedError }, "Email is not valid 'test@example.net'");
-          expect(result).to.deep.equal(EmailingAttempt.failure('test@example.net'));
+          expect(result).to.deep.equal(
+            EmailingAttempt.failure('test@example.net', EmailingAttempt.errorCode.INVALID_DOMAIN)
+          );
         });
       });
 

--- a/api/tests/unit/infrastructure/mailers/mailer_test.js
+++ b/api/tests/unit/infrastructure/mailers/mailer_test.js
@@ -115,11 +115,11 @@ function _enableMailing() {
 }
 
 function _mailAddressIsValid(recipient) {
-  sinon.stub(mailCheck, 'checkMail').withArgs(recipient).resolves();
+  sinon.stub(mailCheck, 'checkDomainIsValid').withArgs(recipient).resolves();
 }
 
 function _mailAddressIsInvalid(recipient, expectedError) {
-  sinon.stub(mailCheck, 'checkMail').withArgs(recipient).rejects(expectedError);
+  sinon.stub(mailCheck, 'checkDomainIsValid').withArgs(recipient).rejects(expectedError);
 }
 
 function _mockMailingProvider() {

--- a/api/tests/unit/infrastructure/mailers/mailer_test.js
+++ b/api/tests/unit/infrastructure/mailers/mailer_test.js
@@ -32,6 +32,25 @@ describe('Unit | Infrastructure | Mailers | mailer', function () {
         expect(result).to.deep.equal(EmailingAttempt.success('test@example.net'));
         expect(mailingProvider.sendEmail).to.have.not.been.called;
       });
+
+      context('when email is invalid', function () {
+        it('should return an error status', async function () {
+          // given
+          _disableMailing();
+          const recipient = 'test@example.net';
+
+          const expectedError = new Error('fail');
+          _mailAddressIsInvalid(recipient, expectedError);
+
+          // when
+          const result = await mailer.sendEmail({ to: recipient });
+
+          // then
+          expect(result).to.deep.equal(
+            EmailingAttempt.failure('test@example.net', EmailingAttempt.errorCode.INVALID_DOMAIN)
+          );
+        });
+      });
     });
 
     context('when mailing is enabled', function () {


### PR DESCRIPTION
## :christmas_tree: Problème

Lorsqu’une invitation est envoyée depuis Pix Admin à une adresse dont le nom de domaine est inexistant, sendinblue renvoie une erreur 503, que l’API renvoie au front avec le même statut et le message :

> Le service d’envoi d’email est momentanément indisponible, veuillez réessayer ultérieurement.

Or si le domaine n’est pas bon, le problème n’est pas temporaire, il ne sert à rien de réessayer plus tard.

## :gift: Proposition

- [x] Renvoyer un statut 400
- [x] Mieux informer l’utilisateur en indiquant que le problème vient du domaine de l'adresse e-mail

## :star2: Remarques

- Un problème similaire existe peut-être côté invitations à rejoindre un centre de certif, à vérifier.

## :santa: Pour tester

1. Se connecter à Pix Admin
2. Se rendre sur la page "Invitations" d'une organisation
3. Envoyer une invitation à une adresse dont le domaine n'existe pas (ex: user@pixerror.fr)
4. Constater qu'un message d'erreur explicite apparaît