### PR TITLE
[BUGFIX] Clé expirée à tort par `InMemoryTemporaryStorage.update()`

### DIFF
--- a/api/lib/infrastructure/temporary-storage/InMemoryTemporaryStorage.js
+++ b/api/lib/infrastructure/temporary-storage/InMemoryTemporaryStorage.js
@@ -17,8 +17,9 @@ class InMemoryTemporaryStorage extends TemporaryStorage {
 
   update(key, value) {
     const storageKey = trim(key);
-    const ttl = (this._client.getTtl(storageKey) - Date.now()) / 1000;
-    this._client.set(storageKey, value, ttl);
+    const timeoutMs = this._client.getTtl(storageKey);
+    const expirationDelaySeconds = timeoutMs === 0 ? 0 : (timeoutMs - Date.now()) / 1000;
+    this._client.set(storageKey, value, expirationDelaySeconds);
   }
 
   get(key) {


### PR DESCRIPTION
## :christmas_tree: Problème
Il semble que la mise à jour d'une clé dans le stockage temporaire en mémoire provoque parfois accidentellement son expiration.

## :gift: Proposition
Améliorer la gestion du TTL dans la mise à jour d'une clé afin d'éviter l'expiration accidentelle.

## :santa: Pour tester
Vérifier la CI
