### PR TITLE
[TECH] Script de migration automatique des critères de type "SkillSet" des RTs vers des critères "CappedTubes" (PIX-5698)

### DIFF
--- a/api/db/database-builder/factory/build-badge-criterion.js
+++ b/api/db/database-builder/factory/build-badge-criterion.js
@@ -8,6 +8,7 @@ const buildBadgeCriterion = function ({
   badgeId,
   skillSetIds = [],
   cappedTubes,
+  name = null,
 } = {}) {
   const values = {
     id,
@@ -16,6 +17,7 @@ const buildBadgeCriterion = function ({
     badgeId,
     skillSetIds,
     cappedTubes,
+    name,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'badge-criteria',
@@ -23,12 +25,13 @@ const buildBadgeCriterion = function ({
   });
 };
 
-buildBadgeCriterion.scopeCampaignParticipation = function ({ id, threshold, badgeId } = {}) {
+buildBadgeCriterion.scopeCampaignParticipation = function ({ id, threshold, badgeId, name } = {}) {
   return buildBadgeCriterion({
     id,
     scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
     threshold,
     badgeId,
+    name,
     skillSetIds: [],
     cappedTubes: [],
   });
@@ -45,12 +48,13 @@ buildBadgeCriterion.scopeSkillSets = function ({ id, threshold, badgeId, skillSe
   });
 };
 
-buildBadgeCriterion.scopeCappedTubes = function ({ id, threshold, badgeId, cappedTubes } = {}) {
+buildBadgeCriterion.scopeCappedTubes = function ({ id, threshold, badgeId, cappedTubes, name } = {}) {
   return buildBadgeCriterion({
     id,
     scope: BadgeCriterion.SCOPES.CAPPED_TUBES,
     threshold,
     badgeId,
+    name,
     skillSetIds: [],
     cappedTubes,
   });

--- a/api/scripts/data-generation/target-profiles-migration/migration-test-pro-tab.csv
+++ b/api/scripts/data-generation/target-profiles-migration/migration-test-pro-tab.csv
@@ -1,0 +1,23 @@
+id;nom;;responsable;"Si obsolète, mettre ""OBSOLETE""";"On garde (passer sous le nouveau modèle) ?
+OUI / NON";"Sujets entiers ? (sans capage)
+OUI / NON";"Capage uniforme ?
+Si OUI indiquer le niveau max
+Si NON mettre NON";"Capage multiforme
+SI OUI (précisez lesquels et à combien)
+¤¤¤";"Compétence globale (si un sujet débarque dans la comp alors j'ajoute à la maj du PC en auto)
+OUI / NON";"Si paliers :
+Taux fixe OU
+Par niveau, précisez
+¤¤¤";Lien vers PC spéciaux et descriptifs clés de lecture;;;
+;"Attention - merci de créer un nouveau fichier pour chaque responsable. En reprenant l'onglet PRO et l'onglet Profil cible spécial. L'onglet ""Profil cible spécial"" servira à chaque profil cible avec du capage multiforme et/ou des paliers.  
+";Paliers déjà configurés ? (rempli automatiquement);;Obsolète ? ;"Oui : vous souhaitez que le profil cible s'actualise en fonction des évolutions du référentiel (les PC qui ont vocation à durer)
+Non : le profil cible n'évolue pas en fonction des évolutions du référentiel";Oui : vous souhaitez que votre PC prenne en compte l'ensemble des acquis d'un sujet ;Oui : l'ensemble de vos sujets s'arrête à un même niveau ;"SI CAPPAGE MULTI
+Oui : mettre ""Oui"" et ouvrir un nouvel onglet pour renseigner l'information dans un nouvel onglet spécifique au profil cible *
+";Oui : vous souhaitez ue votre PC prenne en compte l'introduction d'un nouveau sujet dans la compétence car l'intégralité de la compétence doit etre couvert;"SI PALIERS
+Oui : mettre ""Oui"" et ouvrir un nouvel onglet pour renseigner l'information dans un nouvel onglet spécifique au profil cible ";Lien vers PC spéciaux et descriptifs clés de lecture;;;* NB : n'ouvrir qu'un onglet par PC si besoin de renseigner capage multiforme (colonne G) et paliers (colonne I), le faire au sein d'un meme onglet
+2000;Profil cible qui n'existe pas ;OSEF;OSEF;;Non;;;;OSEF;OSEF;;;;
+2001;Profil cible à archiver -> MIGRATION AUTO;OSEF;OSEF;obsolete;;;;;OSEF;OSEF;;;;
+2002;Profil cible avec traitement automatique -> MIGRATION AUTO;OSEF;OSEF;;Non;;;;OSEF;OSEF;;;;
+2003;Profil cible sans capage;OSEF;OSEF;;Oui;Oui;;;OSEF;OSEF;;;;
+2004;Profil cible avec capage uniforme;OSEF;OSEF;;Oui;Non;6;;OSEF;OSEF;;;;
+2005;Profil cible avec capage multiforme;OSEF;OSEF;;Oui;Non;;Oui;OSEF;OSEF;;;;

--- a/api/scripts/data-generation/target-profiles-migration/target-profiles-for-migrations.js
+++ b/api/scripts/data-generation/target-profiles-migration/target-profiles-for-migrations.js
@@ -1,0 +1,484 @@
+require('dotenv').config({ path: `${__dirname}/../../../.env` });
+const fs = require('fs').promises;
+const _ = require('lodash');
+const papa = require('papaparse');
+const { performance } = require('perf_hooks');
+const logger = require('../../../lib/infrastructure/logger');
+const cache = require('../../../lib/infrastructure/caches/learning-content-cache');
+const { knex, disconnect } = require('../../../db/knex-database-connection');
+const DatabaseBuilder = require('../../../db/database-builder/database-builder');
+
+const HEADERS = {
+  ID: 'id',
+  TO_OUTDATE: 'Si obsolète, mettre "OBSOLETE"',
+  MORE_THAN_AUTO_MIGRATION: 'On garde (passer sous le nouveau modèle) ?\nOUI / NON',
+  UNCAP: 'Sujets entiers ? (sans capage)\nOUI / NON',
+  UNIFORM_CAP: 'Capage uniforme ?\nSi OUI indiquer le niveau max\nSi NON mettre NON',
+  MULTIFORM_CAP: 'Capage multiforme\nSI OUI (précisez lesquels et à combien)\n¤¤¤',
+};
+
+const TARGET_PROFILE_ID_TO_OUTDATE = 2001;
+const TARGET_PROFILE_ID_AUTO = 2002;
+const TARGET_PROFILE_ID_UNCAP = 2003;
+const TARGET_PROFILE_ID_UNIFORM_CAP = 2004;
+const TARGET_PROFILE_ID_MULTIFORM_CAP = 2005;
+
+const tubeIdCodageEmblematique = 'recJJVWsUD0A4g7bf';
+const skillIdsCodageEmblematique = {
+  3: 'recXO3Ei4vf25mJE7',
+  4: 'recVfp1idTGE727dl',
+  5: 'rec3wTu36JBVMu70s',
+  6: 'recqUtUE0mrjZYmcI',
+  7: 'recCQPm1mgdexw3jV',
+};
+const tubeIdTerminal = 'rec1ahEQ4rwrml6Lo';
+const skillIdsTerminal = {
+  3: 'recNXnzzW5yvqQlA',
+  4: 'rec2Qat2a1iwKpqR2',
+  5: 'rec145HIb1bvzOuod',
+};
+const tubeIdEditerDocEnLigne = 'reciWLZDyQmXNn6lc';
+const skillIdsEditerDocEnLigne = {
+  1: 'recXDYAkqqIDCDePc',
+  4: 'recwOLZ8bzMQK9NF9',
+};
+const tubeIdPartageDroits = 'recd3rYCdpWLtHXLk';
+const skillIdsPartageDroits = {
+  2: 'rec7EvARki1b9t574',
+  4: 'recqSPZiRJYzfCDaS',
+  5: 'recp7rTXpecbxjE5d',
+  6: 'recIyRA2zdCdlX6UD',
+};
+const allSkillIds = [
+  ...Object.values(skillIdsCodageEmblematique),
+  ...Object.values(skillIdsTerminal),
+  ...Object.values(skillIdsEditerDocEnLigne),
+  ...Object.values(skillIdsPartageDroits),
+];
+
+let allSkills;
+let allTubes;
+async function _cacheLearningContentData() {
+  const skillRepository = require('../../../lib/infrastructure/repositories/skill-repository');
+  allSkills = await skillRepository.list();
+  const tubeRepository = require('../../../lib/infrastructure/repositories/tube-repository');
+  allTubes = await tubeRepository.list();
+}
+
+const prepareData = async () => {
+  console.log('prepareData...');
+  await _cacheLearningContentData();
+
+  const databaseBuilder = new DatabaseBuilder({ knex, emptyFirst: true });
+
+  databaseBuilder.factory.buildTargetProfile({
+    id: TARGET_PROFILE_ID_TO_OUTDATE,
+    name: 'PC à périmer',
+  });
+  allSkillIds.forEach((skillId) =>
+    databaseBuilder.factory.buildTargetProfileSkill({
+      targetProfileId: TARGET_PROFILE_ID_TO_OUTDATE,
+      skillId,
+    })
+  );
+
+  databaseBuilder.factory.buildTargetProfile({
+    id: TARGET_PROFILE_ID_AUTO,
+    name: 'PC à migrer automatiquement',
+  });
+  allSkillIds.forEach((skillId) =>
+    databaseBuilder.factory.buildTargetProfileSkill({
+      targetProfileId: TARGET_PROFILE_ID_AUTO,
+      skillId,
+    })
+  );
+
+  databaseBuilder.factory.buildTargetProfile({
+    id: TARGET_PROFILE_ID_UNCAP,
+    name: 'PC avec sujets non plafonnés',
+  });
+  allSkillIds.forEach((skillId) =>
+    databaseBuilder.factory.buildTargetProfileSkill({
+      targetProfileId: TARGET_PROFILE_ID_UNCAP,
+      skillId,
+    })
+  );
+
+  databaseBuilder.factory.buildTargetProfile({
+    id: TARGET_PROFILE_ID_UNIFORM_CAP,
+    name: 'PC avec sujets plafonnés au même niveau',
+  });
+  allSkillIds.forEach((skillId) =>
+    databaseBuilder.factory.buildTargetProfileSkill({
+      targetProfileId: TARGET_PROFILE_ID_UNIFORM_CAP,
+      skillId,
+    })
+  );
+
+  databaseBuilder.factory.buildTargetProfile({
+    id: TARGET_PROFILE_ID_MULTIFORM_CAP,
+    name: 'PC avec sujets plafonnés à différents niveaux',
+  });
+  allSkillIds.forEach((skillId) =>
+    databaseBuilder.factory.buildTargetProfileSkill({
+      targetProfileId: TARGET_PROFILE_ID_MULTIFORM_CAP,
+      skillId,
+    })
+  );
+
+  await databaseBuilder.commit();
+};
+
+const doThingForPRO = async (file) => {
+  const report = {};
+  const actions = await _parseFile(file, report);
+  await _doActions(actions, report);
+  return report;
+};
+
+async function _parseFile(file, report) {
+  const data = await fs.readFile(file, 'utf8');
+  const csvRawData = data.toString('utf8').replace(/^\uFEFF/, '');
+  const parsedCSVData = papa.parse(csvRawData, { header: true });
+  const actions = [];
+  for (const line of parsedCSVData.data.filter((line) => line[HEADERS.ID].length !== 0)) {
+    let shouldOutdate, shouldUncap, uniformCap, hasMultiformCap;
+    const id = parseInt(line[HEADERS.ID]);
+    if (line[HEADERS.TO_OUTDATE].toLowerCase() === 'obsolete') {
+      shouldOutdate = true;
+      shouldUncap = false;
+      uniformCap = -1;
+      hasMultiformCap = false;
+      actions.push({ id, shouldOutdate, shouldUncap, uniformCap, hasMultiformCap });
+      continue;
+    }
+    shouldOutdate = false;
+    if (line[HEADERS.MORE_THAN_AUTO_MIGRATION].toLowerCase() === 'non') {
+      shouldUncap = false;
+      uniformCap = -1;
+      hasMultiformCap = false;
+      actions.push({ id, shouldOutdate, shouldUncap, uniformCap, hasMultiformCap });
+      continue;
+    }
+    if (line[HEADERS.UNCAP].toLowerCase() === 'oui') {
+      shouldUncap = true;
+      uniformCap = -1;
+      hasMultiformCap = false;
+      actions.push({ id, shouldOutdate, shouldUncap, uniformCap, hasMultiformCap });
+      continue;
+    }
+    shouldUncap = false;
+    const uniformCapValue = parseInt(line[HEADERS.UNIFORM_CAP]);
+    if (!isNaN(uniformCapValue)) {
+      uniformCap = uniformCapValue;
+      hasMultiformCap = false;
+      actions.push({ id, shouldOutdate, shouldUncap, uniformCap, hasMultiformCap });
+      continue;
+    } else if (line[HEADERS.MULTIFORM_CAP].toLowerCase() === 'oui') {
+      uniformCap = -1;
+      hasMultiformCap = true;
+      actions.push({ id, shouldOutdate, shouldUncap, uniformCap, hasMultiformCap });
+      continue;
+    }
+    report[id.toString()] = `${id}: rien à faire`;
+  }
+  return actions;
+}
+
+async function _doActions(actions, report) {
+  for (const tpAction of actions) {
+    const trx = await knex.transaction();
+    try {
+      const exists = await _checkIfTPExists(tpAction.id, trx);
+      if (!exists) {
+        report[tpAction.id.toString()] = `${tpAction.id}: PC n'existe pas`;
+        continue;
+      }
+      const alreadyHasTubes = await _checkIfTPAlreadyHasTubes(tpAction.id, trx);
+      if (alreadyHasTubes) {
+        report[tpAction.id.toString()] = `${tpAction.id}: PC déjà converti`;
+        continue;
+      }
+      await _doAutomaticMigration(tpAction.id, trx);
+      if (tpAction.shouldOutdate) {
+        await _outdate(tpAction.id, trx);
+      }
+      if (tpAction.shouldUncap) {
+        await _uncap(tpAction.id, trx);
+      }
+      if (tpAction.uniformCap !== -1) {
+        await _uniformCap(tpAction.id, tpAction.uniformCap, trx);
+      }
+      if (tpAction.hasMultiformCap) {
+        console.log(`${tpAction.id}: multiform todo`);
+      }
+      await trx.commit();
+    } catch (err) {
+      await trx.rollback();
+      report[tpAction.id.toString()] = `${tpAction.id}: ${err}`;
+    }
+  }
+}
+
+async function _checkIfTPExists(id, trx) {
+  const potentialTP = await trx('target-profiles').where({ id }).first();
+  return Boolean(potentialTP);
+}
+
+async function _checkIfTPAlreadyHasTubes(id, trx) {
+  const potentialTube = await trx('target-profile_tubes').where({ targetProfileId: id }).first();
+  return Boolean(potentialTube);
+}
+
+async function _doAutomaticMigration(id, trx) {
+  const skillIds = await trx('target-profiles_skills').pluck('skillId').where({ targetProfileId: id });
+  const skills = skillIds.map((skillId) => {
+    const foundSkill = allSkills.find((skill) => skill.id === skillId);
+    if (!foundSkill) throw new Error(`L'acquis "${skillId}" n'existe pas dans le référentiel.`);
+    if (!foundSkill.tubeId) throw new Error(`L'acquis "${skillId}" n'appartient à aucun sujet.`);
+    const tubeExists = Boolean(allTubes.find((tube) => tube.id === foundSkill.tubeId));
+    if (!tubeExists) throw new Error(`Le sujet "${foundSkill.tubeId}" n'existe pas dans le référentiel.`);
+    return foundSkill;
+  });
+  const skillsGroupedByTubeId = _.groupBy(skills, 'tubeId');
+  const tubes = [];
+  for (const [tubeId, skills] of Object.entries(skillsGroupedByTubeId)) {
+    const skillWithHighestDifficulty = _.maxBy(skills, 'difficulty');
+    tubes.push({
+      tubeId,
+      level: skillWithHighestDifficulty.difficulty,
+    });
+  }
+  const completeTubes = tubes.map((tube) => {
+    return { ...tube, targetProfileId: id };
+  });
+  await trx.batchInsert('target-profile_tubes', completeTubes);
+}
+
+async function _outdate(id, trx) {
+  await trx('target-profiles').update({ outdated: true }).where({ id });
+}
+
+async function _uncap(id, trx) {
+  await trx('target-profile_tubes').update({ level: 8 }).where({ targetProfileId: id });
+}
+
+async function _uniformCap(id, cap, trx) {
+  await trx('target-profile_tubes').update({ level: cap }).where({ targetProfileId: id });
+}
+
+const checkData = async (report) => {
+  if (report['2000'] !== "2000: PC n'existe pas") console.log('PC 2000 KO');
+  await _checkTP2001();
+  await _checkTP2002();
+  await _checkTP2003();
+  await _checkTP2004();
+  await _checkTP2005();
+};
+
+async function _checkTP2001() {
+  const EXPECTED_TUBES_AUTO = {
+    [tubeIdCodageEmblematique]: 7,
+    [tubeIdTerminal]: 5,
+    [tubeIdEditerDocEnLigne]: 4,
+    [tubeIdPartageDroits]: 6,
+  };
+  const { outdated } = await knex('target-profiles')
+    .select('outdated')
+    .where({ id: TARGET_PROFILE_ID_TO_OUTDATE })
+    .first();
+  if (outdated === false) console.log('PC 2001 KO');
+  const targetProfileTubes = await knex('target-profile_tubes')
+    .select('tubeId', 'level')
+    .where({ targetProfileId: TARGET_PROFILE_ID_TO_OUTDATE })
+    .orderBy('tubeId');
+  if (targetProfileTubes.length !== 4) console.log('PC 2001 KO');
+  if (
+    targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdCodageEmblematique).level !==
+    EXPECTED_TUBES_AUTO[tubeIdCodageEmblematique]
+  )
+    console.log('PC 2001 KO');
+  if (targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdTerminal).level !== EXPECTED_TUBES_AUTO[tubeIdTerminal])
+    console.log('PC 2001 KO');
+  if (
+    targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdEditerDocEnLigne).level !==
+    EXPECTED_TUBES_AUTO[tubeIdEditerDocEnLigne]
+  )
+    console.log('PC 2001 KO');
+  if (
+    targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdPartageDroits).level !==
+    EXPECTED_TUBES_AUTO[tubeIdPartageDroits]
+  )
+    console.log('PC 2001 KO');
+}
+
+async function _checkTP2002() {
+  const EXPECTED_TUBES_AUTO = {
+    [tubeIdCodageEmblematique]: 7,
+    [tubeIdTerminal]: 5,
+    [tubeIdEditerDocEnLigne]: 4,
+    [tubeIdPartageDroits]: 6,
+  };
+  const { outdated } = await knex('target-profiles').select('outdated').where({ id: TARGET_PROFILE_ID_AUTO }).first();
+  if (outdated === true) console.log('PC 2002 KO');
+  const targetProfileTubes = await knex('target-profile_tubes')
+    .select('tubeId', 'level')
+    .where({ targetProfileId: TARGET_PROFILE_ID_AUTO })
+    .orderBy('tubeId');
+  if (targetProfileTubes.length !== 4) console.log('PC 2002 KO');
+  if (
+    targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdCodageEmblematique).level !==
+    EXPECTED_TUBES_AUTO[tubeIdCodageEmblematique]
+  )
+    console.log('PC 2002 KO');
+  if (targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdTerminal).level !== EXPECTED_TUBES_AUTO[tubeIdTerminal])
+    console.log('PC 2002 KO');
+  if (
+    targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdEditerDocEnLigne).level !==
+    EXPECTED_TUBES_AUTO[tubeIdEditerDocEnLigne]
+  )
+    console.log('PC 2002 KO');
+  if (
+    targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdPartageDroits).level !==
+    EXPECTED_TUBES_AUTO[tubeIdPartageDroits]
+  )
+    console.log('PC 2002 KO');
+}
+
+async function _checkTP2003() {
+  const EXPECTED_TUBES_AUTO = {
+    [tubeIdCodageEmblematique]: 8,
+    [tubeIdTerminal]: 8,
+    [tubeIdEditerDocEnLigne]: 8,
+    [tubeIdPartageDroits]: 8,
+  };
+  const { outdated } = await knex('target-profiles').select('outdated').where({ id: TARGET_PROFILE_ID_UNCAP }).first();
+  if (outdated === true) console.log('PC 2003 KO');
+  const targetProfileTubes = await knex('target-profile_tubes')
+    .select('tubeId', 'level')
+    .where({ targetProfileId: TARGET_PROFILE_ID_UNCAP })
+    .orderBy('tubeId');
+  if (targetProfileTubes.length !== 4) console.log('PC 2003 KO');
+  if (
+    targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdCodageEmblematique).level !==
+    EXPECTED_TUBES_AUTO[tubeIdCodageEmblematique]
+  )
+    console.log('PC 2003 KO');
+  if (targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdTerminal).level !== EXPECTED_TUBES_AUTO[tubeIdTerminal])
+    console.log('PC 2003 KO');
+  if (
+    targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdEditerDocEnLigne).level !==
+    EXPECTED_TUBES_AUTO[tubeIdEditerDocEnLigne]
+  )
+    console.log('PC 2003 KO');
+  if (
+    targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdPartageDroits).level !==
+    EXPECTED_TUBES_AUTO[tubeIdPartageDroits]
+  )
+    console.log('PC 2003 KO');
+}
+
+async function _checkTP2004() {
+  const EXPECTED_TUBES_AUTO = {
+    [tubeIdCodageEmblematique]: 6,
+    [tubeIdTerminal]: 6,
+    [tubeIdEditerDocEnLigne]: 6,
+    [tubeIdPartageDroits]: 6,
+  };
+  const { outdated } = await knex('target-profiles')
+    .select('outdated')
+    .where({ id: TARGET_PROFILE_ID_UNIFORM_CAP })
+    .first();
+  if (outdated === true) console.log('PC 2004 KO');
+  const targetProfileTubes = await knex('target-profile_tubes')
+    .select('tubeId', 'level')
+    .where({ targetProfileId: TARGET_PROFILE_ID_UNIFORM_CAP })
+    .orderBy('tubeId');
+  if (targetProfileTubes.length !== 4) console.log('PC 2004 KO');
+  if (
+    targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdCodageEmblematique).level !==
+    EXPECTED_TUBES_AUTO[tubeIdCodageEmblematique]
+  )
+    console.log('PC 2004 KO');
+  if (targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdTerminal).level !== EXPECTED_TUBES_AUTO[tubeIdTerminal])
+    console.log('PC 2004 KO');
+  if (
+    targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdEditerDocEnLigne).level !==
+    EXPECTED_TUBES_AUTO[tubeIdEditerDocEnLigne]
+  )
+    console.log('PC 2004 KO');
+  if (
+    targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdPartageDroits).level !==
+    EXPECTED_TUBES_AUTO[tubeIdPartageDroits]
+  )
+    console.log('PC 2004 KO');
+}
+
+async function _checkTP2005() {
+  const EXPECTED_TUBES_AUTO = {
+    [tubeIdCodageEmblematique]: 7,
+    [tubeIdTerminal]: 4,
+    [tubeIdEditerDocEnLigne]: 2,
+    [tubeIdPartageDroits]: 4,
+  };
+  const { outdated } = await knex('target-profiles')
+    .select('outdated')
+    .where({ id: TARGET_PROFILE_ID_MULTIFORM_CAP })
+    .first();
+  if (outdated === true) console.log('PC 2005 KO');
+  const targetProfileTubes = await knex('target-profile_tubes')
+    .select('tubeId', 'level')
+    .where({ targetProfileId: TARGET_PROFILE_ID_MULTIFORM_CAP })
+    .orderBy('tubeId');
+  if (targetProfileTubes.length !== 4) console.log('PC 2005 KO');
+  if (
+    targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdCodageEmblematique).level !==
+    EXPECTED_TUBES_AUTO[tubeIdCodageEmblematique]
+  )
+    console.log('PC 2005 KO');
+  if (targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdTerminal).level !== EXPECTED_TUBES_AUTO[tubeIdTerminal])
+    console.log('PC 2005 KO');
+  if (
+    targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdEditerDocEnLigne).level !==
+    EXPECTED_TUBES_AUTO[tubeIdEditerDocEnLigne]
+  )
+    console.log('PC 2005 KO');
+  if (
+    targetProfileTubes.find(({ tubeId }) => tubeId === tubeIdPartageDroits).level !==
+    EXPECTED_TUBES_AUTO[tubeIdPartageDroits]
+  )
+    console.log('PC 2005 KO');
+}
+
+const isLaunchedFromCommandLine = require.main === module;
+
+async function main() {
+  const startTime = performance.now();
+  logger.info(`Script ${__filename} has started`);
+  await prepareData();
+  const file = process.argv[2];
+  const report = await doThingForPRO(file);
+  console.log(report);
+  await checkData(report);
+  const endTime = performance.now();
+  const duration = Math.round(endTime - startTime);
+  logger.info(`Script has ended: took ${duration} milliseconds`);
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    } finally {
+      //const databaseBuilder = new DatabaseBuilder({ knex, emptyFirst: false });
+      //await databaseBuilder.clean();
+      await disconnect();
+      await cache.quit();
+    }
+  }
+})();
+
+module.exports = { prepareData, doThingForPRO, checkData };

--- a/api/scripts/prod/target-profile-migrations/convert-badges.js
+++ b/api/scripts/prod/target-profile-migrations/convert-badges.js
@@ -1,0 +1,132 @@
+require('dotenv').config();
+const _ = require('lodash');
+const { knex, disconnect } = require('../../../db/knex-database-connection');
+const logger = require('../../../lib/infrastructure/logger');
+const cache = require('../../../lib/infrastructure/caches/learning-content-cache');
+
+let allSkills;
+let allTubes;
+async function _cacheLearningContentData() {
+  const skillRepository = require('../../../lib/infrastructure/repositories/skill-repository');
+  allSkills = await skillRepository.list();
+  const tubeRepository = require('../../../lib/infrastructure/repositories/tube-repository');
+  allTubes = await tubeRepository.list();
+}
+
+async function main() {
+  try {
+    await doJob();
+  } catch (err) {
+    logger.error(err);
+    throw err;
+  } finally {
+    await disconnect();
+    await cache.quit();
+  }
+}
+
+async function doJob() {
+  await _cacheLearningContentData();
+  const badgeIds = await _findBadgeIdsToConvert();
+  if (badgeIds.length === 0) {
+    logger.info('Aucun RT à convertir.');
+    return;
+  }
+  logger.info(`${badgeIds.length} à convertir...`);
+  for (const badgeId of badgeIds) {
+    const trx = await knex.transaction();
+    try {
+      logger.info(`Conversion de ${badgeId}...`);
+      const targetProfileTubes = await _findTargetProfileTubes(badgeId, trx);
+      await _convertBadge(badgeId, targetProfileTubes, trx);
+      await _deleteSkillSetCriteria(badgeId, trx);
+      await trx.commit();
+    } catch (err) {
+      logger.error(`${badgeId} Echec. Raison : ${err}`);
+      await trx.rollback();
+    }
+  }
+}
+
+async function _findBadgeIdsToConvert() {
+  const ids = await knex('badge-criteria').pluck('badgeId').where('scope', 'SkillSet');
+  return _.uniq(ids);
+}
+
+async function _findTargetProfileTubes(badgeId, trx) {
+  return trx('target-profile_tubes')
+    .select({
+      id: 'tubeId',
+      level: 'level',
+    })
+    .join('target-profiles', 'target-profiles.id', 'target-profile_tubes.targetProfileId')
+    .join('badges', 'badges.targetProfileId', 'target-profiles.id')
+    .where('badges.id', badgeId);
+}
+
+async function _convertBadge(badgeId, targetProfileTubes, trx) {
+  const criteria = await trx('badge-criteria').select('threshold', 'skillSetIds').where({ scope: 'SkillSet', badgeId });
+  const newCriteria = [];
+  for (const { threshold, skillSetIds } of criteria) {
+    for (const skillSetId of skillSetIds) {
+      const skillSet = await trx('skill-sets').select('name', 'skillIds').where({ id: skillSetId }).first();
+      const tubesWithLevel = await _computeTubeIdsAndLevelsForSkills(skillSet.skillIds);
+      _checkBadgeCriterionCappedTubesWithinTargetProfileCappedTubes(tubesWithLevel, targetProfileTubes);
+      newCriteria.push({
+        name: skillSet.name,
+        threshold,
+        scope: 'CappedTubes',
+        cappedTubes: JSON.stringify(tubesWithLevel),
+        badgeId,
+      });
+    }
+  }
+  await trx.batchInsert('badge-criteria', newCriteria);
+}
+
+async function _computeTubeIdsAndLevelsForSkills(skillIds) {
+  const skills = _findSkills(skillIds);
+  const skillsGroupedByTubeId = _.groupBy(skills, 'tubeId');
+  const tubes = [];
+  for (const [tubeId, skills] of Object.entries(skillsGroupedByTubeId)) {
+    const skillWithHighestDifficulty = _.maxBy(skills, 'difficulty');
+    tubes.push({
+      id: tubeId,
+      level: skillWithHighestDifficulty.difficulty,
+    });
+  }
+  return tubes;
+}
+
+function _findSkills(skillIds) {
+  return skillIds.map((skillId) => {
+    const foundSkill = allSkills.find((skill) => skill.id === skillId);
+    if (!foundSkill) throw new Error(`L'acquis "${skillId}" n'existe pas dans le référentiel.`);
+    if (!foundSkill.tubeId) throw new Error(`L'acquis "${skillId}" n'appartient à aucun sujet.`);
+    const tube = allTubes.find((tube) => tube.id === foundSkill.tubeId);
+    if (!tube) throw new Error(`Le sujet "${foundSkill.tubeId}" n'existe pas dans le référentiel.`);
+    return foundSkill;
+  });
+}
+
+function _checkBadgeCriterionCappedTubesWithinTargetProfileCappedTubes(badgeCappedTubes, targetProfileCappedTubes) {
+  for (const badgeCappedTube of badgeCappedTubes) {
+    const tubeInTargetProfile = targetProfileCappedTubes.find((cappedTube) => cappedTube.id === badgeCappedTube.id);
+    if (!tubeInTargetProfile)
+      throw new Error('Le RT contient des acquis qui ne sont pas compris dans le profil cible.');
+    if (badgeCappedTube.level > tubeInTargetProfile.level)
+      throw new Error('Le RT contient des acquis avec un niveau supérieur au profil cible.');
+  }
+}
+
+async function _deleteSkillSetCriteria(badgeId, trx) {
+  await trx('badge-criteria').where({ badgeId, scope: 'SkillSet' }).del();
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  doJob,
+};

--- a/api/scripts/prod/target-profile-migrations/convert-badges.js
+++ b/api/scripts/prod/target-profile-migrations/convert-badges.js
@@ -15,7 +15,8 @@ async function _cacheLearningContentData() {
 
 async function main() {
   try {
-    await doJob();
+    const dryRun = process.env.DRY_RUN === 'true';
+    await doJob(dryRun);
   } catch (err) {
     logger.error(err);
     throw err;
@@ -25,7 +26,7 @@ async function main() {
   }
 }
 
-async function doJob() {
+async function doJob(dryRun) {
   await _cacheLearningContentData();
   const badgeIds = await _findBadgeIdsToConvert();
   if (badgeIds.length === 0) {
@@ -40,7 +41,8 @@ async function doJob() {
       const targetProfileTubes = await _findTargetProfileTubes(badgeId, trx);
       await _convertBadge(badgeId, targetProfileTubes, trx);
       await _deleteSkillSetCriteria(badgeId, trx);
-      await trx.commit();
+      if (dryRun) await trx.rollback();
+      else await trx.commit();
     } catch (err) {
       logger.error(`${badgeId} Echec. Raison : ${err}`);
       await trx.rollback();

--- a/api/scripts/prod/target-profile-migrations/convert-badges.js
+++ b/api/scripts/prod/target-profile-migrations/convert-badges.js
@@ -116,8 +116,7 @@ function _checkBadgeCriterionCappedTubesWithinTargetProfileCappedTubes(badgeCapp
     const tubeInTargetProfile = targetProfileCappedTubes.find((cappedTube) => cappedTube.id === badgeCappedTube.id);
     if (!tubeInTargetProfile)
       throw new Error('Le RT contient des acquis qui ne sont pas compris dans le profil cible.');
-    if (badgeCappedTube.level > tubeInTargetProfile.level)
-      throw new Error('Le RT contient des acquis avec un niveau supérieur au profil cible.');
+    badgeCappedTube.level = Math.min(badgeCappedTube.level, tubeInTargetProfile.level);
   }
 }
 

--- a/api/scripts/prod/target-profile-migrations/convert-target-profiles-into-new-format.js
+++ b/api/scripts/prod/target-profile-migrations/convert-target-profiles-into-new-format.js
@@ -8,7 +8,8 @@ const { autoMigrateTargetProfile } = require('./common');
 
 async function main() {
   try {
-    await doJob();
+    const dryRun = process.env.DRY_RUN === 'true';
+    await doJob(dryRun);
   } catch (err) {
     logger.error(err);
     throw err;
@@ -18,7 +19,7 @@ async function main() {
   }
 }
 
-async function doJob() {
+async function doJob(dryRun) {
   const targetProfileIds = await _findTargetProfileIdsToConvert();
   if (targetProfileIds.length === 0) {
     logger.info('Aucun profil cible à convertir.');
@@ -30,7 +31,8 @@ async function doJob() {
     try {
       logger.info(`Conversion de ${targetProfileId}...`);
       await _convertTargetProfile(targetProfileId, trx);
-      await trx.commit();
+      if (dryRun) await trx.rollback();
+      else await trx.commit();
     } catch (err) {
       logger.error(`${targetProfileId} Echec. Raison : ${err}`);
       await trx.rollback();

--- a/api/tests/acceptance/scripts/target-profile-migrations/convert-badges_test.js
+++ b/api/tests/acceptance/scripts/target-profile-migrations/convert-badges_test.js
@@ -13,7 +13,7 @@ describe('Acceptance | Scripts | convert-badges', function () {
     const badgeAlreadyConvertedId = 1;
     const badgeToConvertId = 2;
     const badgeWithNoSkillSetsId = 3;
-    const badgeConversionErrorTargetProfileTubesTooLowLevelId = 4;
+    const badgeLevelFlooredToTubeLevelId = 4;
     const badgeConversionErrorTubeNotInTargetProfile = 5;
     const badgeConversionErrorUnknownSkillId = 6;
     const badgeConversionErrorNoCorrespondingTubeId = 7;
@@ -24,10 +24,7 @@ describe('Acceptance | Scripts | convert-badges', function () {
     _buildBadgeAlreadyConverted(badgeAlreadyConvertedId);
     _buildBadgeToConvert(badgeToConvertId, learningContent);
     _buildBadgeWithNoSkillSets(badgeWithNoSkillSetsId);
-    _buildBadgeWithConversionErrorTargetProfileTubesTooLowLevel(
-      badgeConversionErrorTargetProfileTubesTooLowLevelId,
-      learningContent
-    );
+    _buildBadgeFlooredToTubeLevel(badgeLevelFlooredToTubeLevelId, learningContent);
     _buildBadgeWithConversionErrorTubeNotInTargetProfile(badgeConversionErrorTubeNotInTargetProfile, learningContent);
     _buildBadgeWithConversionErrorUnknownSkillId(badgeConversionErrorUnknownSkillId);
     _buildBadgeWithConversionErrorNoCorrespondingTubeId(badgeConversionErrorNoCorrespondingTubeId, learningContent);
@@ -42,7 +39,7 @@ describe('Acceptance | Scripts | convert-badges', function () {
     const criteriaForAlreadyConverted = await _getCriteria(badgeAlreadyConvertedId);
     const criteriaForToConvert = await _getCriteria(badgeToConvertId);
     const criteriaForNoSkillSets = await _getCriteria(badgeWithNoSkillSetsId);
-    const criteriaForErrorLowerLevel = await _getCriteria(badgeConversionErrorTargetProfileTubesTooLowLevelId);
+    const criteriaForFlooredToTubeLevel = await _getCriteria(badgeLevelFlooredToTubeLevelId);
     const criteriaForErrorTubeNotInTargetProfile = await _getCriteria(badgeConversionErrorTubeNotInTargetProfile);
     const criteriaForErrorUnknownSkill = await _getCriteria(badgeConversionErrorUnknownSkillId);
     const criteriaForErrorNoCorrespondingTube = await _getCriteria(badgeConversionErrorNoCorrespondingTubeId);
@@ -96,13 +93,13 @@ describe('Acceptance | Scripts | convert-badges', function () {
       [{ scope: 'CampaignParticipation', threshold: 40, name: null }],
       'Echec RT sans skill sets'
     );
-    expect(criteriaForErrorLowerLevel).to.deep.equal(
+    expect(criteriaForFlooredToTubeLevel).to.deep.equal(
       [
         {
-          scope: 'SkillSet',
-          name: null,
+          scope: 'CappedTubes',
+          name: 'OnlyCriterion',
           threshold: 50,
-          skillSets: [{ name: 'OnlyCriterion', skillIds: ['skill2TubeD', 'skill4TubeD'] }],
+          cappedTubes: [{ id: 'tubeD', level: 3 }],
         },
       ],
       'Echec RT avec niveau supérieur au profil cible'
@@ -139,9 +136,6 @@ describe('Acceptance | Scripts | convert-badges', function () {
         },
       ],
       'Echec RT acquis sans sujet'
-    );
-    expect(loggerErrorStub).to.have.been.calledWith(
-      '4 Echec. Raison : Error: Le RT contient des acquis avec un niveau supérieur au profil cible.'
     );
     expect(loggerErrorStub).to.have.been.calledWith(
       '5 Echec. Raison : Error: Le RT contient des acquis qui ne sont pas compris dans le profil cible.'
@@ -251,7 +245,7 @@ function _buildBadgeWithNoSkillSets(badgeId) {
   databaseBuilder.factory.buildBadgeCriterion.scopeCampaignParticipation({ threshold: 40, badgeId });
 }
 
-function _buildBadgeWithConversionErrorTargetProfileTubesTooLowLevel(badgeId, learningContent) {
+function _buildBadgeFlooredToTubeLevel(badgeId, learningContent) {
   const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
   databaseBuilder.factory.buildTargetProfileTube({ tubeId: 'tubeD', level: 3, targetProfileId });
   databaseBuilder.factory.buildBadge({ id: badgeId, targetProfileId, key: `badge_${badgeId}` });

--- a/api/tests/acceptance/scripts/target-profile-migrations/convert-badges_test.js
+++ b/api/tests/acceptance/scripts/target-profile-migrations/convert-badges_test.js
@@ -14,7 +14,7 @@ describe('Acceptance | Scripts | convert-badges', function () {
     const badgeToConvertId = 2;
     const badgeWithNoSkillSetsId = 3;
     const badgeLevelFlooredToTubeLevelId = 4;
-    const badgeConversionErrorTubeNotInTargetProfile = 5;
+    const badgeTubeNotInTargetProfile = 5;
     const badgeConversionErrorUnknownSkillId = 6;
     const badgeConversionErrorNoCorrespondingTubeId = 7;
     const learningContent = {
@@ -25,7 +25,7 @@ describe('Acceptance | Scripts | convert-badges', function () {
     _buildBadgeToConvert(badgeToConvertId, learningContent);
     _buildBadgeWithNoSkillSets(badgeWithNoSkillSetsId);
     _buildBadgeFlooredToTubeLevel(badgeLevelFlooredToTubeLevelId, learningContent);
-    _buildBadgeWithConversionErrorTubeNotInTargetProfile(badgeConversionErrorTubeNotInTargetProfile, learningContent);
+    _buildBadgeWithTubeNotInTargetProfile(badgeTubeNotInTargetProfile, learningContent);
     _buildBadgeWithConversionErrorUnknownSkillId(badgeConversionErrorUnknownSkillId);
     _buildBadgeWithConversionErrorNoCorrespondingTubeId(badgeConversionErrorNoCorrespondingTubeId, learningContent);
 
@@ -40,7 +40,7 @@ describe('Acceptance | Scripts | convert-badges', function () {
     const criteriaForToConvert = await _getCriteria(badgeToConvertId);
     const criteriaForNoSkillSets = await _getCriteria(badgeWithNoSkillSetsId);
     const criteriaForFlooredToTubeLevel = await _getCriteria(badgeLevelFlooredToTubeLevelId);
-    const criteriaForErrorTubeNotInTargetProfile = await _getCriteria(badgeConversionErrorTubeNotInTargetProfile);
+    const criteriaForTubeNotInTargetProfile = await _getCriteria(badgeTubeNotInTargetProfile);
     const criteriaForErrorUnknownSkill = await _getCriteria(badgeConversionErrorUnknownSkillId);
     const criteriaForErrorNoCorrespondingTube = await _getCriteria(badgeConversionErrorNoCorrespondingTubeId);
 
@@ -104,13 +104,13 @@ describe('Acceptance | Scripts | convert-badges', function () {
       ],
       'Echec RT avec niveau supérieur au profil cible'
     );
-    expect(criteriaForErrorTubeNotInTargetProfile).to.deep.equal(
+    expect(criteriaForTubeNotInTargetProfile).to.deep.equal(
       [
         {
-          scope: 'SkillSet',
-          name: null,
+          scope: 'CappedTubes',
+          name: 'OnlyCriterion',
           threshold: 50,
-          skillSets: [{ name: 'OnlyCriterion', skillIds: ['skill2TubeF'] }],
+          cappedTubes: [{ id: 'tubeE', level: 4 }],
         },
       ],
       'Echec RT avec acquis non présent dans le profil cible'
@@ -136,9 +136,6 @@ describe('Acceptance | Scripts | convert-badges', function () {
         },
       ],
       'Echec RT acquis sans sujet'
-    );
-    expect(loggerErrorStub).to.have.been.calledWith(
-      '5 Echec. Raison : Error: Le RT contient des acquis qui ne sont pas compris dans le profil cible.'
     );
     expect(loggerErrorStub).to.have.been.calledWith(
       `6 Echec. Raison : Error: L'acquis "unknownSkillId" n'existe pas dans le référentiel.`
@@ -271,13 +268,13 @@ function _buildBadgeFlooredToTubeLevel(badgeId, learningContent) {
   learningContent.tubes.push(tube);
 }
 
-function _buildBadgeWithConversionErrorTubeNotInTargetProfile(badgeId, learningContent) {
+function _buildBadgeWithTubeNotInTargetProfile(badgeId, learningContent) {
   const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-  databaseBuilder.factory.buildTargetProfileTube({ tubeId: 'tubeE', level: 3, targetProfileId });
+  databaseBuilder.factory.buildTargetProfileTube({ tubeId: 'tubeE', level: 5, targetProfileId });
   databaseBuilder.factory.buildBadge({ id: badgeId, targetProfileId, key: `badge_${badgeId}` });
   const skillSetId = databaseBuilder.factory.buildSkillSet({
     name: 'OnlyCriterion',
-    skillIds: ['skill2TubeF'],
+    skillIds: ['skill2TubeF', 'skill4TubeE'],
   }).id;
   databaseBuilder.factory.buildBadgeCriterion.scopeSkillSets({
     threshold: 50,

--- a/api/tests/acceptance/scripts/target-profile-migrations/convert-badges_test.js
+++ b/api/tests/acceptance/scripts/target-profile-migrations/convert-badges_test.js
@@ -36,7 +36,7 @@ describe('Acceptance | Scripts | convert-badges', function () {
     await databaseBuilder.commit();
 
     // when
-    await doJob();
+    await doJob(false);
 
     // then
     const criteriaForAlreadyConverted = await _getCriteria(badgeAlreadyConvertedId);

--- a/api/tests/acceptance/scripts/target-profile-migrations/convert-badges_test.js
+++ b/api/tests/acceptance/scripts/target-profile-migrations/convert-badges_test.js
@@ -1,0 +1,345 @@
+const _ = require('lodash');
+const { expect, databaseBuilder, sinon, mockLearningContent } = require('../../../test-helper');
+const { knex } = require('../../../../db/knex-database-connection');
+const logger = require('../../../../lib/infrastructure/logger');
+
+const { doJob } = require('../../../../scripts/prod/target-profile-migrations/convert-badges');
+
+describe('Acceptance | Scripts | convert-badges', function () {
+  it('should execute the script as expected', async function () {
+    // given
+    sinon.stub(logger, 'info');
+    const loggerErrorStub = sinon.stub(logger, 'error');
+    const badgeAlreadyConvertedId = 1;
+    const badgeToConvertId = 2;
+    const badgeWithNoSkillSetsId = 3;
+    const badgeConversionErrorTargetProfileTubesTooLowLevelId = 4;
+    const badgeConversionErrorTubeNotInTargetProfile = 5;
+    const badgeConversionErrorUnknownSkillId = 6;
+    const badgeConversionErrorNoCorrespondingTubeId = 7;
+    const learningContent = {
+      skills: [],
+      tubes: [],
+    };
+    _buildBadgeAlreadyConverted(badgeAlreadyConvertedId);
+    _buildBadgeToConvert(badgeToConvertId, learningContent);
+    _buildBadgeWithNoSkillSets(badgeWithNoSkillSetsId);
+    _buildBadgeWithConversionErrorTargetProfileTubesTooLowLevel(
+      badgeConversionErrorTargetProfileTubesTooLowLevelId,
+      learningContent
+    );
+    _buildBadgeWithConversionErrorTubeNotInTargetProfile(badgeConversionErrorTubeNotInTargetProfile, learningContent);
+    _buildBadgeWithConversionErrorUnknownSkillId(badgeConversionErrorUnknownSkillId);
+    _buildBadgeWithConversionErrorNoCorrespondingTubeId(badgeConversionErrorNoCorrespondingTubeId, learningContent);
+
+    mockLearningContent(learningContent);
+    await databaseBuilder.commit();
+
+    // when
+    await doJob();
+
+    // then
+    const criteriaForAlreadyConverted = await _getCriteria(badgeAlreadyConvertedId);
+    const criteriaForToConvert = await _getCriteria(badgeToConvertId);
+    const criteriaForNoSkillSets = await _getCriteria(badgeWithNoSkillSetsId);
+    const criteriaForErrorLowerLevel = await _getCriteria(badgeConversionErrorTargetProfileTubesTooLowLevelId);
+    const criteriaForErrorTubeNotInTargetProfile = await _getCriteria(badgeConversionErrorTubeNotInTargetProfile);
+    const criteriaForErrorUnknownSkill = await _getCriteria(badgeConversionErrorUnknownSkillId);
+    const criteriaForErrorNoCorrespondingTube = await _getCriteria(badgeConversionErrorNoCorrespondingTubeId);
+
+    expect(criteriaForAlreadyConverted).to.deep.equal(
+      [
+        { scope: 'CampaignParticipation', threshold: 20, name: null },
+        {
+          scope: 'CappedTubes',
+          threshold: 25,
+          name: null,
+          cappedTubes: [{ id: 'alreadyConvertedTubeId', level: 1 }],
+        },
+      ],
+      'Echec RT déjà converti'
+    );
+    expect(criteriaForToConvert).to.deep.equal(
+      [
+        { scope: 'CampaignParticipation', threshold: 30, name: null },
+        {
+          scope: 'CappedTubes',
+          name: 'Critère1SkillSet1',
+          threshold: 35,
+          cappedTubes: [
+            { id: 'tubeA', level: 3 },
+            { id: 'tubeB', level: 4 },
+          ],
+        },
+        {
+          scope: 'CappedTubes',
+          name: 'Critère1SkillSet2',
+          threshold: 35,
+          cappedTubes: [
+            { id: 'tubeA', level: 5 },
+            { id: 'tubeC', level: 7 },
+          ],
+        },
+        {
+          scope: 'CappedTubes',
+          name: 'Critère2SkillSet1',
+          threshold: 36,
+          cappedTubes: [
+            { id: 'tubeB', level: 1 },
+            { id: 'tubeC', level: 3 },
+          ],
+        },
+      ],
+      'Echec RT à convertir'
+    );
+    expect(criteriaForNoSkillSets).to.deep.equal(
+      [{ scope: 'CampaignParticipation', threshold: 40, name: null }],
+      'Echec RT sans skill sets'
+    );
+    expect(criteriaForErrorLowerLevel).to.deep.equal(
+      [
+        {
+          scope: 'SkillSet',
+          name: null,
+          threshold: 50,
+          skillSets: [{ name: 'OnlyCriterion', skillIds: ['skill2TubeD', 'skill4TubeD'] }],
+        },
+      ],
+      'Echec RT avec niveau supérieur au profil cible'
+    );
+    expect(criteriaForErrorTubeNotInTargetProfile).to.deep.equal(
+      [
+        {
+          scope: 'SkillSet',
+          name: null,
+          threshold: 50,
+          skillSets: [{ name: 'OnlyCriterion', skillIds: ['skill2TubeF'] }],
+        },
+      ],
+      'Echec RT avec acquis non présent dans le profil cible'
+    );
+    expect(criteriaForErrorUnknownSkill).to.deep.equal(
+      [
+        {
+          scope: 'SkillSet',
+          name: null,
+          threshold: 50,
+          skillSets: [{ name: 'OnlyCriterion', skillIds: ['unknownSkillId'] }],
+        },
+      ],
+      'Echec RT avec acquis inconnu'
+    );
+    expect(criteriaForErrorNoCorrespondingTube).to.deep.equal(
+      [
+        {
+          scope: 'SkillSet',
+          name: null,
+          threshold: 50,
+          skillSets: [{ name: 'OnlyCriterion', skillIds: ['skillWithoutTube'] }],
+        },
+      ],
+      'Echec RT acquis sans sujet'
+    );
+    expect(loggerErrorStub).to.have.been.calledWith(
+      '4 Echec. Raison : Error: Le RT contient des acquis avec un niveau supérieur au profil cible.'
+    );
+    expect(loggerErrorStub).to.have.been.calledWith(
+      '5 Echec. Raison : Error: Le RT contient des acquis qui ne sont pas compris dans le profil cible.'
+    );
+    expect(loggerErrorStub).to.have.been.calledWith(
+      `6 Echec. Raison : Error: L'acquis "unknownSkillId" n'existe pas dans le référentiel.`
+    );
+    expect(loggerErrorStub).to.have.been.calledWith(
+      `7 Echec. Raison : Error: Le sujet "someUnknownTube" n'existe pas dans le référentiel.`
+    );
+  });
+});
+
+async function _getCriteria(badgeId) {
+  const rawCriteria = await knex('badge-criteria')
+    .select('scope', 'threshold', 'cappedTubes', 'skillSetIds', 'name')
+    .where({ badgeId })
+    .orderBy('threshold', 'ASC');
+  const criteria = [];
+  for (const rawCriterion of rawCriteria) {
+    const criterion = { scope: rawCriterion.scope, threshold: rawCriterion.threshold, name: rawCriterion.name };
+    if (rawCriterion.scope === 'CappedTubes') {
+      criterion.cappedTubes = rawCriterion.cappedTubes;
+    } else if (rawCriterion.scope === 'SkillSet') {
+      const skillSets = [];
+      for (const skillSetId of rawCriterion.skillSetIds) {
+        skillSets.push(
+          ...(await knex('skill-sets').select('name', 'skillIds').where({ id: skillSetId }).orderBy('name', 'ASC'))
+        );
+      }
+      criterion.skillSets = skillSets;
+    }
+    criteria.push(criterion);
+  }
+  return criteria;
+}
+
+function _buildBadgeAlreadyConverted(badgeId) {
+  const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+  databaseBuilder.factory.buildTargetProfileTube({
+    tubeId: 'alreadyConvertedTubeId',
+    level: 9000,
+    targetProfileId,
+  });
+  databaseBuilder.factory.buildBadge({ id: badgeId, targetProfileId, key: `badge_${badgeId}` });
+  databaseBuilder.factory.buildBadgeCriterion.scopeCampaignParticipation({ threshold: 20, badgeId });
+  databaseBuilder.factory.buildBadgeCriterion.scopeCappedTubes({
+    threshold: 25,
+    badgeId,
+    cappedTubes: JSON.stringify([{ id: 'alreadyConvertedTubeId', level: 1 }]),
+  });
+}
+
+function _buildBadgeToConvert(badgeId, learningContent) {
+  const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+  databaseBuilder.factory.buildTargetProfileTube({ tubeId: 'tubeA', level: 5, targetProfileId });
+  databaseBuilder.factory.buildTargetProfileTube({ tubeId: 'tubeB', level: 6, targetProfileId });
+  databaseBuilder.factory.buildTargetProfileTube({ tubeId: 'tubeC', level: 8, targetProfileId });
+  databaseBuilder.factory.buildBadge({ id: badgeId, targetProfileId, key: `badge_${badgeId}` });
+  databaseBuilder.factory.buildBadgeCriterion.scopeCampaignParticipation({ threshold: 30, badgeId });
+  const criteria1SkillSetId1 = databaseBuilder.factory.buildSkillSet({
+    name: 'Critère1SkillSet1',
+    skillIds: ['skill1TubeA', 'skill3TubeA', 'skill4TubeB'],
+  }).id;
+  const criteria1SkillSetId2 = databaseBuilder.factory.buildSkillSet({
+    name: 'Critère1SkillSet2',
+    skillIds: ['skill2TubeA', 'skill4TubeA', 'skill5TubeA', 'skill1TubeC', 'skill4TubeC', 'skill7TubeC'],
+  }).id;
+  databaseBuilder.factory.buildBadgeCriterion.scopeSkillSets({
+    threshold: 35,
+    badgeId,
+    skillSetIds: [criteria1SkillSetId1, criteria1SkillSetId2],
+  });
+  const criteria2SkillSetId1 = databaseBuilder.factory.buildSkillSet({
+    name: 'Critère2SkillSet1',
+    skillIds: ['skill1TubeB', 'skill1TubeC', 'skill2TubeC', 'skill3TubeC'],
+  }).id;
+  databaseBuilder.factory.buildBadgeCriterion.scopeSkillSets({
+    threshold: 36,
+    badgeId,
+    skillSetIds: [criteria2SkillSetId1],
+  });
+
+  // Insert skills up to level 8 for three tubes
+  const tubes = {
+    A: { id: 'tubeA', skills: [] },
+    B: { id: 'tubeB', skills: [] },
+    C: { id: 'tubeC', skills: [] },
+  };
+  for (const letter of ['A', 'B', 'C']) {
+    const skills = _.times(8, (i) => ({
+      id: `skill${i + 1}Tube${letter}`,
+      name: `@skill${i + 1}Tube${letter}`,
+      tubeId: `tube${letter}`,
+      level: i + 1,
+    }));
+    tubes[letter].skills.push(...skills);
+    learningContent.skills.push(...skills);
+    learningContent.tubes.push(tubes[letter]);
+  }
+}
+
+function _buildBadgeWithNoSkillSets(badgeId) {
+  const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+  databaseBuilder.factory.buildTargetProfileTube({ targetProfileId });
+  databaseBuilder.factory.buildBadge({ id: badgeId, targetProfileId, key: `badge_${badgeId}` });
+  databaseBuilder.factory.buildBadgeCriterion.scopeCampaignParticipation({ threshold: 40, badgeId });
+}
+
+function _buildBadgeWithConversionErrorTargetProfileTubesTooLowLevel(badgeId, learningContent) {
+  const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+  databaseBuilder.factory.buildTargetProfileTube({ tubeId: 'tubeD', level: 3, targetProfileId });
+  databaseBuilder.factory.buildBadge({ id: badgeId, targetProfileId, key: `badge_${badgeId}` });
+  const skillSetId = databaseBuilder.factory.buildSkillSet({
+    name: 'OnlyCriterion',
+    skillIds: ['skill2TubeD', 'skill4TubeD'],
+  }).id;
+  databaseBuilder.factory.buildBadgeCriterion.scopeSkillSets({
+    threshold: 50,
+    badgeId,
+    skillSetIds: [skillSetId],
+  });
+
+  const tube = { id: 'tubeD', skills: [] };
+  const skills = _.times(8, (i) => ({
+    id: `skill${i + 1}TubeD`,
+    name: `@skill${i + 1}TubeD`,
+    tubeId: `tubeD`,
+    level: i + 1,
+  }));
+  tube.skills.push(...skills);
+  learningContent.skills.push(...skills);
+  learningContent.tubes.push(tube);
+}
+
+function _buildBadgeWithConversionErrorTubeNotInTargetProfile(badgeId, learningContent) {
+  const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+  databaseBuilder.factory.buildTargetProfileTube({ tubeId: 'tubeE', level: 3, targetProfileId });
+  databaseBuilder.factory.buildBadge({ id: badgeId, targetProfileId, key: `badge_${badgeId}` });
+  const skillSetId = databaseBuilder.factory.buildSkillSet({
+    name: 'OnlyCriterion',
+    skillIds: ['skill2TubeF'],
+  }).id;
+  databaseBuilder.factory.buildBadgeCriterion.scopeSkillSets({
+    threshold: 50,
+    badgeId,
+    skillSetIds: [skillSetId],
+  });
+
+  // Insert skills up to level 8 for three tubes
+  const tubes = {
+    E: { id: 'tubeE', skills: [] },
+    F: { id: 'tubeF', skills: [] },
+  };
+  for (const letter of ['E', 'F']) {
+    const skills = _.times(8, (i) => ({
+      id: `skill${i + 1}Tube${letter}`,
+      name: `@skill${i + 1}Tube${letter}`,
+      tubeId: `tube${letter}`,
+      level: i + 1,
+    }));
+    tubes[letter].skills.push(...skills);
+    learningContent.skills.push(...skills);
+    learningContent.tubes.push(tubes[letter]);
+  }
+}
+
+function _buildBadgeWithConversionErrorUnknownSkillId(badgeId) {
+  const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+  databaseBuilder.factory.buildTargetProfileTube({ targetProfileId });
+  databaseBuilder.factory.buildBadge({ id: badgeId, targetProfileId, key: `badge_${badgeId}` });
+  const skillSetId = databaseBuilder.factory.buildSkillSet({ name: 'OnlyCriterion', skillIds: ['unknownSkillId'] }).id;
+  databaseBuilder.factory.buildBadgeCriterion.scopeSkillSets({
+    threshold: 50,
+    badgeId,
+    skillSetIds: [skillSetId],
+  });
+}
+
+function _buildBadgeWithConversionErrorNoCorrespondingTubeId(badgeId, learningContent) {
+  const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+  databaseBuilder.factory.buildTargetProfileTube({ targetProfileId });
+  databaseBuilder.factory.buildBadge({ id: badgeId, targetProfileId, key: `badge_${badgeId}` });
+  const skillSetId = databaseBuilder.factory.buildSkillSet({
+    name: 'OnlyCriterion',
+    skillIds: ['skillWithoutTube'],
+  }).id;
+  databaseBuilder.factory.buildBadgeCriterion.scopeSkillSets({
+    threshold: 50,
+    badgeId,
+    skillSetIds: [skillSetId],
+  });
+
+  const skill = {
+    id: 'skillWithoutTube',
+    name: '@skillWithoutTube',
+    tubeId: 'someUnknownTube',
+    level: 2,
+  };
+  learningContent.skills.push(skill);
+}

--- a/api/tests/acceptance/scripts/target-profile-migrations/convert-target-profiles-into-new-format_test.js
+++ b/api/tests/acceptance/scripts/target-profile-migrations/convert-target-profiles-into-new-format_test.js
@@ -31,7 +31,7 @@ describe('Acceptance | Scripts | convert-target-profiles-into-new-format', funct
     await databaseBuilder.commit();
 
     // when
-    await doJob();
+    await doJob(false);
 
     // then
     const { tubes: tubesForAlreadyConverted, migrationStatus: migrationStatusAlreadyConverted } =


### PR DESCRIPTION
## :gift: Proposition
Pour l’obtention d’un RT il peut y avoir un % de réussite sur toute la campagne ET/OU un (ou plusieurs dans le cas des profils cible pix+Droit par exemple) % de réussite sur un groupe d’acquis. On va transformer le groupe d’acquis figé en liste de sujets capés en niveau (par exemple : @excel1, @excel2, @excel3, @tableau1, @tableur4 se transforme en Excel niveau 3 et tableur niveau 4. Le pourcentage de réussite ne change pas.).

La migration est à faire de manière automatique pour les PC, aucun fichier ne sera utilisé pour des traitement spécifiques.

## :star2: Remarques

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
