### PR TITLE
[TECH] Remplacer le PixDropdown du choix du propriétaire par le nouveau PixSelect (PIX-6055)

### DIFF
--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -26,20 +26,17 @@
   </div>
 
   <div class="form__field-with-info form__field">
-    <PixDropdown
-      @id="campaign-owner"
+    <PixSelect
       @options={{this.campaignOwnerOptions}}
-      @onSelect={{this.onChangeCampaignOwner}}
-      @selectedOption={{this.currentUserOptionId}}
+      @onChange={{this.onChangeCampaignOwner}}
+      @value={{this.ownerId}}
       @isSearchable={{true}}
       @placeholder={{t "pages.campaign-creation.owner.placeholder"}}
+      @searchLabel={{t "pages.campaign-creation.owner.search-placeholder"}}
       @searchPlaceholder={{t "pages.campaign-creation.owner.search-placeholder"}}
-      @clearLabel={{t "pages.campaign-creation.owner.clear-label"}}
-      @expandLabel={{t "pages.campaign-creation.owner.expand-label"}}
-      @collapseLabel={{t "pages.campaign-creation.owner.collapse-label"}}
-      @pageSize={{10}}
       @label={{t "pages.campaign-creation.owner.label"}}
-      @requiredLabel={{t "common.form.mandatory-fields-title"}}
+      @requiredText={{t "common.form.mandatory-fields-title"}}
+      @hideDefaultOption={{true}}
     />
 
     <div class="form__field-info">

--- a/orga/app/components/campaign/create-form.js
+++ b/orga/app/components/campaign/create-form.js
@@ -15,6 +15,7 @@ export default class CreateForm extends Component {
   @tracked isCampaignGoalProfileCollection = null;
   @tracked targetProfile;
   @tracked targetProfilesOptions = [];
+  @tracked ownerId;
 
   constructor() {
     super(...arguments);
@@ -22,14 +23,7 @@ export default class CreateForm extends Component {
       organization: this.currentUser.organization,
     };
     this._setTargetProfilesOptions(this.args.targetProfiles);
-    this.campaign.ownerId = this.currentUser.prescriber.id;
-  }
-
-  get currentUserOptionId() {
-    const currentUserOption = this.args.membersSortedByFullName.find(
-      (member) => member.get('fullName') === this.currentUser.prescriber.fullName
-    );
-    return currentUserOption.get('id');
+    this.ownerId = this.currentUser.prescriber.id;
   }
 
   _setTargetProfilesOptions(targetProfiles) {
@@ -48,13 +42,6 @@ export default class CreateForm extends Component {
     if (!this.args.membersSortedByFullName) return [];
 
     return this.args.membersSortedByFullName.map((member) => ({ value: member.id, label: member.fullName }));
-  }
-
-  @action
-  cleanInput() {
-    const input = document.getElementById('campaign-target-profile');
-    input.value = '';
-    this.targetProfile = '';
   }
 
   @action
@@ -119,13 +106,14 @@ export default class CreateForm extends Component {
   onChangeCampaignOwner(newOwnerId) {
     const selectedMember = this.args.membersSortedByFullName.find((member) => newOwnerId === member.id);
     if (selectedMember) {
-      this.campaign.ownerId = selectedMember.id;
+      this.ownerId = selectedMember.id;
     }
   }
 
   @action
   onSubmit(event) {
     event.preventDefault();
+    this.campaign.ownerId = this.ownerId;
     this.args.onSubmit(this.campaign);
   }
 }

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -73,9 +73,11 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
         @targetProfiles={{this.targetProfiles}}
         @membersSortedByFullName={{this.defaultMembers}} />`
     );
+    await click(screen.getByLabelText(t('pages.campaign-creation.owner.label'), { exact: false }));
+    await screen.findByRole('listbox');
 
     // then
-    assert.dom(screen.getByTitle('Adam Troisjour')).exists();
+    assert.dom(screen.getByRole('option', { name: 'Adam Troisjour', selected: true })).exists();
   });
 
   test('[a11y] it should display a message that some inputs are required', async function (assert) {

--- a/orga/tests/unit/components/campaign/create-form_test.js
+++ b/orga/tests/unit/components/campaign/create-form_test.js
@@ -29,7 +29,7 @@ module('Unit | Component | Campaign::CreateForm', (hooks) => {
       await component.onChangeCampaignOwner(newOwnerId);
 
       //then
-      assert.deepEqual(component.campaign.ownerId, 7);
+      assert.deepEqual(component.ownerId, 7);
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Dans la page de création d'une campagne, on choisissait le propriétaire d'une campagne via le PixDropdown. Depuis, une refonte du composant PixSelect a été faite. 

## :gift: Proposition
Remplacer PixDropdown par PixSelect

## :star2: Remarques

## :santa: Pour tester
Vérifier la non régression: 
- Aller sur Pix Orga
- Créer une campagne, changer le nom du propriétaire, voir que le changement a bien été pris en compte
