### PR TITLE
[CHORE] Changer le nombre de résultats par défaut pour les organisations SCO (PIX-6624)

### DIFF
--- a/orga/app/controllers/authenticated/campaigns/list/all-campaigns.js
+++ b/orga/app/controllers/authenticated/campaigns/list/all-campaigns.js
@@ -6,7 +6,7 @@ const DEFAULT_PAGE_NUMBER = 1;
 
 export default class AuthenticatedCampaignsListAllCampaignsController extends Controller {
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
-  @tracked pageSize = 25;
+  @tracked pageSize = 50;
   @tracked name = null;
   @tracked ownerName = null;
   @tracked status = null;

--- a/orga/app/controllers/authenticated/campaigns/list/my-campaigns.js
+++ b/orga/app/controllers/authenticated/campaigns/list/my-campaigns.js
@@ -6,7 +6,7 @@ const DEFAULT_PAGE_NUMBER = 1;
 
 export default class AuthenticatedCampaignsListMyCampaignsController extends Controller {
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
-  @tracked pageSize = 25;
+  @tracked pageSize = 50;
   @tracked name = null;
   @tracked status = null;
 

--- a/orga/app/controllers/authenticated/sco-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sco-organization-participants/list.js
@@ -16,7 +16,7 @@ export default class ListController extends Controller {
   @tracked connexionType = null;
   @tracked certificability = [];
   @tracked pageNumber = null;
-  @tracked pageSize = null;
+  @tracked pageSize = 50;
 
   @action
   triggerFiltering(fieldName, value) {

--- a/orga/app/routes/authenticated/campaigns/list/all-campaigns.js
+++ b/orga/app/routes/authenticated/campaigns/list/all-campaigns.js
@@ -45,7 +45,7 @@ export default class AuthenticatedCampaignsListAllCampaignsRoute extends Route {
   resetController(controller, isExiting) {
     if (isExiting) {
       controller.pageNumber = 1;
-      controller.pageSize = 25;
+      controller.pageSize = 50;
       controller.name = null;
       controller.ownerName = null;
       controller.status = null;

--- a/orga/app/routes/authenticated/campaigns/list/my-campaigns.js
+++ b/orga/app/routes/authenticated/campaigns/list/my-campaigns.js
@@ -45,7 +45,7 @@ export default class AuthenticatedCampaignsListAllCampaignsRoute extends Route {
   resetController(controller, isExiting) {
     if (isExiting) {
       controller.pageNumber = 1;
-      controller.pageSize = 25;
+      controller.pageSize = 50;
       controller.name = null;
       controller.ownerName = null;
       controller.status = null;

--- a/orga/app/routes/authenticated/sco-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sco-organization-participants/list.js
@@ -39,7 +39,7 @@ export default class ListRoute extends Route {
       controller.connexionType = null;
       controller.certificability = [];
       controller.pageNumber = null;
-      controller.pageSize = null;
+      controller.pageSize = 50;
     }
   }
 


### PR DESCRIPTION
## :christmas_tree: Problème
Retour utilisateurs: Le nombre de résultatas à afficher par défaut n'est pas suffisant.

## :gift: Proposition
Passer de 25 à 50 résultats par page

## :star2: Remarques
Pour la liste des campagnes, même si c'est une demande sco et sup, le changement est fait pour toutes les campagnes.
⚠️ Il manque l'alerte Datadog

## :santa: Pour tester
- Se connecter à Pix Orga
- aller sur les page "mes campagnes" et "toutes les campagnes" et voir que 50 est mis par défaut
- aller sur l'onglet "Élèves" et voir que 50 est mis par défaut
