### PR TITLE
[FEATURE] Validation des infos du candidat dans le CSV d'import de session (PIX-6175).

### DIFF
--- a/api/lib/domain/services/certification-sessions-service.js
+++ b/api/lib/domain/services/certification-sessions-service.js
@@ -1,5 +1,6 @@
 module.exports = {
   groupBySessions,
+  associateSessionIdToParsedData,
 };
 
 function groupBySessions(data) {
@@ -18,4 +19,23 @@ function groupBySessions(data) {
   );
 
   return groupedSessions;
+}
+
+function associateSessionIdToParsedData(parsedCsvData, sessions) {
+  const parsedDataWithSessionId = parsedCsvData.map((parsedCsvline) => {
+    const matchedSession = sessions.find((session) => {
+      return (
+        parsedCsvline['* Nom du site'] === session.address &&
+        parsedCsvline['* Nom de la salle'] === session.room &&
+        parsedCsvline['* Date de début'] === session.date &&
+        parsedCsvline['* Heure de début (heure locale)'] === session.time &&
+        parsedCsvline['* Surveillant(s)'] === session.examiner &&
+        parsedCsvline['Observations (optionnel)'] === session.description
+      );
+    });
+
+    parsedCsvline.sessionId = matchedSession.id.toString();
+    return parsedCsvline;
+  });
+  return parsedDataWithSessionId;
 }

--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -39,9 +39,8 @@ module.exports = async function createSessions({
       return domainSession;
     });
 
-    await sessionRepository.saveSessions(domainSessions);
+    return sessionRepository.saveSessions(domainSessions);
   } catch (e) {
     throw new EntityValidationError(e);
   }
-  return;
 };

--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -2,8 +2,10 @@ const sessionValidator = require('../validators/session-validator');
 const { EntityValidationError } = require('../errors');
 const { UnprocessableEntityError } = require('../../application/http-errors');
 const Session = require('../models/Session');
+const CertificationCandidate = require('../models/CertificationCandidate');
 const sessionCodeService = require('../services/session-code-service');
 const certificationSessionsService = require('../services/certification-sessions-service');
+const dayjs = require('dayjs');
 
 module.exports = async function createSessions({
   data,
@@ -39,7 +41,29 @@ module.exports = async function createSessions({
       return domainSession;
     });
 
-    return sessionRepository.saveSessions(domainSessions);
+    const savedSessions = await sessionRepository.saveSessions(domainSessions);
+    const dataWithSessionIds = certificationSessionsService.associateSessionIdToParsedData(data, savedSessions);
+
+    dataWithSessionIds.map((data) => {
+      return new CertificationCandidate({
+        sessionId: data['sessionId'],
+        lastName: data[' * Nom de naissance'],
+        firstName: data['* Prénom'],
+        birthdate: dayjs(data['* Date de naissance (format: jj/mm/aaaa)'], 'DD/MM/YYYY').format('YYYY-MM-DD'),
+        sex: data['* Sexe (M ou F)'],
+        birthINSEECode: data['Code Insee'] ? data['Code Insee'] : null,
+        birthPostalCode: data['Code postal'] ? data['Code postal'] : null,
+        birthCity: data['Nom de la commune'],
+        birthCountry: data['* Pays'],
+        resultRecipientEmail: data['E-mail du destinataire des résultats (formateur, enseignant…)'],
+        email: data['E-mail de convocation'],
+        externalId: data['Identifiant local'],
+        extraTimePercentage: data['Temps majoré ?'],
+        billingMode: 'FREE',
+      }).validate();
+    });
+
+    return;
   } catch (e) {
     throw new EntityValidationError(e);
   }

--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -68,6 +68,10 @@ module.exports = async function createSessions({
     const dataWithSessionIds = certificationSessionsService.associateSessionIdToParsedData(data, savedSessions);
 
     dataWithSessionIds.map((data) => {
+      if (!_hasCandidateInformation(data)) {
+        return;
+      }
+
       return new CertificationCandidate({
         sessionId: data['sessionId'],
         lastName: data['* Nom de naissance'],

--- a/api/lib/infrastructure/repositories/sessions/session-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-repository.js
@@ -21,7 +21,8 @@ module.exports = {
     const sessions = sessionsData.map((session) => {
       return _.omit(session, ['certificationCandidates']);
     });
-    return knex.batchInsert('sessions', sessions);
+    const recordedSessions = await knex.batchInsert('sessions', sessions).returning('*');
+    return recordedSessions.map((recordedSession) => new Session(recordedSession));
   },
 
   async isSessionCodeAvailable(accessCode) {

--- a/api/tests/unit/domain/services/certification-sessions-service_test.js
+++ b/api/tests/unit/domain/services/certification-sessions-service_test.js
@@ -1,4 +1,4 @@
-const { expect } = require('../../../test-helper');
+const { expect, domainBuilder } = require('../../../test-helper');
 const certificationSessionsService = require('../../../../lib/domain/services/certification-sessions-service');
 
 describe('Unit | Service | certification-sessions-service', function () {
@@ -86,6 +86,247 @@ describe('Unit | Service | certification-sessions-service', function () {
 
         // when
         const result = certificationSessionsService.groupBySessions(data);
+
+        // then
+        expect(result).to.deep.equal(expectedData);
+      });
+    });
+  });
+
+  describe('#associateSessionIdToParsedData', function () {
+    context('when there is one session', function () {
+      context('when there is one candidate information', function () {
+        it('should return an array of parsedData with matching session id', function () {
+          // given
+          const savedSessions = [
+            domainBuilder.buildSession({
+              id: 201,
+              certificationCenterId: 101,
+              certificationCenter: 'Centre sans candidat',
+              address: 'site1',
+              room: 'salle1',
+              examiner: 'surveillant un',
+              date: '2022-01-01',
+              time: '01:00',
+              description: 'non',
+            }),
+          ];
+
+          const parsedCsvData = [
+            {
+              '* Nom du site': 'site1',
+              '* Nom de la salle': 'salle1',
+              '* Date de début': '2022-01-01',
+              '* Heure de début (heure locale)': '01:00',
+              '* Surveillant(s)': 'surveillant un',
+              'Observations (optionnel)': 'non',
+              ' * Nom de naissance': 'Man',
+              '* Prénom': 'Iron',
+              '* Date de naissance (format: jj/mm/aaaa)': '01/01/2000',
+              '* Sexe (M ou F)': 'M',
+              'Code Insee': '75115',
+              'Code postal': '',
+              'Nom de la commune': '',
+              '* Pays': 'France',
+              'E-mail du destinataire des résultats (formateur, enseignant…)': 'destinataire@email.com',
+              'E-mail de convocation': 'convocation@email.com',
+              'Identifiant local': '12345R',
+              'Temps majoré ?': '10',
+            },
+          ];
+
+          const expectedData = [
+            {
+              sessionId: '201',
+              '* Nom du site': 'site1',
+              '* Nom de la salle': 'salle1',
+              '* Date de début': '2022-01-01',
+              '* Heure de début (heure locale)': '01:00',
+              '* Surveillant(s)': 'surveillant un',
+              'Observations (optionnel)': 'non',
+              ' * Nom de naissance': 'Man',
+              '* Prénom': 'Iron',
+              '* Date de naissance (format: jj/mm/aaaa)': '01/01/2000',
+              '* Sexe (M ou F)': 'M',
+              'Code Insee': '75115',
+              'Code postal': '',
+              'Nom de la commune': '',
+              '* Pays': 'France',
+              'E-mail du destinataire des résultats (formateur, enseignant…)': 'destinataire@email.com',
+              'E-mail de convocation': 'convocation@email.com',
+              'Identifiant local': '12345R',
+              'Temps majoré ?': '10',
+            },
+          ];
+
+          // when
+          const result = certificationSessionsService.associateSessionIdToParsedData(parsedCsvData, savedSessions);
+
+          // then
+          expect(result).to.deep.equal(expectedData);
+        });
+      });
+    });
+    context('when there are two sessions with multiple candidate', function () {
+      it('should return an array of parsedData with matching session id', function () {
+        // given
+
+        const savedSessions = [
+          domainBuilder.buildSession({
+            id: 201,
+            certificationCenterId: 101,
+            certificationCenter: 'Centre avec un candidat',
+            address: 'site1',
+            room: 'salle1',
+            examiner: 'surveillant un',
+            date: '2022-01-01',
+            time: '01:00',
+            description: 'non',
+          }),
+          domainBuilder.buildSession({
+            id: 202,
+            certificationCenterId: 101,
+            certificationCenter: 'Centre avec deux candidats',
+            address: 'site2',
+            room: 'salle2',
+            examiner: 'surveillant deux',
+            date: '2022-01-02',
+            time: '02:00',
+            description: 'oui',
+          }),
+        ];
+
+        const parsedCsvData = [
+          {
+            '* Nom du site': 'site1',
+            '* Nom de la salle': 'salle1',
+            '* Date de début': '2022-01-01',
+            '* Heure de début (heure locale)': '01:00',
+            '* Surveillant(s)': 'surveillant un',
+            'Observations (optionnel)': 'non',
+            ' * Nom de naissance': 'Man',
+            '* Prénom': 'Iron',
+            '* Date de naissance (format: jj/mm/aaaa)': '01/01/2000',
+            '* Sexe (M ou F)': 'M',
+            'Code Insee': '75115',
+            'Code postal': '',
+            'Nom de la commune': '',
+            '* Pays': 'France',
+            'E-mail du destinataire des résultats (formateur, enseignant…)': 'destinataire@email.com',
+            'E-mail de convocation': 'convocation@email.com',
+            'Identifiant local': '12345R',
+            'Temps majoré ?': '10',
+          },
+          {
+            '* Nom du site': 'site2',
+            '* Nom de la salle': 'salle2',
+            '* Date de début': '2022-01-02',
+            '* Heure de début (heure locale)': '02:00',
+            '* Surveillant(s)': 'surveillant deux',
+            'Observations (optionnel)': 'oui',
+            ' * Nom de naissance': 'Black',
+            '* Prénom': 'Widow',
+            '* Date de naissance (format: jj/mm/aaaa)': '02/01/2000',
+            '* Sexe (M ou F)': 'F',
+            'Code Insee': '75115',
+            'Code postal': '',
+            'Nom de la commune': '',
+            '* Pays': 'France',
+            'E-mail du destinataire des résultats (formateur, enseignant…)': 'destinataire@email.com',
+            'E-mail de convocation': 'convocation@email.com',
+            'Identifiant local': '12346R',
+            'Temps majoré ?': '10',
+          },
+          {
+            '* Nom du site': 'site1',
+            '* Nom de la salle': 'salle1',
+            '* Date de début': '2022-01-01',
+            '* Heure de début (heure locale)': '01:00',
+            '* Surveillant(s)': 'surveillant un',
+            'Observations (optionnel)': 'non',
+            ' * Nom de naissance': 'Super',
+            '* Prénom': 'Women',
+            '* Date de naissance (format: jj/mm/aaaa)': '03/01/2000',
+            '* Sexe (M ou F)': 'F',
+            'Code Insee': '75115',
+            'Code postal': '',
+            'Nom de la commune': '',
+            '* Pays': 'France',
+            'E-mail du destinataire des résultats (formateur, enseignant…)': 'destinataire@email.com',
+            'E-mail de convocation': 'convocation@email.com',
+            'Identifiant local': '12316R',
+            'Temps majoré ?': '10',
+          },
+        ];
+
+        const expectedData = [
+          {
+            sessionId: '201',
+            '* Nom du site': 'site1',
+            '* Nom de la salle': 'salle1',
+            '* Date de début': '2022-01-01',
+            '* Heure de début (heure locale)': '01:00',
+            '* Surveillant(s)': 'surveillant un',
+            'Observations (optionnel)': 'non',
+            ' * Nom de naissance': 'Man',
+            '* Prénom': 'Iron',
+            '* Date de naissance (format: jj/mm/aaaa)': '01/01/2000',
+            '* Sexe (M ou F)': 'M',
+            'Code Insee': '75115',
+            'Code postal': '',
+            'Nom de la commune': '',
+            '* Pays': 'France',
+            'E-mail du destinataire des résultats (formateur, enseignant…)': 'destinataire@email.com',
+            'E-mail de convocation': 'convocation@email.com',
+            'Identifiant local': '12345R',
+            'Temps majoré ?': '10',
+          },
+          {
+            sessionId: '202',
+            '* Nom du site': 'site2',
+            '* Nom de la salle': 'salle2',
+            '* Date de début': '2022-01-02',
+            '* Heure de début (heure locale)': '02:00',
+            '* Surveillant(s)': 'surveillant deux',
+            'Observations (optionnel)': 'oui',
+            ' * Nom de naissance': 'Black',
+            '* Prénom': 'Widow',
+            '* Date de naissance (format: jj/mm/aaaa)': '02/01/2000',
+            '* Sexe (M ou F)': 'F',
+            'Code Insee': '75115',
+            'Code postal': '',
+            'Nom de la commune': '',
+            '* Pays': 'France',
+            'E-mail du destinataire des résultats (formateur, enseignant…)': 'destinataire@email.com',
+            'E-mail de convocation': 'convocation@email.com',
+            'Identifiant local': '12346R',
+            'Temps majoré ?': '10',
+          },
+          {
+            sessionId: '201',
+            '* Nom du site': 'site1',
+            '* Nom de la salle': 'salle1',
+            '* Date de début': '2022-01-01',
+            '* Heure de début (heure locale)': '01:00',
+            '* Surveillant(s)': 'surveillant un',
+            'Observations (optionnel)': 'non',
+            ' * Nom de naissance': 'Super',
+            '* Prénom': 'Women',
+            '* Date de naissance (format: jj/mm/aaaa)': '03/01/2000',
+            '* Sexe (M ou F)': 'F',
+            'Code Insee': '75115',
+            'Code postal': '',
+            'Nom de la commune': '',
+            '* Pays': 'France',
+            'E-mail du destinataire des résultats (formateur, enseignant…)': 'destinataire@email.com',
+            'E-mail de convocation': 'convocation@email.com',
+            'Identifiant local': '12316R',
+            'Temps majoré ?': '10',
+          },
+        ];
+
+        // when
+        const result = certificationSessionsService.associateSessionIdToParsedData(parsedCsvData, savedSessions);
 
         // then
         expect(result).to.deep.equal(expectedData);


### PR DESCRIPTION
## :christmas_tree: Problème

Lors de l'import 

## :gift: Proposition

- Vérification des champs liés au candidat dans le CSV

## :star2: Remarques

TODO:
- Correction des tests unitaires du use case afin de passer les bonnes données (tableau de { header: value } )
- Sortir la validation du candidat en dehors du premier mapping afin de pouvoir récupérer l’id de la session créée (Comment savoir à quelle session appartient tel candidat ?)
- Remplacer les valeurs du candidat en dur dans le code par des données dynamique (utilisation de la fonction de validation des données d’un candidat utilisé dans l’import ODS?)

## :santa: Pour tester
TBD

