### PR TITLE
[BUGFIX] Corriger les propositions de choix de langue lors du téléchargement PDF d'un profil cible (PIX-6376)

### DIFF
--- a/admin/app/components/target-profiles/pdf-parameters-modal.hbs
+++ b/admin/app/components/target-profiles/pdf-parameters-modal.hbs
@@ -5,7 +5,7 @@
       @selectedOption={{this.language}}
       @onChange={{this.onChangeLanguage}}
       @options={{this.options}}
-      @label="Langue du référentiel (fr ou en) :"
+      @label="Langue du référentiel (français ou anglais) :"
     />
   </:content>
   <:footer>

--- a/admin/app/components/target-profiles/pdf-parameters-modal.js
+++ b/admin/app/components/target-profiles/pdf-parameters-modal.js
@@ -8,8 +8,8 @@ export default class PdfParametersModal extends Component {
   constructor() {
     super(...arguments);
     this.options = [
-      { value: 'fr', label: 'fr' },
-      { value: 'en', label: 'en' },
+      { value: 'fr', label: 'Français' },
+      { value: 'en', label: 'Anglais' },
     ];
     this.language = 'fr';
   }


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsqu'on télécharge un PDF sur PixAdmin, les propositions de langues sont `fr` et `en`.

## :gift: Proposition
Mettre `Français` et `Anglais`.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Se rendre sur [https://admin-pr5414.review.pix.fr/target-profiles/500](https://admin-pr5414.review.pix.fr/target-profiles/500) 

Vérifier que les langues dans la pop in de choix de langue sont  `Français` et `Anglais`.
