### PR TITLE
[CHORE] Changer le nombre de résultats par défaut pour les organisations SUP (PIX-6625)

### DIFF
--- a/orga/app/controllers/authenticated/sup-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sup-organization-participants/list.js
@@ -8,7 +8,7 @@ export default class ListController extends Controller {
   @tracked groups = [];
   @tracked certificability = [];
   @tracked pageNumber = null;
-  @tracked pageSize = null;
+  @tracked pageSize = 50;
 
   @action
   triggerFiltering(fieldName, value) {

--- a/orga/app/routes/authenticated/sup-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sup-organization-participants/list.js
@@ -40,7 +40,7 @@ export default class ListRoute extends Route {
       controller.groups = [];
       controller.certificability = [];
       controller.pageNumber = null;
-      controller.pageSize = null;
+      controller.pageSize = 50;
     }
   }
 


### PR DESCRIPTION
## :christmas_tree: Problème
Retour utilisateurs: Le nombre de résultas à afficher par défaut n'est pas suffisant.

## :gift: Proposition
Passer de 25 à 50 résultats par page. 

## :star2: Remarques
⚠️ Il manque l'alerte Datadog

## :santa: Pour tester
Se connecter à Pix Orga avec un compte Sup
Aller sur l'onglet "Étudiants" et voir que 50 est mis par défaut
