### PR TITLE
[TECH] Séparer les phases de test et de lint dans la CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,10 +111,15 @@ jobs:
           paths:
             - ~/.npm
       - run:
-          name: Lint and test
-          command: |
-            npm run lint
-            npm run test:ci
+          name: Lint
+          command: npm run lint
+          environment:
+            TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci
+            TEST_REDIS_URL: redis://localhost:6379
+          when: always
+      - run:
+          name: Test
+          command: npm run test:ci
           environment:
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci
             TEST_REDIS_URL: redis://localhost:6379

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
           when: always
       - run:
           name: Test
-          command: npm run test:ci
+          command: npm run test
           environment:
             TEST_DATABASE_URL: postgres://circleci@localhost:5432/circleci
             TEST_REDIS_URL: redis://localhost:6379

--- a/api/db/migrations/20220922141959_modify-messages-in-complementary-certification-badges.js
+++ b/api/db/migrations/20220922141959_modify-messages-in-complementary-certification-badges.js
@@ -66,4 +66,5 @@ exports.up = async function (knex) {
  * @param { import('knex').Knex } knex
  * @returns { Promise<void> }
  */
+// eslint-disable-next-line no-empty-function
 exports.down = function (_) {};

--- a/api/package.json
+++ b/api/package.json
@@ -161,7 +161,6 @@
     "test:api:debug": "NODE_ENV=test mocha --inspect-brk=9229 --recursive --exit --reporter dot tests",
     "test:api:watch": "NODE_ENV=test mocha --recursive tests --watch --reporter dot",
     "test:api:bail": "npm run test:api:unit -- --bail && npm run test:api:integration -- --bail && npm run test:api:acceptance -- --bail",
-    "test:ci": "npm run test",
     "test:lint": "npm test && npm run lint"
   },
   "optionalDependencies": {


### PR DESCRIPTION
## :christmas_tree: Problème
Les phases de test et de lint sont exécutées dans la même étape dans la CI.
L'aperçu n'indique pas clairement où est le problème, il faut aller dans l'onglet Tests.

![image](https://user-images.githubusercontent.com/56302715/209784686-64f585a9-78f5-45c2-bf18-7f3bb558f481.png)
![image](https://user-images.githubusercontent.com/56302715/209784729-0baec561-a4b8-4d2a-bcb5-744712e0a597.png)

## :gift: Proposition
Séparer les deux tâches

## :star2: Remarques
Une longue discussion a eu lieu sur l'intérêt d'exécuter le lint avant les tests, mais il n'y a pas eu de convergence.
On garde donc l'ordre existant.

Suppression d'un warning sur `no-empty-function`

## :santa: Pour tester
Introduire une erreur de lint, vérifier que les tests ne sont pas exécutés.
