### PR TITLE
[FEATURE] Gestion des créations et groupage par session  (PIX-6659)

### DIFF
--- a/api/lib/domain/services/certification-sessions-service.js
+++ b/api/lib/domain/services/certification-sessions-service.js
@@ -1,0 +1,21 @@
+module.exports = {
+  groupBySessions,
+};
+
+function groupBySessions(data) {
+  const groupedSessions = data.filter(
+    (session, index, self) =>
+      index ===
+      self.findIndex(
+        (currentSession) =>
+          currentSession['* Nom du site'] === session['* Nom du site'] &&
+          currentSession['* Nom de la salle'] === session['* Nom de la salle'] &&
+          currentSession['* Date de début'] === session['* Date de début'] &&
+          currentSession['* Heure de début (heure locale)'] === session['* Heure de début (heure locale)'] &&
+          currentSession['* Surveillant(s)'] === session['* Surveillant(s)'] &&
+          currentSession['Observations (optionnel)'] === session['Observations (optionnel)']
+      )
+  );
+
+  return groupedSessions;
+}

--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -3,6 +3,7 @@ const { EntityValidationError } = require('../errors');
 const { UnprocessableEntityError } = require('../../application/http-errors');
 const Session = require('../models/Session');
 const sessionCodeService = require('../services/session-code-service');
+const certificationSessionsService = require('../services/certification-sessions-service');
 
 module.exports = async function createSessions({
   data,
@@ -16,8 +17,10 @@ module.exports = async function createSessions({
 
   const { name: certificationCenter } = await certificationCenterRepository.get(certificationCenterId);
 
+  const groupedSessions = certificationSessionsService.groupBySessions(data);
+
   try {
-    const domainSessions = data.map((data) => {
+    const domainSessions = groupedSessions.map((data) => {
       const accessCode = sessionCodeService.getNewSessionCodeWithoutAvailabilityCheck();
       const domainSession = new Session({
         certificationCenterId,

--- a/api/tests/unit/domain/services/certification-sessions-service_test.js
+++ b/api/tests/unit/domain/services/certification-sessions-service_test.js
@@ -1,0 +1,95 @@
+const { expect } = require('../../../test-helper');
+const certificationSessionsService = require('../../../../lib/domain/services/certification-sessions-service');
+
+describe('Unit | Service | certification-sessions-service', function () {
+  describe('#groupBySessions', function () {
+    context('when there are unique sessions each line', function () {
+      it('should return a list of unique sessions', function () {
+        // given
+        const sessions = [
+          {
+            '* Nom du site': 'site1',
+            '* Nom de la salle': 'salle1',
+            '* Date de début': '2022-01-01',
+            '* Heure de début (heure locale)': '01:00',
+            '* Surveillant(s)': 'surveillant un',
+            'Observations (optionnel)': 'non',
+          },
+          {
+            '* Nom du site': 'site2',
+            '* Nom de la salle': 'salle2',
+            '* Date de début': '2022-02-02',
+            '* Heure de début (heure locale)': '02:00',
+            '* Surveillant(s)': 'surveillant deux',
+            'Observations (optionnel)': 'non',
+          },
+        ];
+
+        const expectedSessions = sessions;
+
+        // when
+        const result = certificationSessionsService.groupBySessions(sessions);
+
+        // then
+        expect(result).to.deep.equal(expectedSessions);
+      });
+    });
+
+    context('when there are two non following lines with the same session information', function () {
+      it('should return a list of two unique sessions', function () {
+        // given
+        const data = [
+          {
+            '* Nom du site': 'site1',
+            '* Nom de la salle': 'salle1',
+            '* Date de début': '2022-01-01',
+            '* Heure de début (heure locale)': '01:00',
+            '* Surveillant(s)': 'surveillant un',
+            'Observations (optionnel)': 'non',
+          },
+          {
+            '* Nom du site': 'site2',
+            '* Nom de la salle': 'salle2',
+            '* Date de début': '2022-02-02',
+            '* Heure de début (heure locale)': '02:00',
+            '* Surveillant(s)': 'surveillant deux',
+            'Observations (optionnel)': 'non',
+          },
+          {
+            '* Nom du site': 'site1',
+            '* Nom de la salle': 'salle1',
+            '* Date de début': '2022-01-01',
+            '* Heure de début (heure locale)': '01:00',
+            '* Surveillant(s)': 'surveillant un',
+            'Observations (optionnel)': 'non',
+          },
+        ];
+
+        const expectedData = [
+          {
+            '* Nom du site': 'site1',
+            '* Nom de la salle': 'salle1',
+            '* Date de début': '2022-01-01',
+            '* Heure de début (heure locale)': '01:00',
+            '* Surveillant(s)': 'surveillant un',
+            'Observations (optionnel)': 'non',
+          },
+          {
+            '* Nom du site': 'site2',
+            '* Nom de la salle': 'salle2',
+            '* Date de début': '2022-02-02',
+            '* Heure de début (heure locale)': '02:00',
+            '* Surveillant(s)': 'surveillant deux',
+            'Observations (optionnel)': 'non',
+          },
+        ];
+
+        // when
+        const result = certificationSessionsService.groupBySessions(data);
+
+        // then
+        expect(result).to.deep.equal(expectedData);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème

Lors de la PR #5354, nous enregistrons chacune des lignes du CSV d'import de sessions, et ce, même si elles se trouvent en plusieurs exemplaires dans le fichier.

## :gift: Proposition

Ajout d'un service pour filtrer la donnée reçue en entrée du usecase afin d'obtenir un tableau de sessions uniques.

## :star2: Remarques
N/A

## :santa: Pour tester

```
N° de session;* Nom du site;* Nom de la salle;* Date de début;* Heure de début (heure locale);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: jj/mm/aaaa);* Sexe (M ou F);Code Insee;Code postal;Nom de la commune;* Pays;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant local;Temps majoré ?
;site1;salle1;2022-10-19;12:00;surveillant;non;;;;;;;;;;;;
;site2;salle2;2022-12-23;14:00;surveillant deux;non;;;;;;;;;;;;
;site1;salle1;2022-10-19;12:00;surveillant;non;;;;;;;;;;;;
```

Dans Pix-certif, importer le fichier ci-dessus grâce au bouton d'import de sessions en masse et vérifier que seules deux sessions ont été importées.