### PR TITLE
[TECH] Ecrire correctement le terme "profil cible" dans les applicatifs / seeds (PIX-6660)

### DIFF
--- a/admin/app/components/badges/campaign-criterion.hbs
+++ b/admin/app/components/badges/campaign-criterion.hbs
@@ -1,3 +1,3 @@
 <p data-testid="triste">L‘évalué doit obtenir
   <strong>{{@criterion.threshold}}%</strong>
-  sur l‘ensemble des acquis du profil-cible.</p>
+  sur l‘ensemble des acquis du profil cible.</p>

--- a/admin/app/components/target-profiles/target-profile.hbs
+++ b/admin/app/components/target-profiles/target-profile.hbs
@@ -102,7 +102,7 @@
       @route="authenticated.target-profiles.target-profile.organizations"
       @model={{@model}}
       class="navbar-item"
-      aria-label="Organisations du profil-cible"
+      aria-label="Organisations du profil cible"
     >
       Organisations
     </LinkTo>

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation_test.js
@@ -61,7 +61,7 @@ module('Acceptance | Target profile creation', function (hooks) {
       server.get('/admin/frameworks', (schema) => schema.frameworks.all());
       const screen = await visit('/target-profiles/list');
       await clickByName('Nouveau profil cible');
-      await fillByLabel('Nom (obligatoire) :', 'Un profil-cible, et vite !');
+      await fillByLabel('Nom (obligatoire) :', 'Un profil cible, et vite !');
       await fillByLabel("Identifiant de l'organisation de référence :", 1);
       await fillByLabel('Référentiel :', 'Pi');
       const otherFrameworkChoice = screen.getByLabelText('Pix + Cuisine');
@@ -74,7 +74,7 @@ module('Acceptance | Target profile creation', function (hooks) {
       // then
       assert.strictEqual(currentURL(), '/target-profiles/1');
       await _unfoldLearningContent();
-      assert.dom(screen.getByRole('heading', { name: 'Un profil-cible, et vite !' })).exists();
+      assert.dom(screen.getByRole('heading', { name: 'Un profil cible, et vite !' })).exists();
       let isMobileCompliant = screen.getByTestId('mobile-compliant-tube_f1_a1_c1_th1_tu1').getAttribute('aria-label');
       let isTabletCompliant = screen.getByTestId('tablet-compliant-tube_f1_a1_c1_th1_tu1').getAttribute('aria-label');
       assert.deepEqual(

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -14,7 +14,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
       const badge = server.create('badge', { id: 200 });
       const targetProfile = server.create('target-profile', {
         id: 1,
-        name: 'Profil-cible extra croustillant',
+        name: 'Profil cible extra croustillant',
         badges: [badge],
       });
       server.create('stage', { id: 100, targetProfile });
@@ -69,7 +69,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
     let targetProfile;
 
     hooks.beforeEach(async function () {
-      targetProfile = server.create('target-profile', { id: 1, name: 'Profil-cible extra croustillant' });
+      targetProfile = server.create('target-profile', { id: 1, name: 'Profil cible extra croustillant' });
       await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
     });
 
@@ -122,7 +122,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
 
         // when
         await visit('/target-profiles/1/stages/100');
-        await clickByName('Profil-cible extra croustillant');
+        await clickByName('Profil cible extra croustillant');
 
         // then
         assert.strictEqual(currentURL(), '/target-profiles/1/insights');
@@ -245,7 +245,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         assert.dom(screen.getByText('Lacunes')).exists();
         assert.deepEqual(
           screen.getByTestId('triste').innerText,
-          'L‘évalué doit obtenir 50% sur l‘ensemble des acquis du profil-cible.'
+          'L‘évalué doit obtenir 50% sur l‘ensemble des acquis du profil cible.'
         );
       });
 
@@ -255,7 +255,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
 
         // when
         await visit('/target-profiles/1/badges/100');
-        await clickByName('Profil-cible extra croustillant');
+        await clickByName('Profil cible extra croustillant');
 
         // then
         assert.strictEqual(currentURL(), '/target-profiles/1/insights');
@@ -427,7 +427,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         assert.dom(screen.getByText('Lacunes')).exists();
         assert.deepEqual(
           screen.getByTestId('triste').innerText,
-          'L‘évalué doit obtenir 50% sur l‘ensemble des acquis du profil-cible.'
+          'L‘évalué doit obtenir 50% sur l‘ensemble des acquis du profil cible.'
         );
         const labelsForCappedTubes = screen.getAllByTestId('toujourstriste');
         assert.deepEqual(

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/organizations_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/organizations_test.js
@@ -68,7 +68,7 @@ module('Acceptance | Target Profile Organizations', function (hooks) {
 
       test('should list organizations', async function (assert) {
         const screen = await visit('/target-profiles/1');
-        await clickByName('Organisations du profil-cible');
+        await clickByName('Organisations du profil cible');
 
         assert.dom(screen.getByText('My organization')).exists();
         assert.dom(screen.getByText('My other organization')).exists();
@@ -77,7 +77,7 @@ module('Acceptance | Target Profile Organizations', function (hooks) {
       test('it should redirect to organization details on click', async function (assert) {
         // given
         await visit('/target-profiles/1');
-        await clickByName('Organisations du profil-cible');
+        await clickByName('Organisations du profil cible');
 
         // when
         await clickByName('456');
@@ -88,7 +88,7 @@ module('Acceptance | Target Profile Organizations', function (hooks) {
 
       test('should be able to add new organization to the target profile', async function (assert) {
         const screen = await visit('/target-profiles/1');
-        await clickByName('Organisations du profil-cible');
+        await clickByName('Organisations du profil cible');
 
         await fillByLabel('Rattacher une ou plusieurs organisation(s)', '42');
         await clickByName('Valider le rattachement');
@@ -98,7 +98,7 @@ module('Acceptance | Target Profile Organizations', function (hooks) {
 
       test('should be able to attach an organization with given target profile', async function (assert) {
         const screen = await visit('/target-profiles/1');
-        await clickByName('Organisations du profil-cible');
+        await clickByName('Organisations du profil cible');
 
         await fillByLabel("Rattacher les organisations d'un profil cible existant", '43');
         await clickByName('Valider le rattachement à partir de ce profil cible');

--- a/admin/tests/integration/components/badges/badge_test.js
+++ b/admin/tests/integration/components/badges/badge_test.js
@@ -76,7 +76,7 @@ module('Integration | Component | Badges::Badge', function (hooks) {
     // then
     assert.deepEqual(
       screen.getByTestId('triste').innerText,
-      'L‘évalué doit obtenir 25% sur l‘ensemble des acquis du profil-cible.'
+      'L‘évalué doit obtenir 25% sur l‘ensemble des acquis du profil cible.'
     );
     assert.deepEqual(
       screen.getByTestId('toujourstriste').innerText,

--- a/admin/tests/integration/components/badges/campaign-criterion_test.js
+++ b/admin/tests/integration/components/badges/campaign-criterion_test.js
@@ -20,7 +20,7 @@ module('Integration | Component | Badges::CampaignCriterion', function (hooks) {
     // then
     assert.deepEqual(
       screen.getByTestId('triste').innerText,
-      'L‘évalué doit obtenir 60% sur l‘ensemble des acquis du profil-cible.'
+      'L‘évalué doit obtenir 60% sur l‘ensemble des acquis du profil cible.'
     );
   });
 });

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -430,7 +430,7 @@ exports.register = async (server) => {
         tags: ['api', 'admin', 'target-profiles', 'organizations'],
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
-            '- Elle permet de rattacher des profil-cibles à une organisation',
+            '- Elle permet de rattacher des profil cibles à une organisation',
         ],
       },
     },
@@ -458,7 +458,7 @@ exports.register = async (server) => {
         handler: organizationController.findTargetProfileSummariesForAdmin,
         tags: ['api', 'organizations', 'target-profiles'],
         notes: [
-          `- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n- Elle retourne la liste des profil-cibles d'une organisation`,
+          `- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n- Elle retourne la liste des profil cibles d'une organisation`,
         ],
       },
     },

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -437,7 +437,7 @@ exports.register = async (server) => {
         handler: targetProfileController.getLearningContentAsPdf,
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
-            '- Elle permet de récupérer le référentiel du profil-cible en version pdf',
+            '- Elle permet de récupérer le référentiel du profil cible en version pdf',
         ],
         tags: ['api', 'learning-content', 'target-profile', 'PDF'],
       },

--- a/api/lib/domain/usecases/attach-target-profiles-to-organization.js
+++ b/api/lib/domain/usecases/attach-target-profiles-to-organization.js
@@ -12,7 +12,7 @@ module.exports = async function attachTargetProfilesToOrganization({
   const foundTargetProfileIds = foundTargetProfiles.map((tp) => tp.id);
   const unknownTargetProfileIds = _.difference(uniqTargetProfileIds, foundTargetProfileIds);
   if (unknownTargetProfileIds.length > 0) {
-    throw new NotFoundError(`Le(s) profil-cible(s) [${unknownTargetProfileIds.join(', ')}] n'existe(nt) pas.`);
+    throw new NotFoundError(`Le(s) profil cible(s) [${unknownTargetProfileIds.join(', ')}] n'existe(nt) pas.`);
   }
 
   return targetProfileShareRepository.addTargetProfilesToOrganization({

--- a/api/tests/unit/domain/usecases/attach-target-profiles-to-organization_test.js
+++ b/api/tests/unit/domain/usecases/attach-target-profiles-to-organization_test.js
@@ -34,7 +34,7 @@ describe('Unit | UseCase | attach-target-profiles-to-organization', function () 
 
       // then
       expect(err).to.be.instanceOf(NotFoundError);
-      expect(err.message).to.equal("Le(s) profil-cible(s) [55, 66] n'existe(nt) pas.");
+      expect(err.message).to.equal("Le(s) profil cible(s) [55, 66] n'existe(nt) pas.");
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
L'orthographe n'est pas su et reproduite correctement partout du terme "profil cible".
La bonne orthographe est "profil cible" et non "profil-cible", car le mot cible fait office dans ce cas d'apport de qualification.
c.f: https://1024pix.slack.com/archives/C66CN9STX/p1670519099483579?thread_ts=1670517551.784599&cid=C66CN9STX
ou https://andreracicot.ca/plurielnomsadjectives/

## :gift: Proposition
Corriger l'orthographe

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
