### PR TITLE
[TECH] Retirer Bookshelf du repository des Sessions

### DIFF
--- a/api/lib/domain/services/session-code-service.js
+++ b/api/lib/domain/services/session-code-service.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const config = require('../../config');
-const sessionRepository = require('../../infrastructure/repositories/sessions/session-repository');
 
 function _randomLetter() {
   const letters = config.availableCharacterForCode.letters.split('');
@@ -26,12 +25,6 @@ function _generateSessionCode() {
 
 module.exports = {
   async getNewSessionCode() {
-    const newSessionCode = _generateSessionCode();
-    const codeAvailable = await sessionRepository.isSessionCodeAvailable(newSessionCode);
-    return codeAvailable ? newSessionCode : this.getNewSessionCode();
-  },
-
-  getNewSessionCodeWithoutAvailabilityCheck() {
     return _generateSessionCode();
   },
 };

--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -74,7 +74,7 @@ async function _saveNewSessionReturningId(sessionRepository, domainSession, doma
 }
 
 function _createAndValidateNewSessionToSave(session, certificationCenterId, certificationCenter) {
-  const accessCode = sessionCodeService.getNewSessionCodeWithoutAvailabilityCheck();
+  const accessCode = sessionCodeService.getNewSessionCode();
   const domainSession = new Session({
     ...session,
     certificationCenterId,

--- a/api/lib/infrastructure/repositories/sessions/session-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-repository.js
@@ -24,11 +24,6 @@ module.exports = {
     return knex.batchInsert('sessions', sessions);
   },
 
-  async isSessionCodeAvailable(accessCode) {
-    const sessionWithAccessCode = await knex('sessions').where({ accessCode }).returning('id');
-    return !sessionWithAccessCode.length;
-  },
-
   async isFinalized(id) {
     const session = await knex('sessions').where({ id }).whereNotNull('finalizedAt').returning('id');
     return Boolean(session.length);

--- a/api/lib/infrastructure/repositories/sessions/session-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-repository.js
@@ -25,8 +25,8 @@ module.exports = {
   },
 
   async isFinalized(id) {
-    const session = await knex('sessions').where({ id }).whereNotNull('finalizedAt').returning('id');
-    return Boolean(session.length);
+    const session = await knex.select('id').from('sessions').where({ id }).whereNotNull('finalizedAt').first();
+    return Boolean(session);
   },
 
   async get(sessionId) {
@@ -93,8 +93,9 @@ module.exports = {
   },
 
   async doesUserHaveCertificationCenterMembershipForSession(userId, sessionId) {
-    const session = await knex('sessions')
+    const sessions = await knex
       .select('sessions.id')
+      .from('sessions')
       .where({
         'sessions.id': sessionId,
         'certification-center-memberships.userId': userId,
@@ -106,7 +107,7 @@ module.exports = {
         'certification-center-memberships.certificationCenterId',
         'certification-centers.id'
       );
-    return Boolean(session.length);
+    return Boolean(sessions.length);
   },
 
   async finalize({ id, examinerGlobalComment, hasIncident, hasJoiningIssue, finalizedAt }) {

--- a/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
@@ -58,45 +58,6 @@ describe('Integration | Repository | Session', function () {
     });
   });
 
-  describe('#isSessionCodeAvailable', function () {
-    beforeEach(function () {
-      databaseBuilder.factory.buildSession({
-        certificationCenter: 'Paris',
-        address: 'Paris',
-        room: 'The lost room',
-        examiner: 'Bernard',
-        date: '2018-02-23',
-        time: '12:00',
-        description: 'The lost examen',
-        accessCode: 'ABCD12',
-      });
-
-      return databaseBuilder.commit();
-    });
-
-    it('should return true if the accessCode is not in database', async function () {
-      // given
-      const accessCode = 'DEFG34';
-
-      // when
-      const isAvailable = await sessionRepository.isSessionCodeAvailable(accessCode);
-
-      // then
-      expect(isAvailable).to.be.equal(true);
-    });
-
-    it('should return false if the accessCode is in database', async function () {
-      // given
-      const accessCode = 'ABCD12';
-
-      // when
-      const isAvailable = await sessionRepository.isSessionCodeAvailable(accessCode);
-
-      // then
-      expect(isAvailable).to.be.equal(false);
-    });
-  });
-
   describe('#isFinalized', function () {
     let finalizedSessionId;
     let notFinalizedSessionId;

--- a/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
@@ -68,7 +68,7 @@ describe('Integration | Repository | Session', function () {
         date: '2018-02-23',
         time: '12:00',
         description: 'The lost examen',
-        accessCode: 'ABC123',
+        accessCode: 'ABCD12',
       });
 
       return databaseBuilder.commit();
@@ -76,7 +76,7 @@ describe('Integration | Repository | Session', function () {
 
     it('should return true if the accessCode is not in database', async function () {
       // given
-      const accessCode = 'DEF123';
+      const accessCode = 'DEFG34';
 
       // when
       const isAvailable = await sessionRepository.isSessionCodeAvailable(accessCode);
@@ -87,7 +87,7 @@ describe('Integration | Repository | Session', function () {
 
     it('should return false if the accessCode is in database', async function () {
       // given
-      const accessCode = 'ABC123';
+      const accessCode = 'ABCD12';
 
       // when
       const isAvailable = await sessionRepository.isSessionCodeAvailable(accessCode);

--- a/api/tests/unit/domain/services/session-code-service_test.js
+++ b/api/tests/unit/domain/services/session-code-service_test.js
@@ -1,55 +1,14 @@
-const { expect, sinon } = require('../../../test-helper');
+const { expect } = require('../../../test-helper');
 const sessionCodeService = require('../../../../lib/domain/services/session-code-service');
-const sessionRepository = require('../../../../lib/infrastructure/repositories/sessions/session-repository');
-const _ = require('lodash');
 
 describe('Unit | Service | CodeSession', function () {
   describe('#getNewSessionCode', function () {
     it('should return a non ambiguous session code with 4 random capital letters and 2 random numbers', async function () {
-      // given
-      sinon.stub(sessionRepository, 'isSessionCodeAvailable').resolves(true);
-
       // when
       const result = await sessionCodeService.getNewSessionCode();
 
       // then
       expect(result).to.match(/[B,C,D,F,G,H,J,K,M,P,Q,R,T,V,W,X,Y]{4}[2,3,4,6,7,8,9]{2}/);
-    });
-
-    it('should return a new code if first code was not unique', async function () {
-      // given
-      sinon.stub(sessionRepository, 'isSessionCodeAvailable').onCall(0).resolves(false).onCall(1).resolves(true);
-      sinon
-        .stub(_, 'sample')
-        .returns('A')
-        .onCall(6)
-        .returns('B')
-        .onCall(7)
-        .returns('B')
-        .onCall(8)
-        .returns('B')
-        .onCall(9)
-        .returns('B')
-        .onCall(10)
-        .returns('2')
-        .onCall(11)
-        .returns('2');
-
-      // when
-      const result = await sessionCodeService.getNewSessionCode();
-
-      // then
-      expect(result).to.equal('BBBB22');
-    });
-  });
-
-  describe('#getNewSessionCodeWithoutAvailabilityCheck', function () {
-    it('should return a non ambiguous session code with 4 random capital letters and 2 random numbers', async function () {
-      // when
-      const sessionCode = sessionCodeService.getNewSessionCodeWithoutAvailabilityCheck();
-
-      // then
-      expect(sessionCode).to.match(/[B,C,D,F,G,H,J,K,M,P,Q,R,T,V,W,X,Y]{4}[2,3,4,6,7,8,9]{2}/);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/unit/domain/usecases/create-sessions_test.js
@@ -31,9 +31,9 @@ describe('Unit | UseCase | create-sessions', function () {
     certificationCandidateRepository = { saveInSession: sinon.stub(), deleteBySessionId: sinon.stub() };
     complementaryCertificationRepository = { getByLabel: sinon.stub() };
     sessionRepository = { save: sinon.stub(), getExistingSessionByInformation: sinon.stub() };
-    sinon.stub(sessionCodeService, 'getNewSessionCodeWithoutAvailabilityCheck');
+    sinon.stub(sessionCodeService, 'getNewSessionCode');
     sinon.stub(certificationCpfService, 'getBirthInformation');
-    sessionCodeService.getNewSessionCodeWithoutAvailabilityCheck.returns(accessCode);
+    sessionCodeService.getNewSessionCode.returns(accessCode);
     certificationCenterRepository.get.withArgs(certificationCenterId).resolves(certificationCenter);
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
D'après l'[ADR N°28](https://github.com/1024pix/pix/blob/dev/docs/adr/0028-remplacer-orm-bookshelfjs-par-query-builder-knexjs.md) il faut remplacer les usages de l'ORM Bookshelf par des usages du query builder Knex.

## :gift: Proposition
Remplacer les appels à Bookshelf par des requêtes Knex.

## :star2: Remarques
La méthode isSessionCodeAvailable et surtout le code qu'elle appelle me semblent bizarres. Pourquoi vouloir s'assurer qu'un code d'accès est unique.

## :santa: Pour tester
L'ensemble des tests et notamment ceux du session-repository doivent passer. 
