### PR TITLE
[FEATURE] Rendre le participant cliquable pour accéder a sa page de détail (PIX-6066)

### DIFF
--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -51,8 +51,19 @@
     {{#if @participants}}
       <tbody>
         {{#each @participants as |participant index|}}
-          <tr aria-label={{t "pages.organization-participants.table.row-title"}}>
-            <td class="ellipsis" title={{participant.lastName}}>{{participant.lastName}}</td>
+          <tr
+            aria-label={{t "pages.organization-participants.table.row-title"}}
+            {{on "click" (fn @onClickLearner participant.id)}}
+            class="tr--clickable"
+          >
+            <td class="table__column">
+              <LinkTo
+                @route="authenticated.organization-participants.organization-participant"
+                @model={{participant.id}}
+              >
+                {{participant.lastName}}
+              </LinkTo>
+            </td>
             <td class="ellipsis" title={{participant.firstName}}>{{participant.firstName}}</td>
             <td class="table__column--right">{{participant.participationCount}}</td>
             <td>

--- a/orga/app/controllers/authenticated/campaigns/list/all-campaigns.js
+++ b/orga/app/controllers/authenticated/campaigns/list/all-campaigns.js
@@ -1,10 +1,12 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 
 const DEFAULT_PAGE_NUMBER = 1;
 
 export default class AuthenticatedCampaignsListAllCampaignsController extends Controller {
+  @service router;
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 50;
   @tracked name = null;
@@ -36,7 +38,6 @@ export default class AuthenticatedCampaignsListAllCampaignsController extends Co
   @action
   goToCampaignPage(campaignId, event) {
     event.preventDefault();
-    event.stopPropagation();
-    this.transitionToRoute('authenticated.campaigns.campaign', campaignId);
+    this.router.transitionTo('authenticated.campaigns.campaign', campaignId);
   }
 }

--- a/orga/app/controllers/authenticated/campaigns/list/my-campaigns.js
+++ b/orga/app/controllers/authenticated/campaigns/list/my-campaigns.js
@@ -1,10 +1,12 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 
 const DEFAULT_PAGE_NUMBER = 1;
 
 export default class AuthenticatedCampaignsListMyCampaignsController extends Controller {
+  @service router;
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 50;
   @tracked name = null;
@@ -34,7 +36,6 @@ export default class AuthenticatedCampaignsListMyCampaignsController extends Con
   @action
   goToCampaignPage(campaignId, event) {
     event.preventDefault();
-    event.stopPropagation();
-    this.transitionToRoute('authenticated.campaigns.campaign', campaignId);
+    this.router.transitionTo('authenticated.campaigns.campaign', campaignId);
   }
 }

--- a/orga/app/controllers/authenticated/organization-participants/list.js
+++ b/orga/app/controllers/authenticated/organization-participants/list.js
@@ -6,6 +6,7 @@ import { tracked } from '@glimmer/tracking';
 export default class ListController extends Controller {
   @service currentUser;
   @service intl;
+  @service router;
 
   @tracked pageNumber = 1;
   @tracked pageSize = 25;
@@ -23,6 +24,12 @@ export default class ListController extends Controller {
     this.pageNumber = null;
     this.fullName = null;
     this.certificability = [];
+  }
+
+  @action
+  goToLearnerPage(learnerId, event) {
+    event.preventDefault();
+    this.router.transitionTo('authenticated.organization-participants.organization-participant', learnerId);
   }
 
   get certificabilityOptions() {

--- a/orga/app/templates/authenticated/organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/organization-participants/list.hbs
@@ -8,6 +8,7 @@
       @triggerFiltering={{this.triggerFiltering}}
       @onResetFilter={{this.resetFilters}}
       @fullName={{this.fullName}}
+      @onClickLearner={{this.goToLearnerPage}}
       @certificabilityFilter={{this.certificability}}
       @certificabilityOptions={{this.certificabilityOptions}}
     />

--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -17,7 +17,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
       organization = organization;
     }
     this.owner.register('service:current-user', CurrentUserStub);
-    this.set('stub', () => {});
+    this.set('noop', sinon.stub());
   });
 
   test('it should display the header labels', async function (assert) {
@@ -26,7 +26,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
     // when
     await render(
-      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.stub}} />`
+      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.noop}} @onClickLearner={{this.noop}}/>`
     );
 
     // then
@@ -54,12 +54,38 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
     // when
     await render(
-      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.stub}}/>`
+      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.noop}} @onClickLearner={{this.noop}}/>`
     );
 
     // then
     assert.contains('La Terreur');
     assert.contains("L'asticot");
+  });
+
+  test('it should display a link to access participant detail', async function (assert) {
+    // given
+    this.owner.setupRouter();
+
+    const participants = [
+      {
+        lastName: 'Chase',
+        firstName: 'PatPatrouille',
+        id: 34,
+      },
+      {
+        lastName: 'Ruben',
+        firstName: 'PatPatrouille',
+        id: 56,
+      },
+    ];
+    this.set('participants', participants);
+
+    // when
+    const screen = await render(
+      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.noop}} @onClickLearner={{this.noop}}/>`
+    );
+    // then
+    assert.dom(screen.getByRole('link', { name: 'Ruben' })).hasProperty('href', /\/participants\/56/g);
   });
 
   test('it should display the participant firstName and lastName', async function (assert) {
@@ -75,7 +101,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
     // when
     await render(
-      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.stub}}/>`
+      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.noop}} @onClickLearner={{this.noop}}/>`
     );
 
     // then
@@ -104,7 +130,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
     // when
     const screen = await render(
-      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.stub}}/>`
+      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.noop}} @onClickLearner={{this.noop}}/>`
     );
     const allRows = screen.getAllByLabelText(this.intl.t('pages.organization-participants.table.row-title'));
 
@@ -134,7 +160,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
     // when
     const screen = await render(
-      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.stub}}/>`
+      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.noop}} @onClickLearner={{this.noop}}/>`
     );
     const allRows = screen.getAllByLabelText(this.intl.t('pages.organization-participants.table.row-title'));
 
@@ -166,7 +192,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
     // when
     await render(
-      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.stub}}/>`
+      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.noop}} @onClickLearner={{this.noop}}/>`
     );
 
     // then
@@ -188,7 +214,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
     // when
     await render(
-      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.triggerFiltering}}/>`
+      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.triggerFiltering}} @onClickLearner={{this.noop}}/>`
     );
     await fillByLabel('Recherche sur le nom et prénom', 'Karam');
     // then
@@ -205,7 +231,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     this.set('certificability', []);
 
     const { getByPlaceholderText, findByRole } = await render(
-      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.triggerFiltering}} @certificabilityOptions={{this.certificabilityOptions}} @certificability={{this.certificability}} />`
+      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.triggerFiltering}} @certificabilityOptions={{this.certificabilityOptions}} @certificability={{this.certificability}} @onClickLearner={{this.noop}}/>`
     );
 
     // when
@@ -230,7 +256,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
     // when
     await render(
-      hbs`<OrganizationParticipant::List @participants={{this.participants}}  @triggerFiltering={{this.triggerFiltering}}/>`
+      hbs`<OrganizationParticipant::List @participants={{this.participants}}  @triggerFiltering={{this.triggerFiltering}} @onClickLearner={{this.noop}}/>`
     );
     await fillByLabel('Recherche sur le nom et prénom', 'Karam');
 
@@ -253,7 +279,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
 
     // when
     const screen = await render(
-      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.triggerFiltering}}/>`
+      hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.triggerFiltering}} @onClickLearner={{this.noop}}/>`
     );
     assert
       .dom(

--- a/orga/tests/unit/controllers/authenticated/campaigns/list/all-campaigns_test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/list/all-campaigns_test.js
@@ -46,15 +46,14 @@ module('Unit | Controller | authenticated/campaigns/list/all-campaigns', functio
   module('#action goToCampaignPage', function () {
     test('it should call transitionToRoute with appropriate arguments', function (assert) {
       // given
-      controller.transitionToRoute = sinon.stub();
+      controller.router = { transitionTo: sinon.stub() };
 
       // when
       controller.send('goToCampaignPage', 123, event);
 
       // then
       assert.true(event.preventDefault.called);
-      assert.true(event.stopPropagation.called);
-      assert.true(controller.transitionToRoute.calledWith('authenticated.campaigns.campaign', 123));
+      assert.true(controller.router.transitionTo.calledWith('authenticated.campaigns.campaign', 123));
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
On veut pouvoir accéder a la page de détail d'un participant en cliquant sur son nom depuis la liste de tous les participants

## :gift: Proposition
Rendre la ligne du participant cliquable

## :star2: Remarques
⚠️ Ne pas merger cette PR avant que la 6140 ne soit done.

## :santa: Pour tester

- Se connecter a pix orga avec un compte pro
- Aller sur la liste des participants
- Cliquer sur un participant
- Vérifier qu'on accède bien a sa page de détail
