### PR TITLE
[CHORE] Mise a jour de Pix-ui a la version 23.3.0 dans pix orga (PIX-6142).

### DIFF
--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.0",
-        "@1024pix/pix-ui": "^23.2.0",
+        "@1024pix/pix-ui": "^23.3.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
         "@ember/optional-features": "^2.0.0",
@@ -1049,12 +1049,13 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "23.2.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-23.2.0.tgz",
-      "integrity": "sha512-pkTY2H1CX5Md196QtEtbR3RCIuo7bP1eYP00C6h8bQeXzjIjOPfXJZvx7rz8ZK/ugRs65ADjAdT8Ud5+CZizFw==",
+      "version": "23.3.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-23.3.0.tgz",
+      "integrity": "sha512-b3WuosMB0xUk0QeileWvqHJIkKUbroKNvZQHMfxgy/+XVTYf0q4PB3Op6nJFr9aix22KX5VmFKeNlvndBiO8bg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
+        "color": "^4.2.3",
         "ember-cli-babel": "^7.26.8",
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-sass": "^11.0.1",
@@ -11592,6 +11593,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -11609,6 +11623,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -31270,6 +31294,21 @@
       "integrity": "sha1-m4tVWdgOMxpUTdE91ZOC5dDZRBE=",
       "dev": true
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "dev": true
+    },
     "node_modules/sinon": {
       "version": "14.0.2",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.2.tgz",
@@ -34916,11 +34955,12 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "23.2.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-23.2.0.tgz",
-      "integrity": "sha512-pkTY2H1CX5Md196QtEtbR3RCIuo7bP1eYP00C6h8bQeXzjIjOPfXJZvx7rz8ZK/ugRs65ADjAdT8Ud5+CZizFw==",
+      "version": "23.3.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-23.3.0.tgz",
+      "integrity": "sha512-b3WuosMB0xUk0QeileWvqHJIkKUbroKNvZQHMfxgy/+XVTYf0q4PB3Op6nJFr9aix22KX5VmFKeNlvndBiO8bg==",
       "dev": true,
       "requires": {
+        "color": "^4.2.3",
         "ember-cli-babel": "^7.26.8",
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-sass": "^11.0.1",
@@ -43342,6 +43382,16 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      }
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -43356,6 +43406,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "color-support": {
       "version": "1.1.3",
@@ -59017,6 +59077,23 @@
       "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.3.0.tgz",
       "integrity": "sha1-m4tVWdgOMxpUTdE91ZOC5dDZRBE=",
       "dev": true
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+          "dev": true
+        }
+      }
     },
     "sinon": {
       "version": "14.0.2",

--- a/orga/package.json
+++ b/orga/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.0",
-    "@1024pix/pix-ui": "^23.2.0",
+    "@1024pix/pix-ui": "^23.3.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
## :christmas_tree: Problème
Besoin de mettre a jour pix ui dans pix orga pour utiliser le nouveau composant carte

## :gift: Proposition
Mettre a jour Pix ui a la version 23.3.0

## :star2: Remarques
Pas de breaking change, juste un fix css sur le Pix Select et ajout du composant Carte

## :santa: Pour tester
Vérifier que la CI passe
