### PR TITLE
[BUGFIX] Reprendre le design des tutoriels "Pour en apprendre davantage" sur Pix-App (PIX-6584)

### DIFF
--- a/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
@@ -1,16 +1,10 @@
 .learning-more-panel {
   display: flex;
   flex-direction: column;
-  background-color: white;
   border-radius: 10px;
 }
 
 .learning-more-panel__container {
-  margin: 25px 15px;
-
-  @include device-is('desktop') {
-    margin: 25px 40px;
-  }
 
   & .tutorial-card {
     margin-bottom: 16px;
@@ -18,7 +12,7 @@
 }
 
 .learning-more-panel__hint-title {
-  @include tutorial-panel-title(white);
+  @include tutorial-panel-title($pix-neutral-10);
 }
 
 .learning-more-panel__tutorial-info {

--- a/mon-pix/app/styles/components/_tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_tutorial-panel.scss
@@ -1,7 +1,7 @@
 .tutorial-panel {
   display: flex;
   flex-direction: column;
-  margin-bottom: 40px;
+  margin-bottom: 30px;
 }
 
 .tutorial-panel__hint-container-body {


### PR DESCRIPTION
## :christmas_tree: Problème
Il y a une régression design sur les tutoriels "Pour en apprendre davantage" qui sont dans un encadré blanc.
![image](https://user-images.githubusercontent.com/49011144/209966698-a1fdbcd2-b042-4e74-a3ff-340396afb1c8.png)


## :gift: Proposition
Corriger le css.

## :santa: Pour tester
Vérifier visuellement que les tutoriels "Pour en apprendre davantage" sont similiares aux tutoriels "Pour réussir la prochaine fois"
