### PR TITLE
[FEATURE] Changer le select de la méthode de connexion pour un multi select orga sco (PIX-6626)

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -777,7 +777,7 @@ exports.register = async (server) => {
             'page[size]': Joi.number().integer().empty(''),
             'page[number]': Joi.number().integer().empty(''),
             'filter[divisions][]': [Joi.string(), Joi.array().items(Joi.string())],
-            'filter[connexionType]': Joi.string().empty(''),
+            'filter[connexionType][]': [Joi.string(), Joi.array().items(Joi.string())],
             'filter[search]': Joi.string().empty(''),
             'filter[certificability][]': [Joi.string(), Joi.array().items(Joi.string())],
           }),

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -237,6 +237,9 @@ module.exports = {
     if (filter.divisions && !Array.isArray(filter.divisions)) {
       filter.divisions = [filter.divisions];
     }
+    if (filter.connexionType && !Array.isArray(filter.connexionType)) {
+      filter.connexionType = [filter.connexionType];
+    }
     if (filter.certificability) {
       filter.certificability = mapCertificabilityByLabel(filter.certificability);
     }

--- a/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
@@ -15,18 +15,27 @@ function _setFilters(qb, { search, divisions, connexionType, certificability } =
   if (!_.isEmpty(divisions)) {
     qb.whereIn('division', divisions);
   }
-  if (connexionType === 'none') {
-    qb.whereRaw('"users"."username" IS NULL');
-    qb.whereRaw('"users"."email" IS NULL');
-    // we only retrieve GAR authentication method in join clause
-    qb.whereRaw('"authentication-methods"."externalIdentifier" IS NULL');
-  } else if (connexionType === 'identifiant') {
-    qb.whereRaw('"users"."username" IS NOT NULL');
-  } else if (connexionType === 'email') {
-    qb.whereRaw('"users"."email" IS NOT NULL');
-  } else if (connexionType === 'mediacentre') {
-    // we only retrieve GAR authentication method in join clause
-    qb.whereRaw('"authentication-methods"."externalIdentifier" IS NOT NULL');
+  if (!_.isEmpty(connexionType)) {
+    qb.where(function () {
+      if (connexionType.includes('none')) {
+        this.orWhere(function () {
+          this.whereRaw('"users"."username" IS NULL');
+          this.whereRaw('"users"."email" IS NULL');
+          // we only retrieve GAR authentication method in join clause
+          this.whereRaw('"authentication-methods"."externalIdentifier" IS NULL');
+        });
+      }
+      if (connexionType.includes('identifiant')) {
+        this.orWhereRaw('"users"."username" IS NOT NULL');
+      }
+      if (connexionType.includes('email')) {
+        this.orWhereRaw('"users"."email" IS NOT NULL');
+      }
+      if (connexionType.includes('mediacentre')) {
+        // we only retrieve GAR authentication method in join clause
+        this.orWhereRaw('"authentication-methods"."externalIdentifier" IS NOT NULL');
+      }
+    });
   }
   if (certificability) {
     qb.where(function (query) {

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1082,35 +1082,67 @@ describe('Acceptance | Application | organization-controller', function () {
         expect(response.statusCode).to.equal(200);
         expect(response.result.data).to.deep.equal(expectedResult.data);
       });
+      context('Certificability filter', function () {
+        it('should filter certificability with one value', async function () {
+          // given
+          options = {
+            method: 'GET',
+            url: `/api/organizations/${organization.id}/sco-participants?filter[certificability][]=eligible`,
+            headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+          };
 
-      it('should filter certificability with one value', async function () {
-        // given
-        options = {
-          method: 'GET',
-          url: `/api/organizations/${organization.id}/sco-participants?filter[certificability][]=eligible`,
-          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
-        };
+          // when
+          const response = await server.inject(options);
 
-        // when
-        const response = await server.inject(options);
+          // then
+          expect(response.statusCode).to.equal(200);
+        });
 
-        // then
-        expect(response.statusCode).to.equal(200);
+        it('should filter certificability with two values', async function () {
+          // given
+          options = {
+            method: 'GET',
+            url: `/api/organizations/${organization.id}/sco-participants?filter[certificability][]=eligible&filter[certificability][]=not-available`,
+            headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+        });
       });
+      context('Connexion type filter', function () {
+        it('should filter connexion type with one value', async function () {
+          // given
+          options = {
+            method: 'GET',
+            url: `/api/organizations/${organization.id}/sco-participants?filter[connexionType][]=none`,
+            headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+          };
 
-      it('should filter certificability with two values', async function () {
-        // given
-        options = {
-          method: 'GET',
-          url: `/api/organizations/${organization.id}/sco-participants?filter[certificability][]=eligible&filter[certificability][]=not-available`,
-          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
-        };
+          // when
+          const response = await server.inject(options);
 
-        // when
-        const response = await server.inject(options);
+          // then
+          expect(response.statusCode).to.equal(200);
+        });
 
-        // then
-        expect(response.statusCode).to.equal(200);
+        it('should filter connexion type with two values', async function () {
+          // given
+          options = {
+            method: 'GET',
+            url: `/api/organizations/${organization.id}/sco-participants?filter[connexionType][]=none&filter[connexionType][]=email`,
+            headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(200);
+        });
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
@@ -260,7 +260,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
             data: [{ lastName }],
           } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
             organizationId,
-            filter: { connexionType: 'none' },
+            filter: { connexionType: ['none'] },
           });
 
           // then
@@ -273,7 +273,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
             data: [{ lastName }],
           } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
             organizationId,
-            filter: { connexionType: 'identifiant' },
+            filter: { connexionType: ['identifiant'] },
           });
 
           // then
@@ -286,7 +286,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
             data: [{ lastName }],
           } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
             organizationId,
-            filter: { connexionType: 'email' },
+            filter: { connexionType: ['email'] },
           });
 
           // then
@@ -299,11 +299,22 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
             data: [{ lastName }],
           } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
             organizationId,
-            filter: { connexionType: 'mediacentre' },
+            filter: { connexionType: ['mediacentre'] },
           });
 
           // then
           expect(lastName).to.equal('Norris');
+        });
+        it('should return sco participants filtered by "none" & "mediacentre" user connexion', async function () {
+          // when
+          const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+            organizationId,
+            filter: { connexionType: ['mediacentre', 'none'] },
+          });
+
+          // then
+          expect(data[0].lastName).to.equal('Lee');
+          expect(data[1].lastName).to.equal('Norris');
         });
       });
 

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -657,7 +657,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       // then
       expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWith({
         organizationId,
-        filter: { lastName: 'Bob', firstName: 'Tom', connexionType: 'email', divisions: ['D1'] },
+        filter: { lastName: 'Bob', firstName: 'Tom', connexionType: ['email'], divisions: ['D1'] },
         page: {},
       });
     });

--- a/high-level-tests/e2e/cypress/support/step_definitions/student.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/student.js
@@ -4,7 +4,7 @@ When(`je veux gérer le compte d'un élève`, () => {
 });
 
 When('je sélectionne la méthode de connexion {string}', (value) => {
-  cy.contains('Méthode de connexion').click();
+  cy.get('[placeholder="Méthode de connexion"]').click();
   cy.contains(value).click();
 });
 
@@ -12,7 +12,7 @@ Then(`je vois la modale de gestion du compte de l'élève`, () => {
   cy.contains('Gestion du compte Pix de l’élève');
 });
 
-Then('je vois l\'identifiant généré', () => {
+Then("je vois l'identifiant généré", () => {
   cy.contains('Identifiant');
 });
 
@@ -20,10 +20,10 @@ Then('je vois le mot de passe généré', () => {
   cy.contains('Nouveau mot de passe à usage unique');
 });
 
-Then('je vois {int} élève\(s\)', (studentsCount) => {
+Then('je vois {int} élève(s)', (studentsCount) => {
   cy.get('[aria-label="Élève"]').should('have.lengthOf', studentsCount);
 });
 
-Then('je vois {int} étudiant\(s\)', (studentsCount) => {
+Then('je vois {int} étudiant(s)', (studentsCount) => {
   cy.get('[aria-label="Étudiant"]').should('have.lengthOf', studentsCount);
 });

--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -26,13 +26,14 @@
     @emptyMessage={{t "pages.sco-organization-participants.filter.division.empty"}}
   />
 
-  <Ui::SelectFilter
+  <Ui::MultiSelectFilter
     @field="connexionType"
-    @options={{this.connectionTypesOptions}}
+    @title={{t "pages.sco-organization-participants.filter.login-method.aria-label"}}
+    @onSelect={{@onFilter}}
     @selectedOption={{@connexionTypeFilter}}
-    @triggerFiltering={{@onFilter}}
+    @options={{this.connectionTypesOptions}}
+    @placeholder={{t "pages.sco-organization-participants.filter.login-method.empty-option"}}
     @ariaLabel={{t "pages.sco-organization-participants.filter.login-method.aria-label"}}
-    @emptyOptionLabel={{t "pages.sco-organization-participants.filter.login-method.empty-option"}}
   />
   <Ui::MultiSelectFilter
     @field="certificability"

--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -27,10 +27,10 @@
   />
 
   <Ui::MultiSelectFilter
-    @field="connexionType"
+    @field="connectionTypes"
     @title={{t "pages.sco-organization-participants.filter.login-method.aria-label"}}
     @onSelect={{@onFilter}}
-    @selectedOption={{@connexionTypeFilter}}
+    @selectedOption={{@connectionTypeFilter}}
     @options={{this.connectionTypesOptions}}
     @placeholder={{t "pages.sco-organization-participants.filter.login-method.empty-option"}}
     @ariaLabel={{t "pages.sco-organization-participants.filter.login-method.aria-label"}}

--- a/orga/app/controllers/authenticated/sco-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sco-organization-participants/list.js
@@ -13,7 +13,7 @@ export default class ListController extends Controller {
 
   @tracked search = null;
   @tracked divisions = [];
-  @tracked connexionType = [];
+  @tracked connectionTypes = [];
   @tracked certificability = [];
   @tracked pageNumber = null;
   @tracked pageSize = 50;
@@ -28,7 +28,7 @@ export default class ListController extends Controller {
   resetFiltering() {
     this.pageNumber = null;
     this.divisions = [];
-    this.connexionType = [];
+    this.connectionTypes = [];
     this.search = null;
     this.certificability = [];
   }

--- a/orga/app/controllers/authenticated/sco-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sco-organization-participants/list.js
@@ -13,7 +13,7 @@ export default class ListController extends Controller {
 
   @tracked search = null;
   @tracked divisions = [];
-  @tracked connexionType = null;
+  @tracked connexionType = [];
   @tracked certificability = [];
   @tracked pageNumber = null;
   @tracked pageSize = 50;
@@ -28,7 +28,7 @@ export default class ListController extends Controller {
   resetFiltering() {
     this.pageNumber = null;
     this.divisions = [];
-    this.connexionType = null;
+    this.connexionType = [];
     this.search = null;
     this.certificability = [];
   }

--- a/orga/app/routes/authenticated/sco-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sco-organization-participants/list.js
@@ -7,7 +7,7 @@ export default class ListRoute extends Route {
   queryParams = {
     search: { refreshModel: true },
     divisions: { refreshModel: true },
-    connexionType: { refreshModel: true },
+    connectionTypes: { refreshModel: true },
     certificability: { refreshModel: true },
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
@@ -22,7 +22,7 @@ export default class ListRoute extends Route {
         organizationId: this.currentUser.organization.id,
         search: params.search,
         divisions: params.divisions,
-        connexionType: params.connexionType,
+        connexionType: params.connectionTypes,
         certificability: params.certificability,
       },
       page: {
@@ -36,7 +36,7 @@ export default class ListRoute extends Route {
     if (isExiting) {
       controller.search = null;
       controller.divisions = [];
-      controller.connexionType = [];
+      controller.connectionTypes = [];
       controller.certificability = [];
       controller.pageNumber = null;
       controller.pageSize = 50;

--- a/orga/app/routes/authenticated/sco-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sco-organization-participants/list.js
@@ -36,7 +36,7 @@ export default class ListRoute extends Route {
     if (isExiting) {
       controller.search = null;
       controller.divisions = [];
-      controller.connexionType = null;
+      controller.connexionType = [];
       controller.certificability = [];
       controller.pageNumber = null;
       controller.pageSize = 50;

--- a/orga/app/templates/authenticated/sco-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sco-organization-participants/list.hbs
@@ -9,7 +9,7 @@
     @students={{@model}}
     @searchFilter={{this.search}}
     @divisionsFilter={{this.divisions}}
-    @connexionTypeFilter={{this.connexionType}}
+    @connectionTypeFilter={{this.connectionTypes}}
     @certificabilityFilter={{this.certificability}}
     @onFilter={{this.triggerFiltering}}
     @onResetFilter={{this.resetFiltering}}

--- a/orga/mirage/handlers/find-filtered-paginated-sco-organization-participants.js
+++ b/orga/mirage/handlers/find-filtered-paginated-sco-organization-participants.js
@@ -38,9 +38,9 @@ function _filtersFromQueryParams(schema, organizationId, queryParams) {
   if (connexionTypeFilter) {
     return schema.scoOrganizationParticipants.where((scoOrganizationParticipant) => {
       if (connexionTypeFilter === '') return true;
-      if (connexionTypeFilter === 'identifiant' && scoOrganizationParticipant.hasUsername) return true;
-      if (connexionTypeFilter === 'email' && scoOrganizationParticipant.hasEmail) return true;
-      if (connexionTypeFilter === 'mediacentre' && scoOrganizationParticipant.isAuthenticatedFromGar) return true;
+      if (connexionTypeFilter.includes('identifiant') && scoOrganizationParticipant.hasUsername) return true;
+      if (connexionTypeFilter.includes('email') && scoOrganizationParticipant.hasEmail) return true;
+      if (connexionTypeFilter.includes('mediacentre') && scoOrganizationParticipant.isAuthenticatedFromGar) return true;
       return false;
     });
   }

--- a/orga/tests/acceptance/sco-organization-participant-list_test.js
+++ b/orga/tests/acceptance/sco-organization-participant-list_test.js
@@ -144,13 +144,12 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
             screen.getByLabelText(this.intl.t('pages.sco-organization-participants.filter.login-method.aria-label'))
           );
           await click(
-            await screen.findByRole('option', {
+            await screen.findByRole('checkbox', {
               name: this.intl.t('pages.sco-organization-participants.connection-types.email'),
             })
           );
-
           // then
-          assert.strictEqual(currentURL(), '/eleves?connexionType=email');
+          assert.strictEqual(currentURL(), '/eleves?connexionType=%5B%22email%22%5D');
           assert.contains('Rambo');
           assert.notContains('Norris');
         });

--- a/orga/tests/acceptance/sco-organization-participant-list_test.js
+++ b/orga/tests/acceptance/sco-organization-participant-list_test.js
@@ -149,7 +149,7 @@ module('Acceptance | Sco Organization Participant List', function (hooks) {
             })
           );
           // then
-          assert.strictEqual(currentURL(), '/eleves?connexionType=%5B%22email%22%5D');
+          assert.strictEqual(currentURL(), '/eleves?connectionTypes=%5B%22email%22%5D');
           assert.contains('Rambo');
           assert.notContains('Norris');
         });

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -164,7 +164,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       assert.ok(true);
     });
 
-    test('it should trigger filtering with connexionType', async function (assert) {
+    test('it should trigger filtering with connectionType', async function (assert) {
       // given
       const triggerFiltering = sinon.spy();
       this.set('triggerFiltering', triggerFiltering);
@@ -179,7 +179,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       await click(await screen.findByRole('checkbox', { name: 'Adresse e-mail' }));
 
       // then
-      sinon.assert.calledWithExactly(triggerFiltering, 'connexionType', ['email']);
+      sinon.assert.calledWithExactly(triggerFiltering, 'connectionTypes', ['email']);
       assert.ok(true);
     });
 

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -176,10 +176,10 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
 
       // when
       await click(screen.getByLabelText('Rechercher par méthode de connexion'));
-      await click(await screen.findByRole('option', { name: 'Adresse e-mail' }));
+      await click(await screen.findByRole('checkbox', { name: 'Adresse e-mail' }));
 
       // then
-      sinon.assert.calledWithExactly(triggerFiltering, 'connexionType', 'email');
+      sinon.assert.calledWithExactly(triggerFiltering, 'connexionType', ['email']);
       assert.ok(true);
     });
 

--- a/orga/tests/unit/controllers/authenticated/sco-organization-participants/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/sco-organization-participants/list_test.js
@@ -113,7 +113,7 @@ module('Unit | Controller | authenticated/sco-organization-participants/list', f
       // given
       controller.search = 'th';
       controller.divisions = ['ing'];
-      controller.connexionType = 'co';
+      controller.connectionTypes = 'co';
       controller.certificability = ['ool'];
       controller.pageNumber = 1;
       controller.pageSize = 10;
@@ -124,7 +124,7 @@ module('Unit | Controller | authenticated/sco-organization-participants/list', f
       // then
       assert.strictEqual(controller.search, null);
       assert.deepEqual(controller.divisions, []);
-      assert.deepEqual(controller.connexionType, []);
+      assert.deepEqual(controller.connectionTypes, []);
       assert.deepEqual(controller.certificability, []);
       assert.strictEqual(controller.pageNumber, null);
       assert.strictEqual(controller.pageSize, 10);

--- a/orga/tests/unit/controllers/authenticated/sco-organization-participants/list_test.js
+++ b/orga/tests/unit/controllers/authenticated/sco-organization-participants/list_test.js
@@ -124,7 +124,7 @@ module('Unit | Controller | authenticated/sco-organization-participants/list', f
       // then
       assert.strictEqual(controller.search, null);
       assert.deepEqual(controller.divisions, []);
-      assert.strictEqual(controller.connexionType, null);
+      assert.deepEqual(controller.connexionType, []);
       assert.deepEqual(controller.certificability, []);
       assert.strictEqual(controller.pageNumber, null);
       assert.strictEqual(controller.pageSize, 10);


### PR DESCRIPTION
## :christmas_tree: Problème
Dans un Pix Orga sco avec import, onglet “élèves”, on peut filtrer sur le nom/prénom, la classe, la méthode de connexion et la certificabilité. Pour la méthode de connexion, le composant actuel est un dropdown, or les prescripteurs voudraient pouvoir filtrer les élèves sur des combinaisons de méthodes de connexion.

## :gift: Proposition
Dans les Pix Orga de type sco avec import, remplacer le composant de filtre sur la méthode de connexion par un multiselect.

## :star2: Remarques
Revoir le style du multiselect quand le isSearchable est à false.

## :santa: Pour tester

- Se connecter a Pix Orga avec un compte Sco
- Aller sur la liste des élèves
- Verifier le filtre par méthode de connexion -> MultiSelect
