### PR TITLE
[TECH] Supprimer les règles .editorconfig obsolètes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,15 +13,9 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 
-[*.js]
-quote_type = single
-spaces_around_brackets = both
 
 [*.hbs]
 insert_final_newline = false
 
 [*.{diff,md}]
 trim_trailing_whitespace = false
-
-[*.yaml]
-quote_type = single


### PR DESCRIPTION
## :christmas_tree: Problème
Des règles sont obsolètes, seules les[ suivantes](https://editorconfig.org/) existent
```
indent_style: set to "tab" or "space" to use hard tabs or soft tabs respectively.
indent_size: a whole number defining the number of columns used for each indentation level and the width of soft tabs (when supported). When set to "tab", the value of tab_width (if specified) will be used.
tab_width: a whole number defining the number of columns used to represent a tab character. This defaults to the value of indent_size and doesn't usually need to be specified.
end_of_line: set to "lf", "cr", or "crlf" to control how line breaks are represented.
charset: set to "latin1", "utf-8", "utf-8-bom", "utf-16be" or "utf-16le" to control the character set.
trim_trailing_whitespace: set to "true" to remove any whitespace characters preceding newline characters and "false" to ensure it doesn't.
insert_final_newline: set to "true" to ensure file ends with a newline when saving and "false" to ensure it doesn't.
```

## :gift: Proposition
Les supprimer

## :santa: Pour tester
Aucune idée
