### PR TITLE
Monter la version de PG de 13 à 14 en local et sur la CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
   api_build_and_test:
     docker:
       - image: cimg/node:16.18.1
-      - image: postgres:13.7-alpine
+      - image: postgres:14.6-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -243,7 +243,7 @@ jobs:
   e2e_test:
     docker:
       - image: cimg/node:16.18.1-browsers
-      - image: postgres:13.7-alpine
+      - image: postgres:14.6-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:13.7-alpine
+    image: postgres:14.6-alpine
     container_name: pix-api-postgres
     ports:
       - '${PIX_DATABASE_PORT:-5432}:5432'

--- a/scalingo.json
+++ b/scalingo.json
@@ -22,8 +22,15 @@
     "first-deploy": "./scripts/scalingo-post-ra-creation.sh"
   },
   "addons": [
-    "postgresql:postgresql-sandbox",
-    "redis:redis-sandbox"
+    {
+      "plan": "postgresql:postgresql-sandbox",
+      "options": {
+        "version": "14"
+      }
+    },
+    {
+      "plan": "redis:redis-sandbox"
+    }
   ],
   "formation": {
     "web": {

--- a/scalingo.json
+++ b/scalingo.json
@@ -22,15 +22,8 @@
     "first-deploy": "./scripts/scalingo-post-ra-creation.sh"
   },
   "addons": [
-    {
-      "plan": "postgresql:postgresql-sandbox",
-      "options": {
-        "version": "14"
-      }
-    },
-    {
-      "plan": "redis:redis-sandbox"
-    }
+    "postgresql:postgresql-sandbox",
+    "redis:redis-sandbox"
   ],
   "formation": {
     "web": {


### PR DESCRIPTION
## :unicorn: Problème
On est en 13.
La v14 est disponible sur Scalingo.
https://www.postgresql.org/docs/14/release-14.html

## :robot: Solution
Monter en 14.

## :rainbow: Remarques
A merger après https://github.com/1024pix/pix-db-replication/pull/126 sinon erreur de version de dump.

## :100: Pour tester
Monter la version de l'addon de RA et se connecter sur pix-app
Test de perf avec `high-level-tests/load-testing` ?
Vérifier la CI
