### PR TITLE
[FEATURE] Informer l'utilisateur que son compte est bloqué de manière uniforme dans Pix Orga, Pix Certif et Pix Admin (PIX-6435)

### DIFF
--- a/admin/app/components/login-form.js
+++ b/admin/app/components/login-form.js
@@ -6,6 +6,8 @@ import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';
 
 export default class LoginForm extends Component {
+  @service url;
+  @service intl;
   @service session;
 
   @tracked email;
@@ -20,33 +22,47 @@ export default class LoginForm extends Component {
     const scope = 'pix-admin';
     try {
       await this.session.authenticate('authenticator:oauth2', identification, password, scope);
-    } catch (response) {
-      this._manageErrorsApi(response);
+    } catch (responseError) {
+      this._handleApiError(responseError);
     }
   }
 
-  _manageErrorsApi(response = {}) {
-    const nbErrors = get(response, 'responseJSON.errors.length', 0);
-    if (nbErrors > 0) {
-      const firstError = response.responseJSON.errors[0];
-      const messageError = this._showErrorMessages(firstError.status, firstError.detail);
-      this.errorMessage = messageError;
-    } else {
-      this.errorMessage = ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE;
+  _handleApiError(responseError) {
+    const errors = get(responseError, 'responseJSON.errors');
+    const error = Array.isArray(errors) && errors.length > 0 && errors[0];
+    switch (error?.code) {
+      case 'USER_IS_TEMPORARY_BLOCKED':
+        this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_IS_TEMPORARY_BLOCKED.I18N_KEY, {
+          url: this.url.forgottenPasswordUrl,
+          htmlSafe: true,
+        });
+        break;
+      case 'USER_IS_BLOCKED':
+        this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_IS_BLOCKED.I18N_KEY, {
+          url: 'https://support.pix.org/support/tickets/new',
+          htmlSafe: true,
+        });
+        break;
+      default:
+        this.errorMessage = this.intl.t(this._getI18nKeyByStatus(responseError.status));
     }
   }
 
-  _showErrorMessages(statusCode, error) {
-    const httpStatusCodeMessages = {
-      400: ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.MESSAGE,
-      500: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
-      422: ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.MESSAGE,
-      502: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
-      504: ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.MESSAGE,
-      401: error,
-      403: error,
-      default: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
-    };
-    return httpStatusCodeMessages[statusCode] || httpStatusCodeMessages['default'];
+  _getI18nKeyByStatus(status) {
+    switch (status) {
+      case 400:
+        return ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.I18N_KEY;
+      case 401:
+        return ENV.APP.API_ERROR_MESSAGES.LOGIN_UNAUTHORIZED.I18N_KEY;
+      // TODO: This case should be handled with a specific error code like USER_IS_TEMPORARY_BLOCKED or USER_IS_BLOCKED
+      case 403:
+        return ENV.APP.API_ERROR_MESSAGES.LOGIN_NO_PERMISSION.I18N_KEY;
+      case 422:
+        return ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.I18N_KEY;
+      case 504:
+        return ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.I18N_KEY;
+      default:
+        return ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY;
+    }
   }
 }

--- a/admin/app/routes/application.js
+++ b/admin/app/routes/application.js
@@ -1,12 +1,17 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 
+const defaultLocale = 'fr';
+
 export default class ApplicationRoute extends Route {
+  @service intl;
   @service currentUser;
   @service featureToggles;
   @service oidcIdentityProviders;
 
   async beforeModel() {
+    this.intl.setLocale([defaultLocale]);
+
     await this.featureToggles.load();
 
     await this.oidcIdentityProviders.load().catch();

--- a/admin/app/services/url.js
+++ b/admin/app/services/url.js
@@ -1,10 +1,24 @@
-import Service from '@ember/service';
-import config from 'pix-admin/config/environment';
+import Service, { inject as service } from '@ember/service';
+
+import ENV from 'pix-admin/config/environment';
 
 export default class Url extends Service {
-  definedHomeUrl = config.rootURL;
+  @service currentDomain;
+  @service intl;
+
+  definedHomeUrl = ENV.rootURL;
+  pixAppUrlWithoutExtension = ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION;
 
   get homeUrl() {
     return this.definedHomeUrl;
+  }
+
+  get forgottenPasswordUrl() {
+    const currentLanguage = this.intl.t('current-lang');
+    let url = `${this.pixAppUrlWithoutExtension}${this.currentDomain.getExtension()}/mot-de-passe-oublie`;
+    if (currentLanguage === 'en') {
+      url += '?lang=en';
+    }
+    return url;
   }
 }

--- a/admin/config/ember-intl.js
+++ b/admin/config/ember-intl.js
@@ -1,0 +1,92 @@
+/*jshint node:true*/
+
+module.exports = function (/* environment */) {
+  return {
+    /**
+     * Merges the fallback locale's translations into all other locales as a
+     * build-time fallback strategy.
+     *
+     * NOTE: a side effect of this option could result in missing translation warnings to be masked.
+     *
+     * @property fallbackLocale
+     * @type {String?}
+     * @default "null"
+     */
+    fallbackLocale: null,
+
+    /**
+     * Path where translations are kept.  This is relative to the project root.
+     * For example, if your translations are an npm dependency, set this to:
+     *`'./node_modules/path/to/translations'`
+     *
+     * @property inputPath
+     * @type {String}
+     * @default "'translations'"
+     */
+    inputPath: 'translations',
+
+    /**
+     * Prevents the translations from being bundled with the application code.
+     * This enables asynchronously loading the translations for the active locale
+     * by fetching them from the asset folder of the build.
+     *
+     * See: https://ember-intl.github.io/ember-intl/docs/guide/asynchronously-loading-translations
+     *
+     * @property publicOnly
+     * @type {Boolean}
+     * @default "false"
+     */
+    publicOnly: false,
+
+    /**
+     * Cause a build error if ICU argument mismatches are detected.
+     *
+     * @property errorOnNamedArgumentMismatch
+     * @type {Boolean}
+     * @default "false"
+     */
+    errorOnNamedArgumentMismatch: false,
+
+    /**
+     * Cause a build error if missing translations are detected.
+     *
+     * See https://ember-intl.github.io/ember-intl/docs/guide/missing-translations#throwing-a-build-error-on-missing-required-translation
+     *
+     * @property errorOnMissingTranslations
+     * @type {Boolean}
+     * @default "false"
+     */
+    errorOnMissingTranslations: true,
+
+    /**
+     * Filter missing translations to ignore expected missing translations.
+     *
+     * See https://ember-intl.github.io/ember-intl/docs/guide/missing-translations#requiring-translations
+     *
+     * @property requiresTranslation
+     * @type {Function}
+     * @default "function(key,locale){return true}"
+     */
+    requiresTranslation(/* key, locale */) {
+      return true;
+    },
+
+    /**
+     * removes empty translations from the build output.
+     *
+     * @property stripEmptyTranslations
+     * @type {Boolean}
+     * @default false
+     */
+    stripEmptyTranslations: false,
+
+    /**
+     * Add the subdirectories of the translations as a namespace for all keys.
+     *
+     * @property wrapTranslationsWithNamespace
+     * @type {Boolean}
+     * @default false
+     */
+    wrapTranslationsWithNamespace: false,
+  };
+};

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -34,22 +34,38 @@ module.exports = function (environment) {
     },
 
     APP: {
-      // Here you can pass flags/options to your application instance
-      // when it is created
       API_HOST: process.env.API_HOST || '',
+      PIX_APP_URL_WITHOUT_EXTENSION: process.env.PIX_APP_URL_WITHOUT_EXTENSION || 'https://app.pix.',
       API_ERROR_MESSAGES: {
-        BAD_REQUEST: { CODE: '400', MESSAGE: 'Les données envoyées ne sont pas au bon format.' },
+        BAD_REQUEST: {
+          CODE: '400',
+          I18N_KEY: 'common.api-error-messages.bad-request-error',
+        },
+        LOGIN_UNAUTHORIZED: {
+          CODE: '401',
+          I18N_KEY: 'common.api-error-messages.login-unauthorized-error',
+        },
+        USER_IS_TEMPORARY_BLOCKED: {
+          CODE: '403',
+          I18N_KEY: 'common.api-error-messages.login-user-temporary-blocked-error',
+        },
+        USER_IS_BLOCKED: {
+          CODE: '403',
+          I18N_KEY: 'common.api-error-messages.login-user-blocked-error',
+        },
+        LOGIN_NO_PERMISSION: {
+          CODE: '403',
+          I18N_KEY: 'pages.login.api-error-messages.login-no-permission',
+        },
+        NOT_FOUND: '404',
         INTERNAL_SERVER_ERROR: {
           CODE: '500',
-          MESSAGE: 'Le service est momentanément indisponible. Veuillez réessayer ultérieurement.',
+          I18N_KEY: 'common.api-error-messages.internal-server-error',
         },
         GATEWAY_TIMEOUT: {
           CODE: '504',
-          MESSAGE: 'Le service subit des ralentissements. Veuillez réessayer ultérieurement.',
+          I18N_KEY: 'common.api-error-messages.gateway-timeout-error',
         },
-        UNAUTHORIZED: { CODE: '401', MESSAGE: "L'adresse e-mail et/ou le mot de passe saisis sont incorrects." },
-        FORBIDDEN: '403',
-        NOT_FOUND: '404',
       },
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({
         environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS',

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -47,6 +47,7 @@
         "ember-fetch": "^8.1.2",
         "ember-file-upload": "^7.1.0",
         "ember-flatpickr": "^3.2.3",
+        "ember-intl": "^5.7.2",
         "ember-load-initializers": "^2.1.2",
         "ember-page-title": "^7.0.0",
         "ember-qunit": "^5.1.5",
@@ -7617,6 +7618,25 @@
       "integrity": "sha512-M/BexG/p05C5lFfMunxo/QcgIJnMT2vDVCd00wNqK2ImZONIlEETZwWJu1QtLxtmYlSHlCFl3JNzp0tLe7OJ5g==",
       "dev": true
     },
+    "node_modules/@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "dev": true,
+      "dependencies": {
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@mrmlnc/readdir-enhanced/node_modules/glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha512-Iozmtbqv0noj0uDDqoL0zNq0VBEfK2YFoMAZoxJe4cwphvLR+JskfF30QhXHOR4m3KrE6NLRYw+U9MRXvifyig==",
+      "dev": true
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -10956,6 +10976,190 @@
         "node": "*"
       }
     },
+    "node_modules/broccoli-merge-files": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-files/-/broccoli-merge-files-0.8.0.tgz",
+      "integrity": "sha512-S6dXHECbDkr7YMuCitAAQT8EZeW/kXom0Y8+QmQfiSkWspkKDGrr4vXgEZJjWqfa/FSx/Y18NEEOuMmbIW+XNQ==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-plugin": "^1.3.0",
+        "fast-glob": "^2.2.6",
+        "lodash.defaults": "^4.2.0",
+        "p-event": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/broccoli-merge-files/node_modules/@nodelib/fs.stat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+      "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/broccoli-merge-files/node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/broccoli-merge-files/node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/broccoli-merge-files/node_modules/fast-glob": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+      "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+      "dev": true,
+      "dependencies": {
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.1.2",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.3",
+        "micromatch": "^3.1.10"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/broccoli-merge-files/node_modules/fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
+      "dev": true,
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/broccoli-merge-files/node_modules/fill-range/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/broccoli-merge-files/node_modules/glob-parent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      }
+    },
+    "node_modules/broccoli-merge-files/node_modules/glob-parent/node_modules/is-glob": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+      "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/broccoli-merge-files/node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/broccoli-merge-files/node_modules/is-number/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/broccoli-merge-files/node_modules/micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/broccoli-merge-files/node_modules/to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/broccoli-merge-trees": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
@@ -12036,6 +12240,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -12274,6 +12484,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/cldr-core": {
+      "version": "36.0.0",
+      "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-36.0.0.tgz",
+      "integrity": "sha512-QLnAjt20rZe38c8h8OJ9jPND+O4o5O8Nw0TK/P3KpNn1cmOhMu0rk6Kc3ap96c5OStQ9gAngs9+Be2sum26NOw==",
+      "dev": true
     },
     "node_modules/clean-base-url": {
       "version": "1.0.0",
@@ -20827,6 +21043,1188 @@
         "object-assign": "4.1.1"
       }
     },
+    "node_modules/ember-intl": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ember-intl/-/ember-intl-5.7.2.tgz",
+      "integrity": "sha512-gs17uY1ywzMaUpx1gxfBkFQYRTWTSa/zbkL13MVtffG9aBLP+998MibytZOUxIipMtLCm4sr/g6/1aaKRr9/+g==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-caching-writer": "^3.0.3",
+        "broccoli-funnel": "^3.0.3",
+        "broccoli-merge-files": "^0.8.0",
+        "broccoli-merge-trees": "^4.2.0",
+        "broccoli-source": "^3.0.0",
+        "broccoli-stew": "^3.0.0",
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "cldr-core": "^36.0.0",
+        "ember-auto-import": "^1.5.3",
+        "ember-cli-babel": "^7.23.0",
+        "ember-cli-typescript": "^4.0.0",
+        "extend": "^3.0.2",
+        "fast-memoize": "^2.5.2",
+        "has-unicode": "^2.0.1",
+        "intl-messageformat": "^9.3.6",
+        "intl-messageformat-parser": "^6.0.5",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify": "^1.0.1",
+        "locale-emoji": "^0.3.0",
+        "lodash.castarray": "^4.4.0",
+        "lodash.last": "^3.0.0",
+        "lodash.omit": "^4.5.0",
+        "mkdirp": "^1.0.4",
+        "silent-error": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 10.*"
+      },
+      "peerDependencies": {
+        "typescript": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ember-intl/node_modules/@embroider/shared-internals": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-1.8.3.tgz",
+      "integrity": "sha512-N5Gho6Qk8z5u+mxLCcMYAoQMbN4MmH+z2jXwQHVs859bxuZTxwF6kKtsybDAASCtd2YGxEmzcc1Ja/wM28824w==",
+      "dev": true,
+      "dependencies": {
+        "babel-import-util": "^1.1.0",
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^9.1.0",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.21",
+        "resolve-package-path": "^4.0.1",
+        "semver": "^7.3.5",
+        "typescript-memoize": "^1.0.1"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@embroider/shared-internals/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@embroider/shared-internals/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@embroider/shared-internals/node_modules/resolve-package-path": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
+      "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
+      "dev": true,
+      "dependencies": {
+        "path-root": "^0.1.1"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@embroider/shared-internals/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@formatjs/ecma402-abstract": {
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.4.tgz",
+      "integrity": "sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/intl-localematcher": "0.2.25",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@formatjs/fast-memoize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz",
+      "integrity": "sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.0.tgz",
+      "integrity": "sha512-Qxv/lmCN6hKpBSss2uQ8IROVnta2r9jd3ymUEIjm2UyIkUCHVcbUVRGL/KS/wv7876edvsPe+hjHVJ4z8YuVaw==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.4",
+        "@formatjs/icu-skeleton-parser": "1.3.6",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.6.tgz",
+      "integrity": "sha512-I96mOxvml/YLrwU2Txnd4klA7V8fRhb6JG/4hm3VMNmeJo1F03IpV2L3wWt7EweqNLES59SZ4d6hVOPCSf80Bg==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.25.tgz",
+      "integrity": "sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@webassemblyjs/ast": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
+      "integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
+      "integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==",
+      "dev": true
+    },
+    "node_modules/ember-intl/node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
+      "integrity": "sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==",
+      "dev": true
+    },
+    "node_modules/ember-intl/node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
+      "integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==",
+      "dev": true
+    },
+    "node_modules/ember-intl/node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
+      "integrity": "sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@webassemblyjs/ieee754": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
+      "integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
+      "dev": true,
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@webassemblyjs/leb128": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
+      "integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
+      "dev": true,
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@webassemblyjs/utf8": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
+      "integrity": "sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==",
+      "dev": true
+    },
+    "node_modules/ember-intl/node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
+      "integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/helper-wasm-section": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0",
+        "@webassemblyjs/wasm-opt": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0",
+        "@webassemblyjs/wast-printer": "1.9.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
+      "integrity": "sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/ieee754": "1.9.0",
+        "@webassemblyjs/leb128": "1.9.0",
+        "@webassemblyjs/utf8": "1.9.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
+      "integrity": "sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
+      "integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-api-error": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/ieee754": "1.9.0",
+        "@webassemblyjs/leb128": "1.9.0",
+        "@webassemblyjs/utf8": "1.9.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
+      "integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/ember-intl/node_modules/acorn": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/braces/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/broccoli-funnel": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz",
+      "integrity": "sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==",
+      "dev": true,
+      "dependencies": {
+        "array-equal": "^1.0.0",
+        "broccoli-plugin": "^4.0.7",
+        "debug": "^4.1.1",
+        "fs-tree-diff": "^2.0.1",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "walk-sync": "^2.0.2"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-intl/node_modules/broccoli-funnel/node_modules/walk-sync": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^2.0.0",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-intl/node_modules/broccoli-merge-trees": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz",
+      "integrity": "sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-plugin": "^4.0.2",
+        "merge-trees": "^2.0.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-intl/node_modules/broccoli-plugin": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
+      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-node-api": "^1.7.0",
+        "broccoli-output-wrapper": "^3.2.5",
+        "fs-merger": "^3.2.1",
+        "promise-map-series": "^0.3.0",
+        "quick-temp": "^0.1.8",
+        "rimraf": "^3.0.2",
+        "symlink-or-copy": "^1.3.1"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-intl/node_modules/broccoli-plugin/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ember-intl/node_modules/broccoli-source": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-3.0.1.tgz",
+      "integrity": "sha512-ZbGVQjivWi0k220fEeIUioN6Y68xjMy0xiLAc0LdieHI99gw+tafU8w0CggBDYVNsJMKUr006AZaM7gNEwCxEg==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-node-api": "^1.6.0"
+      },
+      "engines": {
+        "node": "8.* || 10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-intl/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ember-intl/node_modules/ember-auto-import": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-1.12.2.tgz",
+      "integrity": "sha512-gLqML2k77AuUiXxWNon1FSzuG1DV7PEPpCLCU5aJvf6fdL6rmFfElsZRh+8ELEB/qP9dT+LHjNEunVzd2dYc8A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.1.6",
+        "@babel/preset-env": "^7.10.2",
+        "@babel/traverse": "^7.1.6",
+        "@babel/types": "^7.1.6",
+        "@embroider/shared-internals": "^1.0.0",
+        "babel-core": "^6.26.3",
+        "babel-loader": "^8.0.6",
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babylon": "^6.18.0",
+        "broccoli-debug": "^0.6.4",
+        "broccoli-node-api": "^1.7.0",
+        "broccoli-plugin": "^4.0.0",
+        "broccoli-source": "^3.0.0",
+        "debug": "^3.1.0",
+        "ember-cli-babel": "^7.0.0",
+        "enhanced-resolve": "^4.0.0",
+        "fs-extra": "^6.0.1",
+        "fs-tree-diff": "^2.0.0",
+        "handlebars": "^4.3.1",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.19",
+        "mkdirp": "^0.5.1",
+        "resolve-package-path": "^3.1.0",
+        "rimraf": "^2.6.2",
+        "semver": "^7.3.4",
+        "symlink-or-copy": "^1.2.0",
+        "typescript-memoize": "^1.0.0-alpha.3",
+        "walk-sync": "^0.3.3",
+        "webpack": "^4.43.0"
+      },
+      "engines": {
+        "node": ">= 10.*"
+      }
+    },
+    "node_modules/ember-intl/node_modules/ember-auto-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/ember-intl/node_modules/ember-auto-import/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ember-intl/node_modules/ember-cli-typescript": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
+      "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-to-html": "^0.6.15",
+        "broccoli-stew": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^4.0.0",
+        "fs-extra": "^9.0.1",
+        "resolve": "^1.5.0",
+        "rsvp": "^4.8.1",
+        "semver": "^7.3.2",
+        "stagehand": "^1.0.0",
+        "walk-sync": "^2.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-intl/node_modules/ember-cli-typescript/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ember-intl/node_modules/ember-cli-typescript/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/ember-intl/node_modules/ember-cli-typescript/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/ember-cli-typescript/node_modules/walk-sync": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^2.0.0",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-intl/node_modules/enhanced-resolve": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+      "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.5.0",
+        "tapable": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/eslint-scope": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/ember-intl/node_modules/fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
+      "dev": true,
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/fill-range/node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "dev": true,
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ember-intl/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ember-intl/node_modules/fs-extra": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/fs-tree-diff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+      "dev": true,
+      "dependencies": {
+        "@types/symlink-or-copy": "^1.2.0",
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-intl/node_modules/intl-messageformat": {
+      "version": "9.13.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.13.0.tgz",
+      "integrity": "sha512-7sGC7QnSQGa5LZP7bXLDhVDtQOeKGeBFGHF2Y8LVBwYZoQZCgWeKoPGTa5GMG8g/TzDgeXuYJQis7Ggiw2xTOw==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.11.4",
+        "@formatjs/fast-memoize": "1.2.1",
+        "@formatjs/icu-messageformat-parser": "2.1.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/is-number/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "node_modules/ember-intl/node_modules/loader-runner": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
+      "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.3.0 <5.0.0 || >=5.10"
+      }
+    },
+    "node_modules/ember-intl/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ember-intl/node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ember-intl/node_modules/make-dir/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/ember-intl/node_modules/matcher-collection": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
+      "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "minimatch": "^3.0.2"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-intl/node_modules/micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "dependencies": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ember-intl/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/ember-intl/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ember-intl/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ember-intl/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ember-intl/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ember-intl/node_modules/pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ember-intl/node_modules/promise-map-series": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
+      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
+      "dev": true,
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-intl/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/ember-intl/node_modules/resolve-package-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+      "dev": true,
+      "dependencies": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12"
+      }
+    },
+    "node_modules/ember-intl/node_modules/rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-intl/node_modules/schema-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.1.0",
+        "ajv-errors": "^1.0.0",
+        "ajv-keywords": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/ember-intl/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ember-intl/node_modules/serialize-javascript": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/tapable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ember-intl/node_modules/terser": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/terser-webpack-plugin": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+      "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
+      "dev": true,
+      "dependencies": {
+        "cacache": "^12.0.2",
+        "find-cache-dir": "^2.1.0",
+        "is-wsl": "^1.1.0",
+        "schema-utils": "^1.0.0",
+        "serialize-javascript": "^4.0.0",
+        "source-map": "^0.6.1",
+        "terser": "^4.1.2",
+        "webpack-sources": "^1.4.0",
+        "worker-farm": "^1.7.0"
+      },
+      "engines": {
+        "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ember-intl/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/ember-intl/node_modules/watchpack": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
+      "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "neo-async": "^2.5.0"
+      },
+      "optionalDependencies": {
+        "chokidar": "^3.4.1",
+        "watchpack-chokidar2": "^2.0.1"
+      }
+    },
+    "node_modules/ember-intl/node_modules/webpack": {
+      "version": "4.46.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.46.0.tgz",
+      "integrity": "sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==",
+      "dev": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/wasm-edit": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0",
+        "acorn": "^6.4.1",
+        "ajv": "^6.10.2",
+        "ajv-keywords": "^3.4.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^4.5.0",
+        "eslint-scope": "^4.0.3",
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^2.4.0",
+        "loader-utils": "^1.2.3",
+        "memory-fs": "^0.4.1",
+        "micromatch": "^3.1.10",
+        "mkdirp": "^0.5.3",
+        "neo-async": "^2.6.1",
+        "node-libs-browser": "^2.2.1",
+        "schema-utils": "^1.0.0",
+        "tapable": "^1.1.3",
+        "terser-webpack-plugin": "^1.4.3",
+        "watchpack": "^1.7.4",
+        "webpack-sources": "^1.4.1"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        },
+        "webpack-command": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ember-intl/node_modules/webpack-sources": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+      "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+      "dev": true,
+      "dependencies": {
+        "source-list-map": "^2.0.0",
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/ember-intl/node_modules/webpack/node_modules/memory-fs": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+      "integrity": "sha512-cda4JKCxReDXFXRqOHPQscuIYg1PvxbE2S2GP45rnwfEK+vZaXC8C1OFvdHIbgw0DLzowXGVoxLaAmlgRy14GQ==",
+      "dev": true,
+      "dependencies": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "node_modules/ember-intl/node_modules/webpack/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/ember-load-initializers": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ember-load-initializers/-/ember-load-initializers-2.1.2.tgz",
@@ -25468,6 +26866,12 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fast-memoize": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
+      "dev": true
+    },
     "node_modules/fast-ordered-set": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.3.tgz",
@@ -27407,6 +28811,32 @@
         "tslib": "2.4.0"
       }
     },
+    "node_modules/intl-messageformat-parser": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-6.4.4.tgz",
+      "integrity": "sha512-7AaFKNZEfzLQR6+jivOuz9e7yA8ka5KrmLebgY4QHTRLf8r64dp3LjnW98LkBWjdk8GK0sawD2dHDqW++A/pXA==",
+      "deprecated": "We've written a new parser that's 6x faster and is backwards compatible. Please use @formatjs/icu-messageformat-parser",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.6.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/intl-messageformat-parser/node_modules/@formatjs/ecma402-abstract": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.6.4.tgz",
+      "integrity": "sha512-ukFjGD9dLsxcD9D5AEshJqQElPQeUAlTALT/lzIV6OcYojyuU81gw/uXDUOrs6XW79jtOJwQDkLqHbCJBJMOTw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/intl-messageformat-parser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
     "node_modules/intl-messageformat/node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -28453,6 +29883,12 @@
       "integrity": "sha512-9M2KvGT6duzGMgkOcTkWb+PR/Q2Oe54df/tLgHGVmFpAmtqJ553xJh6N63iFYI2yjo2PeJXbS5skHi/QpJq4vA==",
       "dev": true
     },
+    "node_modules/locale-emoji": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/locale-emoji/-/locale-emoji-0.3.0.tgz",
+      "integrity": "sha512-JGm8+naU49CBDnH1jksS3LecPdfWQLxFgkLN6ZhYONKa850pJ0Xt8DPGJnYK0ZuJI8jTuiDDPCDtSL3nyacXwg==",
+      "dev": true
+    },
     "node_modules/locate-character": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-2.0.5.tgz",
@@ -28592,6 +30028,12 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true
+    },
     "node_modules/lodash.find": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
@@ -28696,6 +30138,12 @@
         "lodash.isarguments": "^3.0.0",
         "lodash.isarray": "^3.0.0"
       }
+    },
+    "node_modules/lodash.last": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
+      "integrity": "sha512-14mq7rSkCxG4XMy9lF2FbIOqqgF0aH0NfPuQ3LPR3vIh0kHnUvIYP70dqa1Hf47zyXfQ8FzAg0MYOQeSuE1R7A==",
+      "dev": true
     },
     "node_modules/lodash.lowerfirst": {
       "version": "4.3.1",
@@ -29374,10 +30822,13 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -30515,6 +31966,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-event": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
+      "integrity": "sha512-NQCqOFhbpVTMX4qMe8PF8lbGtzZ+LCiN7pcNrb/413Na7+TRoe1xkKUzuWa/YEJdGQ0FvKtj35EEbDoVPO2kbA==",
+      "dev": true,
+      "dependencies": {
+        "p-timeout": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/p-finally": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
@@ -30583,6 +32046,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "dev": true,
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/p-timeout/node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/p-try": {
@@ -30758,8 +32242,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/path-exists": {
       "version": "3.0.0",
@@ -44284,6 +45767,24 @@
       "integrity": "sha512-M/BexG/p05C5lFfMunxo/QcgIJnMT2vDVCd00wNqK2ImZONIlEETZwWJu1QtLxtmYlSHlCFl3JNzp0tLe7OJ5g==",
       "dev": true
     },
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
+      },
+      "dependencies": {
+        "glob-to-regexp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+          "integrity": "sha512-Iozmtbqv0noj0uDDqoL0zNq0VBEfK2YFoMAZoxJe4cwphvLR+JskfF30QhXHOR4m3KrE6NLRYw+U9MRXvifyig==",
+          "dev": true
+        }
+      }
+    },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -47347,6 +48848,164 @@
         }
       }
     },
+    "broccoli-merge-files": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-files/-/broccoli-merge-files-0.8.0.tgz",
+      "integrity": "sha512-S6dXHECbDkr7YMuCitAAQT8EZeW/kXom0Y8+QmQfiSkWspkKDGrr4vXgEZJjWqfa/FSx/Y18NEEOuMmbIW+XNQ==",
+      "dev": true,
+      "requires": {
+        "broccoli-plugin": "^1.3.0",
+        "fast-glob": "^2.2.6",
+        "lodash.defaults": "^4.2.0",
+        "p-event": "^2.3.1"
+      },
+      "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+          "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fast-glob": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+          "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+          "dev": true,
+          "requires": {
+            "@mrmlnc/readdir-enhanced": "^2.2.1",
+            "@nodelib/fs.stat": "^1.1.2",
+            "glob-parent": "^3.1.0",
+            "is-glob": "^4.0.0",
+            "merge2": "^1.2.3",
+            "micromatch": "^3.1.10"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
     "broccoli-merge-trees": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
@@ -48168,6 +49827,12 @@
         "get-intrinsic": "^1.0.2"
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -48361,6 +50026,12 @@
           }
         }
       }
+    },
+    "cldr-core": {
+      "version": "36.0.0",
+      "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-36.0.0.tgz",
+      "integrity": "sha512-QLnAjt20rZe38c8h8OJ9jPND+O4o5O8Nw0TK/P3KpNn1cmOhMu0rk6Kc3ap96c5OStQ9gAngs9+Be2sum26NOw==",
+      "dev": true
     },
     "clean-base-url": {
       "version": "1.0.0",
@@ -55218,6 +56889,987 @@
         }
       }
     },
+    "ember-intl": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ember-intl/-/ember-intl-5.7.2.tgz",
+      "integrity": "sha512-gs17uY1ywzMaUpx1gxfBkFQYRTWTSa/zbkL13MVtffG9aBLP+998MibytZOUxIipMtLCm4sr/g6/1aaKRr9/+g==",
+      "dev": true,
+      "requires": {
+        "broccoli-caching-writer": "^3.0.3",
+        "broccoli-funnel": "^3.0.3",
+        "broccoli-merge-files": "^0.8.0",
+        "broccoli-merge-trees": "^4.2.0",
+        "broccoli-source": "^3.0.0",
+        "broccoli-stew": "^3.0.0",
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "cldr-core": "^36.0.0",
+        "ember-auto-import": "^1.5.3",
+        "ember-cli-babel": "^7.23.0",
+        "ember-cli-typescript": "^4.0.0",
+        "extend": "^3.0.2",
+        "fast-memoize": "^2.5.2",
+        "has-unicode": "^2.0.1",
+        "intl-messageformat": "^9.3.6",
+        "intl-messageformat-parser": "^6.0.5",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify": "^1.0.1",
+        "locale-emoji": "^0.3.0",
+        "lodash.castarray": "^4.4.0",
+        "lodash.last": "^3.0.0",
+        "lodash.omit": "^4.5.0",
+        "mkdirp": "^1.0.4",
+        "silent-error": "^1.1.1"
+      },
+      "dependencies": {
+        "@embroider/shared-internals": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-1.8.3.tgz",
+          "integrity": "sha512-N5Gho6Qk8z5u+mxLCcMYAoQMbN4MmH+z2jXwQHVs859bxuZTxwF6kKtsybDAASCtd2YGxEmzcc1Ja/wM28824w==",
+          "dev": true,
+          "requires": {
+            "babel-import-util": "^1.1.0",
+            "ember-rfc176-data": "^0.3.17",
+            "fs-extra": "^9.1.0",
+            "js-string-escape": "^1.0.1",
+            "lodash": "^4.17.21",
+            "resolve-package-path": "^4.0.1",
+            "semver": "^7.3.5",
+            "typescript-memoize": "^1.0.1"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "9.1.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+              "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+              "dev": true,
+              "requires": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+              }
+            },
+            "jsonfile": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+              "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+              }
+            },
+            "resolve-package-path": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
+              "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
+              "dev": true,
+              "requires": {
+                "path-root": "^0.1.1"
+              }
+            },
+            "universalify": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+              "dev": true
+            }
+          }
+        },
+        "@formatjs/ecma402-abstract": {
+          "version": "1.11.4",
+          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.4.tgz",
+          "integrity": "sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==",
+          "dev": true,
+          "requires": {
+            "@formatjs/intl-localematcher": "0.2.25",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@formatjs/fast-memoize": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.1.tgz",
+          "integrity": "sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@formatjs/icu-messageformat-parser": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.0.tgz",
+          "integrity": "sha512-Qxv/lmCN6hKpBSss2uQ8IROVnta2r9jd3ymUEIjm2UyIkUCHVcbUVRGL/KS/wv7876edvsPe+hjHVJ4z8YuVaw==",
+          "dev": true,
+          "requires": {
+            "@formatjs/ecma402-abstract": "1.11.4",
+            "@formatjs/icu-skeleton-parser": "1.3.6",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@formatjs/icu-skeleton-parser": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.6.tgz",
+          "integrity": "sha512-I96mOxvml/YLrwU2Txnd4klA7V8fRhb6JG/4hm3VMNmeJo1F03IpV2L3wWt7EweqNLES59SZ4d6hVOPCSf80Bg==",
+          "dev": true,
+          "requires": {
+            "@formatjs/ecma402-abstract": "1.11.4",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@formatjs/intl-localematcher": {
+          "version": "0.2.25",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.25.tgz",
+          "integrity": "sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@webassemblyjs/ast": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
+          "integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/helper-module-context": "1.9.0",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+            "@webassemblyjs/wast-parser": "1.9.0"
+          }
+        },
+        "@webassemblyjs/helper-api-error": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
+          "integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==",
+          "dev": true
+        },
+        "@webassemblyjs/helper-buffer": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
+          "integrity": "sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA==",
+          "dev": true
+        },
+        "@webassemblyjs/helper-wasm-bytecode": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
+          "integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==",
+          "dev": true
+        },
+        "@webassemblyjs/helper-wasm-section": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
+          "integrity": "sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-buffer": "1.9.0",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+            "@webassemblyjs/wasm-gen": "1.9.0"
+          }
+        },
+        "@webassemblyjs/ieee754": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
+          "integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
+          "dev": true,
+          "requires": {
+            "@xtuc/ieee754": "^1.2.0"
+          }
+        },
+        "@webassemblyjs/leb128": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
+          "integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
+          "dev": true,
+          "requires": {
+            "@xtuc/long": "4.2.2"
+          }
+        },
+        "@webassemblyjs/utf8": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
+          "integrity": "sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==",
+          "dev": true
+        },
+        "@webassemblyjs/wasm-edit": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
+          "integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-buffer": "1.9.0",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+            "@webassemblyjs/helper-wasm-section": "1.9.0",
+            "@webassemblyjs/wasm-gen": "1.9.0",
+            "@webassemblyjs/wasm-opt": "1.9.0",
+            "@webassemblyjs/wasm-parser": "1.9.0",
+            "@webassemblyjs/wast-printer": "1.9.0"
+          }
+        },
+        "@webassemblyjs/wasm-gen": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
+          "integrity": "sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+            "@webassemblyjs/ieee754": "1.9.0",
+            "@webassemblyjs/leb128": "1.9.0",
+            "@webassemblyjs/utf8": "1.9.0"
+          }
+        },
+        "@webassemblyjs/wasm-opt": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
+          "integrity": "sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-buffer": "1.9.0",
+            "@webassemblyjs/wasm-gen": "1.9.0",
+            "@webassemblyjs/wasm-parser": "1.9.0"
+          }
+        },
+        "@webassemblyjs/wasm-parser": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
+          "integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-api-error": "1.9.0",
+            "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+            "@webassemblyjs/ieee754": "1.9.0",
+            "@webassemblyjs/leb128": "1.9.0",
+            "@webassemblyjs/utf8": "1.9.0"
+          }
+        },
+        "@webassemblyjs/wast-printer": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
+          "integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/wast-parser": "1.9.0",
+            "@xtuc/long": "4.2.2"
+          }
+        },
+        "acorn": {
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "broccoli-funnel": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz",
+          "integrity": "sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "broccoli-plugin": "^4.0.7",
+            "debug": "^4.1.1",
+            "fs-tree-diff": "^2.0.1",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "walk-sync": "^2.0.2"
+          },
+          "dependencies": {
+            "walk-sync": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+              "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+              "dev": true,
+              "requires": {
+                "@types/minimatch": "^3.0.3",
+                "ensure-posix-path": "^1.1.0",
+                "matcher-collection": "^2.0.0",
+                "minimatch": "^3.0.4"
+              }
+            }
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz",
+          "integrity": "sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^4.0.2",
+            "merge-trees": "^2.0.0"
+          }
+        },
+        "broccoli-plugin": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
+          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
+          "dev": true,
+          "requires": {
+            "broccoli-node-api": "^1.7.0",
+            "broccoli-output-wrapper": "^3.2.5",
+            "fs-merger": "^3.2.1",
+            "promise-map-series": "^0.3.0",
+            "quick-temp": "^0.1.8",
+            "rimraf": "^3.0.2",
+            "symlink-or-copy": "^1.3.1"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+              "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
+          }
+        },
+        "broccoli-source": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-3.0.1.tgz",
+          "integrity": "sha512-ZbGVQjivWi0k220fEeIUioN6Y68xjMy0xiLAc0LdieHI99gw+tafU8w0CggBDYVNsJMKUr006AZaM7gNEwCxEg==",
+          "dev": true,
+          "requires": {
+            "broccoli-node-api": "^1.6.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ember-auto-import": {
+          "version": "1.12.2",
+          "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-1.12.2.tgz",
+          "integrity": "sha512-gLqML2k77AuUiXxWNon1FSzuG1DV7PEPpCLCU5aJvf6fdL6rmFfElsZRh+8ELEB/qP9dT+LHjNEunVzd2dYc8A==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.1.6",
+            "@babel/preset-env": "^7.10.2",
+            "@babel/traverse": "^7.1.6",
+            "@babel/types": "^7.1.6",
+            "@embroider/shared-internals": "^1.0.0",
+            "babel-core": "^6.26.3",
+            "babel-loader": "^8.0.6",
+            "babel-plugin-syntax-dynamic-import": "^6.18.0",
+            "babylon": "^6.18.0",
+            "broccoli-debug": "^0.6.4",
+            "broccoli-node-api": "^1.7.0",
+            "broccoli-plugin": "^4.0.0",
+            "broccoli-source": "^3.0.0",
+            "debug": "^3.1.0",
+            "ember-cli-babel": "^7.0.0",
+            "enhanced-resolve": "^4.0.0",
+            "fs-extra": "^6.0.1",
+            "fs-tree-diff": "^2.0.0",
+            "handlebars": "^4.3.1",
+            "js-string-escape": "^1.0.1",
+            "lodash": "^4.17.19",
+            "mkdirp": "^0.5.1",
+            "resolve-package-path": "^3.1.0",
+            "rimraf": "^2.6.2",
+            "semver": "^7.3.4",
+            "symlink-or-copy": "^1.2.0",
+            "typescript-memoize": "^1.0.0-alpha.3",
+            "walk-sync": "^0.3.3",
+            "webpack": "^4.43.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.7",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+              "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.6",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+              "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+              "dev": true,
+              "requires": {
+                "minimist": "^1.2.6"
+              }
+            }
+          }
+        },
+        "ember-cli-typescript": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz",
+          "integrity": "sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==",
+          "dev": true,
+          "requires": {
+            "ansi-to-html": "^0.6.15",
+            "broccoli-stew": "^3.0.0",
+            "debug": "^4.0.0",
+            "execa": "^4.0.0",
+            "fs-extra": "^9.0.1",
+            "resolve": "^1.5.0",
+            "rsvp": "^4.8.1",
+            "semver": "^7.3.2",
+            "stagehand": "^1.0.0",
+            "walk-sync": "^2.2.0"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "9.1.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+              "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+              "dev": true,
+              "requires": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+              }
+            },
+            "jsonfile": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+              "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+              }
+            },
+            "universalify": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+              "dev": true
+            },
+            "walk-sync": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+              "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+              "dev": true,
+              "requires": {
+                "@types/minimatch": "^3.0.3",
+                "ensure-posix-path": "^1.1.0",
+                "matcher-collection": "^2.0.0",
+                "minimatch": "^3.0.4"
+              }
+            }
+          }
+        },
+        "enhanced-resolve": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+          "integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.5.0",
+            "tapable": "^1.0.0"
+          }
+        },
+        "eslint-scope": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "execa": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "find-cache-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+          "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^2.0.0",
+            "pkg-dir": "^3.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+          "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "fs-tree-diff": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "dev": true,
+          "requires": {
+            "@types/symlink-or-copy": "^1.2.0",
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "intl-messageformat": {
+          "version": "9.13.0",
+          "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-9.13.0.tgz",
+          "integrity": "sha512-7sGC7QnSQGa5LZP7bXLDhVDtQOeKGeBFGHF2Y8LVBwYZoQZCgWeKoPGTa5GMG8g/TzDgeXuYJQis7Ggiw2xTOw==",
+          "dev": true,
+          "requires": {
+            "@formatjs/ecma402-abstract": "1.11.4",
+            "@formatjs/fast-memoize": "1.2.1",
+            "@formatjs/icu-messageformat-parser": "2.1.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+          "dev": true
+        },
+        "loader-runner": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
+          "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+              "dev": true
+            }
+          }
+        },
+        "matcher-collection": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
+          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "minimatch": "^3.0.2"
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        },
+        "promise-map-series": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
+          "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "resolve-package-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+          "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.17.0"
+          }
+        },
+        "rsvp": {
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "serialize-javascript": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+          "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.21",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+          "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "tapable": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+          "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+          "dev": true
+        },
+        "terser": {
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+          "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
+          }
+        },
+        "terser-webpack-plugin": {
+          "version": "1.4.5",
+          "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+          "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
+          "dev": true,
+          "requires": {
+            "cacache": "^12.0.2",
+            "find-cache-dir": "^2.1.0",
+            "is-wsl": "^1.1.0",
+            "schema-utils": "^1.0.0",
+            "serialize-javascript": "^4.0.0",
+            "source-map": "^0.6.1",
+            "terser": "^4.1.2",
+            "webpack-sources": "^1.4.0",
+            "worker-farm": "^1.7.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        },
+        "watchpack": {
+          "version": "1.7.5",
+          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
+          "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
+          "dev": true,
+          "requires": {
+            "chokidar": "^3.4.1",
+            "graceful-fs": "^4.1.2",
+            "neo-async": "^2.5.0",
+            "watchpack-chokidar2": "^2.0.1"
+          }
+        },
+        "webpack": {
+          "version": "4.46.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.46.0.tgz",
+          "integrity": "sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==",
+          "dev": true,
+          "requires": {
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-module-context": "1.9.0",
+            "@webassemblyjs/wasm-edit": "1.9.0",
+            "@webassemblyjs/wasm-parser": "1.9.0",
+            "acorn": "^6.4.1",
+            "ajv": "^6.10.2",
+            "ajv-keywords": "^3.4.1",
+            "chrome-trace-event": "^1.0.2",
+            "enhanced-resolve": "^4.5.0",
+            "eslint-scope": "^4.0.3",
+            "json-parse-better-errors": "^1.0.2",
+            "loader-runner": "^2.4.0",
+            "loader-utils": "^1.2.3",
+            "memory-fs": "^0.4.1",
+            "micromatch": "^3.1.10",
+            "mkdirp": "^0.5.3",
+            "neo-async": "^2.6.1",
+            "node-libs-browser": "^2.2.1",
+            "schema-utils": "^1.0.0",
+            "tapable": "^1.1.3",
+            "terser-webpack-plugin": "^1.4.3",
+            "watchpack": "^1.7.4",
+            "webpack-sources": "^1.4.1"
+          },
+          "dependencies": {
+            "memory-fs": {
+              "version": "0.4.1",
+              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+              "integrity": "sha512-cda4JKCxReDXFXRqOHPQscuIYg1PvxbE2S2GP45rnwfEK+vZaXC8C1OFvdHIbgw0DLzowXGVoxLaAmlgRy14GQ==",
+              "dev": true,
+              "requires": {
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.6",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+              "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+              "dev": true,
+              "requires": {
+                "minimist": "^1.2.6"
+              }
+            }
+          }
+        },
+        "webpack-sources": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+          "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+          "dev": true,
+          "requires": {
+            "source-list-map": "^2.0.0",
+            "source-map": "~0.6.1"
+          }
+        }
+      }
+    },
     "ember-load-initializers": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ember-load-initializers/-/ember-load-initializers-2.1.2.tgz",
@@ -58789,6 +61441,12 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-memoize": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
+      "dev": true
+    },
     "fast-ordered-set": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.3.tgz",
@@ -60354,6 +63012,33 @@
         }
       }
     },
+    "intl-messageformat-parser": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-6.4.4.tgz",
+      "integrity": "sha512-7AaFKNZEfzLQR6+jivOuz9e7yA8ka5KrmLebgY4QHTRLf8r64dp3LjnW98LkBWjdk8GK0sawD2dHDqW++A/pXA==",
+      "dev": true,
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.6.4",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@formatjs/ecma402-abstract": {
+          "version": "1.6.4",
+          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.6.4.tgz",
+          "integrity": "sha512-ukFjGD9dLsxcD9D5AEshJqQElPQeUAlTALT/lzIV6OcYojyuU81gw/uXDUOrs6XW79jtOJwQDkLqHbCJBJMOTw==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -61148,6 +63833,12 @@
       "integrity": "sha512-9M2KvGT6duzGMgkOcTkWb+PR/Q2Oe54df/tLgHGVmFpAmtqJ553xJh6N63iFYI2yjo2PeJXbS5skHi/QpJq4vA==",
       "dev": true
     },
+    "locale-emoji": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/locale-emoji/-/locale-emoji-0.3.0.tgz",
+      "integrity": "sha512-JGm8+naU49CBDnH1jksS3LecPdfWQLxFgkLN6ZhYONKa850pJ0Xt8DPGJnYK0ZuJI8jTuiDDPCDtSL3nyacXwg==",
+      "dev": true
+    },
     "locate-character": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-2.0.5.tgz",
@@ -61284,6 +63975,12 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true
+    },
     "lodash.find": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
@@ -61388,6 +64085,12 @@
         "lodash.isarguments": "^3.0.0",
         "lodash.isarray": "^3.0.0"
       }
+    },
+    "lodash.last": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
+      "integrity": "sha512-14mq7rSkCxG4XMy9lF2FbIOqqgF0aH0NfPuQ3LPR3vIh0kHnUvIYP70dqa1Hf47zyXfQ8FzAg0MYOQeSuE1R7A==",
+      "dev": true
     },
     "lodash.lowerfirst": {
       "version": "4.3.1",
@@ -61958,9 +64661,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
       "dev": true
     },
     "minimist-options": {
@@ -62901,6 +65604,15 @@
       "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
       "dev": true
     },
+    "p-event": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
+      "integrity": "sha512-NQCqOFhbpVTMX4qMe8PF8lbGtzZ+LCiN7pcNrb/413Na7+TRoe1xkKUzuWa/YEJdGQ0FvKtj35EEbDoVPO2kbA==",
+      "dev": true,
+      "requires": {
+        "p-timeout": "^2.0.1"
+      }
+    },
     "p-finally": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
@@ -62949,6 +65661,23 @@
           "requires": {
             "p-finally": "^1.0.0"
           }
+        }
+      }
+    },
+    "p-timeout": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "dev": true,
+      "requires": {
+        "p-finally": "^1.0.0"
+      },
+      "dependencies": {
+        "p-finally": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+          "dev": true
         }
       }
     },
@@ -63105,8 +65834,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "path-exists": {
       "version": "3.0.0",

--- a/admin/package.json
+++ b/admin/package.json
@@ -75,6 +75,7 @@
     "ember-fetch": "^8.1.2",
     "ember-file-upload": "^7.1.0",
     "ember-flatpickr": "^3.2.3",
+    "ember-intl": "^5.7.2",
     "ember-load-initializers": "^2.1.2",
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^5.1.5",

--- a/admin/tests/helpers/setup-intl-rendering.js
+++ b/admin/tests/helpers/setup-intl-rendering.js
@@ -1,0 +1,7 @@
+import setupIntl from './setup-intl';
+import { setupRenderingTest } from 'ember-qunit';
+
+export default function setupIntlRenderingTest(hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
+}

--- a/admin/tests/helpers/setup-intl.js
+++ b/admin/tests/helpers/setup-intl.js
@@ -1,0 +1,10 @@
+export default function setupIntl(hooks, locale = ['fr']) {
+  hooks.beforeEach(function () {
+    this.intl = this.owner.lookup('service:intl');
+    this.intl.setLocale(locale);
+
+    this.dayjs = this.owner.lookup('service:dayjs');
+    this.dayjs.setLocale(locale[0]);
+    this.dayjs.self.locale(locale[0]);
+  });
+}

--- a/admin/tests/integration/components/login-form_test.js
+++ b/admin/tests/integration/components/login-form_test.js
@@ -1,20 +1,21 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import { render, fillByLabel, clickByName } from '@1024pix/ember-testing-library';
+import { render as renderScreen, fillByLabel, clickByName } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 import { reject } from 'rsvp';
-import ENV from 'pix-admin/config/environment';
 import sinon from 'sinon';
 
-const NOT_SUPER_ADMIN_MSG = "Vous n'avez pas les droits pour vous connecter.";
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+
+import ENV from 'pix-admin/config/environment';
+const ApiErrorMessages = ENV.APP.API_ERROR_MESSAGES;
 
 module('Integration | Component | login-form', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it displays a entry form', async function (assert) {
     // when
-    const screen = await render(hbs`<LoginForm />`);
+    const screen = await renderScreen(hbs`<LoginForm />`);
 
     // then
     assert.dom(screen.getByRole('textbox', { name: 'Adresse e-mail' })).exists();
@@ -24,7 +25,7 @@ module('Integration | Component | login-form', function (hooks) {
 
   test('should hide error message by default', async function (assert) {
     // when
-    await render(hbs`<LoginForm />`);
+    await renderScreen(hbs`<LoginForm />`);
 
     // then
     assert.dom('p.login-form__error').doesNotExist();
@@ -45,18 +46,19 @@ module('Integration | Component | login-form', function (hooks) {
     test('should display good error message when an error 401 occurred', async function (assert) {
       // given
       const errorResponse = {
+        status: Number(ApiErrorMessages.LOGIN_UNAUTHORIZED.CODE),
         responseJSON: {
           errors: [
             {
-              status: ENV.APP.API_ERROR_MESSAGES.UNAUTHORIZED.CODE,
-              detail: ENV.APP.API_ERROR_MESSAGES.UNAUTHORIZED.MESSAGE,
+              status: ApiErrorMessages.LOGIN_UNAUTHORIZED.CODE,
+              detail: ApiErrorMessages.LOGIN_UNAUTHORIZED.I18N_KEY,
             },
           ],
         },
       };
       sessionStub.authenticate = () => reject(errorResponse);
 
-      await render(hbs`<LoginForm />`);
+      const screen = await renderScreen(hbs`<LoginForm />`);
 
       // when
       await fillByLabel('Adresse e-mail', 'pix@example.net');
@@ -64,25 +66,25 @@ module('Integration | Component | login-form', function (hooks) {
       await clickByName('Je me connecte');
 
       // then
-      assert.dom('p.login-form__error').exists();
-      assert.dom('p.login-form__error').hasText(ENV.APP.API_ERROR_MESSAGES.UNAUTHORIZED.MESSAGE);
+      assert.dom(screen.getByText(this.intl.t(ApiErrorMessages.LOGIN_UNAUTHORIZED.I18N_KEY))).exists();
     });
 
     test('should display good error message when an error 400 occurred', async function (assert) {
       // given
       const errorResponse = {
+        status: Number(ApiErrorMessages.BAD_REQUEST.CODE),
         responseJSON: {
           errors: [
             {
-              status: ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.CODE,
-              detail: ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.MESSAGE,
+              status: ApiErrorMessages.BAD_REQUEST.CODE,
+              detail: ApiErrorMessages.BAD_REQUEST.I18N_KEY,
             },
           ],
         },
       };
       sessionStub.authenticate = () => reject(errorResponse);
 
-      await render(hbs`<LoginForm />`);
+      const screen = await renderScreen(hbs`<LoginForm />`);
 
       // when
       await fillByLabel('Adresse e-mail', 'pix@');
@@ -90,18 +92,18 @@ module('Integration | Component | login-form', function (hooks) {
       await clickByName('Je me connecte');
 
       // then
-      assert.dom('p.login-form__error').exists();
-      assert.dom('p.login-form__error').hasText(ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.MESSAGE);
+      assert.dom(screen.getByText(this.intl.t(ApiErrorMessages.BAD_REQUEST.I18N_KEY))).exists();
     });
 
     test('should display good error message when an error 403 occurred', async function (assert) {
       // given
       const errorResponse = {
-        responseJSON: { errors: [{ status: ENV.APP.API_ERROR_MESSAGES.FORBIDDEN, detail: NOT_SUPER_ADMIN_MSG }] },
+        status: Number(ApiErrorMessages.LOGIN_NO_PERMISSION.CODE),
+        responseJSON: { errors: [{ status: ApiErrorMessages.LOGIN_NO_PERMISSION.CODE }] },
       };
       sessionStub.authenticate = () => reject(errorResponse);
 
-      await render(hbs`<LoginForm />`);
+      const screen = await renderScreen(hbs`<LoginForm />`);
 
       // when
       await fillByLabel('Adresse e-mail', 'pix@example.net');
@@ -109,25 +111,25 @@ module('Integration | Component | login-form', function (hooks) {
       await clickByName('Je me connecte');
 
       // then
-      assert.dom('p.login-form__error').exists();
-      assert.dom('p.login-form__error').hasText(NOT_SUPER_ADMIN_MSG);
+      assert.dom(screen.getByText(this.intl.t(ApiErrorMessages.LOGIN_NO_PERMISSION.I18N_KEY))).exists();
     });
 
     test('should display good error message when an 500 error occurred', async function (assert) {
       // given
       const errorResponse = {
+        status: Number(ApiErrorMessages.INTERNAL_SERVER_ERROR.CODE),
         responseJSON: {
           errors: [
             {
-              status: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.CODE,
-              detail: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
+              status: ApiErrorMessages.INTERNAL_SERVER_ERROR.CODE,
+              detail: ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY,
             },
           ],
         },
       };
       sessionStub.authenticate = () => reject(errorResponse);
 
-      await render(hbs`<LoginForm />`);
+      const screen = await renderScreen(hbs`<LoginForm />`);
 
       // when
       await fillByLabel('Adresse e-mail', 'pix@example.net');
@@ -135,18 +137,18 @@ module('Integration | Component | login-form', function (hooks) {
       await clickByName('Je me connecte');
 
       // then
-      assert.dom('p.login-form__error').exists();
-      assert.dom('p.login-form__error').hasText(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE);
+      assert.dom(screen.getByText(this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY))).exists();
     });
 
     test('should display good error message when an non handled status code', async function (assert) {
       // given
       const errorResponse = {
-        responseJSON: { errors: [{ status: 502, detail: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE }] },
+        status: 418,
+        responseJSON: { errors: [{ status: 418 }] },
       };
       sessionStub.authenticate = () => reject(errorResponse);
 
-      await render(hbs`<LoginForm />`);
+      const screen = await renderScreen(hbs`<LoginForm />`);
 
       // when
       await fillByLabel('Adresse e-mail', 'pix@example.net');
@@ -154,8 +156,7 @@ module('Integration | Component | login-form', function (hooks) {
       await clickByName('Je me connecte');
 
       // then
-      assert.dom('p.login-form__error').exists();
-      assert.dom('p.login-form__error').hasText(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE);
+      assert.dom(screen.getByText(this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY))).exists();
     });
   });
 });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -1,0 +1,19 @@
+{
+  "common": {
+    "api-error-messages": {
+      "bad-request-error": "The data entered was not in the correct format.",
+      "login-unauthorized-error": "There was an error in the email address or username/password entered.",
+      "login-user-temporary-blocked-error": "You have reached too many failed login attempts. Please try again later or <a href=\"{url}\">reset your password here</a>.",
+      "login-user-blocked-error": "Your account has reached the maximum number of failed login attempts and has been temporarily blocked. Please <a href=\"{url}\">contact us</a> to unblock it.",
+    "internal-server-error": "An error occurred, our teams are working on finding a solution. Please try again later.",
+      "gateway-timeout-error": "The service is being slow. Please try again later."
+    }
+  },
+  "pages": {
+    "login": {
+      "api-error-messages": {
+        "login-no-permission": "You don't have the permission to connect."
+      }
+    }
+  }
+}

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -1,0 +1,19 @@
+{
+  "common": {
+    "api-error-messages": {
+      "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
+      "login-unauthorized-error": "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects.",
+      "login-user-temporary-blocked-error": "Vous avez effectué trop de tentatives de connexion. Réessayez plus tard ou cliquez sur <a href=\"{url}\">mot de passe oublié</a> pour le réinitialiser.",
+      "login-user-blocked-error": "Votre compte est bloqué car vous avez effectué trop de tentatives de connexion. Pour le débloquer, <a href=\"{url}\">contactez-nous</a>.",
+    "internal-server-error": "Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.",
+      "gateway-timeout-error": "Le service subit des ralentissements. Veuillez réessayer ultérieurement."
+    }
+  },
+  "pages": {
+    "login": {
+      "api-error-messages": {
+        "login-no-permission": "Vous n'avez pas les droits pour vous connecter."
+      }
+    }
+  }
+}

--- a/certif/app/components/auth/toggable-login-form.js
+++ b/certif/app/components/auth/toggable-login-form.js
@@ -21,9 +21,9 @@ export default class ToggableLoginForm extends Component {
   @tracked emailValidationMessage = null;
 
   ERROR_MESSAGES = {
-    DEFAULT: this.intl.t('common.api-errors-messages.default'),
-    STATUS_400: this.intl.t('common.api-errors-messages.bad-request'),
-    STATUS_401: this.intl.t('pages.login-or-register.login-form.errors.status.401'),
+    DEFAULT: this.intl.t('common.api-error-messages.internal-server-error'),
+    STATUS_400: this.intl.t('common.api-error-messages.bad-request-error'),
+    STATUS_401: this.intl.t('common.api-error-messages.login-unauthorized-error'),
     STATUS_403: this.intl.t('pages.login-or-register.login-form.errors.status.403'),
     STATUS_404: this.intl.t('pages.login-or-register.login-form.errors.status.404'),
     STATUS_409: this.intl.t('pages.login-or-register.login-form.errors.status.409'),

--- a/certif/app/components/login-form.js
+++ b/certif/app/components/login-form.js
@@ -6,6 +6,8 @@ import ENV from 'pix-certif/config/environment';
 import get from 'lodash/get';
 
 export default class LoginForm extends Component {
+  @service url;
+  @service intl;
   @service session;
 
   email = null;
@@ -36,9 +38,9 @@ export default class LoginForm extends Component {
     const scope = 'pix-certif';
     try {
       await this.session.authenticate('authenticator:oauth2', email, password, scope);
-    } catch (response) {
+    } catch (responseError) {
       this.isErrorMessagePresent = true;
-      this._manageErrorsApi(response);
+      this._handleApiError(responseError);
     }
   }
 
@@ -47,29 +49,48 @@ export default class LoginForm extends Component {
     this.isPasswordVisible = !this.isPasswordVisible;
   }
 
-  _manageErrorsApi(response = {}) {
-    const nbErrors = get(response, 'responseJSON.errors.length', 0);
-
-    if (nbErrors > 0) {
-      const firstError = response.responseJSON.errors[0];
-      const messageError = this._showErrorMessages(firstError.status, firstError.detail);
-      this.errorMessage = messageError;
-    } else {
-      this.errorMessage = ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE;
+  _handleApiError(responseError) {
+    const errors = get(responseError, 'responseJSON.errors');
+    const error = Array.isArray(errors) && errors.length > 0 && errors[0];
+    switch (error?.code) {
+      case 'SHOULD_CHANGE_PASSWORD':
+        this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.SHOULD_CHANGE_PASSWORD.I18N_KEY, {
+          url: this.url.forgottenPasswordUrl,
+          htmlSafe: true,
+        });
+        break;
+      case 'USER_IS_TEMPORARY_BLOCKED':
+        this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_IS_TEMPORARY_BLOCKED.I18N_KEY, {
+          url: this.url.forgottenPasswordUrl,
+          htmlSafe: true,
+        });
+        break;
+      case 'USER_IS_BLOCKED':
+        this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_IS_BLOCKED.I18N_KEY, {
+          url: 'https://support.pix.org/support/tickets/new',
+          htmlSafe: true,
+        });
+        break;
+      default:
+        this.errorMessage = this.intl.t(this._getI18nKeyByStatus(responseError.status));
     }
   }
 
-  _showErrorMessages(statusCode, apiError) {
-    const httpStatusCodeMessages = {
-      400: ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.MESSAGE,
-      500: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
-      422: ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.MESSAGE,
-      502: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
-      504: ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.MESSAGE,
-      401: apiError,
-      403: apiError,
-      default: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
-    };
-    return httpStatusCodeMessages[statusCode] || httpStatusCodeMessages['default'];
+  _getI18nKeyByStatus(status) {
+    switch (status) {
+      case 400:
+        return ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.I18N_KEY;
+      case 401:
+        return ENV.APP.API_ERROR_MESSAGES.LOGIN_UNAUTHORIZED.I18N_KEY;
+      // TODO: This case should be handled with a specific error code like USER_IS_TEMPORARY_BLOCKED or USER_IS_BLOCKED
+      case 403:
+        return ENV.APP.API_ERROR_MESSAGES.NOT_LINKED_CERTIFICATION.I18N_KEY;
+      case 422:
+        return ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.I18N_KEY;
+      case 504:
+        return ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.I18N_KEY;
+      default:
+        return ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY;
+    }
   }
 }

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -1,12 +1,13 @@
 import Service, { inject as service } from '@ember/service';
 
-import config from 'pix-certif/config/environment';
+import ENV from 'pix-certif/config/environment';
 
 export default class Url extends Service {
-  definedHomeUrl = config.rootURL;
-
   @service currentDomain;
   @service intl;
+
+  definedHomeUrl = ENV.rootURL;
+  pixAppUrlWithoutExtension = ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION;
 
   get homeUrl() {
     return this.definedHomeUrl;
@@ -26,7 +27,10 @@ export default class Url extends Service {
 
   get forgottenPasswordUrl() {
     const currentLanguage = this.intl.t('current-lang');
-    if (currentLanguage === 'en') return 'https://app.pix.org/mot-de-passe-oublie?lang=en';
-    return `https://app.pix.${this.currentDomain.getExtension()}/mot-de-passe-oublie`;
+    let url = `${this.pixAppUrlWithoutExtension}${this.currentDomain.getExtension()}/mot-de-passe-oublie`;
+    if (currentLanguage === 'en') {
+      url += '?lang=en';
+    }
+    return url;
   }
 }

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -42,19 +42,42 @@ module.exports = function (environment) {
         CONTENT: process.env.BANNER_CONTENT || '',
         TYPE: process.env.BANNER_TYPE || '',
       },
+      PIX_APP_URL_WITHOUT_EXTENSION: process.env.PIX_APP_URL_WITHOUT_EXTENSION || 'https://app.pix.',
       API_ERROR_MESSAGES: {
-        BAD_REQUEST: { CODE: '400', MESSAGE: 'Les données envoyées ne sont pas au bon format.' },
+        BAD_REQUEST: {
+          CODE: '400',
+          I18N_KEY: 'common.api-error-messages.bad-request-error',
+        },
+        LOGIN_UNAUTHORIZED: {
+          CODE: '401',
+          I18N_KEY: 'common.api-error-messages.login-unauthorized-error',
+        },
+        SHOULD_CHANGE_PASSWORD: {
+          CODE: '401',
+          I18N_KEY: 'pages.login-form.errors.should-change-password',
+        },
+        USER_IS_TEMPORARY_BLOCKED: {
+          CODE: '403',
+          I18N_KEY: 'common.api-error-messages.login-user-temporary-blocked-error',
+        },
+        USER_IS_BLOCKED: {
+          CODE: '403',
+          I18N_KEY: 'common.api-error-messages.login-user-blocked-error',
+        },
+        NOT_LINKED_CERTIFICATION: {
+          CODE: '403',
+          I18N_KEY: 'pages.login-or-register.login-form.errors.status.403',
+        },
+        FORBIDDEN: '403',
+        NOT_FOUND: '404',
         INTERNAL_SERVER_ERROR: {
           CODE: '500',
-          MESSAGE: 'Le service est momentanément indisponible. Veuillez réessayer ultérieurement.',
+          I18N_KEY: 'common.api-error-messages.internal-server-error',
         },
         GATEWAY_TIMEOUT: {
           CODE: '504',
-          MESSAGE: 'Le service subit des ralentissements. Veuillez réessayer ultérieurement.',
+          I18N_KEY: 'common.api-error-messages.gateway-timeout-error',
         },
-        UNAUTHORIZED: { CODE: '401', MESSAGE: "L'adresse e-mail et/ou le mot de passe saisis sont incorrects." },
-        FORBIDDEN: '403',
-        NOT_FOUND: '404',
       },
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({
         environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS',

--- a/certif/tests/unit/components/auth/toggable-login-form_test.js
+++ b/certif/tests/unit/components/auth/toggable-login-form_test.js
@@ -106,7 +106,7 @@ module('Unit | Component | toggable-login-form', (hooks) => {
             await component.authenticate(eventStub);
 
             // then
-            assert.strictEqual(component.errorMessage, this.intl.t('common.api-errors-messages.bad-request'));
+            assert.strictEqual(component.errorMessage, this.intl.t('common.api-error-messages.bad-request-error'));
             assert.false(component.isLoading);
             assert.true(component.isErrorMessagePresent);
           });
@@ -144,7 +144,10 @@ module('Unit | Component | toggable-login-form', (hooks) => {
                 await component.authenticate(eventStub);
 
                 // then
-                assert.strictEqual(component.errorMessage, this.intl.t('common.api-errors-messages.default'));
+                assert.strictEqual(
+                  component.errorMessage,
+                  this.intl.t('common.api-error-messages.internal-server-error')
+                );
                 assert.false(component.isLoading);
                 assert.true(component.isErrorMessagePresent);
               });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -7,9 +7,13 @@
       "quit": "Quitter",
       "update": "Modifier"
     },
-    "api-errors-messages": {
-      "bad-request": "The data entered was not in the correct format.",
-      "default": "The service is temporarily unavailable. Please try again later."
+    "api-error-messages": {
+      "bad-request-error": "The data entered was not in the correct format.",
+      "internal-server-error": "An error occurred, our teams are working on finding a solution. Please try again later.",
+      "login-unauthorized-error": "There was an error in the email address or username/password entered.",
+      "login-user-temporary-blocked-error": "You have reached too many failed login attempts. Please try again later or <a href=\"{url}\">reset your password here</a>.",
+      "login-user-blocked-error": "Your account has reached the maximum number of failed login attempts and has been temporarily blocked. Please <a href=\"{url}\">contact us</a> to unblock it.",
+      "gateway-timeout-error": "The service is being slow. Please try again later."
     },
     "form": {
       "mandatory-all-fields": "All fields are required."
@@ -27,6 +31,7 @@
     "login": {
       "title": "Login",
       "errors": {
+        "should-change-password": "You currently have a temporary password. <a href=\"{url}\">Reset your password here</a>.",
         "invitation-was-cancelled": "This invitation is no longer valid.<br/>Please contact the administrator of your Pix Certif space.",
         "invitation-already-accepted": "This invitation has already been accepted.<br/>Please log in or contact the administrator of your Pix Certif space."
       }
@@ -36,7 +41,6 @@
       "login-form": {
         "errors": {
           "status": {
-            "401": "Missing or invalid credentials",
             "403": "Access to this Pix Certif space is limited to invited members. Each Pix Certif space is managed by an administrator specific to the organisation using it. Please contact your administrator to get invited.",
             "404": "This email address doesn't match any Pix user.",
             "409": "This invitation has been already accepted or cancelled.",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -7,9 +7,13 @@
       "quit": "Quitter",
       "update": "Modifier"
     },
-    "api-errors-messages": {
-      "bad-request": "Les données que vous avez soumises ne sont pas au bon format.",
-      "default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement."
+    "api-error-messages": {
+      "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
+      "internal-server-error": "Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.",
+      "login-unauthorized-error": "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects.",
+      "login-user-temporary-blocked-error": "Vous avez effectué trop de tentatives de connexion. Réessayez plus tard ou cliquez sur <a href=\"{url}\">mot de passe oublié</a> pour le réinitialiser.",
+      "login-user-blocked-error": "Votre compte est bloqué car vous avez effectué trop de tentatives de connexion. Pour le débloquer, <a href=\"{url}\">contactez-nous</a>.",
+      "gateway-timeout-error": "Le service subit des ralentissements. Veuillez réessayer ultérieurement."
     },
     "form": {
       "mandatory-all-fields": "Tous les champs sont obligatoires."
@@ -27,6 +31,7 @@
     "login": {
       "title": "Connectez-vous",
       "errors": {
+        "should-change-password": "Vous avez actuellement un mot de passe temporaire. Cliquez sur <a href=\"{url}\">mot de passe oublié</a> pour le réinitialiser.",
         "invitation-was-cancelled": "Cette invitation n’est plus valide.<br/>Contactez l’administrateur de votre espace Pix Certif.",
         "invitation-already-accepted": "Cette invitation a déjà été acceptée.<br/>Connectez-vous ou contactez l’administrateur de votre espace Pix Certif."
       }
@@ -36,7 +41,6 @@
       "login-form": {
         "errors": {
           "status": {
-            "401": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects.",
             "403": "L'accès à Pix Certif est limité aux membres invités. Chaque espace est géré par un administrateur Pix Certif propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite.",
             "404": "Cet email n'appartient à aucun utilisateur.",
             "409": "Cette invitation a déjà été acceptée ou annulée.",

--- a/docs/Ember.md
+++ b/docs/Ember.md
@@ -83,7 +83,7 @@ module('Unit | Service | Error messages', function(hooks) {
     const message = errorMessages.getErrorMessage('CAMPAIGN_NAME_IS_REQUIRED');
     
     // then
-    assert.equal(message, t('api-errors-messages.campaign-creation.name-required'));
+    assert.equal(message, t('api-error-messages.campaign-creation.name-required'));
   });
 });
 ```

--- a/mon-pix/app/components/routes/campaigns/join-sco-information-modal.js
+++ b/mon-pix/app/components/routes/campaigns/join-sco-information-modal.js
@@ -36,7 +36,7 @@ export default class JoinScoInformationModal extends Component {
         this.isAccountBelongingToAnotherUser = true;
       } else {
         this.displayContinueButton = !ACCOUNT_WITH_SAMLID_ALREADY_EXISTS_ERRORS.includes(error.meta.shortCode);
-        const defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE);
+        const defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY);
         this.message =
           this.intl.t(getJoinErrorsMessageByShortCode(error.meta), { value: error.meta.value, htmlSafe: true }) ||
           defaultMessage;

--- a/mon-pix/app/components/routes/login-form.js
+++ b/mon-pix/app/components/routes/login-form.js
@@ -81,8 +81,8 @@ export default class LoginForm extends Component {
   }
 
   _manageErrorsApi(errorsApi) {
-    const defaultErrorMessage = this.intl.t('api-error-messages.internal-server-error');
-    const errorMessageStatusCode4xx = this.intl.t('api-error-messages.bad-request-error');
+    const defaultErrorMessage = this.intl.t('common.api-error-messages.internal-server-error');
+    const errorMessageStatusCode4xx = this.intl.t('common.api-error-messages.bad-request-error');
     const invalidCredentialsErrorMessage = this.intl.t('pages.login-or-register.login-form.error');
     const unexpectedUserAccountErrorMessage = this.intl.t(
       'pages.login-or-register.login-form.unexpected-user-account-error'

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -171,7 +171,7 @@ export default class RegisterForm extends Component {
             const message = this._showErrorMessageByShortCode(error.meta);
             return (this.errorMessage = message);
           }
-          const defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE);
+          const defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY);
           return (this.errorMessage = error.detail ? error.detail : defaultMessage);
         });
       }
@@ -179,7 +179,7 @@ export default class RegisterForm extends Component {
   }
 
   _showErrorMessageByShortCode(meta) {
-    const defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE);
+    const defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY);
     return (
       this.intl.t(getRegisterErrorsMessageByShortCode(meta), { value: meta.value, htlmSafe: true }) || defaultMessage
     );

--- a/mon-pix/app/components/signin-form.js
+++ b/mon-pix/app/components/signin-form.js
@@ -34,44 +34,55 @@ export default class SigninForm extends Component {
     this.hasFailed = false;
     try {
       await this.session.authenticateUser(this.login, this.password);
-    } catch (response) {
-      const shouldChangePassword = get(response, 'responseJSON.errors[0].title') === 'PasswordShouldChange';
-      if (shouldChangePassword) {
-        const passwordResetToken = response.responseJSON.errors[0].meta;
-        await this._updateExpiredPassword(passwordResetToken);
-      } else {
-        this.errorMessage = this._findErrorMessage(get(response, 'responseJSON.errors[0].code'), response.status);
-      }
+    } catch (responseError) {
       this.hasFailed = true;
+      this._handleApiError(responseError);
     }
   }
 
-  _findErrorMessage(errorCode, statusCode) {
-    let httpStatusCodeMessages;
-
-    switch (errorCode) {
+  async _handleApiError(responseError) {
+    const errors = get(responseError, 'responseJSON.errors');
+    const error = Array.isArray(errors) && errors.length > 0 && errors[0];
+    switch (error?.code) {
+      case 'SHOULD_CHANGE_PASSWORD': {
+        const passwordResetToken = error.meta;
+        await this._updateExpiredPassword(passwordResetToken);
+        break;
+      }
       case 'USER_IS_TEMPORARY_BLOCKED':
-        return this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_IS_TEMPORARY_BLOCKED.MESSAGE, {
+        this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_IS_TEMPORARY_BLOCKED.I18N_KEY, {
           url: '/mot-de-passe-oublie',
           htmlSafe: true,
         });
+        break;
       case 'USER_IS_BLOCKED':
-        return this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_IS_BLOCKED.MESSAGE, {
+        this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.USER_IS_BLOCKED.I18N_KEY, {
           url: 'https://support.pix.org/support/tickets/new',
           htmlSafe: true,
         });
+        break;
       default:
-        httpStatusCodeMessages = {
-          400: this.intl.t(ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.MESSAGE),
-          401: this.intl.t(ENV.APP.API_ERROR_MESSAGES.LOGIN_UNAUTHORIZED.MESSAGE),
-          default: this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE),
-        };
-        return httpStatusCodeMessages[statusCode] || httpStatusCodeMessages['default'];
+        this.errorMessage = this.intl.t(this._getI18nKeyByStatus(responseError.status));
     }
   }
 
   async _updateExpiredPassword(passwordResetToken) {
     this.store.createRecord('reset-expired-password-demand', { passwordResetToken });
     return this.router.replaceWith('update-expired-password');
+  }
+
+  _getI18nKeyByStatus(status) {
+    switch (status) {
+      case 400:
+        return ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.I18N_KEY;
+      case 401:
+        return ENV.APP.API_ERROR_MESSAGES.LOGIN_UNAUTHORIZED.I18N_KEY;
+      case 422:
+        return ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.I18N_KEY;
+      case 504:
+        return ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.I18N_KEY;
+      default:
+        return ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY;
+    }
   }
 }

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -156,7 +156,7 @@ export default class SignupForm extends Component {
         if (error) {
           this._manageErrorsApi(error);
         } else {
-          this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE);
+          this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY);
         }
         this._tokenHasBeenUsed = true;
         this.isLoading = false;
@@ -173,11 +173,11 @@ export default class SignupForm extends Component {
 
   _showErrorMessages(statusCode) {
     const httpStatusCodeMessages = {
-      400: ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.MESSAGE,
-      500: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
-      502: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
-      504: ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.MESSAGE,
-      default: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
+      400: ENV.APP.API_ERROR_MESSAGES.BAD_REQUEST.I18N_KEY,
+      500: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY,
+      502: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY,
+      504: ENV.APP.API_ERROR_MESSAGES.GATEWAY_TIMEOUT.I18N_KEY,
+      default: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY,
     };
     return this.intl.t(httpStatusCodeMessages[statusCode] || httpStatusCodeMessages['default']);
   }

--- a/mon-pix/app/components/update-expired-password-form.js
+++ b/mon-pix/app/components/update-expired-password-form.js
@@ -115,8 +115,8 @@ export default class UpdateExpiredPasswordForm extends Component {
 
   _showErrorMessages(statusCode) {
     const httpStatusCodeMessages = {
-      401: ENV.APP.API_ERROR_MESSAGES.LOGIN_UNAUTHORIZED.MESSAGE,
-      default: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE,
+      401: ENV.APP.API_ERROR_MESSAGES.LOGIN_UNAUTHORIZED.I18N_KEY,
+      default: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY,
     };
     return this.intl.t(httpStatusCodeMessages[statusCode] || httpStatusCodeMessages['default']);
   }

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -77,31 +77,31 @@ module.exports = function (environment) {
       API_ERROR_MESSAGES: {
         BAD_REQUEST: {
           CODE: '400',
-          MESSAGE: 'api-error-messages.bad-request-error',
+          I18N_KEY: 'common.api-error-messages.bad-request-error',
         },
         LOGIN_UNAUTHORIZED: {
           CODE: '401',
-          MESSAGE: 'api-error-messages.login-unauthorized-error',
+          I18N_KEY: 'common.api-error-messages.login-unauthorized-error',
         },
         USER_IS_TEMPORARY_BLOCKED: {
           CODE: '403',
-          MESSAGE: 'api-error-messages.login-user-temporary-blocked-error',
+          I18N_KEY: 'common.api-error-messages.login-user-temporary-blocked-error',
         },
         USER_IS_BLOCKED: {
           CODE: '403',
-          MESSAGE: 'api-error-messages.login-user-blocked-error',
+          I18N_KEY: 'common.api-error-messages.login-user-blocked-error',
         },
         INTERNAL_SERVER_ERROR: {
           CODE: '500',
-          MESSAGE: 'api-error-messages.internal-server-error',
+          I18N_KEY: 'common.api-error-messages.internal-server-error',
         },
         BAD_GATEWAY: {
           CODE: '502',
-          MESSAGE: 'api-error-messages.internal-server-error',
+          I18N_KEY: 'common.api-error-messages.internal-server-error',
         },
         GATEWAY_TIMEOUT: {
           CODE: '504',
-          MESSAGE: 'api-error-messages.internal-server-error',
+          I18N_KEY: 'common.api-error-messages.gateway-timeout-error',
         },
       },
       AUTHENTICATED_SOURCE_FROM_GAR: 'external',

--- a/mon-pix/mirage/routes/authentication/index.js
+++ b/mon-pix/mirage/routes/authentication/index.js
@@ -14,7 +14,13 @@ export default function index(config) {
     }
 
     if (foundUser.shouldChangePassword) {
-      return new Response(401, {}, { errors: [{ title: 'PasswordShouldChange', meta: foundUser.id }] });
+      return new Response(
+        401,
+        {},
+        {
+          errors: [{ title: 'PasswordShouldChange', code: 'SHOULD_CHANGE_PASSWORD', meta: foundUser.id }],
+        }
+      );
     }
 
     const response = {

--- a/mon-pix/mirage/routes/authentication/post-authentications.js
+++ b/mon-pix/mirage/routes/authentication/post-authentications.js
@@ -35,7 +35,13 @@ export default function (schema, request) {
         user_id: foundUser.id,
       };
     }
-    return new Response(401, {}, { errors: [{ title: 'PasswordShouldChange', meta: foundUser.id }] });
+    return new Response(
+      401,
+      {},
+      {
+        errors: [{ title: 'PasswordShouldChange', code: 'SHOULD_CHANGE_PASSWORD', meta: foundUser.id }],
+      }
+    );
   }
   return new Response(401, {}, 'Authentication failed');
 }

--- a/mon-pix/tests/acceptance/update-expired-password_test.js
+++ b/mon-pix/tests/acceptance/update-expired-password_test.js
@@ -10,6 +10,9 @@ import setupIntl from '../helpers/setup-intl';
 import { clickByLabel } from '../helpers/click-by-label';
 import { visit } from '@1024pix/ember-testing-library';
 
+import ENV from '../../config/environment';
+const ApiErrorMessages = ENV.APP.API_ERROR_MESSAGES;
+
 module('Acceptance | Update Expired Password', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -85,11 +88,8 @@ module('Acceptance | Update Expired Password', function (hooks) {
     await clickByLabel(this.intl.t('pages.update-expired-password.button'));
     // then
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/mise-a-jour-mot-de-passe-expire');
-    const expectedErrorMessage = this.intl.t('api-error-messages.login-unauthorized-error');
-    assert.ok(screen.getByText(expectedErrorMessage));
+    assert.strictEqual(currentURL(), '/mise-a-jour-mot-de-passe-expire');
+    assert.dom(screen.getByText(this.intl.t(ApiErrorMessages.LOGIN_UNAUTHORIZED.I18N_KEY))).exists();
   });
 
   test('should display error message when update password fails with http 404 error', async function (assert) {
@@ -130,10 +130,7 @@ module('Acceptance | Update Expired Password', function (hooks) {
     await clickByLabel(this.intl.t('pages.update-expired-password.button'));
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/mise-a-jour-mot-de-passe-expire');
-    const expectedErrorMessage = this.intl.t('api-error-messages.internal-server-error');
-    assert.ok(screen.getByText(expectedErrorMessage));
+    assert.strictEqual(currentURL(), '/mise-a-jour-mot-de-passe-expire');
+    assert.dom(screen.getByText(this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY))).exists();
   });
 });

--- a/mon-pix/tests/integration/components/signin-form_test.js
+++ b/mon-pix/tests/integration/components/signin-form_test.js
@@ -5,11 +5,11 @@ import hbs from 'htmlbars-inline-precompile';
 
 import Service from '@ember/service';
 
-import ENV from '../../../config/environment';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { contains } from '../../helpers/contains';
 import { clickByLabel } from '../../helpers/click-by-label';
 
+import ENV from '../../../config/environment';
 const ApiErrorMessages = ENV.APP.API_ERROR_MESSAGES;
 
 module('Integration | Component | signin form', function (hooks) {
@@ -59,7 +59,6 @@ module('Integration | Component | signin form', function (hooks) {
     module('When error api occurs', function () {
       test('should display related error message if unauthorized error', async function (assert) {
         // given
-        const expectedErrorMessage = ApiErrorMessages.LOGIN_UNAUTHORIZED.MESSAGE;
         class sessionService extends Service {
           authenticateUser = sinon.stub().rejects({ status: 401 });
         }
@@ -72,14 +71,12 @@ module('Integration | Component | signin form', function (hooks) {
         await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('div[id="sign-in-error-message"]').textContent.trim(), this.intl.t(expectedErrorMessage));
+        const expectedErrorMessage = this.intl.t(ApiErrorMessages.LOGIN_UNAUTHORIZED.I18N_KEY);
+        assert.strictEqual(find('div[id="sign-in-error-message"]').textContent.trim(), expectedErrorMessage);
       });
 
       test('should display related error message if bad request error', async function (assert) {
         // given
-        const expectedErrorMessage = ApiErrorMessages.BAD_REQUEST.MESSAGE;
         class sessionService extends Service {
           authenticateUser = sinon.stub().rejects({ status: 400 });
         }
@@ -92,9 +89,8 @@ module('Integration | Component | signin form', function (hooks) {
         await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('div[id="sign-in-error-message"]').textContent.trim(), this.intl.t(expectedErrorMessage));
+        const expectedErrorMessage = this.intl.t(ApiErrorMessages.BAD_REQUEST.I18N_KEY);
+        assert.strictEqual(find('div[id="sign-in-error-message"]').textContent.trim(), expectedErrorMessage);
       });
 
       test('should display an error if api cannot be reached', async function (assert) {
@@ -113,11 +109,9 @@ module('Integration | Component | signin form', function (hooks) {
 
         // then
         assert.ok(document.querySelector('div.sign-form__notification-message--error'));
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+        assert.strictEqual(
           find('div[id="sign-in-error-message"]').textContent.trim(),
-          this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.MESSAGE)
+          this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY)
         );
       });
 
@@ -125,10 +119,6 @@ module('Integration | Component | signin form', function (hooks) {
         module('when is user is temporary blocked', function () {
           test('displays a specific error', async function (assert) {
             // given
-            const expectedErrorMessage = this.intl.t(ApiErrorMessages.USER_IS_TEMPORARY_BLOCKED.MESSAGE, {
-              url: '/mot-de-passe-oublie',
-              htmlSafe: true,
-            });
             class sessionService extends Service {
               authenticateUser = sinon
                 .stub()
@@ -143,6 +133,10 @@ module('Integration | Component | signin form', function (hooks) {
             await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
 
             // then
+            const expectedErrorMessage = this.intl.t(ApiErrorMessages.USER_IS_TEMPORARY_BLOCKED.I18N_KEY, {
+              url: '/mot-de-passe-oublie',
+              htmlSafe: true,
+            });
             assert.deepEqual(find('div[id="sign-in-error-message"]').innerHTML.trim(), expectedErrorMessage.string);
           });
         });
@@ -150,10 +144,6 @@ module('Integration | Component | signin form', function (hooks) {
         module('when is user blocked', function () {
           test('displays a specific error', async function (assert) {
             // given
-            const expectedErrorMessage = this.intl.t(ApiErrorMessages.USER_IS_BLOCKED.MESSAGE, {
-              url: 'https://support.pix.org/support/tickets/new',
-              htmlSafe: true,
-            });
             class sessionService extends Service {
               authenticateUser = sinon
                 .stub()
@@ -168,6 +158,10 @@ module('Integration | Component | signin form', function (hooks) {
             await clickByLabel(this.intl.t('pages.sign-in.actions.submit'));
 
             // then
+            const expectedErrorMessage = this.intl.t(ApiErrorMessages.USER_IS_BLOCKED.I18N_KEY, {
+              url: 'https://support.pix.org/support/tickets/new',
+              htmlSafe: true,
+            });
             assert.deepEqual(find('div[id="sign-in-error-message"]').innerHTML.trim(), expectedErrorMessage.string);
           });
         });

--- a/mon-pix/tests/integration/components/signup-form_test.js
+++ b/mon-pix/tests/integration/components/signup-form_test.js
@@ -14,12 +14,12 @@ import hbs from 'htmlbars-inline-precompile';
 import ENV from '../../../config/environment';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
+const ApiErrorMessages = ENV.APP.API_ERROR_MESSAGES;
+
 const FORM_TITLE = '.sign-form-title';
 const INPUT_TEXT_FIELD_CLASS_DEFAULT = 'form-textfield__input-container--default';
 
 const userEmpty = EmberObject.create({});
-
-const ApiErrorMessages = ENV.APP.API_ERROR_MESSAGES;
 
 module('Integration | Component | SignupForm', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -44,9 +44,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         await render(hbs`<SignupForm @user={{this.user}} />`);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find(FORM_TITLE).textContent, expectedTitle);
+        assert.strictEqual(find(FORM_TITLE).textContent, expectedTitle);
       });
     });
   });
@@ -64,9 +62,7 @@ module('Integration | Component | SignupForm', function (hooks) {
 
     test('should return correct form title', function (assert) {
       const formTitle = this.intl.t('pages.sign-up.first-title');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find(FORM_TITLE).textContent, formTitle);
+      assert.strictEqual(find(FORM_TITLE).textContent, formTitle);
     });
 
     test('should display form elements', async function (assert) {
@@ -117,7 +113,6 @@ module('Integration | Component | SignupForm', function (hooks) {
 
     test('should display an error if api cannot be reached', async function (assert) {
       // given
-      const expectedErrorMessage = ApiErrorMessages.INTERNAL_SERVER_ERROR.MESSAGE;
       const stubCatchedApiErrorInternetDisconnected = undefined;
 
       const user = EmberObject.create({
@@ -135,19 +130,16 @@ module('Integration | Component | SignupForm', function (hooks) {
 
       // then
       assert.dom('div[id="sign-up-error-message"]').exists();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('div[id="sign-up-error-message"]').textContent.trim(), this.intl.t(expectedErrorMessage));
+      const expectedErrorMessage = this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY);
+      assert.strictEqual(find('div[id="sign-up-error-message"]').textContent.trim(), expectedErrorMessage);
     });
 
     test('should display related error message if internal server error', async function (assert) {
       // given
-      const expectedErrorMessage = ApiErrorMessages.INTERNAL_SERVER_ERROR.MESSAGE;
       const apiReturn = {
         errors: [
           {
             status: 500,
-            detail: expectedErrorMessage,
             title: 'Internal server error',
           },
         ],
@@ -168,19 +160,16 @@ module('Integration | Component | SignupForm', function (hooks) {
 
       // then
       assert.dom('div[id="sign-up-error-message"]').exists();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('div[id="sign-up-error-message"]').textContent.trim(), this.intl.t(expectedErrorMessage));
+      const expectedErrorMessage = this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY);
+      assert.strictEqual(find('div[id="sign-up-error-message"]').textContent.trim(), expectedErrorMessage);
     });
 
     test('should display related error message if bad gateway error', async function (assert) {
       // given
-      const expectedErrorMessage = ApiErrorMessages.BAD_GATEWAY.MESSAGE;
       const apiReturn = {
         errors: [
           {
             status: 502,
-            detail: expectedErrorMessage,
             title: 'Bad gateway error',
           },
         ],
@@ -200,19 +189,16 @@ module('Integration | Component | SignupForm', function (hooks) {
 
       // then
       assert.dom('div[id="sign-up-error-message"]').exists();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('div[id="sign-up-error-message"]').textContent.trim(), this.intl.t(expectedErrorMessage));
+      const expectedErrorMessage = this.intl.t(ApiErrorMessages.BAD_GATEWAY.I18N_KEY);
+      assert.strictEqual(find('div[id="sign-up-error-message"]').textContent.trim(), expectedErrorMessage);
     });
 
     test('should display related error message if gateway timeout error', async function (assert) {
       // given
-      const expectedErrorMessage = ApiErrorMessages.GATEWAY_TIMEOUT.MESSAGE;
       const apiReturn = {
         errors: [
           {
             status: 504,
-            detail: expectedErrorMessage,
             title: 'Gateway timeout error',
           },
         ],
@@ -232,14 +218,12 @@ module('Integration | Component | SignupForm', function (hooks) {
 
       // then
       assert.dom('div[id="sign-up-error-message"]').exists();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('div[id="sign-up-error-message"]').textContent.trim(), this.intl.t(expectedErrorMessage));
+      const expectedErrorMessage = this.intl.t(ApiErrorMessages.GATEWAY_TIMEOUT.I18N_KEY);
+      assert.strictEqual(find('div[id="sign-up-error-message"]').textContent.trim(), expectedErrorMessage);
     });
 
     test('should display related error message if not implemented error', async function (assert) {
       // given
-      const expectedErrorMessage = ApiErrorMessages.INTERNAL_SERVER_ERROR.MESSAGE;
       const apiReturn = {
         errors: [
           {
@@ -264,9 +248,8 @@ module('Integration | Component | SignupForm', function (hooks) {
 
       // then
       assert.dom('div[id="sign-up-error-message"]').exists();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('div[id="sign-up-error-message"]').textContent.trim(), this.intl.t(expectedErrorMessage));
+      const expectedErrorMessage = this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY);
+      assert.strictEqual(find('div[id="sign-up-error-message"]').textContent.trim(), expectedErrorMessage);
     });
   });
 
@@ -364,9 +347,7 @@ module('Integration | Component | SignupForm', function (hooks) {
           assert.ok(
             find('#validationMessage-firstName').getAttribute('class').includes('form-textfield__message--error')
           );
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('.form-textfield__message--error').textContent.trim(), emptyFirstnameErrorMessage);
+          assert.strictEqual(find('.form-textfield__message--error').textContent.trim(), emptyFirstnameErrorMessage);
           assert.ok(find('#firstName').getAttribute('class').includes('form-textfield__input--error'));
           assert.dom('.form-textfield-icon__state--error').exists();
         });
@@ -389,9 +370,7 @@ module('Integration | Component | SignupForm', function (hooks) {
           assert.ok(
             find('#validationMessage-lastName').getAttribute('class').includes('form-textfield__message--error')
           );
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('.form-textfield__message--error').textContent.trim(), emptyLastnameErrorMessage);
+          assert.strictEqual(find('.form-textfield__message--error').textContent.trim(), emptyLastnameErrorMessage);
           assert.ok(find('#lastName').getAttribute('class').includes('form-textfield__input--error'));
           assert.dom('.form-textfield-icon__state--error').exists();
         });
@@ -414,9 +393,7 @@ module('Integration | Component | SignupForm', function (hooks) {
           assert.ok(
             find('.form-textfield__message-email').getAttribute('class').includes('form-textfield__message--error')
           );
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('.form-textfield__message--error').textContent.trim(), emptyEmailErrorMessage);
+          assert.strictEqual(find('.form-textfield__message--error').textContent.trim(), emptyEmailErrorMessage);
           assert.ok(find('#email').getAttribute('class').includes('form-textfield__input--error'));
           assert.dom('.form-textfield-icon__state--error').exists();
         });
@@ -439,9 +416,7 @@ module('Integration | Component | SignupForm', function (hooks) {
           assert.ok(
             find('.form-textfield__message-password').getAttribute('class').includes('form-textfield__message--error')
           );
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('.form-textfield__message--error').textContent.trim(), incorrectPasswordErrorMessage);
+          assert.strictEqual(find('.form-textfield__message--error').textContent.trim(), incorrectPasswordErrorMessage);
           assert.ok(find('#password').getAttribute('class').includes('form-textfield__input--error'));
           assert.dom('.form-textfield-icon__state--error').exists();
         });
@@ -482,9 +457,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         // then
         return settled().then(() => {
           assert.dom('.sign-form__validation-error').exists();
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('.sign-form__validation-error').textContent.trim(), uncheckedCheckboxCguErrorMessage);
+          assert.strictEqual(find('.sign-form__validation-error').textContent.trim(), uncheckedCheckboxCguErrorMessage);
         });
       });
 
@@ -518,9 +491,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('#validationMessage-email').textContent, expectedMaxLengthEmailError);
+        assert.strictEqual(find('#validationMessage-email').textContent, expectedMaxLengthEmailError);
       });
 
       test('should not display success notification message when an error occurred during the form submission', async function (assert) {

--- a/mon-pix/tests/integration/components/update-expired-password-form_test.js
+++ b/mon-pix/tests/integration/components/update-expired-password-form_test.js
@@ -8,6 +8,9 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { contains } from '../../helpers/contains';
 import { clickByLabel } from '../../helpers/click-by-label';
 
+import ENV from '../../../config/environment';
+const ApiErrorMessages = ENV.APP.API_ERROR_MESSAGES;
+
 const PASSWORD_INPUT_CLASS = '.form-textfield__input';
 
 module('Integration | Component | update-expired-password-form', function (hooks) {
@@ -50,8 +53,6 @@ module('Integration | Component | update-expired-password-form', function (hooks
   module('errors cases', function () {
     test('should display an error, when saving fails', async function (assert) {
       // given
-      const expectedErrorMessage = this.intl.t('api-error-messages.internal-server-error');
-
       const resetExpiredPasswordDemand = EmberObject.create({
         login: 'toto',
         password: 'Password123',
@@ -70,7 +71,7 @@ module('Integration | Component | update-expired-password-form', function (hooks
       await clickByLabel(this.intl.t('pages.update-expired-password.button'));
 
       // then
-      assert.ok(contains(expectedErrorMessage));
+      assert.ok(contains(this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY)));
     });
   });
 });

--- a/mon-pix/tests/unit/components/signin-form_test.js
+++ b/mon-pix/tests/unit/components/signin-form_test.js
@@ -21,6 +21,7 @@ module('Unit | Component | signin-form', function (hooks) {
               errors: [
                 {
                   title: 'PasswordShouldChange',
+                  code: 'SHOULD_CHANGE_PASSWORD',
                   meta: 'PASSWORD_RESET_TOKEN',
                 },
               ],

--- a/mon-pix/tests/unit/components/update-expired-password-form_test.js
+++ b/mon-pix/tests/unit/components/update-expired-password-form_test.js
@@ -6,6 +6,9 @@ import Service from '@ember/service';
 
 import setupIntl from '../../helpers/setup-intl';
 
+import ENV from '../../../config/environment';
+const ApiErrorMessages = ENV.APP.API_ERROR_MESSAGES;
+
 const ERROR_PASSWORD_MESSAGE = 'pages.update-expired-password.fields.error';
 
 const VALIDATION_MAP = {
@@ -132,7 +135,6 @@ module('Unit | Component | Update Expired Password Form', function (hooks) {
 
       test('should set error message if http 401 error', async function (assert) {
         // given
-        const expectedErrorMessage = component.intl.t('api-error-messages.login-unauthorized-error');
         const response = {
           errors: [{ status: '401' }],
         };
@@ -142,23 +144,18 @@ module('Unit | Component | Update Expired Password Form', function (hooks) {
         await component.actions.handleUpdatePasswordAndAuthenticate.call(component);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.errorMessage, expectedErrorMessage);
+        assert.strictEqual(component.errorMessage, component.intl.t(ApiErrorMessages.LOGIN_UNAUTHORIZED.I18N_KEY));
       });
 
       test('should set validation with errors data', async function (assert) {
         // given
-        const expectedErrorMessage = component.intl.t('api-error-messages.internal-server-error');
         component.resetExpiredPasswordDemand.updateExpiredPassword.rejects();
 
         // when
         await component.actions.handleUpdatePasswordAndAuthenticate.call(component);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.errorMessage, expectedErrorMessage);
+        assert.strictEqual(component.errorMessage, component.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY));
       });
     });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1,8 +1,6 @@
 {
   "current-lang": "en",
   "api-error-messages": {
-    "bad-request-error": "The data entered was not in the correct format.",
-    "internal-server-error": "An error occurred, our teams are working on finding a solution. Please try again later.",
     "join-error": {
       "r11": "{ value }",
       "r12": "You already have a Pix account under the username '<br>'{ value }.'<br>'To continue, log in with this account or ask for help from a teacher.'<br>'(Code R12)",
@@ -24,9 +22,6 @@
         }
       }
     },
-    "login-unauthorized-error": "There was an error in the email address or username/password entered.",
-    "login-user-temporary-blocked-error": "You have reached too many failed login attempts. Please try again later or <a href=\"{ url }\">reset your password here</a>.",
-    "login-user-blocked-error": "Your account has reached the maximum number of failed login attempts and has been temporarily blocked. Please <a href=\"{ url }\">contact us</a> to unblock it.",
     "register-error": {
       "s51": "{ value }",
       "s52": "You already have a Pix account under the username '<br>'{ value }.'<br>'To continue, log in with this account or ask for help from a teacher.'<br>'(Code S52)",
@@ -46,6 +41,14 @@
       "close": "Close",
       "quit": "Exit",
       "sign-out": "Sign out"
+    },
+    "api-error-messages": {
+      "bad-request-error": "The data entered was not in the correct format.",
+      "internal-server-error": "An error occurred, our teams are working on finding a solution. Please try again later.",
+      "login-unauthorized-error": "There was an error in the email address or username/password entered.",
+      "login-user-temporary-blocked-error": "You have reached too many failed login attempts. Please try again later or <a href=\"{url}\">reset your password here</a>.",
+      "login-user-blocked-error": "Your account has reached the maximum number of failed login attempts and has been temporarily blocked. Please <a href=\"{url}\">contact us</a> to unblock it.",
+      "gateway-timeout-error": "The service is being slow. Please try again later."
     },
     "cgu": {
       "accept": "I agree to the ",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1,8 +1,6 @@
 {
   "current-lang": "fr",
   "api-error-messages": {
-    "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
-    "internal-server-error": "Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.",
     "join-error": {
       "r11": "Vous possédez déjà un compte Pix avec l’adresse e-mail'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R11)",
       "r12": "Vous possédez déjà un compte Pix utilisé avec l’identifiant sous la forme prénom.nom suivi de 4 chiffres:'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R12)",
@@ -24,9 +22,6 @@
         }
       }
     },
-    "login-unauthorized-error": "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects.",
-    "login-user-temporary-blocked-error": "Vous avez effectué trop de tentatives de connexion. Réessayez plus tard ou cliquez sur <a href=\"{ url }\">mot de passe oublié</a> pour le réinitialiser.",
-    "login-user-blocked-error": "Votre compte est bloqué car vous avez effectué trop de tentatives de connexion. Pour le débloquer, <a href=\"{ url }\">contactez-nous</a>.",
     "register-error": {
       "s51": "Vous possédez déjà un compte Pix avec l’adresse e-mail'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R51)",
       "s52": "Vous possédez déjà un compte Pix utilisé avec l’identifiant sous la forme prénom.nom suivi de 4 chiffres:'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R52)",
@@ -46,6 +41,14 @@
       "close": "Fermer",
       "quit": "Quitter",
       "sign-out": "Se déconnecter"
+    },
+    "api-error-messages": {
+      "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
+      "internal-server-error": "Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.",
+      "login-unauthorized-error": "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects.",
+      "login-user-temporary-blocked-error": "Vous avez effectué trop de tentatives de connexion. Réessayez plus tard ou cliquez sur <a href=\"{url}\">mot de passe oublié</a> pour le réinitialiser.",
+      "login-user-blocked-error": "Votre compte est bloqué car vous avez effectué trop de tentatives de connexion. Pour le débloquer, <a href=\"{url}\">contactez-nous</a>.",
+      "gateway-timeout-error": "Le service subit des ralentissements. Veuillez réessayer ultérieurement."
     },
     "cgu": {
       "accept": "J'accepte les ",

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -118,7 +118,7 @@
         @categoriesPlaceholder={{t "pages.campaign-creation.target-profiles-category-placeholder"}}
         @value={{this.targetProfile.id}}
         @requiredText={{t "common.form.mandatory-fields-title"}}
-        @errorMessage={{if @errors.targetProfile (t "api-errors-messages.campaign-creation.target-profile-required")}}
+        @errorMessage={{if @errors.targetProfile (t "api-error-messages.campaign-creation.target-profile-required")}}
         @isSearchable={{true}}
         @searchLabel={{t "pages.campaign-creation.target-profiles-search-placeholder"}}
       />

--- a/orga/app/components/campaign/header/archived-banner.js
+++ b/orga/app/components/campaign/header/archived-banner.js
@@ -14,7 +14,7 @@ export default class CampaignArchivedBanner extends Component {
       const campaign = this.store.peekRecord('campaign', this.args.campaign.id);
       await campaign.unarchive();
     } catch (err) {
-      this.notifications.error(this.intl.t('api-errors-messages.global'));
+      this.notifications.error(this.intl.t('api-error-messages.global'));
     }
   }
 

--- a/orga/app/components/campaign/settings/view.js
+++ b/orga/app/components/campaign/settings/view.js
@@ -51,7 +51,7 @@ export default class CampaignView extends Component {
       const campaign = this.store.peekRecord('campaign', campaignId);
       await campaign.archive();
     } catch (err) {
-      this.notifications.error(this.intl.t('api-errors-messages.global'));
+      this.notifications.error(this.intl.t('api-error-messages.global'));
     }
   }
 }

--- a/orga/app/components/campaign/update-form.js
+++ b/orga/app/components/campaign/update-form.js
@@ -54,11 +54,11 @@ export default class UpdateForm extends Component {
   _handleErrors(errorResponse) {
     const errors = errorResponse.errors;
     if (!errors) {
-      return this.notifications.error(this.intl.t('api-errors-messages.global'));
+      return this.notifications.error(this.intl.t('api-error-messages.global'));
     }
     return errorResponse.errors.forEach((error) => {
       if (error.status !== '422') {
-        return this.notifications.error(this.intl.t('api-errors-messages.global'));
+        return this.notifications.error(this.intl.t('api-error-messages.global'));
       }
     });
   }

--- a/orga/app/components/sup-organization-participant/edit-student-number-modal.js
+++ b/orga/app/components/sup-organization-participant/edit-student-number-modal.js
@@ -44,7 +44,7 @@ export default class EditStudentNumberModal extends Component {
   _handleError(errorResponse) {
     errorResponse.errors.forEach((error) => {
       if (error.detail === 'STUDENT_NUMBER_EXISTS') {
-        return (this.error = this.intl.t('api-errors-messages.edit-student-number.student-number-exists', {
+        return (this.error = this.intl.t('api-error-messages.edit-student-number.student-number-exists', {
           firstName: this.args.student.firstName,
           lastName: this.args.student.lastName,
         }));

--- a/orga/app/components/team/invitations-list.js
+++ b/orga/app/components/team/invitations-list.js
@@ -20,7 +20,7 @@ export default class TeamInvitationsListComponent extends Component {
 
       this.notifications.success(this.intl.t('pages.team-invitations.invitation-cancelled-succeed-message'));
     } catch (e) {
-      this.notifications.error(this.intl.t('api-errors-messages.global'));
+      this.notifications.error(this.intl.t('api-error-messages.global'));
     }
   }
 }

--- a/orga/app/controllers/authenticated/campaigns/new.js
+++ b/orga/app/controllers/authenticated/campaigns/new.js
@@ -23,7 +23,7 @@ export default class NewController extends Controller {
     } catch (errorResponse) {
       errorResponse.errors.forEach((error) => {
         if (error.status === '500') {
-          this.notifications.sendError(this.intl.t('api-errors-messages.global'));
+          this.notifications.sendError(this.intl.t('api-error-messages.global'));
         }
       });
       this.errors = this.model.campaign.errors;

--- a/orga/app/services/error-messages.js
+++ b/orga/app/services/error-messages.js
@@ -1,43 +1,43 @@
 import Service, { inject as service } from '@ember/service';
 
 const CAMPAIGN_CREATION_ERRORS = {
-  CAMPAIGN_NAME_IS_REQUIRED: 'api-errors-messages.campaign-creation.name-required',
-  CAMPAIGN_PURPOSE_IS_REQUIRED: 'api-errors-messages.campaign-creation.purpose-required',
-  TARGET_PROFILE_IS_REQUIRED: 'api-errors-messages.campaign-creation.target-profile-required',
-  EXTERNAL_USER_ID_IS_REQUIRED: 'api-errors-messages.campaign-creation.external-user-id-required',
-  OWNER_NOT_IN_ORGANIZATION: 'api-errors-messages.campaign-creation.owner_not_in_organization',
-  CAMPAIGN_TITLE_IS_TOO_LONG: 'api-errors-messages.campaign-creation.title_too_long',
-  CUSTOM_LANDING_PAGE_TEXT_IS_TOO_LONG: 'api-errors-messages.campaign-creation.custom-landing-page-text_too_long',
+  CAMPAIGN_NAME_IS_REQUIRED: 'api-error-messages.campaign-creation.name-required',
+  CAMPAIGN_PURPOSE_IS_REQUIRED: 'api-error-messages.campaign-creation.purpose-required',
+  TARGET_PROFILE_IS_REQUIRED: 'api-error-messages.campaign-creation.target-profile-required',
+  EXTERNAL_USER_ID_IS_REQUIRED: 'api-error-messages.campaign-creation.external-user-id-required',
+  OWNER_NOT_IN_ORGANIZATION: 'api-error-messages.campaign-creation.owner_not_in_organization',
+  CAMPAIGN_TITLE_IS_TOO_LONG: 'api-error-messages.campaign-creation.title_too_long',
+  CUSTOM_LANDING_PAGE_TEXT_IS_TOO_LONG: 'api-error-messages.campaign-creation.custom-landing-page-text_too_long',
 };
 
 const CSV_IMPORT_ERRORS = {
-  ENCODING_NOT_SUPPORTED: 'api-errors-messages.student-csv-import.encoding-not-supported',
-  BAD_CSV_FORMAT: 'api-errors-messages.student-csv-import.bad-csv-format',
-  HEADER_REQUIRED: 'api-errors-messages.student-csv-import.header-required',
-  HEADER_UNKNOWN: 'api-errors-messages.student-csv-import.header-unknown',
-  FIELD_MIN_LENGTH: 'api-errors-messages.student-csv-import.field-min-length',
-  FIELD_MAX_LENGTH: 'api-errors-messages.student-csv-import.field-max-length',
-  FIELD_LENGTH: 'api-errors-messages.student-csv-import.field-length',
-  FIELD_DATE_FORMAT: 'api-errors-messages.student-csv-import.field-date-format',
-  FIELD_EMAIL_FORMAT: 'api-errors-messages.student-csv-import.field-email-format',
-  FIELD_REQUIRED: 'api-errors-messages.student-csv-import.field-required',
-  FIELD_BAD_VALUES: 'api-errors-messages.student-csv-import.field-bad-values',
-  IDENTIFIER_UNIQUE: 'api-errors-messages.student-csv-import.identifier-unique',
-  INSEE_CODE_INVALID: 'api-errors-messages.student-csv-import.insee-code-invalid',
-  PAYLOAD_TOO_LARGE: 'api-errors-messages.student-csv-import.payload-too-large',
-  STUDENT_NUMBER_UNIQUE: 'api-errors-messages.student-csv-import.student-number-unique',
-  STUDENT_NUMBER_FORMAT: 'api-errors-messages.student-csv-import.student-number-format',
+  ENCODING_NOT_SUPPORTED: 'api-error-messages.student-csv-import.encoding-not-supported',
+  BAD_CSV_FORMAT: 'api-error-messages.student-csv-import.bad-csv-format',
+  HEADER_REQUIRED: 'api-error-messages.student-csv-import.header-required',
+  HEADER_UNKNOWN: 'api-error-messages.student-csv-import.header-unknown',
+  FIELD_MIN_LENGTH: 'api-error-messages.student-csv-import.field-min-length',
+  FIELD_MAX_LENGTH: 'api-error-messages.student-csv-import.field-max-length',
+  FIELD_LENGTH: 'api-error-messages.student-csv-import.field-length',
+  FIELD_DATE_FORMAT: 'api-error-messages.student-csv-import.field-date-format',
+  FIELD_EMAIL_FORMAT: 'api-error-messages.student-csv-import.field-email-format',
+  FIELD_REQUIRED: 'api-error-messages.student-csv-import.field-required',
+  FIELD_BAD_VALUES: 'api-error-messages.student-csv-import.field-bad-values',
+  IDENTIFIER_UNIQUE: 'api-error-messages.student-csv-import.identifier-unique',
+  INSEE_CODE_INVALID: 'api-error-messages.student-csv-import.insee-code-invalid',
+  PAYLOAD_TOO_LARGE: 'api-error-messages.student-csv-import.payload-too-large',
+  STUDENT_NUMBER_UNIQUE: 'api-error-messages.student-csv-import.student-number-unique',
+  STUDENT_NUMBER_FORMAT: 'api-error-messages.student-csv-import.student-number-format',
 };
 
 const XML_IMPORT_ERRORS = {
-  EMPTY: 'api-errors-messages.student-xml-import.empty',
-  ENCODING_NOT_SUPPORTED: 'api-errors-messages.student-xml-import.encoding-not-supported',
-  INE_REQUIRED: 'api-errors-messages.student-xml-import.ine-required',
-  INE_UNIQUE: 'api-errors-messages.student-xml-import.ine-unique',
-  INVALID_FILE: 'api-errors-messages.student-xml-import.invalid-file',
-  INVALID_FILE_EXTENSION: 'api-errors-messages.student-xml-import.invalid-file-extension',
-  PAYLOAD_TOO_LARGE: 'api-errors-messages.student-xml-import.payload-too-large',
-  UAI_MISMATCHED: 'api-errors-messages.student-xml-import.uai-mismatched',
+  EMPTY: 'api-error-messages.student-xml-import.empty',
+  ENCODING_NOT_SUPPORTED: 'api-error-messages.student-xml-import.encoding-not-supported',
+  INE_REQUIRED: 'api-error-messages.student-xml-import.ine-required',
+  INE_UNIQUE: 'api-error-messages.student-xml-import.ine-unique',
+  INVALID_FILE: 'api-error-messages.student-xml-import.invalid-file',
+  INVALID_FILE_EXTENSION: 'api-error-messages.student-xml-import.invalid-file-extension',
+  PAYLOAD_TOO_LARGE: 'api-error-messages.student-xml-import.payload-too-large',
+  UAI_MISMATCHED: 'api-error-messages.student-xml-import.uai-mismatched',
 };
 
 const ERROR_MESSAGES = {
@@ -52,7 +52,7 @@ export default class ErrorMessagesService extends Service {
   _formatMeta(meta) {
     if (!meta) return;
     if (meta.valids) {
-      meta.valids = meta.valids.join(this.intl.t('api-errors-messages.or-separator'));
+      meta.valids = meta.valids.join(this.intl.t('api-error-messages.or-separator'));
     }
     return meta;
   }

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -53,4 +53,13 @@ export default class Url extends Service {
     }
     return `https://pix.${this.currentDomain.getExtension()}/accessibilite-pix-orga`;
   }
+
+  get forgottenPasswordUrl() {
+    const currentLanguage = this.intl.t('current-lang');
+    let url = `${this.pixAppUrlWithoutExtension}${this.currentDomain.getExtension()}/mot-de-passe-oublie`;
+    if (currentLanguage === 'en') {
+      url += '?lang=en';
+    }
+    return url;
+  }
 }

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -49,6 +49,44 @@ module.exports = function (environment) {
         minValue: 0,
       }),
       PIX_APP_URL_WITHOUT_EXTENSION: process.env.PIX_APP_URL_WITHOUT_EXTENSION || 'https://app.pix.',
+      API_ERROR_MESSAGES: {
+        BAD_REQUEST: {
+          CODE: '400',
+          I18N_KEY: 'common.api-error-messages.bad-request-error',
+        },
+        LOGIN_UNAUTHORIZED: {
+          CODE: '401',
+          I18N_KEY: 'common.api-error-messages.login-unauthorized-error',
+        },
+        SHOULD_CHANGE_PASSWORD: {
+          CODE: '401',
+          I18N_KEY: 'pages.login-form.errors.should-change-password',
+        },
+        USER_IS_TEMPORARY_BLOCKED: {
+          CODE: '403',
+          I18N_KEY: 'common.api-error-messages.login-user-temporary-blocked-error',
+        },
+        USER_IS_BLOCKED: {
+          CODE: '403',
+          I18N_KEY: 'common.api-error-messages.login-user-blocked-error',
+        },
+        NOT_LINKED_ORGANIZATION: {
+          CODE: '403',
+          I18N_KEY: 'pages.login-form.errors.status.403',
+        },
+        INTERNAL_SERVER_ERROR: {
+          CODE: '500',
+          I18N_KEY: 'common.api-error-messages.internal-server-error',
+        },
+        BAD_GATEWAY: {
+          CODE: '502',
+          I18N_KEY: 'common.api-error-messages.internal-server-error',
+        },
+        GATEWAY_TIMEOUT: {
+          CODE: '504',
+          I18N_KEY: 'common.api-error-messages.internal-server-error',
+        },
+      },
     },
 
     fontawesome: {

--- a/orga/tests/acceptance/campaign-parameters_test.js
+++ b/orga/tests/acceptance/campaign-parameters_test.js
@@ -40,6 +40,6 @@ module('Acceptance | Campaign Parameters', function (hooks) {
     await clickByName('Archiver');
 
     // then
-    assert.dom(screen.getByText(this.intl.t('api-errors-messages.global'))).exists();
+    assert.dom(screen.getByText(this.intl.t('api-error-messages.global'))).exists();
   });
 });

--- a/orga/tests/acceptance/join_test.js
+++ b/orga/tests/acceptance/join_test.js
@@ -13,6 +13,9 @@ import {
 } from '../helpers/test-init';
 import setupIntl from '../helpers/setup-intl';
 
+import ENV from '../../config/environment';
+const ApiErrorMessages = ENV.APP.API_ERROR_MESSAGES;
+
 module('Acceptance | join', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -237,8 +240,6 @@ module('Acceptance | join', function (hooks) {
 
       test('it should remain on join page', async function (assert) {
         // given
-        const expectedErrorMessage = this.intl.t('pages.login-form.errors.status.401');
-
         server.post(
           '/token',
           {
@@ -259,7 +260,7 @@ module('Acceptance | join', function (hooks) {
 
         assert.strictEqual(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
         assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
-        assert.contains(expectedErrorMessage);
+        assert.contains(this.intl.t(ApiErrorMessages.LOGIN_UNAUTHORIZED.I18N_KEY));
       });
     });
 

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -536,9 +536,9 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       await clickByName(t('pages.campaign-creation.yes'));
 
       // then
-      assert.contains(t('api-errors-messages.campaign-creation.name-required'));
-      assert.contains(t('api-errors-messages.campaign-creation.purpose-required'));
-      assert.contains(t('api-errors-messages.campaign-creation.external-user-id-required'));
+      assert.contains(t('api-error-messages.campaign-creation.name-required'));
+      assert.contains(t('api-error-messages.campaign-creation.purpose-required'));
+      assert.contains(t('api-error-messages.campaign-creation.external-user-id-required'));
     });
 
     test('it should display errors messages when the target profile field is empty', async function (assert) {
@@ -566,7 +566,7 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       await clickByName(t('pages.campaign-creation.purpose.assessment'));
 
       // then
-      assert.contains(t('api-errors-messages.campaign-creation.target-profile-required'));
+      assert.contains(t('api-error-messages.campaign-creation.target-profile-required'));
     });
   });
 });

--- a/orga/tests/integration/components/team/invitations-list_test.js
+++ b/orga/tests/integration/components/team/invitations-list_test.js
@@ -103,7 +103,7 @@ module('Integration | Component | Team::InvitationsList', function (hooks) {
     await clickByName(this.intl.t('pages.team-invitations.cancel-invitation'));
 
     // then
-    sinon.assert.calledWith(notifications.error, this.intl.t('api-errors-messages.global'));
+    sinon.assert.calledWith(notifications.error, this.intl.t('api-error-messages.global'));
     assert.ok(true);
   });
 });

--- a/orga/tests/unit/services/error-messages_test.js
+++ b/orga/tests/unit/services/error-messages_test.js
@@ -30,7 +30,7 @@ module('Unit | Service | Error messages', function (hooks) {
     // When
     const message = errorMessages.getErrorMessage('CAMPAIGN_NAME_IS_REQUIRED');
     // Then
-    assert.strictEqual(message, t('api-errors-messages.campaign-creation.name-required'));
+    assert.strictEqual(message, t('api-error-messages.campaign-creation.name-required'));
   });
 
   test('should return the message with parameters', function (assert) {
@@ -41,7 +41,7 @@ module('Unit | Service | Error messages', function (hooks) {
     // Then
     assert.strictEqual(
       message,
-      t('api-errors-messages.student-csv-import.field-min-length', { line: 1, field: 'Boo', limit: 2 })
+      t('api-error-messages.student-csv-import.field-min-length', { line: 1, field: 'Boo', limit: 2 })
     );
   });
 
@@ -53,10 +53,10 @@ module('Unit | Service | Error messages', function (hooks) {
     // Then
     assert.strictEqual(
       message,
-      t('api-errors-messages.student-csv-import.field-bad-values', {
+      t('api-error-messages.student-csv-import.field-bad-values', {
         line: 1,
         field: 'Boo',
-        valids: `A${t('api-errors-messages.or-separator')}B`,
+        valids: `A${t('api-error-messages.or-separator')}B`,
       })
     );
   });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1,7 +1,6 @@
 {
   "current-lang": "en",
-  "api-errors-messages": {
-    "bad-request": "The data entered was not in the correct format.",
+  "api-error-messages": {
     "campaign-creation": {
       "external-user-id-required": "Please specify the type of external user ID which the participants will be required to fill when starting the customised test.",
       "name-required": "Please name your campaign.",
@@ -144,6 +143,14 @@
       "cancel": "Cancel",
       "close": "Close",
       "global": "Actions"
+    },
+    "api-error-messages": {
+      "bad-request-error": "The data entered was not in the correct format.",
+      "internal-server-error": "An error occurred, our teams are working on finding a solution. Please try again later.",
+      "login-unauthorized-error": "There was an error in the email address or username/password entered.",
+      "login-user-temporary-blocked-error": "You have reached too many failed login attempts. Please try again later or <a href=\"{url}\">reset your password here</a>.",
+      "login-user-blocked-error": "Your account has reached the maximum number of failed login attempts and has been temporarily blocked. Please <a href=\"{url}\">contact us</a> to unblock it.",
+      "gateway-timeout-error": "The service is being slow. Please try again later."
     },
     "filters": {
       "loading": "Loading...",
@@ -585,10 +592,9 @@
       "errors": {
         "invalid-email": "Your email address is invalid.",
         "empty-password": "Your password can't be empty.",
+        "should-change-password": "You currently have a temporary password. <a href=\"{url}\">Reset your password here</a>.",
         "status": {
-          "401": "Missing or invalid credentials",
-          "403": "Access to this Pix Orga space is limited to invited members. Each Pix Orga space is managed by an administrator specific to the organisation using it. Please contact your administrator to get invited.",
-          "401-should-change-password": "An error occurred. Please change your password."
+          "403": "Access to this Pix Orga space is limited to invited members. Each Pix Orga space is managed by an administrator specific to the organisation using it. Please contact your administrator to get invited."
         }
       },
       "forgot-password": "Forgot your password?",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1,7 +1,6 @@
 {
   "current-lang": "fr",
-  "api-errors-messages": {
-    "bad-request": "Les données que vous avez soumises ne sont pas au bon format.",
+  "api-error-messages": {
     "campaign-creation": {
       "external-user-id-required": "Veuillez préciser le libellé du champ qui sera demandé à vos participants au démarrage du parcours.",
       "name-required": "Veuillez donner un nom à votre campagne.",
@@ -144,6 +143,14 @@
       "cancel": "Annuler",
       "close": "Fermer",
       "global": "Actions"
+    },
+    "api-error-messages": {
+      "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
+      "internal-server-error": "Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.",
+      "login-unauthorized-error": "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects.",
+      "login-user-temporary-blocked-error": "Vous avez effectué trop de tentatives de connexion. Réessayez plus tard ou cliquez sur <a href=\"{url}\">mot de passe oublié</a> pour le réinitialiser.",
+      "login-user-blocked-error": "Votre compte est bloqué car vous avez effectué trop de tentatives de connexion. Pour le débloquer, <a href=\"{url}\">contactez-nous</a>.",
+      "gateway-timeout-error": "Le service subit des ralentissements. Veuillez réessayer ultérieurement."
     },
     "filters": {
       "loading": "Chargement...",
@@ -585,10 +592,9 @@
       "errors": {
         "invalid-email": "Votre adresse e-mail n’est pas valide.",
         "empty-password": "Le champ mot de passe est obligatoire.",
+        "should-change-password": "Vous avez actuellement un mot de passe temporaire. Cliquez sur <a href=\"{url}\">mot de passe oublié</a> pour le réinitialiser.",
         "status": {
-          "401": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects.",
-          "403": "L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite.",
-          "401-should-change-password": "Erreur, vous devez changer votre mot de passe."
+          "403": "L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite."
         }
       },
       "forgot-password": "Mot de passe oublié ?",


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement l’information qu'un compte est bloqué (temporairement ou définitif) n’est donnée à l'utilisateur que sur le formulaire de connexion de Pix App. Cette information est manquante sur les formulaires de connexion de Pix Orga, Pix Certif et Pix Admin.

C’est surtout urgent pour Pix Orga où le message est déroutant (“vous n’avez pas accès à Pix Orga”) là où dans les autres apps on a une traduction du message d’erreur “User has been temporary blocked”.

## :gift: Proposition

Implémenter la prise en compte des messages d'erreur API qui véhiculent l'information du blocage de compte dans les applications Pix Orga, Pix Certif et Pix Admin. Et en même temps uniformiser le plus possible la gestion des erreurs API au moment de la connexion dans les 4 applications clientes que sont Pix App, Pix Orga, Pix Certif et Pix Admin.

### Au niveau technique

L'uniformisation est centrée sur les fichiers `signin-form.js` pour Pix App et `login-form.js` pour Pix Orga, Pix Certif et Pix Admin en standardisant l'utilisation des fonctions suivantes :
* `_handleApiError`
* `_getMessageIdByStatus`

Le support de l'i18n est ajouté à Pix Admin. En effet, même si Pix Admin n'est pas prévue actuellement pour être utilisée par d'autres que les agents de Pix, cela est pertinent car :
   * cela rend la gestion des erreurs cohérente entre toutes les applis
   * cela rend le code plus élégant en manipulant uniquement des identifiants de messages et en cantonnant les messages dans les fichiers de traduction, ce qui pourra être utilisé par la suite pour tout nouveau message à afficher dans Pix Admin

Enfin, pour toutes les applications, une uniformisation des clés de traduction est faite sur `common.api-error-messages` et sur `api-error-messages`.

## :star2: Remarques

* Le cas d'utilisation de `SHOULD_CHANGE_PASSWORD` est différent suivant les applications et n'est donc pas géré de manière générique : il y a un fonctionnement particulier dans Pix App, un fonctionnement particulier dans Pix Orga et Pix Certif et pas de gestion de ce cas dans Pix Admin
* Le cas d'utilisation de l'API error avec un status `403` est différent dans toutes les applications et n'est donc pas géré de manière générique

## :santa: Pour tester

1. Tester les différents stades de blocage des comptes en suivant le même plan de test que #5276 pour les 4 applications :
   * Pix App
   * Pix Orga
   * Pix Certif
   * Pix Admin
2. Dans Pix App, tester le cas d'un utilisateur devant changer son mot de passe : l'utilisateur doit être redirigé vers la page pour mettre à jour son mot de passe.
3. Dans Pix Orga et dans Pix Certif, tester le cas d'un utilisateur devant changer son mot de passe : le message d'information suivant doit être affiché : 
   > Vous avez actuellement un mot de passe temporaire. Allez sur xxx/mot-de-passe-oublie pour le réinitialiser.
4. Dans Pix Admin, faire un test de non-régression sur le cas des utilisateurs non-autorisés. Le message d'information suivant doit être affiché : 
   > Vous n'avez pas les droits pour vous connecter.
5. Dans Pix Orga, faire un test de non-régression sur le cas des utilisateurs non-invités. Le message d'information suivant doit être affiché : 
   > L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite.
   
   Le test automatisé correspondant est `it should display an not linked organisation message when authentication fails` de https://github.com/1024pix/pix/blob/dev/orga/tests/integration/components/auth/login-form_test.js
6. Dans Pix Certif, faire un test de non-régression sur le cas des utilisateurs non-invités. Le message d'information suivant doit être affiché : 
   > L'accès à Pix Certif est limité aux membres invités. Chaque espace est géré par un administrateur Pix Certif propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite.
   
   Le test automatisé correspondant est `it should display a not linked certification message when authentication fails with Forbidden Access` de https://github.com/1024pix/pix/blob/dev/certif/tests/integration/components/login-form_test.js

   Pour pouvoir reproduire ce dernier cas il faut empêcher la redirection automatique vers l'espace surveillant. Pour ce faire une solution est d'exécuter la requête SQL suivante : 
   ```sql
   update "certification-centers" set "isSupervisorAccessEnabled"=false;
   ```
