### PR TITLE
[BUGFIX] Corriger l'erreur d'année sur un test CPF (pix-6704)

### DIFF
--- a/api/tests/unit/infrastructure/jobs/cpf-export/handlers/send-email_test.js
+++ b/api/tests/unit/infrastructure/jobs/cpf-export/handlers/send-email_test.js
@@ -21,8 +21,7 @@ describe('Unit | Infrastructure | jobs | cpf-export | send-email', function () {
     const month = '01';
     sinon.stub(cpf, 'plannerJob').value({ cron: `0 0 ${day} ${month} *` });
 
-    // eslint-disable-next-line no-restricted-syntax
-    const expectedDate = new Date('2022-15-01');
+    const expectedDate = new Date('2022-01-15T00:00:00Z');
     const cronExpressionParserStub = {
       prev: () => ({
         toDate: () => expectedDate,


### PR DESCRIPTION
## :christmas_tree: Problème
Le test qui récupère les fichiers CPF exportés depuis le dernier CRON est en erreur depuis le changement d'année.

## :gift: Proposition
Faire un stub de la date renvoyée par le cron parser pour que l'année attendue dans le test soit bonne.

## :santa: Pour tester
Les tests passent.