### PR TITLE
[FEATURE] Migration de reprise des données des utilisateurs déjà anonymisés (PIX-6630)

### DIFF
--- a/api/db/migrations/20230103093529_set-date-for-hasBeenAnonymised-column-on-users-table.js
+++ b/api/db/migrations/20230103093529_set-date-for-hasBeenAnonymised-column-on-users-table.js
@@ -1,0 +1,9 @@
+const TABLE_NAME = 'users';
+
+exports.up = function (knex) {
+  return knex(TABLE_NAME).whereILike('email', 'email\\_%@example.net').update({ hasBeenAnonymised: true });
+};
+
+exports.down = function (knex) {
+  return knex(TABLE_NAME).whereILike('email', 'email\\_%@example.net').update({ hasBeenAnonymised: false });
+};


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement, suite à l'ajout de nouvelles colonnes **hasBeenAnonymised** et **hasBeenAnonymisedBy** sur la table **Users**, les utilisateurs anonymes ont toujours les valeurs par défaut pour ces colonnes **FALSE** et **NULL**.

## :gift: Proposition

Créer un script de migration de base de données pour mettre à jour la valeur de la colonne `hasBeenAnonymised` pour tous les utilisateurs anonymes (FALSE -> TRUE).

## :star2: Remarques

Test à faire en local uniquement

## :santa: Pour tester

- Se mettre sur la branche `dev` et récupérer la dernière version du code
- Exécutez la commande, dans le dossier de l'api, `npm run db:reset` pour avoir une base de données propre
- Lancez l'api et l'application admin
- Anonymisez des utilisateurs
- Vérifiez en base de données que ces utilisateurs ont bien été anonymisé
- Pour chacun des ces utilisateurs anonymisés, supprimer les valeurs des colonnes `hasBeenAnonymised (FALSE)` et `hasBeenAnonymisedBy (NULL)` pour obtenir l'état actuel des utilisateurs anonymisés en production
- Stoppez l'api et l'application admin
- Se mettre sur la branche de cette PR
- Exécutez la commande, dans le dossier de l'api, `npm run db:migrate`
- Constatez en base de données que les utilisateurs anonymisés ont la valeur `TRUE` pour la colonne `hasBeenAnonymised`
- Exécutez la commande, dans le dossier de l'api, `npm run db:rollback:latest`
- Constatez en base de données que les utilisateurs anonymisés ont la valeur `FALSE` pour la colonne `hasBeenAnonymised`