### PR TITLE
[FEATURE] Afficher le nom du membre qui a fait l'action d'anonymisation sur la page de détail d'un utilisateur dans Pix Admin (PIX-4221).

### DIFF
--- a/admin/app/components/users/user-overview.hbs
+++ b/admin/app/components/users/user-overview.hbs
@@ -173,10 +173,16 @@
           @backgroundColor="transparent-light"
           @isBorderVisible={{true}}
           @triggerAction={{this.changeEditionMode}}
+          @isDisabled={{@user.hasBeenAnonymised}}
         >
           Modifier
         </PixButton>
-        <PixButton @size="small" @backgroundColor="red" @triggerAction={{this.toggleDisplayAnonymizeModal}}>
+        <PixButton
+          @size="small"
+          @backgroundColor="red"
+          @triggerAction={{this.toggleDisplayAnonymizeModal}}
+          @isDisabled={{@user.hasBeenAnonymised}}
+        >
           Anonymiser cet utilisateur
         </PixButton>
         {{#if @user.userLogin.blockedAt}}

--- a/admin/app/components/users/user-overview.hbs
+++ b/admin/app/components/users/user-overview.hbs
@@ -92,6 +92,11 @@
     <section class="page-section">
       <div class="user-detail-personal-information-section__content">
         <div>
+          {{#if @user.hasBeenAnonymised}}
+            <PixMessage @type="warning" class="user-detail-personal-information-section__anonymisation-message">
+              {{this.anonymisationMessage}}
+            </PixMessage>
+          {{/if}}
           <div>
             <span>Prénom : </span>
             <span>{{@user.firstName}}</span>

--- a/admin/app/components/users/user-overview.js
+++ b/admin/app/components/users/user-overview.js
@@ -102,6 +102,12 @@ export default class UserOverview extends Component {
     return urlDashboardPrefix && urlDashboardPrefix + this.args.user.id;
   }
 
+  get anonymisationMessage() {
+    return this.args.user.anonymisedByFullName
+      ? `Utilisateur anonymisé par ${this.args.user.anonymisedByFullName}.`
+      : 'Utilisateur anonymisé.';
+  }
+
   get canModifyEmail() {
     return !!(this.args.user.email || this.args.user.username);
   }

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -17,6 +17,8 @@ export default class User extends Model {
   @attr() lastPixCertifTermsOfServiceValidatedAt;
   @attr() lastLoggedAt;
   @attr() emailConfirmedAt;
+  @attr() hasBeenAnonymised;
+  @attr() anonymisedByFullName;
 
   // includes
   @belongsTo('profile') profile;

--- a/admin/app/styles/components/users/user-detail-personal-information-section.scss
+++ b/admin/app/styles/components/users/user-detail-personal-information-section.scss
@@ -15,6 +15,10 @@
       margin-right: 12px;
     }
   }
+
+  &__anonymisation-message {
+    margin-bottom: 16px;
+  }
 }
 
 .organization-learners-table {

--- a/admin/tests/integration/components/users/user-overview_test.js
+++ b/admin/tests/integration/components/users/user-overview_test.js
@@ -403,6 +403,34 @@ module('Integration | Component | users | user-overview', function (hooks) {
         assert.dom(screen.queryByRole('button', { name: 'Confirmer' })).doesNotExist();
         assert.dom(screen.queryByRole('button', { name: 'Annuler' })).doesNotExist();
       });
+
+      test('should display an anonymisation message with the full name of the admin member', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const user = store.createRecord('user', { hasBeenAnonymised: true, anonymisedByFullName: 'Laurent Gina' });
+        this.set('user', user);
+
+        // when
+        const screen = await render(hbs`<Users::UserOverview @user={{this.user}} />`);
+
+        // then
+        assert.dom(screen.getByText('Utilisateur anonymisé par Laurent Gina.')).exists();
+      });
+
+      module('When the admin member who anonymised the user is not set in database', function () {
+        test('should display an anonymisation message', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const user = store.createRecord('user', { hasBeenAnonymised: true, anonymisedByFullName: null });
+          this.set('user', user);
+
+          // when
+          const screen = await render(hbs`<Users::UserOverview @user={{this.user}} />`);
+
+          // then
+          assert.dom(screen.getByText('Utilisateur anonymisé.')).exists();
+        });
+      });
     });
   });
 

--- a/admin/tests/integration/components/users/user-overview_test.js
+++ b/admin/tests/integration/components/users/user-overview_test.js
@@ -417,6 +417,20 @@ module('Integration | Component | users | user-overview', function (hooks) {
         assert.dom(screen.getByText('Utilisateur anonymisé par Laurent Gina.')).exists();
       });
 
+      test('should disable action buttons "Modifier" and "Anonymiser cet utilisateur"', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const user = store.createRecord('user', { hasBeenAnonymised: true, anonymisedByFullName: 'Laurent Gina' });
+        this.set('user', user);
+
+        // when
+        const screen = await render(hbs`<Users::UserOverview @user={{this.user}} />`);
+
+        // then
+        assert.dom(screen.getByRole('button', { name: 'Modifier' })).hasAttribute('disabled');
+        assert.dom(screen.getByRole('button', { name: 'Anonymiser cet utilisateur' })).hasAttribute('disabled');
+      });
+
       module('When the admin member who anonymised the user is not set in database', function () {
         test('should display an anonymisation message', async function (assert) {
           // given

--- a/api/lib/domain/models/UserDetailsForAdmin.js
+++ b/api/lib/domain/models/UserDetailsForAdmin.js
@@ -21,6 +21,8 @@ class UserDetailsForAdmin {
     userLogin,
     hasBeenAnonymised,
     hasBeenAnonymisedBy,
+    anonymisedByFirstName,
+    anonymisedByLastName,
   } = {}) {
     this.id = id;
     this.cgu = cgu;
@@ -43,6 +45,8 @@ class UserDetailsForAdmin {
     this.hasBeenAnonymised = hasBeenAnonymised;
     this.hasBeenAnonymisedBy = hasBeenAnonymisedBy;
     this.updatedAt = updatedAt;
+    this.anonymisedByFirstName = anonymisedByFirstName;
+    this.anonymisedByLastName = anonymisedByLastName;
   }
 }
 

--- a/api/lib/domain/models/UserDetailsForAdmin.js
+++ b/api/lib/domain/models/UserDetailsForAdmin.js
@@ -20,7 +20,6 @@ class UserDetailsForAdmin {
     emailConfirmedAt,
     userLogin,
     hasBeenAnonymised,
-    hasBeenAnonymisedBy,
     anonymisedByFirstName,
     anonymisedByLastName,
   } = {}) {
@@ -43,7 +42,6 @@ class UserDetailsForAdmin {
     this.emailConfirmedAt = emailConfirmedAt;
     this.userLogin = userLogin;
     this.hasBeenAnonymised = hasBeenAnonymised;
-    this.hasBeenAnonymisedBy = hasBeenAnonymisedBy;
     this.updatedAt = updatedAt;
     this.anonymisedByFirstName = anonymisedByFirstName;
     this.anonymisedByLastName = anonymisedByLastName;

--- a/api/lib/domain/models/UserDetailsForAdmin.js
+++ b/api/lib/domain/models/UserDetailsForAdmin.js
@@ -48,6 +48,12 @@ class UserDetailsForAdmin {
     this.anonymisedByFirstName = anonymisedByFirstName;
     this.anonymisedByLastName = anonymisedByLastName;
   }
+
+  get anonymisedByFullName() {
+    return this.anonymisedByFirstName && this.anonymisedByLastName
+      ? `${this.anonymisedByFirstName} ${this.anonymisedByLastName}`
+      : null;
+  }
 }
 
 module.exports = UserDetailsForAdmin;

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -441,7 +441,6 @@ function _fromKnexDTOToUserDetailsForAdmin({ userDTO, organizationLearnersDTO, a
     authenticationMethods: authenticationMethodsDTO,
     userLogin,
     hasBeenAnonymised: userDTO.hasBeenAnonymised,
-    hasBeenAnonymisedBy: userDTO.hasBeenAnonymisedBy,
     updatedAt: userDTO.updatedAt,
     createdAt: userDTO.createdAt,
     anonymisedByFirstName: userDTO.anonymisedByFirstName,

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -90,12 +90,15 @@ module.exports = {
   async getUserDetailsForAdmin(userId) {
     const userDTO = await knex('users')
       .leftJoin('user-logins', 'user-logins.userId', 'users.id')
+      .leftJoin('users AS anonymisedBy', 'anonymisedBy.id', 'users.hasBeenAnonymisedBy')
       .select([
         'users.*',
         'user-logins.id AS userLoginId',
         'user-logins.failureCount',
         'user-logins.temporaryBlockedUntil',
         'user-logins.blockedAt',
+        'anonymisedBy.firstName AS anonymisedByFirstName',
+        'anonymisedBy.lastName AS anonymisedByLastName',
       ])
       .where({ 'users.id': userId })
       .first();
@@ -441,6 +444,8 @@ function _fromKnexDTOToUserDetailsForAdmin({ userDTO, organizationLearnersDTO, a
     hasBeenAnonymisedBy: userDTO.hasBeenAnonymisedBy,
     updatedAt: userDTO.updatedAt,
     createdAt: userDTO.createdAt,
+    anonymisedByFirstName: userDTO.anonymisedByFirstName,
+    anonymisedByLastName: userDTO.anonymisedByLastName,
   });
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/user-anonymized-details-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-anonymized-details-for-admin-serializer.js
@@ -10,7 +10,7 @@ module.exports = {
         'username',
         'cgu',
         'hasBeenAnonymised',
-        'hasBeenAnonymisedBy',
+        'anonymisedByFullName',
         'updatedAt',
         'pixOrgaTermsOfServiceAccepted',
         'pixCertifTermsOfServiceAccepted',

--- a/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
@@ -26,6 +26,8 @@ module.exports = {
         'lastPixCertifTermsOfServiceValidatedAt',
         'lastLoggedAt',
         'emailConfirmedAt',
+        'hasBeenAnonymised',
+        'anonymisedByFullName',
         'organizationLearners',
         'authenticationMethods',
         'profile',

--- a/api/tests/acceptance/application/users/users-controller-get-user-details-for-admin_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-user-details-for-admin_test.js
@@ -96,6 +96,8 @@ describe('Acceptance | Controller | users-controller-get-user-details-for-admin'
           'pix-certif-terms-of-service-accepted': false,
           'pix-orga-terms-of-service-accepted': false,
           username: user.username,
+          'has-been-anonymised': false,
+          'anonymised-by-full-name': null,
         });
 
         expect(response.result.data.relationships).to.deep.equal({

--- a/api/tests/acceptance/application/users/users-route_test.js
+++ b/api/tests/acceptance/application/users/users-route_test.js
@@ -53,7 +53,7 @@ describe('Acceptance | Route | users', function () {
       expect(updatedUserAttributes.username).to.be.null;
 
       expect(updatedUserAttributes['has-been-anonymised']).to.be.true;
-      expect(updatedUserAttributes['has-been-anonymised-by']).to.equal(1234);
+      expect(updatedUserAttributes['anonymised-by-full-name']).to.equal('Super Papa');
       expect(updatedUserAttributes['updated-at']).to.exist;
     });
 

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -1043,7 +1043,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
         expect(userDetailsForAdmin.lastLoggedAt).to.deep.equal(lastLoggedAt);
         expect(userDetailsForAdmin.emailConfirmedAt).to.deep.equal(emailConfirmedAt);
         expect(userDetailsForAdmin.hasBeenAnonymised).to.be.false;
-        expect(userDetailsForAdmin.hasBeenAnonymisedBy).to.be.null;
       });
 
       it('should return a UserNotFoundError if no user is found', async function () {
@@ -1153,7 +1152,9 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
           // then
           expect(userDetailsForAdmin.authenticationMethods.length).to.equal(0);
           expect(userDetailsForAdmin.hasBeenAnonymised).to.be.true;
-          expect(userDetailsForAdmin.hasBeenAnonymisedBy).to.equal(1);
+
+          const { hasBeenAnonymisedBy } = await knex('users').where({ id: userInDB.id }).first();
+          expect(hasBeenAnonymisedBy).to.equal(1);
         });
 
         it("should return the anonymisedBy's first and last names", async function () {

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -1155,6 +1155,29 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
           expect(userDetailsForAdmin.hasBeenAnonymised).to.be.true;
           expect(userDetailsForAdmin.hasBeenAnonymisedBy).to.equal(1);
         });
+
+        it("should return the anonymisedBy's first and last names", async function () {
+          // given
+          const adminWhoAnonymisedUser = databaseBuilder.factory.buildUser({
+            id: 1,
+            firstName: 'Laurent',
+            lastName: 'Gina',
+          });
+          const userInDB = databaseBuilder.factory.buildUser({
+            ...userToInsert,
+            id: 2,
+            hasBeenAnonymised: true,
+            hasBeenAnonymisedBy: adminWhoAnonymisedUser.id,
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const userDetailsForAdmin = await userRepository.getUserDetailsForAdmin(userInDB.id);
+
+          // then
+          expect(userDetailsForAdmin.anonymisedByFirstName).to.equal('Laurent');
+          expect(userDetailsForAdmin.anonymisedByLastName).to.equal('Gina');
+        });
       });
 
       context('when user has login details', function () {

--- a/api/tests/unit/domain/models/UserDetailsForAdmin_test.js
+++ b/api/tests/unit/domain/models/UserDetailsForAdmin_test.js
@@ -1,0 +1,22 @@
+const { expect } = require('../../../test-helper');
+const UserDetailsForAdmin = require('../../../../lib/domain/models/UserDetailsForAdmin');
+
+describe('Unit | Domain | Models | UserDetailsForAdmin', function () {
+  describe('#anonymisedByFullName', function () {
+    it('should return the full name of user who anonymised the user', function () {
+      // given
+      const user = new UserDetailsForAdmin({ anonymisedByFirstName: 'Sarah', anonymisedByLastName: 'Visseuse' });
+
+      // when / then
+      expect(user.anonymisedByFullName).equal('Sarah Visseuse');
+    });
+
+    it('should return null if user is not anonymised', function () {
+      // given
+      const user = new UserDetailsForAdmin({ anonymisedByFirstName: null, anonymisedByLastName: null });
+
+      // when / then
+      expect(user.anonymisedByFullName).to.be.null;
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-anonymized-details-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-anonymized-details-for-admin-serializer_test.js
@@ -27,7 +27,7 @@ describe('Unit | Serializer | JSONAPI | user-anonymized-details-for-admin-serial
             'pix-orga-terms-of-service-accepted': modelObject.pixOrgaTermsOfServiceAccepted,
             'pix-certif-terms-of-service-accepted': modelObject.pixCertifTermsOfServiceAccepted,
             'has-been-anonymised': modelObject.hasBeenAnonymised,
-            'has-been-anonymised-by': modelObject.hasBeenAnonymisedBy,
+            'anonymised-by-full-name': modelObject.anonymisedByFullName,
             'updated-at': now,
           },
           relationships: {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-details-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-details-for-admin-serializer_test.js
@@ -14,6 +14,8 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
         lastPixCertifTermsOfServiceValidatedAt: now,
         lastLoggedAt: now,
         emailConfirmedAt: now,
+        hasBeenAnonymised: false,
+        anonymisedByFullName: null,
         organizationLearners: [domainBuilder.buildOrganizationLearnerForAdmin()],
         authenticationMethods: [{ id: 1, identityProvider: 'PIX' }],
         userLogin: [{ id: 123, failureCount: 8 }],
@@ -40,6 +42,8 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
             'last-pix-certif-terms-of-service-validated-at': now,
             'last-logged-at': now,
             'email-confirmed-at': now,
+            'has-been-anonymised': false,
+            'anonymised-by-full-name': null,
           },
           relationships: {
             'certification-center-memberships': {


### PR DESCRIPTION
## :christmas_tree: Problème
Lorsqu'un utilisateur est anonymisé sur Pix Admin, ses informations sont modifiées mais aucun message n'indique qu'il a été anonymisé, ni par qui.

## :gift: Proposition
Indiquer que l'utilisateur est anonymisé et afficher le nom de l'agent Pix qui a effectué l'action.

## :star2: Remarques
On désactive également les boutons "Modifer" et "Anonymiser cet utilisateur" lorsque l'utilisateur est anonymisé.

## :santa: Pour tester
**Cas 1 : utilisateur anonymisé avec agent Pix connu**

- Se connecter sur Pix Admin (superadmin@example.net)
- Aller dans utilisateurs et choisir un utilisateur au hasard
- Dans la page de détails, cliquer sur le bouton Anonymiser
- Constater qu'un bandeau jaune indique que l'utilisateur est anonymisé + le nom et prénom de l'agent qui a fait l'action.
- Constater que les boutons "Modifer" et "Anonymiser cet utilisateur" sont désactivés.

<img width="374" alt="Capture d’écran 2023-01-04 à 12 05 28" src="https://user-images.githubusercontent.com/58915422/210564747-a1f6fc37-2117-4d66-a805-aa8c56b42a89.png">


**Cas 2 : utilisateur anonymisé avec agent Pix inconnu**

En prod nous avons des utilisateurs anonymisés mais qui n'ont pas d'agent Pix associé car la colonne indiquant quel agent a effectué l'action (`hasBeenAnonymisedBy`) n'a été implémenté que très récemment.

- En BDD, changer la colonne `hasBeenAnonymised` d'un utilisateur à true et laisser `hasBeenAnonymisedBy` à null
- Dans le menu utilisateur sur Pix Admin, retrouver cet utilisateur
- Constater qu'un bandeau jaune indique que l'utilisateur est anonymisé, sans nom et prénom d'un agent
