### PR TITLE
[FEATURE] Calculer la capacité minimum pour une probabilité donnée (PIX-6713)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -195,6 +195,7 @@ module.exports = (function () {
       maxReachableLevel: _getNumber(process.env.MAX_REACHABLE_LEVEL, 5),
       newYearOrganizationLearnersImportDate: _getDate(process.env.NEW_YEAR_ORGANIZATION_LEARNERS_IMPORT_DATE),
       numberOfChallengesForFlashMethod: _getNumber(process.env.NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD),
+      successProbabilityThreshold: parseFloat(process.env.SUCCESS_PROBABILITY_THRESHOLD ?? '0.95'),
       pixCertifScoBlockedAccessWhitelist: getArrayOfStrings(process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_WHITELIST),
       pixCertifScoBlockedAccessDateLycee: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_LYCEE,
       pixCertifScoBlockedAccessDateCollege: process.env.PIX_CERTIF_SCO_BLOCKED_ACCESS_DATE_COLLEGE,

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -43,6 +43,7 @@ class Challenge {
    * @param discriminant
    * @param difficulty
    * @param responsive
+   * @param successProbabilityThreshold
    */
   constructor({
     id,
@@ -68,6 +69,7 @@ class Challenge {
     focused,
     discriminant,
     difficulty,
+    successProbabilityThreshold,
     responsive,
   } = {}) {
     this.id = id;
@@ -94,6 +96,7 @@ class Challenge {
     this.discriminant = discriminant;
     this.difficulty = difficulty;
     this.responsive = responsive;
+    this.successProbabilityThreshold = successProbabilityThreshold;
   }
 
   isTimed() {
@@ -122,6 +125,11 @@ class Challenge {
 
   get isTabletCompliant() {
     return this._isCompliant('Tablet');
+  }
+
+  set successProbabilityThreshold(successProbabilityThreshold) {
+    if (this.difficulty == null || this.discriminant == null || successProbabilityThreshold == null) return;
+    this.minimumCapability = this.difficulty - Math.log(1 / successProbabilityThreshold - 1) / this.discriminant;
   }
 
   _isCompliant(type) {

--- a/api/lib/domain/services/algorithm-methods/data-fetcher.js
+++ b/api/lib/domain/services/algorithm-methods/data-fetcher.js
@@ -85,7 +85,7 @@ async function fetchForFlashCampaigns({
 }) {
   const [allAnswers, challenges, { estimatedLevel } = {}] = await Promise.all([
     answerRepository.findByAssessment(assessment.id),
-    challengeRepository.findFlashCompatible(locale),
+    challengeRepository.findFlashCompatible({ locale }),
     flashAssessmentResultRepository.getLatestByAssessmentId(assessment.id),
   ]);
 

--- a/api/sample.env
+++ b/api/sample.env
@@ -682,6 +682,9 @@ ENABLE_KNEX_PERFORMANCE_MONITORING=false
 # Number of challenges given to the user during a flash test.
 NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD=48
 
+# Success probability threshold used to compute the minimum capability
+# to succeed on a challenge
+SUCCESS_PROBABILITY_THRESHOLD=0.95
 
 # ========
 # TOKENS

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -446,7 +446,7 @@ describe('Integration | Repository | challenge-repository', function () {
   });
 
   describe('#findFlashCompatible', function () {
-    it('should return only flash compatible challenges with skills', async function () {
+    beforeEach(function () {
       // given
       const skill = domainBuilder.buildSkill({ id: 'recSkill1' });
       const flashCompatibleChallenge = domainBuilder.buildChallenge({
@@ -463,15 +463,42 @@ describe('Integration | Repository | challenge-repository', function () {
         ],
       };
       mockLearningContent(learningContent);
-      const locale = 'fr-fr';
+    });
 
+    it('should return only flash compatible challenges with skills', async function () {
       // when
-      const actualChallenges = await challengeRepository.findFlashCompatible(locale);
+      const actualChallenges = await challengeRepository.findFlashCompatible({ locale: 'fr-fr' });
 
       // then
       expect(actualChallenges).to.have.lengthOf(1);
       expect(actualChallenges[0]).to.be.instanceOf(Challenge);
-      expect(_.omit(actualChallenges[0], 'validator')).to.deep.equal(_.omit(actualChallenges[0], 'validator'));
+      expect(_.omit(actualChallenges[0], 'validator')).to.deep.contain({
+        id: 'recCHAL1',
+        status: 'validé',
+        locales: ['fr-fr'],
+        difficulty: -8.99,
+        discriminant: 3.57,
+        minimumCapability: -8.165227176704079,
+      });
+      expect(actualChallenges[0].skill).to.contain({
+        id: 'recSkill1',
+      });
+    });
+
+    it('should allow overriding success probability threshold default value', async function () {
+      // given
+      const successProbabilityThreshold = 0.75;
+
+      // when
+      const actualChallenges = await challengeRepository.findFlashCompatible({
+        locale: 'fr-fr',
+        successProbabilityThreshold,
+      });
+
+      // then
+      expect(actualChallenges).to.have.lengthOf(1);
+      expect(actualChallenges[0]).to.be.instanceOf(Challenge);
+      expect(actualChallenges[0].minimumCapability).to.equal(-8.682265465359073);
     });
   });
 

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -40,6 +40,39 @@ describe('Unit | Domain | Models | Challenge', function () {
         focused: false,
         discriminant: 0.75,
         difficulty: -0.23,
+        successProbabilityThreshold: 0.85,
+        responsive: 'Smartphone',
+      };
+
+      const expectedChallengeDataObject = {
+        id: 'recwWzTquPlvIl4So',
+        type: 'QCM',
+        instruction:
+          "Les moteurs de recherche affichent certains liens en raison d'un accord commercial.\n\nDans quels encadrés se trouvent ces liens ?",
+        proposals: '- 1\n- 2\n- 3\n- 4\n- 5',
+        timer: 1234,
+        illustrationUrl: 'https://dl.airtable.com/2MGErxGTQl2g2KiqlYgV_venise4.png',
+        attachments: [
+          'https://dl.airtable.com/nHWKNZZ7SQeOKsOvVykV_navigationdiaporama5.pptx',
+          'https://dl.airtable.com/rsXNJrSPuepuJQDByFVA_navigationdiaporama5.odp',
+        ],
+        embedUrl: 'https://github.page.io/pages/mon-epreuve.html',
+        embedTitle: 'Epreuve de selection d’imprimante',
+        embedHeight: 400,
+        status: 'validé',
+        answer: [],
+        skill: new Skill('recUDrCWD76fp5MsE'),
+        validator: undefined,
+        competenceId: 'recsvLz0W2ShyfD63',
+        illustrationAlt: "Texte alternatif à l'image",
+        format: 'phrase',
+        locales: ['fr'],
+        autoReply: true,
+        alternativeInstruction: 'Pour aider les personnes ne pouvant voir ou afficher les instructions',
+        focused: false,
+        discriminant: 0.75,
+        difficulty: -0.23,
+        minimumCapability: 2.0828014071841414,
         responsive: 'Smartphone',
       };
 
@@ -48,7 +81,60 @@ describe('Unit | Domain | Models | Challenge', function () {
 
       // then
       expect(challengeDataObject).to.be.an.instanceof(Challenge);
-      expect(challengeDataObject).to.deep.equal(challengeRawData);
+      expect(challengeDataObject).to.deep.include(expectedChallengeDataObject);
+    });
+  });
+
+  describe('#successProbabilityThreshold', function () {
+    describe('when there is no discriminant or difficulty', function () {
+      it('should return early', function () {
+        // given
+        const challengeRawData = {
+          discriminant: 1,
+          difficulty: null,
+        };
+        const challengeDataObject = new Challenge(challengeRawData);
+
+        // when
+        challengeDataObject.successProbabilityThreshold = 0.95;
+
+        // then
+        expect(challengeDataObject.minimumCapability).to.be.undefined;
+      });
+    });
+
+    describe('when successProbabilityThreshold is undefined', function () {
+      it('should return early', function () {
+        // given
+        const challengeRawData = {
+          discriminant: 1,
+          difficulty: 2,
+        };
+        const challengeDataObject = new Challenge(challengeRawData);
+
+        // when
+        challengeDataObject.successProbabilityThreshold = undefined;
+
+        // then
+        expect(challengeDataObject.minimumCapability).to.be.undefined;
+      });
+    });
+
+    describe('when there is a discriminant and a difficulty', function () {
+      it('should compute and set minimum capability ', function () {
+        // given
+        const challengeRawData = {
+          discriminant: 0.75,
+          difficulty: 2,
+        };
+        const challengeDataObject = new Challenge(challengeRawData);
+
+        // when
+        challengeDataObject.successProbabilityThreshold = 0.95;
+
+        // then
+        expect(challengeDataObject.minimumCapability).to.equal(5.925918638888589);
+      });
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
L'information de capacité minimum pour réussir un challenge n'est pas présente dans l'API.

## :gift: Proposition
Ajouter sur le modèle Challenge un setter successProbabilityThreshold :
 - Il accepte en entrée successProbabilityThreshold un flottant entre 0 et 1
 - Il calcule la capacité minimum et la stocke dans une propriété minimumCapability

Dans la méthode findFlashCompatible du ChallengeRepository, faire un premier appel au setter successProbabilityThreshold avec la valeur par défaut :
 - Cette valeur par défaut est définie par une nouvelle variable d’environnement `SUCCESS_PROBABILITY_THRESHOLD`

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Pas de test utilisateur possible pour le moment.