### PR TITLE
[TECH] Linter les titres de PR

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -1,0 +1,14 @@
+name: pr title check
+on:
+  pull_request:
+    types: [opened, edited, ready_for_review, reopened]
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: Slashgear/action-check-pr-title@v4.0.0
+        with:
+          regexp: '\[[A-Z]+\] .+'

--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   lint-pr-title:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.event.pull_request.state == "open"
     permissions:
       pull-requests: read
     steps:

--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   lint-pr-title:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false && github.event.pull_request.state == "open"
+    if: github.event.pull_request.draft == false && github.event.pull_request.state == 'open'
     permissions:
       pull-requests: read
     steps:

--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: Slashgear/action-check-pr-title@v4.0.0
         with:
-          regexp: '\[[A-Z]+\] .+'
+          regexp: '^\[[A-Z]+\] '


### PR DESCRIPTION
## :christmas_tree: Problème
Notre [guide de contribution](https://github.com/1024pix/pix/blob/dev/CONTRIBUTING.md#format) impose un format de titre de PR. La validation du respect de formatage n'est validé que par l'humain aujourd'hui.

## :gift: Proposition
Implémenter une GitHub Action qui valide cette règle. Je propose de valider uniquement qu'un contexte soit donné entre crochets au début du titre : 

```
\[[A-Z]+\] .+
```

En effet, il est important pour la génération du changelog. Par contre il n'y a pas nécessairement de ticket Jira associé, donc pas obligatoire de faire cette validation IMO.

## :star2: Remarques
J'ouvre une PR sur https://github.com/Slashgear/action-check-pr-title pour proposer un message d'erreur plus lisible quand l'action fail.

## :santa: Pour tester
Lire le fil de discussion de cette PR où je pense avoir tout testé :) 