### PR TITLE
[DOC] Mettre les bons numéros pour les ADR existantes.

### DIFF
--- a/docs/adr/0014-generer-des-fichiers-pdf.md
+++ b/docs/adr/0014-generer-des-fichiers-pdf.md
@@ -1,4 +1,4 @@
-# 13. générer des fichiers pdf
+# 14. générer des fichiers pdf
 
 Date: 2020-09-24
 

--- a/docs/adr/0015-utiliser-type-stockage-JSONB-base-de-donnees.md
+++ b/docs/adr/0015-utiliser-type-stockage-JSONB-base-de-donnees.md
@@ -1,4 +1,4 @@
-# 14. Utiliser le type de données JSONB en base de données
+# 15. Utiliser le type de données JSONB en base de données
 
 Date: 2020-11-20
 

--- a/docs/adr/0016-stockage-du-referentiel-en-cache.md
+++ b/docs/adr/0016-stockage-du-referentiel-en-cache.md
@@ -1,4 +1,4 @@
-# 15. Modification du stockage en cache du référentiel de contenu
+# 16. Modification du stockage en cache du référentiel de contenu
 
 Date : 2020-12-02
 

--- a/docs/adr/0017-utilisation-de-hasMany-dans-Ember.md
+++ b/docs/adr/0017-utilisation-de-hasMany-dans-Ember.md
@@ -1,4 +1,4 @@
-# 16. Utilisation de `hasMany` avec les filtres et pagination dans Ember
+# 17. Utilisation de `hasMany` avec les filtres et pagination dans Ember
 
 Date : 2021-01-12
 

--- a/docs/adr/0039-mise-à-jour-des-dépendances.md
+++ b/docs/adr/0039-mise-à-jour-des-dépendances.md
@@ -1,4 +1,4 @@
-# 38. Faciliter la mise à jour des dépendances
+# 39. Faciliter la mise à jour des dépendances
 
 Date : 2022-12-05
 


### PR DESCRIPTION
## :christmas_tree: Problème
Les numéros des ADR n'avaient pas été bien suivis.
Il y avait deux fois les numéro 13 et 38, mais pas de numéro 17.

## :gift: Proposition
Renommer les fichiers et remettre les bons numéros dans le document.
En cas de doute, la date notée dans l'ADR permet de choisir l'ADR le plus ancien/récent.

## :star2: Remarques
Avoir un numéro d'ADR permet de renseigner facilement l'adr (exemple : "_suite à l'ADR n° 23_",...) mais cela peut être compliqué à numéroter, surtout quand plusieurs ADR sont écris durant la même période.

## :santa: Pour tester
Vérifier que tous les ADR sont là.