### PR TITLE
[TECH] Bloquer la finalisation de la session s'il manque des "abort reasons" (PIX-6722)

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -901,6 +901,14 @@ class SessionWithAbortReasonOnCompletedCertificationCourseError extends DomainEr
   }
 }
 
+class SessionWithMissingAbortReasonError extends DomainError {
+  constructor(
+    message = "Une ou plusieurs certifications non terminées n'ont pas de “Raison de l’abandon” renseignées. La session ne peut donc pas être finalisée."
+  ) {
+    super(message);
+  }
+}
+
 class SessionAlreadyPublishedError extends DomainError {
   constructor(message = 'La session est déjà publiée.') {
     super(message);
@@ -1371,6 +1379,7 @@ module.exports = {
   SessionStartedDeletionError,
   SessionWithoutStartedCertificationError,
   SessionWithAbortReasonOnCompletedCertificationCourseError,
+  SessionWithMissingAbortReasonError,
   SiecleXmlImportError,
   SupervisorAccessNotAuthorizedError,
   TargetProfileInvalidError,

--- a/api/lib/domain/usecases/finalize-session.js
+++ b/api/lib/domain/usecases/finalize-session.js
@@ -2,6 +2,7 @@ const {
   SessionAlreadyFinalizedError,
   SessionWithoutStartedCertificationError,
   SessionWithAbortReasonOnCompletedCertificationCourseError,
+  SessionWithMissingAbortReasonError,
 } = require('../errors');
 const SessionFinalized = require('../events/SessionFinalized');
 const bluebird = require('bluebird');
@@ -30,6 +31,10 @@ module.exports = async function finalizeSession({
 
   if (hasNoStartedCertification) {
     throw new SessionWithoutStartedCertificationError();
+  }
+
+  if (_hasMissingAbortReasonForUncompletedCertificationCourse({ abortReasonCount, uncompletedCertificationCount })) {
+    throw new SessionWithMissingAbortReasonError();
   }
 
   if (
@@ -71,6 +76,10 @@ module.exports = async function finalizeSession({
 
 function _hasAbortReasonForCompletedCertificationCourse({ abortReasonCount, uncompletedCertificationCount }) {
   return abortReasonCount > uncompletedCertificationCount;
+}
+
+function _hasMissingAbortReasonForUncompletedCertificationCourse({ abortReasonCount, uncompletedCertificationCount }) {
+  return abortReasonCount < uncompletedCertificationCount;
 }
 
 function _countAbortReasons(certificationReports) {


### PR DESCRIPTION
## :christmas_tree: Problème
On ne doit pas finaliser une session s'il manque des "abort reason". La verification n'est faite que coté front

## :gift: Proposition
Faire une 2nde verification coté back

## :star2: Remarques
Nouvelle exception SessionWithMissingAbortReasonError

## :santa: Pour tester
[TECH UNIQUEMENT] 
Démarrer une certification (ne pas la terminer)
Finaliser la session SANS selectionner une "abort reason" (en bypassant les verifications du bouton)
S'assurer que la session n'est pas finalisée


