### PR TITLE
[FEATURE] Paramétrer la date de mise à jour de la politique de confidentialité avec une variable d'environnement (PIX-6597)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -77,6 +77,10 @@ module.exports = (function () {
       fetchTimeOut: ms(process.env.FETCH_TIMEOUT_MILLISECONDS || '20s'),
     },
 
+    dataProtectionPolicy: {
+      updateDate: process.env.DATA_PROTECTION_POLICY_UPDATE_DATE || null,
+    },
+
     lcms: {
       url: _removeTrailingSlashFromUrl(process.env.CYPRESS_LCMS_API_URL || process.env.LCMS_API_URL || ''),
       apiKey: process.env.CYPRESS_LCMS_API_KEY || process.env.LCMS_API_KEY,
@@ -424,6 +428,8 @@ module.exports = (function () {
       url: process.env.TEST_REDIS_URL,
       database: 1,
     };
+
+    config.dataProtectionPolicy.updateDate = '2022-12-25 00:00:01';
 
     config.partner.fetchTimeOut = '5ms';
   }

--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -1,5 +1,7 @@
 const toLower = require('lodash/toLower');
 const isNil = require('lodash/isNil');
+const dayjs = require('dayjs');
+const config = require('../../config');
 
 const AuthenticationMethod = require('./AuthenticationMethod');
 
@@ -72,6 +74,12 @@ class User {
     );
 
     return pixAuthenticationMethod ? pixAuthenticationMethod.authenticationComplement.shouldChangePassword : null;
+  }
+
+  get shouldSeeDataProtectionPolicyInformationBanner() {
+    const isNotOrganizationLearner = this.cgu === true;
+    const parsedDate = new Date(this.lastDataProtectionPolicySeenAt);
+    return dayjs(parsedDate).isBefore(dayjs(config.dataProtectionPolicy.updateDate)) && isNotOrganizationLearner;
   }
 
   isLinkedToOrganizations() {

--- a/api/lib/domain/read-models/UserWithActivity.js
+++ b/api/lib/domain/read-models/UserWithActivity.js
@@ -1,8 +1,15 @@
 class UserWithActivity {
-  constructor({ user, hasAssessmentParticipations, codeForLastProfileToShare, hasRecommendedTrainings }) {
+  constructor({
+    user,
+    hasAssessmentParticipations,
+    codeForLastProfileToShare,
+    hasRecommendedTrainings,
+    shouldSeeDataProtectionPolicyInformationBanner,
+  }) {
     this.hasAssessmentParticipations = hasAssessmentParticipations;
     this.codeForLastProfileToShare = codeForLastProfileToShare;
     this.hasRecommendedTrainings = hasRecommendedTrainings;
+    this.shouldSeeDataProtectionPolicyInformationBanner = shouldSeeDataProtectionPolicyInformationBanner;
     Object.assign(this, user);
   }
 }

--- a/api/lib/domain/usecases/get-current-user.js
+++ b/api/lib/domain/usecases/get-current-user.js
@@ -12,10 +12,12 @@ module.exports = async function getCurrentUser({
     userRecommendedTrainingRepository.hasRecommendedTrainings(authenticatedUserId),
   ]);
   const user = await userRepository.get(authenticatedUserId);
+  const shouldSeeDataProtectionPolicyInformationBanner = user.shouldSeeDataProtectionPolicyInformationBanner;
   return new UserWithActivity({
     user,
     hasAssessmentParticipations,
     codeForLastProfileToShare,
     hasRecommendedTrainings,
+    shouldSeeDataProtectionPolicyInformationBanner,
   });
 };

--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -28,6 +28,7 @@ module.exports = {
         'hasSeenOtherChallengesTooltip',
         'trainings',
         'lastDataProtectionPolicySeenAt',
+        'shouldSeeDataProtectionPolicyInformationBanner',
       ],
       certificationCenterMemberships: {
         ref: 'id',

--- a/api/lib/infrastructure/serializers/jsonapi/user-with-activity-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-with-activity-serializer.js
@@ -29,6 +29,7 @@ module.exports = {
         'hasRecommendedTrainings',
         'codeForLastProfileToShare',
         'trainings',
+        'shouldSeeDataProtectionPolicyInformationBanner',
       ],
       certificationCenterMemberships: {
         ref: 'id',

--- a/api/sample.env
+++ b/api/sample.env
@@ -878,6 +878,16 @@ TEST_REDIS_URL=redis://localhost:6379
 # type: string
 # sample:CPF_SEND_EMAIL_JOB_CRON=0 0 1 1 *
 
+# ========
+# DATA PROTECTION POLICY CONFIGURATION
+# ========
+
+# Date of last data protection policy has been updated
+#
+# presence: required for displaying a banner on Pix App so user can see new protection policy
+# type: string
+# sample:DATA_PROTECTION_POLICY_UPDATE_DATE='2022-12-28 00:00:01'
+
 # =======
 # HTTP
 # =======

--- a/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
@@ -63,6 +63,7 @@ describe('Acceptance | Controller | users-controller-get-current-user', function
             'has-assessment-participations': true,
             'code-for-last-profile-to-share': expectedCode,
             'has-recommended-trainings': true,
+            'should-see-data-protection-policy-information-banner': true,
             'last-data-protection-policy-seen-at': null,
           },
           relationships: {

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -1,4 +1,5 @@
 const { expect, domainBuilder } = require('../../../test-helper');
+const config = require('../../../../lib/config');
 
 const User = require('../../../../lib/domain/models/User');
 
@@ -248,6 +249,99 @@ describe('Unit | Domain | Models | User', function () {
 
         // then
         expect(shouldChangePassword).to.be.null;
+      });
+    });
+  });
+
+  describe('#shouldSeeDataProtectionPolicyInformationBanner', function () {
+    context('when user has not seen data protection policy but data protection date is not setted', function () {
+      it('should return false', function () {
+        // given
+        config.dataProtectionPolicy.updateDate = null;
+        const user = new User({ lastDataProtectionPolicySeenAt: null });
+
+        // then
+        expect(user.shouldSeeDataProtectionPolicyInformationBanner).to.be.false;
+      });
+    });
+
+    context('when user has not seen data protection policy and data protection has been updated', function () {
+      it('should return true', function () {
+        // given
+        config.dataProtectionPolicy.updateDate = new Date();
+        const user = new User({ lastDataProtectionPolicySeenAt: null, cgu: true });
+
+        // then
+        expect(user.shouldSeeDataProtectionPolicyInformationBanner).to.be.true;
+      });
+
+      it('should return false for an organization learner', function () {
+        // given
+        config.dataProtectionPolicy.updateDate = new Date();
+        const user = new User({ lastDataProtectionPolicySeenAt: null, cgu: false });
+
+        // then
+        expect(user.shouldSeeDataProtectionPolicyInformationBanner).to.be.false;
+      });
+    });
+
+    context('when user has seen data protection policy but data protection date is not setted', function () {
+      it('should return false', function () {
+        // given
+        config.dataProtectionPolicy.updateDate = null;
+        const user = new User({ lastDataProtectionPolicySeenAt: new Date(), cgu: true });
+
+        // then
+        expect(user.shouldSeeDataProtectionPolicyInformationBanner).to.be.false;
+      });
+
+      it('should return false for an organization learner', function () {
+        // given
+        config.dataProtectionPolicy.updateDate = null;
+        const user = new User({ lastDataProtectionPolicySeenAt: new Date(), cgu: false });
+
+        // then
+        expect(user.shouldSeeDataProtectionPolicyInformationBanner).to.be.false;
+      });
+    });
+
+    context('when user has seen data protection policy but data protection has not been updated since', function () {
+      it('should return false', function () {
+        // given
+        config.dataProtectionPolicy.updateDate = new Date();
+        const user = new User({ lastDataProtectionPolicySeenAt: new Date(Date.now() + 3600 * 1000), cgu: true });
+
+        // then
+        expect(user.shouldSeeDataProtectionPolicyInformationBanner).to.be.false;
+      });
+
+      it('should return false for an organization learner', function () {
+        // given
+        config.dataProtectionPolicy.updateDate = new Date();
+        const user = new User({ lastDataProtectionPolicySeenAt: new Date(Date.now() + 3600 * 1000), cgu: false });
+
+        // then
+        expect(user.shouldSeeDataProtectionPolicyInformationBanner).to.be.false;
+      });
+    });
+
+    context('when user has seen data protection policy but data protection has been updated', function () {
+      it('should return true', function () {
+        // given
+        config.dataProtectionPolicy.updateDate = new Date(Date.now() + 3600 * 1000);
+        const user = new User({ lastDataProtectionPolicySeenAt: new Date(), cgu: true });
+
+        // then
+        expect(user.shouldSeeDataProtectionPolicyInformationBanner).to.be.true;
+      });
+
+      it('should return false for an organization learner', function () {
+        // given
+        config.dataProtectionPolicy.updateDate = new Date(Date.now() + 3600 * 1000);
+        const user = new User({ lastDataProtectionPolicySeenAt: new Date(), cgu: false });
+
+        // then
+        expect(user.shouldSeeDataProtectionPolicyInformationBanner).to.be.false;
       });
     });
   });

--- a/api/tests/unit/domain/usecases/get-current-user_test.js
+++ b/api/tests/unit/domain/usecases/get-current-user_test.js
@@ -19,7 +19,7 @@ describe('Unit | UseCase | get-current-user', function () {
 
   it('should get the current user', async function () {
     // given
-    userRepository.get.withArgs(1).resolves({ id: 1 });
+    userRepository.get.withArgs(1).resolves({ id: 1, shouldSeeDataProtectionPolicyInformationBanner: true });
     campaignParticipationRepository.hasAssessmentParticipations.withArgs(1).resolves(false);
     campaignParticipationRepository.getCodeOfLastParticipationToProfilesCollectionCampaignForUser
       .withArgs(1)
@@ -40,6 +40,7 @@ describe('Unit | UseCase | get-current-user', function () {
       hasAssessmentParticipations: false,
       codeForLastProfileToShare: 'SOMECODE',
       hasRecommendedTrainings: false,
+      shouldSeeDataProtectionPolicyInformationBanner: true,
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -52,6 +52,8 @@ describe('Unit | Serializer | JSONAPI | user-serializer', function () {
               'has-seen-focused-challenge-tooltip': userModelObject.hasSeenFocusedChallengeTooltip,
               'has-seen-other-challenges-tooltip': userModelObject.hasSeenOtherChallengesTooltip,
               'last-data-protection-policy-seen-at': userModelObject.lastDataProtectionPolicySeenAt,
+              'should-see-data-protection-policy-information-banner':
+                userModelObject.shouldSeeDataProtectionPolicyInformationBanner,
             },
             relationships: {
               'certification-center-memberships': {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-with-activity-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-with-activity-serializer_test.js
@@ -17,7 +17,6 @@ describe('Unit | Serializer | JSONAPI | user-with-activity-serializer', function
           email: 'lskywalker@deathstar.empire',
           username: 'luke.skywalker1234',
           cgu: true,
-          lang: 'fr',
           isAnonymous: false,
           lastTermsOfServiceValidatedAt: '2020-05-04T13:18:26.323Z',
           mustValidateTermsOfService: true,
@@ -61,6 +60,8 @@ describe('Unit | Serializer | JSONAPI | user-with-activity-serializer', function
               'has-assessment-participations': userModelObject.hasAssessmentParticipations,
               'code-for-last-profile-to-share': userModelObject.codeForLastProfileToShare,
               'has-recommended-trainings': userModelObject.hasRecommendedTrainings,
+              'should-see-data-protection-policy-information-banner':
+                userModelObject.shouldSeeDataProtectionPolicyInformationBanner,
             },
             relationships: {
               'certification-center-memberships': {

--- a/mon-pix/app/components/data-protection-policy-information-banner.js
+++ b/mon-pix/app/components/data-protection-policy-information-banner.js
@@ -13,14 +13,17 @@ export default class DataProtectionPolicyInformationBanner extends Component {
   _rawBannerContent = ENV.APP.BANNER_CONTENT;
 
   get shouldDisplayDataProtectionPolicyInformation() {
-    const hasNotAlreadySeenDataProtectionPolicyInformation =
-      this.currentUser.user?.lastDataProtectionPolicySeenAt === null;
-
-    const isNotAStudent = this.currentUser.user?.cgu === true;
+    const isUserLoggedIn = typeof this.currentUser.user !== 'undefined';
+    if (!isUserLoggedIn) {
+      return false;
+    }
 
     const isCommunicationBannerDisplayed = !isEmpty(this._rawBannerContent) && !isEmpty(this.bannerType);
+    if (isCommunicationBannerDisplayed) {
+      return false;
+    }
 
-    return hasNotAlreadySeenDataProtectionPolicyInformation && isNotAStudent && !isCommunicationBannerDisplayed;
+    return this.currentUser.user.shouldSeeDataProtectionPolicyInformationBanner;
   }
 
   get dataProtectionPolicyUrl() {

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -17,6 +17,7 @@ export default class User extends Model {
   @attr('string') codeForLastProfileToShare;
   @attr('string') lang;
   @attr('boolean') isAnonymous;
+  @attr('boolean') shouldSeeDataProtectionPolicyInformationBanner;
   @attr() lastDataProtectionPolicySeenAt;
 
   // includes

--- a/mon-pix/mirage/routes/users/index.js
+++ b/mon-pix/mirage/routes/users/index.js
@@ -71,7 +71,10 @@ export default function index(config) {
 
   config.patch('/users/:id/has-seen-last-data-protection-policy-information', (schema, request) => {
     const user = schema.users.find(request.params.id);
-    user.update({ lastDataProtectionPolicySeenAt: new Date('2022-12-24') });
+    user.update({
+      lastDataProtectionPolicySeenAt: new Date('2022-12-24'),
+      shouldSeeDataProtectionPolicyInformationBanner: false,
+    });
     return user;
   });
 }

--- a/mon-pix/tests/acceptance/user-dashboard_test.js
+++ b/mon-pix/tests/acceptance/user-dashboard_test.js
@@ -296,9 +296,7 @@ module('Acceptance | User dashboard page', function (hooks) {
             await click('.new-information-content-text__button');
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), '/campagnes/SNAP1234/collecte/envoi-profil');
+            assert.strictEqual(currentURL(), '/campagnes/SNAP1234/collecte/envoi-profil');
           });
         });
       });

--- a/mon-pix/tests/integration/components/data-protection-policy-information-banner_test.js
+++ b/mon-pix/tests/integration/components/data-protection-policy-information-banner_test.js
@@ -8,53 +8,10 @@ import ENV from 'mon-pix/config/environment';
 module('Integration | Component | data-protection-policy-information-banner', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  module('when user has not seen the data protection policy information', function () {
-    test('should display the banner', async function (assert) {
+  module('when user is not logged in', function () {
+    test('should never display the data protection policy banner', async function (assert) {
       // given
-      const store = this.owner.lookup('service:store');
-
-      class CurrentUserStub extends Service {
-        user = store.createRecord('user', {
-          lastDataProtectionPolicySeenAt: null,
-          cgu: true,
-        });
-      }
-      this.owner.register('service:currentUser', CurrentUserStub);
-
-      // when
-      const screen = await render(hbs`<DataProtectionPolicyInformationBanner />`);
-
-      // then
-      assert.dom(screen.getByRole('alert')).exists();
-      assert
-        .dom(
-          screen.getByRole('link', {
-            name: this.intl.t('common.data-protection-policy-information-banner.url-label'),
-          })
-        )
-        .exists();
-
-      const content = screen.getByText((content) =>
-        content.startsWith(
-          'Notre politique de confidentialité a évolué. Nous vous invitons à en prendre connaissance :'
-        )
-      );
-      assert.dom(content).exists();
-    });
-  });
-
-  module('when user already seen the data protection policy information', function () {
-    test('should not display the banner', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-
-      class CurrentUserStub extends Service {
-        user = store.createRecord('user', {
-          lastDataProtectionPolicySeenAt: new Date('2000-01-22T15:15:52Z'),
-          cgu: true,
-        });
-      }
-      this.owner.register('service:currentUser', CurrentUserStub);
+      _userIsNotLoggedIn(this);
 
       // when
       const screen = await render(hbs`<DataProtectionPolicyInformationBanner />`);
@@ -71,61 +28,112 @@ module('Integration | Component | data-protection-policy-information-banner', fu
     });
   });
 
-  module('when user is a student', function () {
-    test('should not display the banner', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
+  module('when user is logged in', function () {
+    module('when communication banner is displayed', function () {
+      test('should never display the data protection policy banner', async function (assert) {
+        // given
+        _communicationBannerIsDisplayed();
+        _userShouldSeeTheDataProtectionPolicyUpdateInformation(this);
 
-      class CurrentUserStub extends Service {
-        user = store.createRecord('user', {
-          lastDataProtectionPolicySeenAt: null,
-          cgu: false,
-        });
-      }
-      this.owner.register('service:currentUser', CurrentUserStub);
+        // when
+        const screen = await render(hbs`<DataProtectionPolicyInformationBanner />`);
 
-      // when
-      const screen = await render(hbs`<DataProtectionPolicyInformationBanner />`);
-
-      // then
-      assert.dom(screen.queryByRole('alert')).doesNotExist();
-      assert
-        .dom(
-          screen.queryByRole('link', {
-            name: this.intl.t('common.data-protection-policy-information-banner.url-label'),
-          })
-        )
-        .doesNotExist();
+        // then
+        assert.dom(screen.queryByRole('alert')).doesNotExist();
+        assert
+          .dom(
+            screen.queryByRole('link', {
+              name: this.intl.t('common.data-protection-policy-information-banner.url-label'),
+            })
+          )
+          .doesNotExist();
+      });
     });
-  });
 
-  module('when communication banner is displayed', function () {
-    test('should not display the data protection policy banner', async function (assert) {
-      // given
-      ENV.APP.BANNER_CONTENT = 'information banner text ...';
-      ENV.APP.BANNER_TYPE = 'error';
-      const store = this.owner.lookup('service:store');
+    module('when communication banner is not displayed', function () {
+      module('when user should not see the data protection policy update information', function () {
+        test('should not display the banner', async function (assert) {
+          // given
+          _communicationBannerIsNotDisplayed();
+          _userShouldNotSeeTheDataProtectionPolicyUpdateInformation(this);
 
-      class CurrentUserStub extends Service {
-        user = store.createRecord('user', {
-          lastDataProtectionPolicySeenAt: null,
-          cgu: true,
+          // when
+          const screen = await render(hbs`<DataProtectionPolicyInformationBanner />`);
+
+          // then
+          assert.dom(screen.queryByRole('alert')).doesNotExist();
+          assert
+            .dom(
+              screen.queryByRole('link', {
+                name: this.intl.t('common.data-protection-policy-information-banner.url-label'),
+              })
+            )
+            .doesNotExist();
         });
-      }
-      this.owner.register('service:currentUser', CurrentUserStub);
+      });
 
-      // when
-      const screen = await render(hbs`<DataProtectionPolicyInformationBanner />`);
+      module('when user should see the data protection policy update information', function () {
+        test('should display the banner', async function (assert) {
+          // given
+          _communicationBannerIsNotDisplayed();
+          _userShouldSeeTheDataProtectionPolicyUpdateInformation(this);
 
-      // then
-      assert.dom(screen.queryByRole('alert')).doesNotExist();
-      assert
-        .dom(
-          screen.queryByRole('link', {
-            name: this.intl.t('common.data-protection-policy-information-banner.url-label'),
-          })
-        )
-        .doesNotExist();
+          // when
+          const screen = await render(hbs`<DataProtectionPolicyInformationBanner />`);
+
+          // then
+          assert.dom(screen.getByRole('alert')).exists();
+          assert
+            .dom(
+              screen.getByRole('link', {
+                name: this.intl.t('common.data-protection-policy-information-banner.url-label'),
+              })
+            )
+            .exists();
+
+          const content = screen.getByText((content) =>
+            content.startsWith(
+              'Notre politique de confidentialité a évolué. Nous vous invitons à en prendre connaissance :'
+            )
+          );
+          assert.dom(content).exists();
+        });
+      });
     });
   });
 });
+
+function _userIsNotLoggedIn(component) {
+  class CurrentUserStub extends Service {
+    user = undefined;
+  }
+  component.owner.register('service:currentUser', CurrentUserStub);
+}
+
+function _communicationBannerIsDisplayed() {
+  ENV.APP.BANNER_CONTENT = 'information banner text ...';
+  ENV.APP.BANNER_TYPE = 'error';
+}
+
+function _communicationBannerIsNotDisplayed() {
+  ENV.APP.BANNER_CONTENT = undefined;
+  ENV.APP.BANNER_TYPE = undefined;
+}
+
+function _userShouldSeeTheDataProtectionPolicyUpdateInformation(component) {
+  _stubUserWithShouldSeeTheDataProtectionPolicyUpdateInformationAs(true, component);
+}
+
+function _userShouldNotSeeTheDataProtectionPolicyUpdateInformation(component) {
+  _stubUserWithShouldSeeTheDataProtectionPolicyUpdateInformationAs(false, component);
+}
+
+function _stubUserWithShouldSeeTheDataProtectionPolicyUpdateInformationAs(shouldSeeValue, component) {
+  const store = component.owner.lookup('service:store');
+  class CurrentUserStub extends Service {
+    user = store.createRecord('user', {
+      shouldSeeDataProtectionPolicyInformationBanner: shouldSeeValue,
+    });
+  }
+  component.owner.register('service:currentUser', CurrentUserStub);
+}

--- a/mon-pix/tests/unit/models/user_test.js
+++ b/mon-pix/tests/unit/models/user_test.js
@@ -26,9 +26,7 @@ module('Unit | Model | user model', function (hooks) {
       const fullName = model.fullName;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(fullName, 'Manu Phillip');
+      assert.strictEqual(fullName, 'Manu Phillip');
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Cette variable d’env servira à déterminer l’affichage ou non de la bannière informant les utilisateurs de la mise à jour de la politique de confidentialité, en comparant avec la date enregistrée dans le champ lastDataProtectionPolicySeenAt de la table users.
Si l'utilisateur a déjà vu la politique de confidentialité mais qu'elle a été mise à jour, la bannière s'affichera à nouveau.
Voir la PR sur l'affichage de la bannière https://github.com/1024pix/pix/pull/5356

## :gift: Proposition
Règles :

- Si DATA_PROTECTION_POLICY_UPDATE_DATE est NULL (valeur par défaut) :arrow_right: La bannière n'est **jamais** affichée
- Si DATA_PROTECTION_POLICY_UPDATE_DATE est renseignée mais lastDataProtectionPolicySeenAt est NULL  :arrow_right:  La bannière est affichée
Si DATA_PROTECTION_POLICY_UPDATE_DATE est plus récent que (supérieur à)  lastDataProtectionPolicySeenAt  :arrow_right:  La bannière est affichée
Si lastDataProtectionPolicySeenAt est plus récent que (supérieur à)DATA_PROTECTION_POLICY_UPDATE_DATE :arrow_right:  La bannière n'est pas  affichée

## :star2: Remarques
Côté front on n'a plus besoin de regarder la valeur de `this.currentUser.user.lastDataProtectionPolicySeenAt` car la propriété est calculée et renvoyée par l'api.
On pourrait aussi envisager de déléguer du front au back la condition `const isNotAStudent = this.currentUser.user.cgu === true;`

:question: D'ailleurs, parle-t-on encore de 'student' ? Ne devrait-on pas toujours  parler de organization learners #DDD :bulb:  ? 

On ne vérifie pas que la date renseignée manuellement soit valide  DATA_PROTECTION_POLICY_UPDATE_DATE, on peut mettre une date dans le futur lointain.


## :santa: Pour tester

Dans le .env de pix App, supprimer les variables suivantes pour ne pas  afficher une page incident 
`BANNER_CONTENT`="Hello World"
`BANNER_TYPE`="warning"

**Scénario 1: Cas sans bannière incident**
2. Dans le .env de Pix, ajouter la variable DATA_PROTECTION_POLICY_UPDATE_DATE="2022-12-28 00:00:01"
3. Se connecter sur Pix App avec sco.admin@example.net
4. Sur le dashboard, constater que la bannière incident s'affiche mais pas la bannière de politique de confidentialité. (voir remarques)

5. Fermer la fenêtre de la bannière
6. Constater dans le network que l'appel api PATCH sur `api/users/4/has-seen-last-data-protection-policy-information` renvoie bien un payload contenant   `"should-see-data-protection-policy-information-banner": false`
7. Se déconnecter (ou recharger la page pour que le currentUser soit rechargé)
8. Observer que la bannière ne s'affiche plus

9. Dans le .env de Pix, modifier la variable pour mettre une date supérieur à celle d'aujourd'h!ç DATA_PROTECTION_POLICY_UPDATE_DATE="2022-12-28 00:00:01" (car l'utilisateur aura eu la variable `last-data-protection-policy-seen-at`m mise à jour par l'appel api cité plus haut.
10. Recharger la page et observer que la bannière est réapparue.
11. Elle reste visible quelque soit l'onglet de navigation, si on recharge la page ou si on se connecte/déconnecte. (Sauf sur la page /campagnes)


 **Scénario de non régression : Cas élèves**
- Se connecter avec un élève (user gar, george de cambrigde)
- Sur l'accueil, constater que la bannière n'apparaît pas.


** Scénario avec un nouvel utilisateur
- créer un compte
- se connecter
- observer que la bannière s'affiche
- fermer la bannière
- se déconnecter/reconnecter
- observer que la bannière ne s'affiche pas
- modifier la var d'env avec une date récente DATA_PROTECTION_POLICY_UPDATE_DATE='2022-01-03 00:00:01'
- rafraichir et observer que la bannière apparaît

**Scénario : Cas sans bannière incident**
- Dans le .env de pix App, supprimer les variables suivantes pour ne pas  afficher une page incident 
`BANNER_CONTENT`="Hello World"
`BANNER_TYPE`="warning"
- Sur le dashboard, constater que la bannière incident s'affiche mais pas la bannière de politique de confidentialité. (voir remarques)
