### PR TITLE
[TECH] Correction d'un test flaky sur l'api

### DIFF
--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -1013,6 +1013,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
           cgu: true,
           lang: 'en',
           createdAt: now,
+          updatedAt: now,
           lastTermsOfServiceValidatedAt,
           lastPixOrgaTermsOfServiceValidatedAt,
           lastPixCertifTermsOfServiceValidatedAt: lastLoggedAt,


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, un test est flaky dans le fichier `user-repository_test.js`. Cela provient du fait qu'on laisse la base de donnée créer la date `updatedAt`, et on s'attend à ce qu'elle soit égale à une date `now` créée par nos soins juste avant. Cela peut fonctionner de temps en temps sur une machine très rapide, mais sur un machine un peu plus lente, ça devient flaky.

## :gift: Proposition
Fixer la date `updatedAt` en lui donnant la valeur `now` qui est la même date que celle assignée à `createdAt`.

## :star2: Remarques

## :santa: Pour tester

- Vérifier que les tests passent sur la CI
- Constater sur la durée que ce test n'est plus flaky sur Datadog