### PR TITLE
[FEATURE] Calculer le score Pix total pour des questions flash auxquelles l'utilisateur a répondu (PIX-6717).

### DIFF
--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -15,6 +15,7 @@ module.exports = {
   getPossibleNextChallenges,
   getEstimatedLevelAndErrorRate,
   getNonAnsweredChallenges,
+  calculateTotalPixScore,
 };
 
 function getPossibleNextChallenges({ allAnswers, challenges, estimatedLevel = DEFAULT_ESTIMATED_LEVEL } = {}) {
@@ -116,6 +117,17 @@ function getNonAnsweredChallenges({ allAnswers, challenges }) {
   const nonAnsweredChallenges = _.filter(challenges, filterNonAnsweredChallenge);
 
   return nonAnsweredChallenges;
+}
+
+function calculateTotalPixScore({ allAnswers, challenges }) {
+  const correctAnswers = allAnswers.filter((answer) => answer.isOk());
+  const successedChallenges = correctAnswers.map((answer) =>
+    challenges.find((challenge) => challenge.id === answer.challengeId)
+  );
+  const directPixScore = successedChallenges.reduce((acc, challenge) => acc + challenge.skill.pixValue, 0);
+  const totalPixScore = directPixScore;
+
+  return totalPixScore;
 }
 
 function _getReward({ estimatedLevel, discriminant, difficulty }) {

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -683,4 +683,81 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
       expect(result).to.be.deep.equal([challenges[2]]);
     });
   });
+
+  describe('#calculateTotalPixScore', function () {
+    describe('when there is no answer', function () {
+      it('should return a score of 0', function () {
+        // given
+        const challenges = [
+          domainBuilder.buildChallenge({
+            id: 'ChallengeFirstAnswers',
+            discriminant: 1.86350005965093,
+            difficulty: 0.194712138508747,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'ChallengeSecondAnswers',
+            discriminant: 2.25422414740233,
+            difficulty: 0.823376599163319,
+          }),
+        ];
+
+        const allAnswers = [];
+
+        // when
+        const result = flash.calculateTotalPixScore({ allAnswers, challenges });
+
+        // then
+        expect(result).to.equal(0);
+      });
+    });
+
+    describe('when there are answers', function () {
+      it('should return a score of 11', function () {
+        // given
+        const skills = [
+          domainBuilder.buildSkill({ id: 'FirstSkill', pixValue: 1 }),
+          domainBuilder.buildSkill({ id: 'SecondSkill', pixValue: 10 }),
+          domainBuilder.buildSkill({ id: 'ThirdSkill', pixValue: 100 }),
+          domainBuilder.buildSkill({ id: 'FourthSkill', pixValue: 1000 }),
+          domainBuilder.buildSkill({ id: 'FifthSkill', pixValue: 10000 }),
+        ];
+
+        const challenges = [
+          domainBuilder.buildChallenge({
+            id: 'First',
+            skill: skills[0],
+          }),
+          domainBuilder.buildChallenge({
+            id: 'Second',
+            skill: skills[1],
+          }),
+          domainBuilder.buildChallenge({
+            id: 'Third',
+            skill: skills[2],
+          }),
+          domainBuilder.buildChallenge({
+            id: 'Fourth',
+            skill: skills[3],
+          }),
+          domainBuilder.buildChallenge({
+            id: 'Fifth',
+            skill: skills[4],
+          }),
+        ];
+
+        const allAnswers = [
+          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
+          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id }),
+          domainBuilder.buildAnswer({ result: AnswerStatus.KO, challengeId: challenges[2].id }),
+          domainBuilder.buildAnswer({ result: AnswerStatus.SKIPPED, challengeId: challenges[3].id }),
+        ];
+
+        // when
+        const result = flash.calculateTotalPixScore({ allAnswers, challenges });
+
+        // then
+        expect(result).to.equal(11);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Le calcul du score Pix à partir de la capacité de l'utilisateur n'est pas implémenté.

## :gift: Proposition
Créer une nouvelle fonction qui sera responsable du calcul du score Pix total à partir de la capacité de l’utilisateur.
 - Elle accepte en entrée les réponses de l’utilisateur et les challenges correspondant.
 - Elle calcule le score direct (le nombre de Pix obtenu pour chaque question répondue).
 - Elle renvoie le score total obtenu pour ces questions.

## :star2: Remarques
Pour le moment le calcul du score Pix obtenu par inférence n'est pas présent.

## :santa: Pour tester
Pas de test utilisateur possible.