### PR TITLE
[FEATURE] Afficher le prénom / nom de l'étudiant dans sa page de détail (PIX-6700)

### DIFF
--- a/orga/app/routes/authenticated/sup-organization-participants/sup-organization-participant.js
+++ b/orga/app/routes/authenticated/sup-organization-participants/sup-organization-participant.js
@@ -1,7 +1,13 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class SupOrganizationParticipantRoute extends Route {
+  @service store;
+  @service router;
+
   model(params) {
-    return { id: params.etudiant_id };
+    return this.store
+      .findRecord('organization-learner', params.etudiant_id)
+      .catch(() => this.router.replaceWith('authenticated.sup-organization-participants'));
   }
 }

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -68,6 +68,7 @@
 @import 'pages/authenticated/campaigns/details/participants/participant/results';
 @import 'pages/authenticated/campaigns/participant-profile';
 @import 'pages/authenticated/organization-participants/organization-participant.scss';
+@import 'pages/authenticated/sup-organization-participants/sup-organization-participant.scss';
 @import 'pages/authenticated/certifications';
 @import 'pages/authenticated/organization-participants';
 @import 'pages/authenticated/sup-organization-participants/list';

--- a/orga/app/styles/pages/authenticated/sup-organization-participants/sup-organization-participant.scss
+++ b/orga/app/styles/pages/authenticated/sup-organization-participants/sup-organization-participant.scss
@@ -1,0 +1,7 @@
+.learner-header {
+    margin-bottom: $spacing-m;
+
+    &-title {
+        text-transform: capitalize;
+    }
+}

--- a/orga/app/templates/authenticated/sup-organization-participants/sup-organization-participant.hbs
+++ b/orga/app/templates/authenticated/sup-organization-participants/sup-organization-participant.hbs
@@ -1,0 +1,13 @@
+<article>
+  <header class="learner-header">
+    <Ui::PreviousPageButton
+      @route="authenticated.sup-organization-participants"
+      @backButtonAriaLabel={{t "common.actions.back"}}
+      aria-label={{t "pages.organization-learner.header.aria-label-title"}}
+      class="learner-header-title"
+    >
+      {{t "common.fullname" firstName=@model.firstName lastName=@model.lastName}}
+    </Ui::PreviousPageButton>
+  </header>
+  {{outlet}}
+</article>

--- a/orga/tests/unit/routes/authenticated/sup-organization-participant/sup-organization-participant_test.js
+++ b/orga/tests/unit/routes/authenticated/sup-organization-participant/sup-organization-participant_test.js
@@ -1,0 +1,54 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/sup-organization-participants/sup-organization-participant', function (hooks) {
+  setupTest(hooks);
+
+  let route;
+  let store;
+
+  hooks.beforeEach(function () {
+    route = this.owner.lookup('route:authenticated/sup-organization-participants/sup-organization-participant');
+    store = this.owner.lookup('service:store');
+    sinon.stub(route.router, 'replaceWith');
+    sinon.stub(store, 'findRecord');
+  });
+
+  test('should return participant using the parameter given', async function (assert) {
+    // given
+    store.findRecord.resolves();
+
+    // when
+    await route.model({ etudiant_id: 29 });
+
+    // then
+    sinon.assert.calledWith(store.findRecord, 'organization-learner', 29);
+    assert.ok(true);
+  });
+
+  test('should return participant model when the store find it', async function (assert) {
+    // given
+    const expectedModel = Symbol('Participant');
+    store.findRecord.resolves(expectedModel);
+
+    // when
+    const model = await route.model({ etudiant_id: 29 });
+
+    // then
+    assert.strictEqual(model, expectedModel);
+    assert.ok(route.router.replaceWith.notCalled);
+  });
+
+  test('should redirect to students page if student is not found', async function (assert) {
+    // given
+    store.findRecord.rejects({ errors: [{ status: '403' }] });
+
+    // when
+    const model = await route.model({ etudiant_id: 3334 });
+
+    // then
+    assert.strictEqual(model, undefined);
+    assert.ok(route.router.replaceWith.calledWith('authenticated.sup-organization-participants'));
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
La page n'affichait pas de titre.

## :gift: Proposition
Ajout du prénom et du nom en titre de page, avec une flèche de retour.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester

- Se connecter a pix orga avec un compte sup
- Aller sur la liste des étudiants
- Ajouter l'id 888 à la fin de l'URL
- Vérifier que le prénom et le nom du participant s'affiche bien avec la flèche de retour
