### PR TITLE
[FEATURE] Rendre l'étudiant cliquable pour accéder a sa page de détail (PIX-6702)

### DIFF
--- a/orga/app/components/sup-organization-participant/list.hbs
+++ b/orga/app/components/sup-organization-participant/list.hbs
@@ -79,9 +79,20 @@
     {{#if @students}}
       <tbody>
         {{#each @students as |student index|}}
-          <tr aria-label={{t "pages.sup-organization-participants.table.row-title"}}>
+          <tr
+            aria-label={{t "pages.sup-organization-participants.table.row-title"}}
+            {{on "click" (fn @onClickLearner student.id)}}
+            class="tr--clickable"
+          >
             <td class="ellipsis">{{student.studentNumber}}</td>
-            <td class="ellipsis">{{student.lastName}}</td>
+            <td class="ellipsis">
+              <LinkTo
+                @route="authenticated.sup-organization-participants.sup-organization-participant"
+                @model={{student.id}}
+              >
+                {{student.lastName}}
+              </LinkTo>
+            </td>
             <td class="ellipsis">{{student.firstName}}</td>
             <td class="table__column--center">{{dayjs-format student.birthdate "DD/MM/YYYY"}}</td>
             <td class="ellipsis">{{student.group}}</td>

--- a/orga/app/controllers/authenticated/sup-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sup-organization-participants/list.js
@@ -1,14 +1,22 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 
 export default class ListController extends Controller {
+  @service router;
   @tracked search = null;
   @tracked studentNumber = null;
   @tracked groups = [];
   @tracked certificability = [];
   @tracked pageNumber = null;
   @tracked pageSize = 50;
+
+  @action
+  goToLearnerPage(learnerId, event) {
+    event.preventDefault();
+    this.router.transitionTo('authenticated.sup-organization-participants.sup-organization-participant', learnerId);
+  }
 
   @action
   triggerFiltering(fieldName, value) {

--- a/orga/app/templates/authenticated/sup-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sup-organization-participants/list.hbs
@@ -9,6 +9,7 @@
     @groupsFilter={{this.groups}}
     @certificabilityFilter={{this.certificability}}
     @onFilter={{this.triggerFiltering}}
+    @onClickLearner={{this.goToLearnerPage}}
     @onResetFilter={{this.onResetFilter}}
   />
 </div>

--- a/orga/tests/integration/components/sup-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list_test.js
@@ -27,7 +27,7 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
 
     // when
     await render(
-      hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @groups={{this.groups}}/>`
+      hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @groups={{this.groups}} @onClickLearner={{this.noop}}/>`
     );
 
     // then
@@ -49,11 +49,39 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
 
     // when
     await render(
-      hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @groups={{this.groups}}/>`
+      hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @groups={{this.groups}} @onClickLearner={{this.noop}}/>`
     );
 
     // then
+
     assert.dom('[aria-label="Étudiant"]').exists({ count: 2 });
+  });
+
+  test('it should display a link to access student detail', async function (assert) {
+    // given
+    const students = [
+      {
+        lastName: 'Skywalker',
+        firstName: 'Anakin',
+        id: 66,
+        birthdate: new Date('1977-05-25'),
+      },
+      {
+        lastName: 'Kenobi',
+        firstName: 'Obiwan',
+        id: 33,
+        birthdate: new Date('1977-05-25'),
+      },
+    ];
+    this.set('students', students);
+    this.set('groups', []);
+
+    // when
+    const screen = await render(
+      hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @groups={{this.groups}} @onClickLearner={{this.noop}}/>`
+    );
+    // then
+    assert.dom(screen.getByRole('link', { name: 'Kenobi' })).hasProperty('href', /\/etudiants\/33/g);
   });
 
   test('it should display the student number, firstName, lastName, birthdate, group, participation count and and last participation date of student', async function (assert) {
@@ -75,7 +103,7 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
 
     // when
     await render(
-      hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @groups={{this.groups}}/>`
+      hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @groups={{this.groups}} @onClickLearner={{this.noop}}/>`
     );
 
     // then
@@ -102,7 +130,9 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
     this.set('students', students);
 
     // when
-    await render(hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} />`);
+    await render(
+      hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
+    );
 
     // then
     assert.contains('SUP - Campagne de collecte de profils');
@@ -125,7 +155,9 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
     this.set('students', students);
 
     // when
-    await render(hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}}/>`);
+    await render(
+      hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
+    );
 
     // then
     assert.contains(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible'));
@@ -147,7 +179,9 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
     this.set('students', students);
 
     // when
-    await render(hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}}/>`);
+    await render(
+      hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
+    );
 
     // then
     assert.contains('03/01/2022');
@@ -170,7 +204,7 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
 
     // when
     const screen = await render(
-      hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}} @groups={{this.groups}}/>`
+      hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}} @groups={{this.groups}} @onClickLearner={{this.noop}}/>`
     );
 
     // then
@@ -191,7 +225,7 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
       this.set('students', []);
 
       await render(
-        hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}}/>`
+        hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}} @onClickLearner={{this.noop}}/>`
       );
 
       // when
@@ -210,7 +244,7 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
 
       // when
       await render(
-        hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}} @groups={{this.groups}}/>`
+        hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}} @groups={{this.groups}} @onClickLearner={{this.noop}}/>`
       );
 
       await fillByLabel('Entrer un numéro étudiant', 'LATERREURGIGI123');
@@ -230,6 +264,7 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
   @students={{this.students}}
   @onFilter={{this.triggerFiltering}}
   @groups={{this.groups}}
+  @onClickLearner={{this.noop}}
 />`);
       const select = await getByPlaceholderText('Rechercher par groupe');
       await click(select);
@@ -251,7 +286,7 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
       this.set('certificability', []);
 
       const { getByPlaceholderText, findByRole } = await render(
-        hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}} @certificability={{this.certificability}} />`
+        hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}} @certificability={{this.certificability}} @onClickLearner={{this.noop}}/>`
       );
 
       // when
@@ -277,7 +312,7 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
       this.set('groups', []);
       // when
       await render(
-        hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @groups={{this.groups}}/>`
+        hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @groups={{this.groups}} @onClickLearner={{this.noop}}/>`
       );
 
       // then
@@ -294,7 +329,7 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
       this.set('groups', []);
       // when
       await render(
-        hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @groups={{this.groups}}/>`
+        hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @groups={{this.groups}} @onClickLearner={{this.noop}}/>`
       );
 
       // then


### PR DESCRIPTION
## :christmas_tree: Problème
On veut pouvoir accéder a la page de détail d'un étudiant en cliquant sur son nom depuis la liste de tous les étudiants

## :gift: Proposition
Rendre la ligne de l'étudiant cliquable

## :star2: Remarques
⚠️ Ne pas merger cette PR avant que la 6700 ne soit done.

## :santa: Pour tester

- Se connecter a pix orga avec un compte sup
- Aller sur la liste des étudiants
- Cliquer sur un étudiant
- Vérifier qu'on accède bien a sa page de détail
