### PR TITLE
[FEATURE] Changement de la date de fin de passage des sessions dans le SCO (PIX-6731).

### DIFF
--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -70,7 +70,7 @@
         @actionLabel="documentation pour voir les nouveautés."
         @actionUrl="https://cloud.pix.fr/s/GqwW6dFDDrHezfS"
         @canCloseBanner="true"
-      >La certification Pix se déroulera du 14 novembre 2022 au 31 mars 2023 pour les lycées et du 6 mars au 16 juin
+      >La certification Pix se déroulera du 14 novembre 2022 au 17 mars 2023 pour les lycées et du 6 mars au 16 juin
         2023 pour les collèges. Pensez à consulter la
       </PixBanner>
 

--- a/certif/tests/acceptance/authenticated_test.js
+++ b/certif/tests/acceptance/authenticated_test.js
@@ -134,7 +134,7 @@ module('Acceptance | authenticated', function (hooks) {
       assert
         .dom(
           screen.getByText(
-            'La certification Pix se déroulera du 14 novembre 2022 au 31 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges. Pensez à consulter la'
+            'La certification Pix se déroulera du 14 novembre 2022 au 17 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges. Pensez à consulter la'
           )
         )
         .exists();
@@ -151,7 +151,7 @@ module('Acceptance | authenticated', function (hooks) {
 
       // then
       const certificationBannerMessage = screen.queryByText(
-        'La certification Pix se déroulera du 14 novembre 2022 au 31 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges. Pensez à consulter la'
+        'La certification Pix se déroulera du 14 novembre 2022 au 17 mars 2023 pour les lycées et du 6 mars au 16 juin 2023 pour les collèges. Pensez à consulter la'
       );
       assert.dom(certificationBannerMessage).doesNotExist();
     });


### PR DESCRIPTION
## :christmas_tree: Problème

Un changement de date de fin de sessions a été décidé pour le SCO.  

## :gift: Proposition

Changement du 31 mars au 17 mars.

## :santa: Pour tester

- Se connecter à Pix Certif avec un compte SCO (certifsco@example.net par exemple)
- Constater la présence du bandeau et l'exactitude du message délivré.
