### PR TITLE
[FEATURE] Flash : Calculer le nombre de Pix obtenus par inférence (PIX-6719)

### DIFF
--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -624,7 +624,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
     });
   });
 
-  describe('#getNonAnsweredChallenges', function () {
+  describe('#getChallengesForNonAnsweredSkills', function () {
     it('should return the same list of challenges if there is no answers', function () {
       // given
       const challenges = [
@@ -643,7 +643,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
       const allAnswers = [];
 
       // when
-      const result = flash.getNonAnsweredChallenges({ allAnswers, challenges });
+      const result = flash.getChallengesForNonAnsweredSkills({ allAnswers, challenges });
 
       // then
       expect(result).to.be.deep.equal(challenges);
@@ -677,7 +677,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
       const allAnswers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id })];
 
       // when
-      const result = flash.getNonAnsweredChallenges({ allAnswers, challenges });
+      const result = flash.getChallengesForNonAnsweredSkills({ allAnswers, challenges });
 
       // then
       expect(result).to.be.deep.equal([challenges[2]]);

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -17,7 +17,7 @@ describe('Integration | Repository | challenge-repository', function () {
 
       const learningContent = {
         skills: [{ ...skill, status: 'actif' }],
-        challenges: [{ ...challenge, skillId: 'recSkill1', alpha: 0, delta: 0 }],
+        challenges: [{ ...challenge, skillId: 'recSkill1', alpha: 1, delta: 0 }],
       };
 
       mockLearningContent(learningContent);
@@ -565,13 +565,13 @@ function _buildChallenge({ id, skill, status = 'validé' }) {
     type: Challenge.Type.QCM,
     locales: ['fr'],
     autoReply: false,
-    discriminant: 0,
+    discriminant: 1,
     difficulty: 0,
     answer: undefined,
     responsive: 'Smartphone/Tablette',
     competenceId: 'recCOMP1',
     skillId: skill.id,
-    alpha: 0,
+    alpha: 1,
     delta: 0,
     skill,
   };

--- a/api/tests/tooling/domain-builder/factory/build-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge.js
@@ -20,8 +20,9 @@ module.exports = function buildChallenge({
   type = Challenge.Type.QCM,
   locales = ['fr'],
   autoReply = false,
-  discriminant = 0,
+  discriminant = 1,
   difficulty = 0,
+  successProbabilityThreshold,
   responsive = 'Smartphone/Tablette',
   focused = false,
   // includes
@@ -49,6 +50,7 @@ module.exports = function buildChallenge({
     autoReply,
     discriminant,
     difficulty,
+    successProbabilityThreshold,
     alternativeInstruction,
     responsive,
     focused,


### PR DESCRIPTION
## :christmas_tree: Problème
Pour le moment le calcul du score Pix flash n'inclut que les Pix obtenus directement, mais pas les Pix obtenus par inférence.

## :gift: Proposition
- Ré-utiliser la méthode getNonAnsweredChallenges présente dans le fichier flash.js. La renommer en getChallengesForNonAnsweredSkills 

- Créer une fonction qui doit calculer le score Pix obtenu par inférence.
  - Elle prend en entrée des challenges compatibles avec le calcul flash et la capacité de l’utilisateur.
  - Elle filtre les challenges pour garder uniquement ceux dont la capacité minimum est inférieure ou égale à la capacité de l’utilisateur.
  - Elle renvoie la somme des scores Pix associés aux acquis de ces challenges. 

- Intégrer le résultat de cette fonction du total du score Pix obtenu par inférence au total des scores Pix obtenus en direct.

## :star2: Remarques
N/A

## :santa: Pour tester
Pas de test utilisateur possible pour le moment.