### PR TITLE
[TECH] Supprimer une notification slack non utilisée.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,6 @@ jobs:
           root: ~/pix
           paths:
             - .
-      - notify-ci-errors-on-slack
 
   api_build_and_test:
     docker:
@@ -126,7 +125,6 @@ jobs:
           path: /home/circleci/test-results
       - store_artifacts:
           path: /home/circleci/test-results
-      - notify-ci-errors-on-slack
 
   mon_pix_build_and_test:
     docker:
@@ -155,7 +153,6 @@ jobs:
       - run:
           name: Test
           command: npm run test:ci
-      - notify-ci-errors-on-slack
 
   orga_build_and_test:
     docker:
@@ -183,7 +180,6 @@ jobs:
       - run:
           name: Test
           command: npm run test:ci
-      - notify-ci-errors-on-slack
 
   certif_build_and_test:
     docker:
@@ -211,7 +207,6 @@ jobs:
       - run:
           name: Test
           command: npm run test:ci
-      - notify-ci-errors-on-slack
 
   admin_build_and_test:
     docker:
@@ -239,7 +234,6 @@ jobs:
       - run:
           name: Test
           command: npm run test:ci
-      - notify-ci-errors-on-slack
 
   e2e_test:
     docker:
@@ -338,7 +332,6 @@ jobs:
           command: npm run test:ci
       - store_test_results:
           path: /home/circleci/test-results
-      - notify-ci-errors-on-slack
 
   algo_test:
     docker:
@@ -382,12 +375,3 @@ jobs:
       - run:
           name: Test
           command: npm run test:ci
-      - notify-ci-errors-on-slack
-
-commands:
-  notify-ci-errors-on-slack:
-    steps:
-      - slack/notify:
-          event: fail
-          channel: engineering
-          branch_pattern: dev


### PR DESCRIPTION
## :christmas_tree: Problème
Le workflow CircleCI du projet requière une variable `SLACK_ACCESS_TOKEN` qui n'est finalement jamais utilisée pour envoyer des messages sur slack

## :gift: Proposition
Supprimer le code en question, puis supprimer le token de CircleCI

## :star2: Remarques
Le token contenu dans la variable utilisée dans cette commande était un token d'une App de test, qui envoyait des messages sur un Slack de test, et ne se déclenchait jamais.

## :santa: Pour tester
Merger la PR et supprimer la variable du contexte Pix de CircleCI
