### PR TITLE
[BUGFIX] Corriger le test en erreur sur get user shared profile (PIX-6708)

### DIFF
--- a/api/lib/domain/usecases/get-user-profile-shared-for-campaign.js
+++ b/api/lib/domain/usecases/get-user-profile-shared-for-campaign.js
@@ -23,17 +23,16 @@ module.exports = async function getUserProfileSharedForCampaign({
   const [
     { multipleSendings: campaignAllowsRetry },
     isOrganizationLearnerActive,
-    competencesWithArea,
     knowledgeElementsGroupedByCompetenceId,
   ] = await Promise.all([
     campaignRepository.get(campaignId),
     organizationLearnerRepository.isActive({ campaignId, userId }),
-    competenceRepository.listPixCompetencesOnly({ locale }),
-    await knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({
+    knowledgeElementRepository.findUniqByUserIdGroupedByCompetenceId({
       userId,
       limitDate: campaignParticipation.sharedAt,
     }),
   ]);
+  const competencesWithArea = await competenceRepository.listPixCompetencesOnly({ locale });
 
   return new SharedProfileForCampaign({
     campaignParticipation,

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -94,7 +94,7 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObject(BookshelfKnowledgeElement, savedKnowledgeElement);
   },
 
-  async findUniqByUserId({ userId, limitDate, domainTransaction }) {
+  findUniqByUserId({ userId, limitDate, domainTransaction }) {
     return _findAssessedByUserIdAndLimitDateQuery({ userId, limitDate, domainTransaction });
   },
 

--- a/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
+++ b/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
@@ -76,13 +76,13 @@ describe('Acceptance | Route | GET /users/{userId}/campaigns/{campaignId}/profil
       ];
       _.each(knowledgeElements, (ke) => databaseBuilder.factory.buildKnowledgeElement(ke));
 
+      await databaseBuilder.commit();
+
       options = {
         method: 'GET',
         url: `/api/users/${userId}/campaigns/${campaign.id}/profile`,
         headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
       };
-
-      return databaseBuilder.commit();
     });
 
     describe('Success case', function () {


### PR DESCRIPTION
## :christmas_tree: Problème
Le test d'acceptance pour récupérer le profile d'un utilisateur ayant partagé sa participation est en erreur souvent

## :gift: Proposition
Corriger ce test

## :star2: Remarques
Nous avons identifier que le Promise.all avec le  `competenceRepository.listPixCompetencesOnly`. le mockLearningContent ne semblait pas fonctionner nous avions une 500 content null sur `getLatestRelease()` dans `lcms.js` 🤔 .

cette erreur a disparu lorsque nous avons extrait l'appel du Promise.all, (tests run 100x en local toujours OK)

## :santa: Pour tester
Vérifier que la CI passe