### PR TITLE
[TECH] Mettre à jour la GitHub Action d'auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -18,6 +18,6 @@ jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-      - uses: 1024pix/pix-actions/auto-merge@v0
+      - uses: 1024pix/pix-actions/auto-merge@v0.1.4
         with:
           auto_merge_token: '${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}'


### PR DESCRIPTION
## :christmas_tree: Problème
Nous n'utilisons pas la dernière version de notre GitHub Action d'auto-merge, ce qui fait que nous utilisons une version de node 12 au lieu de node 16. De plus la version node 12 est déprécié
<img width="1364" alt="image" src="https://user-images.githubusercontent.com/26384707/210968203-2c27fa1a-a682-414e-8640-40e495798e87.png">


## :gift: Proposition
Utiliser notre dernière mise à jour de la GitHub action qui utilise la bonne version d['automerge action](https://github.com/pascalgn/automerge-action) qui utilise node 16 

## :star2: Remarques
On pourrait penser que `v0` prend la dernière version de 0 comme c'est fait habituellement, cependant on a un tag qui match exactement, il doit donc être privilégié.

## :santa: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
