### PR TITLE
[FEATURE] Personnalisation du message de détail de l'activité d'un prescrit sans participations

### DIFF
--- a/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
@@ -203,14 +203,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
           organizationId: organization.id,
         });
 
-        const expectedOrganizationLeaner = databaseBuilder.factory.buildOrganizationLearner({
+        const expectedOrganizationLearner = databaseBuilder.factory.buildOrganizationLearner({
           organizationId: organization.id,
           firstName: 'John',
           lastName: 'Rambo',
         });
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
-          organizationLearnerId: expectedOrganizationLeaner.id,
+          organizationLearnerId: expectedOrganizationLearner.id,
           status: CampaignParticipationStatuses.SHARED,
           isCertifiable: true,
         });
@@ -237,7 +237,7 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
 
         // then
         expect(data.length).to.equal(1);
-        expect(data[0].id).to.equal(expectedOrganizationLeaner.id);
+        expect(data[0].id).to.equal(expectedOrganizationLearner.id);
       });
 
       it('should return sup participants that are not eligible for certificability or not communicate', async function () {
@@ -248,14 +248,14 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
           organizationId: organization.id,
         });
 
-        const eligibleOrganizationLeaner = databaseBuilder.factory.buildOrganizationLearner({
+        const eligibleOrganizationLearner = databaseBuilder.factory.buildOrganizationLearner({
           organizationId: organization.id,
           firstName: 'John',
           lastName: 'Rambo',
         });
         databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
-          organizationLearnerId: eligibleOrganizationLeaner.id,
+          organizationLearnerId: eligibleOrganizationLearner.id,
           status: CampaignParticipationStatuses.SHARED,
           isCertifiable: true,
         });

--- a/orga/app/components/organization-learner/activity.hbs
+++ b/orga/app/components/organization-learner/activity.hbs
@@ -5,5 +5,5 @@
     class="activity__participants-list"
   />
 {{else}}
-  <OrganizationLearner::Activity::EmptyState @firstName="Jacques" @lastName="Chirac" />
+  <OrganizationLearner::Activity::EmptyState @firstName={{@learner.firstName}} @lastName={{@learner.lastName}} />
 {{/if}}

--- a/orga/app/components/organization-learner/activity/empty-state.hbs
+++ b/orga/app/components/organization-learner/activity/empty-state.hbs
@@ -4,8 +4,8 @@
   <div class="empty-state__text">
     <p>{{t
         "pages.organization-learner.activity.empty-state"
-        organizationLearnerFirstName=@firstName
-        organizationLearnerLastName=@lastName
+        organizationLearnerFirstName=this.firstName
+        organizationLearnerLastName=this.lastName
       }}</p>
   </div>
 </section>

--- a/orga/app/components/organization-learner/activity/empty-state.js
+++ b/orga/app/components/organization-learner/activity/empty-state.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import capitalize from 'lodash/capitalize';
+
+export default class EmptyState extends Component {
+  get firstName() {
+    const { firstName } = this.args;
+    return capitalize(firstName);
+  }
+
+  get lastName() {
+    const { lastName } = this.args;
+    return capitalize(lastName);
+  }
+}

--- a/orga/app/models/organization-learner-activity.js
+++ b/orga/app/models/organization-learner-activity.js
@@ -1,5 +1,5 @@
 import Model, { hasMany } from '@ember-data/model';
 
-export default class OrganizationLeanerActivity extends Model {
+export default class OrganizationLearnerActivity extends Model {
   @hasMany('OrganizationLearnerParticipation') organizationLearnerParticipations;
 }

--- a/orga/app/models/organization-learner.js
+++ b/orga/app/models/organization-learner.js
@@ -1,6 +1,6 @@
 import Model, { attr } from '@ember-data/model';
 
-export default class OrganizationParticipant extends Model {
+export default class OrganizationLearner extends Model {
   @attr('string') lastName;
   @attr('string') firstName;
 }

--- a/orga/app/routes/authenticated/organization-participants/organization-participant/activity.js
+++ b/orga/app/routes/authenticated/organization-participants/organization-participant/activity.js
@@ -1,3 +1,4 @@
+import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
@@ -8,8 +9,11 @@ export default class ActivityRoute extends Route {
   async model() {
     const organizationLearner = this.modelFor('authenticated.organization-participants.organization-participant');
     try {
-      return await this.store.queryRecord('organizationLearnerActivity', {
-        organizationLearnerId: organizationLearner.id,
+      return RSVP.hash({
+        organizationLearner,
+        activity: await this.store.queryRecord('organizationLearnerActivity', {
+          organizationLearnerId: organizationLearner.id,
+        }),
       });
     } catch (_) {
       return this.router.replaceWith('authenticated.organization-participants');

--- a/orga/app/routes/authenticated/sco-organization-participants/sco-organization-participant/activity.js
+++ b/orga/app/routes/authenticated/sco-organization-participants/sco-organization-participant/activity.js
@@ -1,3 +1,4 @@
+import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
@@ -10,8 +11,11 @@ export default class ActivityRoute extends Route {
       'authenticated.sco-organization-participants.sco-organization-participant'
     );
     try {
-      return await this.store.queryRecord('organizationLearnerActivity', {
-        organizationLearnerId: organizationLearner.id,
+      return RSVP.hash({
+        organizationLearner,
+        activity: await this.store.queryRecord('organizationLearnerActivity', {
+          organizationLearnerId: organizationLearner.id,
+        }),
       });
     } catch (_) {
       return this.router.replaceWith('authenticated.sco-organization-participants');

--- a/orga/app/routes/authenticated/sup-organization-participants/sup-organization-participant/activity.js
+++ b/orga/app/routes/authenticated/sup-organization-participants/sup-organization-participant/activity.js
@@ -1,3 +1,4 @@
+import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
@@ -10,8 +11,11 @@ export default class ActivityRoute extends Route {
       'authenticated.sup-organization-participants.sup-organization-participant'
     );
     try {
-      return await this.store.queryRecord('organizationLearnerActivity', {
-        organizationLearnerId: organizationLearner.id,
+      return RSVP.hash({
+        organizationLearner,
+        activity: await this.store.queryRecord('organizationLearnerActivity', {
+          organizationLearnerId: organizationLearner.id,
+        }),
       });
     } catch (_) {
       return this.router.replaceWith('authenticated.sup-organization-participants');

--- a/orga/app/templates/authenticated/organization-participants/organization-participant/activity.hbs
+++ b/orga/app/templates/authenticated/organization-participants/organization-participant/activity.hbs
@@ -1,3 +1,6 @@
 {{page-title (t "pages.organization-participant-activity.title")}}
 
-<OrganizationLearner::Activity @participations={{@model.organizationLearnerParticipations}} />
+<OrganizationLearner::Activity
+  @participations={{@model.activity.organizationLearnerParticipations}}
+  @learner={{@model.organizationLearner}}
+/>

--- a/orga/app/templates/authenticated/sco-organization-participants/sco-organization-participant/activity.hbs
+++ b/orga/app/templates/authenticated/sco-organization-participants/sco-organization-participant/activity.hbs
@@ -1,3 +1,6 @@
 {{page-title (t "pages.sco-organization-participant-activity.title")}}
 
-<OrganizationLearner::Activity @participations={{@model.organizationLearnerParticipations}} />
+<OrganizationLearner::Activity
+  @participations={{@model.activity.organizationLearnerParticipations}}
+  @learner={{@model.organizationLearner}}
+/>

--- a/orga/app/templates/authenticated/sup-organization-participants/sup-organization-participant/activity.hbs
+++ b/orga/app/templates/authenticated/sup-organization-participants/sup-organization-participant/activity.hbs
@@ -1,3 +1,6 @@
 {{page-title (t "pages.sup-organization-participant-activity.title")}}
 
-<OrganizationLearner::Activity @participations={{@model.organizationLearnerParticipations}} />
+<OrganizationLearner::Activity
+  @participations={{@model.activity.organizationLearnerParticipations}}
+  @learner={{@model.organizationLearner}}
+/>

--- a/orga/tests/integration/components/organization-learner/activity_test.js
+++ b/orga/tests/integration/components/organization-learner/activity_test.js
@@ -4,35 +4,31 @@ import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | OrganizationLearner::Activity', function (hooks) {
-  let lastName;
-  let firstName;
-
   setupIntlRenderingTest(hooks);
-
-  hooks.beforeEach(function () {
-    lastName = 'Dylan';
-    firstName = 'Bob';
-    this.set('learner', { lastName, firstName });
-  });
 
   module('#Empty state', function () {
     test('it should display the empty state when no participations', async function (assert) {
       // given
       const participations = [];
       this.set('participations', participations);
+      this.set('learner', { lastName: 'dylan', firstName: 'bob' });
 
       // when
-      await render(
+      const screen = await render(
         hbs`<OrganizationLearner::Activity @participations={{this.participations}} @learner={{this.learner}}/>`
       );
 
       // then
-      assert.contains(
-        this.intl.t('pages.organization-learner.activity.empty-state', {
-          organizationLearnerFirstName: firstName,
-          organizationLearnerLastName: lastName,
-        })
-      );
+      assert
+        .dom(
+          screen.queryByText(
+            this.intl.t('pages.organization-learner.activity.empty-state', {
+              organizationLearnerFirstName: 'Bob',
+              organizationLearnerLastName: 'Dylan',
+            })
+          )
+        )
+        .exists();
     });
 
     test('it should not display the empty state when there is participations', async function (assert) {
@@ -47,19 +43,24 @@ module('Integration | Component | OrganizationLearner::Activity', function (hook
         },
       ];
       this.set('participations', participations);
+      this.set('learner', { lastName: 'Dylan', firstName: 'Bob' });
 
       // when
-      await render(
+      const screen = await render(
         hbs`<OrganizationLearner::Activity @participations={{this.participations}} @learner={{this.learner}}/>`
       );
 
       // then
-      assert.notContains(
-        this.intl.t('pages.organization-learner.activity.empty-state', {
-          organizationLearnerFirstName: 'Dylan',
-          organizationLearnerLastName: 'Bob',
-        })
-      );
+      assert
+        .dom(
+          screen.queryByText(
+            this.intl.t('pages.organization-learner.activity.empty-state', {
+              organizationLearnerFirstName: 'Bob',
+              organizationLearnerLastName: 'Dylan',
+            })
+          )
+        )
+        .doesNotExist();
     });
   });
 });

--- a/orga/tests/integration/components/organization-learner/activity_test.js
+++ b/orga/tests/integration/components/organization-learner/activity_test.js
@@ -4,7 +4,16 @@ import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | OrganizationLearner::Activity', function (hooks) {
+  let lastName;
+  let firstName;
+
   setupIntlRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    lastName = 'Dylan';
+    firstName = 'Bob';
+    this.set('learner', { lastName, firstName });
+  });
 
   module('#Empty state', function () {
     test('it should display the empty state when no participations', async function (assert) {
@@ -13,13 +22,15 @@ module('Integration | Component | OrganizationLearner::Activity', function (hook
       this.set('participations', participations);
 
       // when
-      await render(hbs`<OrganizationLearner::Activity @participations={{this.participations}} />`);
+      await render(
+        hbs`<OrganizationLearner::Activity @participations={{this.participations}} @learner={{this.learner}}/>`
+      );
 
       // then
       assert.contains(
         this.intl.t('pages.organization-learner.activity.empty-state', {
-          organizationLearnerFirstName: 'Jacques',
-          organizationLearnerLastName: 'Chirac',
+          organizationLearnerFirstName: firstName,
+          organizationLearnerLastName: lastName,
         })
       );
     });
@@ -38,13 +49,15 @@ module('Integration | Component | OrganizationLearner::Activity', function (hook
       this.set('participations', participations);
 
       // when
-      await render(hbs`<OrganizationLearner::Activity @participations={{this.participations}} />`);
+      await render(
+        hbs`<OrganizationLearner::Activity @participations={{this.participations}} @learner={{this.learner}}/>`
+      );
 
       // then
       assert.notContains(
         this.intl.t('pages.organization-learner.activity.empty-state', {
-          organizationLearnerFirstName: 'Jacques',
-          organizationLearnerLastName: 'Chirac',
+          organizationLearnerFirstName: 'Dylan',
+          organizationLearnerLastName: 'Bob',
         })
       );
     });

--- a/orga/tests/unit/routes/authenticated/organization-participants/organization-participant/activity_test.js
+++ b/orga/tests/unit/routes/authenticated/organization-participants/organization-participant/activity_test.js
@@ -7,6 +7,7 @@ module('Unit | Route | authenticated/organization-participants/organization-part
 
   let route;
   let store;
+  const organizationLearner = { id: '123' };
 
   hooks.beforeEach(function () {
     route = this.owner.lookup('route:authenticated/organization-participants/organization-participant/activity');
@@ -18,14 +19,15 @@ module('Unit | Route | authenticated/organization-participants/organization-part
 
   test("should return model if user is authorized to display participant's activity", async function (assert) {
     // given
-    const expectedModel = {};
-    store.queryRecord.resolves(expectedModel);
+    const activity = Symbol('activity');
+    const expectedModel = { organizationLearner, activity };
+    store.queryRecord.resolves(activity);
 
     // when
     const model = await route.model();
 
     // then
-    assert.strictEqual(model, expectedModel);
+    assert.deepEqual(model, expectedModel);
     assert.ok(route.router.replaceWith.notCalled);
   });
 

--- a/orga/tests/unit/routes/authenticated/sco-organization-participants/sco-organization-participant/activity_test.js
+++ b/orga/tests/unit/routes/authenticated/sco-organization-participants/sco-organization-participant/activity_test.js
@@ -9,6 +9,7 @@ module(
 
     let route;
     let store;
+    const organizationLearner = { id: '123' };
 
     hooks.beforeEach(function () {
       route = this.owner.lookup(
@@ -22,14 +23,15 @@ module(
 
     test("should return model if user is authorized to display student's activity", async function (assert) {
       // given
-      const expectedModel = {};
-      store.queryRecord.resolves(expectedModel);
+      const activity = Symbol('activity');
+      const expectedModel = { organizationLearner, activity };
+      store.queryRecord.resolves(activity);
 
       // when
       const model = await route.model();
 
       // then
-      assert.strictEqual(model, expectedModel);
+      assert.deepEqual(model, expectedModel);
       assert.ok(route.router.replaceWith.notCalled);
     });
 

--- a/orga/tests/unit/routes/authenticated/sup-organization-participants/sup-organization-participant/activity_test.js
+++ b/orga/tests/unit/routes/authenticated/sup-organization-participants/sup-organization-participant/activity_test.js
@@ -9,6 +9,7 @@ module(
 
     let route;
     let store;
+    const organizationLearner = { id: '123' };
 
     hooks.beforeEach(function () {
       route = this.owner.lookup(
@@ -22,14 +23,15 @@ module(
 
     test("should return model if user is authorized to display student's activity", async function (assert) {
       // given
-      const expectedModel = {};
-      store.queryRecord.resolves(expectedModel);
+      const activity = Symbol('activity');
+      const expectedModel = { organizationLearner, activity };
+      store.queryRecord.resolves(activity);
 
       // when
       const model = await route.model();
 
       // then
-      assert.strictEqual(model, expectedModel);
+      assert.deepEqual(model, expectedModel);
       assert.ok(route.router.replaceWith.notCalled);
     });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Dans l'écran de détail de l'activité d'un prescrit, le message d'information indiquant que celui-ci n'a pas de participation n'est pas adapté à son nom.

## :santa: Pour tester
Depuis l'application Orga, accéder à la page de détail d'un participant n'ayant aucune participation (pour chacun des types d'organisation).
↪️ Le prénom et le nom du participant font partie du message d'information (en anglais également).