### PR TITLE
[FEATURE] Rendre l'élève cliquable pour accéder a sa page de détail (PIX-6701)

### DIFF
--- a/orga/app/components/dropdown/icon-trigger.js
+++ b/orga/app/components/dropdown/icon-trigger.js
@@ -6,7 +6,8 @@ export default class IconTrigger extends Component {
   @tracked display = false;
 
   @action
-  toggle() {
+  toggle(event) {
+    event.stopPropagation();
     this.display = !this.display;
   }
 

--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -94,8 +94,19 @@
     {{#if @students}}
       <tbody>
         {{#each @students as |student index|}}
-          <tr aria-label={{t "pages.sco-organization-participants.table.row-title"}}>
-            <td class="ellipsis" title={{student.lastName}}>{{student.lastName}}</td>
+          <tr
+            aria-label={{t "pages.sco-organization-participants.table.row-title"}}
+            {{on "click" (fn @onClickLearner student.id)}}
+            class="tr--clickable"
+          >
+            <td class="ellipsis">
+              <LinkTo
+                @route="authenticated.sco-organization-participants.sco-organization-participant"
+                @model={{student.id}}
+              >
+                {{student.lastName}}
+              </LinkTo>
+            </td>
             <td class="ellipsis" title={{student.firstName}}>{{student.firstName}}</td>
             <td class="table__column--center">{{dayjs-format student.birthdate "DD/MM/YYYY" allow-empty=true}}</td>
             <td class="ellipsis">{{student.division}}</td>

--- a/orga/app/components/sco-organization-participant/list.js
+++ b/orga/app/components/sco-organization-participant/list.js
@@ -53,7 +53,8 @@ export default class ScoList extends Component {
   }
 
   @action
-  openAuthenticationMethodModal(student) {
+  openAuthenticationMethodModal(student, event) {
+    event.stopPropagation();
     this.student = student;
     this.isShowingAuthenticationMethodModal = true;
   }

--- a/orga/app/components/sup-organization-participant/list.js
+++ b/orga/app/components/sup-organization-participant/list.js
@@ -59,7 +59,8 @@ export default class ListItems extends Component {
   }
 
   @action
-  openEditStudentNumberModal(student) {
+  openEditStudentNumberModal(student, event) {
+    event.stopPropagation();
     this.selectedStudent = student;
     this.isShowingEditStudentNumberModal = true;
   }

--- a/orga/app/controllers/authenticated/sco-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sco-organization-participants/list.js
@@ -8,6 +8,7 @@ export default class ListController extends Controller {
   @service intl;
   @service errorMessages;
   @service store;
+  @service router;
 
   @tracked isLoading = false;
 
@@ -17,6 +18,12 @@ export default class ListController extends Controller {
   @tracked certificability = [];
   @tracked pageNumber = null;
   @tracked pageSize = 50;
+
+  @action
+  goToLearnerPage(learnerId, event) {
+    event.preventDefault();
+    this.router.transitionTo('authenticated.sco-organization-participants.sco-organization-participant', learnerId);
+  }
 
   @action
   triggerFiltering(fieldName, value) {

--- a/orga/app/templates/authenticated/sco-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sco-organization-participants/list.hbs
@@ -12,6 +12,7 @@
     @connectionTypeFilter={{this.connectionTypes}}
     @certificabilityFilter={{this.certificability}}
     @onFilter={{this.triggerFiltering}}
+    @onClickLearner={{this.goToLearnerPage}}
     @onResetFilter={{this.resetFiltering}}
   />
 

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -32,7 +32,9 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
     this.set('students', []);
 
     // when
-    await render(hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} />`);
+    await render(
+      hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
+    );
 
     // then
     assert.contains('Nom');
@@ -52,10 +54,39 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
     this.set('students', students);
 
     // when
-    await render(hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} />`);
+    await render(
+      hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
+    );
 
     // then
     assert.dom('[aria-label="Élève"]').exists({ count: 2 });
+  });
+
+  test('it should display a link to access student detail', async function (assert) {
+    // given
+    const students = [
+      {
+        lastName: 'Michael',
+        firstName: 'Jackson',
+        id: 77,
+        birthdate: new Date('2000-01-01'),
+      },
+      {
+        lastName: 'Michel',
+        firstName: 'Patrick',
+        id: 22,
+        birthdate: new Date('2011-11-11'),
+      },
+    ];
+    this.set('students', students);
+    this.set('groups', []);
+
+    // when
+    const screen = await render(
+      hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
+    );
+    // then
+    assert.dom(screen.getByRole('link', { name: 'Michel' })).hasProperty('href', /\/eleves\/22/g);
   });
 
   test('it should display the firstName, lastName, birthdate, division, participation count, last participation date of student, the last participation tooltip and certifiableAt', async function (assert) {
@@ -75,7 +106,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
 
     // when
     const screen = await render(
-      hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} />`
+      hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
     );
 
     // then
@@ -100,7 +131,9 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
     this.set('students', []);
 
     // when
-    await render(hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}}/>`);
+    await render(
+      hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
+    );
 
     // then
     assert.contains(this.intl.t('pages.sco-organization-participants.table.description'));
@@ -115,7 +148,9 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
     ]);
 
     // when
-    await render(hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} />`);
+    await render(
+      hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
+    );
 
     // then
     assert.contains(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible'));
@@ -129,7 +164,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('students', []);
 
       await render(
-        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}}/>`
+        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}} @onClickLearner={{this.noop}}/>`
       );
 
       // when
@@ -149,6 +184,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       const { getByPlaceholderText, findByRole } = await render(hbs`<ScoOrganizationParticipant::List
         @students={{this.students}}
         @onFilter={{this.triggerFiltering}}
+        @onClickLearner={{this.noop}}
       />`);
 
       // when
@@ -171,7 +207,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('students', []);
 
       const screen = await render(
-        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}} />`
+        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}} @onClickLearner={{this.noop}}/>`
       );
 
       // when
@@ -191,7 +227,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('certificability', []);
 
       const { getByPlaceholderText, findByRole } = await render(
-        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}} @certificability={{this.certificability}} />`
+        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}} @certificability={{this.certificability}} @onClickLearner={{this.noop}}/>`
       );
 
       // when
@@ -222,7 +258,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       ]);
 
       await render(
-        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}} @onResetFilter={{this.resetFiltered}} />`
+        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}} @onResetFilter={{this.resetFiltered}} @onClickLearner={{this.noop}}/>`
       );
 
       // when
@@ -244,7 +280,9 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
           birthdate: '2010-01-01',
         }),
       ]);
-      return render(hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} />`);
+      return render(
+        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
+      );
     });
 
     test('it should display dash for authentication method', async function (assert) {
@@ -270,11 +308,15 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
           isAuthenticatedFromGar: false,
         }),
       ]);
-      return render(hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} />`);
+      return render(
+        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
+      );
     });
     test('it should display the manage account entry menu', async function (assert) {
       // given
-      await render(hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} />`);
+      await render(
+        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
+      );
 
       // when
       await clickByName('Afficher les actions');
@@ -296,7 +338,9 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
           isAuthenticatedFromGar: false,
         }),
       ]);
-      return render(hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} />`);
+      return render(
+        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
+      );
     });
 
     test('it should display "Identifiant" as authentication method', async function (assert) {
@@ -320,7 +364,9 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
           isAuthenticatedFromGar: false,
         }),
       ]);
-      return render(hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} />`);
+      return render(
+        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
+      );
     });
 
     test('it should display "Adresse email" as authentication method', async function (assert) {
@@ -349,7 +395,9 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
 
     test('it should display "Mediacentre" as authentication method', async function (assert) {
       // when
-      await render(hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} />`);
+      await render(
+        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
+      );
 
       // then
       assert.dom('[aria-label="Élève"]').containsText('Mediacentre');
@@ -357,7 +405,9 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
 
     test('it should display the action menu', async function (assert) {
       // when
-      await render(hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} />`);
+      await render(
+        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
+      );
 
       // then
       assert.dom('[aria-label="Afficher les actions"]').exists();
@@ -373,7 +423,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
 
       // when
       const screen = await render(
-        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} />`
+        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
       );
 
       // then
@@ -394,7 +444,9 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       students.meta = { participantCount: 1 };
       this.set('students', students);
       // when
-      await render(hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}}/>`);
+      await render(
+        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
+      );
 
       // then
       assert.contains('Aucun élève.');
@@ -408,7 +460,9 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       students.meta = { participantCount: 0 };
       this.set('students', students);
       // when
-      await render(hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}}/>`);
+      await render(
+        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
+      );
 
       // then
       assert.contains('L’administrateur doit importer la base élèves en cliquant sur le bouton importer.');


### PR DESCRIPTION
## :christmas_tree: Problème
On veut pouvoir accéder a la page de détail d'un élève en cliquant sur son nom depuis la liste de tous les élèves

## :gift: Proposition
Rendre la ligne de l'élève cliquable

## :star2: Remarques
⚠️ Ne pas merger cette PR avant que la 6701 ne soit done.

## :santa: Pour tester

- Se connecter a pix orga avec un compte sco
- Aller sur la liste des élèves
- Cliquer sur un élève
- Vérifier qu'on accède bien a sa page de détail
