### PR TITLE
[FEATURE] Afficher le score Pix calculé à la fin de la campagne flash (PIX-6720)

### DIFF
--- a/api/lib/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/lib/domain/read-models/participant-results/AssessmentResult.js
@@ -21,6 +21,7 @@ class AssessmentResult {
     this.isShared = Boolean(participationResults.sharedAt);
     this.participantExternalId = participationResults.participantExternalId;
     this.estimatedFlashLevel = participationResults.estimatedFlashLevel;
+    this.flashPixScore = participationResults.flashPixScore;
 
     this.totalSkillsCount = competences.flatMap(({ skillIds }) => skillIds).length;
     this.testedSkillsCount = knowledgeElements.length;

--- a/api/lib/domain/services/algorithm-methods/data-fetcher.js
+++ b/api/lib/domain/services/algorithm-methods/data-fetcher.js
@@ -77,16 +77,16 @@ async function fetchForCompetenceEvaluations({
 }
 
 async function fetchForFlashCampaigns({
-  assessment,
+  assessmentId,
   answerRepository,
   challengeRepository,
   flashAssessmentResultRepository,
   locale,
 }) {
   const [allAnswers, challenges, { estimatedLevel } = {}] = await Promise.all([
-    answerRepository.findByAssessment(assessment.id),
+    answerRepository.findByAssessment(assessmentId),
     challengeRepository.findFlashCompatible({ locale }),
-    flashAssessmentResultRepository.getLatestByAssessmentId(assessment.id),
+    flashAssessmentResultRepository.getLatestByAssessmentId(assessmentId),
   ]);
 
   return {

--- a/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -15,7 +15,7 @@ module.exports = async function getNextChallengeForCampaignAssessment({
 
   if (assessment.isFlash()) {
     const inputValues = await dataFetcher.fetchForFlashCampaigns({
-      assessment,
+      assessmentId: assessment.id,
       answerRepository,
       challengeRepository,
       flashAssessmentResultRepository,

--- a/api/lib/infrastructure/repositories/participant-result-repository.js
+++ b/api/lib/infrastructure/repositories/participant-result-repository.js
@@ -55,7 +55,7 @@ async function _getParticipationResults(userId, campaignId, locale) {
   let flashPixScore;
   if (isFlash) {
     const { allAnswers, challenges, estimatedLevel } = await dataFetcher.fetchForFlashCampaigns({
-      assessment: { id: assessmentId },
+      assessmentId,
       locale,
       answerRepository,
       challengeRepository,

--- a/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
@@ -12,6 +12,7 @@ module.exports = {
         'isShared',
         'participantExternalId',
         'estimatedFlashLevel',
+        'flashPixScore',
         'campaignParticipationBadges',
         'competenceResults',
         'reachedStage',

--- a/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
+++ b/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
@@ -204,6 +204,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
             'is-disabled': false,
             'participant-external-id': 'participantExternalId',
             'estimated-flash-level': undefined,
+            'flash-pix-score': undefined,
           },
           relationships: {
             'campaign-participation-badges': {

--- a/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
@@ -50,12 +50,17 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
           { id: 'recTube2', competenceId: 'rec2' },
         ],
         skills: [
-          { id: 'skill1', status: 'actif', tubeId: 'recTube1', competenceId: 'rec1' },
+          { id: 'skill1', status: 'actif', tubeId: 'recTube1', competenceId: 'rec1', pixValue: 2 },
           { id: 'skill2', status: 'archivé', tubeId: 'recTube1', competenceId: 'rec1' },
-          { id: 'skill3', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2' },
-          { id: 'skill4', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2' },
+          { id: 'skill3', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', pixValue: 20 },
+          { id: 'skill4', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', pixValue: 200 },
           { id: 'skill5', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2' },
           { id: 'skill6', status: 'périmé', tubeId: 'recTube2', competenceId: 'rec2' },
+        ],
+        challenges: [
+          { id: 'challenge1', skillId: 'skill1', status: 'validé', locales: ['FR'], alpha: 1, delta: 0 },
+          { id: 'challenge2', skillId: 'skill3', status: 'validé', locales: ['FR'], alpha: 1, delta: 4 },
+          { id: 'challenge3', skillId: 'skill4', status: 'validé', locales: ['FR'], alpha: 2.57, delta: 1.4 },
         ],
       };
 
@@ -1027,7 +1032,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
     });
 
     context('when campaign is flash', function () {
-      it('returns the estimated flash level', async function () {
+      it('returns the estimated flash level and calculated pix score', async function () {
         // given
         const { id: userId } = databaseBuilder.factory.buildUser();
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({
@@ -1043,8 +1048,16 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
           userId,
           method: Assessment.methods.FLASH,
         });
+        const answers = [
+          databaseBuilder.factory.buildAnswer({
+            assessmentId,
+            challengeId: 'challenge1',
+            result: 'ok',
+          }),
+        ];
         const { estimatedLevel } = databaseBuilder.factory.buildFlashAssessmentResult({
           assessmentId,
+          answerId: answers[0].id,
         });
         await databaseBuilder.commit();
 
@@ -1060,6 +1073,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         // then
         expect(participantResult).to.contain({
           estimatedFlashLevel: estimatedLevel,
+          flashPixScore: 202,
         });
       });
     });

--- a/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
+++ b/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
@@ -169,7 +169,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
 
     it('fetches answers and challenges', async function () {
       // given
-      const assessment = domainBuilder.buildAssessment.ofTypeCampaign({
+      const { id: assessmentId } = domainBuilder.buildAssessment.ofTypeCampaign({
         state: 'started',
         method: 'FLASH',
         campaignParticipationId: 1,
@@ -179,13 +179,13 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
       const challenges = Symbol('challenge');
       const estimatedLevel = Symbol('estimatedLevel');
 
-      answerRepository.findByAssessment.withArgs(assessment.id).resolves([answer]);
+      answerRepository.findByAssessment.withArgs(assessmentId).resolves([answer]);
       challengeRepository.findFlashCompatible.withArgs().resolves(challenges);
-      flashAssessmentResultRepository.getLatestByAssessmentId.withArgs(assessment.id).resolves({ estimatedLevel });
+      flashAssessmentResultRepository.getLatestByAssessmentId.withArgs(assessmentId).resolves({ estimatedLevel });
 
       // when
       const data = await dataFetcher.fetchForFlashCampaigns({
-        assessment,
+        assessmentId,
         answerRepository,
         challengeRepository,
         flashAssessmentResultRepository,

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -69,7 +69,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessment
         // then
         expect(flash.getPossibleNextChallenges).to.have.been.called;
         expect(dataFetcher.fetchForFlashCampaigns).to.have.been.calledWith({
-          assessment,
+          assessmentId: assessment.id,
           answerRepository,
           challengeRepository,
           flashAssessmentResultRepository,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -33,6 +33,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
         participantExternalId: 'greg@lafleche.fr',
         masteryRate: 0.5,
         estimatedFlashLevel: -2.4672347856,
+        flashPixScore: 374.3438957781,
         isDeleted: false,
       };
 
@@ -94,6 +95,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
             'is-disabled': false,
             'participant-external-id': 'greg@lafleche.fr',
             'estimated-flash-level': -2.4672347856,
+            'flash-pix-score': 374.3438957781,
           },
           id: '1',
           relationships: {

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -44,7 +44,7 @@
                 {{t "pages.skill-review.flash.abstract"}}
               </p>
               <p class="rounded-panel-title skill-review-result-abstract__subtext">
-                {{t "pages.skill-review.flash.pixCount" count=this.flashPixCount}}
+                {{t "pages.skill-review.flash.pixScore" score=this.flashPixScore}}
                 <br />
                 <span class="skill-review-result-abstract__nonDefinitive">
                   {{t "pages.skill-review.flash.nonDefinitive"}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -131,8 +131,8 @@ export default class SkillReview extends Component {
     return this.args.model.campaignParticipationResult.estimatedFlashLevel;
   }
 
-  get flashPixCount() {
-    return ((this.estimatedFlashLevel + 10) / 20) * 1024;
+  get flashPixScore() {
+    return this.args.model.campaignParticipationResult.flashPixScore;
   }
 
   get participantExternalId() {

--- a/mon-pix/app/models/campaign-participation-result.js
+++ b/mon-pix/app/models/campaign-participation-result.js
@@ -13,6 +13,7 @@ export default class CampaignParticipationResult extends Model {
   @attr('boolean') isShared;
   @attr('string') participantExternalId;
   @attr('number') estimatedFlashLevel;
+  @attr('number') flashPixScore;
 
   // includes
   @hasMany('campaignParticipationBadges') campaignParticipationBadges;

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1386,7 +1386,7 @@
       },
       "flash": {
         "abstract": "Congratulations, you went all the way !",
-        "pixCount": "You got {count, number, ::.} Pix",
+        "pixScore": "You got {score, number, ::.} Pix",
         "nonDefinitive": "(non-definitive calculation)"
       },
       "trainings": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1386,7 +1386,7 @@
       },
       "flash": {
         "abstract": "Bravo, vous êtes allé·e jusqu'au bout !",
-        "pixCount": "Vous avez obtenu {count, number, ::.} Pix",
+        "pixScore": "Vous avez obtenu {score, number, ::.} Pix",
         "nonDefinitive": "(calcul non définitif)"
       },
       "trainings": {


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement le score Pix affiché à la fin de la campagne flash est calculé avec une règle de 3.

## :gift: Proposition
Renvoyer le score Pix calculé depuis le endpoint assessment-result
- Dans le modèle AssessmentResult, ajouter un champ flashPixScore
-  Dans le ParticipantResultRepository, après avoir lu la capacité estimée de l’utilisateur, calculer son score Pix
-  Stocker le score Pix calculé dans la propriété flashPixScore de l' AssessmentResult
-  Impacter le serializer pour ajouter le champ flashPixScore dans la payload du endpoint

Afficher le score à la place du pixCount en règle de 3 sur l'écran de fin campagne.

## :star2: Remarques
N/A

## :santa: Pour tester
Se connecter sur la RA et lancer la campagne flash avec le code `FLASH1234`.
Terminer la campagne et voir le score !
