### PR TITLE
[BUGFIX] L'utilisateur est bloqué définitivement alors qu'il ne devrait pas (PIX-6749)

### DIFF
--- a/api/lib/application/usecases/checkIfUserIsBlocked.js
+++ b/api/lib/application/usecases/checkIfUserIsBlocked.js
@@ -4,10 +4,10 @@ const userLoginRepository = require('../../infrastructure/repositories/user-logi
 module.exports = {
   async execute(username) {
     const foundUserLogin = await userLoginRepository.findByUsername(username);
-    if (foundUserLogin?.isUserBlocked()) {
+    if (foundUserLogin?.isUserMarkedAsBlocked()) {
       throw new UserIsBlocked();
     }
-    if (foundUserLogin?.isUserTemporaryBlocked()) {
+    if (foundUserLogin?.isUserMarkedAsTemporaryBlocked()) {
       throw new UserIsTemporaryBlocked();
     }
   },

--- a/api/lib/domain/models/UserLogin.js
+++ b/api/lib/domain/models/UserLogin.js
@@ -15,7 +15,7 @@ class UserLogin {
     this.failureCount++;
   }
 
-  isUserTemporaryBlocked() {
+  isUserMarkedAsTemporaryBlocked() {
     const now = new Date();
     return !!this.temporaryBlockedUntil && this.temporaryBlockedUntil > now;
   }
@@ -25,34 +25,34 @@ class UserLogin {
     this.temporaryBlockedUntil = null;
   }
 
-  shouldBlockUserTemporarily() {
+  shouldMarkUserAsTemporarilyBlocked() {
     return this.failureCount % settings.login.temporaryBlockingThresholdFailureCount === 0;
   }
 
-  blockUserTemporarily() {
+  markUserAsTemporarilyBlocked() {
     const commonRatio = Math.pow(2, this.failureCount / settings.login.temporaryBlockingThresholdFailureCount - 1);
     this.temporaryBlockedUntil = new Date(Date.now() + settings.login.temporaryBlockingBaseTimeMs * commonRatio);
   }
 
-  hasBeenTemporaryBlocked() {
+  hasFailedAtLeastOnce() {
     return this.failureCount > 0 || !!this.temporaryBlockedUntil;
   }
 
-  shouldBlockUser() {
+  shouldMarkUserAsBlocked() {
     return this.failureCount >= settings.login.blockingLimitFailureCount;
   }
 
-  blockUser() {
+  markUserAsBlocked() {
     this.blockedAt = new Date();
   }
 
-  unblockUser() {
+  resetUserBlocking() {
     this.failureCount = 0;
     this.temporaryBlockedUntil = null;
     this.blockedAt = null;
   }
 
-  isUserBlocked() {
+  isUserMarkedAsBlocked() {
     return !!this.blockedAt;
   }
 }

--- a/api/lib/domain/models/UserLogin.js
+++ b/api/lib/domain/models/UserLogin.js
@@ -53,7 +53,7 @@ class UserLogin {
   }
 
   isUserBlocked() {
-    return !!this.blockedAt || this.failureCount >= settings.login.blockingLimitFailureCount;
+    return !!this.blockedAt;
   }
 }
 

--- a/api/lib/domain/services/authentication/pix-authentication-service.js
+++ b/api/lib/domain/services/authentication/pix-authentication-service.js
@@ -20,10 +20,10 @@ async function getUserByUsernameAndPassword({ username, password, userRepository
     if (error instanceof PasswordNotMatching) {
       userLogin.incrementFailureCount();
 
-      if (userLogin.shouldBlockUser()) {
-        userLogin.blockUser();
-      } else if (userLogin.shouldBlockUserTemporarily()) {
-        userLogin.blockUserTemporarily();
+      if (userLogin.shouldMarkUserAsBlocked()) {
+        userLogin.markUserAsBlocked();
+      } else if (userLogin.shouldMarkUserAsTemporarilyBlocked()) {
+        userLogin.markUserAsTemporarilyBlocked();
       }
 
       await userLoginRepository.update(userLogin);
@@ -32,7 +32,7 @@ async function getUserByUsernameAndPassword({ username, password, userRepository
     throw error;
   }
 
-  if (userLogin.hasBeenTemporaryBlocked()) {
+  if (userLogin.hasFailedAtLeastOnce()) {
     userLogin.resetUserTemporaryBlocking();
     await userLoginRepository.update(userLogin);
   }

--- a/api/lib/domain/usecases/unblock-user-account.js
+++ b/api/lib/domain/usecases/unblock-user-account.js
@@ -1,6 +1,6 @@
 module.exports = async function unblockUserAccount({ userId, userLoginRepository }) {
   const userLogin = await userLoginRepository.findByUserId(userId);
-  userLogin.unblockUser();
+  userLogin.resetUserBlocking();
 
   return await userLoginRepository.update(userLogin);
 };

--- a/api/tests/unit/domain/models/UserLogin_test.js
+++ b/api/tests/unit/domain/models/UserLogin_test.js
@@ -54,7 +54,7 @@ describe('Unit | Domain | Models | UserLogin', function () {
         });
 
         // when
-        const result = userLogin.isUserTemporaryBlocked();
+        const result = userLogin.isUserMarkedAsTemporaryBlocked();
 
         // then
         expect(result).to.be.false;
@@ -71,7 +71,7 @@ describe('Unit | Domain | Models | UserLogin', function () {
         });
 
         // when
-        const result = userLogin.isUserTemporaryBlocked();
+        const result = userLogin.isUserMarkedAsTemporaryBlocked();
 
         // then
         expect(result).to.be.true;
@@ -87,7 +87,7 @@ describe('Unit | Domain | Models | UserLogin', function () {
         });
 
         // when
-        const result = userLogin.isUserTemporaryBlocked();
+        const result = userLogin.isUserMarkedAsTemporaryBlocked();
 
         // then
         expect(result).to.be.false;
@@ -95,7 +95,7 @@ describe('Unit | Domain | Models | UserLogin', function () {
     });
   });
 
-  describe('#blockUserTemporarily', function () {
+  describe('#markUserAsTemporarilyBlocked', function () {
     it('should set temporary block until date', function () {
       // given
       const multipleOfThreshold = 10 * 2;
@@ -105,7 +105,7 @@ describe('Unit | Domain | Models | UserLogin', function () {
       });
 
       // when
-      userLogin.blockUserTemporarily();
+      userLogin.markUserAsTemporarilyBlocked();
 
       // then
       expect(userLogin.temporaryBlockedUntil).to.deepEqualInstance(new Date('2022-11-28T12:04:00Z'));
@@ -119,7 +119,7 @@ describe('Unit | Domain | Models | UserLogin', function () {
         const userLogin = new UserLogin({ failureCount: 1, temporaryBlockedUntil: null });
 
         // when
-        const result = userLogin.hasBeenTemporaryBlocked();
+        const result = userLogin.hasFailedAtLeastOnce();
 
         // then
         expect(result).to.be.true;
@@ -132,7 +132,7 @@ describe('Unit | Domain | Models | UserLogin', function () {
         const userLogin = new UserLogin({ temporaryBlockedUntil: new Date('2022-11-28T15:00:00Z') });
 
         // when
-        const result = userLogin.hasBeenTemporaryBlocked();
+        const result = userLogin.hasFailedAtLeastOnce();
 
         // then
         expect(result).to.be.true;
@@ -145,7 +145,7 @@ describe('Unit | Domain | Models | UserLogin', function () {
         const userLogin = new UserLogin({ failureCount: 0, temporaryBlockedUntil: null });
 
         // when
-        const result = userLogin.hasBeenTemporaryBlocked();
+        const result = userLogin.hasFailedAtLeastOnce();
 
         // then
         expect(result).to.be.false;
@@ -160,7 +160,7 @@ describe('Unit | Domain | Models | UserLogin', function () {
         const userLogin = new UserLogin({ failureCount: 50, blockedAt: null });
 
         // when
-        const result = userLogin.isUserBlocked();
+        const result = userLogin.isUserMarkedAsBlocked();
 
         // then
         expect(result).to.be.false;
@@ -173,7 +173,7 @@ describe('Unit | Domain | Models | UserLogin', function () {
         const userLogin = new UserLogin({ failureCount: 50, blockedAt: new Date('2022-11-29') });
 
         // when
-        const result = userLogin.isUserBlocked();
+        const result = userLogin.isUserMarkedAsBlocked();
 
         // then
         expect(result).to.be.true;
@@ -186,7 +186,7 @@ describe('Unit | Domain | Models | UserLogin', function () {
         const userLogin = new UserLogin({ failureCount: 50, blockedAt: null });
 
         // when
-        const result = userLogin.isUserBlocked();
+        const result = userLogin.isUserMarkedAsBlocked();
 
         // then
         expect(result).to.be.false;
@@ -194,27 +194,27 @@ describe('Unit | Domain | Models | UserLogin', function () {
     });
   });
 
-  describe('#blockUser', function () {
+  describe('#markUserAsBlocked', function () {
     it('blocks user', function () {
       // given
       const userLogin = new UserLogin({});
 
       // when
-      userLogin.blockUser();
+      userLogin.markUserAsBlocked();
 
       // then
       expect(userLogin.blockedAt).to.deepEqualInstance(new Date('2022-11-28T12:00:00Z'));
     });
   });
 
-  describe('#shouldBlockUserTemporarily', function () {
+  describe('#shouldMarkUserAsTemporarilyBlocked', function () {
     context('when failure count is lower than failure count threshold', function () {
       it('returns false', function () {
         // given
         const userLogin = new UserLogin({ failureCount: 5 });
 
         // when
-        const result = userLogin.shouldBlockUserTemporarily();
+        const result = userLogin.shouldMarkUserAsTemporarilyBlocked();
 
         // then
         expect(result).to.be.false;
@@ -227,7 +227,7 @@ describe('Unit | Domain | Models | UserLogin', function () {
         const userLogin = new UserLogin({ failureCount: 20 });
 
         // when
-        const result = userLogin.shouldBlockUserTemporarily();
+        const result = userLogin.shouldMarkUserAsTemporarilyBlocked();
 
         // then
         expect(result).to.be.true;
@@ -235,14 +235,14 @@ describe('Unit | Domain | Models | UserLogin', function () {
     });
   });
 
-  describe('#shouldBlockUser', function () {
+  describe('#shouldMarkUserAsBlocked', function () {
     context('when failure count is lower than the limit failure count', function () {
       it('returns false', function () {
         // given
         const userLogin = new UserLogin({ failureCount: 49 });
 
         // when
-        const result = userLogin.shouldBlockUser();
+        const result = userLogin.shouldMarkUserAsBlocked();
 
         // then
         expect(result).to.be.false;
@@ -255,7 +255,7 @@ describe('Unit | Domain | Models | UserLogin', function () {
         const userLogin = new UserLogin({ failureCount: 50 });
 
         // when
-        const result = userLogin.shouldBlockUser();
+        const result = userLogin.shouldMarkUserAsBlocked();
 
         // then
         expect(result).to.be.true;
@@ -274,7 +274,7 @@ describe('Unit | Domain | Models | UserLogin', function () {
       });
 
       // when
-      userLogin.unblockUser();
+      userLogin.resetUserBlocking();
 
       // then
       expect(userLogin.failureCount).to.equal(0);

--- a/api/tests/unit/domain/models/UserLogin_test.js
+++ b/api/tests/unit/domain/models/UserLogin_test.js
@@ -116,7 +116,7 @@ describe('Unit | Domain | Models | UserLogin', function () {
     context('when user has failure count greater than 0', function () {
       it('should return true', function () {
         // given
-        const userLogin = new UserLogin({ failureCount: 1 });
+        const userLogin = new UserLogin({ failureCount: 1, temporaryBlockedUntil: null });
 
         // when
         const result = userLogin.hasBeenTemporaryBlocked();
@@ -142,7 +142,7 @@ describe('Unit | Domain | Models | UserLogin', function () {
     context('when user has no failure count nor temporary blocked until date', function () {
       it('should return false', function () {
         // given
-        const userLogin = new UserLogin({});
+        const userLogin = new UserLogin({ failureCount: 0, temporaryBlockedUntil: null });
 
         // when
         const result = userLogin.hasBeenTemporaryBlocked();
@@ -154,23 +154,23 @@ describe('Unit | Domain | Models | UserLogin', function () {
   });
 
   describe('#isUserBlocked', function () {
-    context('when user reaches the limit failure count', function () {
-      it('returns true', function () {
+    context('when user reaches the limit failure count but is not yet blocked', function () {
+      it('returns false', function () {
         // given
-        const userLogin = new UserLogin({ failureCount: 50 });
+        const userLogin = new UserLogin({ failureCount: 50, blockedAt: null });
 
         // when
         const result = userLogin.isUserBlocked();
 
         // then
-        expect(result).to.be.true;
+        expect(result).to.be.false;
       });
     });
 
     context('when user has blockedAt date', function () {
       it('returns true', function () {
         // given
-        const userLogin = new UserLogin({ blockedAt: new Date('2022-11-29') });
+        const userLogin = new UserLogin({ failureCount: 50, blockedAt: new Date('2022-11-29') });
 
         // when
         const result = userLogin.isUserBlocked();
@@ -183,7 +183,7 @@ describe('Unit | Domain | Models | UserLogin', function () {
     context('when user has no failure count nor blockedAt date', function () {
       it('returns false', function () {
         // given
-        const userLogin = new UserLogin({});
+        const userLogin = new UserLogin({ failureCount: 50, blockedAt: null });
 
         // when
         const result = userLogin.isUserBlocked();

--- a/api/tests/unit/domain/services/authentication/pix-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/pix-authentication-service_test.js
@@ -89,7 +89,7 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
       context('when user is not temporary blocked', function () {
         it('should not reset password failure count', async function () {
           // given
-          const userLogin = { hasBeenTemporaryBlocked: sinon.stub().returns(false) };
+          const userLogin = { hasFailedAtLeastOnce: sinon.stub().returns(false) };
           userLoginRepository.findByUserId.withArgs(user.id).resolves(userLogin);
 
           // when
@@ -110,7 +110,7 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
           const user = domainBuilder.buildUser({ username });
           const resetUserTemporaryBlockingStub = sinon.stub();
           const userLogin = {
-            hasBeenTemporaryBlocked: sinon.stub().returns(true),
+            hasFailedAtLeastOnce: sinon.stub().returns(true),
             resetUserTemporaryBlocking: resetUserTemporaryBlockingStub,
           };
           userLoginRepository.findByUserId.withArgs(user.id).resolves(userLogin);
@@ -153,10 +153,10 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
             encryptionService.checkPassword.rejects(new PasswordNotMatching());
             const userLoginCreated = {
               incrementFailureCount: sinon.stub(),
-              shouldBlockUserTemporarily: sinon.stub().returns(false),
-              blockUserTemporarily: sinon.stub(),
-              shouldBlockUser: sinon.stub().returns(false),
-              blockUser: sinon.stub(),
+              shouldMarkUserAsTemporarilyBlocked: sinon.stub().returns(false),
+              markUserAsTemporarilyBlocked: sinon.stub(),
+              shouldMarkUserAsBlocked: sinon.stub().returns(false),
+              markUserAsBlocked: sinon.stub(),
             };
             userLoginRepository.findByUserId.withArgs(user.id).resolves(null);
             userLoginRepository.create.resolves(userLoginCreated);
@@ -171,8 +171,8 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
             // then
             expect(userLoginRepository.create).to.have.been.calledWith({ userId: user.id });
             expect(userLoginCreated.incrementFailureCount).to.have.been.calledOnce;
-            expect(userLoginCreated.blockUserTemporarily).to.not.have.been.called;
-            expect(userLoginCreated.blockUser).to.not.have.been.called;
+            expect(userLoginCreated.markUserAsTemporarilyBlocked).to.not.have.been.called;
+            expect(userLoginCreated.markUserAsBlocked).to.not.have.been.called;
             expect(userLoginRepository.update).to.have.been.calledWith(userLoginCreated);
             expect(error).to.be.an.instanceof(PasswordNotMatching);
           });
@@ -185,10 +185,10 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
             encryptionService.checkPassword.rejects(new PasswordNotMatching());
             const userLogin = {
               incrementFailureCount: sinon.stub(),
-              shouldBlockUserTemporarily: sinon.stub().returns(true),
-              blockUserTemporarily: sinon.stub(),
-              shouldBlockUser: sinon.stub().returns(false),
-              blockUser: sinon.stub(),
+              shouldMarkUserAsTemporarilyBlocked: sinon.stub().returns(true),
+              markUserAsTemporarilyBlocked: sinon.stub(),
+              shouldMarkUserAsBlocked: sinon.stub().returns(false),
+              markUserAsBlocked: sinon.stub(),
             };
             userLoginRepository.findByUserId.withArgs(user.id).resolves(userLogin);
 
@@ -202,8 +202,8 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
             // then
             expect(userLoginRepository.create).to.not.have.been.called;
             expect(userLogin.incrementFailureCount).to.have.been.calledOnce;
-            expect(userLogin.blockUserTemporarily).to.have.been.calledOnce;
-            expect(userLogin.blockUser).to.not.have.been.called;
+            expect(userLogin.markUserAsTemporarilyBlocked).to.have.been.calledOnce;
+            expect(userLogin.markUserAsBlocked).to.not.have.been.called;
             expect(userLoginRepository.update).to.have.been.calledWith(userLogin);
             expect(error).to.be.an.instanceof(PasswordNotMatching);
           });
@@ -216,10 +216,10 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
             encryptionService.checkPassword.rejects(new PasswordNotMatching());
             const userLogin = {
               incrementFailureCount: sinon.stub(),
-              shouldBlockUserTemporarily: sinon.stub().returns(false),
-              blockUserTemporarily: sinon.stub(),
-              shouldBlockUser: sinon.stub().returns(true),
-              blockUser: sinon.stub(),
+              shouldMarkUserAsTemporarilyBlocked: sinon.stub().returns(false),
+              markUserAsTemporarilyBlocked: sinon.stub(),
+              shouldMarkUserAsBlocked: sinon.stub().returns(true),
+              markUserAsBlocked: sinon.stub(),
             };
             userLoginRepository.findByUserId.withArgs(user.id).resolves(userLogin);
 
@@ -234,8 +234,8 @@ describe('Unit | Domain | Services | pix-authentication-service', function () {
             expect(userLoginRepository.create).to.not.have.been.called;
             expect(error).to.be.an.instanceof(PasswordNotMatching);
             expect(userLogin.incrementFailureCount).to.have.been.calledOnce;
-            expect(userLogin.blockUser).to.have.been.calledOnce;
-            expect(userLogin.blockUserTemporarily).to.not.have.been.called;
+            expect(userLogin.markUserAsBlocked).to.have.been.calledOnce;
+            expect(userLogin.markUserAsTemporarilyBlocked).to.not.have.been.called;
             expect(userLoginRepository.update).to.have.been.calledWith(userLogin);
           });
         });


### PR DESCRIPTION
## :christmas_tree: Problème

Certains utilisateurs sont considérés comme bloqués définitivement car ils ont plus de 50 tentatives à leur actifs mais sans pour autant avoir de date de blocage définitif. Ils ne peuvent donc pas être débloqués par le support.

## :gift: Proposition

Dans le prehandler, vérifier uniquement s’il y a une date de blocage (dans la méthode `isBlocked`) et pas que le nombre de tentatives est supérieur ou égal à 50 (`shouldBeBlocked`). La deuxième condition devrait être utilisée uniquement dans le use case pour savoir s’il faut bloquer définitivement l’utilisateur (en ajoutant une date `blockedAt`).

## :star2: Remarques

Aujourd'hui une confusion existe car derrière l'expression "bloquer l'utilisateur", on met deux actions différentes qui surviennent à différents moments :
- empêcher l'utilisateur de se connecter parce qu'il a une date de blocage définitive (`blockedAt`) : un évènement qui survient dans le prehandler
- ajouter une date de blocage définitive (`blockedAt`) à l'utilisateur parce qu'il a dépassé les 50 tentatives : un évènement qui survient dans le use-case
Pour distinguer ces deux actions, j'ai renommé la seconde `markUserAsBlocked` dans les méthodes sur modèle `userLogin` pour expliciter le fait qu'on ajoute une information de blocage à l'utilisateur, mais que ce n'est pas encore le blocage proprement dit.

## :santa: Pour tester

### Non regression

- Vérifier que l'utilisateur est bloqué temporairement après 10 tentatives
- Vérifier que l'utilisateur est bloqué définitivement après 50 tentatives

### Bug corrigé

- Choisir un utilisateur, vérifier qu'il n'a pas de date de blocage temporaire ou définitif, et lui ajouter 60 tentatives (`failureCount` de la table `user-logins`)
- Tenter de se connecter avec le bon mot de passe et constater qu'on est pas bloqué

