### PR TITLE
[FEATURE] Changer le texte du lien vers le site vitrine depuis App (PIX-6748).

### DIFF
--- a/mon-pix/app/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/components/password-reset-demand-form.hbs
@@ -1,7 +1,7 @@
 <main class="sign-form__container" role="main">
 
-  <a href={{this.showcaseUrl}} class="pix-logo__link">
-    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.showcase-homepage' extension=this.urlExtension}}" />
+  <a href={{this.showcase.url}} class="pix-logo__link">
+    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{this.showcase.linkText}}" />
   </a>
 
   <div class="sign-form__header">
@@ -48,7 +48,7 @@
     </div>
 
     <div class="password-reset-demand-form__home-link">
-      <a href={{this.showcaseUrl}} class="link">{{t "pages.password-reset-demand.actions.back-home"}}</a>
+      <a href={{this.showcase.url}} class="link">{{this.showcase.linkText}}</a>
     </div>
   {{else}}
     <form {{on "submit" this.savePasswordResetDemand}} class="sign-form__body">

--- a/mon-pix/app/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/components/password-reset-demand-form.hbs
@@ -1,7 +1,7 @@
 <main class="sign-form__container" role="main">
 
   <a href={{this.showcaseUrl}} class="pix-logo__link">
-    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
+    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.showcase-homepage' extension=this.urlExtension}}" />
   </a>
 
   <div class="sign-form__header">

--- a/mon-pix/app/components/password-reset-demand-form.js
+++ b/mon-pix/app/components/password-reset-demand-form.js
@@ -18,6 +18,10 @@ export default class PasswordResetDemandForm extends Component {
     return this.url.showcaseUrl;
   }
 
+  get urlExtension() {
+    return this.url.extensionUrl;
+  }
+
   get error() {
     return this.errors.shift();
   }

--- a/mon-pix/app/components/password-reset-demand-form.js
+++ b/mon-pix/app/components/password-reset-demand-form.js
@@ -14,12 +14,8 @@ export default class PasswordResetDemandForm extends Component {
 
   email = '';
 
-  get showcaseUrl() {
-    return this.url.showcaseUrl;
-  }
-
-  get urlExtension() {
-    return this.url.extensionUrl;
+  get showcase() {
+    return this.url.showcase;
   }
 
   get error() {

--- a/mon-pix/app/components/reset-password-form.hbs
+++ b/mon-pix/app/components/reset-password-form.hbs
@@ -1,7 +1,7 @@
 <div class="sign-form__container">
 
-  <a href={{this.showcaseUrl}} class="pix-logo__link">
-    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.showcase-homepage' extension=this.urlExtension}}" />
+  <a href={{this.showcase.url}} class="pix-logo__link">
+    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{this.showcase.linkText}}" />
   </a>
 
   <div class="sign-form__header">

--- a/mon-pix/app/components/reset-password-form.hbs
+++ b/mon-pix/app/components/reset-password-form.hbs
@@ -1,7 +1,7 @@
 <div class="sign-form__container">
 
   <a href={{this.showcaseUrl}} class="pix-logo__link">
-    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
+    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.showcase-homepage' extension=this.urlExtension}}" />
   </a>
 
   <div class="sign-form__header">

--- a/mon-pix/app/components/reset-password-form.js
+++ b/mon-pix/app/components/reset-password-form.js
@@ -21,6 +21,10 @@ export default class ResetPasswordForm extends Component {
     return this.url.showcaseUrl;
   }
 
+  get urlExtension() {
+    return this.url.extensionUrl;
+  }
+
   @action
   validatePassword() {
     const password = this.args.user.password;

--- a/mon-pix/app/components/reset-password-form.js
+++ b/mon-pix/app/components/reset-password-form.js
@@ -17,12 +17,8 @@ export default class ResetPasswordForm extends Component {
   @tracked hasSucceeded = false;
   @tracked validation = new ValidationForm();
 
-  get showcaseUrl() {
-    return this.url.showcaseUrl;
-  }
-
-  get urlExtension() {
-    return this.url.extensionUrl;
+  get showcase() {
+    return this.url.showcase;
   }
 
   @action

--- a/mon-pix/app/components/signin-form.hbs
+++ b/mon-pix/app/components/signin-form.hbs
@@ -1,7 +1,7 @@
 <main class="sign-form__container" role="main">
 
-  <a href={{this.showcaseUrl}} class="pix-logo__link">
-    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.showcase-homepage' extension=this.urlExtension}}" />
+  <a href={{this.showcase.url}} class="pix-logo__link">
+    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{this.showcase.linkText}}" />
   </a>
 
   <div class="sign-form__header">

--- a/mon-pix/app/components/signin-form.hbs
+++ b/mon-pix/app/components/signin-form.hbs
@@ -1,7 +1,7 @@
 <main class="sign-form__container" role="main">
 
   <a href={{this.showcaseUrl}} class="pix-logo__link">
-    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
+    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.showcase-homepage' extension=this.urlExtension}}" />
   </a>
 
   <div class="sign-form__header">

--- a/mon-pix/app/components/signin-form.js
+++ b/mon-pix/app/components/signin-form.js
@@ -20,12 +20,8 @@ export default class SigninForm extends Component {
   login = '';
   password = '';
 
-  get showcaseUrl() {
-    return this.url.showcaseUrl;
-  }
-
-  get urlExtension() {
-    return this.url.extensionUrl;
+  get showcase() {
+    return this.url.showcase;
   }
 
   get displayPoleEmploiButton() {

--- a/mon-pix/app/components/signin-form.js
+++ b/mon-pix/app/components/signin-form.js
@@ -24,6 +24,10 @@ export default class SigninForm extends Component {
     return this.url.showcaseUrl;
   }
 
+  get urlExtension() {
+    return this.url.extensionUrl;
+  }
+
   get displayPoleEmploiButton() {
     return this.url.isFrenchDomainExtension;
   }

--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -1,6 +1,6 @@
 <main class="sign-form__container" role="main">
   <a href={{this.showcaseUrl}} class="pix-logo__link">
-    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
+    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.showcase-homepage' extension=this.urlExtension}}" />
   </a>
 
   <div class="sign-form__header">

--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -1,6 +1,6 @@
 <main class="sign-form__container" role="main">
-  <a href={{this.showcaseUrl}} class="pix-logo__link">
-    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.showcase-homepage' extension=this.urlExtension}}" />
+  <a href={{this.showcase.url}} class="pix-logo__link">
+    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{this.showcase.linkText}}" />
   </a>
 
   <div class="sign-form__header">

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -62,6 +62,10 @@ export default class SignupForm extends Component {
     return this.url.showcaseUrl;
   }
 
+  get urlExtension() {
+    return this.url.extensionUrl;
+  }
+
   get cguUrl() {
     return this.url.cguUrl;
   }

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -58,12 +58,8 @@ export default class SignupForm extends Component {
   @tracked validation = new SignupFormValidation();
   _tokenHasBeenUsed = null;
 
-  get showcaseUrl() {
-    return this.url.showcaseUrl;
-  }
-
-  get urlExtension() {
-    return this.url.extensionUrl;
+  get showcase() {
+    return this.url.showcase;
   }
 
   get cguUrl() {

--- a/mon-pix/app/components/update-expired-password-form.hbs
+++ b/mon-pix/app/components/update-expired-password-form.hbs
@@ -1,7 +1,7 @@
 <div class="update-expired-password-form__container">
 
-  <a href={{this.showcaseUrl}} class="pix-logo__link">
-    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.showcase-homepage' extension=this.urlExtension}}" />
+  <a href={{this.showcase.url}} class="pix-logo__link">
+    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{this.showcase.linkText}}" />
   </a>
 
   <div class="update-expired-password-form__header">

--- a/mon-pix/app/components/update-expired-password-form.hbs
+++ b/mon-pix/app/components/update-expired-password-form.hbs
@@ -1,7 +1,7 @@
 <div class="update-expired-password-form__container">
 
   <a href={{this.showcaseUrl}} class="pix-logo__link">
-    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
+    <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.showcase-homepage' extension=this.urlExtension}}" />
   </a>
 
   <div class="update-expired-password-form__header">

--- a/mon-pix/app/components/update-expired-password-form.js
+++ b/mon-pix/app/components/update-expired-password-form.js
@@ -36,12 +36,8 @@ export default class UpdateExpiredPasswordForm extends Component {
 
   @tracked errorMessage = null;
 
-  get showcaseUrl() {
-    return this.url.showcaseUrl;
-  }
-
-  get urlExtension() {
-    return this.url.extensionUrl;
+  get showcase() {
+    return this.url.showcase;
   }
 
   get validationMessage() {

--- a/mon-pix/app/components/update-expired-password-form.js
+++ b/mon-pix/app/components/update-expired-password-form.js
@@ -40,6 +40,10 @@ export default class UpdateExpiredPasswordForm extends Component {
     return this.url.showcaseUrl;
   }
 
+  get urlExtension() {
+    return this.url.extensionUrl;
+  }
+
   get validationMessage() {
     if (this.validation.message) {
       return this.intl.t(this.validation.message);

--- a/mon-pix/app/controllers/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/controllers/authentication/login-or-register-oidc.js
@@ -19,12 +19,8 @@ export default class LoginOrRegisterOidcController extends Controller {
   @tracked username = '';
   @tracked authenticationMethods = [];
 
-  get showcaseUrl() {
-    return this.url.showcaseUrl;
-  }
-
-  get urlExtension() {
-    return this.url.extensionUrl;
+  get showcase() {
+    return this.url.showcase;
   }
 
   @action toggleOidcReconciliation() {

--- a/mon-pix/app/controllers/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/controllers/authentication/login-or-register-oidc.js
@@ -23,6 +23,10 @@ export default class LoginOrRegisterOidcController extends Controller {
     return this.url.showcaseUrl;
   }
 
+  get urlExtension() {
+    return this.url.extensionUrl;
+  }
+
   @action toggleOidcReconciliation() {
     this.showOidcReconciliation = !this.showOidcReconciliation;
   }

--- a/mon-pix/app/controllers/terms-of-service.js
+++ b/mon-pix/app/controllers/terms-of-service.js
@@ -12,12 +12,8 @@ export default class TermsOfServiceController extends Controller {
   @tracked isTermsOfServiceValidated = false;
   @tracked showErrorTermsOfServiceNotSelected = false;
 
-  get showcaseUrl() {
-    return this.url.showcaseUrl;
-  }
-
-  get urlExtension() {
-    return this.url.extensionUrl;
+  get showcase() {
+    return this.url.showcase;
   }
 
   @action

--- a/mon-pix/app/controllers/terms-of-service.js
+++ b/mon-pix/app/controllers/terms-of-service.js
@@ -16,6 +16,10 @@ export default class TermsOfServiceController extends Controller {
     return this.url.showcaseUrl;
   }
 
+  get urlExtension() {
+    return this.url.extensionUrl;
+  }
+
   @action
   async submit() {
     if (this.isTermsOfServiceValidated) {

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -14,8 +14,8 @@ export default class Url extends Service {
     return this.currentDomain.getExtension() === FRENCH_DOMAIN_EXTENSION;
   }
 
-  get showcaseUrl() {
-    return this._showcaseWebsiteUrl;
+  get showcase() {
+    return { url: this._showcaseWebsiteUrl, linkText: this._showcaseWebsiteLinkText };
   }
 
   get homeUrl() {
@@ -29,10 +29,6 @@ export default class Url extends Service {
       return 'https://pix.org/en-gb/terms-and-conditions';
     }
     return `https://pix.${this.currentDomain.getExtension()}/conditions-generales-d-utilisation`;
-  }
-
-  get extensionUrl() {
-    return this.currentDomain.getExtension();
   }
 
   get dataProtectionPolicyUrl() {
@@ -50,6 +46,10 @@ export default class Url extends Service {
       return `https://pix.${this.currentDomain.getExtension()}/en-gb`;
     }
     return `https://pix.${this.currentDomain.getExtension()}`;
+  }
+
+  get _showcaseWebsiteLinkText() {
+    return this.intl.t('navigation.showcase-homepage', { extension: this.currentDomain.getExtension() });
   }
 
   get accessibilityUrl() {

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -49,7 +49,7 @@ export default class Url extends Service {
   }
 
   get _showcaseWebsiteLinkText() {
-    return this.intl.t('navigation.showcase-homepage', { extension: this.currentDomain.getExtension() });
+    return this.intl.t('navigation.showcase-homepage', { tld: this.currentDomain.getExtension() });
   }
 
   get accessibilityUrl() {

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -31,6 +31,10 @@ export default class Url extends Service {
     return `https://pix.${this.currentDomain.getExtension()}/conditions-generales-d-utilisation`;
   }
 
+  get extensionUrl() {
+    return this.currentDomain.getExtension();
+  }
+
   get dataProtectionPolicyUrl() {
     const currentLanguage = this.intl.t('current-lang');
     if (currentLanguage === 'en') {

--- a/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
@@ -2,8 +2,8 @@
 
 <PixBackgroundHeader>
   <PixBlock @shadow="light" class="login-or-register-oidc-form">
-    <a href={{this.showcaseUrl}} class="login-or-register-oidc-form__logo">
-      <img src="/images/pix-logo.svg" alt="{{t 'navigation.showcase-homepage' extension=this.urlExtension}}" />
+    <a href={{this.showcase.url}} class="login-or-register-oidc-form__logo">
+      <img src="/images/pix-logo.svg" alt="{{this.showcase.linkText}}" />
     </a>
 
     {{#if this.showOidcReconciliation}}

--- a/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/templates/authentication/login-or-register-oidc.hbs
@@ -3,7 +3,7 @@
 <PixBackgroundHeader>
   <PixBlock @shadow="light" class="login-or-register-oidc-form">
     <a href={{this.showcaseUrl}} class="login-or-register-oidc-form__logo">
-      <img src="/images/pix-logo.svg" alt="{{t 'common.pix'}}" />
+      <img src="/images/pix-logo.svg" alt="{{t 'navigation.showcase-homepage' extension=this.urlExtension}}" />
     </a>
 
     {{#if this.showOidcReconciliation}}

--- a/mon-pix/app/templates/terms-of-service.hbs
+++ b/mon-pix/app/templates/terms-of-service.hbs
@@ -3,8 +3,8 @@
   <div class="terms-of-service-form">
 
     <div class="terms-of-service-form__logo">
-      <a href={{this.showcaseUrl}}>
-        <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.showcase-homepage' extension=this.urlExtension}}" />
+      <a href={{this.showcase.url}}>
+        <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{this.showcase.linkText}}" />
       </a>
     </div>
 

--- a/mon-pix/app/templates/terms-of-service.hbs
+++ b/mon-pix/app/templates/terms-of-service.hbs
@@ -4,7 +4,7 @@
 
     <div class="terms-of-service-form__logo">
       <a href={{this.showcaseUrl}}>
-        <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}" />
+        <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{t 'navigation.showcase-homepage' extension=this.urlExtension}}" />
       </a>
     </div>
 

--- a/mon-pix/tests/integration/components/signup-form_test.js
+++ b/mon-pix/tests/integration/components/signup-form_test.js
@@ -70,9 +70,7 @@ module('Integration | Component | SignupForm', function (hooks) {
       const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
 
       // then
-      assert.ok(
-        screen.getByRole('link', { name: this.intl.t('navigation.showcase-homepage', { extension: 'localhost' }) })
-      );
+      assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.showcase-homepage', { tld: 'localhost' }) }));
       assert.ok(screen.getByRole('heading', { name: this.intl.t('pages.sign-up.first-title') }));
       assert.ok(screen.getByRole('link', { name: this.intl.t('pages.sign-up.subtitle.link') }));
       assert.ok(screen.getByRole('textbox', { name: this.intl.t('pages.sign-up.fields.firstname.label') }));
@@ -354,9 +352,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         await triggerEvent('#lastName', 'focusout');
 
         // then
-        assert.ok(
-          find('#validationMessage-lastName').getAttribute('class').includes('form-textfield__message--error')
-        );
+        assert.ok(find('#validationMessage-lastName').getAttribute('class').includes('form-textfield__message--error'));
         assert.strictEqual(find('.form-textfield__message--error').textContent.trim(), emptyLastnameErrorMessage);
         assert.ok(find('#lastName').getAttribute('class').includes('form-textfield__input--error'));
         assert.dom('.form-textfield-icon__state--error').exists();

--- a/mon-pix/tests/integration/components/signup-form_test.js
+++ b/mon-pix/tests/integration/components/signup-form_test.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import { clickByLabel } from '../../helpers/click-by-label';
 import Service from '@ember/service';
 
-import { fillIn, find, findAll, settled, triggerEvent } from '@ember/test-helpers';
+import { fillIn, find, findAll, triggerEvent } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
 
 import ArrayProxy from '@ember/array/proxy';
@@ -70,7 +70,9 @@ module('Integration | Component | SignupForm', function (hooks) {
       const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
 
       // then
-      assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.homepage') }));
+      assert.ok(
+        screen.getByRole('link', { name: this.intl.t('navigation.showcase-homepage', { extension: 'localhost' }) })
+      );
       assert.ok(screen.getByRole('heading', { name: this.intl.t('pages.sign-up.first-title') }));
       assert.ok(screen.getByRole('link', { name: this.intl.t('pages.sign-up.subtitle.link') }));
       assert.ok(screen.getByRole('textbox', { name: this.intl.t('pages.sign-up.fields.firstname.label') }));
@@ -264,8 +266,6 @@ module('Integration | Component | SignupForm', function (hooks) {
       session = this.owner.lookup('service:session', sessionService);
     });
     module('behavior when signup successful (test external calls)', function () {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
       test('should return true if action <Signup> is handled', async function (assert) {
         // given
         let isFormSubmitted = false;
@@ -290,13 +290,9 @@ module('Integration | Component | SignupForm', function (hooks) {
         await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
-        return settled().then(() => {
-          assert.true(isFormSubmitted);
-        });
+        assert.true(isFormSubmitted);
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
       test('should authenticate the user and empty the password', async function (assert) {
         // given
         const authenticateUserStub = sinon.stub();
@@ -320,18 +316,14 @@ module('Integration | Component | SignupForm', function (hooks) {
         await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
-        return settled().then(() => {
-          sinon.assert.calledOnce(session.authenticateUser);
-          sinon.assert.calledWith(session.authenticateUser, 'toto@pix.fr', 'gipix2017');
-          assert.notOk(user.password);
-          assert.ok(true);
-        });
+        sinon.assert.calledOnce(session.authenticateUser);
+        sinon.assert.calledWith(session.authenticateUser, 'toto@pix.fr', 'gipix2017');
+        assert.notOk(user.password);
+        assert.ok(true);
       });
     });
 
     module('Errors management', function () {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
       test('should display an error message on first name field, when field is empty and focus-out', async function (assert) {
         // given
         const emptyFirstnameErrorMessage = this.intl.t('pages.sign-up.fields.firstname.error');
@@ -343,18 +335,14 @@ module('Integration | Component | SignupForm', function (hooks) {
         await triggerEvent('#firstName', 'focusout');
 
         // then
-        return settled().then(() => {
-          assert.ok(
-            find('#validationMessage-firstName').getAttribute('class').includes('form-textfield__message--error')
-          );
-          assert.strictEqual(find('.form-textfield__message--error').textContent.trim(), emptyFirstnameErrorMessage);
-          assert.ok(find('#firstName').getAttribute('class').includes('form-textfield__input--error'));
-          assert.dom('.form-textfield-icon__state--error').exists();
-        });
+        assert.ok(
+          find('#validationMessage-firstName').getAttribute('class').includes('form-textfield__message--error')
+        );
+        assert.strictEqual(find('.form-textfield__message--error').textContent.trim(), emptyFirstnameErrorMessage);
+        assert.ok(find('#firstName').getAttribute('class').includes('form-textfield__input--error'));
+        assert.dom('.form-textfield-icon__state--error').exists();
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
       test('should display an error message on last name field, when field is empty and focus-out', async function (assert) {
         // given
         const emptyLastnameErrorMessage = this.intl.t('pages.sign-up.fields.lastname.error');
@@ -366,18 +354,14 @@ module('Integration | Component | SignupForm', function (hooks) {
         await triggerEvent('#lastName', 'focusout');
 
         // then
-        return settled().then(() => {
-          assert.ok(
-            find('#validationMessage-lastName').getAttribute('class').includes('form-textfield__message--error')
-          );
-          assert.strictEqual(find('.form-textfield__message--error').textContent.trim(), emptyLastnameErrorMessage);
-          assert.ok(find('#lastName').getAttribute('class').includes('form-textfield__input--error'));
-          assert.dom('.form-textfield-icon__state--error').exists();
-        });
+        assert.ok(
+          find('#validationMessage-lastName').getAttribute('class').includes('form-textfield__message--error')
+        );
+        assert.strictEqual(find('.form-textfield__message--error').textContent.trim(), emptyLastnameErrorMessage);
+        assert.ok(find('#lastName').getAttribute('class').includes('form-textfield__input--error'));
+        assert.dom('.form-textfield-icon__state--error').exists();
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
       test('should display an error message on email field, when field is empty and focus-out', async function (assert) {
         // given
         const emptyEmailErrorMessage = this.intl.t('pages.sign-up.fields.email.error');
@@ -389,18 +373,14 @@ module('Integration | Component | SignupForm', function (hooks) {
         await triggerEvent('#email', 'focusout');
 
         // then
-        return settled().then(() => {
-          assert.ok(
-            find('.form-textfield__message-email').getAttribute('class').includes('form-textfield__message--error')
-          );
-          assert.strictEqual(find('.form-textfield__message--error').textContent.trim(), emptyEmailErrorMessage);
-          assert.ok(find('#email').getAttribute('class').includes('form-textfield__input--error'));
-          assert.dom('.form-textfield-icon__state--error').exists();
-        });
+        assert.ok(
+          find('.form-textfield__message-email').getAttribute('class').includes('form-textfield__message--error')
+        );
+        assert.strictEqual(find('.form-textfield__message--error').textContent.trim(), emptyEmailErrorMessage);
+        assert.ok(find('#email').getAttribute('class').includes('form-textfield__input--error'));
+        assert.dom('.form-textfield-icon__state--error').exists();
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
       test('should display an error message on password field, when field is empty and focus-out', async function (assert) {
         // given
         const incorrectPasswordErrorMessage = this.intl.t('pages.sign-up.fields.password.error');
@@ -412,18 +392,14 @@ module('Integration | Component | SignupForm', function (hooks) {
         await triggerEvent('#password', 'focusout');
 
         // then
-        return settled().then(() => {
-          assert.ok(
-            find('.form-textfield__message-password').getAttribute('class').includes('form-textfield__message--error')
-          );
-          assert.strictEqual(find('.form-textfield__message--error').textContent.trim(), incorrectPasswordErrorMessage);
-          assert.ok(find('#password').getAttribute('class').includes('form-textfield__input--error'));
-          assert.dom('.form-textfield-icon__state--error').exists();
-        });
+        assert.ok(
+          find('.form-textfield__message-password').getAttribute('class').includes('form-textfield__message--error')
+        );
+        assert.strictEqual(find('.form-textfield__message--error').textContent.trim(), incorrectPasswordErrorMessage);
+        assert.ok(find('#password').getAttribute('class').includes('form-textfield__input--error'));
+        assert.dom('.form-textfield-icon__state--error').exists();
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
       test("should display an error message on cgu field, when cgu isn't accepted and form is submitted", async function (assert) {
         // given
         const uncheckedCheckboxCguErrorMessage = this.intl.t('common.cgu.error');
@@ -455,10 +431,8 @@ module('Integration | Component | SignupForm', function (hooks) {
         await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
-        return settled().then(() => {
-          assert.dom('.sign-form__validation-error').exists();
-          assert.strictEqual(find('.sign-form__validation-error').textContent.trim(), uncheckedCheckboxCguErrorMessage);
-        });
+        assert.dom('.sign-form__validation-error').exists();
+        assert.strictEqual(find('.sign-form__validation-error').textContent.trim(), uncheckedCheckboxCguErrorMessage);
       });
 
       test('should display an error message on email field, when email above a maximum length of 255 and focus-out', async function (assert) {
@@ -516,15 +490,11 @@ module('Integration | Component | SignupForm', function (hooks) {
         await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
-        return settled().then(() => {
-          assert.dom('.signup-form__notification-message').doesNotExist();
-        });
+        assert.dom('.signup-form__notification-message').doesNotExist();
       });
     });
 
     module('Successfull cases', function () {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
       test('should display first name field as validated without error message, when field is filled and focus-out', async function (assert) {
         // given
         this.set('user', userEmpty);
@@ -535,18 +505,14 @@ module('Integration | Component | SignupForm', function (hooks) {
         await triggerEvent('#firstName', 'focusout');
 
         // then
-        return settled().then(() => {
-          assert.ok(
-            find('#validationMessage-firstName').getAttribute('class').includes('form-textfield__message--success')
-          );
-          assert.dom('.form-textfield__message--error').doesNotExist();
-          assert.ok(find('#firstName').getAttribute('class').includes('form-textfield__input--success'));
-          assert.dom('.form-textfield-icon__state--success').exists();
-        });
+        assert.ok(
+          find('#validationMessage-firstName').getAttribute('class').includes('form-textfield__message--success')
+        );
+        assert.dom('.form-textfield__message--error').doesNotExist();
+        assert.ok(find('#firstName').getAttribute('class').includes('form-textfield__input--success'));
+        assert.dom('.form-textfield-icon__state--success').exists();
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
       test('should display last name field as validated without error message, when field is filled and focus-out', async function (assert) {
         // given
         this.set('user', userEmpty);
@@ -557,18 +523,14 @@ module('Integration | Component | SignupForm', function (hooks) {
         await triggerEvent('#lastName', 'focusout');
 
         // then
-        return settled().then(() => {
-          assert.ok(
-            find('#validationMessage-lastName').getAttribute('class').includes('form-textfield__message--success')
-          );
-          assert.dom('.form-textfield__message--error').doesNotExist();
-          assert.ok(find('#lastName').getAttribute('class').includes('form-textfield__input--success'));
-          assert.dom('.form-textfield-icon__state--success').exists();
-        });
+        assert.ok(
+          find('#validationMessage-lastName').getAttribute('class').includes('form-textfield__message--success')
+        );
+        assert.dom('.form-textfield__message--error').doesNotExist();
+        assert.ok(find('#lastName').getAttribute('class').includes('form-textfield__input--success'));
+        assert.dom('.form-textfield-icon__state--success').exists();
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
       test('should display email field as validated without error message, when field is filled and focus-out', async function (assert) {
         // given
         this.set('user', userEmpty);
@@ -579,18 +541,14 @@ module('Integration | Component | SignupForm', function (hooks) {
         await triggerEvent('#email', 'focusout');
 
         // then
-        return settled().then(() => {
-          assert.ok(
-            find('.form-textfield__message-email').getAttribute('class').includes('form-textfield__message--success')
-          );
-          assert.dom('.form-textfield__message--error').doesNotExist();
-          assert.ok(find('#email').getAttribute('class').includes('form-textfield__input--success'));
-          assert.dom('.form-textfield-icon__state--success').exists();
-        });
+        assert.ok(
+          find('.form-textfield__message-email').getAttribute('class').includes('form-textfield__message--success')
+        );
+        assert.dom('.form-textfield__message--error').doesNotExist();
+        assert.ok(find('#email').getAttribute('class').includes('form-textfield__input--success'));
+        assert.dom('.form-textfield-icon__state--success').exists();
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
       test('should display password field as validated without error message, when field is filled and focus-out', async function (assert) {
         // given
         this.set('user', userEmpty);
@@ -601,14 +559,12 @@ module('Integration | Component | SignupForm', function (hooks) {
         await triggerEvent('#password', 'focusout');
 
         // then
-        return settled().then(() => {
-          assert.ok(
-            find('.form-textfield__message-password').getAttribute('class').includes('form-textfield__message--success')
-          );
-          assert.dom('.form-textfield__message--error').doesNotExist();
-          assert.ok(find('#password').getAttribute('class').includes('form-textfield__input--success'));
-          assert.dom('.form-textfield-icon__state--success').exists();
-        });
+        assert.ok(
+          find('.form-textfield__message-password').getAttribute('class').includes('form-textfield__message--success')
+        );
+        assert.dom('.form-textfield__message--error').doesNotExist();
+        assert.ok(find('#password').getAttribute('class').includes('form-textfield__input--success'));
+        assert.dom('.form-textfield-icon__state--success').exists();
       });
 
       test('should not display an error message on cgu field, when cgu is accepted and form is submitted', async function (assert) {
@@ -628,13 +584,9 @@ module('Integration | Component | SignupForm', function (hooks) {
         await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
-        return settled().then(() => {
-          assert.dom('.sign-form__validation-error').doesNotExist();
-        });
+        assert.dom('.sign-form__validation-error').doesNotExist();
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
       test('should reset validation property, when all things are ok and form is submitted', async function (assert) {
         // given
         const validUser = EmberObject.create({
@@ -656,13 +608,11 @@ module('Integration | Component | SignupForm', function (hooks) {
         await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
-        return settled().then(() => {
-          assert.ok(
-            findAll('.form-textfield__input-field-container')[0]
-              .getAttribute('class')
-              .includes(INPUT_TEXT_FIELD_CLASS_DEFAULT)
-          );
-        });
+        assert.ok(
+          findAll('.form-textfield__input-field-container')[0]
+            .getAttribute('class')
+            .includes(INPUT_TEXT_FIELD_CLASS_DEFAULT)
+        );
       });
     });
   });

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -43,9 +43,7 @@ module('Unit | Service | locale', function (hooks) {
 
       // then
       const expectedDefinedHomeUrl = `${service.definedHomeUrl}?lang=${this.intl.t('current-lang')}`;
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(homeUrl, expectedDefinedHomeUrl);
+      assert.strictEqual(homeUrl, expectedDefinedHomeUrl);
     });
   });
 
@@ -97,10 +95,8 @@ module('Unit | Service | locale', function (hooks) {
         const showcase = service.showcase;
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(showcase.url, testCase.expectedShowcaseUrl);
-        assert.equal(showcase.linkText, testCase.expectedShowcaseLinkText);
+        assert.strictEqual(showcase.url, testCase.expectedShowcaseUrl);
+        assert.strictEqual(showcase.linkText, testCase.expectedShowcaseLinkText);
       });
     });
   });
@@ -116,9 +112,7 @@ module('Unit | Service | locale', function (hooks) {
       const cguUrl = service.cguUrl;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(cguUrl, expectedCguUrl);
+      assert.strictEqual(cguUrl, expectedCguUrl);
     });
 
     test('should get "pix.org" english url when current language is en', function (assert) {
@@ -132,9 +126,7 @@ module('Unit | Service | locale', function (hooks) {
       const cguUrl = service.cguUrl;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(cguUrl, expectedCguUrl);
+      assert.strictEqual(cguUrl, expectedCguUrl);
     });
 
     test('should get "pix.org" french url when current language is fr', function (assert) {
@@ -148,9 +140,7 @@ module('Unit | Service | locale', function (hooks) {
       const cguUrl = service.cguUrl;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(cguUrl, expectedCguUrl);
+      assert.strictEqual(cguUrl, expectedCguUrl);
     });
   });
 
@@ -165,9 +155,7 @@ module('Unit | Service | locale', function (hooks) {
       const cguUrl = service.dataProtectionPolicyUrl;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(cguUrl, expectedCguUrl);
+      assert.strictEqual(cguUrl, expectedCguUrl);
     });
 
     test('should get "pix.org" english url when current language is en', function (assert) {
@@ -181,9 +169,7 @@ module('Unit | Service | locale', function (hooks) {
       const cguUrl = service.dataProtectionPolicyUrl;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(cguUrl, expectedCguUrl);
+      assert.strictEqual(cguUrl, expectedCguUrl);
     });
 
     test('should get "pix.org" french url when current language is fr', function (assert) {
@@ -197,9 +183,7 @@ module('Unit | Service | locale', function (hooks) {
       const cguUrl = service.dataProtectionPolicyUrl;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(cguUrl, expectedCguUrl);
+      assert.strictEqual(cguUrl, expectedCguUrl);
     });
   });
 });

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 
 import setupIntl from 'mon-pix/tests/helpers/setup-intl';
 
-module('Unit | Service | locale', function (hooks) {
+module.only('Unit | Service | locale', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks);
 
@@ -179,6 +179,21 @@ module('Unit | Service | locale', function (hooks) {
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(cguUrl, expectedCguUrl);
+    });
+  });
+
+  module('#extensionUrl', function () {
+    test('should get extension url', function (assert) {
+      // given
+      const expectedExtension = 'fr';
+      const service = this.owner.lookup('service:url');
+      service.currentDomain = { getExtension: sinon.stub().returns(expectedExtension) };
+
+      // when
+      const homeUrl = service.extensionUrl;
+
+      // then
+      assert.deepEqual(homeUrl, expectedExtension);
     });
   });
 });

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 
 import setupIntl from 'mon-pix/tests/helpers/setup-intl';
 
-module.only('Unit | Service | locale', function (hooks) {
+module('Unit | Service | locale', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks);
 
@@ -61,10 +61,30 @@ module.only('Unit | Service | locale', function (hooks) {
     });
 
     [
-      { language: 'fr', currentDomainExtension: 'fr', expectedShowcaseUrl: 'https://pix.fr' },
-      { language: 'fr', currentDomainExtension: 'org', expectedShowcaseUrl: 'https://pix.org' },
-      { language: 'en', currentDomainExtension: 'fr', expectedShowcaseUrl: 'https://pix.fr/en-gb' },
-      { language: 'en', currentDomainExtension: 'org', expectedShowcaseUrl: 'https://pix.org/en-gb' },
+      {
+        language: 'fr',
+        currentDomainExtension: 'fr',
+        expectedShowcaseUrl: 'https://pix.fr',
+        expectedShowcaseLinkText: "Page d'accueil de Pix.fr",
+      },
+      {
+        language: 'fr',
+        currentDomainExtension: 'org',
+        expectedShowcaseUrl: 'https://pix.org',
+        expectedShowcaseLinkText: "Page d'accueil de Pix.org",
+      },
+      {
+        language: 'en',
+        currentDomainExtension: 'fr',
+        expectedShowcaseUrl: 'https://pix.fr/en-gb',
+        expectedShowcaseLinkText: "Pix.fr's Homepage",
+      },
+      {
+        language: 'en',
+        currentDomainExtension: 'org',
+        expectedShowcaseUrl: 'https://pix.org/en-gb',
+        expectedShowcaseLinkText: "Pix.org's Homepage",
+      },
     ].forEach(function (testCase) {
       test(`should get "${testCase.expectedShowcaseUrl}" when current domain="${testCase.currentDomainExtension}" and lang="${testCase.language}"`, function (assert) {
         // given
@@ -74,12 +94,13 @@ module.only('Unit | Service | locale', function (hooks) {
         this.intl.setLocale([testCase.language]);
 
         // when
-        const showcaseUrl = service.showcaseUrl;
+        const showcase = service.showcase;
 
         // then
         // TODO: Fix this the next time the file is edited.
         // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(showcaseUrl, testCase.expectedShowcaseUrl);
+        assert.equal(showcase.url, testCase.expectedShowcaseUrl);
+        assert.equal(showcase.linkText, testCase.expectedShowcaseLinkText);
       });
     });
   });
@@ -179,21 +200,6 @@ module.only('Unit | Service | locale', function (hooks) {
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line qunit/no-assert-equal
       assert.equal(cguUrl, expectedCguUrl);
-    });
-  });
-
-  module('#extensionUrl', function () {
-    test('should get extension url', function (assert) {
-      // given
-      const expectedExtension = 'fr';
-      const service = this.owner.lookup('service:url');
-      service.currentDomain = { getExtension: sinon.stub().returns(expectedExtension) };
-
-      // when
-      const homeUrl = service.extensionUrl;
-
-      // then
-      assert.deepEqual(homeUrl, expectedExtension);
     });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -134,7 +134,7 @@
       "sign-up": "Sign up"
     },
     "pix": "Pix",
-    "showcase-homepage": "Pix.{ extension }'s Homepage",
+    "showcase-homepage": "Pix.{ tld }'s Homepage",
     "user": {
       "account": "My account",
       "certifications": "My certifications",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -134,6 +134,7 @@
       "sign-up": "Sign up"
     },
     "pix": "Pix",
+    "showcase-homepage": "Pix.{ extension }'s Homepage",
     "user": {
       "account": "My account",
       "certifications": "My certifications",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -134,6 +134,7 @@
       "sign-up": "S'inscrire"
     },
     "pix": "Pix",
+    "showcase-homepage": "Page d'accueil de Pix.{ extension }",
     "user": {
       "account": "Mon compte",
       "certifications": "Mes certifications",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -134,7 +134,7 @@
       "sign-up": "S'inscrire"
     },
     "pix": "Pix",
-    "showcase-homepage": "Page d'accueil de Pix.{ extension }",
+    "showcase-homepage": "Page d'accueil de Pix.{ tld }",
     "user": {
       "account": "Mon compte",
       "certifications": "Mes certifications",


### PR DESCRIPTION
## :christmas_tree: Problème
Suite à l'audit accessibilité, un problème sur le site App est remonté : 
> Etant donné que Pix possède plusieurs sites, il faudrait préciser dans l'intitulé du lien "page d'accueil du site [Pix.fr](http://pix.fr/)."

## :gift: Proposition
Dans cette PR : 
- Le premier commit est un ajout simple de l'extension dans la traduction pour pouvoir dire si on retourne sur pix.fr ou pix.org
- Le second commit est une proposition de refacto pour que la méthode `showcase` de `url` renvoie aussi le texte à afficher, les deux étant utilisé ensemble.

Cette PR contient aussi du nettoyage sur les erreurs lint `no-assert-equal` et `require-expect` sur les tests rencontrés.

## :star2: Remarques
Le cas de : 
- site en .fr
- langue EN
est possible dans le service `url` mais le site `pix.fr/en-gb` n'existe pas.

Cette PR ne concernant pas cette problème, elle n'a pas été traité ici.

## :santa: Pour tester
Aller sur le site, sur les pages de connexion et d'inscription
Vérifier le alt des images de lien de retour à l'accueil Pix.
