### PR TITLE
[TECH] Réparer l'usage du CLI des tests de l'algo

### DIFF
--- a/high-level-tests/test-algo/algo.js
+++ b/high-level-tests/test-algo/algo.js
@@ -28,7 +28,6 @@ function _readUsersKEFile(path) {
 }
 
 function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targetSkills, userId, userResult, userKE }) {
-
   let result;
   const isFirstAnswer = !allAnswers.length;
   switch (userResult) {
@@ -42,10 +41,10 @@ function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targe
       result = POSSIBLE_ANSWER_STATUSES[Math.round(Math.random())];
       break;
     case 'firstOKthenKO':
-      isFirstAnswer ? result = AnswerStatus.OK : result = AnswerStatus.KO;
+      isFirstAnswer ? (result = AnswerStatus.OK) : (result = AnswerStatus.KO);
       break;
     case 'firstKOthenOK':
-      isFirstAnswer ? result = AnswerStatus.KO : result = AnswerStatus.OK;
+      isFirstAnswer ? (result = AnswerStatus.KO) : (result = AnswerStatus.OK);
       break;
     case 'KE': {
       const ke = find(userKE, (ke) => challenge.skill.id === ke.skillId);
@@ -68,18 +67,30 @@ function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targe
   const newKnowledgeElements = KnowledgeElement.createKnowledgeElementsForAnswer({
     answer: newAnswer,
     challenge,
-    previouslyFailedSkills: _getSkillsFilteredByStatus(allKnowledgeElements, targetSkills, KnowledgeElement.StatusType.INVALIDATED),
-    previouslyValidatedSkills: _getSkillsFilteredByStatus(allKnowledgeElements, targetSkills, KnowledgeElement.StatusType.VALIDATED),
+    previouslyFailedSkills: _getSkillsFilteredByStatus(
+      allKnowledgeElements,
+      targetSkills,
+      KnowledgeElement.StatusType.INVALIDATED,
+    ),
+    previouslyValidatedSkills: _getSkillsFilteredByStatus(
+      allKnowledgeElements,
+      targetSkills,
+      KnowledgeElement.StatusType.VALIDATED,
+    ),
     targetSkills,
     userId,
   });
 
-  return { answerStatus: result, updatedAnswers: [...allAnswers, newAnswer], updatedKnowledgeElements: [...allKnowledgeElements, ...newKnowledgeElements] };
+  return {
+    answerStatus: result,
+    updatedAnswers: [...allAnswers, newAnswer],
+    updatedKnowledgeElements: [...allKnowledgeElements, ...newKnowledgeElements],
+  };
 }
 
 async function _getReferentiel({
   assessment,
-  targetProfileId,
+  campaignId,
   answerRepository,
   challengeRepository,
   knowledgeElementRepository,
@@ -87,8 +98,8 @@ async function _getReferentiel({
   improvementService,
   campaignRepository,
 }) {
-  if (targetProfileId) {
-    const skills = await campaignRepository.findSkillsByCampaignParticipationId(assessment.campaignParticipationId);
+  if (campaignId) {
+    const skills = await campaignRepository.findSkills({ campaignId });
     const campaignRepositoryStub = {
       findSkillsByCampaignParticipationId: () => {
         return skills;
@@ -125,14 +136,7 @@ async function _getReferentiel({
   }
 }
 
-async function _getChallenge({
-  challenges,
-  targetSkills,
-  assessment,
-  locale,
-  knowledgeElements,
-  allAnswers,
-}) {
+async function _getChallenge({ challenges, targetSkills, assessment, locale, knowledgeElements, allAnswers }) {
   const result = smartRandom.getPossibleSkillsForNextChallenge({
     knowledgeElements,
     challenges,
@@ -150,7 +154,12 @@ async function _getChallenge({
 
   const challengeLevel = _getChallengeLevel({ assessment, result });
 
-  return { challenge, hasAssessmentEnded: result.hasAssessmentEnded, estimatedLevel: result.levelEstimated, challengeLevel };
+  return {
+    challenge,
+    hasAssessmentEnded: result.hasAssessmentEnded,
+    estimatedLevel: result.levelEstimated,
+    challengeLevel,
+  };
 }
 
 function _getChallengeLevel({ assessment, result }) {
@@ -161,12 +170,20 @@ function _getChallengeLevel({ assessment, result }) {
   return chosenSkill ? chosenSkill.difficulty : null;
 }
 
-async function proceedAlgo(challenges, targetSkills, assessment, locale, knowledgeElements, allAnswers, userResult, userKE) {
+async function proceedAlgo(
+  challenges,
+  targetSkills,
+  assessment,
+  locale,
+  knowledgeElements,
+  allAnswers,
+  userResult,
+  userKE,
+) {
   let isAssessmentOver = false;
   const algoResult = new AlgoResult();
 
   while (!isAssessmentOver) {
-
     const { challenge, hasAssessmentEnded, estimatedLevel, challengeLevel } = await _getChallenge({
       challenges,
       targetSkills,
@@ -201,8 +218,7 @@ async function proceedAlgo(challenges, targetSkills, assessment, locale, knowled
 }
 
 async function launchTest(argv) {
-
-  const { competenceId, targetProfileId, locale, userResult, usersKEFile, enabledCsvOutput } = argv;
+  const { competenceId, campaignId, locale, userResult, usersKEFile, enabledCsvOutput } = argv;
 
   const allAnswers = [];
   const knowledgeElements = [];
@@ -224,7 +240,7 @@ async function launchTest(argv) {
 
   const { challenges, targetSkills } = await _getReferentiel({
     assessment,
-    targetProfileId,
+    campaignId,
     answerRepository,
     challengeRepository,
     knowledgeElementRepository,
@@ -241,7 +257,7 @@ async function launchTest(argv) {
 
   if (enabledCsvOutput) {
     const writeResults = algoResults.map((algoResult) => {
-      return algoResult.writeCsvFile(targetProfileId ?? competenceId);
+      return algoResult.writeCsvFile(campaignId ?? competenceId);
     });
     await Promise.all(writeResults);
   }

--- a/high-level-tests/test-algo/algo.js
+++ b/high-level-tests/test-algo/algo.js
@@ -41,10 +41,10 @@ function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targe
       result = POSSIBLE_ANSWER_STATUSES[Math.round(Math.random())];
       break;
     case 'firstOKthenKO':
-      isFirstAnswer ? (result = AnswerStatus.OK) : (result = AnswerStatus.KO);
+      result = isFirstAnswer ? AnswerStatus.OK : AnswerStatus.KO;
       break;
     case 'firstKOthenOK':
-      isFirstAnswer ? (result = AnswerStatus.KO) : (result = AnswerStatus.OK);
+      result = isFirstAnswer ? AnswerStatus.KO : AnswerStatus.OK;
       break;
     case 'KE': {
       const ke = find(userKE, (ke) => challenge.skill.id === ke.skillId);

--- a/high-level-tests/test-algo/index.js
+++ b/high-level-tests/test-algo/index.js
@@ -11,9 +11,9 @@ async function index() {
       type: 'string',
       description: 'L\'id de la compétence',
     })
-    .option('targetProfileId', {
+    .option('campaignId', {
       type: 'number',
-      description: 'L\'id du target profile',
+      description: 'L\'id d\'une campagne',
     })
     .option('locale', {
       type: 'string',
@@ -38,8 +38,7 @@ async function index() {
     })
     .check((argv) => {
       return Boolean(argv.competenceId || argv.targetProfileId);
-    })
-    .argv;
+    }).argv;
 
   await launchTest(argv);
 

--- a/high-level-tests/test-algo/tests/algo_test.js
+++ b/high-level-tests/test-algo/tests/algo_test.js
@@ -14,9 +14,7 @@ describe('#answerTheChallenge', () => {
     previousKE = [{ id: 1 }];
     challenge = { id: 'recId' };
     newKe = { id: 'KE-id' };
-    sinon
-      .stub(KnowledgeElement, 'createKnowledgeElementsForAnswer')
-      .returns([newKe]);
+    sinon.stub(KnowledgeElement, 'createKnowledgeElementsForAnswer').returns([newKe]);
     sinon.stub(console, 'log');
   });
 
@@ -203,9 +201,7 @@ describe('#answerTheChallenge', () => {
       },
       { userKE: null, answerStatus: 'ko' },
     ].forEach((testCase) => {
-      it(`should return the list of answers with ${
-        testCase.answerStatus
-      } answers for ${
+      it(`should return the list of answers with ${testCase.answerStatus} answers for ${
         testCase.userKE ? testCase.userKE.status : 'empty'
       } KE`, () => {
         // given
@@ -235,9 +231,9 @@ describe('#answerTheChallenge', () => {
 });
 
 describe('#_getReferentiel', () => {
-  it('should return skills and challenges from a given targetProfile', async () => {
+  it('should return skills and challenges from a given campaign', async () => {
     // given
-    const targetProfileId = 1;
+    const campaignId = 1;
     const answerRepository = {};
     const assessment = {};
     const challengeRepository = {};
@@ -245,19 +241,11 @@ describe('#_getReferentiel', () => {
     const skillRepository = {};
     const improvementService = {};
     const campaignRepository = {
-      findSkillsByCampaignParticipationId: () => {},
+      findSkills: () => {},
     };
 
-    const expectedSkills = [
-      { id: 'recSkill1' },
-      { id: 'recSkill2' },
-      { id: 'recSkill3' },
-    ];
-    const expectedChallenges = [
-      { id: 'recChallenge1' },
-      { id: 'recChallenge2' },
-      { id: 'recChallenge3' },
-    ];
+    const expectedSkills = [{ id: 'recSkill1' }, { id: 'recSkill2' }, { id: 'recSkill3' }];
+    const expectedChallenges = [{ id: 'recChallenge1' }, { id: 'recChallenge2' }, { id: 'recChallenge3' }];
 
     sinon.stub(DataFetcher, 'fetchForCampaigns').returns({
       targetSkills: expectedSkills,
@@ -267,7 +255,7 @@ describe('#_getReferentiel', () => {
     // when
     const result = await _getReferentiel({
       assessment,
-      targetProfileId,
+      campaignId,
       answerRepository,
       challengeRepository,
       knowledgeElementRepository,
@@ -284,7 +272,7 @@ describe('#_getReferentiel', () => {
   it('should return skills and challenges from a given assessment', async () => {
     // given
     const assessment = { competenceId: 1 };
-    const targetProfileId = null;
+    const campaignId = null;
     const answerRepository = {};
     const challengeRepository = {};
     const knowledgeElementRepository = {};
@@ -292,16 +280,8 @@ describe('#_getReferentiel', () => {
     const improvementService = {};
     const targetProfileRepository = {};
 
-    const expectedSkills = [
-      { id: 'recSkill1' },
-      { id: 'recSkill2' },
-      { id: 'recSkill3' },
-    ];
-    const expectedChallenges = [
-      { id: 'recChallenge1' },
-      { id: 'recChallenge2' },
-      { id: 'recChallenge3' },
-    ];
+    const expectedSkills = [{ id: 'recSkill1' }, { id: 'recSkill2' }, { id: 'recSkill3' }];
+    const expectedChallenges = [{ id: 'recChallenge1' }, { id: 'recChallenge2' }, { id: 'recChallenge3' }];
 
     sinon.stub(DataFetcher, 'fetchForCompetenceEvaluations').returns({
       targetSkills: expectedSkills,
@@ -311,7 +291,7 @@ describe('#_getReferentiel', () => {
     // when
     const result = await _getReferentiel({
       assessment,
-      targetProfileId,
+      campaignId,
       answerRepository,
       challengeRepository,
       knowledgeElementRepository,

--- a/high-level-tests/test-algo/tests/tests.sh
+++ b/high-level-tests/test-algo/tests/tests.sh
@@ -17,6 +17,7 @@ testExit() {
   if [ "$actualExitCode" != "$expectedExitCode" ]; then
     echo "${RED}❌ TEST FAILED: expected $command to exit with $expectedExitCode but got $actualExitCode ${RESET}"
     echo "$output"
+    exit 2
   else
     echo "${GREEN}✅ SUCCESS ${RESET}"
   fi


### PR DESCRIPTION
## :christmas_tree: Problème
Le CLI de tests de l'algo, permet d'être lancé avec un `targetProfileId` afin d'être lancer sur les acquis associés.
Désormais, le profil cible n'a plus d'acquis précis c'est une campagne qui a cette information.  

## :gift: Proposition
Remplacer l'option `targetProfileId` par `campaignId`.

## :star2: Remarques
Les tests cassaient mais l'erreur ne faisait pas casser la CI, c'est désormais le cas. 

## :santa: Pour tester
- Lancer le cli avec l'id d'une campagne 
- Revert le dernier commit et constater en lancant `npm test` que la commande sort en erreur