### PR TITLE
[TECH] Mise à jour du projectId cypress

### DIFF
--- a/high-level-tests/e2e/cypress.json
+++ b/high-level-tests/e2e/cypress.json
@@ -8,7 +8,7 @@
   "blockHosts": ["*stats.pix.fr*", "*analytics.pix.fr*"],
   "screenshotsFolder": "cypress/snapshots/actual",
   "trashAssetsBeforeRuns": true,
-  "projectId": "g2rfqp",
+  "projectId": "3cjm89",
   "numTestsKeptInMemory": 0,
   "viewportWidth": 1500,
   "nodeVersion": "system",


### PR DESCRIPTION
## :christmas_tree: Problème
Avec le renouvellement des credentials circleci, nous avons créé un nouveau compte cypress. Le `projectId` a donc changé.

## :gift: Proposition
Mise à jour du `projectId` dans cypress.

## :santa: Pour tester
Regarder le résultat des tests dans le cloud cypress.
