### PR TITLE
[FEATURE] Créer une route pour l'appel au simulateur (PIX-6762)

### DIFF
--- a/api/lib/application/scoring-simulator/index.js
+++ b/api/lib/application/scoring-simulator/index.js
@@ -1,0 +1,27 @@
+const securityPreHandlers = require('../security-pre-handlers');
+const scoringSimulatorController = require('./scoring-simulator-controller');
+
+exports.register = async (server) => {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/scoring-simulator/old',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: scoringSimulatorController.calculateOldScores,
+        tags: ['api'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés',
+          "Elle renvoie le score Pix calculé avec l'ancien algorithme pour une liste de questions et réponses données",
+        ],
+      },
+    },
+  ]);
+};
+
+exports.name = 'scoring-simulator-api';

--- a/api/lib/application/scoring-simulator/scoring-simulator-controller.js
+++ b/api/lib/application/scoring-simulator/scoring-simulator-controller.js
@@ -1,0 +1,5 @@
+module.exports = {
+  async calculateOldScores(request, h) {
+    return h.response({}).code(200);
+  },
+};

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -38,6 +38,7 @@ module.exports = [
   require('./application/prescribers'),
   require('./application/progressions'),
   require('./application/saml'),
+  require('./application/scoring-simulator'),
   require('./application/organization-learners'),
   require('./application/scorecards'),
   require('./application/sco-organization-learners'),

--- a/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
@@ -1,0 +1,73 @@
+const { expect } = require('chai');
+const createServer = require('../../../../server');
+const { databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const {
+  ROLES: { SUPER_ADMIN },
+} = require('../../../../lib/domain/constants').PIX_ADMIN;
+
+describe('Acceptance | Controller | scoring-simulator-controller', function () {
+  let server;
+  let adminAuthorization;
+
+  beforeEach(async function () {
+    server = await createServer();
+
+    const { id: adminId } = databaseBuilder.factory.buildUser.withRole({
+      role: SUPER_ADMIN,
+    });
+    adminAuthorization = generateValidRequestAuthorizationHeader(adminId);
+    await databaseBuilder.commit();
+  });
+
+  describe('#calculateOldScores', function () {
+    let options;
+
+    beforeEach(async function () {
+      options = {
+        method: 'POST',
+        url: `/api/scoring-simulator/old`,
+        payload: {},
+        headers: {},
+      };
+    });
+
+    it('should return status code 200', async function () {
+      // given
+      options.headers.authorization = adminAuthorization;
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response).to.have.property('statusCode', 200);
+    });
+
+    describe('when there is no connected user', function () {
+      it('should return status code 401', async function () {
+        // given
+        options.headers.authorization = undefined;
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response).to.have.property('statusCode', 401);
+      });
+    });
+
+    describe('when connected user does not have role SUPER_ADMIN', function () {
+      it('should return status code 403', async function () {
+        // given
+        const { id: userId } = databaseBuilder.factory.buildUser();
+        options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
+        await databaseBuilder.commit();
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response).to.have.property('statusCode', 403);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
Il n'existe pas de route pour simuler le calcul d'un score Pix avec l'ancien algorithme.

## :gift: Proposition
Créer une route `/api/scoring-simulator/old` permettant de le faire.

## :star2: Remarques
N/A

## :santa: Pour tester
Faire un curl sur la route :
```
TOKEN=$(curl 'https://api-pr5472.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin%40example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr5472.review.pix.fr/api/scoring-simulator/old -H "Authorization: Bearer $TOKEN" -X POST
```