### PR TITLE
[TECH] Montée en version Pix UI vers v24.0.1 (PIX-6493)

### DIFF
--- a/api/lib/domain/models/CertificationReport.js
+++ b/api/lib/domain/models/CertificationReport.js
@@ -70,7 +70,7 @@ class CertificationReport {
   }
 
   static idFromCertificationCourseId(certificationCourseId) {
-    return `CertificationReport:${certificationCourseId}`;
+    return `CertificationReport-${certificationCourseId}`;
   }
 }
 

--- a/certif/app/components/add-student-list.hbs
+++ b/certif/app/components/add-student-list.hbs
@@ -7,11 +7,11 @@
         @label="Filtrer la liste des élèves en cochant la ou les classes souhaitées"
         @emptyMessage={{this.emptyMessage}}
         @id={{"add-student-list__multi-select"}}
-        @onSelect={{this.selectDivision}}
-        @innerText={{"Chercher une classe ..."}}
+        @onChange={{this.selectDivision}}
+        @placeholder={{"Chercher une classe ..."}}
         @isSearchable={{true}}
         @screenReaderOnly={{true}}
-        @selected={{this.selectedDivisions}}
+        @values={{this.selectedDivisions}}
         @options={{@certificationCenterDivisions}}
         as |option|
       >

--- a/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.hbs
@@ -14,9 +14,9 @@
     <div class="candidate-information-change-certification-issue-report-fields__details">
       <label for="subcategory-for-category-candidate-information-change">Sélectionnez une sous-catégorie :</label>
       <PixSelect
-        id="subcategory-for-category-candidate-information-change"
+        @id="subcategory-for-category-candidate-information-change"
         @options={{this.options}}
-        @selectedOption={{@candidateInformationChangeCategory.subcategory}}
+        @value={{@candidateInformationChangeCategory.subcategory}}
         @onChange={{this.onChangeSubcategory}}
       />
       <label for="text-area-for-category-candidate-information-change">{{this.subcategoryTextAreaLabel}}</label>

--- a/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.js
@@ -8,14 +8,15 @@ import {
   subcategoryToLabel,
   subcategoryToTextareaLabel,
 } from 'pix-certif/models/certification-issue-report';
+
 export default class CandidateInformationChangeCertificationIssueReportFieldsComponent extends Component {
   @tracked
   subcategoryTextAreaLabel = subcategoryToTextareaLabel[this.args.candidateInformationChangeCategory.subcategory];
 
   @action
-  onChangeSubcategory(event) {
-    this.args.candidateInformationChangeCategory.subcategory = event.target.value;
-    this.subcategoryTextAreaLabel = subcategoryToTextareaLabel[event.target.value];
+  onChangeSubcategory(option) {
+    this.args.candidateInformationChangeCategory.subcategory = option;
+    this.subcategoryTextAreaLabel = subcategoryToTextareaLabel[option];
   }
 
   options = [

--- a/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.hbs
@@ -27,9 +27,9 @@
       <label for="subcategory-for-category-in-challenge">Sélectionnez une sous-catégorie :</label>
       <PixSelect
         aria-label="Sélectionner la sous-catégorie"
-        id="subcategory-for-category-in-challenge"
+        @id="subcategory-for-category-in-challenge"
         @options={{this.options}}
-        @selectedOption={{@inChallengeCategory.subcategory}}
+        @value={{@inChallengeCategory.subcategory}}
         @onChange={{this.onChangeSubcategory}}
       />
     </div>

--- a/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.js
@@ -2,14 +2,14 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import {
   certificationIssueReportSubcategories,
-  subcategoryToLabel,
   subcategoryToCode,
+  subcategoryToLabel,
 } from 'pix-certif/models/certification-issue-report';
 
 export default class InChallengeCertificationIssueReportFields extends Component {
   @action
-  onChangeSubcategory(event) {
-    this.args.inChallengeCategory.subcategory = event.target.value;
+  onChangeSubcategory(option) {
+    this.args.inChallengeCategory.subcategory = option;
   }
 
   get categoryCode() {

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -334,6 +334,7 @@
       aria-label="Fermer la modale d'ajout de candidat"
       @triggerAction={{@closeModal}}
       @backgroundColor="transparent-light"
+      @isBorderVisible="true"
     >
       Fermer
     </PixButton>

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -98,11 +98,11 @@
           Pays de naissance
         </label>
         <PixSelect
-          id="birth-country"
+          @id="birth-country"
           class="birth-country-selector"
           @options={{this.countryOptions}}
           @onChange={{this.selectBirthCountry}}
-          @selectedOption={{this.defaultCountryOption}}
+          @value={{this.selectedCountryInseeCode}}
           required
         />
       </div>
@@ -253,12 +253,13 @@
             <span class="required-field-indicator">*</span>
             Tarification part Pix</label>
           <PixSelect
-            id="billing-mode"
+            @id="billing-mode"
             class="birth-country-selector"
             @options={{this.billingModeOptions}}
-            @onChange={{fn @updateCandidateData @candidateData "billingMode"}}
-            @emptyOptionLabel={{"-- Choisissez --"}}
-            @emptyOptionNotSelectable={{true}}
+            @onChange={{fn @updateCandidateDataFromValue @candidateData "billingMode"}}
+            @value={{@candidateData.billingMode}}
+            @placeholder={{"-- Choisissez --"}}
+            @hideDefaultOption={{true}}
             required
           />
         </div>

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -103,6 +103,7 @@
           @options={{this.countryOptions}}
           @onChange={{this.selectBirthCountry}}
           @value={{this.selectedCountryInseeCode}}
+          @hideDefaultOption={{true}}
           required
         />
       </div>

--- a/certif/app/components/new-certification-candidate-modal.js
+++ b/certif/app/components/new-certification-candidate-modal.js
@@ -43,8 +43,8 @@ export default class NewCertificationCandidateModal extends Component {
   }
 
   @action
-  selectBirthCountry(event) {
-    this.selectedCountryInseeCode = event.target.value;
+  selectBirthCountry(option) {
+    this.selectedCountryInseeCode = option;
     const countryName = this._getCountryName();
     this.args.updateCandidateDataFromValue(this.args.candidateData, 'birthCountry', countryName);
     this.args.updateCandidateDataFromValue(this.args.candidateData, 'birthCity', '');
@@ -131,10 +131,6 @@ export default class NewCertificationCandidateModal extends Component {
     return this.args.countries?.map((country) => {
       return { label: country.name, value: country.code };
     });
-  }
-
-  get defaultCountryOption() {
-    return FRANCE_INSEE_CODE;
   }
 
   get billingModeOptions() {

--- a/certif/app/components/select-referer-modal.hbs
+++ b/certif/app/components/select-referer-modal.hbs
@@ -10,10 +10,12 @@
         {{t "pages.team.select-referer-modal.title"}}
       </label>
       <PixSelect
-        id="referer"
+        @id="referer"
         @options={{@options}}
+        @value={{@selectedReferer}}
+        @placeholder={{(t "pages.team.select-referer-modal.empty-option")}}
+        @hideDefaultOption={{true}}
         @onChange={{@onSelectReferer}}
-        @emptyOptionLabel={{(t "pages.team.select-referer-modal.empty-option")}}
         @emptyOptionNotSelectable={{true}}
       />
     </div>

--- a/certif/app/components/select-referer-modal.hbs
+++ b/certif/app/components/select-referer-modal.hbs
@@ -7,7 +7,7 @@
   <:content>
     <div class="select-referer-modal__referer-selector">
       <label for="referer" class="select-referer-modal__label">
-        {{t "pages.team.select-referer-modal.title"}}
+        {{t "pages.team.select-referer-modal.label"}}
       </label>
       <PixSelect
         @id="referer"

--- a/certif/app/components/session-delete-confirm-modal.hbs
+++ b/certif/app/components/session-delete-confirm-modal.hbs
@@ -4,11 +4,7 @@
   @showModal={{@showModal}}
 >
   <:content>
-    <p class="session-delete-confirmation-modal">{{t
-        "pages.sessions.list.delete-modal.label"
-        sessionId=@sessionId
-        htmlSafe=true
-      }}</p>
+    <p>{{t "pages.sessions.list.delete-modal.label" sessionId=@sessionId htmlSafe=true}}</p>
     {{#if (gt @enrolledCandidatesCount 0)}}
       <p class="session-delete-confirmation-modal">{{t
           "pages.sessions.list.delete-modal.enrolled-candidates"

--- a/certif/app/components/session-delete-confirm-modal.hbs
+++ b/certif/app/components/session-delete-confirm-modal.hbs
@@ -1,12 +1,17 @@
 <PixModal
+  class="session-delete-confirmation-modal-warning"
   @title={{t "pages.sessions.list.delete-modal.title"}}
   @onCloseButtonClick={{@close}}
   @showModal={{@showModal}}
 >
   <:content>
-    <p>{{t "pages.sessions.list.delete-modal.label" sessionId=@sessionId htmlSafe=true}}</p>
+    <p class="session-delete-confirmation-modal-warning__content">{{t
+        "pages.sessions.list.delete-modal.label"
+        sessionId=@sessionId
+        htmlSafe=true
+      }}</p>
     {{#if (gt @enrolledCandidatesCount 0)}}
-      <p class="session-delete-confirmation-modal">{{t
+      <p class="session-delete-confirmation-modal-warning__content">{{t
           "pages.sessions.list.delete-modal.enrolled-candidates"
           enrolledCandidatesCount=@enrolledCandidatesCount
           htmlSafe=true

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -93,11 +93,11 @@
           </td>
           <td class="finalization-report-abort-reason">
             <PixSelect
-              id={{concat "finalization-report-abort-reason__select" report.id}}
-              @emptyOptionLabel={{"-- Choisissez --"}}
+              @id={{concat "finalization-report-abort-reason__select" report.id}}
+              @placeholder={{"-- Choisissez --"}}
               @onChange={{fn @onChangeAbortReason report}}
-              @emptyOptionNotSelectable={{true}}
-              @selectedOption={{report.abortReason}}
+              @hideDefaultOption={{true}}
+              @value={{report.abortReason}}
               required="required"
               @options={{this.abortOptions}}
             />

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -46,8 +46,8 @@ export default class SessionsFinalizeController extends Controller {
   }
 
   @action
-  async abort(certificationReport, event) {
-    const { value: abortReason } = event.target;
+  async abort(certificationReport, option) {
+    const abortReason = option;
 
     try {
       await certificationReport.abort(abortReason);

--- a/certif/app/controllers/authenticated/team.js
+++ b/certif/app/controllers/authenticated/team.js
@@ -34,8 +34,8 @@ export default class Team extends Controller {
   }
 
   @action
-  onSelectReferer(event) {
-    this.selectedReferer = event.target.value;
+  onSelectReferer(option) {
+    this.selectedReferer = option;
   }
 
   @action

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -5,6 +5,7 @@ $navbar-height: 60px;
 @import "pix-design-tokens";
 @import "globals/errors";
 @import "globals/forms";
+@import "globals/modals";
 @import "globals/pages";
 @import "globals/panels";
 @import "globals/tables";

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -43,7 +43,6 @@ $navbar-height: 60px;
 @import "components/finalization-confirmation-modal";
 @import "components/register-form";
 @import "components/select-referer-modal";
-@import "components/session-delete-confirm-modal";
 @import "components/session-finalization-step-container";
 @import "components/session-finalization/reports-information-step";
 @import "components/session-finalization/complementary-information-step";

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -45,6 +45,7 @@ $navbar-height: 60px;
 @import "components/register-form";
 @import "components/select-referer-modal";
 @import "components/session-finalization-step-container";
+@import "components/session-delete-confirm-modal";
 @import "components/session-finalization/reports-information-step";
 @import "components/session-finalization/complementary-information-step";
 @import "components/session-finalization/formbuilder-link-step";

--- a/certif/app/styles/components/add-issue-report-modal.scss
+++ b/certif/app/styles/components/add-issue-report-modal.scss
@@ -1,9 +1,10 @@
 /* stylelint-disable no-descending-specificity */
 
 .add-issue-report-modal {
-  min-width: 650px;
-  max-width: 650px;
+  min-width: 850px;
+  max-width: 850px;
   margin: 100px auto;
+  overflow: visible;
 
   /* to fix in pix UI */
   input {
@@ -16,8 +17,9 @@
     margin-bottom: 4px;
   }
 
-  .pix-select select {
+  .pix-select {
     width: 100%;
+    max-width: 100%;
   }
 
   label[for^="text-area-for-category"] {

--- a/certif/app/styles/components/finalize.scss
+++ b/certif/app/styles/components/finalize.scss
@@ -48,8 +48,4 @@
   select:invalid {
     border: $pix-error-70 1px solid;
   }
-
-  .pix-select {
-    max-width: 210px;
-  }
 }

--- a/certif/app/styles/components/new-certification-candidate-modal.scss
+++ b/certif/app/styles/components/new-certification-candidate-modal.scss
@@ -39,7 +39,6 @@
       }
 
       input {
-        border: 1.2px $pix-neutral-35 solid;
         box-sizing: border-box;
         width: 248px;
         height: 36px;
@@ -51,7 +50,6 @@
       }
 
       .birth-country-selector {
-        border: 1.2px $pix-neutral-35 solid;
         height: 36px;
         width: 248px;
       }

--- a/certif/app/styles/components/select-referer-modal.scss
+++ b/certif/app/styles/components/select-referer-modal.scss
@@ -15,6 +15,12 @@
 
   &__referer-selector {
     margin: 0 24px;
+    display: flex;
+    flex-direction: column;
+
+    .pix-select {
+      width: 100%;
+    }
   }
 
   &__actions {

--- a/certif/app/styles/components/session-delete-confirm-modal.scss
+++ b/certif/app/styles/components/session-delete-confirm-modal.scss
@@ -1,0 +1,13 @@
+/* stylelint-disable no-descending-specificity */
+
+.session-delete-confirmation-modal-warning {
+  margin-bottom: 14px;
+
+  &__content {
+    margin-bottom: 14px;
+
+    span {
+      font-weight: 700;
+    }
+  }
+}

--- a/certif/app/styles/components/session-delete-confirm-modal.scss
+++ b/certif/app/styles/components/session-delete-confirm-modal.scss
@@ -1,3 +1,0 @@
-.session-delete-confirmation-modal span {
-  font-weight: bold;
-}

--- a/certif/app/styles/components/session-finalization/reports-information-step.scss
+++ b/certif/app/styles/components/session-finalization/reports-information-step.scss
@@ -27,14 +27,11 @@
     table-layout: initial;
 
     th {
-      width: 20%;
-    }
-
-    th:nth-child(2) {
       width: 10%;
     }
 
-    th:nth-child(3),
+    th:nth-child(1),
+    th:nth-child(2),
     th:nth-child(4) {
       width: 20%;
     }
@@ -51,6 +48,7 @@
 
   .finalization-report-examiner-comment {
     display: flex;
+    flex-direction: column;
 
     .add-button {
       color: $pix-neutral-70;
@@ -88,7 +86,7 @@
         list-style-type: disc;
 
         li {
-          list-style-type: '- ';
+          list-style-type: "- ";
         }
       }
     }

--- a/certif/app/styles/globals/modals.scss
+++ b/certif/app/styles/globals/modals.scss
@@ -2,4 +2,5 @@
   display: flex;
   justify-content: end;
   column-gap: 16px;
+  padding: 18px 24px;
 }

--- a/certif/app/styles/globals/modals.scss
+++ b/certif/app/styles/globals/modals.scss
@@ -1,0 +1,5 @@
+.pix-modal__footer {
+  display: flex;
+  justify-content: end;
+  column-gap: 16px;
+}

--- a/certif/app/styles/globals/pages.scss
+++ b/certif/app/styles/globals/pages.scss
@@ -1,8 +1,4 @@
 .page {
   padding: 48px 35px;
   flex-grow: 1;
-
-  &__title {
-    margin-bottom: 55px;
-  }
 }

--- a/certif/app/styles/globals/titles.scss
+++ b/certif/app/styles/globals/titles.scss
@@ -3,6 +3,7 @@
   font-weight: 300;
   font-size: 2.25rem;
   color: $pix-neutral-80;
+  margin: 24px 0;
 }
 
 .form-title {

--- a/certif/app/styles/pages/authenticated/team.scss
+++ b/certif/app/styles/pages/authenticated/team.scss
@@ -34,6 +34,7 @@
 
   &__no-referer-description {
     color: $pix-neutral-50;
+    margin: 16px 0;
   }
 
   &__no-referer-bell-icon {

--- a/certif/app/templates/authenticated/sessions/new.hbs
+++ b/certif/app/templates/authenticated/sessions/new.hbs
@@ -136,6 +136,7 @@
           data-test-id="session-form__cancel-button"
           @backgroundColor="transparent-light"
           @triggerAction={{this.cancel}}
+          @isBorderVisible="true"
           aria-label="Annuler la création de session et retourner vers la page précédente"
         >
           Annuler

--- a/certif/app/templates/authenticated/sessions/update.hbs
+++ b/certif/app/templates/authenticated/sessions/update.hbs
@@ -135,6 +135,7 @@
           data-test-id="session-form__cancel-button"
           @triggerAction={{this.cancel}}
           @backgroundColor="transparent-light"
+          @isBorderVisible="true"
           aria-label="Annuler la modification de la session et retourner vers la page précédente"
         >
           Annuler

--- a/certif/app/templates/authenticated/team.hbs
+++ b/certif/app/templates/authenticated/team.hbs
@@ -41,5 +41,6 @@
   @onValidateReferer={{this.onValidateReferer}}
   @noSelectedReferer={{not this.selectedReferer.length}}
   @options={{this.membersSelectOptionsSortedByLastName}}
+  @selectedReferer={{this.selectedReferer}}
 />
 <MembersList @members={{@model.members}} @hasCleaHabilitation={{this.model.hasCleaHabilitation}} />

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^20.2.4",
+        "@1024pix/pix-ui": "^21.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.5",
         "@ember/optional-features": "^2.0.0",
@@ -1003,281 +1003,23 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.2.4.tgz",
-      "integrity": "sha512-G71jhEna46WoniRqzfaibGdnaRFynjaWPhBlCVdEPtWtkTWhE7srpv8fRBAko64geth6H7WE+ErI9b9p0WSnsg==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-21.0.0.tgz",
+      "integrity": "sha512-4ehKzkP+xf/d1PAZsIP5bEUTAHH3T2le/DyIx0tURMzBqwRPC3oL1A7HnJZrwwpOtWxGXCInjEFrgY3hYVz+Wg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "ember-cli-babel": "^7.26.6",
-        "ember-cli-htmlbars": "^5.6.2",
-        "ember-cli-sass": "^10.0.1",
+        "ember-cli-htmlbars": "^6.1.1",
+        "ember-cli-sass": "^11.0.1",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-click-outside": "^2.0.0",
+        "ember-click-outside": "^4.0.0",
         "ember-prop-modifier": "^1.0.1",
-        "ember-truth-helpers": "^3.0.0"
+        "ember-truth-helpers": "^3.1.1"
       },
       "engines": {
         "node": "16",
         "npm": ">=8.13.2 <9"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/async-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "^2.5.1",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "rsvp": "^4.8.5",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/broccoli-merge-trees": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
-      "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-plugin": "^1.3.0",
-        "merge-trees": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/broccoli-merge-trees/node_modules/broccoli-plugin": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
-      "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-      "dev": true,
-      "dependencies": {
-        "promise-map-series": "^0.2.1",
-        "quick-temp": "^0.1.3",
-        "rimraf": "^2.3.4",
-        "symlink-or-copy": "^1.1.8"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/broccoli-merge-trees/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/broccoli-persistent-filter": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
-      "integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
-      "dev": true,
-      "dependencies": {
-        "async-disk-cache": "^2.0.0",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^4.0.3",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^3.0.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^2.0.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/editions": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-      "dev": true,
-      "dependencies": {
-        "errlop": "^2.0.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/editions/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-cli-htmlbars": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-      "dev": true,
-      "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^3.1.2",
-        "broccoli-plugin": "^4.0.3",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-version-checker": "^5.1.2",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
-        "semver": "^7.3.4",
-        "silent-error": "^1.1.1",
-        "strip-bom": "^4.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-cli-sass": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-sass/-/ember-cli-sass-10.0.1.tgz",
-      "integrity": "sha512-dWVoX03O2Mot1dEB1AN3ofC8DDZb6iU4Kfkbr3WYi9S9bGVHrpR/ngsR7tuVBuTugTyG53FPtLLqYdqx7XjXdA==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-funnel": "^2.0.1",
-        "broccoli-merge-trees": "^3.0.1",
-        "broccoli-sass-source-maps": "^4.0.0",
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-cli-sass/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-cli-sass/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/istextorbinary": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-      "dev": true,
-      "dependencies": {
-        "binaryextensions": "^2.1.2",
-        "editions": "^2.2.0",
-        "textextensions": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/sync-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.6",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -17014,87 +16756,201 @@
       "dev": true
     },
     "node_modules/ember-click-outside": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-2.0.0.tgz",
-      "integrity": "sha512-d53L+Of9rRhB8RU32xKFDG58e8MJZRPFF9HAuUIcn3Hl5U7v8Gb9YqB59khcryCkRXWzLOvVgmNFjNaV9iZJyQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-4.0.0.tgz",
+      "integrity": "sha512-3SstFhDWu3K5PQzo0FZwk66Ehe1l6QFU/R+WjAt8yOXw2sHzJHOdx2N+fNWJHZsJ97BSqdL7L0qotJEMX46u6Q==",
       "dev": true,
       "dependencies": {
-        "ember-cli-babel": "^7.18.0",
-        "ember-cli-htmlbars": "^4.2.3",
-        "ember-modifier": "^2.1.0"
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-htmlbars": "^5.7.1",
+        "ember-modifier": "^2.1.0 || ^3.0.0"
       },
       "engines": {
-        "node": "10.* || >= 12"
+        "node": "12.* || 14.* || >= 16"
       }
     },
-    "node_modules/ember-click-outside/node_modules/babel-plugin-htmlbars-inline-precompile": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.2.0.tgz",
-      "integrity": "sha512-IUeZmgs9tMUGXYu1vfke5I18yYJFldFGdNFQOWslXTnDWXzpwPih7QFduUqvT+awDpDuNtXpdt5JAf43Q1Hhzg==",
+    "node_modules/ember-click-outside/node_modules/async-disk-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
+      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
       "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "heimdalljs": "^0.2.3",
+        "istextorbinary": "^2.5.1",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^3.0.0",
+        "rsvp": "^4.8.5",
+        "username-sync": "^1.0.2"
+      },
       "engines": {
-        "node": "8.* || 10.* || >= 12.*"
+        "node": "8.* || >= 10.*"
       }
     },
-    "node_modules/ember-click-outside/node_modules/broccoli-output-wrapper": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-2.0.0.tgz",
-      "integrity": "sha512-V/ozejo+snzNf75i/a6iTmp71k+rlvqjE3+jYfimuMwR1tjNNRdtfno+NGNQB2An9bIAeqZnKhMDurAznHAdtA==",
+    "node_modules/ember-click-outside/node_modules/broccoli-persistent-filter": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
+      "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
       "dev": true,
       "dependencies": {
-        "heimdalljs-logger": "^0.1.10"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/broccoli-plugin": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz",
-      "integrity": "sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-node-api": "^1.6.0",
-        "broccoli-output-wrapper": "^2.0.0",
-        "fs-merger": "^3.0.1",
+        "async-disk-cache": "^2.0.0",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^4.0.3",
+        "fs-tree-diff": "^2.0.0",
+        "hash-for-dep": "^1.5.0",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
         "promise-map-series": "^0.2.1",
-        "quick-temp": "^0.1.3",
-        "rimraf": "^2.3.4",
-        "symlink-or-copy": "^1.1.8"
+        "rimraf": "^3.0.0",
+        "symlink-or-copy": "^1.0.1",
+        "sync-disk-cache": "^2.0.0"
       },
       "engines": {
-        "node": "8.* || 10.* || >= 12.*"
+        "node": "10.* || >= 12.*"
       }
     },
-    "node_modules/ember-click-outside/node_modules/ember-cli-htmlbars": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.5.0.tgz",
-      "integrity": "sha512-bYJpK1pqFu9AadDAGTw05g2LMNzY8xTCIqQm7dMJmKEoUpLRFbPf4SfHXrktzDh7Q5iggl6Skzf1M0bPlIxARw==",
+    "node_modules/ember-click-outside/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^3.2.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^2.3.1",
-        "broccoli-plugin": "^3.1.0",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.0",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
-        "semver": "^6.3.0",
-        "strip-bom": "^4.0.0",
-        "walk-sync": "^2.0.2"
+        "ms": "2.1.2"
       },
       "engines": {
-        "node": "8.* || 10.* || >= 12.*"
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
-    "node_modules/ember-click-outside/node_modules/semver": {
+    "node_modules/ember-click-outside/node_modules/editions": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+      "dev": true,
+      "dependencies": {
+        "errlop": "^2.0.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/ember-click-outside/node_modules/editions/node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/ember-click-outside/node_modules/ember-cli-htmlbars": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
+      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
+      "dev": true,
+      "dependencies": {
+        "@ember/edition-utils": "^1.2.0",
+        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
+        "broccoli-debug": "^0.6.5",
+        "broccoli-persistent-filter": "^3.1.2",
+        "broccoli-plugin": "^4.0.3",
+        "common-tags": "^1.8.0",
+        "ember-cli-babel-plugin-helpers": "^1.1.1",
+        "ember-cli-version-checker": "^5.1.2",
+        "fs-tree-diff": "^2.0.1",
+        "hash-for-dep": "^1.5.1",
+        "heimdalljs-logger": "^0.1.10",
+        "json-stable-stringify": "^1.0.1",
+        "semver": "^7.3.4",
+        "silent-error": "^1.1.1",
+        "strip-bom": "^4.0.0",
+        "walk-sync": "^2.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-click-outside/node_modules/istextorbinary": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
+      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
+      "dev": true,
+      "dependencies": {
+        "binaryextensions": "^2.1.2",
+        "editions": "^2.2.0",
+        "textextensions": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/ember-click-outside/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ember-click-outside/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/ember-click-outside/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ember-click-outside/node_modules/rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-click-outside/node_modules/sync-disk-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
+      "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "heimdalljs": "^0.2.6",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^3.0.0",
+        "username-sync": "^1.0.2"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
       }
     },
     "node_modules/ember-compatibility-helpers": {
@@ -36007,222 +35863,18 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.2.4.tgz",
-      "integrity": "sha512-G71jhEna46WoniRqzfaibGdnaRFynjaWPhBlCVdEPtWtkTWhE7srpv8fRBAko64geth6H7WE+ErI9b9p0WSnsg==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-21.0.0.tgz",
+      "integrity": "sha512-4ehKzkP+xf/d1PAZsIP5bEUTAHH3T2le/DyIx0tURMzBqwRPC3oL1A7HnJZrwwpOtWxGXCInjEFrgY3hYVz+Wg==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6",
-        "ember-cli-htmlbars": "^5.6.2",
-        "ember-cli-sass": "^10.0.1",
+        "ember-cli-htmlbars": "^6.1.1",
+        "ember-cli-sass": "^11.0.1",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-click-outside": "^2.0.0",
+        "ember-click-outside": "^4.0.0",
         "ember-prop-modifier": "^1.0.1",
-        "ember-truth-helpers": "^3.0.0"
-      },
-      "dependencies": {
-        "async-disk-cache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-          "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "heimdalljs": "^0.2.3",
-            "istextorbinary": "^2.5.1",
-            "mkdirp": "^0.5.0",
-            "rimraf": "^3.0.0",
-            "rsvp": "^4.8.5",
-            "username-sync": "^1.0.2"
-          }
-        },
-        "broccoli-merge-trees": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
-          "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "^1.3.0",
-            "merge-trees": "^2.0.0"
-          },
-          "dependencies": {
-            "broccoli-plugin": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
-              "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-              "dev": true,
-              "requires": {
-                "promise-map-series": "^0.2.1",
-                "quick-temp": "^0.1.3",
-                "rimraf": "^2.3.4",
-                "symlink-or-copy": "^1.1.8"
-              }
-            },
-            "rimraf": {
-              "version": "2.7.1",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-              "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-              "dev": true,
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            }
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
-          "integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
-          "dev": true,
-          "requires": {
-            "async-disk-cache": "^2.0.0",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^4.0.3",
-            "fs-tree-diff": "^2.0.0",
-            "hash-for-dep": "^1.5.0",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^3.0.0",
-            "symlink-or-copy": "^1.0.1",
-            "sync-disk-cache": "^2.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "editions": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-          "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-          "dev": true,
-          "requires": {
-            "errlop": "^2.0.0",
-            "semver": "^6.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            }
-          }
-        },
-        "ember-cli-htmlbars": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-          "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-          "dev": true,
-          "requires": {
-            "@ember/edition-utils": "^1.2.0",
-            "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-            "broccoli-debug": "^0.6.5",
-            "broccoli-persistent-filter": "^3.1.2",
-            "broccoli-plugin": "^4.0.3",
-            "common-tags": "^1.8.0",
-            "ember-cli-babel-plugin-helpers": "^1.1.1",
-            "ember-cli-version-checker": "^5.1.2",
-            "fs-tree-diff": "^2.0.1",
-            "hash-for-dep": "^1.5.1",
-            "heimdalljs-logger": "^0.1.10",
-            "json-stable-stringify": "^1.0.1",
-            "semver": "^7.3.4",
-            "silent-error": "^1.1.1",
-            "strip-bom": "^4.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "ember-cli-sass": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-sass/-/ember-cli-sass-10.0.1.tgz",
-          "integrity": "sha512-dWVoX03O2Mot1dEB1AN3ofC8DDZb6iU4Kfkbr3WYi9S9bGVHrpR/ngsR7tuVBuTugTyG53FPtLLqYdqx7XjXdA==",
-          "dev": true,
-          "requires": {
-            "broccoli-funnel": "^2.0.1",
-            "broccoli-merge-trees": "^3.0.1",
-            "broccoli-sass-source-maps": "^4.0.0",
-            "ember-cli-version-checker": "^2.1.0"
-          },
-          "dependencies": {
-            "ember-cli-version-checker": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-              "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-              "dev": true,
-              "requires": {
-                "resolve": "^1.3.3",
-                "semver": "^5.3.0"
-              }
-            },
-            "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-              "dev": true
-            }
-          }
-        },
-        "istextorbinary": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-          "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-          "dev": true,
-          "requires": {
-            "binaryextensions": "^2.1.2",
-            "editions": "^2.2.0",
-            "textextensions": "^2.5.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.6"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
-        },
-        "sync-disk-cache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
-          "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "heimdalljs": "^0.2.6",
-            "mkdirp": "^0.5.0",
-            "rimraf": "^3.0.0",
-            "username-sync": "^1.0.2"
-          }
-        }
+        "ember-truth-helpers": "^3.1.1"
       }
     },
     "@ampproject/remapping": {
@@ -49052,73 +48704,154 @@
       }
     },
     "ember-click-outside": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-2.0.0.tgz",
-      "integrity": "sha512-d53L+Of9rRhB8RU32xKFDG58e8MJZRPFF9HAuUIcn3Hl5U7v8Gb9YqB59khcryCkRXWzLOvVgmNFjNaV9iZJyQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-4.0.0.tgz",
+      "integrity": "sha512-3SstFhDWu3K5PQzo0FZwk66Ehe1l6QFU/R+WjAt8yOXw2sHzJHOdx2N+fNWJHZsJ97BSqdL7L0qotJEMX46u6Q==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^7.18.0",
-        "ember-cli-htmlbars": "^4.2.3",
-        "ember-modifier": "^2.1.0"
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-htmlbars": "^5.7.1",
+        "ember-modifier": "^2.1.0 || ^3.0.0"
       },
       "dependencies": {
-        "babel-plugin-htmlbars-inline-precompile": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.2.0.tgz",
-          "integrity": "sha512-IUeZmgs9tMUGXYu1vfke5I18yYJFldFGdNFQOWslXTnDWXzpwPih7QFduUqvT+awDpDuNtXpdt5JAf43Q1Hhzg==",
-          "dev": true
-        },
-        "broccoli-output-wrapper": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-2.0.0.tgz",
-          "integrity": "sha512-V/ozejo+snzNf75i/a6iTmp71k+rlvqjE3+jYfimuMwR1tjNNRdtfno+NGNQB2An9bIAeqZnKhMDurAznHAdtA==",
+        "async-disk-cache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
+          "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
           "dev": true,
           "requires": {
-            "heimdalljs-logger": "^0.1.10"
+            "debug": "^4.1.1",
+            "heimdalljs": "^0.2.3",
+            "istextorbinary": "^2.5.1",
+            "mkdirp": "^0.5.0",
+            "rimraf": "^3.0.0",
+            "rsvp": "^4.8.5",
+            "username-sync": "^1.0.2"
           }
         },
-        "broccoli-plugin": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz",
-          "integrity": "sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==",
+        "broccoli-persistent-filter": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
+          "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
           "dev": true,
           "requires": {
-            "broccoli-node-api": "^1.6.0",
-            "broccoli-output-wrapper": "^2.0.0",
-            "fs-merger": "^3.0.1",
+            "async-disk-cache": "^2.0.0",
+            "async-promise-queue": "^1.0.3",
+            "broccoli-plugin": "^4.0.3",
+            "fs-tree-diff": "^2.0.0",
+            "hash-for-dep": "^1.5.0",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
             "promise-map-series": "^0.2.1",
-            "quick-temp": "^0.1.3",
-            "rimraf": "^2.3.4",
-            "symlink-or-copy": "^1.1.8"
+            "rimraf": "^3.0.0",
+            "symlink-or-copy": "^1.0.1",
+            "sync-disk-cache": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "editions": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+          "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+          "dev": true,
+          "requires": {
+            "errlop": "^2.0.0",
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
           }
         },
         "ember-cli-htmlbars": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.5.0.tgz",
-          "integrity": "sha512-bYJpK1pqFu9AadDAGTw05g2LMNzY8xTCIqQm7dMJmKEoUpLRFbPf4SfHXrktzDh7Q5iggl6Skzf1M0bPlIxARw==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
+          "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
           "dev": true,
           "requires": {
             "@ember/edition-utils": "^1.2.0",
-            "babel-plugin-htmlbars-inline-precompile": "^3.2.0",
+            "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
             "broccoli-debug": "^0.6.5",
-            "broccoli-persistent-filter": "^2.3.1",
-            "broccoli-plugin": "^3.1.0",
+            "broccoli-persistent-filter": "^3.1.2",
+            "broccoli-plugin": "^4.0.3",
             "common-tags": "^1.8.0",
-            "ember-cli-babel-plugin-helpers": "^1.1.0",
+            "ember-cli-babel-plugin-helpers": "^1.1.1",
+            "ember-cli-version-checker": "^5.1.2",
             "fs-tree-diff": "^2.0.1",
             "hash-for-dep": "^1.5.1",
             "heimdalljs-logger": "^0.1.10",
             "json-stable-stringify": "^1.0.1",
-            "semver": "^6.3.0",
+            "semver": "^7.3.4",
+            "silent-error": "^1.1.1",
             "strip-bom": "^4.0.0",
-            "walk-sync": "^2.0.2"
+            "walk-sync": "^2.2.0"
           }
         },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+        "istextorbinary": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
+          "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
+          "dev": true,
+          "requires": {
+            "binaryextensions": "^2.1.2",
+            "editions": "^2.2.0",
+            "textextensions": "^2.5.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.6"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "rsvp": {
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+          "dev": true
+        },
+        "sync-disk-cache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
+          "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "heimdalljs": "^0.2.6",
+            "mkdirp": "^0.5.0",
+            "rimraf": "^3.0.0",
+            "username-sync": "^1.0.2"
+          }
         }
       }
     },

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^23.3.0",
+        "@1024pix/pix-ui": "^24.0.1",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.5",
         "@ember/optional-features": "^2.0.0",
@@ -1003,9 +1003,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "23.3.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-23.3.0.tgz",
-      "integrity": "sha512-b3WuosMB0xUk0QeileWvqHJIkKUbroKNvZQHMfxgy/+XVTYf0q4PB3Op6nJFr9aix22KX5VmFKeNlvndBiO8bg==",
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-24.0.1.tgz",
+      "integrity": "sha512-hymu4ttHwswbP/VJTERYyP31nATR4LrG7yaYc7kKz9ztM2IvWs1tJZcXjFTdkvcTlslTJssEhLLvTmuIUd6U2Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -35902,9 +35902,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "23.3.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-23.3.0.tgz",
-      "integrity": "sha512-b3WuosMB0xUk0QeileWvqHJIkKUbroKNvZQHMfxgy/+XVTYf0q4PB3Op6nJFr9aix22KX5VmFKeNlvndBiO8bg==",
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-24.0.1.tgz",
+      "integrity": "sha512-hymu4ttHwswbP/VJTERYyP31nATR4LrG7yaYc7kKz9ztM2IvWs1tJZcXjFTdkvcTlslTJssEhLLvTmuIUd6U2Q==",
       "dev": true,
       "requires": {
         "color": "^4.2.3",

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^21.0.0",
+        "@1024pix/pix-ui": "^23.3.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.5",
         "@ember/optional-features": "^2.0.0",
@@ -1003,13 +1003,14 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-21.0.0.tgz",
-      "integrity": "sha512-4ehKzkP+xf/d1PAZsIP5bEUTAHH3T2le/DyIx0tURMzBqwRPC3oL1A7HnJZrwwpOtWxGXCInjEFrgY3hYVz+Wg==",
+      "version": "23.3.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-23.3.0.tgz",
+      "integrity": "sha512-b3WuosMB0xUk0QeileWvqHJIkKUbroKNvZQHMfxgy/+XVTYf0q4PB3Op6nJFr9aix22KX5VmFKeNlvndBiO8bg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "ember-cli-babel": "^7.26.6",
+        "color": "^4.2.3",
+        "ember-cli-babel": "^7.26.8",
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-sass": "^11.0.1",
         "ember-cli-string-utils": "^1.1.0",
@@ -11146,6 +11147,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -11163,6 +11177,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -31761,6 +31785,21 @@
       "integrity": "sha1-m4tVWdgOMxpUTdE91ZOC5dDZRBE=",
       "dev": true
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "dev": true
+    },
     "node_modules/sinon": {
       "version": "14.0.2",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.2.tgz",
@@ -35863,12 +35902,13 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-21.0.0.tgz",
-      "integrity": "sha512-4ehKzkP+xf/d1PAZsIP5bEUTAHH3T2le/DyIx0tURMzBqwRPC3oL1A7HnJZrwwpOtWxGXCInjEFrgY3hYVz+Wg==",
+      "version": "23.3.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-23.3.0.tgz",
+      "integrity": "sha512-b3WuosMB0xUk0QeileWvqHJIkKUbroKNvZQHMfxgy/+XVTYf0q4PB3Op6nJFr9aix22KX5VmFKeNlvndBiO8bg==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^7.26.6",
+        "color": "^4.2.3",
+        "ember-cli-babel": "^7.26.8",
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-sass": "^11.0.1",
         "ember-cli-string-utils": "^1.1.0",
@@ -44102,6 +44142,16 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      }
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -44116,6 +44166,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "color-support": {
       "version": "1.1.3",
@@ -60713,6 +60773,23 @@
       "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.3.0.tgz",
       "integrity": "sha1-m4tVWdgOMxpUTdE91ZOC5dDZRBE=",
       "dev": true
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+          "dev": true
+        }
+      }
     },
     "sinon": {
       "version": "14.0.2",

--- a/certif/package.json
+++ b/certif/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^21.0.0",
+    "@1024pix/pix-ui": "^23.3.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.5",
     "@ember/optional-features": "^2.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^23.3.0",
+    "@1024pix/pix-ui": "^24.0.1",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.5",
     "@ember/optional-features": "^2.0.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^20.2.4",
+    "@1024pix/pix-ui": "^21.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.5",
     "@ember/optional-features": "^2.0.0",

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -299,7 +299,12 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           await fillIn(screen.getByLabelText('Identifiant externe'), '44AA3355');
           await fillIn(screen.getByLabelText('* Code INSEE de naissance'), '75100');
           await fillIn(screen.getByLabelText('Temps majoré (%)'), '20');
-          await fillIn(screen.getByLabelText('* Tarification part Pix'), 'PREPAID');
+          await click(screen.getByLabelText('* Tarification part Pix'));
+          await click(
+            await screen.findByRole('option', {
+              name: 'Prépayée',
+            })
+          );
           await fillIn(screen.getByLabelText('Code de prépaiement'), '12345');
           await fillIn(
             screen.getByLabelText('E-mail du destinataire des résultats (formateur, enseignant...)'),
@@ -402,7 +407,13 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
               await click(screen.getByLabelText('Code INSEE'));
               await fillIn(screen.getByLabelText('Identifiant externe'), '44AA3355');
               await fillIn(screen.getByLabelText('* Code INSEE de naissance'), '75100');
-              await fillIn(screen.getByLabelText('* Tarification part Pix'), 'PREPAID');
+              await click(screen.getByLabelText('* Tarification part Pix'));
+              await click(
+                await screen.findByRole('option', {
+                  name: 'Prépayée',
+                })
+              );
+
               await fillIn(screen.getByLabelText('Code de prépaiement'), '12345');
 
               // when
@@ -428,7 +439,12 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
     await fillIn(screen.getByLabelText('Identifiant externe'), '44AA3355');
     await fillIn(screen.getByLabelText('* Code INSEE de naissance'), '75100');
     await fillIn(screen.getByLabelText('Temps majoré (%)'), '20');
-    await fillIn(screen.getByLabelText('* Tarification part Pix'), 'FREE');
+    await click(screen.getByLabelText('* Tarification part Pix'));
+    await click(
+      await screen.findByRole('option', {
+        name: 'Gratuite',
+      })
+    );
     await fillIn(
       screen.getByLabelText('E-mail du destinataire des résultats (formateur, enseignant...)'),
       'guybrush.threepwood@example.net'

--- a/certif/tests/acceptance/team_test.js
+++ b/certif/tests/acceptance/team_test.js
@@ -1,13 +1,13 @@
 import { module, test } from 'qunit';
-import { currentURL, click, fillIn } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { visit as visitScreen } from '@1024pix/ember-testing-library';
 
 import { setupApplicationTest } from 'ember-qunit';
 import {
-  createCertificationPointOfContactWithTermsOfServiceAccepted,
   authenticateSession,
   createAllowedCertificationCenterAccess,
   createCertificationPointOfContactWithCustomCenters,
+  createCertificationPointOfContactWithTermsOfServiceAccepted,
 } from '../helpers/test-init';
 import setupIntl from '../helpers/setup-intl';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -67,9 +67,11 @@ module('Acceptance | authenticated | team', function (hooks) {
                 screen.getByRole('button', { name: this.intl.t('pages.team.no-referer-section.select-referer-button') })
               );
               await screen.findByRole('dialog');
-              await fillIn(
-                screen.getByRole('combobox', { name: this.intl.t('pages.team.select-referer-modal.title') }),
-                '102'
+              await click(screen.getByLabelText(this.intl.t('pages.team.select-referer-modal.label')));
+              await click(
+                await screen.findByRole('option', {
+                  name: 'Lili Dupont',
+                })
               );
               await click(screen.getByRole('button', { name: 'Valider la sélection de référent' }));
               await waitForDialogClose();

--- a/certif/tests/integration/components/issue-report-modal/in-challenge-certification-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/in-challenge-certification-issue-report-fields_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import {
@@ -40,76 +41,72 @@ module('Integration | Component | in-challenge-certification-issue-report-fields
     assert.ok(toggleOnCategory.calledOnceWith(inChallengeCategory));
   });
 
-  test('it should show dropdown menu with code & subcategories when category is checked', async function (assert) {
-    // given
-    const toggleOnCategory = sinon.stub();
-    const inChallengeCategory = new RadioButtonCategoryWithSubcategoryAndQuestionNumber({
-      name: 'IN_CHALLENGE',
-      isChecked: true,
-    });
-    this.set('toggleOnCategory', toggleOnCategory);
-    this.set('inChallengeCategory', inChallengeCategory);
+  [
+    `${subcategoryToCode[certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]} ${
+      subcategoryToLabel[certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]
+    }`,
+    `${subcategoryToCode[certificationIssueReportSubcategories.EMBED_NOT_WORKING]} ${
+      subcategoryToLabel[certificationIssueReportSubcategories.EMBED_NOT_WORKING]
+    }`,
+    `${subcategoryToCode[certificationIssueReportSubcategories.FILE_NOT_OPENING]} ${
+      subcategoryToLabel[certificationIssueReportSubcategories.FILE_NOT_OPENING]
+    }`,
+    `${subcategoryToCode[certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]} ${
+      subcategoryToLabel[certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]
+    }`,
+    `${subcategoryToCode[certificationIssueReportSubcategories.WEBSITE_BLOCKED]} ${
+      subcategoryToLabel[certificationIssueReportSubcategories.WEBSITE_BLOCKED]
+    }`,
+    `${subcategoryToCode[certificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED]} ${
+      subcategoryToLabel[certificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED]
+    }`,
+    `${subcategoryToCode[certificationIssueReportSubcategories.SOFTWARE_NOT_WORKING]} ${
+      subcategoryToLabel[certificationIssueReportSubcategories.SOFTWARE_NOT_WORKING]
+    }`,
+    `${subcategoryToCode[certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT]} ${
+      subcategoryToLabel[certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT]
+    }`,
+    `${subcategoryToCode[certificationIssueReportSubcategories.SKIP_ON_OOPS]} ${
+      subcategoryToLabel[certificationIssueReportSubcategories.SKIP_ON_OOPS]
+    }`,
+    `${subcategoryToCode[certificationIssueReportSubcategories.ACCESSIBILITY_ISSUE]} ${
+      subcategoryToLabel[certificationIssueReportSubcategories.ACCESSIBILITY_ISSUE]
+    }`,
+  ].forEach(function (subcategory) {
+    test(`it should select the subcategory: ${subcategory} when category is checked`, async function (assert) {
+      // given
+      const toggleOnCategory = sinon.stub();
+      const inChallengeCategory = new RadioButtonCategoryWithSubcategoryAndQuestionNumber({
+        name: 'IN_CHALLENGE',
+        isChecked: true,
+      });
+      this.set('toggleOnCategory', toggleOnCategory);
+      this.set('inChallengeCategory', inChallengeCategory);
 
-    // when
-    await render(hbs`
+      // when
+      const screen = await render(hbs`
       <IssueReportModal::InChallengeCertificationIssueReportFields
         @inChallengeCategory={{this.inChallengeCategory}}
         @toggleOnCategory={{this.toggleOnCategory}}
         @maxlength={{500}}
       />`);
-    await click('[aria-label="Sélectionner la sous-catégorie"]');
+      await click(screen.getByLabelText('Sélectionnez une sous-catégorie :'));
+      await click(
+        await screen.findByRole('option', {
+          name: subcategory,
+        })
+      );
 
-    // then
-    assert.contains(
-      `${subcategoryToCode[certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]} ${
-        subcategoryToLabel[certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]
-      }`
-    );
-    assert.contains(
-      `${subcategoryToCode[certificationIssueReportSubcategories.EMBED_NOT_WORKING]} ${
-        subcategoryToLabel[certificationIssueReportSubcategories.EMBED_NOT_WORKING]
-      }`
-    );
-    assert.contains(
-      `${subcategoryToCode[certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]} ${
-        subcategoryToLabel[certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]
-      }`
-    );
-    assert.contains(
-      `${subcategoryToCode[certificationIssueReportSubcategories.WEBSITE_BLOCKED]} ${
-        subcategoryToLabel[certificationIssueReportSubcategories.WEBSITE_BLOCKED]
-      }`
-    );
-    assert.contains(
-      `${subcategoryToCode[certificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED]} ${
-        subcategoryToLabel[certificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED]
-      }`
-    );
-    assert.contains(
-      `${subcategoryToCode[certificationIssueReportSubcategories.SOFTWARE_NOT_WORKING]} ${
-        subcategoryToLabel[certificationIssueReportSubcategories.SOFTWARE_NOT_WORKING]
-      }`
-    );
-    assert.contains(
-      `${subcategoryToCode[certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT]} ${
-        subcategoryToLabel[certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT]
-      }`
-    );
-    assert.contains(
-      `${subcategoryToCode[certificationIssueReportSubcategories.FILE_NOT_OPENING]} ${
-        subcategoryToLabel[certificationIssueReportSubcategories.FILE_NOT_OPENING]
-      }`
-    );
-    assert.contains(
-      `${subcategoryToCode[certificationIssueReportSubcategories.SKIP_ON_OOPS]} ${
-        subcategoryToLabel[certificationIssueReportSubcategories.SKIP_ON_OOPS]
-      }`
-    );
-    assert.contains(
-      `${subcategoryToCode[certificationIssueReportSubcategories.ACCESSIBILITY_ISSUE]} ${
-        subcategoryToLabel[certificationIssueReportSubcategories.ACCESSIBILITY_ISSUE]
-      }`
-    );
+      // then
+      assert
+        .dom(
+          screen.getByRole('option', {
+            selected: true,
+            name: subcategory,
+          })
+        )
+        .exists();
+    });
   });
 
   test('category', async function (assert) {
@@ -143,19 +140,30 @@ module('Integration | Component | in-challenge-certification-issue-report-fields
     this.set('inChallengeCategory', inChallengeCategory);
 
     // when
-    await render(hbs`
+    const screen = await render(hbs`
       <IssueReportModal::InChallengeCertificationIssueReportFields
         @inChallengeCategory={{this.inChallengeCategory}}
         @toggleOnCategory={{this.toggleOnCategory}}
         @maxlength={{500}}
       />`);
-    await click('[aria-label="Sélectionner la sous-catégorie"]');
-
-    //
-    assert.contains(
-      `${subcategoryToCode[certificationIssueReportSubcategories.FILE_NOT_OPENING]} ${
-        subcategoryToLabel[certificationIssueReportSubcategories.FILE_NOT_OPENING]
-      }`
+    await click(screen.getByLabelText('Sélectionnez une sous-catégorie :'));
+    await click(
+      await screen.findByRole('option', {
+        name: `${subcategoryToCode[certificationIssueReportSubcategories.FILE_NOT_OPENING]} ${
+          subcategoryToLabel[certificationIssueReportSubcategories.FILE_NOT_OPENING]
+        }`,
+      })
     );
+
+    // then
+    assert
+      .dom(
+        screen.getByRole('option', {
+          name: `${subcategoryToCode[certificationIssueReportSubcategories.FILE_NOT_OPENING]} ${
+            subcategoryToLabel[certificationIssueReportSubcategories.FILE_NOT_OPENING]
+          }`,
+        })
+      )
+      .exists();
   });
 });

--- a/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
@@ -31,26 +31,25 @@ module('Integration | Component | new-certification-candidate-modal', function (
     this.set('updateCandidateStub', updateCandidateStub);
     this.set('updateCandidateWithEventStub', updateCandidateWithEventStub);
     this.set('countries', []);
-    this.set('candidateData', [
-      {
-        firstName: '',
-        lastName: '',
-        birthdate: '',
-        birthCity: '',
-        birthCountry: '',
-        email: '',
-        externalId: '',
-        resultRecipientEmail: '',
-        birthPostalCode: '',
-        birthInseeCode: '',
-        sex: '',
-        extraTimePercentage: '',
-      },
-    ]);
+    this.set('candidateData', {
+      firstName: '',
+      lastName: '',
+      birthdate: '',
+      birthCity: '',
+      birthCountry: '',
+      email: '',
+      externalId: '',
+      resultRecipientEmail: '',
+      birthPostalCode: '',
+      birthInseeCode: '',
+      sex: '',
+      extraTimePercentage: '',
+    });
 
     // when
     const screen = await renderScreen(hbs`
       <NewCertificationCandidateModal
+        @showModal={{true}}
         @closeModal={{this.closeModal}}
         @countries={{this.countries}}
         @updateCandidateData={{this.updateCandidateStub}}
@@ -92,39 +91,41 @@ module('Integration | Component | new-certification-candidate-modal', function (
       const closeModalStub = sinon.stub();
       const updateCandidateStub = sinon.stub();
       const updateCandidateWithEventStub = sinon.stub();
+      const updateCandidateFromValueStub = sinon.stub();
+      this.set('updateCandidateFromValueStub', updateCandidateFromValueStub);
       this.set('shouldDisplayPaymentOptions', shouldDisplayPaymentOptions);
       this.set('closeModal', closeModalStub);
       this.set('updateCandidateStub', updateCandidateStub);
       this.set('updateCandidateWithEventStub', updateCandidateWithEventStub);
       this.set('countries', []);
-      this.set('candidateData', [
-        {
-          firstName: '',
-          lastName: '',
-          birthdate: '',
-          birthCity: '',
-          birthCountry: '',
-          email: '',
-          externalId: '',
-          resultRecipientEmail: '',
-          birthPostalCode: '',
-          birthInseeCode: '',
-          sex: '',
-          extraTimePercentage: '',
-          billingMode: '',
-          prepaymentCode: '',
-        },
-      ]);
+      this.set('candidateData', {
+        firstName: '',
+        lastName: '',
+        birthdate: '',
+        birthCity: '',
+        birthCountry: '',
+        email: '',
+        externalId: '',
+        resultRecipientEmail: '',
+        birthPostalCode: '',
+        birthInseeCode: '',
+        sex: '',
+        extraTimePercentage: '',
+        billingMode: '',
+        prepaymentCode: '',
+      });
 
       // when
       const screen = await renderScreen(hbs`
         <NewCertificationCandidateModal
+          @showModal={{true}}
           @closeModal={{this.closeModal}}
           @countries={{this.countries}}
           @updateCandidateData={{this.updateCandidateStub}}
           @updateCandidateDataWithEvent={{this.updateCandidateStub}}
           @candidateData={{this.candidateData}}
           @shouldDisplayPaymentOptions={{this.shouldDisplayPaymentOptions}}
+          @updateCandidateDataFromValue={{this.updateCandidateFromValueStub}}
         />
       `);
 
@@ -166,22 +167,20 @@ module('Integration | Component | new-certification-candidate-modal', function (
     this.set('closeModal', closeModalStub);
     this.set('updateCandidateStub', updateCandidateStub);
     this.set('updateCandidateWithEventStub', updateCandidateWithEventStub);
-    this.set('candidateData', [
-      {
-        firstName: '',
-        lastName: '',
-        birthdate: '',
-        birthCity: '',
-        birthCountry: '',
-        email: '',
-        externalId: '',
-        resultRecipientEmail: '',
-        birthPostalCode: '',
-        birthInseeCode: '',
-        sex: '',
-        extraTimePercentage: '',
-      },
-    ]);
+    this.set('candidateData', {
+      firstName: '',
+      lastName: '',
+      birthdate: '',
+      birthCity: '',
+      birthCountry: '',
+      email: '',
+      externalId: '',
+      resultRecipientEmail: '',
+      birthPostalCode: '',
+      birthInseeCode: '',
+      sex: '',
+      extraTimePercentage: '',
+    });
     this.set('countries', [
       { id: 1, code: '99123', name: 'Syldavie' },
       { id: 2, code: '99100', name: 'France' },
@@ -191,6 +190,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
     // when
     const screen = await renderScreen(hbs`
       <NewCertificationCandidateModal
+        @showModal={{true}}
         @closeModal={{this.closeModal}}
         @countries={{this.countries}}
         @updateCandidateData={{this.updateCandidateStub}}
@@ -200,10 +200,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
     `);
 
     // then
-    const birthCountryField = screen.getByLabelText('* Pays de naissance');
-    assert.dom(birthCountryField).includesText('Syldavie');
-    assert.dom(birthCountryField).includesText('Botswana');
-    assert.dom(birthCountryField).hasValue('99100');
+    assert.dom(screen.getByRole('button', { name: '* Pays de naissance' })).includesText('France');
   });
 
   module('when close button cross icon is clicked', () => {
@@ -321,6 +318,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
       // when
       const screen = await renderScreen(hbs`
         <NewCertificationCandidateModal
+          @showModal={{true}}
           @closeModal={{this.closeModal}}
           @countries={{this.countries}}
           @updateCandidateData={{this.updateCandidateFromEventStub}}
@@ -329,7 +327,12 @@ module('Integration | Component | new-certification-candidate-modal', function (
         />
       `);
 
-      await fillIn(screen.getByLabelText('* Pays de naissance'), '99123');
+      await click(screen.getByLabelText('* Pays de naissance'));
+      await click(
+        await screen.findByRole('option', {
+          name: 'Borduristan',
+        })
+      );
 
       // then
       assert.dom(screen.queryByLabelText('* Code INSEE de naissance')).isNotVisible();
@@ -471,7 +474,12 @@ module('Integration | Component | new-certification-candidate-modal', function (
       await fillIn(screen.getByLabelText('* Nom de famille'), 'Threepwood');
       await fillIn(screen.getByLabelText('* Date de naissance'), '28/04/2019');
       await click(screen.getByRole('radio', { name: 'Homme' }));
-      await fillIn(screen.getByLabelText('* Pays de naissance'), 99100);
+      await click(screen.getByLabelText('* Pays de naissance'));
+      await click(
+        await screen.findByRole('option', {
+          name: 'FRANCE',
+        })
+      );
       await click(screen.getByRole('radio', { name: 'Code INSEE' }));
       await click(screen.getByRole('radio', { name: 'Certif complémentaire 1' }));
       await fillIn(screen.getByLabelText('Identifiant externe'), '44AA3355');

--- a/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
-import { click, render, find, fillIn } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 import { certificationIssueReportCategories } from 'pix-certif/models/certification-issue-report';
@@ -111,15 +111,19 @@ module('Integration | Component | SessionFinalization::UncompletedReportsInforma
     this.set('abort', abortStub);
 
     // when
-    await render(hbs`
+    const screen = await renderScreen(hbs`
         <SessionFinalization::UncompletedReportsInformationStep
           @certificationReports={{this.certificationReports}}
           @onChangeAbortReason = {{this.abort}}
         />
       `);
 
-    const select = await find(`#finalization-report-abort-reason__select${certificationReport.id}`);
-    await fillIn(select, 'technical');
+    await click(screen.getByRole('button', { name: '-- Choisissez --' }));
+    await click(
+      await screen.findByRole('option', {
+        name: 'Problème technique',
+      })
+    );
 
     // then
     sinon.assert.called(abortStub);

--- a/certif/tests/unit/components/new-certification-candidate-modal_test.js
+++ b/certif/tests/unit/components/new-certification-candidate-modal_test.js
@@ -124,8 +124,8 @@ module('Unit | Component | new-certification-candidate-modal', function (hooks) 
         modal.args.updateCandidateDataFromValue = sinon.stub();
 
         // when
-        const event = { target: { value: '99127' } };
-        await modal.selectBirthCountry(event);
+        const optionSelected = '99127';
+        await modal.selectBirthCountry(optionSelected);
 
         // then
         sinon.assert.calledWith(

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize_test.js
@@ -281,14 +281,10 @@ module('Unit | Controller | ' + FINALIZE_PATH, function (hooks) {
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
       certificationReport.abort = sinon.stub();
       certificationReport.abort.resolves('ok');
-      const event = {
-        target: {
-          value: 'coucou',
-        },
-      };
+      const optionSelected = 'coucou';
 
       // when
-      controller.abort(certificationReport, event);
+      controller.abort(certificationReport, optionSelected);
 
       // then
       sinon.assert.calledWithExactly(certificationReport.abort, 'coucou');

--- a/certif/tests/unit/controllers/team_test.js
+++ b/certif/tests/unit/controllers/team_test.js
@@ -180,15 +180,11 @@ module('Unit | Controller | authenticated/team', function (hooks) {
   module('#onSelectReferer', function () {
     test('should select the id of a selected member', function (assert) {
       // given
-      const event = {
-        target: {
-          value: 102,
-        },
-      };
+      const optionSelected = 102;
       const controller = this.owner.lookup('controller:authenticated/team');
 
       // when
-      controller.onSelectReferer(event);
+      controller.onSelectReferer(optionSelected);
 
       // then
       assert.strictEqual(controller.selectedReferer, 102);

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -218,7 +218,8 @@
         "select-referer-button": "Désigner un référent"
       },
       "select-referer-modal": {
-        "title": "Sélectionner le référent Pix",
+        "title": "Sélection du référent Pix",
+        "label": "Sélectionner un référent Pix",
         "empty-option": "--Sélectionner--",
         "cancel": "Annuler",
         "validate": "Valider",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -218,7 +218,8 @@
         "select-referer-button": "Désigner un référent"
       },
       "select-referer-modal" : {
-        "title": "Sélectionner le référent Pix",
+        "title": "Sélection du référent Pix",
+        "label": "Sélectionner le référent Pix",
         "empty-option": "--Sélectionner--",
         "cancel": "Annuler",
         "validate": "Valider",


### PR DESCRIPTION
## :christmas_tree: Problème
L'app Certif a plusieurs version de retard sur Pix UI

## :gift: Proposition
Faire la monté de version étape par étape

## :star2: Remarques
- ~~ajout de la classe temporaire `fix-select-text-too-long` pour gérer le texte trop long dans le select de la page finalize, voir si une correction est apportée dans les versions suivantes.~~
- ajout de l'overflow: visible et de max-width: 100% sur la modale add-issue-report pour afficher entièrement le select

## :santa: Pour tester
Pix Select:

 - [x] Tester la modale d'ajout d'un candidat et vérifier que la sélection des données sur le pays et la méthode de paiement est toujours OK
 - [x] Tester lors de la finalisation, dans le choix de la raison d'abandon, lorsqu'un candidat n'a pas fini sa certif, que la sélection se fait bien
 - [x] Tester la sélection d'un référent
 - [x] Tester l'ajout d'un signalement de type E1-E12

Alignement des bouttons sur les modales:

- [x] suppression de session
- [x] Ajout de candidat
- [x] Edition de candidat
- [x] Add issue report (finalisation)
- [x] Modification issue report (finalisation)
- [x] Choix du referer
- [ ] Modale de confirmation de la supervision
- [x] Check margin/padding des titres et paragraphes (H + P)