### PR TITLE
[FEATURE] Garantir qu'on ne compte pas un acquis plusieurs fois dans le score Pix direct (PIX-6744)

### DIFF
--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -167,7 +167,16 @@ function _findChallengeForAnswer(challenges, answer) {
 }
 
 function _sumSkillsChallengesPixScore(challenges) {
-  return challenges.reduce((sum, challenge) => sum + challenge.skill.pixValue, 0);
+  const scoreBySkillId = challenges.reduce((acc, challenge) => {
+    if (acc[challenge.skill.id]) return acc;
+
+    return {
+      ...acc,
+      [challenge.skill.id]: challenge.skill.pixValue,
+    };
+  }, {});
+
+  return Object.values(scoreBySkillId).reduce((sum, pixValue) => sum + pixValue, 0);
 }
 
 function _getReward({ estimatedLevel, discriminant, difficulty }) {

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -919,6 +919,41 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         // then
         expect(result).to.equal(110011);
       });
+
+      it('should not count a skill more than once in direct score', function () {
+        // given
+        const skill = domainBuilder.buildSkill({ id: 'FirstSkill', pixValue: 1 });
+
+        const successProbabilityThreshold = 0.95;
+
+        const challenges = [
+          domainBuilder.buildChallenge({
+            id: 'First',
+            skill,
+            discriminant: 0.16,
+            difficulty: -2,
+            successProbabilityThreshold,
+          }),
+          domainBuilder.buildChallenge({
+            id: 'Second',
+            skill,
+            discriminant: 3,
+            difficulty: 6,
+            successProbabilityThreshold,
+          }),
+        ];
+
+        const allAnswers = [
+          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
+          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id }),
+        ];
+
+        // when
+        const result = flash.calculateTotalPixScore({ allAnswers, challenges });
+
+        // then
+        expect(result).to.equal(1);
+      });
     });
   });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Dans le calcul du score Pix direct (nouvel algo), on ne vérifie pas si l'utilisateur a répondu à plusieurs questions sur le même acquis, un acquis pourrait donc être compter plusieurs fois.

## :gift: Proposition
Vérifier qu'on ne compte pas un acquis plusieurs fois.

## :star2: Remarques
Bonus : L'ajout de la structure intermédiaire `scoreBySkillId` dans `_sumSkillsChallengesPixScore()` sera utile par la suite pour le calcul du score par compétence.

## :santa: Pour tester
Pas de test utilisateur possible car normalement un utilisateur n'est pas interrogé plus d'une fois sur le même acquis quel que soit l'algo utilisé.