### PR TITLE
[FEATURE] Améliorer la validation de données pour la route de création des contenus formatifs (PIX-6753)

### DIFF
--- a/api/lib/application/trainings/index.js
+++ b/api/lib/application/trainings/index.js
@@ -56,13 +56,13 @@ exports.register = async (server) => {
           payload: Joi.object({
             data: Joi.object({
               attributes: Joi.object({
-                link: Joi.string().required(),
+                link: Joi.string().uri().required(),
                 title: Joi.string().required(),
                 duration: Joi.string().required(),
                 type: Joi.string().valid('autoformation', 'webinaire').required(),
                 locale: Joi.string().valid('fr-fr', 'fr', 'en-gb').required(),
                 'editor-name': Joi.string().required(),
-                'editor-logo-url': Joi.string().required(),
+                'editor-logo-url': Joi.string().uri().required(),
               }),
               type: Joi.string().valid('trainings'),
             }).required(),

--- a/api/tests/unit/application/trainings/index_test.js
+++ b/api/tests/unit/application/trainings/index_test.js
@@ -105,6 +105,81 @@ describe('Unit | Router | training-router', function () {
       expect(response.statusCode).to.equal(201);
     });
 
+    it('should return 400 if the editorLogoUrl is not a valid url', async function () {
+      // given
+      const invalidPayload = {
+        data: {
+          attributes: {
+            link: 'http://www.example.net',
+            title: 'ma formation',
+            duration: '6h',
+            type: 'webinaire',
+            locale: 'fr-fr',
+            'editor-name': 'ministère',
+            'editor-logo-url': 'image.svg',
+          },
+        },
+      };
+      sinon.stub(trainingController, 'create').callsFake((request, h) => h.response().created());
+
+      sinon
+        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
+
+      // then
+      expect(JSON.parse(response.payload).errors[0].detail).to.equal(
+        '"data.attributes.editor-logo-url" must be a valid uri'
+      );
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return 400 if the link is not a valid url', async function () {
+      // given
+      const invalidPayload = {
+        data: {
+          attributes: {
+            link: 'example',
+            title: 'ma formation',
+            duration: '6h',
+            type: 'webinaire',
+            locale: 'fr-fr',
+            'editor-name': 'ministère',
+            'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+          },
+        },
+      };
+      sinon.stub(trainingController, 'create').callsFake((request, h) => h.response().created());
+
+      sinon
+        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon
+        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
+
+      // then
+
+      expect(JSON.parse(response.payload).errors[0].detail).to.equal('"data.attributes.link" must be a valid uri');
+      expect(response.statusCode).to.equal(400);
+    });
+
     it('should return 400 if in the payload there is no link', async function () {
       // given
       const invalidPayload = {

--- a/api/tests/unit/application/trainings/index_test.js
+++ b/api/tests/unit/application/trainings/index_test.js
@@ -114,8 +114,8 @@ describe('Unit | Router | training-router', function () {
             duration: '6h',
             type: 'webinaire',
             locale: 'fr-fr',
-            editorName: 'ministère',
-            editorLogoUrl: 'http://www.image.pix.fr/image.svg',
+            'editor-name': 'ministère',
+            'editor-logo-url': 'http://www.image.pix.fr/image.svg',
           },
         },
       };
@@ -148,8 +148,8 @@ describe('Unit | Router | training-router', function () {
             duration: '6h',
             type: 'webinaire',
             locale: 'fr-fr',
-            editorName: 'ministère',
-            editorLogoUrl: 'http://www.image.pix.fr/image.svg',
+            'editor-name': 'ministère',
+            'editor-logo-url': 'http://www.image.pix.fr/image.svg',
           },
         },
       };
@@ -182,8 +182,8 @@ describe('Unit | Router | training-router', function () {
             link: 'http://www.example.net',
             type: 'webinaire',
             locale: 'fr-fr',
-            editorName: 'ministère',
-            editorLogoUrl: 'http://www.image.pix.fr/image.svg',
+            'editor-name': 'ministère',
+            'editor-logo-url': 'http://www.image.pix.fr/image.svg',
           },
         },
       };
@@ -216,8 +216,8 @@ describe('Unit | Router | training-router', function () {
             link: 'http://www.example.net',
             duration: '6h',
             locale: 'fr-fr',
-            editorName: 'ministère',
-            editorLogoUrl: 'http://www.image.pix.fr/image.svg',
+            'editor-name': 'ministère',
+            'editor-logo-url': 'http://www.image.pix.fr/image.svg',
           },
         },
       };
@@ -250,8 +250,8 @@ describe('Unit | Router | training-router', function () {
             link: 'http://www.example.net',
             duration: '6h',
             type: 'webinaire',
-            editorName: 'ministère',
-            editorLogoUrl: 'http://www.image.pix.fr/image.svg',
+            'editor-name': 'ministère',
+            'editor-logo-url': 'http://www.image.pix.fr/image.svg',
           },
         },
       };
@@ -275,7 +275,7 @@ describe('Unit | Router | training-router', function () {
       expect(response.statusCode).to.equal(400);
     });
 
-    it('should return 400 if in the payload there is no editorName', async function () {
+    it('should return 400 if in the payload there is no editor-name', async function () {
       // given
       const invalidPayload = {
         data: {
@@ -285,7 +285,7 @@ describe('Unit | Router | training-router', function () {
             duration: '6h',
             type: 'webinaire',
             locale: 'fr-fr',
-            editorLogoUrl: 'http://www.image.pix.fr/image.svg',
+            'editor-logo-url': 'http://www.image.pix.fr/image.svg',
           },
         },
       };
@@ -309,7 +309,7 @@ describe('Unit | Router | training-router', function () {
       expect(response.statusCode).to.equal(400);
     });
 
-    it('should return 400 if in the payload there is no editorLogoUrl', async function () {
+    it('should return 400 if in the payload there is no editor-logo-url', async function () {
       // given
       const invalidPayload = {
         data: {
@@ -319,7 +319,7 @@ describe('Unit | Router | training-router', function () {
             duration: '6h',
             type: 'webinaire',
             locale: 'fr-fr',
-            editorName: 'ministère',
+            'editor-name': 'ministère',
           },
         },
       };

--- a/api/tests/unit/application/trainings/index_test.js
+++ b/api/tests/unit/application/trainings/index_test.js
@@ -20,402 +20,408 @@ describe('Unit | Router | training-router', function () {
       },
     };
 
-    it('should allow user if its role is SUPER_ADMIN', async function () {
-      // given
-      sinon.stub(trainingController, 'create').returns('ok');
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin').callsFake((request, h) => h.response(true));
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
+    describe('Security Prehandlers', function () {
+      it('should allow user if its role is SUPER_ADMIN', async function () {
+        // given
+        sinon.stub(trainingController, 'create').returns('ok');
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response(true));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
-      // when
-      await httpTestServer.request('POST', '/api/admin/trainings', validPayload);
+        // when
+        await httpTestServer.request('POST', '/api/admin/trainings', validPayload);
 
-      // then
-      sinon.assert.calledOnce(trainingController.create);
+        // then
+        sinon.assert.calledOnce(trainingController.create);
+      });
+
+      it('should allow user if the role is METIER', async function () {
+        // given
+        sinon.stub(trainingController, 'create').returns('ok');
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        await httpTestServer.request('POST', '/api/admin/trainings', validPayload);
+
+        // then
+        sinon.assert.calledOnce(trainingController.create);
+      });
+
+      it('should return 403 it if the role is not allowed', async function () {
+        // given
+        sinon.stub(trainingController, 'create').returns('ok');
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/trainings', validPayload);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+        sinon.assert.notCalled(trainingController.create);
+      });
     });
 
-    it('should allow user if the role is METIER', async function () {
-      // given
-      sinon.stub(trainingController, 'create').returns('ok');
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
+    describe('Data validation', function () {
+      it('should return 201 if the payload is valid', async function () {
+        // given
+        sinon.stub(trainingController, 'create').callsFake((request, h) => h.response().created());
 
-      // when
-      await httpTestServer.request('POST', '/api/admin/trainings', validPayload);
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
 
-      // then
-      sinon.assert.calledOnce(trainingController.create);
-    });
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
-    it('should return 403 it if the role is not allowed', async function () {
-      // given
-      sinon.stub(trainingController, 'create').returns('ok');
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/trainings', validPayload);
 
-      // when
-      const response = await httpTestServer.request('POST', '/api/admin/trainings', validPayload);
+        // then
+        expect(response.statusCode).to.equal(201);
+      });
 
-      // then
-      expect(response.statusCode).to.equal(403);
-      sinon.assert.notCalled(trainingController.create);
-    });
-
-    it('should return 201 if the payload is valid', async function () {
-      // given
-      sinon.stub(trainingController, 'create').callsFake((request, h) => h.response().created());
-
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
-
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('POST', '/api/admin/trainings', validPayload);
-
-      // then
-      expect(response.statusCode).to.equal(201);
-    });
-
-    it('should return 400 if the editorLogoUrl is not a valid url', async function () {
-      // given
-      const invalidPayload = {
-        data: {
-          attributes: {
-            link: 'http://www.example.net',
-            title: 'ma formation',
-            duration: '6h',
-            type: 'webinaire',
-            locale: 'fr-fr',
-            'editor-name': 'ministère',
-            'editor-logo-url': 'image.svg',
+      it('should return 400 if the editorLogoUrl is not a valid url', async function () {
+        // given
+        const invalidPayload = {
+          data: {
+            attributes: {
+              link: 'http://www.example.net',
+              title: 'ma formation',
+              duration: '6h',
+              type: 'webinaire',
+              locale: 'fr-fr',
+              'editor-name': 'ministère',
+              'editor-logo-url': 'image.svg',
+            },
           },
-        },
-      };
-      sinon.stub(trainingController, 'create').callsFake((request, h) => h.response().created());
+        };
+        sinon.stub(trainingController, 'create').callsFake((request, h) => h.response().created());
 
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
 
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
-      // when
-      const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
 
-      // then
-      expect(JSON.parse(response.payload).errors[0].detail).to.equal(
-        '"data.attributes.editor-logo-url" must be a valid uri'
-      );
-      expect(response.statusCode).to.equal(400);
-    });
+        // then
+        expect(JSON.parse(response.payload).errors[0].detail).to.equal(
+          '"data.attributes.editor-logo-url" must be a valid uri'
+        );
+        expect(response.statusCode).to.equal(400);
+      });
 
-    it('should return 400 if the link is not a valid url', async function () {
-      // given
-      const invalidPayload = {
-        data: {
-          attributes: {
-            link: 'example',
-            title: 'ma formation',
-            duration: '6h',
-            type: 'webinaire',
-            locale: 'fr-fr',
-            'editor-name': 'ministère',
-            'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+      it('should return 400 if the link is not a valid url', async function () {
+        // given
+        const invalidPayload = {
+          data: {
+            attributes: {
+              link: 'example',
+              title: 'ma formation',
+              duration: '6h',
+              type: 'webinaire',
+              locale: 'fr-fr',
+              'editor-name': 'ministère',
+              'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+            },
           },
-        },
-      };
-      sinon.stub(trainingController, 'create').callsFake((request, h) => h.response().created());
+        };
+        sinon.stub(trainingController, 'create').callsFake((request, h) => h.response().created());
 
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
 
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
-      // when
-      const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
 
-      // then
+        // then
 
-      expect(JSON.parse(response.payload).errors[0].detail).to.equal('"data.attributes.link" must be a valid uri');
-      expect(response.statusCode).to.equal(400);
-    });
+        expect(JSON.parse(response.payload).errors[0].detail).to.equal('"data.attributes.link" must be a valid uri');
+        expect(response.statusCode).to.equal(400);
+      });
 
-    it('should return 400 if in the payload there is no link', async function () {
-      // given
-      const invalidPayload = {
-        data: {
-          attributes: {
-            title: 'ma formation',
-            duration: '6h',
-            type: 'webinaire',
-            locale: 'fr-fr',
-            'editor-name': 'ministère',
-            'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+      it('should return 400 if in the payload there is no link', async function () {
+        // given
+        const invalidPayload = {
+          data: {
+            attributes: {
+              title: 'ma formation',
+              duration: '6h',
+              type: 'webinaire',
+              locale: 'fr-fr',
+              'editor-name': 'ministère',
+              'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+            },
           },
-        },
-      };
-      sinon.stub(trainingController, 'create').returns('ok');
+        };
+        sinon.stub(trainingController, 'create').returns('ok');
 
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
 
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
-      // when
-      const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
 
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
 
-    it('should return 400 if in the payload there is no title', async function () {
-      // given
-      const invalidPayload = {
-        data: {
-          attributes: {
-            link: 'http://www.example.net',
-            duration: '6h',
-            type: 'webinaire',
-            locale: 'fr-fr',
-            'editor-name': 'ministère',
-            'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+      it('should return 400 if in the payload there is no title', async function () {
+        // given
+        const invalidPayload = {
+          data: {
+            attributes: {
+              link: 'http://www.example.net',
+              duration: '6h',
+              type: 'webinaire',
+              locale: 'fr-fr',
+              'editor-name': 'ministère',
+              'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+            },
           },
-        },
-      };
-      sinon.stub(trainingController, 'create').returns('ok');
+        };
+        sinon.stub(trainingController, 'create').returns('ok');
 
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
 
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
-      // when
-      const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
 
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
 
-    it('should return 400 if in the payload there is no duration', async function () {
-      // given
-      const invalidPayload = {
-        data: {
-          attributes: {
-            title: 'ma formation',
-            link: 'http://www.example.net',
-            type: 'webinaire',
-            locale: 'fr-fr',
-            'editor-name': 'ministère',
-            'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+      it('should return 400 if in the payload there is no duration', async function () {
+        // given
+        const invalidPayload = {
+          data: {
+            attributes: {
+              title: 'ma formation',
+              link: 'http://www.example.net',
+              type: 'webinaire',
+              locale: 'fr-fr',
+              'editor-name': 'ministère',
+              'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+            },
           },
-        },
-      };
-      sinon.stub(trainingController, 'create').returns('ok');
+        };
+        sinon.stub(trainingController, 'create').returns('ok');
 
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
 
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
-      // when
-      const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
 
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
 
-    it('should return 400 if in the payload there is no type', async function () {
-      // given
-      const invalidPayload = {
-        data: {
-          attributes: {
-            title: 'ma formation',
-            link: 'http://www.example.net',
-            duration: '6h',
-            locale: 'fr-fr',
-            'editor-name': 'ministère',
-            'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+      it('should return 400 if in the payload there is no type', async function () {
+        // given
+        const invalidPayload = {
+          data: {
+            attributes: {
+              title: 'ma formation',
+              link: 'http://www.example.net',
+              duration: '6h',
+              locale: 'fr-fr',
+              'editor-name': 'ministère',
+              'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+            },
           },
-        },
-      };
-      sinon.stub(trainingController, 'create').returns('ok');
+        };
+        sinon.stub(trainingController, 'create').returns('ok');
 
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
 
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
-      // when
-      const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
 
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
 
-    it('should return 400 if in the payload there is no locale', async function () {
-      // given
-      const invalidPayload = {
-        data: {
-          attributes: {
-            title: 'ma formation',
-            link: 'http://www.example.net',
-            duration: '6h',
-            type: 'webinaire',
-            'editor-name': 'ministère',
-            'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+      it('should return 400 if in the payload there is no locale', async function () {
+        // given
+        const invalidPayload = {
+          data: {
+            attributes: {
+              title: 'ma formation',
+              link: 'http://www.example.net',
+              duration: '6h',
+              type: 'webinaire',
+              'editor-name': 'ministère',
+              'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+            },
           },
-        },
-      };
-      sinon.stub(trainingController, 'create').returns('ok');
+        };
+        sinon.stub(trainingController, 'create').returns('ok');
 
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
 
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
-      // when
-      const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
 
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
 
-    it('should return 400 if in the payload there is no editor-name', async function () {
-      // given
-      const invalidPayload = {
-        data: {
-          attributes: {
-            title: 'ma formation',
-            link: 'http://www.example.net',
-            duration: '6h',
-            type: 'webinaire',
-            locale: 'fr-fr',
-            'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+      it('should return 400 if in the payload there is no editor-name', async function () {
+        // given
+        const invalidPayload = {
+          data: {
+            attributes: {
+              title: 'ma formation',
+              link: 'http://www.example.net',
+              duration: '6h',
+              type: 'webinaire',
+              locale: 'fr-fr',
+              'editor-logo-url': 'http://www.image.pix.fr/image.svg',
+            },
           },
-        },
-      };
-      sinon.stub(trainingController, 'create').returns('ok');
+        };
+        sinon.stub(trainingController, 'create').returns('ok');
 
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
 
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
-      // when
-      const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
 
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
 
-    it('should return 400 if in the payload there is no editor-logo-url', async function () {
-      // given
-      const invalidPayload = {
-        data: {
-          attributes: {
-            title: 'ma formation',
-            link: 'http://www.example.net',
-            duration: '6h',
-            type: 'webinaire',
-            locale: 'fr-fr',
-            'editor-name': 'ministère',
+      it('should return 400 if in the payload there is no editor-logo-url', async function () {
+        // given
+        const invalidPayload = {
+          data: {
+            attributes: {
+              title: 'ma formation',
+              link: 'http://www.example.net',
+              duration: '6h',
+              type: 'webinaire',
+              locale: 'fr-fr',
+              'editor-name': 'ministère',
+            },
           },
-        },
-      };
-      sinon.stub(trainingController, 'create').returns('ok');
+        };
+        sinon.stub(trainingController, 'create').returns('ok');
 
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon
-        .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-        .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-      sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon
+          .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+          .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+        sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleMetier').callsFake((request, h) => h.response(true));
 
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
 
-      // when
-      const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
+        // when
+        const response = await httpTestServer.request('POST', '/api/admin/trainings', invalidPayload);
 
-      // then
-      expect(response.statusCode).to.equal(400);
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
     });
   });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, il y a possibilité de créér des liens de contenu formatif ou bien des url de logo d'éditeurs sur la route POST api/admin/trainings sans qu'ils ne soient des URIs valides.

## :gift: Proposition
Renforcer la validation Joi en utilisant la méthode Joi.string().uri() pour chaque attribut.

## 🌟 Remarques
Le nombre de changements qui semble important est du à un redécoupage des tests dans différents contextes

## :santa: Pour tester
- Aller sur pix admin
- Tenter de créer un contenu formatif ayant un Lien qui n'est pas une Uri valide.
- Constater qu'une erreur est levée.
- Tenter de créer un contenu formatif ayant un Lien qui est une Uri valide.
- Constater que le contenu formatif est bien créé.
- Tenter de créer un contenu formatif ayant un lien de logo éditeur qui n'est pas une Uri valide.
- Constater qu'une erreur est levée.
- Tenter de créer un contenu formatif ayant un lien de logo éditeur qui est une Uri valide.
- Constater que le contenu formatif est bien créé.

