### PR TITLE
[TECH] Rendre les PixSelect QROCM compatibles avec l'auto-answer (PIX-6774)

### DIFF
--- a/mon-pix/app/components/qrocm-proposal.hbs
+++ b/mon-pix/app/components/qrocm-proposal.hbs
@@ -18,6 +18,7 @@
           @options={{block.options}}
           @onChange={{fn this.onChange block.input}}
           @size="big"
+          @id="{{block.input}}"
         />
       </div>
     {{else if (eq block.type "input")}}


### PR DESCRIPTION
## :christmas_tree: Problème
Les PixSelect des QROCM n’ont pas d’identifiant, ce qui les rend très difficiles à remplir avec l’auto-answer.

## :gift: Proposition
Leur ajouter un identifiant au même titre que les autres sortes de champs.

## :star2: Remarques
N/A

## :santa: Pour tester
Ouvrir un challenge QROCM et vérifier via la console du navigateur que l'identifiant présent sur l'élément `<button>` du PixSelect est correct : https://app-pr5477.review.pix.fr/challenges/rechUXZhn1FiLU28x/preview