### PR TITLE
[TECH] Prévenir les messages incorrectement traduits dans l'API

### DIFF
--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -31,7 +31,6 @@ rules:
     - selector: "CallExpression[callee.object.object.name='faker'][callee.object.property.name='internet'][callee.property.name='email']"
       message: Use only faker.internet.exampleEmail()
   knex/avoid-injections: error
-  i18n-json/valid-message-syntax: off
   # Set all recommended rules as blocking for CI
   mocha/no-exclusive-tests: error
   mocha/no-pending-tests: error

--- a/api/tests/tooling/i18n/i18n.js
+++ b/api/tests/tooling/i18n/i18n.js
@@ -9,6 +9,10 @@ function getI18n() {
     directory,
     objectNotation: true,
     updateFiles: false,
+    mustacheConfig: {
+      tags: ['{', '}'],
+      disable: false,
+    },
   });
   return i18n;
 }

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -2,18 +2,18 @@
   "campaign-export": {
     "assessment": {
       "competence-area": {
-        "items-successfully-completed": "Items of the target profile successfully completed in the competence area {{name}}",
-        "mastery-percentage": "% of items successfully completed in the competence area {{name}}",
-        "total-items": "Number of items of the target profile in the competence area {{name}}"
+        "items-successfully-completed": "Items of the target profile successfully completed in the competence area {name}",
+        "mastery-percentage": "% of items successfully completed in the competence area {name}",
+        "total-items": "Number of items of the target profile in the competence area {name}"
       },
       "is-shared": "Shared (Y/N)",
       "mastery-percentage-target-profile": "% of items successfully completed in the target profile",
       "progress": "% of progression",
       "shared-on": "Shared on",
       "skill": {
-        "items-successfully-completed": "Items of the target profile successfully completed in the competence {{name}}",
-        "mastery-percentage": "% of items successfully completed in the competence {{name}}",
-        "total-items": "Number of items of the target profile in the competence {{name}}"
+        "items-successfully-completed": "Items of the target profile successfully completed in the competence {name}",
+        "mastery-percentage": "% of items successfully completed in the competence {name}",
+        "total-items": "Number of items of the target profile in the competence {name}"
       },
       "started-on": "Started on",
       "status": {
@@ -21,14 +21,14 @@
         "not-tested": "Not tested",
         "ok": "OK"
       },
-      "success-rate": "Success rate (/{{value}})",
+      "success-rate": "Success rate (/{value})",
       "target-profile-name": "Customised test",
-      "thematic-result-name": "{{name}} (Y/N)"
+      "thematic-result-name": "{name} (Y/N)"
     },
     "common": {
       "campaign-id": "Campaign ID",
       "campaign-name": "Campaign's name",
-      "file-name": "Results-{{name}}-{{id}}-{{date}}.csv",
+      "file-name": "Results-{name}-{id}-{date}.csv",
       "no": "No",
       "not-available": "NA",
       "organization-name": "Organisation’s name",
@@ -45,8 +45,8 @@
       "is-sent": "Sent (Y/N)",
       "pix-score": "Total pix score",
       "sent-on": "Sent on",
-      "skill-level": "Level reached in the competence {{name}}",
-      "skill-ranking": "Pix score for the competence {{name}}"
+      "skill-level": "Level reached in the competence {name}",
+      "skill-ranking": "Pix score for the competence {name}"
     }
   },
   "certification-center-invitation-email": {
@@ -203,6 +203,6 @@
       "signing": "— The Pix Team",
       "warningMessage": "If this wasn’t you, please reset your password as soon as possible in order to secure your account."
     },
-    "subject": "Your Pix code is {{ code }}"
+    "subject": "Your Pix code is { code }"
   }
 }

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -14,18 +14,18 @@
   "campaign-export": {
     "assessment": {
       "competence-area": {
-        "items-successfully-completed": "Acquis maitrisés du domaine {{ name }}",
-        "mastery-percentage": "% de maitrise des acquis du domaine {{ name }}",
-        "total-items": "Nombre d'acquis du profil cible du domaine {{ name }}"
+        "items-successfully-completed": "Acquis maitrisés du domaine { name }",
+        "mastery-percentage": "% de maitrise des acquis du domaine { name }",
+        "total-items": "Nombre d'acquis du profil cible du domaine { name }"
       },
       "is-shared": "Partage (O/N)",
       "mastery-percentage-target-profile": "% maitrise de l'ensemble des acquis du profil",
       "progress": "% de progression",
       "shared-on": "Date du partage",
       "skill": {
-        "items-successfully-completed": "Acquis maitrisés dans la compétence {{name}}",
-        "mastery-percentage": "% de maitrise des acquis de la compétence {{name}}",
-        "total-items": "Nombre d'acquis du profil cible dans la compétence {{name}}"
+        "items-successfully-completed": "Acquis maitrisés dans la compétence {name}",
+        "mastery-percentage": "% de maitrise des acquis de la compétence {name}",
+        "total-items": "Nombre d'acquis du profil cible dans la compétence {name}"
       },
       "started-on": "Date de début",
       "status": {
@@ -33,14 +33,14 @@
         "not-tested": "Non testé",
         "ok": "OK"
       },
-      "success-rate": "Palier obtenu (/{{value}})",
+      "success-rate": "Palier obtenu (/{value})",
       "target-profile-name": "Parcours",
-      "thematic-result-name": "{{name}} obtenu (O/N)"
+      "thematic-result-name": "{name} obtenu (O/N)"
     },
     "common": {
       "campaign-id": "ID Campagne",
       "campaign-name": "Nom de la campagne",
-      "file-name": "Resultats-{{name}}-{{id}}-{{date}}.csv",
+      "file-name": "Resultats-{name}-{id}-{date}.csv",
       "no": "Non",
       "not-available": "NA",
       "organization-name": "Nom de l'organisation",
@@ -57,8 +57,8 @@
       "is-sent": "Envoi (O/N)",
       "pix-score": "Nombre de pix total",
       "sent-on": "Date de l'envoi",
-      "skill-level": "Niveau pour la compétence {{name}}",
-      "skill-ranking": "Nombre de pix pour la compétence {{name}}"
+      "skill-level": "Niveau pour la compétence {name}",
+      "skill-ranking": "Nombre de pix pour la compétence {name}"
     }
   },
   "certification-center-invitation-email": {
@@ -215,6 +215,6 @@
       "signing": "— L'équipe Pix",
       "warningMessage": "Si ce n'était pas vous, nous vous invitons à réinitialiser votre mot de passe au plus vite afin de sécuriser votre compte."
     },
-    "subject": "Votre code Pix est {{ code }}"
+    "subject": "Votre code Pix est { code }"
   }
 }


### PR DESCRIPTION
## :christmas_tree: Problème
Nos messages utilisent la syntaxe moustache `{{ FOO }}`.
La librairie utilise la syntaxe ICU `{ FOO }` : https://icu.unicode.org/
Cela nous empêche d'activer la règle de lint `i18n-json/valid-message-syntax`.

## :gift: Proposition
Passer nos messages en ICU : https://github.com/mashpie/i18n-node#list-of-all-configuration-options
La règle étant inclue dans le set `recommended`, la désactivation est retirée pour l'activer.

## :star2: Remarques
Cette décision est ouverte à remise en cause.

## :santa: Pour tester
Lancer le lint : `npm run lint:translations`.
La traduction elle-même est couverte par les tests.
