### PR TITLE
[BUGFIX][ADMIN] Laisser afficher la mention archivée lors de la mise à jour des tags d'une organisation (PIX-6445)

### DIFF
--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -48,7 +48,7 @@ export default class Organization extends Model {
   }
 
   get isArchived() {
-    return !!this.archivistFullName;
+    return !!this.archivedAt;
   }
 
   get sortedTargetProfileSummaries() {

--- a/admin/tests/acceptance/authenticated/organizations/information-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management_test.js
@@ -40,6 +40,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
       // given
       const organization = this.server.create('organization', {
         name: 'oldOrganizationName',
+        archivedAt: '2022-12-25',
         archivistFullName: 'Clément Tine',
       });
 
@@ -54,6 +55,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
       // given
       const organization = this.server.create('organization', {
         name: 'oldOrganizationName',
+        archivedAt: '2022-12-25',
         archivistFullName: 'Clément Tine',
       });
 
@@ -69,6 +71,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
       // given
       const organization = this.server.create('organization', {
         name: 'oldOrganizationName',
+        archivedAt: '2022-12-25',
         archivistFullName: 'Clément Tine',
       });
 

--- a/admin/tests/unit/models/organization_test.js
+++ b/admin/tests/unit/models/organization_test.js
@@ -37,7 +37,9 @@ module('Unit | Model | organization', function (hooks) {
     test('it return whether organization is archived', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const model = run(() => store.createRecord('organization', { archivistFullName: 'Anne Héantie' }));
+      const model = run(() =>
+        store.createRecord('organization', { archivedAt: '2022-12-25', archivistFullName: 'Anne Héantie' })
+      );
 
       // when
       const isOrganizationArchived = model.isArchived;

--- a/api/lib/infrastructure/repositories/organization-for-admin-repository.js
+++ b/api/lib/infrastructure/repositories/organization-for-admin-repository.js
@@ -119,8 +119,18 @@ module.exports = {
       .select(['tags.id', 'tags.name'])
       .join('organization-tags', 'organization-tags.tagId', 'tags.id')
       .where('organization-tags.organizationId', organizationDB.id);
+    const archivist = await knex('users')
+      .select(['users.firstName', 'users.lastName'])
+      .join('organizations', 'organizations.archivedBy', 'users.id')
+      .where('organizations.id', organizationDB.id)
+      .first();
 
     const tags = tagsDB.map((tagDB) => new Tag(tagDB));
+
+    if (archivist) {
+      organizationDB.archivistFirstName = archivist.firstName;
+      organizationDB.archivistLastName = archivist.lastName;
+    }
 
     return _toDomain({ ...organizationDB, tags });
   },

--- a/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
@@ -196,10 +196,12 @@ describe('Integration | Repository | Organization-for-admin', function () {
   describe('#update', function () {
     it('should return an OrganizationForAdmin domain object with related tags', async function () {
       // given
-      const userId = databaseBuilder.factory.buildUser().id;
+      const userId = databaseBuilder.factory.buildUser({ firstName: 'Anne', lastName: 'Héantie' }).id;
       const organization = databaseBuilder.factory.buildOrganization({
         name: 'super orga',
         createdBy: userId,
+        archivedBy: userId,
+        archivedAt: now,
       });
       const tagId = databaseBuilder.factory.buildTag({ name: 'orga tag' }).id;
       databaseBuilder.factory.buildTag({ name: 'other tag' }).id;
@@ -217,7 +219,6 @@ describe('Integration | Repository | Organization-for-admin', function () {
         credit: 50,
         email: 'email@example.net',
         documentationUrl: 'https://pix.fr/',
-        archivedAt: null,
         identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
       });
       const organizationSaved = await organizationForAdminRepository.update(organizationToUpdate);
@@ -238,11 +239,11 @@ describe('Integration | Repository | Organization-for-admin', function () {
         formNPSUrl: null,
         showNPS: false,
         showSkills: false,
-        archivedAt: null,
+        archivedAt: now,
         createdBy: userId,
         createdAt: organization.createdAt,
-        archivistFirstName: undefined,
-        archivistLastName: undefined,
+        archivistFirstName: 'Anne',
+        archivistLastName: 'Héantie',
         dataProtectionOfficerFirstName: undefined,
         dataProtectionOfficerLastName: undefined,
         dataProtectionOfficerEmail: undefined,


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement, quand une organisation est archivée et que l'on on modifie les tags, le bandeau d'archivage disparait. Ceci est dû au fonctionnement d'Ember, car l'appel API qui met à jour les tags renvoie null pour l'attribut `archivistFullName` (ce qui à pour conséquence de mettre à jour l'UI).

## :gift: Proposition

Lors de la mise à jour des informations de l'organisation, ajouter, en plus des informations déjà retournées, les informations concernant la personne ayant archivée cette organisation.

## :star2: Remarques

RAS

## :santa: Pour tester

- Allez sur Pix Admin
- Ouvrir les détails d'un organisation non archivée
- Archivez l'organisation et constatez qu'un bandeau s'affiche
- Toujours sur la vue des détails de l'organisation, cliquez sur l'onglet `Tags` pour ouvrir la liste des tags
- Ajoutez ou supprimez un tag pour cette organisation
- Constatez que le bandeau est toujours visible avec les bonnes informations
