### PR TITLE
[BUGFIX] Aligner les boutons dans la modale de suppression d'un membre sur Pix Orga (PIX-6734).

### DIFF
--- a/orga/app/components/team/remove-member-modal.hbs
+++ b/orga/app/components/team/remove-member-modal.hbs
@@ -14,12 +14,20 @@
     </p>
   </:content>
   <:footer>
-    <PixButton @triggerAction={{@onClose}} @backgroundColor="grey">
-      {{t "common.actions.cancel"}}
-    </PixButton>
+    <div class="remove-member-modal__action-buttons--container">
+      <ul class="remove-member-modal__action-buttons--list">
+        <li>
+          <PixButton @triggerAction={{@onClose}} @backgroundColor="grey">
+            {{t "common.actions.cancel"}}
+          </PixButton>
+        </li>
 
-    <PixButton @triggerAction={{@onSubmit}} @backgroundColor="red">
-      {{t "pages.team-members.remove-membership-modal.actions.remove"}}
-    </PixButton>
+        <li>
+          <PixButton @triggerAction={{@onSubmit}} @backgroundColor="red">
+            {{t "pages.team-members.remove-membership-modal.actions.remove"}}
+          </PixButton>
+        </li>
+      </ul>
+    </div>
   </:footer>
 </PixModal>

--- a/orga/app/styles/components/team/remove-member-modal.scss
+++ b/orga/app/styles/components/team/remove-member-modal.scss
@@ -2,4 +2,17 @@
   color: $pix-neutral-90;
   line-height: $spacing-m;
   font-size: 1rem;
+
+  &__action-buttons {
+
+    &--list {
+      display: flex;
+      justify-content: flex-end;
+      gap: $spacing-s;
+    }
+
+    &--container {
+      margin-bottom: $spacing-s;
+    }
+  }
 }


### PR DESCRIPTION
## :christmas_tree: Problème
Dans Pix Orga, depuis la mise à jour de Pix UI ([23.0.0](https://ui.pix.fr/?path=/docs/changelog--page)), les boutons d'action du composant PixModal ne sont plus alignés à droite par défaut.
La modale de suppression de membre a donc vu son design changé.
<img width="439" alt="Capture d’écran 2023-01-10 à 15 11 40" src="https://user-images.githubusercontent.com/58915422/211574089-a9351beb-b00b-4661-8fe3-adc2a8e1e365.png">

## :gift: Proposition
Réaligner les boutons d'action sur la droite.
<img width="439" alt="Capture d’écran 2023-01-10 à 15 14 43" src="https://user-images.githubusercontent.com/58915422/211574415-5ebfffa9-5a24-4655-aeb4-35529631494e.png">

## :santa: Pour tester

- Se connecter sur Pix orga (sco.admin@example.net)
- Aller dans le menu équipe
- Dans le tableau, cliquer sur le bouton action (les trois points)
- cliquer sur supprimer
