### PR TITLE
[BUGFIX] Redonner un style de puces aux listes des modales "Réponses et tutos" (PIX-6783)

### DIFF
--- a/mon-pix/app/styles/components/_comparison-window.scss
+++ b/mon-pix/app/styles/components/_comparison-window.scss
@@ -7,6 +7,18 @@
 
   &__instruction {
     font-size: 1rem;
+
+    ul, ol {
+      padding-left: 2em;
+
+      &:not(:last-child) {
+        margin-bottom: 1em;
+      }
+    }
+
+    li {
+      list-style: unset;
+    }
   }
 
   &__default-message-container {


### PR DESCRIPTION
## :christmas_tree: Problème

Les listes présentes dans les énoncés d'épreuve dans les modales "Réponses et tutos" n'avaient aucun style de puces.

![image](https://user-images.githubusercontent.com/7335131/211579380-fe412285-5adb-4d17-bbf5-4bce08434b3e.png)

Dans l'écran d'épreuve :

![image](https://user-images.githubusercontent.com/7335131/211580143-c45cbdee-3244-4682-b7f5-b0a47f00f336.png)


## :gift: Proposition

Redonner du style manuellement dans le bloc `..comparison-window-content-body__instruction`.

## :santa: Pour tester

- Aller à l'url [de l'épreuve](https://app-pr5483.review.pix.fr/assessments/108642/challenges/0?challengeId=challenge1thgqyImfRaxNZ)
- Vérifier que le style des listes est bon.