### PR TITLE
[FEATURE][ADMIN] Après création d'une organisation, rediriger l'utilisateur vers l'onglet listant les tags (PIX-6738)

### DIFF
--- a/admin/app/components/organizations/creation-form.hbs
+++ b/admin/app/components/organizations/creation-form.hbs
@@ -3,7 +3,7 @@
   <section class="form-section">
     <PixInput
       @id="organizationName"
-      @label="Nom : "
+      @label="Nom"
       onchange={{this.handleOrganizationNameChange}}
       class="form-field"
       required={{true}}
@@ -26,7 +26,7 @@
     </PixSelect>
     <PixInput
       @id="documentationUrl"
-      @label="Lien vers la documentation : "
+      @label="Lien vers la documentation"
       onchange={{this.handleDocumentationUrlChange}}
       class="form-field"
     />

--- a/admin/app/controllers/authenticated/organizations/new.js
+++ b/admin/app/controllers/authenticated/organizations/new.js
@@ -17,7 +17,7 @@ export default class NewController extends Controller {
     try {
       await this.model.save();
       this.notifications.success('L’organisation a été créée avec succès.');
-      this.router.transitionTo('authenticated.organizations.get', this.model.id);
+      this.router.transitionTo('authenticated.organizations.get.all-tags', this.model.id);
     } catch (error) {
       this.notifications.error('Une erreur est survenue.');
     }

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -252,6 +252,21 @@ export default function () {
   });
 
   this.get('/admin/organizations');
+  this.post('/admin/organizations', (schema, request) => {
+    const requestBody = JSON.parse(request.requestBody);
+    const attributes = requestBody.data.attributes;
+
+    const organization = {
+      name: attributes.name,
+      type: attributes.type,
+      credit: attributes.credit,
+      dataProtectionOfficerFirstName: attributes['data-protection-officer-first-name'],
+      dataProtectionOfficerLastName: attributes['data-protection-officer-last-name'],
+      dataProtectionOfficerEmail: attributes['data-protection-officer-email'],
+    };
+
+    return schema.create('organization', organization);
+  });
   this.get('/admin/organizations/:id');
   this.get('/admin/organizations/:id/memberships', findPaginatedOrganizationMemberships);
   this.get('/admin/organizations/:id/target-profile-summaries', findOrganizationTargetProfileSummaries);
@@ -405,6 +420,7 @@ export default function () {
     return new Response(204);
   });
 
+  this.get('/admin/tags');
   this.post('/admin/tags', (schema, request) => {
     const params = JSON.parse(request.requestBody);
     const tagName = params.data.attributes.name;

--- a/admin/tests/acceptance/authenticated/organizations/create-organization_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/create-organization_test.js
@@ -1,0 +1,34 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import { clickByName, visit, fillByLabel, selectByLabelAndOption } from '@1024pix/ember-testing-library';
+import { currentURL } from '@ember/test-helpers';
+
+module('Acceptance | Organizations | Create', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function () {
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+  });
+
+  module('when an organization is created', function () {
+    test('it redirects the user on the organization details page with the tags tab opened', async function (assert) {
+      // given
+      await visit('/organizations/new');
+      await fillByLabel('Nom', 'Stark Corp.');
+      await selectByLabelAndOption(`Sélectionner un type d'organisation`, 'SCO');
+      await fillByLabel('Crédits', 120);
+      await fillByLabel('Prénom du DPO', 'Justin');
+      await fillByLabel('Nom du DPO', 'Ptipeu');
+      await fillByLabel('Adresse e-mail du DPO', 'justin.ptipeu@example.net');
+
+      // when
+      await clickByName('Ajouter');
+
+      // then
+      assert.strictEqual(currentURL(), '/organizations/1/all-tags');
+    });
+  });
+});

--- a/admin/tests/integration/components/organizations/creation-form_test.js
+++ b/admin/tests/integration/components/organizations/creation-form_test.js
@@ -20,8 +20,8 @@ module('Integration | Component | organizations/creation-form', function (hooks)
     );
 
     // then
-    assert.dom(screen.getByRole('textbox', { name: 'Nom :' })).exists();
-    assert.dom(screen.getByRole('textbox', { name: 'Lien vers la documentation :' })).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'Nom' })).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'Lien vers la documentation' })).exists();
     assert.dom(screen.getByRole('combobox', { name: "Sélectionner un type d'organisation" })).exists();
     assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
     assert.dom(screen.getByRole('button', { name: 'Ajouter' })).exists();


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement, après la création d'une organisation via Pix Admin, l'agent Pix est redirigé vers la page de détails de cette organisation avec l'onglet `Équipe` sélectionné.

Dans le processus de création d'une organisation, l'agent Pix doit associer des tags à l'organisation récemment créée. Pour faciliter/inciter l'agent à associé des tags, il faudrait qu'il soit redirigé sur l'onglet `Tags` après création de l'organisation.

## :gift: Proposition

Modifier la redirection actuelle(`Équipe`) vers l'onglet `Tags`

## :star2: Remarques

RAS

## :santa: Pour tester

- Se connecter sur Pix Admin
- Sur la page Organisations, cliquez sur le bouton `+ Nouvelle organisation`
- Créez une nouvelle organisation
- Constatez que vous êtes bien sur la page de détails de la nouvelle organisation et que l'onglet sélectionné est bien `Tags`
- L'URL devrait être au format `organizations/{id}/all-tags`
