### PR TITLE
[TECH] Améliorer l’accessibilité de la page Inscription sur Pix App (PIX-6782).

### DIFF
--- a/mon-pix/app/components/form-textfield.hbs
+++ b/mon-pix/app/components/form-textfield.hbs
@@ -70,5 +70,6 @@
     id="validationMessage-{{@textfieldName}}"
     class="form-textfield__message {{this.validationMessageClass}} form-textfield__message-{{this.textfieldType}}"
     aria-live="polite"
+    role="alert"
   >{{#if this.displayMessage}}{{@validationMessage}}{{/if}}</div>
 </div>

--- a/mon-pix/app/components/form-textfield.js
+++ b/mon-pix/app/components/form-textfield.js
@@ -87,5 +87,9 @@ export default class FormTextfield extends Component {
   @action
   togglePasswordVisibility() {
     this.isPasswordVisible = !this.isPasswordVisible;
+    const InputElement = document.getElementById('password');
+    if (InputElement) {
+      InputElement.focus();
+    }
   }
 }

--- a/mon-pix/app/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/components/password-reset-demand-form.hbs
@@ -15,7 +15,7 @@
 
   {{#if this.hasFailed}}
     <div
-      class="sign-form__notification-message sign-form__notification-message--error"
+      class="password-reset-demand-form__notification-message--error"
       aria-live="polite"
       id="password-reset-demand-failed-message"
     >
@@ -24,12 +24,9 @@
   {{/if}}
 
   {{#if this.hasErrors}}
-    <h2
-      class="sign-form__notification-message sign-form__notification-message--error"
-      id="password-reset-demand-error-message"
-    >
+    <p class="password-reset-demand-form__notification-message--error" id="password-reset-demand-error-message">
       {{this.error}}
-    </h2>
+    </p>
   {{/if}}
 
   {{#if this.hasSucceeded}}

--- a/mon-pix/app/components/signin-form.hbs
+++ b/mon-pix/app/components/signin-form.hbs
@@ -14,13 +14,9 @@
   </div>
 
   {{#if this.hasFailed}}
-    <div
-      class="sign-form__notification-message sign-form__notification-message--error"
-      role="alert"
-      id="sign-in-error-message"
-    >
+    <p class="sign-form__notification-message--error" role="alert" id="sign-in-error-message">
       {{this.errorMessage}}
-    </div>
+    </p>
   {{/if}}
 
   <form {{on "submit" this.signin}} class="sign-form__body">

--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -11,16 +11,14 @@
     </div>
   </div>
 
-  {{#if this.errorMessage}}
-    <div
-      class="sign-form__notification-message sign-form__notification-message--error"
-      aria-live="polite"
-      role="alert"
-      id="sign-up-error-message"
-    >
-      {{this.errorMessage}}
-    </div>
-  {{/if}}
+  <div
+    class="sign-form__notification-message sign-form__notification-message--error"
+    aria-live="polite"
+    role="alert"
+    id="sign-up-error-message"
+  >
+    {{this.errorMessage}}
+  </div>
 
   {{#if this.notificationMessage}}
     <div class="sign-form__notification-message sign-form__notification-message--success" aria-live="polite">
@@ -116,11 +114,11 @@
           {{t "common.cgu.label"}}
         </PixCheckbox>
       </div>
-      {{#if @user.errors.cgu}}
-        <div class="sign-form__validation-error" aria-live="polite" role="alert" id="sign-up-cgu-error-message">
+      <div class="sign-form__validation-error" aria-live="polite" role="alert" id="sign-up-cgu-error-message">
+        {{#if @user.errors.cgu}}
           {{t "common.cgu.error"}}
-        </div>
-      {{/if}}
+        {{/if}}
+      </div>
 
     </fieldset>
     <div class="sign-form-body__bottom-button">

--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -15,6 +15,7 @@
     <div
       class="sign-form__notification-message sign-form__notification-message--error"
       aria-live="polite"
+      role="alert"
       id="sign-up-error-message"
     >
       {{this.errorMessage}}
@@ -116,7 +117,7 @@
         </PixCheckbox>
       </div>
       {{#if @user.errors.cgu}}
-        <div class="sign-form__validation-error" aria-live="polite" id="sign-up-cgu-error-message">
+        <div class="sign-form__validation-error" aria-live="polite" role="alert" id="sign-up-cgu-error-message">
           {{t "common.cgu.error"}}
         </div>
       {{/if}}

--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -20,12 +20,6 @@
     {{this.errorMessage}}
   </div>
 
-  {{#if this.notificationMessage}}
-    <div class="sign-form__notification-message sign-form__notification-message--success" aria-live="polite">
-      {{this.notificationMessage}}
-    </div>
-  {{/if}}
-
   <form {{on "submit" this.signup}} class="sign-form__body">
     <p class="sign-form-body__instruction">{{t "common.form.mandatory-all-fields" htmlSafe=true}}</p>
 

--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -112,15 +112,9 @@
     </fieldset>
 
     <div class="sign-form-body__bottom-button">
-      {{#if this.isLoading}}
-        <button type="button" disabled class="button button--thin button--big button--round button--border-focus">
-          <span class="loader-in-button">&nbsp;</span>
-        </button>
-      {{else}}
-        <PixButton @type="submit" @shape="rounded">
-          {{t "pages.sign-up.actions.submit"}}
-        </PixButton>
-      {{/if}}
+      <PixButton @type="submit" @shape="rounded" @isLoading={{this.isLoading}}>
+        {{t "pages.sign-up.actions.submit"}}
+      </PixButton>
     </div>
   </form>
 </main>

--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -11,14 +11,9 @@
     </div>
   </div>
 
-  <div
-    class="sign-form__notification-message sign-form__notification-message--error"
-    aria-live="polite"
-    role="alert"
-    id="sign-up-error-message"
-  >
+  <p class="sign-form__notification-message--error" aria-live="polite" role="alert" id="sign-up-error-message">
     {{this.errorMessage}}
-  </div>
+  </p>
 
   <form {{on "submit" this.signup}} class="sign-form__body">
     <p class="sign-form-body__instruction">{{t "common.form.mandatory-all-fields" htmlSafe=true}}</p>
@@ -108,13 +103,14 @@
           {{t "common.cgu.label"}}
         </PixCheckbox>
       </div>
-      <div class="sign-form__validation-error" aria-live="polite" role="alert" id="sign-up-cgu-error-message">
+      <p class="sign-form__validation-error" aria-live="polite" role="alert" id="sign-up-cgu-error-message">
         {{#if @user.errors.cgu}}
           {{t "common.cgu.error"}}
         {{/if}}
-      </div>
+      </p>
 
     </fieldset>
+
     <div class="sign-form-body__bottom-button">
       {{#if this.isLoading}}
         <button type="button" disabled class="button button--thin button--big button--round button--border-focus">

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -54,7 +54,6 @@ export default class SignupForm extends Component {
 
   @tracked errorMessage = null;
   @tracked isLoading = false;
-  @tracked notificationMessage = null;
   @tracked validation = new SignupFormValidation();
   _tokenHasBeenUsed = null;
 
@@ -137,7 +136,6 @@ export default class SignupForm extends Component {
   @action
   signup(event) {
     event && event.preventDefault();
-    this.notificationMessage = null;
     this.isLoading = true;
 
     this._trimNamesAndEmailOfUser();

--- a/mon-pix/app/styles/components/_password-reset-demand-form.scss
+++ b/mon-pix/app/styles/components/_password-reset-demand-form.scss
@@ -25,6 +25,15 @@
     align-self: center;
     margin-bottom: 60px;
   }
+
+  &__notification-message--error {
+    margin: 0;
+    color: $pix-error-70;
+    font-weight: 400;
+    font-size: 1rem;
+    line-height: 1.625rem;
+    text-align: center;
+  }
 }
 
 .password-reset-demand-body__text {

--- a/mon-pix/app/styles/components/_signup-form.scss
+++ b/mon-pix/app/styles/components/_signup-form.scss
@@ -11,7 +11,7 @@
     padding: 0 15px;
 
     @include device-is('tablet') {
-      margin: 15px 0;
+      margin: 15px 0 5px;
       padding: 0;
     }
   }

--- a/mon-pix/app/styles/globals/_buttons.scss
+++ b/mon-pix/app/styles/globals/_buttons.scss
@@ -204,6 +204,12 @@
     cursor: pointer;
   }
 
+  &:focus-visible {
+    border-radius: 2px;
+    outline: 1.5px solid $pix-primary;
+    outline-offset: 1px;
+  }
+
   &--underline {
     text-decoration: underline;
   }

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -56,10 +56,6 @@
     line-height: 1.625rem;
     text-align: center;
 
-    &--success {
-      color: $pix-success-70;
-    }
-
     &--error {
       color: $pix-error-70;
     }

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -49,23 +49,21 @@
     width: 100%;
   }
 
-  &__notification-message {
-    width: 100%;
-    color: $pix-neutral-0;
+  &__notification-message--error {
+    margin: 0 0 10px;
+    color: $pix-error-70;
     font-weight: 400;
     font-size: 1rem;
     line-height: 1.625rem;
     text-align: center;
-
-    &--error {
-      color: $pix-error-70;
-    }
   }
 
   &__validation-error {
+    margin: 0;
     padding-bottom: 10px;
     color: $pix-error-70;
     font-weight: normal;
+    font-size: 0.875rem;
   }
 }
 

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -24,6 +24,7 @@
     max-width: 609px;
     margin: 0 auto;
     padding: 20px 10px;
+    color: $pix-neutral-70;
     background-color: $pix-neutral-0;
     border-radius: 10px;
 

--- a/mon-pix/tests/acceptance/password-reset_test.js
+++ b/mon-pix/tests/acceptance/password-reset_test.js
@@ -1,4 +1,5 @@
-import { fillIn, currentURL, visit } from '@ember/test-helpers';
+import { fillIn, currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -58,15 +59,14 @@ module('Acceptance | Reset Password', function (hooks) {
       email: 'brandone.martins@pix.com',
       password: '1024pix!',
     });
-    await visit('/mot-de-passe-oublie');
+    const screen = await visit('/mot-de-passe-oublie');
     await fillIn('#email', 'unexisting@user.com');
 
     // when
     await clickByLabel(this.intl.t('pages.password-reset-demand.actions.reset'));
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/mot-de-passe-oublie');
-    assert.dom('.sign-form__notification-message--error').exists();
+    // then
+    assert.strictEqual(currentURL(), '/mot-de-passe-oublie');
+    assert.dom(screen.getByText(this.intl.t('pages.password-reset-demand.error.message'))).exists();
   });
 });

--- a/mon-pix/tests/integration/components/password-reset-demand-form_test.js
+++ b/mon-pix/tests/integration/components/password-reset-demand-form_test.js
@@ -3,12 +3,13 @@
 
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { fillIn, find, render } from '@ember/test-helpers';
+import { fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { resolve, reject } from 'rsvp';
 import Service from '@ember/service';
 import { clickByLabel } from '../../helpers/click-by-label';
 import { contains } from '../../helpers/contains';
+import { render } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | password reset demand form', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -93,9 +94,9 @@ module('Integration | Component | password reset demand form', function (hooks) 
     this.owner.register('service:errors', errorsServiceStub);
 
     // when
-    await render(hbs`<PasswordResetDemandForm />`);
+    const screen = await render(hbs`<PasswordResetDemandForm />`);
 
     // then
-    assert.ok(find('.sign-form__notification-message--error').textContent.includes(expectedError));
+    assert.dom(screen.getByText(expectedError)).exists();
   });
 });

--- a/mon-pix/tests/integration/components/signup-form_test.js
+++ b/mon-pix/tests/integration/components/signup-form_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 import Service from '@ember/service';
 
-import { fillIn, find, findAll, triggerEvent } from '@ember/test-helpers';
+import { fillIn, findAll, triggerEvent } from '@ember/test-helpers';
 import { render, clickByName } from '@1024pix/ember-testing-library';
 
 import ArrayProxy from '@ember/array/proxy';
@@ -615,47 +615,6 @@ module('Integration | Component | SignupForm', function (hooks) {
             .includes(INPUT_TEXT_FIELD_CLASS_DEFAULT)
         );
       });
-    });
-  });
-
-  module('Loading management', function () {
-    test('should not display any loading spinner by default', async function (assert) {
-      // given
-      this.set('user', userEmpty);
-
-      // when
-      await render(hbs`<SignupForm @user={{this.user}} />`);
-
-      // then
-      assert.dom('.sign-form-body__bottom-button .loader-in-button').doesNotExist();
-    });
-
-    test('should display a loading spinner when user submit signup', async function (assert) {
-      // given
-      class sessionService extends Service {
-        authenticateUser = sinon.stub().resolves();
-      }
-
-      this.owner.register('service:session', sessionService);
-
-      const validUser = EmberObject.create({
-        email: 'toto@pix.fr',
-        firstName: 'Marion',
-        lastName: 'Yade',
-        password: 'gipix2017',
-        cgu: true,
-        save() {
-          return new resolve();
-        },
-      });
-      this.set('user', validUser);
-      await render(hbs`<SignupForm @user={{this.user}} />`);
-
-      // when
-      await clickByName(this.intl.t('pages.sign-up.actions.submit'));
-
-      // then
-      assert.ok(find('.loader-in-button'));
     });
   });
 });

--- a/mon-pix/tests/integration/components/signup-form_test.js
+++ b/mon-pix/tests/integration/components/signup-form_test.js
@@ -437,7 +437,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         await clickByName(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
-        assert.dom(screen.getByText(this.intl.t('common.cgu.error'))).exists();
+        assert.dom(screen.getByText(uncheckedCheckboxCguErrorMessage)).exists();
       });
 
       test('should display an error message on email field, when email above a maximum length of 255 and focus-out', async function (assert) {

--- a/mon-pix/tests/integration/components/signup-form_test.js
+++ b/mon-pix/tests/integration/components/signup-form_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 import Service from '@ember/service';
 
-import { fillIn, findAll, triggerEvent } from '@ember/test-helpers';
+import { fillIn, findAll, triggerEvent, click } from '@ember/test-helpers';
 import { render, clickByName } from '@1024pix/ember-testing-library';
 
 import ArrayProxy from '@ember/array/proxy';
@@ -614,6 +614,27 @@ module('Integration | Component | SignupForm', function (hooks) {
             .getAttribute('class')
             .includes(INPUT_TEXT_FIELD_CLASS_DEFAULT)
         );
+      });
+
+      module('when the password visibility button is clicked', function () {
+        test('it should focus on input', async function (assert) {
+          // given
+          const screen = await render(hbs`<SignupForm />`);
+
+          // when
+          await click(screen.getByRole('button', { name: this.intl.t('common.form.visible-password') }));
+
+          // then
+          assert
+            .dom(
+              screen.getByRole('textbox', {
+                name: `${this.intl.t('pages.sign-up.fields.password.label')} ${this.intl.t(
+                  'pages.sign-up.fields.password.help'
+                )}`,
+              })
+            )
+            .isFocused();
+        });
       });
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème
Suite à l'audit d’accessibilité, plusieurs pages de l'application nécessite des améliorations dont la page inscription

## :gift: Proposition
Prendre les retours de l'audit pour améliorer l'a11y de la page /inscription.

Quelques éléments d'autres pages sont impactés par les modifications.

Le tableau d'audit sera mis à jour lors du merge de ce ticket.

## :star2: Remarques

**Critère 7.3 : Chaque script est-il contrôlable par le clavier et par tout dispositif de pointage (hors cas particuliers) ?** 

  Pour corriger : Donner le focus au champ mot de passe quand on clique sur le bouton pour afficher ou masquer celui-ci

**Critère 7.5 : Dans chaque page web, les messages de statut sont-ils correctement restitués par les technologies d'assistance ?**

Pour corriger : Les messages d'erreur doivent avoir un `role="alert"` car le `aria-live="polite"` ne suffit pas (correspond à un `role="log"`).

**Critère 8.2 : Pour chaque page web, le code source généré est-il valide selon le type de document spécifié ?**

Présence d'attributs `aria-describedby` qui ne pointent vers aucun élément car ils sont lié aux messages d'erreur.
Pour corriger : Laisser le contenant du message d'erreur présent dans le code et le remplir en fonction du besoin. Ainsi, l'attribut pointe toujours vers un élément existant, même si celui-ci est vide de contenu.


**Critère 10.5 : Dans chaque page web, les déclarations CSS de couleurs de fond d'élément et de police sont-elles correctement utilisées ?**

Pas de déclaration de couleur de police par défaut qui puisse être héritée tout au long du document.
Pour corriger : en plus de la couleur de fond par défaut, déclarer une couleur de police par défaut.

<img width="629" alt="Capture d’écran 2023-01-11 à 16 08 40" src="https://user-images.githubusercontent.com/58915422/211841724-fed0921a-32fe-4108-b76c-b97a6926613e.png">

**Critère 10.7 : Dans chaque page web, pour chaque élément recevant le focus, la prise de focus est-elle visible ?**

Le focus n'est signalé que par un soulignement et un léger changement de couleur, il est dégradé par rapport au focus par défaut.
Pour corriger : Laisser le focus par défaut ou ne pas le dégrader en le limitant au soulignement (laisser un encadrement bien visible sur les éléments focusés)

## :santa: Pour tester

1. Sur Pix App, aller sur la page d'inscription
2.  **Critère 7.3** Aller sur le champ mot de passe, constater qu'au click sur le bouton pour masquer/afficher un mot de passe, le focus repasser sur le champ (tester en navigation clavier également)
3. **Critère 8.2** Lancer Wave et constater qu'il n'y a plus d'erreur d'Aria (broken Aria Reference)
avant : 
<img width="361" alt="Capture d’écran 2023-01-19 à 13 58 28" src="https://user-images.githubusercontent.com/58915422/213449105-1c7ce052-5baf-47ac-95fc-a5a703b5f98a.png">
4. **Critère 10.5**
Le screen suivant montre en rouge le texte qui ne possédait pas de couleur par défaut.
<img width="381" alt="Capture d’écran 2023-01-11 à 15 59 26" src="https://user-images.githubusercontent.com/58915422/212028919-48d803da-8891-4f14-93e5-97fd43eea7ea.png">
5. **Critère 10.7**
Cette modifications impacte tous les liens possédant la class css link.
Coté page d'inscription/connexion, faites une navigation au clavier pour constater un encadrement (+ underline) du lien
