### PR TITLE
[FEATURE] Simuler le score Pix avec l'ancien algorithme (PIX-6763).

### DIFF
--- a/api/lib/application/scoring-simulator/index.js
+++ b/api/lib/application/scoring-simulator/index.js
@@ -1,3 +1,4 @@
+const Joi = require('joi');
 const securityPreHandlers = require('../security-pre-handlers');
 const scoringSimulatorController = require('./scoring-simulator-controller');
 
@@ -13,6 +14,29 @@ exports.register = async (server) => {
             assign: 'hasAuthorizationToAccessAdminScope',
           },
         ],
+        validate: {
+          options: {
+            allowUnknown: true,
+          },
+          payload: Joi.object({
+            simulations: Joi.array()
+              .required()
+              .items(
+                Joi.object({
+                  answers: Joi.array()
+                    .required()
+                    .items(
+                      Joi.object({
+                        challengeId: Joi.string().required(),
+                        result: Joi.string().required(),
+                      })
+                    )
+                    .min(1),
+                }).required()
+              )
+              .min(1),
+          }).required(),
+        },
         handler: scoringSimulatorController.calculateOldScores,
         tags: ['api'],
         notes: [

--- a/api/lib/application/scoring-simulator/scoring-simulator-controller.js
+++ b/api/lib/application/scoring-simulator/scoring-simulator-controller.js
@@ -1,6 +1,19 @@
+const OldScoringSimulation = require('../../domain/models/OldScoringSimulation');
+const Answer = require('../../domain/models/Answer');
+const usecases = require('../../domain/usecases');
+
 module.exports = {
   async calculateOldScores(request, h) {
-    return h.response({}).code(200);
+    const simulations = request.payload.simulations.map(
+      (simulation) =>
+        new OldScoringSimulation({
+          answers: simulation.answers.map((answer) => new Answer(answer)),
+        })
+    );
+
+    const results = await usecases.simulateOldScoring({ simulations });
+
+    return h.response({ results });
   },
 
   async calculateFlashScores(request, h) {

--- a/api/lib/domain/models/OldScoringSimulation.js
+++ b/api/lib/domain/models/OldScoringSimulation.js
@@ -1,0 +1,7 @@
+class OldScoringSimulation {
+  constructor({ answers = [] } = {}) {
+    this.answers = answers;
+  }
+}
+
+module.exports = OldScoringSimulation;

--- a/api/lib/domain/models/SimulationResult.js
+++ b/api/lib/domain/models/SimulationResult.js
@@ -1,6 +1,7 @@
 class SimulationResult {
-  constructor({ pixScore } = {}) {
+  constructor({ pixScore, error } = {}) {
     this.pixScore = pixScore;
+    this.error = error;
   }
 }
 

--- a/api/lib/domain/models/SimulationResult.js
+++ b/api/lib/domain/models/SimulationResult.js
@@ -1,0 +1,7 @@
+class SimulationResult {
+  constructor({ pixScore } = {}) {
+    this.pixScore = pixScore;
+  }
+}
+
+module.exports = SimulationResult;

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -415,6 +415,7 @@ module.exports = injectDependencies(
     sendSharedParticipationResultsToPoleEmploi: require('./send-shared-participation-results-to-pole-emploi'),
     sendVerificationCode: require('./send-verification-code'),
     shareCampaignResult: require('./share-campaign-result'),
+    simulateOldScoring: require('./simulate-old-scoring'),
     startCampaignParticipation: require('./start-campaign-participation'),
     startOrResumeCompetenceEvaluation: require('./start-or-resume-competence-evaluation'),
     startWritingCampaignAssessmentResultsToStream: require('./start-writing-campaign-assessment-results-to-stream'),

--- a/api/lib/domain/usecases/simulate-old-scoring.js
+++ b/api/lib/domain/usecases/simulate-old-scoring.js
@@ -10,8 +10,14 @@ module.exports = async function simulateOldScoring({ challengeRepository, simula
     for (const answer of answers) {
       const challenge = challengesById.get(answer.challengeId);
 
+      if (scoreBySkillId[challenge.skill.id] !== undefined) {
+        return new SimulationResult({ error: `Answer for skill ${challenge.skill.id} was already given or inferred` });
+      }
+
       if (answer.isOk()) {
         scoreBySkillId[challenge.skill.id] = challenge.skill.pixValue;
+      } else {
+        scoreBySkillId[challenge.skill.id] = 0;
       }
     }
 

--- a/api/lib/domain/usecases/simulate-old-scoring.js
+++ b/api/lib/domain/usecases/simulate-old-scoring.js
@@ -1,0 +1,24 @@
+const SimulationResult = require('../models/SimulationResult');
+
+module.exports = async function simulateOldScoring({ challengeRepository, simulations }) {
+  const challenges = await challengeRepository.findValidated();
+  const challengesById = new Map(challenges.map((challenge) => [challenge.id, challenge]));
+
+  const simulationResults = simulations.map(({ answers }) => {
+    const scoreBySkillId = {};
+
+    for (const answer of answers) {
+      const challenge = challengesById.get(answer.challengeId);
+
+      if (answer.isOk()) {
+        scoreBySkillId[challenge.skill.id] = challenge.skill.pixValue;
+      }
+    }
+
+    const pixScore = Object.values(scoreBySkillId).reduce((sum, pixValue) => sum + pixValue, 0);
+
+    return new SimulationResult({ pixScore });
+  });
+
+  return simulationResults;
+};

--- a/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
@@ -1,6 +1,10 @@
 const { expect } = require('chai');
 const createServer = require('../../../../server');
-const { databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const {
+  databaseBuilder,
+  generateValidRequestAuthorizationHeader,
+  mockLearningContent,
+} = require('../../../test-helper');
 const {
   ROLES: { SUPER_ADMIN },
 } = require('../../../../lib/domain/constants').PIX_ADMIN;
@@ -17,6 +21,55 @@ describe('Acceptance | Controller | scoring-simulator-controller', function () {
     });
     adminAuthorization = generateValidRequestAuthorizationHeader(adminId);
     await databaseBuilder.commit();
+
+    const learningContent = {
+      competences: [
+        {
+          id: 'rec1',
+          name_i18n: {
+            fr: 'comp1Fr',
+            en: 'comp1En',
+          },
+          index: '1.1',
+          color: 'rec1Color',
+          skillIds: ['skill1', 'skill2'],
+        },
+        {
+          id: 'rec2',
+          name_i18n: {
+            fr: 'comp2Fr',
+            en: 'comp2En',
+          },
+          index: '2.1',
+          color: 'rec2Color',
+          skillIds: ['skill3', 'skill4', 'skill5'],
+        },
+      ],
+      tubes: [
+        { id: 'recTube1', competenceId: 'rec1' },
+        { id: 'recTube2', competenceId: 'rec2' },
+      ],
+      skills: [
+        // tube 1
+        { id: 'skill1', status: 'actif', tubeId: 'recTube1', competenceId: 'rec1', level: 1, pixValue: 1 },
+        { id: 'skill2', status: 'actif', tubeId: 'recTube1', competenceId: 'rec1', level: 3, pixValue: 10 },
+        // tube 2
+        { id: 'skill3', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', level: 2, pixValue: 100 },
+        { id: 'skill4', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', level: 3, pixValue: 1000 },
+        { id: 'skill5', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', level: 5, pixValue: 10000 },
+        { id: 'skill6', status: 'périmé', tubeId: 'recTube2', competenceId: 'rec2', level: 6, pixValue: 100000 },
+      ],
+      challenges: [
+        { id: 'challenge1', skillId: 'skill1', status: 'validé' },
+        { id: 'challenge2', skillId: 'skill2', status: 'validé' },
+        { id: 'challenge3', skillId: 'skill3', status: 'validé' },
+        { id: 'challenge4', skillId: 'skill4', status: 'validé' },
+        { id: 'challenge5', skillId: 'skill5', status: 'validé' },
+        { id: 'challenge6', skillId: 'skill5', status: 'validé' },
+      ],
+    };
+
+    mockLearningContent(learningContent);
   });
 
   describe('#calculateOldScores', function () {
@@ -34,12 +87,52 @@ describe('Acceptance | Controller | scoring-simulator-controller', function () {
     it('should return status code 200', async function () {
       // given
       options.headers.authorization = adminAuthorization;
+      options.payload.simulations = [];
 
       // when
       const response = await server.inject(options);
 
       // then
       expect(response).to.have.property('statusCode', 200);
+    });
+
+    it('should return a payload with simulation results', async function () {
+      // given
+      options.headers.authorization = adminAuthorization;
+      options.payload = {
+        simulations: [
+          {
+            answers: [
+              { challengeId: 'challenge3', result: 'ok' },
+              { challengeId: 'challenge2', result: 'ok' },
+              { challengeId: 'challenge5', result: 'ok' },
+            ],
+          },
+          {
+            answers: [
+              { challengeId: 'challenge2', result: 'ok' },
+              { challengeId: 'challenge1', result: 'ok' },
+            ],
+          },
+        ],
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.result).to.deep.equal({
+        results: [
+          {
+            error: undefined,
+            pixScore: 11111,
+          },
+          {
+            error: 'Answer for skill skill1 was already given or inferred',
+            pixScore: undefined,
+          },
+        ],
+      });
     });
 
     describe('when there is no connected user', function () {

--- a/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
@@ -84,18 +84,6 @@ describe('Acceptance | Controller | scoring-simulator-controller', function () {
       };
     });
 
-    it('should return status code 200', async function () {
-      // given
-      options.headers.authorization = adminAuthorization;
-      options.payload.simulations = [];
-
-      // when
-      const response = await server.inject(options);
-
-      // then
-      expect(response).to.have.property('statusCode', 200);
-    });
-
     it('should return a payload with simulation results', async function () {
       // given
       options.headers.authorization = adminAuthorization;
@@ -121,6 +109,7 @@ describe('Acceptance | Controller | scoring-simulator-controller', function () {
       const response = await server.inject(options);
 
       // then
+      expect(response).to.have.property('statusCode', 200);
       expect(response.result).to.deep.equal({
         results: [
           {
@@ -152,14 +141,37 @@ describe('Acceptance | Controller | scoring-simulator-controller', function () {
       it('should return status code 403', async function () {
         // given
         const { id: userId } = databaseBuilder.factory.buildUser();
-        options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
         await databaseBuilder.commit();
+        options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
+        options.payload = {
+          simulations: [{ answers: [{ challengeId: 'test', result: 'ok' }] }],
+        };
 
         // when
         const response = await server.inject(options);
 
         // then
         expect(response).to.have.property('statusCode', 403);
+      });
+    });
+
+    describe('when request payload is invalid', function () {
+      it('should return status code 400', async function () {
+        // given
+        options.headers.authorization = adminAuthorization;
+        options.payload = {
+          wrongField: [
+            {
+              answers: [],
+            },
+          ],
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response).to.have.property('statusCode', 400);
       });
     });
   });

--- a/api/tests/integration/domain/usecases/simulate-old-scoring_test.js
+++ b/api/tests/integration/domain/usecases/simulate-old-scoring_test.js
@@ -33,26 +33,29 @@ describe('Integration | UseCases | simulateOldScoring', function () {
         { id: 'recTube2', competenceId: 'rec2' },
       ],
       skills: [
-        { id: 'skill1', status: 'actif', tubeId: 'recTube1', competenceId: 'rec1', pixValue: 1 },
-        { id: 'skill2', status: 'archivé', tubeId: 'recTube1', competenceId: 'rec1', pixValue: 10 },
-        { id: 'skill3', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', pixValue: 100 },
-        { id: 'skill4', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', pixValue: 1000 },
-        { id: 'skill5', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', pixValue: 10000 },
-        { id: 'skill6', status: 'périmé', tubeId: 'recTube2', competenceId: 'rec2', pixValue: 100000 },
+        // tube 1
+        { id: 'skill1', status: 'actif', tubeId: 'recTube1', competenceId: 'rec1', level: 1, pixValue: 1 },
+        { id: 'skill2', status: 'actif', tubeId: 'recTube1', competenceId: 'rec1', level: 3, pixValue: 10 },
+        // tube 2
+        { id: 'skill3', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', level: 2, pixValue: 100 },
+        { id: 'skill4', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', level: 3, pixValue: 1000 },
+        { id: 'skill5', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', level: 5, pixValue: 10000 },
+        { id: 'skill6', status: 'périmé', tubeId: 'recTube2', competenceId: 'rec2', level: 6, pixValue: 100000 },
       ],
       challenges: [
         { id: 'challenge1', skillId: 'skill1', status: 'validé' },
-        { id: 'challenge2', skillId: 'skill3', status: 'validé' },
-        { id: 'challenge3', skillId: 'skill4', status: 'validé' },
-        { id: 'challenge4', skillId: 'skill5', status: 'validé' },
+        { id: 'challenge2', skillId: 'skill2', status: 'validé' },
+        { id: 'challenge3', skillId: 'skill3', status: 'validé' },
+        { id: 'challenge4', skillId: 'skill4', status: 'validé' },
         { id: 'challenge5', skillId: 'skill5', status: 'validé' },
+        { id: 'challenge6', skillId: 'skill5', status: 'validé' },
       ],
     };
 
     mockLearningContent(learningContent);
   });
 
-  it('should return 10001 as a direct scoring result', async function () {
+  it('should return computed score with direct scoring result', async function () {
     // given
     const answers = [
       domainBuilder.buildAnswer.ok({
@@ -61,10 +64,10 @@ describe('Integration | UseCases | simulateOldScoring', function () {
       domainBuilder.buildAnswer.ko({
         challengeId: 'challenge2',
       }),
-      domainBuilder.buildAnswer.skipped({
+      domainBuilder.buildAnswer.ok({
         challengeId: 'challenge3',
       }),
-      domainBuilder.buildAnswer.ok({
+      domainBuilder.buildAnswer.skipped({
         challengeId: 'challenge4',
       }),
     ];
@@ -77,15 +80,18 @@ describe('Integration | UseCases | simulateOldScoring', function () {
     // then
     expect(simulationResults).to.have.lengthOf(1);
     expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
-    expect(simulationResults[0]).to.have.property('pixScore', 10001);
+    expect(simulationResults[0]).to.have.property('pixScore', 101);
   });
 
-  describe('when there are more than one answer on the same skill', function () {
-    it('should return an error', async function () {
+  describe('when there are many challenges on the same tube', function () {
+    it('should return computed score with direct and inferred challenges', async function () {
       // given
       const answers = [
-        domainBuilder.buildAnswer.ko({
-          challengeId: 'challenge4',
+        domainBuilder.buildAnswer.ok({
+          challengeId: 'challenge2',
+        }),
+        domainBuilder.buildAnswer.ok({
+          challengeId: 'challenge3',
         }),
         domainBuilder.buildAnswer.ok({
           challengeId: 'challenge5',
@@ -100,7 +106,79 @@ describe('Integration | UseCases | simulateOldScoring', function () {
       // then
       expect(simulationResults).to.have.lengthOf(1);
       expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+      expect(simulationResults[0]).to.have.property('pixScore', 11111);
+    });
+  });
+
+  describe('when there are more than one answer on the same skill', function () {
+    it('should return an error', async function () {
+      // given
+      const answers = [
+        domainBuilder.buildAnswer.ko({
+          challengeId: 'challenge5',
+        }),
+        domainBuilder.buildAnswer.ok({
+          challengeId: 'challenge6',
+        }),
+      ];
+
+      const simulation = new OldScoringSimulation({ answers });
+
+      // when
+      const simulationResults = await usecases.simulateOldScoring({ simulations: [simulation] });
+
+      // then
+      expect(simulationResults).to.have.lengthOf(1);
+      expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
       expect(simulationResults[0]).to.have.property('error', 'Answer for skill skill5 was already given or inferred');
+    });
+  });
+
+  describe('when there is an answer on a skill that was already inferred to be failed', function () {
+    it('should return an error', async function () {
+      // given
+      const answers = [
+        domainBuilder.buildAnswer.ko({
+          challengeId: 'challenge1',
+        }),
+        domainBuilder.buildAnswer.ko({
+          challengeId: 'challenge2',
+        }),
+      ];
+
+      const simulation = new OldScoringSimulation({ answers });
+
+      // when
+      const simulationResults = await usecases.simulateOldScoring({ simulations: [simulation] });
+
+      // then
+      expect(simulationResults).to.have.lengthOf(1);
+      expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+      expect(simulationResults[0]).to.have.property('error', 'Answer for skill skill2 was already given or inferred');
+    });
+  });
+
+  describe('when there is an answer on a skill that was already inferred to be succeeded', function () {
+    it('should return an error', async function () {
+      // given
+      const answers = [
+        domainBuilder.buildAnswer.ok({
+          challengeId: 'challenge2',
+        }),
+        domainBuilder.buildAnswer.ko({
+          challengeId: 'challenge1',
+        }),
+      ];
+
+      const simulation = new OldScoringSimulation({ answers });
+
+      // when
+      const simulationResults = await usecases.simulateOldScoring({ simulations: [simulation] });
+
+      // then
+      expect(simulationResults).to.have.lengthOf(1);
+      expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+      expect(simulationResults[0]).to.have.property('error', 'Answer for skill skill1 was already given or inferred');
     });
   });
 });

--- a/api/tests/integration/domain/usecases/simulate-old-scoring_test.js
+++ b/api/tests/integration/domain/usecases/simulate-old-scoring_test.js
@@ -1,0 +1,79 @@
+const { expect, mockLearningContent, domainBuilder } = require('../../../test-helper');
+const OldScoringSimulation = require('../../../../lib/domain/models/OldScoringSimulation');
+const SimulationResult = require('../../../../lib/domain/models/SimulationResult');
+const usecases = require('../../../../lib/domain/usecases/');
+
+describe('Integration | UseCases | simulateOldScoring', function () {
+  it('should return 10001 as a direct scoring result', async function () {
+    // given
+    const learningContent = {
+      competences: [
+        {
+          id: 'rec1',
+          name_i18n: {
+            fr: 'comp1Fr',
+            en: 'comp1En',
+          },
+          index: '1.1',
+          color: 'rec1Color',
+          skillIds: ['skill1', 'skill2'],
+        },
+        {
+          id: 'rec2',
+          name_i18n: {
+            fr: 'comp2Fr',
+            en: 'comp2En',
+          },
+          index: '2.1',
+          color: 'rec2Color',
+          skillIds: ['skill3', 'skill4', 'skill5'],
+        },
+      ],
+      tubes: [
+        { id: 'recTube1', competenceId: 'rec1' },
+        { id: 'recTube2', competenceId: 'rec2' },
+      ],
+      skills: [
+        { id: 'skill1', status: 'actif', tubeId: 'recTube1', competenceId: 'rec1', pixValue: 1 },
+        { id: 'skill2', status: 'archivé', tubeId: 'recTube1', competenceId: 'rec1', pixValue: 10 },
+        { id: 'skill3', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', pixValue: 100 },
+        { id: 'skill4', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', pixValue: 1000 },
+        { id: 'skill5', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', pixValue: 10000 },
+        { id: 'skill6', status: 'périmé', tubeId: 'recTube2', competenceId: 'rec2', pixValue: 100000 },
+      ],
+      challenges: [
+        { id: 'challenge1', skillId: 'skill1', status: 'validé' },
+        { id: 'challenge2', skillId: 'skill3', status: 'validé' },
+        { id: 'challenge3', skillId: 'skill4', status: 'validé' },
+        { id: 'challenge4', skillId: 'skill5', status: 'validé' },
+      ],
+    };
+
+    mockLearningContent(learningContent);
+
+    const answers = [
+      domainBuilder.buildAnswer.ok({
+        challengeId: 'challenge1',
+      }),
+      domainBuilder.buildAnswer.ko({
+        challengeId: 'challenge2',
+      }),
+      domainBuilder.buildAnswer.skipped({
+        challengeId: 'challenge3',
+      }),
+      domainBuilder.buildAnswer.ok({
+        challengeId: 'challenge4',
+      }),
+    ];
+
+    const simulation = new OldScoringSimulation({ answers });
+
+    // when
+    const simulationResults = await usecases.simulateOldScoring({ simulations: [simulation] });
+
+    // then
+    expect(simulationResults).to.have.lengthOf(1);
+    expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+    expect(simulationResults[0]).to.have.property('pixScore', 10001);
+  });
+});


### PR DESCRIPTION
## :christmas_tree: Problème
La route `/api/scoring-simulator/old` ne fait rien pour le moment.

## :gift: Proposition
Implémenter cette route à l'aide d'un nouveau UC `simulateOldScoring`.

## :star2: Remarques
RAS

## :santa: Pour tester
```
TOKEN=$(curl 'https://api-pr5487.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin%40example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr5487.review.pix.fr/api/scoring-simulator/old \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -X POST \
    -d '{ "simulations": [{ "answers": [{ "challengeId": "rec3wt8JjOQZMoQav", "result": "ok" }] }] }'
```