### PR TITLE
[BUGIFX][ADMIN] Améliorer la gestion des erreurs lors de l'envoi d'une invitation à rejoindre un centre de certification (PIX-6779)

### DIFF
--- a/api/lib/domain/usecases/create-or-update-certification-center-invitation-for-admin.js
+++ b/api/lib/domain/usecases/create-or-update-certification-center-invitation-for-admin.js
@@ -1,4 +1,4 @@
-const { SendingEmailError } = require('../errors');
+const { SendingEmailError, SendingEmailToInvalidDomainError } = require('../errors');
 const CertificationCenterInvitation = require('../models/CertificationCenterInvitation');
 
 module.exports = async function createOrUpdateCertificationCenterInvitationForAdmin({
@@ -36,6 +36,10 @@ module.exports = async function createOrUpdateCertificationCenterInvitationForAd
     code: certificationCenterInvitation.code,
   });
   if (mailerResponse?.status === 'FAILURE') {
+    if (mailerResponse.hasFailedBecauseDomainWasInvalid()) {
+      throw new SendingEmailToInvalidDomainError(email);
+    }
+
     throw new SendingEmailError();
   }
 


### PR DESCRIPTION
## :christmas_tree: Problème

Lorsqu’une invitation à rejoindre un centre de certification est envoyée depuis Pix Admin à une adresse dont le nom de domaine est invalide, l’API renvoie une erreur 503 et le front affiche le message :

> Le service d’envoi d’email est momentanément indisponible, veuillez réessayer ultérieurement.

Or si le domaine n’est pas bon, le problème n’est pas temporaire, il ne sert à rien de réessayer plus tard. Il faudrait renvoyer un statut 4XX et mieux informer l’utilisateur (en lui suggérant par exemple de vérifier le domaine de l’adresse e-mail).

Le problème a été corrigé pour l’envoi des invitations à rejoindre une organisation dans cette [PR#5402](https://github.com/1024pix/pix/pull/5402)

## :gift: Proposition

- [x] Renvoyer un statut 400
- [x] Mieux informer l’utilisateur en indiquant que le problème vient du domaine de l'adresse e-mail

## :star2: Remarques

RAS

## :santa: Pour tester

1. Se connecter à Pix Admin
2. Se rendre sur l'onglet `Invitations` d'un centre de certifications
3. Envoyer une invitation à une adresse dont le domaine n'existe pas `user@pixerror.fr`
4. Constater qu'un message d'erreur explicite apparaît
