### PR TITLE
[BUGFIX] L'image et le titre de la page parcours ne sont pas centrés (PIX-6777).

### DIFF
--- a/mon-pix/app/styles/pages/_user-tests.scss
+++ b/mon-pix/app/styles/pages/_user-tests.scss
@@ -1,3 +1,7 @@
+.user-tests__header {
+  padding-top: 0;
+}
+
 .user-tests-banner {
   position: relative;
   display: flex;

--- a/mon-pix/app/templates/authenticated/user-tests.hbs
+++ b/mon-pix/app/templates/authenticated/user-tests.hbs
@@ -5,7 +5,7 @@
 </header>
 
 <main id="main" role="main">
-  <PixBackgroundHeader>
+  <PixBackgroundHeader class="user-tests__header">
     <div class="user-tests-banner">
       <img src="/images/background/user-test-banner.svg" class="user-tests-banner__icon" role="none" alt="" />
       <h1 class="user-tests-banner__title">{{t "pages.user-tests.title"}}</h1>


### PR DESCRIPTION
## :christmas_tree: Problème
L'image et le titre de la page parcours ne sont pas centrés.

## :gift: Proposition
Centrer l'image et le titre de la page parcours.

## :star2: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :santa: Pour tester
Vérifier que dans l'onglet mes parcours de PixApp le titre et l'image soit centrés
