### PR TITLE
[TECH] Implémenter Normallize/Reset CSS dans  Pix-admin (PIX-3024)

### DIFF
--- a/admin/app/components/actions-on-users-role-in-organization.hbs
+++ b/admin/app/components/actions-on-users-role-in-organization.hbs
@@ -1,10 +1,11 @@
 <td>
   {{#if this.isEditionMode}}
     <PixSelect
+      style="width:100%"
       @onChange={{this.setRoleSelection}}
       @value={{this.selectedNewRole}}
       @options={{this.organizationRoles}}
-      @placeholder="Rôle"
+      @placeholder="- Rôle -"
       @label="Sélectionner un rôle"
       @screenReaderOnly={{true}}
       as |organizationRole|

--- a/admin/app/components/actions-on-users-role-in-organization.hbs
+++ b/admin/app/components/actions-on-users-role-in-organization.hbs
@@ -2,6 +2,7 @@
   {{#if this.isEditionMode}}
     <PixSelect
       @onChange={{this.setRoleSelection}}
+      @value={{this.selectedNewRole}}
       @options={{this.organizationRoles}}
       @placeholder="Rôle"
       @label="Sélectionner un rôle"

--- a/admin/app/components/actions-on-users-role-in-organization.hbs
+++ b/admin/app/components/actions-on-users-role-in-organization.hbs
@@ -3,11 +3,9 @@
     <PixSelect
       @onChange={{this.setRoleSelection}}
       @options={{this.organizationRoles}}
-      placeholder="Sélectionner"
-      aria-label="Sélectionner un rôle"
-      @isSearchable={{false}}
-      @emptyOptionNotSelectable={{true}}
-      @emptyOptionLabel=""
+      @placeholder="Rôle"
+      @label="Sélectionner un rôle"
+      @screenReaderOnly={{true}}
       as |organizationRole|
     >
       {{organizationRole.label}}

--- a/admin/app/components/actions-on-users-role-in-organization.hbs
+++ b/admin/app/components/actions-on-users-role-in-organization.hbs
@@ -1,7 +1,7 @@
 <td>
   {{#if this.isEditionMode}}
     <PixSelect
-      style="width:100%"
+      class="pix-select-in-table"
       @onChange={{this.setRoleSelection}}
       @value={{this.selectedNewRole}}
       @options={{this.organizationRoles}}

--- a/admin/app/components/actions-on-users-role-in-organization.js
+++ b/admin/app/components/actions-on-users-role-in-organization.js
@@ -19,8 +19,8 @@ export default class ActionsOnUsersRoleInOrganization extends Component {
   }
 
   @action
-  setRoleSelection(event) {
-    this.selectedNewRole = event.target.value;
+  setRoleSelection(value) {
+    this.selectedNewRole = value;
     this.isEditionMode = true;
   }
 

--- a/admin/app/components/certification-centers/creation-form.hbs
+++ b/admin/app/components/certification-centers/creation-form.hbs
@@ -18,6 +18,7 @@
         @placeholder="-- Choisissez --"
         @hideDefaultOption={{true}}
         @onChange={{this.selectCertificationCenterType}}
+        @value={{@certificationCenter.type}}
         required={{true}}
         aria-required={{true}}
         as |certificationCenterType|

--- a/admin/app/components/certification-centers/creation-form.hbs
+++ b/admin/app/components/certification-centers/creation-form.hbs
@@ -13,12 +13,10 @@
 
     <div class="form-field">
       <PixSelect
-        @id="certificationCenterTypeSelector"
         @label="Type d'établissement"
         @options={{this.certificationCenterTypes}}
-        @isSearchable={{false}}
-        @emptyOptionNotSelectable={{true}}
-        @emptyOptionLabel={{"-- Choisissez --"}}
+        @placeholder="-- Choisissez --"
+        @hideDefaultOption={{true}}
         @onChange={{this.selectCertificationCenterType}}
         required={{true}}
         aria-required={{true}}

--- a/admin/app/components/certification-centers/creation-form.js
+++ b/admin/app/components/certification-centers/creation-form.js
@@ -36,8 +36,8 @@ export default class CertificationCenterForm extends Component {
   }
 
   @action
-  selectCertificationCenterType(event) {
-    this.args.certificationCenter.type = event.target.value;
+  selectCertificationCenterType(value) {
+    this.args.certificationCenter.type = value;
   }
 
   @action

--- a/admin/app/components/certification-centers/information-edit.hbs
+++ b/admin/app/components/certification-centers/information-edit.hbs
@@ -22,8 +22,7 @@
       <PixSelect
         @label="Type"
         @options={{this.certificationCenterTypes}}
-        @placeholder={{"-- Choisissez --"}}
-        @hideDefaultOption={{true}}
+        @placeholder="-- Choisissez --"
         @value={{this.form.type}}
         @onChange={{this.selectCertificationCenterType}}
         @errorMessage={{v-get this.form "type" "message"}}

--- a/admin/app/components/certification-centers/information-edit.hbs
+++ b/admin/app/components/certification-centers/information-edit.hbs
@@ -19,21 +19,14 @@
     </div>
 
     <div class="form-field">
-      <label for="certification-center-type" class="field__label">Type</label>
-      {{#if (v-get this.form "type" "isInvalid")}}
-        <div class="form-field__error" aria-label="Message d'erreur du champ type">
-          {{v-get this.form "type" "message"}}
-        </div>
-      {{/if}}
       <PixSelect
-        id="certification-center-type"
+        @label="Type"
         @options={{this.certificationCenterTypes}}
-        @isSearchable={{false}}
-        @emptyOptionNotSelectable={{true}}
-        @emptyOptionLabel={{"-- Choisissez --"}}
-        @selectedOption={{this.form.type}}
+        @placeholder={{"-- Choisissez --"}}
+        @hideDefaultOption={{true}}
+        @value={{this.form.type}}
         @onChange={{this.selectCertificationCenterType}}
-        class={{if (v-get this.form "type" "isInvalid") "is-invalid"}}
+        @errorMessage={{v-get this.form "type" "message"}}
       />
     </div>
 

--- a/admin/app/components/certification-centers/information-edit.js
+++ b/admin/app/components/certification-centers/information-edit.js
@@ -93,8 +93,8 @@ export default class InformationEdit extends Component {
   }
 
   @action
-  selectCertificationCenterType(event) {
-    this.form.type = event.target.value;
+  selectCertificationCenterType(value) {
+    this.form.type = value;
   }
 
   @action

--- a/admin/app/components/certification-centers/invitations-action.hbs
+++ b/admin/app/components/certification-centers/invitations-action.hbs
@@ -13,9 +13,12 @@
 
       <PixSelect
         @options={{this.languagesOptions}}
-        @selectedOption={{this.invitationLanguage}}
+        @value={{this.invitationLanguage}}
         @onChange={{this.changeInvitationLanguage}}
-        aria-label="Choisir la langue de l’email d’invitation"
+        @label="Choisir la langue de l’email d’invitation"
+        @screenReaderOnly={{true}}
+        @placeholder="Choix de la langue"
+        @hideDefaultOption={{true}}
       />
 
       <PixButton

--- a/admin/app/components/certification-centers/invitations-action.js
+++ b/admin/app/components/certification-centers/invitations-action.js
@@ -23,7 +23,7 @@ export default class CertificationCenterInvitationsAction extends Component {
   }
 
   @action
-  changeInvitationLanguage(event) {
-    this.invitationLanguage = event.target.value;
+  changeInvitationLanguage(value) {
+    this.invitationLanguage = value;
   }
 }

--- a/admin/app/components/certifications/candidate-edit-modal.hbs
+++ b/admin/app/components/certifications/candidate-edit-modal.hbs
@@ -63,7 +63,7 @@
           @label="Pays de naissance"
           @options={{this.countryOptions}}
           @onChange={{this.selectBirthCountry}}
-          @selectedOption={{this.selectedCountryOption}}
+          @value={{this.selectedCountryOption}}
           required
         />
       </div>

--- a/admin/app/components/certifications/candidate-edit-modal.hbs
+++ b/admin/app/components/certifications/candidate-edit-modal.hbs
@@ -59,11 +59,8 @@
       </div>
 
       <div class="candidate-edit-modal--content__field">
-        <label for="birth-country">
-          Pays de naissance
-        </label>
         <PixSelect
-          id="birth-country"
+          @label="Pays de naissance"
           @options={{this.countryOptions}}
           @onChange={{this.selectBirthCountry}}
           @selectedOption={{this.selectedCountryOption}}

--- a/admin/app/components/certifications/candidate-edit-modal.js
+++ b/admin/app/components/certifications/candidate-edit-modal.js
@@ -122,8 +122,8 @@ export default class CandidateEditModal extends Component {
   }
 
   @action
-  selectBirthCountry(event) {
-    this.selectedCountryInseeCode = event.target.value;
+  selectBirthCountry(value) {
+    this.selectedCountryInseeCode = value;
     this.birthCountry = this._getCountryName();
     this.birthCity = '';
     this.birthPostalCode = '';

--- a/admin/app/components/certifications/details-answer.hbs
+++ b/admin/app/components/certifications/details-answer.hbs
@@ -27,8 +27,7 @@
     <PixSelect
       @onChange={{this.selectOption}}
       @options={{this.resultOptions}}
-      @selectedOption={{this.selectedOption}}
-      @placeholder="Sélectionner un résultat"
+      @value={{this.selectedOption}}
       @hideDefaultOption={{true}}
       @label="Sélectionner un résultat"
       @screenReaderOnly={{true}}

--- a/admin/app/components/certifications/details-answer.hbs
+++ b/admin/app/components/certifications/details-answer.hbs
@@ -28,10 +28,10 @@
       @onChange={{this.selectOption}}
       @options={{this.resultOptions}}
       @selectedOption={{this.selectedOption}}
-      @emptyOptionLabel=""
-      @emptyOptionNotSelectable="true"
-      aria-label="Sélectionner un résultat"
-      @isSearchable={{false}}
+      @placeholder="Sélectionner un résultat"
+      @hideDefaultOption={{true}}
+      @label="Sélectionner un résultat"
+      @screenReaderOnly={{true}}
       class={{this.resultClass}}
       as |result|
     >

--- a/admin/app/components/certifications/details-answer.js
+++ b/admin/app/components/certifications/details-answer.js
@@ -36,10 +36,9 @@ export default class CertificationDetailsAnswer extends Component {
   }
 
   @action
-  selectOption(event) {
+  selectOption(newResult) {
     const answer = this.args.answer;
     const answerResult = this._answerResultValue();
-    const newResult = event.target.value;
     answer.jury = answerResult !== newResult ? newResult : null;
     this.selectedOption = newResult ?? answerResult;
     this.hasJuryResult = !!newResult;

--- a/admin/app/components/certifications/status-select.hbs
+++ b/admin/app/components/certifications/status-select.hbs
@@ -1,14 +1,13 @@
 <div class="certification-status-select">
   {{#if @edition}}
-    <label for="certification-status-selector">Statut :</label>
     <PixSelect
-      id="certification-status-selector"
-      name="certification-status-selector"
+      @label="Statut :"
+      @placeholder="Statut"
       class="certification-status-select__select"
       @options={{this.options}}
       @onChange={{this.selectOption}}
       @selectedOption={{@certification.status}}
-      @emptyOptionNotSelectable={{true}}
+      @hideDefaultOption={{true}}
     />
   {{else}}
     <span>Statut :</span>

--- a/admin/app/components/certifications/status-select.hbs
+++ b/admin/app/components/certifications/status-select.hbs
@@ -2,7 +2,6 @@
   {{#if @edition}}
     <PixSelect
       @label="Statut :"
-      @placeholder="Statut"
       class="certification-status-select__select"
       @options={{this.options}}
       @onChange={{this.selectOption}}

--- a/admin/app/components/certifications/status-select.js
+++ b/admin/app/components/certifications/status-select.js
@@ -1,7 +1,6 @@
 import CertificationInfoField from './info-field';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import find from 'lodash/find';
 import { certificationStatuses } from 'pix-admin/models/certification';
 
 export default class CertificationStatusSelect extends CertificationInfoField {
@@ -15,13 +14,8 @@ export default class CertificationStatusSelect extends CertificationInfoField {
   }
 
   @action
-  selectOption(event) {
-    const selectedOptionValue = event.target.value || null;
+  selectOption(selectedOptionValue) {
     this.args.certification.status = selectedOptionValue;
-    this.selectedOption = this.getOptionByValue(selectedOptionValue);
-  }
-
-  getOptionByValue(value) {
-    return find(this.options, { value });
+    this.selectedOption = selectedOptionValue;
   }
 }

--- a/admin/app/components/organizations/creation-form.hbs
+++ b/admin/app/components/organizations/creation-form.hbs
@@ -14,7 +14,6 @@
       @options={{this.organizationTypes}}
       @value={{@organization.type}}
       @label="Sélectionner un type d'organisation"
-      @placeholder="Sélectionner un type d'organisation"
       @hideDefaultOption={{true}}
       required
       aria-required

--- a/admin/app/components/organizations/creation-form.hbs
+++ b/admin/app/components/organizations/creation-form.hbs
@@ -10,15 +10,14 @@
       aria-required={{true}}
     />
     <PixSelect
-      @id="organizationTypeSelector"
       @onChange={{this.handleOrganizationTypeSelectionChange}}
       @options={{this.organizationTypes}}
-      @isSearchable={{false}}
+      @value={{@organization.type}}
       @label="Sélectionner un type d'organisation"
-      @emptyOptionNotSelectable={{true}}
-      @emptyOptionLabel=""
-      required={{true}}
-      aria-required={{true}}
+      @placeholder="Sélectionner un type d'organisation"
+      @hideDefaultOption={{true}}
+      required
+      aria-required
       class="form-field"
       as |organizationType|
     >

--- a/admin/app/components/organizations/creation-form.js
+++ b/admin/app/components/organizations/creation-form.js
@@ -9,8 +9,8 @@ export default class OrganizationCreationForm extends Component {
   ];
 
   @action
-  handleOrganizationTypeSelectionChange(event) {
-    this.args.organization.type = event.target.value;
+  handleOrganizationTypeSelectionChange(value) {
+    this.args.organization.type = value;
   }
 
   @action

--- a/admin/app/components/organizations/information-section-edit.hbs
+++ b/admin/app/components/organizations/information-section-edit.hbs
@@ -159,7 +159,7 @@
         @label="SSO"
         @placeholder="SSO"
         @options={{this.identityProviderOptions}}
-        @value={{this.currentIdentityProvider}}
+        @value={{this.form.identityProviderForCampaigns}}
         @onChange={{this.onChangeIdentityProvider}}
         @hideDefaultOption={{true}}
       />

--- a/admin/app/components/organizations/information-section-edit.hbs
+++ b/admin/app/components/organizations/information-section-edit.hbs
@@ -156,12 +156,12 @@
 
     <div class="form-field">
       <PixSelect
-        @id="organization-edit-form__identity-provider-for-campaign-select"
         @label="SSO"
+        @placeholder="SSO"
         @options={{this.identityProviderOptions}}
-        @selectedOption={{this.currentIdentityProvider}}
+        @value={{this.currentIdentityProvider}}
         @onChange={{this.onChangeIdentityProvider}}
-        @emptyOptionNotSelectable={{true}}
+        @hideDefaultOption={{true}}
       />
     </div>
 

--- a/admin/app/components/organizations/information-section-edit.js
+++ b/admin/app/components/organizations/information-section-edit.js
@@ -152,11 +152,6 @@ export default class OrganizationInformationSectionEditionMode extends Component
     return [this.noIdentityProviderOption, this.garIdentityProviderOption, ...oidcIdentityProvidersOptions];
   }
 
-  get currentIdentityProvider() {
-    const currentIdentityProvider = this.args.organization.identityProviderForCampaigns;
-    return currentIdentityProvider ?? this.noIdentityProviderOption.value;
-  }
-
   @action
   onChangeIdentityProvider(newIdentityProvider) {
     this.form.identityProviderForCampaigns =
@@ -207,5 +202,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
     this.form.isManagingStudents = this.args.organization.isManagingStudents;
     this.form.documentationUrl = this.args.organization.documentationUrl;
     this.form.showSkills = this.args.organization.showSkills;
+    this.form.identityProviderForCampaigns =
+      this.args.organization.identityProviderForCampaigns ?? this.noIdentityProviderOption.value;
   }
 }

--- a/admin/app/components/organizations/information-section-edit.js
+++ b/admin/app/components/organizations/information-section-edit.js
@@ -158,15 +158,9 @@ export default class OrganizationInformationSectionEditionMode extends Component
   }
 
   @action
-  onChangeIdentityProvider(eventOnChange) {
-    const selectedIndex = eventOnChange.target.selectedIndex;
-    if (selectedIndex >= 0) {
-      const identityProviderForCampaignsValue = eventOnChange.target.options[selectedIndex].value;
-      this.form.identityProviderForCampaigns =
-        identityProviderForCampaignsValue === this.noIdentityProviderOption.value
-          ? null
-          : identityProviderForCampaignsValue;
-    }
+  onChangeIdentityProvider(newIdentityProvider) {
+    this.form.identityProviderForCampaigns =
+      newIdentityProvider === this.noIdentityProviderOption.value ? null : newIdentityProvider;
   }
 
   @action

--- a/admin/app/components/organizations/information-section-view.hbs
+++ b/admin/app/components/organizations/information-section-view.hbs
@@ -25,7 +25,7 @@
 
   <div class="organization-information-section__content">
     <div class="organization-information-section__details">
-      <ul>
+      <ul class="organization-information-section__details__list">
         <li>Type : {{@organization.type}}</li>
         <li>Créée par : {{@organization.creatorFullName}} ({{@organization.createdBy}})</li>
         <li>Créée le : {{@organization.createdAtFormattedDate}}</li>

--- a/admin/app/components/organizations/invitations-action.hbs
+++ b/admin/app/components/organizations/invitations-action.hbs
@@ -13,17 +13,19 @@
 
         <PixSelect
           @options={{this.languagesOptions}}
-          @selectedOption={{this.organizationInvitationLang}}
+          @value={{this.organizationInvitationLang}}
           @onChange={{this.changeOrganizationInvitationLang}}
-          aria-label="Choisir la langue de l’email d’invitation"
+          @label="Choisir la langue de l’email d’invitation"
+          @placeholder="Langue"
           class="organization-invitations__select"
         />
 
         <PixSelect
           @options={{this.rolesOptions}}
-          @selectedOption={{this.organizationInvitationRole}}
+          @value={{this.organizationInvitationRole}}
           @onChange={{this.changeOrganizationInvitationRole}}
-          aria-label="Choisir le rôle du membre"
+          @label="Choisir le rôle du membre"
+          @placeholder="Rôle"
           class="organization-invitations__select"
         />
 

--- a/admin/app/components/organizations/invitations-action.js
+++ b/admin/app/components/organizations/invitations-action.js
@@ -45,12 +45,12 @@ export default class OrganizationInvitationsAction extends Component {
   }
 
   @action
-  changeOrganizationInvitationRole(event) {
-    this.organizationInvitationRole = event.target.value ? event.target.value : null;
+  changeOrganizationInvitationRole(value) {
+    this.organizationInvitationRole = value;
   }
 
   @action
-  changeOrganizationInvitationLang(event) {
-    this.organizationInvitationLang = event.target.value;
+  changeOrganizationInvitationLang(value) {
+    this.organizationInvitationLang = value;
   }
 }

--- a/admin/app/components/organizations/places-lot-creation-form.hbs
+++ b/admin/app/components/organizations/places-lot-creation-form.hbs
@@ -57,26 +57,16 @@
         {{/if}}
       </div>
       <div class="form-field">
-        <label for="category" class="form-field__label">
-          <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-          Catégorie :
-        </label>
         <PixSelect
-          name="category"
-          id="category"
+          @label="Catégorie :"
           class={{if @errors.category "form-control is-invalid" "form-control"}}
           @options={{this.categories}}
           @onChange={{this.selectCategory}}
-          @selectedOption={{this.selectedCategory}}
-          @isValidationActive={{true}}
+          @value={{this.selectedCategory}}
           @emptyOptionNotSelectable={{true}}
+          @errorMessage={{get @errors.category "0.message"}}
+          @requiredText="Champs obligatoire"
         />
-
-        {{#if @errors.category}}
-          <div class="form-field__error">
-            {{get @errors.category "0.message"}}
-          </div>
-        {{/if}}
       </div>
       <div class="form-field">
         <label for="reference" class="form-field__label">

--- a/admin/app/components/organizations/places-lot-creation-form.hbs
+++ b/admin/app/components/organizations/places-lot-creation-form.hbs
@@ -59,11 +59,10 @@
       <div class="form-field">
         <PixSelect
           @label="Catégorie :"
-          class={{if @errors.category "form-control is-invalid" "form-control"}}
           @options={{this.categories}}
+          @placeholder="Sélectionnez une catégorie"
           @onChange={{this.selectCategory}}
-          @value={{this.selectedCategory}}
-          @emptyOptionNotSelectable={{true}}
+          @value={{this.category}}
           @errorMessage={{get @errors.category "0.message"}}
           @requiredText="Champs obligatoire"
         />

--- a/admin/app/components/organizations/places-lot-creation-form.js
+++ b/admin/app/components/organizations/places-lot-creation-form.js
@@ -5,7 +5,6 @@ import { tracked } from '@glimmer/tracking';
 import dayjs from 'dayjs';
 
 const categories = [
-  { value: '', label: 'sélectionnez une catégorie' },
   { value: 'FULL_RATE', label: 'Tarif plein' },
   { value: 'SPECIAL_REDUCE_RATE', label: 'Tarif réduit spécial' },
   { value: 'REDUCE_RATE', label: 'Tarif réduit' },
@@ -45,9 +44,8 @@ export default class PlacesLotCreationForm extends Component {
   }
 
   @action
-  selectCategory(event) {
-    const newValue = event.target.value || null;
-    this.selectedCategory = this.getCategoryByValue(newValue);
+  selectCategory(value) {
+    const newValue = value || null;
     this.category = newValue;
   }
 

--- a/admin/app/components/organizations/team-section.hbs
+++ b/admin/app/components/organizations/team-section.hbs
@@ -51,12 +51,12 @@
             </td>
             <td class="table__column">
               <PixSelect
-                id="organizationRole"
                 @options={{this.options}}
-                @selectedOption={{@organizationRole}}
+                @value={{@organizationRole}}
                 @onChange={{@selectRoleForSearch}}
-                @emptyOptionLabel="Tous"
-                aria-label="Rechercher par rôle"
+                @placeholder="Tous"
+                @label="Rechercher par rôle"
+                @screenReaderOnly={{true}}
               />
             </td>
             {{#if this.accessControl.hasAccessToOrganizationActionsScope}}

--- a/admin/app/components/organizations/team-section.hbs
+++ b/admin/app/components/organizations/team-section.hbs
@@ -51,7 +51,7 @@
             </td>
             <td class="table__column">
               <PixSelect
-                style="width:100%"
+                class="pix-select-in-table"
                 @options={{this.options}}
                 @value={{@organizationRole}}
                 @onChange={{@selectRoleForSearch}}

--- a/admin/app/components/organizations/team-section.hbs
+++ b/admin/app/components/organizations/team-section.hbs
@@ -51,6 +51,7 @@
             </td>
             <td class="table__column">
               <PixSelect
+                style="width:100%"
                 @options={{this.options}}
                 @value={{@organizationRole}}
                 @onChange={{@selectRoleForSearch}}

--- a/admin/app/components/sessions/list-items.hbs
+++ b/admin/app/components/sessions/list-items.hbs
@@ -42,35 +42,35 @@
         </td>
         <td>
           <PixSelect
-            aria-label="Filtrer les sessions en sélectionnant un type de centre de certification"
-            name="certificationCenterType"
+            @label="Filtrer les sessions en sélectionnant un type de centre de certification"
+            @screenReaderOnly={{true}}
             class="sessions-list-items__select"
             @options={{this.certificationCenterTypeOptions}}
             @onChange={{this.selectCertificationCenterType}}
-            @selectedOption={{@certificationCenterType}}
+            @value={{@certificationCenterType}}
           />
         </td>
         <td></td>
         <td>
           <PixSelect
-            aria-label="Filtrer les sessions en sélectionnant un statut"
-            name="status"
+            @label="Filtrer les sessions en sélectionnant un statut"
+            @screenReaderOnly={{true}}
             class="sessions-list-items__select"
             @options={{this.sessionStatusOptions}}
             @onChange={{this.selectSessionStatus}}
-            @selectedOption={{@status}}
+            @value={{@status}}
           />
         </td>
         <td></td>
         <td></td>
         <td>
           <PixSelect
-            aria-label="Filtrer les sessions par leurs résultats diffusés ou non diffusés"
-            name="resultsSentToPrescriberAt"
+            @label="Filtrer les sessions par leurs résultats diffusés ou non diffusés"
+            @screenReaderOnly={{true}}
             class="sessions-list-items__select"
             @options={{this.sessionResultsSentToPrescriberOptions}}
             @onChange={{this.selectSessionResultsSentToPrescriber}}
-            @selectedOption={{@resultsSentToPrescriberAt}}
+            @value={{@resultsSentToPrescriberAt}}
           />
         </td>
       </tr>

--- a/admin/app/components/sessions/list-items.js
+++ b/admin/app/components/sessions/list-items.js
@@ -42,8 +42,7 @@ export default class ListItems extends Component {
   }
 
   @action
-  selectCertificationCenterType(event) {
-    const newValue = event.target.value || null;
+  selectCertificationCenterType(newValue) {
     this.selectedCertificationCenterTypeOption = this.getCertificationCenterTypeOptionByValue(newValue);
     this.args.onChangeCertificationCenterType(newValue);
   }
@@ -56,8 +55,7 @@ export default class ListItems extends Component {
   }
 
   @action
-  selectSessionStatus(event) {
-    const newValue = event.target.value || null;
+  selectSessionStatus(newValue) {
     this.selectedSessionStatusOption = this.getSessionStatusOptionByValue(newValue);
     this.args.onChangeSessionStatus(newValue);
   }
@@ -70,8 +68,7 @@ export default class ListItems extends Component {
   }
 
   @action
-  selectSessionResultsSentToPrescriber(event) {
-    const newValue = event.target.value || null;
+  selectSessionResultsSentToPrescriber(newValue) {
     this.selectedSessionResultsSentToPrescriberOption = this.getSessionResultsSentToPrescriberOptionByValue(newValue);
     this.args.onChangeSessionResultsSent(newValue);
   }

--- a/admin/app/components/stages/stage-level-select.hbs
+++ b/admin/app/components/stages/stage-level-select.hbs
@@ -1,1 +1,8 @@
-<PixSelect ...attributes @options={{this.levelOptions}} @onChange={{@onChange}} @selectedOption={{@value}} />
+<PixSelect
+  ...attributes
+  @options={{this.levelOptions}}
+  @onChange={{@onChange}}
+  @value={{@value}}
+  @id={{@id}}
+  @hideDefaultOption={{true}}
+/>

--- a/admin/app/components/stages/stage-level-select.hbs
+++ b/admin/app/components/stages/stage-level-select.hbs
@@ -4,5 +4,7 @@
   @onChange={{@onChange}}
   @value={{@value}}
   @id={{@id}}
+  @label={{@label}}
+  @screenReaderOnly={{true}}
   @hideDefaultOption={{true}}
 />

--- a/admin/app/components/stages/update-stage.hbs
+++ b/admin/app/components/stages/update-stage.hbs
@@ -6,7 +6,7 @@
       </label>
       {{#if @isTypeLevel}}
         <Stages::StageLevelSelect
-          id="threshold-or-level"
+          @id="threshold-or-level"
           @maxLevel={{@maxLevel}}
           @onChange={{this.setLevel}}
           @value={{this.form.level}}

--- a/admin/app/components/target-profiles/create-target-profile-form.hbs
+++ b/admin/app/components/target-profiles/create-target-profile-form.hbs
@@ -13,13 +13,12 @@
       <div class="form-field form-group">
         <PixSelect
           class="form-control"
-          @id="targetProfileCategory"
           @label="Catégorie :"
           @onChange={{this.onCategoryChange}}
-          @selectedOption={{@targetProfile.category}}
+          @value={{@targetProfile.category}}
           @options={{this.optionsList}}
-          @emptyOptionLabel={{"-"}}
-          @emptyOptionNotSelectable={{true}}
+          @placeholder="-"
+          @hideDefaultOption={{true}}
           required={{true}}
           aria-required={{true}}
         />

--- a/admin/app/components/target-profiles/create-target-profile-form.hbs
+++ b/admin/app/components/target-profiles/create-target-profile-form.hbs
@@ -10,19 +10,16 @@
         aria-required={{true}}
         {{on "change" this.updateTargetProfileName}}
       />
-      <div class="form-field form-group">
-        <PixSelect
-          class="form-control"
-          @label="Catégorie :"
-          @onChange={{this.onCategoryChange}}
-          @value={{@targetProfile.category}}
-          @options={{this.optionsList}}
-          @placeholder="-"
-          @hideDefaultOption={{true}}
-          required={{true}}
-          aria-required={{true}}
-        />
-      </div>
+      <PixSelect
+        @label="Catégorie :"
+        @onChange={{this.onCategoryChange}}
+        @value={{@targetProfile.category}}
+        @options={{this.optionsList}}
+        @placeholder="-"
+        @hideDefaultOption={{true}}
+        required={{true}}
+        aria-required={{true}}
+      />
 
       <div class="form-field form-group create-target-profile__checkbox-container">
         <label class="create-target-profile__is-public-label" for="isPublic">Public : </label>

--- a/admin/app/components/target-profiles/create-target-profile-form.js
+++ b/admin/app/components/target-profiles/create-target-profile-form.js
@@ -16,8 +16,8 @@ export default class CreateTargetProfileForm extends Component {
   }
 
   @action
-  onCategoryChange(event) {
-    this.args.targetProfile.category = event.target.value;
+  onCategoryChange(value) {
+    this.args.targetProfile.category = value;
   }
 
   @action

--- a/admin/app/components/target-profiles/pdf-parameters-modal.hbs
+++ b/admin/app/components/target-profiles/pdf-parameters-modal.hbs
@@ -1,8 +1,7 @@
 <PixModal @title="Paramètres du PDF" @onCloseButtonClick={{@onCloseButtonClicked}} @showModal={{@displayModal}}>
   <:content>
     <PixSelect
-      @id="pdfParameterLanguage"
-      @selectedOption={{this.language}}
+      @value={{this.language}}
       @onChange={{this.onChangeLanguage}}
       @options={{this.options}}
       @label="Langue du référentiel (français ou anglais) :"

--- a/admin/app/components/target-profiles/stages/new-stage.hbs
+++ b/admin/app/components/target-profiles/stages/new-stage.hbs
@@ -12,7 +12,7 @@
           @onChange={{@setLevel}}
           class={{if @errors.level "form-control is-invalid" "form-control"}}
           required="true"
-          aria-label="Niveau du palier"
+          @label="Niveau du palier"
         />
       {{else}}
         <Input

--- a/admin/app/components/target-profiles/tubes-selection.hbs
+++ b/admin/app/components/target-profiles/tubes-selection.hbs
@@ -9,13 +9,13 @@
         class="tubes-selection__multi-select"
         @label="Référentiel :"
         @screenReaderOnly={{true}}
-        @innerText="Séléctionner les référentiels souhaités"
+        @placeholder="Séléctionner les référentiels souhaités"
         @id="framework-list"
         @isSearchable={{true}}
         @showOptionsOnInput={{true}}
-        @onSelect={{this.setSelectedFrameworkIds}}
+        @onChange={{this.setSelectedFrameworkIds}}
         @emptyMessage={{"Pas de résultat"}}
-        @selected={{this.selectedFrameworkIds}}
+        @values={{this.selectedFrameworkIds}}
         @options={{this.frameworkOptions}}
         as |option|
       >

--- a/admin/app/components/target-profiles/tubes-selection/tube.hbs
+++ b/admin/app/components/target-profiles/tubes-selection/tube.hbs
@@ -1,5 +1,5 @@
 <td>
-  <label data-test="label-tube-{{@tube.id}}">
+  <label>
     <TargetProfiles::TubesSelection::Checkbox
       id="tube-{{@tube.id}}"
       @state={{this.state}}
@@ -12,14 +12,13 @@
 </td>
 <td class="table__column--center">
   <PixSelect
-    id="select-level-tube-{{@tube.id}}"
-    data-testid="select-level-tube-{{@tube.id}}"
+    @label="Sélection du niveau du sujet"
+    @screenReaderOnly={{true}}
     @options={{this.levelOptions}}
     @onChange={{this.setLevelTube}}
-    @selectedOption={{this.selectedLevel}}
-    disabled={{not this.checked}}
+    @value={{this.selectedLevel}}
+    @isDisabled={{not this.checked}}
   />
-  <label for="select-level-tube-{{@tube.id}}" class="sr-only">Sélection du niveau du sujet</label>
 </td>
 <td class="table__column--center">
   <div class="icon-container" aria-label="{{if @tube.mobile 'compatible mobile' 'incompatible mobile'}}">

--- a/admin/app/components/target-profiles/tubes-selection/tube.hbs
+++ b/admin/app/components/target-profiles/tubes-selection/tube.hbs
@@ -12,7 +12,7 @@
 </td>
 <td class="table__column--center">
   <PixSelect
-    @label="Sélection du niveau du sujet"
+    @label="Sélection du niveau du sujet suivant : {{@tube.practicalTitle}}"
     @screenReaderOnly={{true}}
     @options={{this.levelOptions}}
     @onChange={{this.setLevelTube}}

--- a/admin/app/components/target-profiles/tubes-selection/tube.js
+++ b/admin/app/components/target-profiles/tubes-selection/tube.js
@@ -36,9 +36,7 @@ export default class Tube extends Component {
   }
 
   @action
-  setLevelTube(event) {
-    const select = event.currentTarget;
-    const level = select.value;
+  setLevelTube(level) {
     const tubeId = this.args.tube.id;
     this.args.setLevelTube(tubeId, level);
   }

--- a/admin/app/components/target-profiles/update-target-profile.hbs
+++ b/admin/app/components/target-profiles/update-target-profile.hbs
@@ -28,14 +28,13 @@
 
         <PixSelect
           class="form-control"
-          @id="targetProfileCategory"
-          @label={{"Catégorie :"}}
+          @label="Catégorie :"
           @onChange={{this.onCategoryChange}}
-          @selectedOption={{@model.category}}
+          @value={{@model.category}}
           @options={{this.optionsList}}
-          @emptyOptionLabel={{"-"}}
-          @emptyOptionNotSelectable={{true}}
-          required={{true}}
+          @placeholder={{"-"}}
+          @hideDefaultOption={{true}}
+          required
         />
 
         <label for="targetProfileDescription" class="form-field__label">

--- a/admin/app/components/target-profiles/update-target-profile.js
+++ b/admin/app/components/target-profiles/update-target-profile.js
@@ -73,8 +73,8 @@ export default class UpdateTargetProfile extends Component {
   }
 
   @action
-  onCategoryChange(event) {
-    this.form.category = event.target.value;
+  onCategoryChange(value) {
+    this.form.category = value;
   }
 
   async _updateTargetProfile() {

--- a/admin/app/components/team/add-member.hbs
+++ b/admin/app/components/team/add-member.hbs
@@ -20,6 +20,7 @@
         @isSearchable={{false}}
         @onChange={{this.roleChanged}}
         @label="Choisir le rôle à assigner au nouveau membre"
+        @placeholder="- Choisissez un rôle -"
         @screenReaderOnly={{true}}
       />
     </section>

--- a/admin/app/components/team/add-member.hbs
+++ b/admin/app/components/team/add-member.hbs
@@ -16,10 +16,11 @@
     <section class="add-member-to-team-form__select {{if this.inviteErrorRaised 'error-padding'}}">
       <PixSelect
         @options={{@roles}}
-        @selectedOption={{this.role}}
+        @value={{this.role}}
         @isSearchable={{false}}
         @onChange={{this.roleChanged}}
-        aria-label="Choisir le rôle à assigner au nouveau membre"
+        @label="Choisir le rôle à assigner au nouveau membre"
+        @screenReaderOnly={{true}}
       />
     </section>
 

--- a/admin/app/components/team/add-member.js
+++ b/admin/app/components/team/add-member.js
@@ -53,8 +53,8 @@ export default class AddMember extends Component {
   }
 
   @action
-  roleChanged(event) {
-    this.role = event?.target?.value ?? null;
+  roleChanged(value) {
+    this.role = value ?? null;
   }
 
   _isEmailValid() {

--- a/admin/app/components/team/list.hbs
+++ b/admin/app/components/team/list.hbs
@@ -20,9 +20,10 @@
               {{#if member.isInEditionMode}}
                 <PixSelect
                   @onChange={{this.setAdminRoleSelection}}
-                  @selectedOption={{member.role}}
+                  @value={{member.role}}
                   @options={{@roles}}
-                  aria-label="Sélectionner un rôle"
+                  @label="Sélectionner un rôle"
+                  @screenReaderOnly={{true}}
                   @isSearchable={{false}}
                   as |role|
                 >

--- a/admin/app/components/team/list.hbs
+++ b/admin/app/components/team/list.hbs
@@ -19,8 +19,8 @@
             <td>
               {{#if member.isInEditionMode}}
                 <PixSelect
-                  @onChange={{this.setAdminRoleSelection}}
-                  @value={{member.role}}
+                  @onChange={{fn this.setAdminRoleSelection member}}
+                  @value={{or member.updatedRole member.role}}
                   @options={{@roles}}
                   @label="Sélectionner un rôle"
                   @screenReaderOnly={{true}}

--- a/admin/app/components/team/list.hbs
+++ b/admin/app/components/team/list.hbs
@@ -24,7 +24,7 @@
                   @options={{@roles}}
                   @label="Sélectionner un rôle"
                   @screenReaderOnly={{true}}
-                  @isSearchable={{false}}
+                  @hideDefaultOption={{true}}
                   as |role|
                 >
                   {{role.label}}

--- a/admin/app/components/team/list.js
+++ b/admin/app/components/team/list.js
@@ -43,13 +43,15 @@ export default class List extends Component {
     try {
       await adminMember.save();
       this.notifications.success(
-        `L'agent ${adminMember.firstName} ${adminMember.lastName} a désormais le rôle ${this.newRole}`
+        `L'agent ${adminMember.firstName} ${adminMember.lastName} a désormais le rôle ${adminMember.updatedRole}`
       );
     } catch (errorResponse) {
       this.errorResponseHandler.notify(errorResponse, this.CUSTOM_ERROR_STATUS_MESSAGES.UPDATE);
       adminMember.role = previousRole;
+      adminMember.updatedRole = null;
     } finally {
       adminMember.isInEditionMode = false;
+      adminMember.updatedRole = null;
     }
   }
 

--- a/admin/app/components/team/list.js
+++ b/admin/app/components/team/list.js
@@ -9,7 +9,6 @@ export default class List extends Component {
   @service errorResponseHandler;
   @tracked displayConfirm = false;
   @tracked editionMode = false;
-  @tracked newRole;
   @tracked confirmPopUpMessage;
 
   CUSTOM_ERROR_STATUS_MESSAGES = {
@@ -27,20 +26,20 @@ export default class List extends Component {
   }
 
   @action
-  setAdminRoleSelection(value) {
-    this.newRole = value;
+  setAdminRoleSelection(adminMember, value) {
+    adminMember.updatedRole = value;
   }
 
   @action
   async updateMemberRole(adminMember) {
     const previousRole = adminMember.role;
 
-    if (!this.newRole || this.newRole === previousRole) {
+    if (!adminMember.updatedRole || adminMember.updatedRole === previousRole) {
       adminMember.isInEditionMode = false;
       return;
     }
 
-    adminMember.role = this.newRole;
+    adminMember.role = adminMember.updatedRole;
     try {
       await adminMember.save();
       this.notifications.success(

--- a/admin/app/components/team/list.js
+++ b/admin/app/components/team/list.js
@@ -27,8 +27,8 @@ export default class List extends Component {
   }
 
   @action
-  setAdminRoleSelection(event) {
-    this.newRole = event.target.value;
+  setAdminRoleSelection(value) {
+    this.newRole = value;
   }
 
   @action

--- a/admin/app/components/trainings/create-training-form.hbs
+++ b/admin/app/components/trainings/create-training-form.hbs
@@ -22,10 +22,9 @@
         {{on "change" (fn this.updateForm "link")}}
       />
       <PixSelect
-        @id="trainingType"
         @label="Format"
-        @emptyOptionLabel={{"-- Sélectionnez un format --"}}
-        @selectedOption={{this.form.type}}
+        @placeholder={{"-- Sélectionnez un format --"}}
+        @value={{this.form.type}}
         @options={{this.optionsTypeList}}
         required={{true}}
         aria-required={{true}}

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -263,8 +263,8 @@ export default class CertificationInformationsController extends Controller {
   }
 
   @action
-  selectJuryLevel(event) {
-    this.selectedJuryLevel = event.target.value;
+  selectJuryLevel(value) {
+    this.selectedJuryLevel = value;
   }
 
   @action

--- a/admin/app/controllers/authenticated/organizations/get/team.js
+++ b/admin/app/controllers/authenticated/organizations/get/team.js
@@ -40,8 +40,8 @@ export default class GetTeamController extends Controller {
   }
 
   @action
-  selectRoleForSearch(event) {
-    this.organizationRole = event.target.value || null;
+  selectRoleForSearch(newValue) {
+    this.organizationRole = newValue || null;
   }
 
   async _getUser(email) {

--- a/admin/app/controllers/authenticated/organizations/get/team.js
+++ b/admin/app/controllers/authenticated/organizations/get/team.js
@@ -40,8 +40,8 @@ export default class GetTeamController extends Controller {
   }
 
   @action
-  selectRoleForSearch(newValue) {
-    this.organizationRole = newValue || null;
+  selectRoleForSearch(value) {
+    this.organizationRole = value;
   }
 
   async _getUser(email) {

--- a/admin/app/models/admin-member.js
+++ b/admin/app/models/admin-member.js
@@ -7,6 +7,7 @@ export default class AdminMember extends Model {
   @attr('string') firstName;
   @attr('string') email;
   @attr('string') role;
+  @attr('string') updatedRole;
   @attr('string') disabledAt;
   @attr() isSuperAdmin;
   @attr() isCertif;

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -78,3 +78,4 @@
 @import "components/campaigns/update";
 @import "components/campaigns/participations-section";
 @import "components/stages/view-stage";
+@import "display/footer-modal"

--- a/admin/app/styles/authenticated.scss
+++ b/admin/app/styles/authenticated.scss
@@ -2,10 +2,6 @@
 $app-sidebar-width-sm: 80px;
 $app-header-height: 60px;
 
-body > div.ember-view {
-  height: 100%;
-}
-
 .app-container {
   display: flex;
   height: 100%;
@@ -28,7 +24,7 @@ body > div.ember-view {
         display: block;
         line-height: $app-header-height;
         width: 100%;
-        height: 100%;
+        height:100%;
         text-decoration: none;
       }
     }
@@ -44,7 +40,6 @@ body > div.ember-view {
 
     .app-page {
       position: relative;
-      height: 100%;
       width: 100%;
       overflow-y: auto;
     }

--- a/admin/app/styles/authenticated.scss
+++ b/admin/app/styles/authenticated.scss
@@ -24,7 +24,7 @@ $app-header-height: 60px;
         display: block;
         line-height: $app-header-height;
         width: 100%;
-        height:100%;
+        height: 100%;
         text-decoration: none;
       }
     }

--- a/admin/app/styles/authenticated/organizations/get.scss
+++ b/admin/app/styles/authenticated/organizations/get.scss
@@ -52,6 +52,7 @@
         padding: 0;
         display: flex;
         flex-wrap: wrap;
+        margin-bottom: $spacing-m;
 
         &__tag {
           margin-right: 6px;

--- a/admin/app/styles/components/certification-details-answer.scss
+++ b/admin/app/styles/components/certification-details-answer.scss
@@ -37,6 +37,9 @@
   }
 
   .jury {
-    color: $pix-error-70;
+
+    button {
+      color: $pix-error-70;
+    }
   }
 }

--- a/admin/app/styles/components/member-item.scss
+++ b/admin/app/styles/components/member-item.scss
@@ -28,3 +28,7 @@
 .disable-membership-button {
   margin-top: 5px;
 }
+
+.pix-select-in-table {
+  max-width: 100%;
+}

--- a/admin/app/styles/components/organization-information-section.scss
+++ b/admin/app/styles/components/organization-information-section.scss
@@ -16,8 +16,8 @@
 
   &__details {
 
-    ul {
-      padding: 0;
+    &__list {
+      margin-bottom: $spacing-m;
     }
 
     .form-actions {

--- a/admin/app/styles/display/footer-modal.scss
+++ b/admin/app/styles/display/footer-modal.scss
@@ -1,0 +1,14 @@
+.pix-modal {
+
+  &__footer {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-s;
+    margin-bottom: $spacing-s;
+
+    @include device-is("tablet") {
+      flex-flow: row wrap;
+      justify-content: flex-end;
+    }
+  }
+}

--- a/admin/app/styles/globals/page.scss
+++ b/admin/app/styles/globals/page.scss
@@ -39,7 +39,6 @@
     left: 80px;
     right: 0;
     bottom: 0;
-    overflow: auto;
     padding: 10px;
 
     .page-section {

--- a/admin/app/styles/globals/tables.scss
+++ b/admin/app/styles/globals/tables.scss
@@ -34,7 +34,6 @@ td,
 th {
   text-align: left;
   padding-left: 30px;
-  overflow: hidden;
   text-overflow: ellipsis;
 }
 

--- a/admin/app/styles/login.scss
+++ b/admin/app/styles/login.scss
@@ -18,6 +18,10 @@
   height: 129px;
   margin-top: 48px;
   text-align: center;
+
+  &__title {
+    margin-bottom: $spacing-s;
+  }
 }
 
 .login-page__section--login-form {

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -126,13 +126,13 @@
                   <div class="certification-informations__pix-edu__row__jury-level-editor">
                     <section>
                       <PixSelect
-                        aria-label="Sélectionner un niveau"
+                        @label="Sélectionner un niveau"
+                        @screenReaderOnly={{true}}
                         @options={{this.juryLevelOptions}}
-                        @selectedOption={{this.selectedJuryLevel}}
-                        @emptyOptionNotSelectable={{true}}
+                        @value={{this.selectedJuryLevel}}
+                        @hideDefaultOption={{true}}
                         @onChange={{this.selectJuryLevel}}
-                        @emptyOptionLabel="Choisir un niveau"
-                        @size="small"
+                        @placeholder="Choisir un niveau"
                       />
                     </section>
                     <section>

--- a/admin/app/templates/login.hbs
+++ b/admin/app/templates/login.hbs
@@ -1,7 +1,7 @@
 <div class="login-page">
   <main class="login-page__main">
     <header class="login-page__header">
-      <h1>Pix Admin</h1>
+      <h1 class="login-page__header__title">Pix Admin</h1>
       <p>Log in to your account</p>
     </header>
 

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^20.2.4",
+        "@1024pix/pix-ui": "^24.0.1",
         "@babel/eslint-parser": "^7.19.1",
         "@ember/optional-features": "^2.0.0",
         "@ember/test-helpers": "^2.8.1",
@@ -1200,345 +1200,24 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.2.4.tgz",
-      "integrity": "sha512-G71jhEna46WoniRqzfaibGdnaRFynjaWPhBlCVdEPtWtkTWhE7srpv8fRBAko64geth6H7WE+ErI9b9p0WSnsg==",
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-24.0.1.tgz",
+      "integrity": "sha512-hymu4ttHwswbP/VJTERYyP31nATR4LrG7yaYc7kKz9ztM2IvWs1tJZcXjFTdkvcTlslTJssEhLLvTmuIUd6U2Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-htmlbars": "^5.6.2",
-        "ember-cli-sass": "^10.0.1",
+        "color": "^4.2.3",
+        "ember-cli-babel": "^7.26.8",
+        "ember-cli-htmlbars": "^6.1.1",
+        "ember-cli-sass": "^11.0.1",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-click-outside": "^2.0.0",
+        "ember-click-outside": "^4.0.0",
         "ember-prop-modifier": "^1.0.1",
-        "ember-truth-helpers": "^3.0.0"
+        "ember-truth-helpers": "^3.1.1"
       },
       "engines": {
         "node": "16",
         "npm": ">=8.13.2 <9"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/async-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "^2.5.1",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "rsvp": "^4.8.5",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/broccoli-persistent-filter": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
-      "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-      "dev": true,
-      "dependencies": {
-        "async-disk-cache": "^2.0.0",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^4.0.3",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^3.0.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^2.0.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/broccoli-plugin": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-node-api": "^1.7.0",
-        "broccoli-output-wrapper": "^3.2.5",
-        "fs-merger": "^3.2.1",
-        "promise-map-series": "^0.3.0",
-        "quick-temp": "^0.1.8",
-        "rimraf": "^3.0.2",
-        "symlink-or-copy": "^1.3.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/broccoli-plugin/node_modules/promise-map-series": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-      "dev": true,
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/editions": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-      "dev": true,
-      "dependencies": {
-        "errlop": "^2.0.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/editions/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-cli-htmlbars": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-      "dev": true,
-      "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^3.1.2",
-        "broccoli-plugin": "^4.0.3",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-version-checker": "^5.1.2",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
-        "semver": "^7.3.4",
-        "silent-error": "^1.1.1",
-        "strip-bom": "^4.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-cli-sass": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-sass/-/ember-cli-sass-10.0.1.tgz",
-      "integrity": "sha512-dWVoX03O2Mot1dEB1AN3ofC8DDZb6iU4Kfkbr3WYi9S9bGVHrpR/ngsR7tuVBuTugTyG53FPtLLqYdqx7XjXdA==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-funnel": "^2.0.1",
-        "broccoli-merge-trees": "^3.0.1",
-        "broccoli-sass-source-maps": "^4.0.0",
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-cli-sass/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-cli-sass/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ember-cli-version-checker": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
-      "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
-      "dev": true,
-      "dependencies": {
-        "resolve-package-path": "^3.1.0",
-        "semver": "^7.3.4",
-        "silent-error": "^1.1.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/fs-tree-diff": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-      "dev": true,
-      "dependencies": {
-        "@types/symlink-or-copy": "^1.2.0",
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/istextorbinary": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-      "dev": true,
-      "dependencies": {
-        "binaryextensions": "^2.1.2",
-        "editions": "^2.2.0",
-        "textextensions": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/matcher-collection": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-      "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "minimatch": "^3.0.2"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/resolve-package-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
-      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
-      "dev": true,
-      "dependencies": {
-        "path-root": "^0.1.1",
-        "resolve": "^1.17.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/sync-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.6",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/@1024pix/pix-ui/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -12679,6 +12358,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -12692,6 +12384,34 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
     "node_modules/colord": {
@@ -18095,78 +17815,167 @@
       "dev": true
     },
     "node_modules/ember-click-outside": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-2.0.0.tgz",
-      "integrity": "sha512-d53L+Of9rRhB8RU32xKFDG58e8MJZRPFF9HAuUIcn3Hl5U7v8Gb9YqB59khcryCkRXWzLOvVgmNFjNaV9iZJyQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-4.0.0.tgz",
+      "integrity": "sha512-3SstFhDWu3K5PQzo0FZwk66Ehe1l6QFU/R+WjAt8yOXw2sHzJHOdx2N+fNWJHZsJ97BSqdL7L0qotJEMX46u6Q==",
       "dev": true,
       "dependencies": {
-        "ember-cli-babel": "^7.18.0",
-        "ember-cli-htmlbars": "^4.2.3",
-        "ember-modifier": "^2.1.0"
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-htmlbars": "^5.7.1",
+        "ember-modifier": "^2.1.0 || ^3.0.0"
       },
       "engines": {
-        "node": "10.* || >= 12"
+        "node": "12.* || 14.* || >= 16"
       }
     },
-    "node_modules/ember-click-outside/node_modules/babel-plugin-htmlbars-inline-precompile": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.2.0.tgz",
-      "integrity": "sha512-IUeZmgs9tMUGXYu1vfke5I18yYJFldFGdNFQOWslXTnDWXzpwPih7QFduUqvT+awDpDuNtXpdt5JAf43Q1Hhzg==",
-      "dev": true,
-      "engines": {
-        "node": "8.* || 10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/broccoli-output-wrapper": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-2.0.0.tgz",
-      "integrity": "sha512-V/ozejo+snzNf75i/a6iTmp71k+rlvqjE3+jYfimuMwR1tjNNRdtfno+NGNQB2An9bIAeqZnKhMDurAznHAdtA==",
+    "node_modules/ember-click-outside/node_modules/async-disk-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
+      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
       "dev": true,
       "dependencies": {
-        "heimdalljs-logger": "^0.1.10"
+        "debug": "^4.1.1",
+        "heimdalljs": "^0.2.3",
+        "istextorbinary": "^2.5.1",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^3.0.0",
+        "rsvp": "^4.8.5",
+        "username-sync": "^1.0.2"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-click-outside/node_modules/broccoli-persistent-filter": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
+      "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
+      "dev": true,
+      "dependencies": {
+        "async-disk-cache": "^2.0.0",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^4.0.3",
+        "fs-tree-diff": "^2.0.0",
+        "hash-for-dep": "^1.5.0",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "promise-map-series": "^0.2.1",
+        "rimraf": "^3.0.0",
+        "symlink-or-copy": "^1.0.1",
+        "sync-disk-cache": "^2.0.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
       }
     },
     "node_modules/ember-click-outside/node_modules/broccoli-plugin": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz",
-      "integrity": "sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
+      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
       "dev": true,
       "dependencies": {
-        "broccoli-node-api": "^1.6.0",
-        "broccoli-output-wrapper": "^2.0.0",
-        "fs-merger": "^3.0.1",
-        "promise-map-series": "^0.2.1",
-        "quick-temp": "^0.1.3",
-        "rimraf": "^2.3.4",
-        "symlink-or-copy": "^1.1.8"
+        "broccoli-node-api": "^1.7.0",
+        "broccoli-output-wrapper": "^3.2.5",
+        "fs-merger": "^3.2.1",
+        "promise-map-series": "^0.3.0",
+        "quick-temp": "^0.1.8",
+        "rimraf": "^3.0.2",
+        "symlink-or-copy": "^1.3.1"
       },
       "engines": {
-        "node": "8.* || 10.* || >= 12.*"
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-click-outside/node_modules/broccoli-plugin/node_modules/promise-map-series": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
+      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
+      "dev": true,
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-click-outside/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ember-click-outside/node_modules/editions": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+      "dev": true,
+      "dependencies": {
+        "errlop": "^2.0.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/ember-click-outside/node_modules/editions/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/ember-click-outside/node_modules/ember-cli-htmlbars": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.5.0.tgz",
-      "integrity": "sha512-bYJpK1pqFu9AadDAGTw05g2LMNzY8xTCIqQm7dMJmKEoUpLRFbPf4SfHXrktzDh7Q5iggl6Skzf1M0bPlIxARw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
+      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
       "dev": true,
       "dependencies": {
         "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^3.2.0",
+        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
         "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^2.3.1",
-        "broccoli-plugin": "^3.1.0",
+        "broccoli-persistent-filter": "^3.1.2",
+        "broccoli-plugin": "^4.0.3",
         "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.0",
+        "ember-cli-babel-plugin-helpers": "^1.1.1",
+        "ember-cli-version-checker": "^5.1.2",
         "fs-tree-diff": "^2.0.1",
         "hash-for-dep": "^1.5.1",
         "heimdalljs-logger": "^0.1.10",
         "json-stable-stringify": "^1.0.1",
-        "semver": "^6.3.0",
+        "semver": "^7.3.4",
+        "silent-error": "^1.1.1",
         "strip-bom": "^4.0.0",
-        "walk-sync": "^2.0.2"
+        "walk-sync": "^2.2.0"
       },
       "engines": {
-        "node": "8.* || 10.* || >= 12.*"
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-click-outside/node_modules/ember-cli-version-checker": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
+      "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
+      "dev": true,
+      "dependencies": {
+        "resolve-package-path": "^3.1.0",
+        "semver": "^7.3.4",
+        "silent-error": "^1.1.1"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
       }
     },
     "node_modules/ember-click-outside/node_modules/fs-tree-diff": {
@@ -18185,6 +17994,23 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/ember-click-outside/node_modules/istextorbinary": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
+      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
+      "dev": true,
+      "dependencies": {
+        "binaryextensions": "^2.1.2",
+        "editions": "^2.2.0",
+        "textextensions": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
     "node_modules/ember-click-outside/node_modules/matcher-collection": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
@@ -18198,13 +18024,78 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/ember-click-outside/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+    "node_modules/ember-click-outside/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/ember-click-outside/node_modules/resolve-package-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
       "dev": true,
+      "dependencies": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12"
+      }
+    },
+    "node_modules/ember-click-outside/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ember-click-outside/node_modules/rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || >= 7.*"
+      }
+    },
+    "node_modules/ember-click-outside/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ember-click-outside/node_modules/sync-disk-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
+      "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "heimdalljs": "^0.2.6",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^3.0.0",
+        "username-sync": "^1.0.2"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
       }
     },
     "node_modules/ember-click-outside/node_modules/walk-sync": {
@@ -36264,6 +36155,21 @@
       "integrity": "sha1-m4tVWdgOMxpUTdE91ZOC5dDZRBE=",
       "dev": true
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "dev": true
+    },
     "node_modules/sinon": {
       "version": "14.0.2",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.2.tgz",
@@ -40897,268 +40803,19 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-20.2.4.tgz",
-      "integrity": "sha512-G71jhEna46WoniRqzfaibGdnaRFynjaWPhBlCVdEPtWtkTWhE7srpv8fRBAko64geth6H7WE+ErI9b9p0WSnsg==",
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-24.0.1.tgz",
+      "integrity": "sha512-hymu4ttHwswbP/VJTERYyP31nATR4LrG7yaYc7kKz9ztM2IvWs1tJZcXjFTdkvcTlslTJssEhLLvTmuIUd6U2Q==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-htmlbars": "^5.6.2",
-        "ember-cli-sass": "^10.0.1",
+        "color": "^4.2.3",
+        "ember-cli-babel": "^7.26.8",
+        "ember-cli-htmlbars": "^6.1.1",
+        "ember-cli-sass": "^11.0.1",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-click-outside": "^2.0.0",
+        "ember-click-outside": "^4.0.0",
         "ember-prop-modifier": "^1.0.1",
-        "ember-truth-helpers": "^3.0.0"
-      },
-      "dependencies": {
-        "async-disk-cache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-          "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "heimdalljs": "^0.2.3",
-            "istextorbinary": "^2.5.1",
-            "mkdirp": "^0.5.0",
-            "rimraf": "^3.0.0",
-            "rsvp": "^4.8.5",
-            "username-sync": "^1.0.2"
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
-          "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-          "dev": true,
-          "requires": {
-            "async-disk-cache": "^2.0.0",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^4.0.3",
-            "fs-tree-diff": "^2.0.0",
-            "hash-for-dep": "^1.5.0",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^3.0.0",
-            "symlink-or-copy": "^1.0.1",
-            "sync-disk-cache": "^2.0.0"
-          }
-        },
-        "broccoli-plugin": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-          "dev": true,
-          "requires": {
-            "broccoli-node-api": "^1.7.0",
-            "broccoli-output-wrapper": "^3.2.5",
-            "fs-merger": "^3.2.1",
-            "promise-map-series": "^0.3.0",
-            "quick-temp": "^0.1.8",
-            "rimraf": "^3.0.2",
-            "symlink-or-copy": "^1.3.1"
-          },
-          "dependencies": {
-            "promise-map-series": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-              "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-              "dev": true
-            }
-          }
-        },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "editions": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-          "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-          "dev": true,
-          "requires": {
-            "errlop": "^2.0.0",
-            "semver": "^6.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            }
-          }
-        },
-        "ember-cli-htmlbars": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-          "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-          "dev": true,
-          "requires": {
-            "@ember/edition-utils": "^1.2.0",
-            "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-            "broccoli-debug": "^0.6.5",
-            "broccoli-persistent-filter": "^3.1.2",
-            "broccoli-plugin": "^4.0.3",
-            "common-tags": "^1.8.0",
-            "ember-cli-babel-plugin-helpers": "^1.1.1",
-            "ember-cli-version-checker": "^5.1.2",
-            "fs-tree-diff": "^2.0.1",
-            "hash-for-dep": "^1.5.1",
-            "heimdalljs-logger": "^0.1.10",
-            "json-stable-stringify": "^1.0.1",
-            "semver": "^7.3.4",
-            "silent-error": "^1.1.1",
-            "strip-bom": "^4.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "ember-cli-sass": {
-          "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-sass/-/ember-cli-sass-10.0.1.tgz",
-          "integrity": "sha512-dWVoX03O2Mot1dEB1AN3ofC8DDZb6iU4Kfkbr3WYi9S9bGVHrpR/ngsR7tuVBuTugTyG53FPtLLqYdqx7XjXdA==",
-          "dev": true,
-          "requires": {
-            "broccoli-funnel": "^2.0.1",
-            "broccoli-merge-trees": "^3.0.1",
-            "broccoli-sass-source-maps": "^4.0.0",
-            "ember-cli-version-checker": "^2.1.0"
-          },
-          "dependencies": {
-            "ember-cli-version-checker": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-              "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-              "dev": true,
-              "requires": {
-                "resolve": "^1.3.3",
-                "semver": "^5.3.0"
-              }
-            },
-            "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-              "dev": true
-            }
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
-          "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
-          "dev": true,
-          "requires": {
-            "resolve-package-path": "^3.1.0",
-            "semver": "^7.3.4",
-            "silent-error": "^1.1.1"
-          }
-        },
-        "fs-tree-diff": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-          "dev": true,
-          "requires": {
-            "@types/symlink-or-copy": "^1.2.0",
-            "heimdalljs-logger": "^0.1.7",
-            "object-assign": "^4.1.0",
-            "path-posix": "^1.0.0",
-            "symlink-or-copy": "^1.1.8"
-          }
-        },
-        "istextorbinary": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-          "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-          "dev": true,
-          "requires": {
-            "binaryextensions": "^2.1.2",
-            "editions": "^2.2.0",
-            "textextensions": "^2.5.0"
-          }
-        },
-        "matcher-collection": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "minimatch": "^3.0.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "resolve-package-path": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
-          "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
-          "dev": true,
-          "requires": {
-            "path-root": "^0.1.1",
-            "resolve": "^1.17.0"
-          }
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "sync-disk-cache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
-          "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "heimdalljs": "^0.2.6",
-            "mkdirp": "^0.5.0",
-            "rimraf": "^3.0.0",
-            "username-sync": "^1.0.2"
-          }
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
-          }
-        }
+        "ember-truth-helpers": "^3.1.1"
       }
     },
     "@ampproject/remapping": {
@@ -50175,6 +49832,33 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -50189,6 +49873,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
+    },
+    "color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "colord": {
       "version": "2.9.3",
@@ -54563,66 +54257,133 @@
       }
     },
     "ember-click-outside": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-2.0.0.tgz",
-      "integrity": "sha512-d53L+Of9rRhB8RU32xKFDG58e8MJZRPFF9HAuUIcn3Hl5U7v8Gb9YqB59khcryCkRXWzLOvVgmNFjNaV9iZJyQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-4.0.0.tgz",
+      "integrity": "sha512-3SstFhDWu3K5PQzo0FZwk66Ehe1l6QFU/R+WjAt8yOXw2sHzJHOdx2N+fNWJHZsJ97BSqdL7L0qotJEMX46u6Q==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^7.18.0",
-        "ember-cli-htmlbars": "^4.2.3",
-        "ember-modifier": "^2.1.0"
+        "ember-cli-babel": "^7.26.6",
+        "ember-cli-htmlbars": "^5.7.1",
+        "ember-modifier": "^2.1.0 || ^3.0.0"
       },
       "dependencies": {
-        "babel-plugin-htmlbars-inline-precompile": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.2.0.tgz",
-          "integrity": "sha512-IUeZmgs9tMUGXYu1vfke5I18yYJFldFGdNFQOWslXTnDWXzpwPih7QFduUqvT+awDpDuNtXpdt5JAf43Q1Hhzg==",
-          "dev": true
-        },
-        "broccoli-output-wrapper": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-2.0.0.tgz",
-          "integrity": "sha512-V/ozejo+snzNf75i/a6iTmp71k+rlvqjE3+jYfimuMwR1tjNNRdtfno+NGNQB2An9bIAeqZnKhMDurAznHAdtA==",
+        "async-disk-cache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
+          "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
           "dev": true,
           "requires": {
-            "heimdalljs-logger": "^0.1.10"
+            "debug": "^4.1.1",
+            "heimdalljs": "^0.2.3",
+            "istextorbinary": "^2.5.1",
+            "mkdirp": "^0.5.0",
+            "rimraf": "^3.0.0",
+            "rsvp": "^4.8.5",
+            "username-sync": "^1.0.2"
+          }
+        },
+        "broccoli-persistent-filter": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
+          "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
+          "dev": true,
+          "requires": {
+            "async-disk-cache": "^2.0.0",
+            "async-promise-queue": "^1.0.3",
+            "broccoli-plugin": "^4.0.3",
+            "fs-tree-diff": "^2.0.0",
+            "hash-for-dep": "^1.5.0",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "promise-map-series": "^0.2.1",
+            "rimraf": "^3.0.0",
+            "symlink-or-copy": "^1.0.1",
+            "sync-disk-cache": "^2.0.0"
           }
         },
         "broccoli-plugin": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz",
-          "integrity": "sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==",
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
+          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
           "dev": true,
           "requires": {
-            "broccoli-node-api": "^1.6.0",
-            "broccoli-output-wrapper": "^2.0.0",
-            "fs-merger": "^3.0.1",
-            "promise-map-series": "^0.2.1",
-            "quick-temp": "^0.1.3",
-            "rimraf": "^2.3.4",
-            "symlink-or-copy": "^1.1.8"
+            "broccoli-node-api": "^1.7.0",
+            "broccoli-output-wrapper": "^3.2.5",
+            "fs-merger": "^3.2.1",
+            "promise-map-series": "^0.3.0",
+            "quick-temp": "^0.1.8",
+            "rimraf": "^3.0.2",
+            "symlink-or-copy": "^1.3.1"
+          },
+          "dependencies": {
+            "promise-map-series": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
+              "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
+              "dev": true
+            }
+          }
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "editions": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+          "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+          "dev": true,
+          "requires": {
+            "errlop": "^2.0.0",
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
           }
         },
         "ember-cli-htmlbars": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.5.0.tgz",
-          "integrity": "sha512-bYJpK1pqFu9AadDAGTw05g2LMNzY8xTCIqQm7dMJmKEoUpLRFbPf4SfHXrktzDh7Q5iggl6Skzf1M0bPlIxARw==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
+          "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
           "dev": true,
           "requires": {
             "@ember/edition-utils": "^1.2.0",
-            "babel-plugin-htmlbars-inline-precompile": "^3.2.0",
+            "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
             "broccoli-debug": "^0.6.5",
-            "broccoli-persistent-filter": "^2.3.1",
-            "broccoli-plugin": "^3.1.0",
+            "broccoli-persistent-filter": "^3.1.2",
+            "broccoli-plugin": "^4.0.3",
             "common-tags": "^1.8.0",
-            "ember-cli-babel-plugin-helpers": "^1.1.0",
+            "ember-cli-babel-plugin-helpers": "^1.1.1",
+            "ember-cli-version-checker": "^5.1.2",
             "fs-tree-diff": "^2.0.1",
             "hash-for-dep": "^1.5.1",
             "heimdalljs-logger": "^0.1.10",
             "json-stable-stringify": "^1.0.1",
-            "semver": "^6.3.0",
+            "semver": "^7.3.4",
+            "silent-error": "^1.1.1",
             "strip-bom": "^4.0.0",
-            "walk-sync": "^2.0.2"
+            "walk-sync": "^2.2.0"
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
+          "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^3.1.0",
+            "semver": "^7.3.4",
+            "silent-error": "^1.1.1"
           }
         },
         "fs-tree-diff": {
@@ -54638,6 +54399,17 @@
             "symlink-or-copy": "^1.1.8"
           }
         },
+        "istextorbinary": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
+          "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
+          "dev": true,
+          "requires": {
+            "binaryextensions": "^2.1.2",
+            "editions": "^2.2.0",
+            "textextensions": "^2.5.0"
+          }
+        },
         "matcher-collection": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
@@ -54648,11 +54420,58 @@
             "minimatch": "^3.0.2"
           }
         },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "resolve-package-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+          "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.17.0"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "rsvp": {
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "sync-disk-cache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
+          "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "heimdalljs": "^0.2.6",
+            "mkdirp": "^0.5.0",
+            "rimraf": "^3.0.0",
+            "username-sync": "^1.0.2"
+          }
         },
         "walk-sync": {
           "version": "2.2.0",
@@ -68954,6 +68773,23 @@
       "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.3.0.tgz",
       "integrity": "sha1-m4tVWdgOMxpUTdE91ZOC5dDZRBE=",
       "dev": true
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+          "dev": true
+        }
+      }
     },
     "sinon": {
       "version": "14.0.2",

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "devDependencies": {
-        "@1024pix/ember-testing-library": "^0.5.0",
+        "@1024pix/ember-testing-library": "^0.6.0",
         "@1024pix/pix-ui": "^24.0.1",
         "@babel/eslint-parser": "^7.19.1",
         "@ember/optional-features": "^2.0.0",
@@ -89,9 +89,9 @@
       }
     },
     "node_modules/@1024pix/ember-testing-library": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/ember-testing-library/-/ember-testing-library-0.5.0.tgz",
-      "integrity": "sha512-CGlNllnB1TUW+MSjp9B1NT78cI4zha2eUtMWx9TptH4rvNxuP7tplUXHgkNYpqp+M+lhhv7jgr4UkpcOYE2sbg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/ember-testing-library/-/ember-testing-library-0.6.0.tgz",
+      "integrity": "sha512-uMRVSOF4J1GisM6wgnlstH2DyU3n+lsM6M+xtAVrTBHDFdPpvacOCAS43UoHHNkvlskhiTbLoWBm1tEhnxdLMA==",
       "dev": true,
       "dependencies": {
         "@testing-library/dom": "^8.9.0",
@@ -39880,9 +39880,9 @@
   },
   "dependencies": {
     "@1024pix/ember-testing-library": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/ember-testing-library/-/ember-testing-library-0.5.0.tgz",
-      "integrity": "sha512-CGlNllnB1TUW+MSjp9B1NT78cI4zha2eUtMWx9TptH4rvNxuP7tplUXHgkNYpqp+M+lhhv7jgr4UkpcOYE2sbg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/ember-testing-library/-/ember-testing-library-0.6.0.tgz",
+      "integrity": "sha512-uMRVSOF4J1GisM6wgnlstH2DyU3n+lsM6M+xtAVrTBHDFdPpvacOCAS43UoHHNkvlskhiTbLoWBm1tEhnxdLMA==",
       "dev": true,
       "requires": {
         "@testing-library/dom": "^8.9.0",

--- a/admin/package.json
+++ b/admin/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^20.2.4",
+    "@1024pix/pix-ui": "^24.0.1",
     "@babel/eslint-parser": "^7.19.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.8.1",

--- a/admin/package.json
+++ b/admin/package.json
@@ -38,7 +38,7 @@
     "test:watch": "ember exam --serve --reporter dot"
   },
   "devDependencies": {
-    "@1024pix/ember-testing-library": "^0.5.0",
+    "@1024pix/ember-testing-library": "^0.6.0",
     "@1024pix/pix-ui": "^24.0.1",
     "@babel/eslint-parser": "^7.19.1",
     "@ember/optional-features": "^2.0.0",

--- a/admin/tests/acceptance/authenticated/certification-centers/form_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/form_test.js
@@ -35,7 +35,11 @@ module('Acceptance | Certification Centers | Form', function (hooks) {
     const screen = await visit('/certification-centers/new');
 
     await fillIn(screen.getByRole('textbox', { name: 'Nom du centre' }), name);
-    await fillIn(screen.getByRole('combobox', { name: "Type d'établissement" }), type.value);
+
+    await click(screen.getByRole('button', { name: "Type d'établissement" }));
+    await screen.findByRole('listbox');
+    await click(screen.getByRole('option', { name: type.label }));
+
     await fillIn(screen.getByRole('textbox', { name: 'Identifiant externe' }), externalId);
 
     await click(screen.getByRole('checkbox', { name: 'Pix+Surf' }));

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -123,7 +123,11 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
       // when
       await fillByLabel('Nom du centre', 'nouveau nom');
-      await fillByLabel('Type', 'SUP');
+
+      await click(screen.getByRole('button', { name: 'Type' }));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Établissement supérieur' }));
+
       await fillByLabel('Identifiant externe', 'nouvel identifiant externe');
       await fillByLabel('Prénom du DPO', 'Justin');
       await fillByLabel('Nom du DPO', 'Ptipeu');

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { click, currentURL } from '@ember/test-helpers';
-import { fillByLabel, clickByName, visit, selectByLabelAndOption, within } from '@1024pix/ember-testing-library';
+import { fillByLabel, clickByName, visit, within } from '@1024pix/ember-testing-library';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { authenticateAdminMemberWithRole } from '../../../../helpers/test-init';
 
@@ -330,10 +330,15 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
 
           // when
           await click(screen.getByRole('button', { name: 'Modifier le volet jury' }));
-          await selectByLabelAndOption('Sélectionner un niveau', 'PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME');
+
+          await click(screen.getByRole('button', { name: 'Sélectionner un niveau' }));
+          await screen.findByRole('listbox');
+          await click(screen.getByRole('option', { name: 'Pix+ Édu Initiale 1er degré Confirmé' }));
+
           await click(screen.getByRole('button', { name: 'Modifier le niveau du jury' }));
 
           const finalResult = within(screen.getByText('NIVEAU FINAL').parentElement);
+
           // then
           assert.dom(screen.getByText('Pix+ Édu Initiale 1er degré Confirmé')).exists();
 
@@ -412,10 +417,14 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
           await _switchCertificationDetail(screen, session.id, certification2.id);
 
           // when
-          await selectByLabelAndOption('Sélectionner un niveau', 'Choisir un niveau');
+          await click(screen.getByRole('button', { name: 'Sélectionner un niveau' }));
+          await screen.findByRole('listbox');
+          await click(screen.getByRole('option', { name: 'Pix+ Édu Initiale 2nd degré Confirmé' }));
 
           // then
-          assert.dom(screen.getByText('Pix+ Édu Initiale 2nd degré Confirmé')).exists();
+          assert
+            .dom(screen.getByRole('button', { name: 'Sélectionner un niveau' }))
+            .containsText('Pix+ Édu Initiale 2nd degré Confirmé');
         });
       });
 

--- a/admin/tests/acceptance/authenticated/organizations/create-organization_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/create-organization_test.js
@@ -2,8 +2,8 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
-import { clickByName, visit, fillByLabel, selectByLabelAndOption } from '@1024pix/ember-testing-library';
-import { currentURL } from '@ember/test-helpers';
+import { clickByName, visit, fillByLabel } from '@1024pix/ember-testing-library';
+import { currentURL, click } from '@ember/test-helpers';
 
 module('Acceptance | Organizations | Create', function (hooks) {
   setupApplicationTest(hooks);
@@ -16,9 +16,13 @@ module('Acceptance | Organizations | Create', function (hooks) {
   module('when an organization is created', function () {
     test('it redirects the user on the organization details page with the tags tab opened', async function (assert) {
       // given
-      await visit('/organizations/new');
+      const screen = await visit('/organizations/new');
       await fillByLabel('Nom', 'Stark Corp.');
-      await selectByLabelAndOption(`Sélectionner un type d'organisation`, 'SCO');
+
+      await click(screen.getByRole('button', { name: `Sélectionner un type d'organisation` }));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Établissement scolaire' }));
+
       await fillByLabel('Crédits', 120);
       await fillByLabel('Prénom du DPO', 'Justin');
       await fillByLabel('Nom du DPO', 'Ptipeu');

--- a/admin/tests/acceptance/authenticated/organizations/memberships-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/memberships-management_test.js
@@ -78,8 +78,11 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
       // when
       const screen = await visit(`/organizations/${organization.id}/team`);
 
+      await click(screen.getByRole('button', { name: 'Rechercher par rôle' }));
+      await screen.findByRole('listbox');
       // then
-      assert.dom(screen.getByRole('combobox', { name: 'Rechercher par rôle' })).hasValue('');
+      assert.dom(screen.getByRole('option', { name: 'Tous' })).exists();
+
       assert.dom(screen.getByText('user@example.com')).exists();
       assert.dom(screen.queryByText('user2@example.com')).exists();
     });
@@ -88,8 +91,10 @@ module('Acceptance | Organizations | Memberships management', function (hooks) {
       // when
       const screen = await visit(`/organizations/${organization.id}/team?organizationRole=ADMIN`);
 
+      await click(screen.getByRole('button', { name: 'Rechercher par rôle' }));
+      await screen.findByRole('listbox');
       // then
-      assert.dom(screen.getByRole('combobox', { name: 'Rechercher par rôle' })).hasValue('ADMIN');
+      assert.dom(screen.getByRole('option', { name: 'Administrateur' })).exists();
       assert.dom(screen.getByText('user@example.com')).exists();
       assert.dom(screen.queryByText('user2@example.com')).doesNotExist();
     });

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation_test.js
@@ -134,7 +134,13 @@ async function _selectLearningContent(screen) {
   await clickByName('area_f1_a2 code · area_f1_a2 title');
   await clickByName('competence_f1_a2_c1 index competence_f1_a2_c1 name');
   await clickByName('tube_f1_a2_c1_th1_tu1 name : tube_f1_a2_c1_th1_tu1 practicalTitle');
-  await fillIn(screen.getByTestId('select-level-tube-tube_f1_a2_c1_th1_tu1'), 2);
+
+  await click(
+    screen.getByRole('button', { name: 'Sélection du niveau du sujet suivant : tube_f1_a2_c1_th1_tu1 practicalTitle' })
+  );
+  await screen.findByRole('listbox');
+  await click(screen.getByRole('option', { name: '2' }));
+
   await clickByName('area_f2_a1 code · area_f2_a1 title');
   await clickByName('competence_f2_a1_c1 index competence_f2_a1_c1 name');
   await clickByName('thematic_f2_a1_c1_th1 name');

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { currentURL, fillIn, click } from '@ember/test-helpers';
+import { currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -322,7 +322,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         assert.dom(screen.queryByText('Enregistrer')).doesNotExist();
       });
 
-      test('it should create a badge', async function (assert) {
+      test.only('it should create a badge', async function (assert) {
         // given
         const tubeThematicDeux = server.create('new-tube', {
           id: 'tubeThematicDeuxNiveauQuatre',
@@ -336,7 +336,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         const tubeThematicUn = server.create('new-tube', {
           id: 'tubeThematicUnNiveauDeux',
           name: '@tubeThematicUnNiveauDeux',
-          practicalTitle: 'Mon tube thématiqe 1 de niveau deux',
+          practicalTitle: 'Mon tube thématique 1 de niveau deux',
           mobile: false,
           tablet: false,
           level: 2,
@@ -405,12 +405,20 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         const thematicDeuxButtons = screen.getAllByText('thematicDeux');
         await click(thematicDeuxButtons[1]);
 
-        const selectLevelTubeThematicUnNiveauDeux = screen.getAllByTestId('select-level-tube-tubeThematicUnNiveauDeux');
-        const selectLevelTubeThematicDeuxNiveauQuatre = screen.getAllByTestId(
-          'select-level-tube-tubeThematicDeuxNiveauQuatre'
-        );
-        await fillIn(selectLevelTubeThematicUnNiveauDeux[0], 2);
-        await fillIn(selectLevelTubeThematicDeuxNiveauQuatre[1], 3);
+        const selectLevelTubeThematicUnNiveauDeux = screen.getAllByRole('button', {
+          name: 'Sélection du niveau du sujet suivant : Mon tube thématique 1 de niveau deux',
+        });
+        await click(selectLevelTubeThematicUnNiveauDeux[0]);
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 2 }));
+
+        const selectLevelTubeThematicDeuxNiveauQuatre = screen.getAllByRole('button', {
+          name: 'Sélection du niveau du sujet suivant : Mon tube thématique 2 de niveau quatre',
+        });
+        await click(selectLevelTubeThematicDeuxNiveauQuatre[1]);
+        await screen.findByRole('listbox');
+        // fail ici, il ne trouve pas cette option alors qu'on clique sur le bon élément
+        await click(screen.getByRole('option', { name: 3 }));
 
         await clickByName('Enregistrer le RT');
         await clickByName('Détails du badge Mon nouveau RT');

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -1,5 +1,5 @@
 import { currentURL, fillIn, click } from '@ember/test-helpers';
-import { visit, clickByName, fillByLabel } from '@1024pix/ember-testing-library';
+import { visit, clickByName, fillByLabel, waitForElementToBeRemoved } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { module, test } from 'qunit';
@@ -410,15 +410,17 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         });
         await click(selectLevelTubeThematicUnNiveauDeux[0]);
         await screen.findByRole('listbox');
-        await click(screen.getByRole('option', { name: 2 }));
+        await click(screen.getByRole('option', { name: '2' }));
+        await waitForElementToBeRemoved(() => screen.queryByRole('listbox'));
 
         const selectLevelTubeThematicDeuxNiveauQuatre = screen.getAllByRole('button', {
           name: 'Sélection du niveau du sujet suivant : Mon tube thématique 2 de niveau quatre',
         });
+
         await click(selectLevelTubeThematicDeuxNiveauQuatre[1]);
         await screen.findByRole('listbox');
-        // fail ici, il ne trouve pas cette option alors qu'on clique sur le bon élément
-        await click(screen.getByRole('option', { name: 3 }));
+        await click(screen.getByRole('option', { name: '3' }));
+        await waitForElementToBeRemoved(() => screen.queryByRole('listbox'));
 
         await clickByName('Enregistrer le RT');
         await clickByName('Détails du badge Mon nouveau RT');

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -322,7 +322,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         assert.dom(screen.queryByText('Enregistrer')).doesNotExist();
       });
 
-      test.only('it should create a badge', async function (assert) {
+      test('it should create a badge', async function (assert) {
         // given
         const tubeThematicDeux = server.create('new-tube', {
           id: 'tubeThematicDeuxNiveauQuatre',

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
@@ -1,9 +1,9 @@
-import { clickByName, visit, fillByLabel, selectByLabelAndOption } from '@1024pix/ember-testing-library';
+import { clickByName, visit, fillByLabel } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { module, test } from 'qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
-import { currentURL } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 
 module('Acceptance | Target Profile Management', function (hooks) {
   setupApplicationTest(hooks);
@@ -101,7 +101,9 @@ module('Acceptance | Target Profile Management', function (hooks) {
       const screen = await visit('/target-profiles/1');
       await clickByName('Éditer');
       await fillByLabel('* Nom', 'nom modifié');
-      await selectByLabelAndOption('Catégorie :', 'SUBJECT');
+      await click(screen.getByRole('button', { name: 'Catégorie :' }));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Thématiques' }));
       await fillByLabel('Description', 'description modifiée');
       await fillByLabel('Commentaire (usage interne)', 'commentaire modifié');
       await clickByName('Enregistrer');
@@ -113,7 +115,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
       await clickByName('Éditer');
       assert.dom(screen.getByDisplayValue('description modifiée')).exists();
       assert.dom(screen.getByDisplayValue('commentaire modifié')).exists();
-      assert.dom(screen.getByDisplayValue('Thématiques')).exists();
+      assert.dom(screen.getByRole('button', { name: 'Catégorie :' })).containsText('Thématiques');
     });
 
     test('it should cancel target profile information edition', async function (assert) {

--- a/admin/tests/acceptance/authenticated/team/list_test.js
+++ b/admin/tests/acceptance/authenticated/team/list_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
-import { currentURL } from '@ember/test-helpers';
-import { visit, clickByName, selectByLabelAndOption } from '@1024pix/ember-testing-library';
+import { currentURL, click } from '@ember/test-helpers';
+import { visit, clickByName } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
@@ -52,7 +52,9 @@ module('Acceptance | Team | List', function (hooks) {
       // when
       const screen = await visit('/equipe');
       await clickByName("Modifier le rôle de l'agent Anne Estésie");
-      await selectByLabelAndOption('Sélectionner un rôle', 'CERTIF');
+      await click(screen.getByRole('button', { name: 'Sélectionner un rôle' }));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'CERTIF' }));
       await clickByName('Valider la modification de rôle');
 
       // then
@@ -129,7 +131,9 @@ module('Acceptance | Team | List', function (hooks) {
       // when
       const screen = await visit('/equipe');
       await clickByName("Modifier le rôle de l'agent Anne Estésie");
-      await selectByLabelAndOption('Sélectionner un rôle', 'CERTIF');
+      await click(screen.getByRole('button', { name: 'Sélectionner un rôle' }));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'CERTIF' }));
       await clickByName('Valider la modification de rôle');
 
       // then

--- a/admin/tests/acceptance/sessions-list_test.js
+++ b/admin/tests/acceptance/sessions-list_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { currentURL, click } from '@ember/test-helpers';
-import { visit, fillByLabel, selectByLabelAndOption } from '@1024pix/ember-testing-library';
+import { visit, fillByLabel } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 

--- a/admin/tests/acceptance/sessions-list_test.js
+++ b/admin/tests/acceptance/sessions-list_test.js
@@ -57,7 +57,6 @@ module('Acceptance | Session List', function (hooks) {
           const screen = await visit('/sessions/list');
 
           // then
-          assert.dom(screen.getByRole('combobox', { name: "Nombre d'élément à afficher par page" })).hasValue('10');
           const sessionCount = screen.getAllByLabelText('Informations de la session de certification', {
             exact: false,
           }).length;
@@ -73,7 +72,6 @@ module('Acceptance | Session List', function (hooks) {
           await click(screen.getByLabelText('Aller à la page suivante'));
 
           // then
-          assert.dom(screen.getByRole('combobox', { name: "Nombre d'élément à afficher par page" })).hasValue('10');
           const sessionCount = screen.getAllByLabelText('Informations de la session de certification', {
             exact: false,
           }).length;
@@ -86,10 +84,11 @@ module('Acceptance | Session List', function (hooks) {
         test('it should display all the finalized sessions', async function (assert) {
           // when
           const screen = await visit('/sessions/list');
-          await selectByLabelAndOption("Nombre d'élément à afficher par page", '25');
+          await click(screen.getByRole('button', { name: "Nombre d'élément à afficher par page" }));
+          await screen.findByRole('listbox');
+          await click(screen.getByRole('option', { name: '25' }));
 
           // then
-          assert.dom(screen.getByRole('combobox', { name: "Nombre d'élément à afficher par page" })).hasValue('25');
           const sessionCount = screen.getAllByLabelText('Informations de la session de certification', {
             exact: false,
           }).length;

--- a/admin/tests/acceptance/sessions-list_test.js
+++ b/admin/tests/acceptance/sessions-list_test.js
@@ -166,7 +166,17 @@ module('Acceptance | Session List', function (hooks) {
         test('it should display the session with status as specified in the dropdown', async function (assert) {
           // when
           const screen = await visit('/sessions/list');
-          await selectByLabelAndOption('Filtrer les sessions en sélectionnant un statut', 'processed');
+          await click(
+            screen.getByRole('button', {
+              name: 'Filtrer les sessions en sélectionnant un statut',
+            })
+          );
+          await screen.findByRole('listbox');
+          await click(
+            screen.getByRole('option', {
+              name: 'Résultats transmis par Pix',
+            })
+          );
 
           // then
           const sessionProcessedCount = screen.getAllByLabelText('Informations de la session de certification', {
@@ -196,7 +206,17 @@ module('Acceptance | Session List', function (hooks) {
         test('it should only display sessions which results have been sent', async function (assert) {
           // when
           const screen = await visit('/sessions/list');
-          await selectByLabelAndOption('Filtrer les sessions par leurs résultats diffusés ou non diffusés', 'true');
+          await click(
+            screen.getByRole('button', {
+              name: 'Filtrer les sessions par leurs résultats diffusés ou non diffusés',
+            })
+          );
+          await screen.findByRole('listbox');
+          await click(
+            screen.getByRole('option', {
+              name: 'Résultats diffusés',
+            })
+          );
 
           // then
           const sessionWithResultSentCount = screen.getAllByLabelText('Informations de la session de certification', {
@@ -208,7 +228,17 @@ module('Acceptance | Session List', function (hooks) {
         test('it should only display sessions which results have not been sent', async function (assert) {
           // when
           const screen = await visit('/sessions/list');
-          await selectByLabelAndOption('Filtrer les sessions par leurs résultats diffusés ou non diffusés', 'false');
+          await click(
+            screen.getByRole('button', {
+              name: 'Filtrer les sessions par leurs résultats diffusés ou non diffusés',
+            })
+          );
+          await screen.findByRole('listbox');
+          await click(
+            screen.getByRole('option', {
+              name: 'Résultats non diffusés',
+            })
+          );
 
           // then
           const sessionCount = screen.getAllByLabelText('Informations de la session de certification', {

--- a/admin/tests/integration/components/actions-on-users-role-in-organization_test.js
+++ b/admin/tests/integration/components/actions-on-users-role-in-organization_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { render, clickByName, selectByLabelAndOption } from '@1024pix/ember-testing-library';
+import { render, clickByName } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import sinon from 'sinon';
 import { click } from '@ember/test-helpers';

--- a/admin/tests/integration/components/actions-on-users-role-in-organization_test.js
+++ b/admin/tests/integration/components/actions-on-users-role-in-organization_test.js
@@ -4,6 +4,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { render, clickByName, selectByLabelAndOption } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import sinon from 'sinon';
+import { click } from '@ember/test-helpers';
 
 module('Integration | Component | actions-on-users-role-in-organization', function (hooks) {
   setupRenderingTest(hooks);
@@ -34,7 +35,10 @@ module('Integration | Component | actions-on-users-role-in-organization', functi
         hbs`<ActionsOnUsersRoleInOrganization @organizationMembership={{this.organizationMembership}} />`
       );
       await clickByName('Modifier le rôle');
-      await selectByLabelAndOption('Sélectionner un rôle', 'MEMBER');
+
+      await click(screen.getByRole('button', { name: 'Sélectionner un rôle' }));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Membre' }));
       await clickByName('Enregistrer');
 
       // then

--- a/admin/tests/integration/components/certification-centers/creation-form_test.js
+++ b/admin/tests/integration/components/certification-centers/creation-form_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, find } from '@ember/test-helpers';
-import { render, selectByLabelAndOption, fillByLabel } from '@1024pix/ember-testing-library';
+import { render, fillByLabel } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import { A as EmberArray } from '@ember/array';
 
@@ -38,7 +38,7 @@ module('Integration | Component | certification-centers/creation-form', function
       this.onSubmit = () => {};
       this.onCancel = () => {};
       this.certificationCenter = {};
-      await render(
+      const screen = await render(
         hbs`<CertificationCenters::CreationForm
           @certificationCenter={{this.certificationCenter}}
           @onSubmit={{this.onSubmit}}
@@ -47,7 +47,9 @@ module('Integration | Component | certification-centers/creation-form', function
       );
 
       // when
-      await selectByLabelAndOption("Type d'établissement", 'SCO');
+      await click(screen.getByRole('button', { name: "Type d'établissement" }));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Établissement scolaire' }));
 
       // then
       assert.strictEqual(this.certificationCenter.type, 'SCO');

--- a/admin/tests/integration/components/certification-centers/information-edit_test.js
+++ b/admin/tests/integration/components/certification-centers/information-edit_test.js
@@ -59,7 +59,9 @@ module('Integration | Component | certification-centers/information-edit', funct
       );
 
       // when
-      await fillByLabel('Type', '');
+      await click(screen.getByRole('button', { name: 'Type' }));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: '-- Choisissez --' }));
 
       // then
       assert.dom(screen.getByText('Le type ne peut pas être vide')).exists();

--- a/admin/tests/integration/components/certification-centers/invitations-action_test.js
+++ b/admin/tests/integration/components/certification-centers/invitations-action_test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, selectByLabelAndOption } from '@1024pix/ember-testing-library';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
-import { clickByText } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 
 module('Integration | Component | certification-center-invitations-action', function (hooks) {
   setupRenderingTest(hooks);
@@ -15,13 +15,13 @@ module('Integration | Component | certification-center-invitations-action', func
     this.set('noop', () => {});
 
     // when
-    await render(
+    const screen = await render(
       hbs`<CertificationCenters::InvitationsAction
   @createInvitation={{this.createInvitation}}
   @onChangeUserEmailToInvite={{this.noop}}
 />`
     );
-    await clickByText('Inviter');
+    await click(screen.getByRole('button', { name: 'Inviter un membre' }));
 
     // then
     assert.ok(createInvitationStub.calledWith('fr-fr'));
@@ -34,14 +34,18 @@ module('Integration | Component | certification-center-invitations-action', func
     this.set('noop', () => {});
 
     // when
-    await render(
+    const screen = await render(
       hbs`<CertificationCenters::InvitationsAction
   @createInvitation={{this.createInvitation}}
   @onChangeUserEmailToInvite={{this.noop}}
 />`
     );
-    await selectByLabelAndOption('Choisir la langue de l’email d’invitation', 'en');
-    await clickByText('Inviter');
+
+    await click(screen.getByRole('button', { name: 'Choisir la langue de l’email d’invitation' }));
+    await screen.findByRole('listbox');
+    await click(screen.getByRole('option', { name: 'Anglais' }));
+
+    await click(screen.getByRole('button', { name: 'Inviter un membre' }));
 
     // then
     assert.ok(createInvitationStub.calledWith('en'));

--- a/admin/tests/integration/components/certifications/candidate-edit-modal_test.js
+++ b/admin/tests/integration/components/certifications/candidate-edit-modal_test.js
@@ -6,6 +6,7 @@ import sinon from 'sinon';
 import EmberObject from '@ember/object';
 import { run } from '@ember/runloop';
 import { setFlatpickrDate } from 'ember-flatpickr/test-support/helpers';
+import { click } from '@ember/test-helpers';
 
 module('Integration | Component | certifications/candidate-edit-modal', function (hooks) {
   setupRenderingTest(hooks);
@@ -149,7 +150,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         // then
         assert.dom(screen.queryByRole('textbox', { name: 'Code Insee de naissance' })).doesNotExist();
         assert.dom(screen.queryByRole('textbox', { name: 'Code postal de naissance' })).doesNotExist();
-        assert.dom(screen.getByRole('combobox', { name: 'Pays de naissance' })).containsText('DANEMARK');
+        assert.dom(screen.getByRole('button', { name: 'Pays de naissance' })).containsText('DANEMARK');
         assert.dom(screen.getByRole('textbox', { name: 'Commune de naissance' })).hasValue('Copenhague');
       });
     });
@@ -183,7 +184,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         assert.dom(screen.getByRole('textbox', { name: 'Code postal de naissance' })).hasValue('66440');
         assert.dom(screen.queryByRole('textbox', { name: 'Code Insee de naissance' })).doesNotExist();
         assert.dom(screen.getByRole('textbox', { name: 'Commune de naissance' })).hasValue('Torreilles');
-        assert.dom(screen.getByRole('combobox', { name: 'Pays de naissance' })).containsText('FRANCE');
+        assert.dom(screen.getByRole('button', { name: 'Pays de naissance' })).containsText('FRANCE');
       });
     });
 
@@ -216,7 +217,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         assert.dom(screen.queryByRole('textbox', { name: 'Code postal de naissance' })).doesNotExist();
         assert.dom(screen.getByRole('textbox', { name: 'Code Insee de naissance' })).hasValue('66212');
         assert.dom(screen.queryByRole('textbox', { name: 'Commune de naissance' })).doesNotExist();
-        assert.dom(screen.getByRole('combobox', { name: 'Pays de naissance' })).containsText('FRANCE');
+        assert.dom(screen.getByRole('button', { name: 'Pays de naissance' })).containsText('FRANCE');
       });
     });
   });
@@ -253,7 +254,11 @@ module('Integration | Component | certifications/candidate-edit-modal', function
       await fillByLabel('Prénom', 'Gideona');
       setFlatpickrDate('#birthdate', new Date('1861-03-17'));
       await clickByName('Femme');
-      await fillByLabel('Pays de naissance', '99100');
+
+      await click(screen.getByRole('button', { name: 'Pays de naissance' }));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'FRANCE' }));
+
       await clickByName('Code postal');
       await fillByLabel('Code postal de naissance', '75001');
       await fillByLabel('Commune de naissance', 'PARIS 01');
@@ -269,7 +274,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
       assert.dom(screen.queryByRole('textbox', { name: 'Code Insee de naissance' })).doesNotExist();
       assert.dom(screen.queryByRole('textbox', { name: 'Code postal de naissance' })).doesNotExist();
       assert.dom(screen.getByRole('textbox', { name: 'Commune de naissance' })).hasValue('Copenhague');
-      assert.dom(screen.getByRole('combobox', { name: 'Pays de naissance' })).containsText('DANEMARK');
+      assert.dom(screen.getByRole('button', { name: 'Pays de naissance' })).containsText('DANEMARK');
     });
 
     test('it should not alter candidate information', async function (assert) {
@@ -291,7 +296,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         run(() => store.createRecord('country', { code: '99100', name: 'FRANCE' })),
       ];
       this.onCancelButtonsClickedStub = sinon.stub();
-      await render(
+      const screen = await render(
         hbs`<Certifications::CandidateEditModal
   @isDisplayed={{true}}
   @candidate={{this.candidate}}
@@ -303,7 +308,11 @@ module('Integration | Component | certifications/candidate-edit-modal', function
       await fillByLabel('Prénom', 'Gideona');
       setFlatpickrDate('#birthdate', new Date('1861-03-17'));
       await clickByName('Femme');
-      await fillByLabel('Pays de naissance', '99100');
+
+      await click(screen.getByRole('button', { name: 'Pays de naissance' }));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'FRANCE' }));
+
       await clickByName('Code postal');
       await fillByLabel('Code postal de naissance', '75001');
       await fillByLabel('Commune de naissance', 'PARIS 01');
@@ -378,7 +387,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         EmberObject.create({ code: '99100', name: 'FRANCE' }),
       ];
       this.onFormSubmitStub = sinon.stub();
-      await render(
+      const screen = await render(
         hbs`<Certifications::CandidateEditModal
   @isDisplayed={{true}}
   @candidate={{this.candidate}}
@@ -390,7 +399,11 @@ module('Integration | Component | certifications/candidate-edit-modal', function
       await fillByLabel('Prénom', 'Gideon');
       setFlatpickrDate('#birthdate', new Date('1861-03-17'));
       await clickByName('Homme');
-      await fillByLabel('Pays de naissance', '99100');
+
+      await click(screen.getByRole('button', { name: 'Pays de naissance' }));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'FRANCE' }));
+
       await clickByName('Code postal');
       await fillByLabel('Code postal de naissance', '75001');
       await fillByLabel('Commune de naissance', 'PARIS 01');
@@ -423,7 +436,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         ];
         this.onFormSubmitStub = sinon.stub();
         this.onFormSubmitStub.resolves();
-        await render(
+        const screen = await render(
           hbs`<Certifications::CandidateEditModal
   @isDisplayed={{true}}
   @candidate={{this.candidate}}
@@ -433,7 +446,10 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         );
 
         // when
-        await fillByLabel('Pays de naissance', '99101');
+        await click(screen.getByRole('button', { name: 'Pays de naissance' }));
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'DANEMARK' }));
+
         await fillByLabel('Commune de naissance', 'Copenhague');
         await clickByName('Enregistrer');
 
@@ -472,7 +488,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         ];
         this.onFormSubmitStub = sinon.stub();
         this.onFormSubmitStub.resolves();
-        await render(
+        const screen = await render(
           hbs`<Certifications::CandidateEditModal
   @isDisplayed={{true}}
   @candidate={{this.candidate}}
@@ -482,7 +498,10 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         );
 
         // when
-        await fillByLabel('Pays de naissance', '99100');
+        await click(screen.getByRole('button', { name: 'Pays de naissance' }));
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'FRANCE' }));
+
         await clickByName('Code INSEE');
         await fillByLabel('Code Insee de naissance', '66212');
         await clickByName('Enregistrer');
@@ -522,7 +541,7 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         ];
         this.onFormSubmitStub = sinon.stub();
         this.onFormSubmitStub.resolves();
-        await render(
+        const screen = await render(
           hbs`<Certifications::CandidateEditModal
   @isDisplayed={{true}}
   @candidate={{this.candidate}}
@@ -532,7 +551,10 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         );
 
         // when
-        await fillByLabel('Pays de naissance', '99100');
+        await click(screen.getByRole('button', { name: 'Pays de naissance' }));
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'FRANCE' }));
+
         await clickByName('Code postal');
         await fillByLabel('Code postal de naissance', '66440');
         await fillByLabel('Commune de naissance', 'Torreilles');
@@ -577,7 +599,9 @@ module('Integration | Component | certifications/candidate-edit-modal', function
         );
 
         // when
-        await fillByLabel('Pays de naissance', '99101');
+        await click(screen.getByRole('button', { name: 'Pays de naissance' }));
+        await screen.findByRole('listbox');
+        await click(screen.getByRole('option', { name: 'DANEMARK' }));
 
         // then
         assert.dom(screen.queryByText('Code Insee de naissance')).doesNotExist();

--- a/admin/tests/integration/components/certifications/details-answer_test.js
+++ b/admin/tests/integration/components/certifications/details-answer_test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, selectByLabelAndOption } from '@1024pix/ember-testing-library';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import { resolve } from 'rsvp';
+import { click } from '@ember/test-helpers';
 
 module('Integration | Component | certifications/details-answer', function (hooks) {
   setupRenderingTest(hooks);
@@ -29,7 +30,7 @@ module('Integration | Component | certifications/details-answer', function (hook
     );
 
     // then
-    assert.dom(screen.getByRole('combobox', { name: 'Sélectionner un résultat' })).containsText('Succès partiel');
+    assert.dom(screen.getByRole('button', { name: 'Sélectionner un résultat' })).containsText('Succès partiel');
   });
 
   test('init answer displayed status with neutralized label when challenge is neutralized', async function (assert) {
@@ -45,7 +46,7 @@ module('Integration | Component | certifications/details-answer', function (hook
     );
 
     // then
-    assert.dom(screen.getByRole('combobox', { name: 'Sélectionner un résultat' })).containsText('Neutralisée');
+    assert.dom(screen.getByRole('button', { name: 'Sélectionner un résultat' })).containsText('Neutralisée');
   });
 
   test('info are correctly displayed', async function (assert) {
@@ -65,7 +66,7 @@ module('Integration | Component | certifications/details-answer', function (hook
     assert.dom(screen.getByText('@skill6')).exists();
     assert.dom(screen.getByText('rec1234')).exists();
     assert.dom(screen.getByText('coucou')).exists();
-    assert.dom(screen.getByRole('combobox', { name: 'Sélectionner un résultat' })).containsText('Succès partiel');
+    assert.dom(screen.getByRole('button', { name: 'Sélectionner un résultat' })).containsText('Succès partiel');
   });
 
   module('when chalenge has been skipped automatically', function () {
@@ -90,7 +91,7 @@ module('Integration | Component | certifications/details-answer', function (hook
       assert.dom(screen.getByText('@skill6')).exists();
       assert.dom(screen.getByText('rec1234')).exists();
       assert.dom(screen.getByText('coucou')).exists();
-      assert.dom(screen.getByRole('combobox', { name: 'Sélectionner un résultat' })).containsText('Abandon');
+      assert.dom(screen.getByRole('button', { name: 'Sélectionner un résultat' })).containsText('Abandon');
     });
   });
 
@@ -103,11 +104,14 @@ module('Integration | Component | certifications/details-answer', function (hook
     const screen = await render(
       hbs`<Certifications::DetailsAnswer @answer={{this.answer}} @onUpdateRate={{this.onUpdateRate}} />`
     );
+
     // when
-    await selectByLabelAndOption('Sélectionner un résultat', 'ok');
+    await click(screen.getByText('Sélectionner un résultat'));
+    await screen.findByRole('listbox');
+    await click(screen.getByRole('option', { name: 'Temps écoulé' }));
 
     // then
-    assert.dom(screen.getByRole('combobox', { name: 'Sélectionner un résultat' })).hasAttribute('class', 'jury');
+    assert.dom('.pix-select.jury').exists();
   });
 
   test('update rate function is called when answer is modified and jury is set', async function (assert) {
@@ -117,16 +121,18 @@ module('Integration | Component | certifications/details-answer', function (hook
       answer: answerData,
       onUpdateRate: () => {
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(answerData.jury, 'ok');
+        assert.strictEqual(answerData.jury, 'timedout');
         return resolve();
       },
     });
-    await render(hbs`<Certifications::DetailsAnswer @answer={{this.answer}} @onUpdateRate={{this.onUpdateRate}} />`);
+    const screen = await render(
+      hbs`<Certifications::DetailsAnswer @answer={{this.answer}} @onUpdateRate={{this.onUpdateRate}} />`
+    );
 
     // when
-    await selectByLabelAndOption('Sélectionner un résultat', 'ok');
+    await click(screen.getByText('Sélectionner un résultat'));
+    await screen.findByRole('listbox');
+    await click(screen.getByRole('option', { name: 'Temps écoulé' }));
   });
 
   test('jury is set back to false when answer is set to default value', async function (assert) {
@@ -135,16 +141,18 @@ module('Integration | Component | certifications/details-answer', function (hook
       answer: answerData,
       onUpdateRate: () => resolve(),
     });
-    await render(hbs`<Certifications::DetailsAnswer @answer={{this.answer}} @onUpdateRate={{this.onUpdateRate}} />`);
+    const screen = await render(
+      hbs`<Certifications::DetailsAnswer @answer={{this.answer}} @onUpdateRate={{this.onUpdateRate}} />`
+    );
 
     // when
-    await selectByLabelAndOption('Sélectionner un résultat', 'ok');
-    await selectByLabelAndOption('Sélectionner un résultat', 'partially');
+    await click(screen.getByText('Sélectionner un résultat'));
+    await screen.findByRole('listbox');
+    await click(screen.getByRole('option', { name: 'Temps écoulé' }));
+    await click(screen.getByRole('option', { name: 'Succès partiel' }));
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(answerData.jury, null);
+    assert.strictEqual(answerData.jury, null);
   });
 
   test('it should render links to challenge preview and info', async function (assert) {

--- a/admin/tests/integration/components/certifications/status-select_test.js
+++ b/admin/tests/integration/components/certifications/status-select_test.js
@@ -1,84 +1,29 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, selectByLabelAndOption } from '@1024pix/ember-testing-library';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
+import { click } from '@ember/test-helpers';
 
 module('Integration | Component | certifications/status-select', function (hooks) {
   setupRenderingTest(hooks);
 
   module('when in edition mode', function () {
-    module('rendering', function () {
-      test('it displays a label', async function (assert) {
-        // given
-        const certification = EmberObject.create({ status: 'started' });
-        this.set('certification', certification);
+    test('it updates the certification status when the selected value changes', async function (assert) {
+      // given
+      const certification = EmberObject.create({ status: 'started' });
+      this.set('certification', certification);
+      const screen = await render(
+        hbs`<Certifications::StatusSelect @edition={{true}} @certification={{this.certification}} />`
+      );
 
-        // when
-        const screen = await render(
-          hbs`<Certifications::StatusSelect @edition={{true}} @certification={{this.certification}} />`
-        );
+      // when
+      await click(screen.getByText('Statut :'));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Validée' }));
 
-        // then
-        assert.dom(screen.getByText('Statut :')).exists();
-      });
-
-      test('it displays a select list', async function (assert) {
-        // given
-        const certification = EmberObject.create({ status: 'started' });
-        this.set('certification', certification);
-
-        // when
-        const screen = await render(
-          hbs`<Certifications::StatusSelect @edition={{true}} @certification={{this.certification}} />`
-        );
-
-        // then
-        assert.dom(screen.getByRole('combobox', { name: 'Statut :' })).exists();
-      });
-
-      test('it has values', async function (assert) {
-        // given
-        const certification = EmberObject.create({ status: 'started' });
-        this.set('certification', certification);
-        const expectedOptions = [
-          { value: 'started', label: 'Démarrée' },
-          { value: 'error', label: 'En erreur' },
-          { value: 'validated', label: 'Validée' },
-          { value: 'rejected', label: 'Rejetée' },
-        ];
-
-        // when
-        await render(hbs`<Certifications::StatusSelect @edition={{true}} @certification={{this.certification}} />`);
-
-        // then
-        const elementOptions = this.element.querySelectorAll('#certification-status-selector > option');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(elementOptions.length, 4);
-        elementOptions.forEach((elementOption, index) => {
-          const expectedOption = expectedOptions[index];
-          assert.dom(elementOption).hasText(expectedOption.label);
-          assert.dom(elementOption).hasValue(expectedOption.value);
-        });
-      });
-    });
-
-    module('behaviour', function () {
-      test('it updates the certification status when the selected value changes', async function (assert) {
-        // given
-        const certification = EmberObject.create({ status: 'started' });
-        this.set('certification', certification);
-        await render(hbs`<Certifications::StatusSelect @edition={{true}} @certification={{this.certification}} />`);
-
-        // when
-        await selectByLabelAndOption('Statut :', 'validated');
-
-        // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(certification.status, 'validated');
-      });
+      // then
+      assert.strictEqual(certification.status, 'validated');
     });
   });
 

--- a/admin/tests/integration/components/organizations/creation-form_test.js
+++ b/admin/tests/integration/components/organizations/creation-form_test.js
@@ -1,8 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, selectByLabelAndOption, fillByLabel } from '@1024pix/ember-testing-library';
+import { render, fillByLabel } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import EmberObject from '@ember/object';
 
 module('Integration | Component | organizations/creation-form', function (hooks) {
   setupRenderingTest(hooks);
@@ -10,7 +10,8 @@ module('Integration | Component | organizations/creation-form', function (hooks)
   hooks.beforeEach(function () {
     this.onSubmit = () => {};
     this.onCancel = () => {};
-    this.organization = EmberObject.create();
+    const store = this.owner.lookup('service:store');
+    this.organization = store.createRecord('organization', { type: '' });
   });
 
   test('it renders', async function (assert) {
@@ -22,7 +23,7 @@ module('Integration | Component | organizations/creation-form', function (hooks)
     // then
     assert.dom(screen.getByRole('textbox', { name: 'Nom' })).exists();
     assert.dom(screen.getByRole('textbox', { name: 'Lien vers la documentation' })).exists();
-    assert.dom(screen.getByRole('combobox', { name: "Sélectionner un type d'organisation" })).exists();
+    assert.dom(screen.getByText("Sélectionner un type d'organisation")).exists();
     assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
     assert.dom(screen.getByRole('button', { name: 'Ajouter' })).exists();
   });
@@ -35,11 +36,12 @@ module('Integration | Component | organizations/creation-form', function (hooks)
       );
 
       // when
-      await selectByLabelAndOption("Sélectionner un type d'organisation", 'SCO');
+      await click(screen.getByText("Sélectionner un type d'organisation"));
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'Établissement scolaire' }));
 
       // then
       assert.strictEqual(this.organization.type, 'SCO');
-      assert.dom(screen.getByText('Établissement scolaire')).exists();
     });
   });
 

--- a/admin/tests/integration/components/organizations/information-section_test.js
+++ b/admin/tests/integration/components/organizations/information-section_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, clickByName, fillByLabel, selectByLabelAndOption } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { render, clickByName, fillByLabel } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
@@ -117,7 +118,9 @@ module('Integration | Component | organizations/information-section', function (
       await fillByLabel('Crédits', 50);
       await clickByName('Gestion d’élèves/étudiants');
       await fillByLabel('Lien vers la documentation', 'https://pix.fr/');
-      await selectByLabelAndOption('SSO', 'OIDC-2');
+      await clickByName('SSO');
+      await screen.findByRole('listbox');
+      await click(screen.getByRole('option', { name: 'organization 2' }));
 
       // when
       await clickByName('Enregistrer');

--- a/admin/tests/integration/components/organizations/places-lot-creation-form_test.js
+++ b/admin/tests/integration/components/organizations/places-lot-creation-form_test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, fillByLabel, clickByName } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
+import { click } from '@ember/test-helpers';
 
 module('Integration | Component | organizations/places-lot-creation-form', function (hooks) {
   setupRenderingTest(hooks);
@@ -19,13 +20,21 @@ module('Integration | Component | organizations/places-lot-creation-form', funct
       reference: '123ABC',
     };
 
-    await render(hbs`<Organizations::PlacesLotCreationForm @create={{this.create}} />`);
+    const screen = await render(hbs`<Organizations::PlacesLotCreationForm @create={{this.create}} />`);
 
     // when
     await fillByLabel('Nombre :', '10');
     await fillByLabel("* Date d'activation :", '2022-10-20');
     await fillByLabel("Date d'expiration :", '2022-12-20');
-    await fillByLabel('* Catégorie :', 'FREE_RATE');
+
+    const select = screen.getByRole('button', { name: /Catégorie/ });
+
+    await click(select);
+
+    await screen.findByRole('listbox');
+
+    await click(screen.getByRole('option', { name: 'Tarif gratuit' }));
+
     await fillByLabel('* Référence :', '123ABC');
     await clickByName('Ajouter');
     // then

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, selectByLabelAndOption } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/sessions | list-items', function (hooks) {
@@ -116,21 +117,21 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
   module('Dropdown menu for certification center type filtering', function () {
     test('it should render a dropdown menu to filter sessions on their certification center type', async function (assert) {
       // given
-      const expectedLabels = { allType: 'Tous', scoType: 'Sco', supType: 'Sup', proType: 'Pro' };
-
-      // when
       const screen = await render(hbs`<Sessions::ListItems />`);
 
+      // when
+      await click(
+        screen.getByRole('button', {
+          name: 'Filtrer les sessions en sélectionnant un type de centre de certification',
+        })
+      );
+      await screen.findByRole('listbox');
+
       // then
-      assert
-        .dom(
-          screen.getByRole('combobox', {
-            name: 'Filtrer les sessions en sélectionnant un type de centre de certification',
-          })
-        )
-        .hasText(
-          `${expectedLabels.allType} ${expectedLabels.scoType} ${expectedLabels.supType} ${expectedLabels.proType}`
-        );
+      assert.dom(screen.getByRole('option', { name: 'Tous' })).exists();
+      assert.dom(screen.getByRole('option', { name: 'Pro' })).exists();
+      assert.dom(screen.getByRole('option', { name: 'Sco' })).exists();
+      assert.dom(screen.getByRole('option', { name: 'Sup' })).exists();
     });
 
     test('it should filter sessions on certification center type when it has changed', async function (assert) {
@@ -145,39 +146,42 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       );
 
       // when
-      await selectByLabelAndOption('Filtrer les sessions en sélectionnant un type de centre de certification', 'PRO');
+      await click(
+        screen.getByRole('button', {
+          name: 'Sco',
+        })
+      );
+      await screen.findByRole('listbox');
+      await click(
+        screen.getByRole('option', {
+          name: 'Pro',
+        })
+      );
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(this.certificationCenterType, 'PRO');
+      assert.strictEqual(this.certificationCenterType, 'PRO');
     });
   });
 
   module('Dropdown menu for status filtering', function () {
     test('it should render a dropdown menu to filter sessions on their status', async function (assert) {
       // given
-      const expectedLabels = {
-        allStatus: 'Tous',
-        createdStatus: 'Créée',
-        finalizedStatus: 'Finalisée',
-        inProcessStatus: 'En cours de traitement',
-        processedStatus: 'Résultats transmis par Pix',
-      };
-
-      // when
       const screen = await render(hbs`<Sessions::ListItems />`);
 
+      // when
+      await click(
+        screen.getByRole('button', {
+          name: 'Filtrer les sessions en sélectionnant un statut',
+        })
+      );
+      await screen.findByRole('listbox');
+
       // then
-      assert
-        .dom(
-          screen.getByRole('combobox', {
-            name: 'Filtrer les sessions en sélectionnant un statut',
-          })
-        )
-        .hasText(
-          `${expectedLabels.allStatus} ${expectedLabels.createdStatus} ${expectedLabels.finalizedStatus} ${expectedLabels.inProcessStatus} ${expectedLabels.processedStatus}`
-        );
+      assert.dom(screen.getByRole('option', { name: 'Tous' })).exists();
+      assert.dom(screen.getByRole('option', { name: 'Créée' })).exists();
+      assert.dom(screen.getByRole('option', { name: 'Finalisée' })).exists();
+      assert.dom(screen.getByRole('option', { name: 'En cours de traitement' })).exists();
+      assert.dom(screen.getByRole('option', { name: 'Résultats transmis par Pix' })).exists();
     });
 
     test('it should filter sessions on (session) "status" when it has changed', async function (assert) {
@@ -189,35 +193,40 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       );
 
       // when
-      await selectByLabelAndOption('Filtrer les sessions en sélectionnant un statut', 'created');
+      await click(
+        screen.getByRole('button', {
+          name: 'Finalisée',
+        })
+      );
+      await screen.findByRole('listbox');
+      await click(
+        screen.getByRole('option', {
+          name: 'Créée',
+        })
+      );
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(this.status, 'created');
+      assert.strictEqual(this.status, 'created');
     });
   });
 
   module('Dropdown menu for resultsSentToPrescriberAt filtering', function () {
     test('it should render a dropdown menu to filter sessions on their results sending', async function (assert) {
       // given
-      const expectedLabels = {
-        all: 'Tous',
-        resultsSent: 'Résultats diffusés',
-        resultsNotSent: 'Résultats non diffusés',
-      };
-
-      // when
       const screen = await render(hbs`<Sessions::ListItems />`);
 
+      // when
+      await click(
+        screen.getByRole('button', {
+          name: 'Filtrer les sessions par leurs résultats diffusés ou non diffusés',
+        })
+      );
+      await screen.findByRole('listbox');
+
       // then
-      assert
-        .dom(
-          screen.getByRole('combobox', {
-            name: 'Filtrer les sessions par leurs résultats diffusés ou non diffusés',
-          })
-        )
-        .hasText(`${expectedLabels.all} ${expectedLabels.resultsSent} ${expectedLabels.resultsNotSent}`);
+      assert.dom(screen.getByRole('option', { name: 'Tous' })).exists();
+      assert.dom(screen.getByRole('option', { name: 'Résultats diffusés' })).exists();
+      assert.dom(screen.getByRole('option', { name: 'Résultats non diffusés' })).exists();
     });
 
     test('it should filter sessions on results sending status when it has changed', async function (assert) {
@@ -234,12 +243,20 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       );
 
       // when
-      await selectByLabelAndOption('Filtrer les sessions par leurs résultats diffusés ou non diffusés', 'false');
+      await click(
+        screen.getByRole('button', {
+          name: 'Résultats diffusés',
+        })
+      );
+      await screen.findByRole('listbox');
+      await click(
+        screen.getByRole('option', {
+          name: 'Résultats non diffusés',
+        })
+      );
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(this.resultsSentToPrescriberAt, 'false');
+      assert.strictEqual(this.resultsSentToPrescriberAt, 'false');
     });
   });
 });

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items_test.js
@@ -146,8 +146,13 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       );
 
       // when
-      await click(screen.getByRole('button', { name: 'Sco' }));
+      await click(
+        screen.getByRole('button', {
+          name: 'Filtrer les sessions en sélectionnant un type de centre de certification',
+        })
+      );
       await screen.findByRole('listbox');
+
       await click(screen.getByRole('option', { name: 'Pro' }));
 
       // then
@@ -185,7 +190,11 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       );
 
       // when
-      await click(screen.getByRole('button', { name: 'Finalisée' }));
+      await click(
+        screen.getByRole('button', {
+          name: 'Filtrer les sessions en sélectionnant un statut',
+        })
+      );
       await screen.findByRole('listbox');
       await click(screen.getByRole('option', { name: 'Créée' }));
 
@@ -227,7 +236,11 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       );
 
       // when
-      await click(screen.getByRole('button', { name: 'Résultats diffusés' }));
+      await click(
+        screen.getByRole('button', {
+          name: 'Filtrer les sessions par leurs résultats diffusés ou non diffusés',
+        })
+      );
       await screen.findByRole('listbox');
       await click(screen.getByRole('option', { name: 'Résultats non diffusés' }));
 

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items_test.js
@@ -138,7 +138,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       // given
       this.set('certificationCenterType', 'SCO');
       this.set('updateCertificationCenterTypeFilter', (newValue) => this.set('certificationCenterType', newValue));
-      await render(
+      const screen = await render(
         hbs`<Sessions::ListItems
   @certificationCenterType={{this.certificationCenterType}}
   @onChangeCertificationCenterType={{this.updateCertificationCenterTypeFilter}}
@@ -146,17 +146,9 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       );
 
       // when
-      await click(
-        screen.getByRole('button', {
-          name: 'Sco',
-        })
-      );
+      await click(screen.getByRole('button', { name: 'Sco' }));
       await screen.findByRole('listbox');
-      await click(
-        screen.getByRole('option', {
-          name: 'Pro',
-        })
-      );
+      await click(screen.getByRole('option', { name: 'Pro' }));
 
       // then
       assert.strictEqual(this.certificationCenterType, 'PRO');
@@ -188,22 +180,14 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       // given
       this.set('status', 'finalized');
       this.set('updateSessionStatusFilter', (newValue) => this.set('status', newValue));
-      await render(
+      const screen = await render(
         hbs`<Sessions::ListItems @status={{this.status}} @onChangeSessionStatus={{this.updateSessionStatusFilter}} />`
       );
 
       // when
-      await click(
-        screen.getByRole('button', {
-          name: 'Finalisée',
-        })
-      );
+      await click(screen.getByRole('button', { name: 'Finalisée' }));
       await screen.findByRole('listbox');
-      await click(
-        screen.getByRole('option', {
-          name: 'Créée',
-        })
-      );
+      await click(screen.getByRole('option', { name: 'Créée' }));
 
       // then
       assert.strictEqual(this.status, 'created');
@@ -235,7 +219,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       this.set('updateSessionResultsSentToPrescriberFilter', (newValue) =>
         this.set('resultsSentToPrescriberAt', newValue)
       );
-      await render(
+      const screen = await render(
         hbs`<Sessions::ListItems
   @resultsSentToPrescriberAt={{this.resultsSentToPrescriberAt}}
   @onChangeSessionResultsSent={{this.updateSessionResultsSentToPrescriberFilter}}
@@ -243,17 +227,9 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
       );
 
       // when
-      await click(
-        screen.getByRole('button', {
-          name: 'Résultats diffusés',
-        })
-      );
+      await click(screen.getByRole('button', { name: 'Résultats diffusés' }));
       await screen.findByRole('listbox');
-      await click(
-        screen.getByRole('option', {
-          name: 'Résultats non diffusés',
-        })
-      );
+      await click(screen.getByRole('option', { name: 'Résultats non diffusés' }));
 
       // then
       assert.strictEqual(this.resultsSentToPrescriberAt, 'false');

--- a/admin/tests/integration/components/stages/update-stage_test.js
+++ b/admin/tests/integration/components/stages/update-stage_test.js
@@ -4,6 +4,7 @@ import { render, clickByName, fillByLabel } from '@1024pix/ember-testing-library
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
+import { click } from '@ember/test-helpers';
 
 module('Integration | Component | UpdateStage', function (hooks) {
   setupRenderingTest(hooks);
@@ -74,18 +75,15 @@ module('Integration | Component | UpdateStage', function (hooks) {
 
       // then
       assert.dom(screen.queryByRole('spinbutton', { name: 'Seuil' })).doesNotExist();
-      assert
-        .dom(screen.queryByRole('combobox', { name: 'Niveau' }))
-        .exists()
-        .hasValue('1');
-      const options = screen.getByRole('combobox', { name: 'Niveau' }).children;
+
+      const selectItem = screen.getByRole('button', { name: 'Niveau' });
+      assert.dom(selectItem).exists();
+
+      click(selectItem);
+      await screen.findByRole('listbox');
+
+      const options = screen.getAllByRole('option');
       assert.strictEqual(options.length, 3);
-      assert.strictEqual(options[0].value, '0');
-      assert.strictEqual(options[0].label, '0');
-      assert.strictEqual(options[1].value, '1');
-      assert.strictEqual(options[1].label, '1');
-      assert.strictEqual(options[2].value, '2');
-      assert.strictEqual(options[2].label, '2');
     });
   });
 

--- a/admin/tests/integration/components/target-profiles/tubes-selection/tube_test.js
+++ b/admin/tests/integration/components/target-profiles/tubes-selection/tube_test.js
@@ -49,7 +49,7 @@ module('Integration | Component | TargetProfiles:TubesSelection::Tube', function
   @tubeLevels={{this.tubeLevels}}
 />`
     );
-    const select = screen.getByRole('button', { name: 'Sélection du niveau du sujet' });
+    const select = screen.getByRole('button', { name: 'Sélection du niveau du sujet suivant : Tube 1' });
 
     // then
     assert.dom(select).hasAttribute('aria-disabled', '');
@@ -71,7 +71,7 @@ module('Integration | Component | TargetProfiles:TubesSelection::Tube', function
   @tubeLevels={{this.tubeLevels}}
 />`
     );
-    const select = screen.getByRole('button', { name: 'Sélection du niveau du sujet' });
+    const select = screen.getByRole('button', { name: 'Sélection du niveau du sujet suivant : Tube 1' });
 
     // then
     assert.dom(select).doesNotHaveAttribute('aria-disabled');

--- a/admin/tests/integration/components/target-profiles/tubes-selection/tube_test.js
+++ b/admin/tests/integration/components/target-profiles/tubes-selection/tube_test.js
@@ -39,7 +39,7 @@ module('Integration | Component | TargetProfiles:TubesSelection::Tube', function
     this.set('selectedTubeIds', selectedTubeIds);
 
     // when
-    await render(
+    const screen = await render(
       hbs`<TargetProfiles::TubesSelection::Tube
   @competence={{this.competence}}
   @thematic={{this.thematic}}
@@ -49,10 +49,10 @@ module('Integration | Component | TargetProfiles:TubesSelection::Tube', function
   @tubeLevels={{this.tubeLevels}}
 />`
     );
-    const select = document.getElementById('select-level-tube-tubeId1');
+    const select = screen.getByRole('button', { name: 'Sélection du niveau du sujet' });
 
     // then
-    assert.dom(select).isDisabled();
+    assert.dom(select).hasAttribute('aria-disabled', '');
   });
 
   test('it should not disable level select is tubes is selected', async function (assert) {
@@ -61,7 +61,7 @@ module('Integration | Component | TargetProfiles:TubesSelection::Tube', function
     this.set('selectedTubeIds', selectedTubeIds);
 
     // when
-    await render(
+    const screen = await render(
       hbs`<TargetProfiles::TubesSelection::Tube
   @competence={{this.competence}}
   @thematic={{this.thematic}}
@@ -71,9 +71,9 @@ module('Integration | Component | TargetProfiles:TubesSelection::Tube', function
   @tubeLevels={{this.tubeLevels}}
 />`
     );
-    const select = document.getElementById('select-level-tube-tubeId1');
+    const select = screen.getByRole('button', { name: 'Sélection du niveau du sujet' });
 
     // then
-    assert.dom(select).isNotDisabled();
+    assert.dom(select).doesNotHaveAttribute('aria-disabled');
   });
 });

--- a/admin/tests/unit/components/certification-centers/information-edit_test.js
+++ b/admin/tests/unit/components/certification-centers/information-edit_test.js
@@ -72,7 +72,7 @@ module('Unit | Component | certification-centers/information-edit', function (ho
   module('#selectCertificationCenterType', function () {
     test('it should update the certification center type', function (assert) {
       // given & when
-      component.selectCertificationCenterType({ target: { value: 'My Super Duper Type' } });
+      component.selectCertificationCenterType('My Super Duper Type');
 
       // then
       assert.strictEqual(component.form.type, 'My Super Duper Type');

--- a/admin/tests/unit/components/organizations/information-section-edit_test.js
+++ b/admin/tests/unit/components/organizations/information-section-edit_test.js
@@ -11,11 +11,9 @@ module('Unit | Component | organizations/information-section-edit', function (ho
       const component = createGlimmerComponent('component:organizations/information-section-edit', {
         organization: { id: 1 },
       });
-      const target = { selectedIndex: 0, options: { 0: { value: 'None' } } };
-      const eventOnChange = { target };
 
       // when
-      component.onChangeIdentityProvider(eventOnChange);
+      component.onChangeIdentityProvider('None');
 
       // then
       assert.strictEqual(component.form.identityProviderForCampaigns, null);

--- a/admin/tests/unit/components/target-profiles/tubes-selection/tube_test.js
+++ b/admin/tests/unit/components/target-profiles/tubes-selection/tube_test.js
@@ -15,17 +15,12 @@ module('Unit | Component | authenticated/target-profiles/tubes-selection/tube', 
   module('#setLevelTube', function () {
     test('it should set a level on tube', function (assert) {
       // given
-      const event = {
-        currentTarget: {
-          value: '5',
-        },
-      };
       const setLevelTubeStub = sinon.stub();
       component.args.tube = { id: 'tubeId1' };
       component.args.setLevelTube = setLevelTubeStub;
 
       // when
-      component.setLevelTube(event);
+      component.setLevelTube('5');
 
       // then
       assert.ok(setLevelTubeStub.calledWith('tubeId1', '5'));

--- a/admin/tests/unit/components/team/list_test.js
+++ b/admin/tests/unit/components/team/list_test.js
@@ -11,10 +11,10 @@ module('Unit | Component | team | list', function (hooks) {
       // given
       const adminMember = {
         role: 'SUPER_ADMIN',
+        updatedRole: 'CERTIF',
         save: sinon.stub(),
       };
       const component = createGlimmerComponent('component:team/list');
-      component.newRole = 'CERTIF';
 
       // when
       await component.updateMemberRole(adminMember);
@@ -28,10 +28,10 @@ module('Unit | Component | team | list', function (hooks) {
         // given
         const adminMember = {
           role: 'SUPER_ADMIN',
+          updatedRole: null,
           save: sinon.stub(),
         };
         const component = createGlimmerComponent('component:team/list');
-        component.newRole = undefined;
 
         // when
         await component.updateMemberRole(adminMember);

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations_test.js
@@ -570,14 +570,9 @@ module('Unit | Controller | authenticated/certifications/certification/informati
     test('it should set selectedJuryLevel', function (assert) {
       // given
       controller.selectedJuryLevel = '';
-      const event = {
-        target: {
-          value: 'REJECTED',
-        },
-      };
 
       // when
-      controller.selectJuryLevel(event);
+      controller.selectJuryLevel('REJECTED');
 
       // then
       assert.strictEqual(controller.selectedJuryLevel, 'REJECTED');


### PR DESCRIPTION
## :christmas_tree: Problème
Pix UI n'est pas à jour sur Pix Admin ce qui empêche l'utilisation de nouvelles features et de nouveau composants.

## :gift: Proposition
Mettre à jour Pix-UI de la version `20.2.4` à la dernière version actuelle `24.0.1`.

## :star2: Remarques
L'une des dernières montées de Pix-UI embarque un reset CSS dans les app, il faut donc vérifier que toute l'UI de l'app est ok.

## :santa: Pour tester
Faire de la non régression visuelle (partout) + fonctionnelle (sur tous les selects) sur tout Pix Admin.
