### PR TITLE
[FEATURE] Permettre de modifier les champs de seuil de pré-requis et d'objectif pour les contenus formatifs (PIX-6730)

### DIFF
--- a/api/db/database-builder/factory/build-training.js
+++ b/api/db/database-builder/factory/build-training.js
@@ -9,6 +9,8 @@ function buildTraining({
   locale = 'fr-fr',
   editorName = "Ministère de l'Éducation nationale et de la Jeunesse",
   editorLogoUrl = 'https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg',
+  prerequisiteThreshold = 30,
+  goalThreshold = 70,
   createdAt = new Date(),
   updatedAt = new Date(),
 } = {}) {
@@ -21,6 +23,8 @@ function buildTraining({
     locale,
     editorName,
     editorLogoUrl,
+    prerequisiteThreshold,
+    goalThreshold,
     createdAt,
     updatedAt,
   };

--- a/api/db/migrations/20230110144114_add_columns_prerequisiteThreshold_goalThreshold_to_trainings_table.js
+++ b/api/db/migrations/20230110144114_add_columns_prerequisiteThreshold_goalThreshold_to_trainings_table.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'trainings';
+const COLUMN_NAME_PREREQUISITE_THRESHOLD = 'prerequisiteThreshold';
+const COLUMN_NAME_GOAL_THRESHOLD = 'goalThreshold';
+
+exports.up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.integer(COLUMN_NAME_PREREQUISITE_THRESHOLD).nullable().defaultTo(null);
+    table.integer(COLUMN_NAME_GOAL_THRESHOLD).nullable().defaultTo(null);
+  });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME_PREREQUISITE_THRESHOLD);
+    table.dropColumn(COLUMN_NAME_GOAL_THRESHOLD);
+  });
+};

--- a/api/db/seeds/data/trainings-builder.js
+++ b/api/db/seeds/data/trainings-builder.js
@@ -7,6 +7,8 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'webinaire',
     duration: '06:00:00',
     locale: 'fr-fr',
+    prerequisiteThreshold: 20,
+    goalThreshold: 90,
   });
   const training2 = databaseBuilder.factory.buildTraining({
     title: 'Speed training',
@@ -16,6 +18,8 @@ function trainingBuilder({ databaseBuilder }) {
     locale: 'fr-fr',
     editorName: 'Autre ministère',
     editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/autre_logo_url.svg',
+    prerequisiteThreshold: null,
+    goalThreshold: 90,
   });
   const training3 = databaseBuilder.factory.buildTraining({
     title: 'Comment toiletter son chien',
@@ -23,6 +27,8 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'autoformation',
     duration: '10:00:00',
     locale: 'fr-fr',
+    prerequisiteThreshold: 10,
+    goalThreshold: 10,
   });
   const training4 = databaseBuilder.factory.buildTraining({
     title: 'Créer un tabouret',
@@ -30,6 +36,8 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'webinaire',
     duration: '47:00:00',
     locale: 'fr-fr',
+    prerequisiteThreshold: 20,
+    goalThreshold: null,
   });
   const training5 = databaseBuilder.factory.buildTraining({
     title: 'Manger bun\'s tous les midis',
@@ -37,6 +45,8 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'webinaire',
     duration: '06:00:00',
     locale: 'fr-fr',
+    prerequisiteThreshold: 35,
+    goalThreshold: 40,
   });
   const training6 = databaseBuilder.factory.buildTraining({
     title: 'Apprendre à jouer à la coinche',
@@ -44,6 +54,8 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'autoformation',
     duration: '50:00:50',
     locale: 'fr-fr',
+    prerequisiteThreshold: 20,
+    goalThreshold: 60,
   });
   const training7 = databaseBuilder.factory.buildTraining({
     title: 'Savoir coudre',
@@ -51,6 +63,8 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'webinaire',
     duration: '00:05:00',
     locale: 'fr-fr',
+    prerequisiteThreshold: 20,
+    goalThreshold: 30,
   });
   const training8 = databaseBuilder.factory.buildTraining({
     title: 'Apprendre à faire du cidre breton',
@@ -58,6 +72,8 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'autoformation',
     duration: '01:00:00',
     locale: 'fr-fr',
+    prerequisiteThreshold: 0,
+    goalThreshold: 20,
   });
   const training9 = databaseBuilder.factory.buildTraining({
     title: 'Apprendre à compter',
@@ -65,6 +81,8 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'webinaire',
     duration: '10:00:00',
     locale: 'fr-fr',
+    prerequisiteThreshold: 50,
+    goalThreshold: 95,
   });
   const training10 = databaseBuilder.factory.buildTraining({
     title: 'Devenir influenceur de bonheur',
@@ -72,6 +90,8 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'autoformation',
     duration: '10:00:00',
     locale: 'fr-fr',
+    prerequisiteThreshold: 20,
+    goalThreshold: 90,
   });
   const training11 = databaseBuilder.factory.buildTraining({
     title: 'Faire carrière dans la haute couture',
@@ -79,6 +99,8 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'autoformation',
     duration: '07:00:00',
     locale: 'fr-fr',
+    prerequisiteThreshold: null,
+    goalThreshold: null,
   });
   const training12 = databaseBuilder.factory.buildTraining({
     title: 'Devenir tiktokeur professionel',
@@ -86,6 +108,8 @@ function trainingBuilder({ databaseBuilder }) {
     type: 'autoformation',
     duration: '12:00:00',
     locale: 'fr-fr',
+    prerequisiteThreshold: 0,
+    goalThreshold: 0,
   });
   databaseBuilder.factory.buildTargetProfileTraining({
     trainingId: training1.id,

--- a/api/lib/application/trainings/index.js
+++ b/api/lib/application/trainings/index.js
@@ -109,15 +109,12 @@ exports.register = async (server) => {
                 }).allow(null),
                 type: Joi.string().valid('autoformation', 'webinaire').allow(null),
                 locale: Joi.string().valid('fr-fr', 'fr', 'en-gb').allow(null),
-                editorName: Joi.string().allow(null),
-                editorLogoUrl: Joi.string().allow(null),
+                'editor-name': Joi.string().allow(null),
+                'editor-logo-url': Joi.string().allow(null),
               }),
               type: Joi.string().valid('trainings'),
             }).required(),
           }).required(),
-          options: {
-            allowUnknown: true,
-          },
         },
         tags: ['api', 'admin', 'trainings'],
         notes: [

--- a/api/lib/domain/models/Training.js
+++ b/api/lib/domain/models/Training.js
@@ -1,5 +1,17 @@
 class Training {
-  constructor({ id, title, link, type, duration, locale, targetProfileIds, editorName, editorLogoUrl } = {}) {
+  constructor({
+    id,
+    title,
+    link,
+    type,
+    duration,
+    locale,
+    targetProfileIds,
+    editorName,
+    editorLogoUrl,
+    prerequisiteThreshold,
+    goalThreshold,
+  } = {}) {
     this.id = id;
     this.title = title;
     this.link = link;
@@ -9,6 +21,8 @@ class Training {
     this.targetProfileIds = targetProfileIds;
     this.editorName = editorName;
     this.editorLogoUrl = editorLogoUrl;
+    this.prerequisiteThreshold = prerequisiteThreshold;
+    this.goalThreshold = goalThreshold;
   }
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
@@ -3,7 +3,17 @@ const { Serializer, Deserializer } = require('jsonapi-serializer');
 module.exports = {
   serialize(training = {}, meta) {
     return new Serializer('trainings', {
-      attributes: ['duration', 'link', 'locale', 'title', 'type', 'editorName', 'editorLogoUrl'],
+      attributes: [
+        'duration',
+        'link',
+        'locale',
+        'title',
+        'type',
+        'editorName',
+        'editorLogoUrl',
+        'prerequisiteThreshold',
+        'goalThreshold',
+      ],
       meta,
     }).serialize(training);
   },

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -31,6 +31,8 @@ describe('Acceptance | Controller | training-controller', function () {
           locale: 'fr',
           'editor-name': 'Un ministère',
           'editor-logo-url': 'https://mon-logo.svg',
+          'prerequisite-threshold': null,
+          'goal-threshold': null,
         },
       };
 
@@ -96,8 +98,8 @@ describe('Acceptance | Controller | training-controller', function () {
               type: 'trainings',
               attributes: {
                 title: updatedTraining.title,
-                editorName: updatedTraining.editorName,
-                editorLogoUrl: updatedTraining.editorLogoUrl,
+                'editor-name': updatedTraining.editorName,
+                'editor-logo-url': updatedTraining.editorLogoUrl,
                 duration: {
                   days: 2,
                   hours: 2,

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -307,6 +307,8 @@ describe('Integration | Repository | training-repository', function () {
         link: 'https://example.net/mon-nouveau-lien',
         editorName: 'Mon nouvel editeur',
         editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/nouveau-logo.svg',
+        prerequisiteThreshold: 10,
+        goalThreshold: 20,
       };
 
       // when
@@ -320,6 +322,7 @@ describe('Integration | Repository | training-repository', function () {
       expect(updatedTraining.type).to.equal(training.type);
       expect(updatedTraining.editorName).to.be.equal(attributesToUpdate.editorName);
       expect(updatedTraining.editorLogoUrl).to.be.equal(attributesToUpdate.editorLogoUrl);
+      expect(updatedTraining.prerequisiteThreshold).to.be.equal(attributesToUpdate.prerequisiteThreshold);
       expect(updatedTraining.updatedAt).to.be.above(currentTraining.updatedAt);
     });
 
@@ -338,6 +341,8 @@ describe('Integration | Repository | training-repository', function () {
         link: 'https://example.net/mon-nouveau-lien',
         editorName: 'Mon nouvel editeur',
         editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/nouveau-logo.svg',
+        prerequisiteThreshold: 10,
+        goalThreshold: 20,
       };
 
       // when
@@ -349,6 +354,8 @@ describe('Integration | Repository | training-repository', function () {
       expect(updatedTraining.link).to.equal(attributesToUpdate.link);
       expect(updatedTraining.editorName).to.be.equal(attributesToUpdate.editorName);
       expect(updatedTraining.editorLogoUrl).to.be.equal(attributesToUpdate.editorLogoUrl);
+      expect(updatedTraining.prerequisiteThreshold).to.be.equal(attributesToUpdate.prerequisiteThreshold);
+      expect(updatedTraining.goalThreshold).to.be.equal(attributesToUpdate.goalThreshold);
       expect(updatedTraining.targetProfileIds).to.deep.equal([targetProfile.id]);
     });
 
@@ -363,6 +370,8 @@ describe('Integration | Repository | training-repository', function () {
         link: 'https://example.net/mon-nouveau-lien',
         editorName: 'Mon nouvel editeur',
         editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/nouveau-logo.svg',
+        prerequisiteThreshold: 10,
+        goalThreshold: 20,
       };
 
       // when
@@ -370,13 +379,15 @@ describe('Integration | Repository | training-repository', function () {
 
       // then
       const trainingNotUpdated = await knex('trainings')
-        .select('title', 'link', 'editorName', 'editorLogoUrl')
+        .select('title', 'link', 'editorName', 'editorLogoUrl', 'prerequisiteThreshold', 'goalThreshold')
         .where({ id: trainingNotToBeUpdated.id })
         .first();
       expect(trainingNotUpdated.title).to.equal(trainingNotToBeUpdated.title);
       expect(trainingNotUpdated.link).to.equal(trainingNotToBeUpdated.link);
       expect(trainingNotUpdated.editorName).to.equal(trainingNotToBeUpdated.editorName);
       expect(trainingNotUpdated.editorLogoUrl).to.equal(trainingNotToBeUpdated.editorLogoUrl);
+      expect(trainingNotUpdated.prerequisiteThreshold).to.equal(trainingNotToBeUpdated.prerequisiteThreshold);
+      expect(trainingNotUpdated.goalThreshold).to.equal(trainingNotToBeUpdated.goalThreshold);
     });
   });
 

--- a/api/tests/tooling/domain-builder/factory/build-training.js
+++ b/api/tests/tooling/domain-builder/factory/build-training.js
@@ -12,6 +12,8 @@ module.exports = function buildTraining({
   targetProfileIds = [1],
   editorName = 'Ministère education nationale',
   editorLogoUrl = 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
+  goalThreshold = 70,
+  prerequisiteThreshold = 30,
 } = {}) {
   return new Training({
     id,
@@ -23,5 +25,7 @@ module.exports = function buildTraining({
     targetProfileIds,
     editorName,
     editorLogoUrl,
+    goalThreshold,
+    prerequisiteThreshold,
   });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -19,6 +19,8 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
             locale: 'fr-fr',
             'editor-name': 'Ministère education nationale',
             'editor-logo-url': 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
+            'prerequisite-threshold': 30,
+            'goal-threshold': 70,
           },
           id: training.id.toString(),
           type: 'trainings',
@@ -55,6 +57,8 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
             locale: 'fr-fr',
             'editor-name': 'Ministère education nationale',
             'editor-logo-url': 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
+            'prerequisite-threshold': 30,
+            'goal-threshold': 70,
           },
           id: training.id.toString(),
           type: 'trainings',
@@ -84,6 +88,8 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
             locale: 'fr-fr',
             'editor-name': 'Ministère education nationale',
             'editor-logo-url': 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
+            'prerequisite-threshold': 30,
+            'goal-threshold': 70,
           },
         },
       };
@@ -100,6 +106,8 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
         type: 'webinaire',
         editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
         editorName: 'Ministère education nationale',
+        prerequisiteThreshold: 30,
+        goalThreshold: 70,
       });
     });
 


### PR DESCRIPTION
## :christmas_tree: Problème
Actuellement, les champs de seuil de pré-requis et d'objectifs des contenus formatif ne sont pas présents dans la base de données.

## :gift: Proposition
Ajouter ces champs dans la table training

## :santa: Pour tester
- Se connecter sur Pix Admin en local, avec un compte METIER ou SUPER_ADMIN
- Récupérer le token d'auth
- Lancer l'API en local
- Lancer la requête cURL 
```
curl 'http://localhost:3000/api/admin/trainings' \
  -H 'accept: application/vnd.api+json' \
  -H 'authorization: Bearer XXXXXXXX' \
  -H 'content-type: application/vnd.api+json' \
  --data-raw $'{"data":{"attributes":{"title":"dsqdqsdqsd","link":"https://dqsd.review.pix.fr","type":"webinaire","locale":"fr","editor-name":"Ministère de l\'éducation nationale","editor-logo-url":"https://images.pix.fr/contenu-formatif/editeur/logo-ministere-education-nationale-et-jeunesse.svg","duration":{"days":"1","hours":0,"minutes":0}},"type":"trainings"}}'
```

- Vérifier qu'on reçoit bien nos 2 nouvelles colonnes
