### PR TITLE
[FEATURE][ADMIN] Afficher un message d'information lorsqu'une organisation n'a pas de tags (PIX-6739)

### DIFF
--- a/admin/app/components/organizations/information-section-view.hbs
+++ b/admin/app/components/organizations/information-section-view.hbs
@@ -9,6 +9,9 @@
         </li>
       {{/each}}
     </ul>
+  {{else}}
+    <PixMessage class="organization-information-section__missing-tags-message" @type="information">Cette organisation
+      n'a pas de tags.</PixMessage>
   {{/if}}
 
   {{#if @organization.isArchived}}

--- a/admin/app/styles/components/organization-information-section.scss
+++ b/admin/app/styles/components/organization-information-section.scss
@@ -10,6 +10,10 @@
     margin-bottom: 16px;
   }
 
+  &__missing-tags-message {
+    margin-bottom: 16px;
+  }
+
   &__details {
 
     ul {

--- a/admin/tests/integration/components/organizations/information-section-view_test.js
+++ b/admin/tests/integration/components/organizations/information-section-view_test.js
@@ -184,10 +184,28 @@ module('Integration | Component | organizations/information-section-view', funct
       // when
       const screen = await render(hbs`<Organizations::InformationSectionView @organization={{this.organization}} />`);
 
-      // expect
+      // then
       assert.dom(screen.getByText('CFA')).exists();
       assert.dom(screen.getByText('PRIVE')).exists();
       assert.dom(screen.getByText('AGRICULTURE')).exists();
+    });
+
+    module('when organization has no tags', function () {
+      test('it should display an informative message', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const organization = store.createRecord('organization', {
+          archivedAt: null,
+          tags: [],
+        });
+        this.set('organization', organization);
+
+        // when
+        const screen = await render(hbs`<Organizations::InformationSectionView @organization={{this.organization}} />`);
+
+        // then
+        assert.dom(screen.getByText("Cette organisation n'a pas de tags.")).exists();
+      });
     });
 
     module('when organization is archived', function () {
@@ -201,7 +219,7 @@ module('Integration | Component | organizations/information-section-view', funct
         // when
         const screen = await render(hbs`<Organizations::InformationSectionView @organization={{this.organization}} />`);
 
-        // expect
+        // then
         assert.dom(screen.getByText('Archivée le 22/02/2022 par Rob Lochon.')).exists();
       });
     });
@@ -264,7 +282,7 @@ module('Integration | Component | organizations/information-section-view', funct
       // when
       const screen = await render(hbs`<Organizations::InformationSectionView @organization={{this.organization}} />`);
 
-      // expect
+      // then
       assert.dom(screen.queryByRole('button', { name: 'Éditer' })).doesNotExist();
       assert.dom(screen.queryByRole('button', { name: "Archiver l'organisation" })).doesNotExist();
     });


### PR DESCRIPTION
## :christmas_tree: Problème
Sur Pix Admin, les organisations sont associées à un/ou plusieurs tag(s). 
Ce système de tagage des orgas permet de comprendre leurs environnements, le contexte de déploiement, le type d’organisation, l’écosystème de l’organisation, si elle fait partie d’un réseau etc.
Il est donc important que les organisations soient tagguées et que ce système soit amélioré.

Actuellement, sur la page de détails d'une organisation, la liste des tags sélectionnés pour cette organisation s'affiche mais aucune mention n'est affichée lorsqu'aucun tag a été sélectionné pour cette orga. 

## :gift: Proposition
Afficher un message d'information à l'agent pix.

## :star2: Remarques
Lorsque l'organisation est archivée, l'agent pix voit les tags et un message informant que l'orga a été archivé et par qui l'action a été faite. 
On affiche donc aussi le message informant qu'aucun tag n'a été sélectionné, même si l'organisation est archivée

## :santa: Pour tester
- se connecter sur pix admin avec un compte super admin
- aller sur le détail d'une organisation
- s'il y a des tags, les désélectionner en allant dans l'onglet Tags en bas de page
- observer l'affichage du message sur fond bleu
- archiver l'orga
- observer que le message est toujours présent et que celui informant de l'archivage apparaît en dessous
