### PR TITLE
[FEATURE] Créer une route pour l'appel au simulateur de l'algorithme Flash (PIX-6765).

### DIFF
--- a/api/lib/application/scoring-simulator/index.js
+++ b/api/lib/application/scoring-simulator/index.js
@@ -21,6 +21,24 @@ exports.register = async (server) => {
         ],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/scoring-simulator/flash',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: scoringSimulatorController.calculateFlashScores,
+        tags: ['api'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés',
+          "Elle renvoie le score Pix calculé avec l'algorithme Flash pour une liste de questions et réponses données",
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/lib/application/scoring-simulator/scoring-simulator-controller.js
+++ b/api/lib/application/scoring-simulator/scoring-simulator-controller.js
@@ -2,4 +2,8 @@ module.exports = {
   async calculateOldScores(request, h) {
     return h.response({}).code(200);
   },
+
+  async calculateFlashScores(request, h) {
+    return h.response({}).code(200);
+  },
 };

--- a/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
@@ -70,4 +70,56 @@ describe('Acceptance | Controller | scoring-simulator-controller', function () {
       });
     });
   });
+
+  describe('#calculateFlashScores', function () {
+    let options;
+
+    beforeEach(async function () {
+      options = {
+        method: 'POST',
+        url: `/api/scoring-simulator/flash`,
+        payload: {},
+        headers: {},
+      };
+    });
+
+    it('should return status code 200', async function () {
+      // given
+      options.headers.authorization = adminAuthorization;
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response).to.have.property('statusCode', 200);
+    });
+
+    describe('when there is no connected user', function () {
+      it('should return status code 401', async function () {
+        // given
+        options.headers.authorization = undefined;
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response).to.have.property('statusCode', 401);
+      });
+    });
+
+    describe('when connected user does not have role SUPER_ADMIN', function () {
+      it('should return status code 403', async function () {
+        // given
+        const { id: userId } = databaseBuilder.factory.buildUser();
+        options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
+        await databaseBuilder.commit();
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response).to.have.property('statusCode', 403);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :christmas_tree: Problème
Il n'existe pas de route pour simuler le calcul d'un score Pix avec l'algorithme Flash.

## :gift: Proposition
Créer une route `/api/scoring-simulator/flash` permettant de le faire.

## :star2: Remarques
Cela ressemble à s'y méprendre à la PR de création d'une route pour le simulateur de l'ancien algo.

## :santa: Pour tester
TOKEN=$(curl 'https://api-pr5495.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin%40example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr5495.review.pix.fr/api/scoring-simulator/flash -H "Authorization: Bearer $TOKEN" -X POST
