### PR TITLE
[FEATURE] Annuler toutes les invitations à rejoindre une organisation qui sont actuellement en attente et non mis à jour depuis plus d'un an (PIX-6794)

### DIFF
--- a/api/db/migrations/20230112103200_cancel-pending-organization-invitations-with-an-updatedAt-greater-than-a-year.js
+++ b/api/db/migrations/20230112103200_cancel-pending-organization-invitations-with-an-updatedAt-greater-than-a-year.js
@@ -1,0 +1,11 @@
+const dayjs = require('dayjs');
+const { StatusType } = require('../../lib/domain/models/OrganizationInvitation');
+
+exports.up = function (knex) {
+  return knex('organization-invitations')
+    .update({ status: StatusType.CANCELLED, updatedAt: new Date() })
+    .where('status', StatusType.PENDING)
+    .andWhere('updatedAt', '<', dayjs().subtract(1, 'year'));
+};
+
+exports.down = function () {};


### PR DESCRIPTION
## :christmas_tree: Problème

Il y a actuellement quasiment 100 000 invitations en attente depuis plus d’un an, et qui n’ont pas été renvoyés.
Par mesure de sécurité, il faudrait annuler ces invitations.

## :gift: Proposition

Ajouter un script de migration pour passer le statut de ces invitations de **pending** à **cancelled**.

## :star2: Remarques

⚠️ La méthode `down` du script de migration n'a pas été implémenté. Il est impossible de remettre les éléments qui ont été modifiés dans leur état précédent (cancelled > pending) sans modifier les invitations qui étaient déjà avec le status cancelled.

## :santa: Pour tester

Test à faire en local.

- Nettoyer son environnement en local
  - Se mettre sur la branche `dev`
  - Récupérer les derniers changements
  - Exécuter la commande `npm run db:reset`
- Se mettre sur la branche de cette PR
- Ajouter des nouvelles entrées dans la table `organization-invitations` avec une valeur pour `updatedAt` supérieure et inférieure à 1 an, et le `status` à **pending**
- Exécuter la commande `npm run db:migrate`
- Constater en base de données que toutes les invitations ayant le statut **pending** et non mis à jour depuis plus d'un an ont le statut **cancelled**