### PR TITLE
[TECH] Implémenter Normalize/Reset CSS dans Pix App (PIX-3026)

### DIFF
--- a/mon-pix/app/components/account-recovery/student-information-form.hbs
+++ b/mon-pix/app/components/account-recovery/student-information-form.hbs
@@ -72,7 +72,7 @@
         @aria-describedby="student-information-error-message"
       />
 
-      <div>
+      <div class="form-textfield">
         <p class="form-textfield__label student-information-form__birthdate-label">
           {{t "pages.account-recovery.find-sco-record.student-information.form.birthdate"}}
         </p>

--- a/mon-pix/app/components/training/card.hbs
+++ b/mon-pix/app/components/training/card.hbs
@@ -1,16 +1,18 @@
 <PixBlock class="training-card" @shadow="light">
   <a class="training-card__content" href={{@training.link}} target="_blank" rel="noopener noreferrer">
     <h3 class="training-card-content__title">{{@training.title}}</h3>
-    <PixTag @color={{this.tagColor}} class="training-card-content__infos">
-      <ul class="training-card-content-infos__list">
-        <li class="training-card-content-infos-list__type">
-          {{this.type}}
-        </li>
-        <li class="training-card-content-infos-list__duration">
-          <time>{{this.durationFormatted}}</time>
-        </li>
-      </ul>
-    </PixTag>
+    <div class="training-card-content__infos" title="{{this.tagTitle}}">
+      <PixTag @color={{this.tagColor}} class="training-card-content-infos__tag">
+        <ul class="training-card-content-infos-tag__list">
+          <li class="training-card-content-infos-tag-list__type">
+            {{this.type}}
+          </li>
+          <li class="training-card-content-infos-tag-list__duration">
+            <time>{{this.durationFormatted}}</time>
+          </li>
+        </ul>
+      </PixTag>
+    </div>
     <div class="training-card-content__illustration">
       <img
         class="training-card-content-illustration__logo"

--- a/mon-pix/app/components/training/card.js
+++ b/mon-pix/app/components/training/card.js
@@ -22,6 +22,9 @@ export default class Card extends Component {
     return this.intl.t(`pages.training.type.${this.args.training.type}`);
   }
 
+  get tagTitle() {
+    return `${this.type} - ${this.durationFormatted}`;
+  }
   get tagColor() {
     if (this.args.training.isAutoformation) {
       return 'blue-light';

--- a/mon-pix/app/styles/components/_certification-not-certifiable.scss
+++ b/mon-pix/app/styles/components/_certification-not-certifiable.scss
@@ -20,6 +20,7 @@
 
 .certification-not-certifiable__title {
   font-weight: $font-light;
+  font-size: 2rem;
   font-family: $font-open-sans;
   text-align: center;
 }

--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -27,7 +27,6 @@
 }
 
 .challenge-statement-instruction {
-
   &__text {
     width: 100%;
 
@@ -169,6 +168,7 @@
 .challenge-statement__action-link {
   width: 156px;
   height: 46px;
+  margin-bottom: $spacing-m;
   color: $pix-neutral-0;
   text-align: center;
   background-color: $pix-primary;
@@ -182,8 +182,6 @@
 }
 
 .challenge-statement__action-help {
-  position: relative;
-  top: 16px;
   font-size: 0.825rem;
 
   &--link {

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -70,12 +70,12 @@
 
   &__resume-or-start-button,
   &__improve-button {
-    margin-top: 30px;
+    margin: $spacing-m 0;
   }
 
   &__reset-button {
     width: 180px;
-    margin-top: 24px;
+    margin-top: $spacing-m;
   }
 
   &__reset-modal {
@@ -162,6 +162,7 @@
   &__name {
     margin: 15px 0;
     font-weight: $font-light;
+    font-size: 2rem;
     font-family: $font-open-sans;
   }
 

--- a/mon-pix/app/styles/components/_training-card.scss
+++ b/mon-pix/app/styles/components/_training-card.scss
@@ -24,10 +24,14 @@
 }
 
 .training-card-content__infos {
-  margin: 0 0 48px 16px;
+  padding: 0 $spacing-s $spacing-xxl;
 }
 
-.training-card-content-infos__list {
+.training-card-content-infos__tag {
+  max-width: 100%;
+}
+
+.training-card-content-infos-tag__list {
   display: flex;
   padding-left: 0;
 
@@ -35,6 +39,13 @@
     margin: 0 1ch;
     content: '-';
   }
+}
+
+.training-card-content-infos-tag-list__duration {
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .training-card-content__illustration {

--- a/mon-pix/app/styles/pages/_challenge.scss
+++ b/mon-pix/app/styles/pages/_challenge.scss
@@ -1,4 +1,34 @@
 .challenge {
+  /* CSS patch to delete when screen improved */
+  line-height: normal;
+
+  p {
+    margin-top: 1em;
+    margin-bottom: 1em;
+
+    p {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+
+  h2 {
+    font-weight: bold;
+    font-size: 1.5em;
+  }
+
+  ol,
+  ul {
+    margin: 1em 0;
+    padding-inline-start: 40px;
+    list-style-type: decimal;
+  }
+
+  ul {
+    list-style-type: disc;
+  }
+
+  /* ! End of CSS patch */
 
   &__content {
     width: 100%;

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -16,6 +16,7 @@
   &__title {
     margin-bottom: $spacing-l;
     font-weight: $font-light;
+    font-size: 2rem;
     text-align: center;
   }
 

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -184,6 +184,7 @@
   &__item {
     width: 100%;
     padding: 0;
+    overflow: hidden;
     transition: all 0.2s ease-in-out;
 
     &:hover {

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -137,6 +137,10 @@
 
 .skill-review-retry {
 
+  &__message {
+    margin-bottom: $spacing-s;
+  }
+
   &__button {
     padding: 10px;
     font-size: 0.875rem;

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -138,7 +138,7 @@
 .skill-review-retry {
 
   &__message {
-    margin-bottom: $spacing-s;
+    margin: 1em 0;
   }
 
   &__button {

--- a/mon-pix/app/styles/pages/_user-tutorials.scss
+++ b/mon-pix/app/styles/pages/_user-tutorials.scss
@@ -107,9 +107,11 @@
 
   &__title {
     font-weight: $font-normal;
+    font-size: 1.5rem;
   }
 
   &__description {
+    margin: 1.2rem 0;
     font-size: 1.2rem;
   }
 

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
-        "@1024pix/pix-ui": "^23.3.0",
+        "@1024pix/pix-ui": "^24.0.1",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
         "@ember/optional-features": "^2.0.0",
@@ -1136,9 +1136,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "23.3.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-23.3.0.tgz",
-      "integrity": "sha512-b3WuosMB0xUk0QeileWvqHJIkKUbroKNvZQHMfxgy/+XVTYf0q4PB3Op6nJFr9aix22KX5VmFKeNlvndBiO8bg==",
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-24.0.1.tgz",
+      "integrity": "sha512-hymu4ttHwswbP/VJTERYyP31nATR4LrG7yaYc7kKz9ztM2IvWs1tJZcXjFTdkvcTlslTJssEhLLvTmuIUd6U2Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -42665,9 +42665,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "23.3.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-23.3.0.tgz",
-      "integrity": "sha512-b3WuosMB0xUk0QeileWvqHJIkKUbroKNvZQHMfxgy/+XVTYf0q4PB3Op6nJFr9aix22KX5VmFKeNlvndBiO8bg==",
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-24.0.1.tgz",
+      "integrity": "sha512-hymu4ttHwswbP/VJTERYyP31nATR4LrG7yaYc7kKz9ztM2IvWs1tJZcXjFTdkvcTlslTJssEhLLvTmuIUd6U2Q==",
       "dev": true,
       "requires": {
         "color": "^4.2.3",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
-    "@1024pix/pix-ui": "^23.3.0",
+    "@1024pix/pix-ui": "^24.0.1",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",
     "@ember/optional-features": "^2.0.0",

--- a/mon-pix/tests/integration/components/training/card_test.js
+++ b/mon-pix/tests/integration/components/training/card_test.js
@@ -27,8 +27,10 @@ module('Integration | Component | Training | Card', function (hooks) {
     assert.strictEqual(find('.training-card__content').href, 'https://training.net/');
     assert.strictEqual(find('.training-card-content__title').textContent.trim(), 'Mon super training');
     assert.dom('.training-card-content__infos').exists();
-    assert.strictEqual(find('.training-card-content-infos-list__type').textContent.trim(), 'Webinaire');
-    assert.strictEqual(find('.training-card-content-infos-list__duration').textContent.trim(), '6h');
+    assert.strictEqual(find('.training-card-content__infos').title, 'Webinaire - 6h');
+    assert.dom('.training-card-content-infos__tag').exists();
+    assert.strictEqual(find('.training-card-content-infos-tag-list__type').textContent.trim(), 'Webinaire');
+    assert.strictEqual(find('.training-card-content-infos-tag-list__duration').textContent.trim(), '6h');
     assert.notOk(find('.training-card-content-illustration__image').alt);
     assert.strictEqual(
       find('.training-card-content-illustration__logo').alt,


### PR DESCRIPTION
🎄 **Problème**

Pix UI n'est pas à jour sur Pix App ce qui empêche l'utilisation de nouvelles features et de nouveau composants.

🎁 **Proposition**

Mettre à jour Pix-UI de la version 23.3.0 à la dernière version actuelle 24.0.1.

🌟 **Remarques**

Vérification des différentes vues/pages pour les flux suivants :

- Passer / Repasser un test de Compétence
- Pages & composants liés  à "Mes formations"
- Pages & composants liés  à "Mes tutos"
- Passer un Parcours

⚠️ 
- Nous avons remarqué que les règles du **reset.css** venant de **pix ui** override les règles qui touche les balises **<h*>**.
- Ne pas oublier de revérifier le rendu des différents  **<h*>** quand les règles du **reset.css** seront allégées.

🎅 **Pour tester**

Vérifier si il n'y a pas de régression visuelle
