### PR TITLE
[FEATURE] Accepter un identifiant de simulation en entrée du simulateur d'ancien score (PIX-6820)

### DIFF
--- a/api/lib/application/scoring-simulator/index.js
+++ b/api/lib/application/scoring-simulator/index.js
@@ -23,6 +23,7 @@ exports.register = async (server) => {
               .required()
               .items(
                 Joi.object({
+                  id: Joi.string(),
                   answers: Joi.array()
                     .required()
                     .items(

--- a/api/lib/application/scoring-simulator/scoring-simulator-controller.js
+++ b/api/lib/application/scoring-simulator/scoring-simulator-controller.js
@@ -7,6 +7,7 @@ module.exports = {
     const simulations = request.payload.simulations.map(
       (simulation) =>
         new OldScoringSimulation({
+          id: simulation.id,
           answers: simulation.answers.map((answer) => new Answer(answer)),
         })
     );

--- a/api/lib/domain/models/OldScoringSimulation.js
+++ b/api/lib/domain/models/OldScoringSimulation.js
@@ -1,5 +1,6 @@
 class OldScoringSimulation {
-  constructor({ answers = [] } = {}) {
+  constructor({ id, answers = [] } = {}) {
+    this.id = id;
     this.answers = answers;
   }
 }

--- a/api/lib/domain/models/SimulationResult.js
+++ b/api/lib/domain/models/SimulationResult.js
@@ -1,5 +1,6 @@
 class SimulationResult {
-  constructor({ pixScore, error } = {}) {
+  constructor({ id, pixScore, error } = {}) {
+    this.id = id;
     this.pixScore = pixScore;
     this.error = error;
   }

--- a/api/lib/domain/usecases/simulate-old-scoring.js
+++ b/api/lib/domain/usecases/simulate-old-scoring.js
@@ -12,14 +12,17 @@ module.exports = async function simulateOldScoring({ challengeRepository, simula
     fp.groupBy('tubeId'),
   )(challenges);
 
-  const simulationResults = simulations.map(({ answers }) => {
+  const simulationResults = simulations.map(({ id, answers }) => {
     const scoreBySkillId = {};
 
     for (const answer of answers) {
       const challenge = challengesById.get(answer.challengeId);
 
       if (scoreBySkillId[challenge.skill.id] !== undefined) {
-        return new SimulationResult({ error: `Answer for skill ${challenge.skill.id} was already given or inferred` });
+        return new SimulationResult({
+          id,
+          error: `Answer for skill ${challenge.skill.id} was already given or inferred`,
+        });
       }
 
       const tubeSkills = skillsByTubeId[challenge.skill.tubeId];
@@ -41,7 +44,7 @@ module.exports = async function simulateOldScoring({ challengeRepository, simula
 
     const pixScore = Object.values(scoreBySkillId).reduce((sum, pixValue) => sum + pixValue, 0);
 
-    return new SimulationResult({ pixScore });
+    return new SimulationResult({ id, pixScore });
   });
 
   return simulationResults;

--- a/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
@@ -97,6 +97,7 @@ describe('Acceptance | Controller | scoring-simulator-controller', function () {
             ],
           },
           {
+            id: 'simulationWithError',
             answers: [
               { challengeId: 'challenge2', result: 'ok' },
               { challengeId: 'challenge1', result: 'ok' },
@@ -113,10 +114,12 @@ describe('Acceptance | Controller | scoring-simulator-controller', function () {
       expect(response.result).to.deep.equal({
         results: [
           {
+            id: undefined,
             error: undefined,
             pixScore: 11111,
           },
           {
+            id: 'simulationWithError',
             error: 'Answer for skill skill1 was already given or inferred',
             pixScore: undefined,
           },

--- a/api/tests/integration/domain/usecases/simulate-old-scoring_test.js
+++ b/api/tests/integration/domain/usecases/simulate-old-scoring_test.js
@@ -98,7 +98,7 @@ describe('Integration | UseCases | simulateOldScoring', function () {
         }),
       ];
 
-      const simulation = new OldScoringSimulation({ answers });
+      const simulation = new OldScoringSimulation({ id: 'simulation1', answers });
 
       // when
       const simulationResults = await usecases.simulateOldScoring({ simulations: [simulation] });
@@ -106,6 +106,7 @@ describe('Integration | UseCases | simulateOldScoring', function () {
       // then
       expect(simulationResults).to.have.lengthOf(1);
       expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+      expect(simulationResults[0]).to.have.property('id', 'simulation1');
       expect(simulationResults[0]).to.have.property('pixScore', 11111);
     });
   });
@@ -122,7 +123,7 @@ describe('Integration | UseCases | simulateOldScoring', function () {
         }),
       ];
 
-      const simulation = new OldScoringSimulation({ answers });
+      const simulation = new OldScoringSimulation({ id: 'simulation1', answers });
 
       // when
       const simulationResults = await usecases.simulateOldScoring({ simulations: [simulation] });
@@ -130,6 +131,7 @@ describe('Integration | UseCases | simulateOldScoring', function () {
       // then
       expect(simulationResults).to.have.lengthOf(1);
       expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+      expect(simulationResults[0]).to.have.property('id', 'simulation1');
       expect(simulationResults[0]).to.have.property('error', 'Answer for skill skill5 was already given or inferred');
     });
   });


### PR DESCRIPTION
## :christmas_tree: Problème
Le simulateur d'ancien score n'accepte pas d'identifiant de simulation en entrée.

## :gift: Proposition
Accepter un identifiant de simulation en entrée du simulateur d'ancien score et le renvoyer sur le résultat de simulation correspondante.

## :star2: Remarques
L'identifiant n'est pas obligatoire.

## :santa: Pour tester
```
TOKEN=$(curl 'https://api-pr5487.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin%40example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr5487.review.pix.fr/api/scoring-simulator/old \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -X POST \
    -d '{ "simulations": [{ "id": "mySimulation", "answers": [{ "challengeId": "rec3wt8JjOQZMoQav", "result": "ok" }] }] }'
```
