### PR TITLE
[TECH] Prévenir les faux positifs dûs au helper catchErr (PIX-6825)

### DIFF
--- a/api/lib/infrastructure/lcms.js
+++ b/api/lib/infrastructure/lcms.js
@@ -8,6 +8,11 @@ module.exports = {
       url: lcms.url + '/releases/latest',
       headers: { Authorization: `Bearer ${lcms.apiKey}` },
     });
+
+    if (!response.isSuccessful) {
+      throw new Error(`An error occurred while fetching ${lcms.url}`);
+    }
+
     return response.data.content;
   },
 

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -151,10 +151,10 @@ function catchErr(promiseFn, ctx) {
   return async (...args) => {
     try {
       await promiseFn.call(ctx, ...args);
-      return 'should have thrown an error';
     } catch (err) {
       return err;
     }
+    throw new Error('Expected an error, but none was thrown.');
   };
 }
 

--- a/api/tests/test-helper_test.js
+++ b/api/tests/test-helper_test.js
@@ -16,17 +16,17 @@ describe('Test helpers', function () {
       expect(result).to.deepEqualInstance(errorToThrow);
     });
 
-    it('returns a string if no error was thrown', async function () {
+    it('throws a specific error if no error was thrown', async function () {
       // given
       const functionToTest = function () {
         return 'All went well';
       };
 
       // when
-      const result = await catchErr(functionToTest)();
+      const promise = catchErr(functionToTest)();
 
       // then
-      expect(result).to.deepEqualInstance('should have thrown an error');
+      await expect(promise).to.be.rejectedWith('Expected an error, but none was thrown.');
     });
   });
 });

--- a/api/tests/test-helper_test.js
+++ b/api/tests/test-helper_test.js
@@ -1,0 +1,32 @@
+const { expect, catchErr } = require('./test-helper');
+
+describe('Test helpers', function () {
+  describe('#catchErr', function () {
+    it('returns the error thrown in the tested function', async function () {
+      // given
+      const errorToThrow = new Error('An error occurred');
+      const functionToTest = function () {
+        throw errorToThrow;
+      };
+
+      // when
+      const result = await catchErr(functionToTest)();
+
+      // then
+      expect(result).to.deepEqualInstance(errorToThrow);
+    });
+
+    it('returns a string if no error was thrown', async function () {
+      // given
+      const functionToTest = function () {
+        return 'All went well';
+      };
+
+      // when
+      const result = await catchErr(functionToTest)();
+
+      // then
+      expect(result).to.deepEqualInstance('should have thrown an error');
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/lcms_test.js
+++ b/api/tests/unit/infrastructure/lcms_test.js
@@ -44,7 +44,8 @@ describe('Unit | Infrastructure | LCMS', function () {
       const error = await catchErr(lcms.getLatestRelease)();
 
       // then
-      expect(error).to.be.not.null;
+      expect(error).to.be.instanceOf(Error);
+      expect(error.message).to.equal(`An error occurred while fetching https://lcms-test.pix.fr/api`);
     });
   });
 

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -1,4 +1,4 @@
-const { expect, catchErr, sinon } = require('../../../../test-helper');
+const { expect, sinon, catchErr } = require('../../../../test-helper');
 const csvSerializer = require('../../../../../lib/infrastructure/serializers/csv/csv-serializer');
 const logger = require('../../../../../lib/infrastructure/logger');
 const _ = require('lodash');
@@ -45,11 +45,11 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
       expect(csv).to.equal(csvExpected);
     });
 
-    context('should throw exceptions invalid format', function () {
+    context('should log errors for invalid format', function () {
       it('given object', async function () {
         // when
         sinon.stub(logger, 'error');
-        await catchErr(csvSerializer.serializeLine)([{}]);
+        csvSerializer.serializeLine([{}]);
         // then
         expect(logger.error).to.have.been.calledWith(
           'Unknown value type in _csvSerializeValue: object: [object Object]'
@@ -59,7 +59,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
       it('given null', async function () {
         // when
         sinon.stub(logger, 'error');
-        await catchErr(csvSerializer.serializeLine)([null]);
+        csvSerializer.serializeLine([null]);
         // then
         expect(logger.error).to.have.been.calledWith('Unknown value type in _csvSerializeValue: object: null');
       });
@@ -67,7 +67,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
       it('given undefined', async function () {
         // when
         sinon.stub(logger, 'error');
-        await catchErr(csvSerializer.serializeLine)([undefined]);
+        csvSerializer.serializeLine([undefined]);
         // then
         expect(logger.error).to.have.been.calledWith('Unknown value type in _csvSerializeValue: undefined: undefined');
       });

--- a/api/tests/unit/scripts/helpers/csvHelpers_test.js
+++ b/api/tests/unit/scripts/helpers/csvHelpers_test.js
@@ -187,10 +187,7 @@ describe('Unit | Scripts | Helpers | csvHelpers.js', function () {
       const headers = ['uai', 'name'];
 
       // when
-      const error = await catchErr(checkCsvHeader)({ filePath: withHeaderFilePath, requiredFieldNames: headers });
-
-      // then
-      expect(error).to.be.equal('should have thrown an error');
+      await checkCsvHeader({ filePath: withHeaderFilePath, requiredFieldNames: headers });
     });
 
     it('should not throw if headers empty', async function () {


### PR DESCRIPTION
## :christmas_tree: Problème

Le helper `catchErr` qui sert à vérifier qui, si une fonction lance une erreur, la capture et la retourne afin qu'elle puisse être vérifié dans le cadre d'un test.

Mais si la fonction testé ne lance pas l'erreur attendue, le comportement du helper est curieux : il renvoie une chaîne de caractère "no error was throwned" mais ne fait pas échouer le test. Cela peut conduire à des faux positifs et c'est le cas d'au moins un test (celui de la méthode `getLatestRelease`, corrigé dans cette PR).

## :gift: Proposition

Lancer une erreur depuis `catchErr` si aucune erreur n'est lancé par la fonction testée.

## :star2: Remarques

- Des tests unitaires ont été ajoutées pour le helper
- Une implémentation qui ne lançait pas d'erreur a été corrigée
- Des utilisations inutiles du helper (car le code testé n'était pas censé lancer d'erreur) ont été supprimées.

## :santa: Pour tester

1. Trouver un test qui utilise le helper `catchErr`
2. Dans l'implémentation testée, supprimer la condition qui déclenche le lancement d'une erreur
3. Constater que le test échoue