### PR TITLE
[FEATURE] Simulateur de nouveau scoring (PIX-6766)

### DIFF
--- a/api/lib/application/scoring-simulator/index.js
+++ b/api/lib/application/scoring-simulator/index.js
@@ -61,6 +61,7 @@ exports.register = async (server) => {
             allowUnknown: true,
           },
           payload: Joi.object({
+            successProbabilityThreshold: Joi.number(),
             simulations: Joi.array()
               .required()
               .items(

--- a/api/lib/application/scoring-simulator/index.js
+++ b/api/lib/application/scoring-simulator/index.js
@@ -56,6 +56,30 @@ exports.register = async (server) => {
             assign: 'hasAuthorizationToAccessAdminScope',
           },
         ],
+        validate: {
+          options: {
+            allowUnknown: true,
+          },
+          payload: Joi.object({
+            simulations: Joi.array()
+              .required()
+              .items(
+                Joi.object({
+                  id: Joi.string(),
+                  estimatedLevel: Joi.number(),
+                  answers: Joi.array()
+                    .items(
+                      Joi.object({
+                        challengeId: Joi.string().required(),
+                        result: Joi.string().required(),
+                      })
+                    )
+                    .min(1),
+                }).required()
+              )
+              .min(1),
+          }).required(),
+        },
         handler: scoringSimulatorController.calculateFlashScores,
         tags: ['api'],
         notes: [

--- a/api/lib/application/scoring-simulator/scoring-simulator-controller.js
+++ b/api/lib/application/scoring-simulator/scoring-simulator-controller.js
@@ -23,11 +23,14 @@ module.exports = {
         new ScoringSimulation({
           id: simulation.id,
           estimatedLevel: simulation.estimatedLevel,
-          answers: simulation.answers.map((answer) => new Answer(answer)),
+          answers: simulation.answers?.map((answer) => new Answer(answer)),
         })
     );
 
-    const results = await usecases.simulateFlashScoring({ simulations });
+    const results = await usecases.simulateFlashScoring({
+      successProbabilityThreshold: request.payload.successProbabilityThreshold,
+      simulations,
+    });
 
     return h.response({ results });
   },

--- a/api/lib/application/scoring-simulator/scoring-simulator-controller.js
+++ b/api/lib/application/scoring-simulator/scoring-simulator-controller.js
@@ -1,4 +1,4 @@
-const OldScoringSimulation = require('../../domain/models/OldScoringSimulation');
+const ScoringSimulation = require('../../domain/models/ScoringSimulation');
 const Answer = require('../../domain/models/Answer');
 const usecases = require('../../domain/usecases');
 
@@ -6,7 +6,7 @@ module.exports = {
   async calculateOldScores(request, h) {
     const simulations = request.payload.simulations.map(
       (simulation) =>
-        new OldScoringSimulation({
+        new ScoringSimulation({
           id: simulation.id,
           answers: simulation.answers.map((answer) => new Answer(answer)),
         })

--- a/api/lib/application/scoring-simulator/scoring-simulator-controller.js
+++ b/api/lib/application/scoring-simulator/scoring-simulator-controller.js
@@ -18,6 +18,17 @@ module.exports = {
   },
 
   async calculateFlashScores(request, h) {
-    return h.response({}).code(200);
+    const simulations = request.payload.simulations.map(
+      (simulation) =>
+        new ScoringSimulation({
+          id: simulation.id,
+          estimatedLevel: simulation.estimatedLevel,
+          answers: simulation.answers.map((answer) => new Answer(answer)),
+        })
+    );
+
+    const results = await usecases.simulateFlashScoring({ simulations });
+
+    return h.response({ results });
   },
 };

--- a/api/lib/domain/models/OldScoringSimulation.js
+++ b/api/lib/domain/models/OldScoringSimulation.js
@@ -1,8 +1,0 @@
-class OldScoringSimulation {
-  constructor({ id, answers = [] } = {}) {
-    this.id = id;
-    this.answers = answers;
-  }
-}
-
-module.exports = OldScoringSimulation;

--- a/api/lib/domain/models/ScoringSimulation.js
+++ b/api/lib/domain/models/ScoringSimulation.js
@@ -1,0 +1,9 @@
+class ScoringSimulation {
+  constructor({ id, estimatedLevel, answers = [] } = {}) {
+    this.id = id;
+    this.estimatedLevel = estimatedLevel;
+    this.answers = answers;
+  }
+}
+
+module.exports = ScoringSimulation;

--- a/api/lib/domain/models/SimulationResult.js
+++ b/api/lib/domain/models/SimulationResult.js
@@ -1,6 +1,7 @@
 class SimulationResult {
-  constructor({ id, pixScore, error } = {}) {
+  constructor({ id, estimatedLevel, pixScore, error } = {}) {
     this.id = id;
+    this.estimatedLevel = estimatedLevel;
     this.pixScore = pixScore;
     this.error = error;
   }

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -415,6 +415,7 @@ module.exports = injectDependencies(
     sendSharedParticipationResultsToPoleEmploi: require('./send-shared-participation-results-to-pole-emploi'),
     sendVerificationCode: require('./send-verification-code'),
     shareCampaignResult: require('./share-campaign-result'),
+    simulateFlashScoring: require('./simulate-flash-scoring'),
     simulateOldScoring: require('./simulate-old-scoring'),
     startCampaignParticipation: require('./start-campaign-participation'),
     startOrResumeCompetenceEvaluation: require('./start-or-resume-competence-evaluation'),

--- a/api/lib/domain/usecases/simulate-flash-scoring.js
+++ b/api/lib/domain/usecases/simulate-flash-scoring.js
@@ -3,10 +3,11 @@ const SimulationResult = require('../models/SimulationResult');
 module.exports = async function simulateFlashScoring({
   challengeRepository,
   flashAlgorithmService,
+  successProbabilityThreshold,
   simulations,
   locale = 'fr',
 }) {
-  const challenges = await challengeRepository.findFlashCompatible({ locale });
+  const challenges = await challengeRepository.findFlashCompatible({ locale, successProbabilityThreshold });
   const challengeIds = new Set(challenges.map(({ id }) => id));
 
   return simulations.map(({ id, estimatedLevel, answers: allAnswers }) => {

--- a/api/lib/domain/usecases/simulate-flash-scoring.js
+++ b/api/lib/domain/usecases/simulate-flash-scoring.js
@@ -1,6 +1,6 @@
 const SimulationResult = require('../models/SimulationResult');
 
-module.exports = async function simulateNewScoring({
+module.exports = async function simulateFlashScoring({
   challengeRepository,
   flashAlgorithmService,
   simulations,
@@ -10,6 +10,13 @@ module.exports = async function simulateNewScoring({
   const challengeIds = new Set(challenges.map(({ id }) => id));
 
   return simulations.map(({ id, estimatedLevel, answers: allAnswers }) => {
+    if (estimatedLevel == undefined) {
+      return new SimulationResult({
+        id,
+        error: 'Simulation should have an estimated level',
+      });
+    }
+
     for (const answer of allAnswers) {
       if (!challengeIds.has(answer.challengeId)) {
         return new SimulationResult({

--- a/api/lib/domain/usecases/simulate-flash-scoring.js
+++ b/api/lib/domain/usecases/simulate-flash-scoring.js
@@ -9,10 +9,11 @@ module.exports = async function simulateNewScoring({
   const challenges = await challengeRepository.findFlashCompatible({ locale });
   const challengeIds = new Set(challenges.map(({ id }) => id));
 
-  return simulations.map(({ estimatedLevel, answers: allAnswers }) => {
+  return simulations.map(({ id, estimatedLevel, answers: allAnswers }) => {
     for (const answer of allAnswers) {
       if (!challengeIds.has(answer.challengeId)) {
         return new SimulationResult({
+          id,
           error: `Challenge ID ${answer.challengeId} is unknown or not compatible with flash algorithm`,
         });
       }
@@ -24,6 +25,6 @@ module.exports = async function simulateNewScoring({
       allAnswers,
     });
 
-    return new SimulationResult({ estimatedLevel, pixScore });
+    return new SimulationResult({ id, estimatedLevel, pixScore });
   });
 };

--- a/api/lib/domain/usecases/simulate-flash-scoring.js
+++ b/api/lib/domain/usecases/simulate-flash-scoring.js
@@ -7,8 +7,17 @@ module.exports = async function simulateNewScoring({
   locale = 'fr',
 }) {
   const challenges = await challengeRepository.findFlashCompatible({ locale });
+  const challengeIds = new Set(challenges.map(({ id }) => id));
 
   return simulations.map(({ estimatedLevel, answers: allAnswers }) => {
+    for (const answer of allAnswers) {
+      if (!challengeIds.has(answer.challengeId)) {
+        return new SimulationResult({
+          error: `Challenge ID ${answer.challengeId} is unknown or not compatible with flash algorithm`,
+        });
+      }
+    }
+
     const pixScore = flashAlgorithmService.calculateTotalPixScore({
       challenges,
       estimatedLevel,

--- a/api/lib/domain/usecases/simulate-flash-scoring.js
+++ b/api/lib/domain/usecases/simulate-flash-scoring.js
@@ -1,0 +1,20 @@
+const SimulationResult = require('../models/SimulationResult');
+
+module.exports = async function simulateNewScoring({
+  challengeRepository,
+  flashAlgorithmService,
+  simulations,
+  locale = 'fr',
+}) {
+  const challenges = await challengeRepository.findFlashCompatible({ locale });
+
+  return simulations.map(({ estimatedLevel, answers: allAnswers }) => {
+    const pixScore = flashAlgorithmService.calculateTotalPixScore({
+      challenges,
+      estimatedLevel,
+      allAnswers,
+    });
+
+    return new SimulationResult({ estimatedLevel, pixScore });
+  });
+};

--- a/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
@@ -274,12 +274,39 @@ describe('Acceptance | Controller | scoring-simulator-controller', function () {
         const { id: userId } = databaseBuilder.factory.buildUser();
         options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
         await databaseBuilder.commit();
+        options.payload = {
+          simulations: [
+            {
+              estimatedLevel: 1,
+            },
+          ],
+        };
 
         // when
         const response = await server.inject(options);
 
         // then
         expect(response).to.have.property('statusCode', 403);
+      });
+    });
+
+    describe('when request payload is invalid', function () {
+      it('should return status code 400', async function () {
+        // given
+        options.headers.authorization = adminAuthorization;
+        options.payload = {
+          wrongField: [
+            {
+              answers: [],
+            },
+          ],
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response).to.have.property('statusCode', 400);
       });
     });
   });

--- a/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
@@ -116,11 +116,13 @@ describe('Acceptance | Controller | scoring-simulator-controller', function () {
           {
             id: undefined,
             error: undefined,
+            estimatedLevel: undefined,
             pixScore: 11111,
           },
           {
             id: 'simulationWithError',
             error: 'Answer for skill skill1 was already given or inferred',
+            estimatedLevel: undefined,
             pixScore: undefined,
           },
         ],

--- a/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
@@ -60,12 +60,12 @@ describe('Acceptance | Controller | scoring-simulator-controller', function () {
         { id: 'skill6', status: 'périmé', tubeId: 'recTube2', competenceId: 'rec2', level: 6, pixValue: 100000 },
       ],
       challenges: [
-        { id: 'challenge1', skillId: 'skill1', status: 'validé' },
-        { id: 'challenge2', skillId: 'skill2', status: 'validé' },
-        { id: 'challenge3', skillId: 'skill3', status: 'validé' },
-        { id: 'challenge4', skillId: 'skill4', status: 'validé' },
-        { id: 'challenge5', skillId: 'skill5', status: 'validé' },
-        { id: 'challenge6', skillId: 'skill5', status: 'validé' },
+        { id: 'challenge1', skillId: 'skill1', status: 'validé', alpha: 0.16, delta: -2, locales: ['fr'] },
+        { id: 'challenge2', skillId: 'skill2', status: 'validé', alpha: 3, delta: 6, locales: ['fr'] },
+        { id: 'challenge3', skillId: 'skill3', status: 'validé', alpha: 1.587, delta: 8.5, locales: ['fr'] },
+        { id: 'challenge4', skillId: 'skill4', status: 'validé', alpha: 2.86789, delta: 0.145, locales: ['fr'] },
+        { id: 'challenge5', skillId: 'skill5', status: 'validé', alpha: 3, delta: 1, locales: ['fr'] },
+        { id: 'challenge6', skillId: 'skill5', status: 'validé', alpha: 1.7, delta: -1, locales: ['fr'] },
       ],
     };
 
@@ -193,15 +193,66 @@ describe('Acceptance | Controller | scoring-simulator-controller', function () {
       };
     });
 
-    it('should return status code 200', async function () {
+    it('should return a payload with simulation results', async function () {
       // given
       options.headers.authorization = adminAuthorization;
+      options.payload = {
+        simulations: [
+          {
+            id: 'simulation1',
+            estimatedLevel: 2.5769829347,
+            answers: [
+              {
+                challengeId: 'challenge3',
+                result: 'ok',
+              },
+              {
+                challengeId: 'challenge2',
+                result: 'ok',
+              },
+              {
+                challengeId: 'challenge5',
+                result: 'ok',
+              },
+            ],
+          },
+          {
+            id: 'simulation2',
+            answers: [
+              {
+                challengeId: 'challenge2',
+                result: 'ok',
+              },
+              {
+                challengeId: 'challenge1',
+                result: 'ok',
+              },
+            ],
+          },
+        ],
+      };
 
       // when
       const response = await server.inject(options);
 
       // then
       expect(response).to.have.property('statusCode', 200);
+      expect(response.result).to.deep.equal({
+        results: [
+          {
+            id: 'simulation1',
+            estimatedLevel: 2.5769829347,
+            pixScore: 11110,
+            error: undefined,
+          },
+          {
+            id: 'simulation2',
+            error: 'Simulation should have an estimated level',
+            estimatedLevel: undefined,
+            pixScore: undefined,
+          },
+        ],
+      });
     });
 
     describe('when there is no connected user', function () {

--- a/api/tests/integration/application/scoring-simulator/scoring-simulator-controller_test.js
+++ b/api/tests/integration/application/scoring-simulator/scoring-simulator-controller_test.js
@@ -1,0 +1,51 @@
+const { expect, sinon, HttpTestServer } = require('../../../test-helper');
+const SimulationResult = require('../../../../lib/domain/models/SimulationResult');
+const ScoringSimulation = require('../../../../lib/domain/models/ScoringSimulation');
+const Answer = require('../../../../lib/domain/models/Answer');
+const usecases = require('../../../../lib/domain/usecases');
+const moduleUnderTest = require('../../../../lib/application/scoring-simulator');
+const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+
+describe('Integration | Application | Scoring-simulator | scoring-simulator-controller', function () {
+  let simulationResults;
+
+  let httpTestServer;
+
+  beforeEach(async function () {
+    sinon.stub(usecases, 'simulateFlashScoring');
+    sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin');
+    httpTestServer = new HttpTestServer();
+    await httpTestServer.register(moduleUnderTest);
+    simulationResults = [new SimulationResult({ pixScore: 10 })];
+  });
+
+  describe('#post', function () {
+    context('When the route is called with correct arguments', function () {
+      it('should resolve a 200 HTTP response', async function () {
+        // given
+        usecases.simulateFlashScoring.resolves({ results: simulationResults });
+        securityPreHandlers.checkAdminMemberHasRoleSuperAdmin.returns(() => {
+          return true;
+        });
+
+        // when
+        const response = await httpTestServer.request('POST', '/api/scoring-simulator/flash', {
+          simulations: [{ estimatedLevel: 2, answers: [{ challengeId: 'okChallengeId', result: 'ok' }] }],
+          successProbabilityThreshold: 0.8,
+        });
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(usecases.simulateFlashScoring).to.have.been.calledWith({
+          simulations: [
+            new ScoringSimulation({
+              estimatedLevel: 2,
+              answers: [new Answer({ challengeId: 'okChallengeId', result: 'ok' })],
+            }),
+          ],
+          successProbabilityThreshold: 0.8,
+        });
+      });
+    });
+  });
+});

--- a/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
+++ b/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
@@ -1,0 +1,84 @@
+const { expect, mockLearningContent, domainBuilder } = require('../../../test-helper');
+const ScoringSimulation = require('../../../../lib/domain/models/ScoringSimulation');
+const SimulationResult = require('../../../../lib/domain/models/SimulationResult');
+const usecases = require('../../../../lib/domain/usecases/');
+const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
+
+describe('Integration | UseCases | simulateFlashScoring', function () {
+  beforeEach(function () {
+    const learningContent = {
+      competences: [
+        {
+          id: 'rec1',
+          name_i18n: {
+            fr: 'comp1Fr',
+            en: 'comp1En',
+          },
+          index: '1.1',
+          color: 'rec1Color',
+          skillIds: ['skill1', 'skill2'],
+        },
+        {
+          id: 'rec2',
+          name_i18n: {
+            fr: 'comp2Fr',
+            en: 'comp2En',
+          },
+          index: '2.1',
+          color: 'rec2Color',
+          skillIds: ['skill3', 'skill4', 'skill5'],
+        },
+      ],
+      tubes: [
+        { id: 'recTube1', competenceId: 'rec1' },
+        { id: 'recTube2', competenceId: 'rec2' },
+      ],
+      skills: [
+        // tube 1
+        { id: 'skill1', status: 'actif', tubeId: 'recTube1', competenceId: 'rec1', pixValue: 1 },
+        { id: 'skill2', status: 'actif', tubeId: 'recTube1', competenceId: 'rec1', pixValue: 10 },
+        // tube 2
+        { id: 'skill3', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', pixValue: 100 },
+        { id: 'skill4', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', pixValue: 1000 },
+        { id: 'skill5', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', pixValue: 10000 },
+        { id: 'skill6', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', pixValue: 100000 },
+        { id: 'skill7', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', pixValue: 1000000 },
+      ],
+      challenges: [
+        { id: 'challenge1', skillId: 'skill1', status: 'validé', alpha: 0.16, delta: -2, locales: ['fr'] },
+        { id: 'challenge2', skillId: 'skill2', status: 'validé', alpha: 3, delta: 6, locales: ['fr'] },
+        { id: 'challenge3', skillId: 'skill3', status: 'validé', alpha: 1.587, delta: 8.5, locales: ['fr'] },
+        { id: 'challenge4', skillId: 'skill4', status: 'validé', alpha: 2.86789, delta: 0.145, locales: ['fr'] },
+        { id: 'challenge5', skillId: 'skill5', status: 'validé', alpha: 3, delta: 1, locales: ['fr'] },
+        { id: 'challenge6', skillId: 'skill6', status: 'validé', alpha: 1.7, delta: -1, locales: ['fr'] },
+        { id: 'challenge7', skillId: 'skill7', status: 'validé', alpha: 2.5, delta: 5, locales: ['fr'] },
+      ],
+    };
+
+    mockLearningContent(learningContent);
+  });
+
+  describe('when there are answers', function () {
+    it('should return a total score that combines inferred and direct challenges values', async function () {
+      // given
+      const answers = [
+        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: 'challenge1' }),
+        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: 'challenge2' }),
+        domainBuilder.buildAnswer({ result: AnswerStatus.KO, challengeId: 'challenge3' }),
+        domainBuilder.buildAnswer({ result: AnswerStatus.SKIPPED, challengeId: 'challenge4' }),
+      ];
+
+      const estimatedLevel = 2;
+
+      const simulation = new ScoringSimulation({ answers, estimatedLevel });
+
+      // when
+      const simulationResults = await usecases.simulateFlashScoring({ simulations: [simulation] });
+
+      // then
+      expect(simulationResults).to.have.lengthOf(1);
+      expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+      expect(simulationResults[0]).to.have.property('pixScore', 110011);
+    });
+  });
+});

--- a/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
+++ b/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
@@ -132,7 +132,6 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
   describe('when there are NO answers', function () {
     it('should return a total score with inferred challenges values', async function () {
       // given
-
       const estimatedLevel = 2;
 
       const simulation = new ScoringSimulation({ id: 'simulation1', estimatedLevel });
@@ -145,6 +144,28 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
       expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
       expect(simulationResults[0]).to.have.property('id', 'simulation1');
       expect(simulationResults[0]).to.have.property('pixScore', 111000);
+    });
+  });
+
+  describe('when there is a custom success probability threshold', function () {
+    it('should return a different total score', async function () {
+      // given
+      const estimatedLevel = 2;
+      const successProbabilityThreshold = 0.65;
+
+      const simulation = new ScoringSimulation({ id: 'simulation1', estimatedLevel });
+
+      // when
+      const simulationResults = await usecases.simulateFlashScoring({
+        simulations: [simulation],
+        successProbabilityThreshold,
+      });
+
+      // then
+      expect(simulationResults).to.have.lengthOf(1);
+      expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+      expect(simulationResults[0]).to.have.property('id', 'simulation1');
+      expect(simulationResults[0]).to.have.property('pixScore', 111001);
     });
   });
 

--- a/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
+++ b/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
@@ -71,7 +71,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
 
       const estimatedLevel = 2;
 
-      const simulation = new ScoringSimulation({ answers, estimatedLevel });
+      const simulation = new ScoringSimulation({ id: 'simulation1', answers, estimatedLevel });
 
       // when
       const simulationResults = await usecases.simulateFlashScoring({ simulations: [simulation] });
@@ -79,6 +79,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
       // then
       expect(simulationResults).to.have.lengthOf(1);
       expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+      expect(simulationResults[0]).to.have.property('id', 'simulation1');
       expect(simulationResults[0]).to.have.property('pixScore', 110011);
     });
 
@@ -89,7 +90,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
 
         const estimatedLevel = 2;
 
-        const simulation = new ScoringSimulation({ answers, estimatedLevel });
+        const simulation = new ScoringSimulation({ id: 'simulation1', answers, estimatedLevel });
 
         // when
         const simulationResults = await usecases.simulateFlashScoring({ simulations: [simulation] });
@@ -97,6 +98,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
         // then
         expect(simulationResults).to.have.lengthOf(1);
         expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+        expect(simulationResults[0]).to.have.property('id', 'simulation1');
         expect(simulationResults[0]).to.have.property(
           'error',
           'Challenge ID unknownChallenge is unknown or not compatible with flash algorithm'

--- a/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
+++ b/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
@@ -128,4 +128,26 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
       });
     });
   });
+
+  describe('when a simulation does NOT have any simulated level', function() {
+    it('should return an error', async function () {
+      // given
+      const answers = [
+        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: 'challenge1' }),
+        domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: 'challenge2' }),
+        domainBuilder.buildAnswer({ result: AnswerStatus.KO, challengeId: 'challenge3' }),
+        domainBuilder.buildAnswer({ result: AnswerStatus.SKIPPED, challengeId: 'challenge4' }),
+      ];
+
+      const simulation = new ScoringSimulation({ id: 'simulation1', answers });
+
+      // when
+      const simulationResults = await usecases.simulateFlashScoring({ simulations: [simulation] });
+
+      // then
+      expect(simulationResults).to.have.lengthOf(1);
+      expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+      expect(simulationResults[0]).to.have.property('error', 'Simulation should have an estimated level');
+    });
+  });
 });

--- a/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
+++ b/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
@@ -52,6 +52,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
         { id: 'challenge5', skillId: 'skill5', status: 'validé', alpha: 3, delta: 1, locales: ['fr'] },
         { id: 'challenge6', skillId: 'skill6', status: 'validé', alpha: 1.7, delta: -1, locales: ['fr'] },
         { id: 'challenge7', skillId: 'skill7', status: 'validé', alpha: 2.5, delta: 5, locales: ['fr'] },
+        { id: 'challenge8', skillId: 'skill7', status: 'validé', locales: ['fr'] },
       ],
     };
 
@@ -79,6 +80,50 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
       expect(simulationResults).to.have.lengthOf(1);
       expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
       expect(simulationResults[0]).to.have.property('pixScore', 110011);
+    });
+
+    describe('when an answer on an unknown challenge is received', function () {
+      it('should return an error', async function () {
+        // given
+        const answers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: 'unknownChallenge' })];
+
+        const estimatedLevel = 2;
+
+        const simulation = new ScoringSimulation({ answers, estimatedLevel });
+
+        // when
+        const simulationResults = await usecases.simulateFlashScoring({ simulations: [simulation] });
+
+        // then
+        expect(simulationResults).to.have.lengthOf(1);
+        expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+        expect(simulationResults[0]).to.have.property(
+          'error',
+          'Challenge ID unknownChallenge is unknown or not compatible with flash algorithm'
+        );
+      });
+    });
+
+    describe('when an answer on a non flash compatible challenge is received', function () {
+      it('should return an error', async function () {
+        // given
+        const answers = [domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: 'challenge8' })];
+
+        const estimatedLevel = 2;
+
+        const simulation = new ScoringSimulation({ answers, estimatedLevel });
+
+        // when
+        const simulationResults = await usecases.simulateFlashScoring({ simulations: [simulation] });
+
+        // then
+        expect(simulationResults).to.have.lengthOf(1);
+        expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+        expect(simulationResults[0]).to.have.property(
+          'error',
+          'Challenge ID challenge8 is unknown or not compatible with flash algorithm'
+        );
+      });
     });
   });
 });

--- a/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
+++ b/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
@@ -129,7 +129,26 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
     });
   });
 
-  describe('when a simulation does NOT have any simulated level', function() {
+  describe('when there are NO answers', function () {
+    it('should return a total score with inferred challenges values', async function () {
+      // given
+
+      const estimatedLevel = 2;
+
+      const simulation = new ScoringSimulation({ id: 'simulation1', estimatedLevel });
+
+      // when
+      const simulationResults = await usecases.simulateFlashScoring({ simulations: [simulation] });
+
+      // then
+      expect(simulationResults).to.have.lengthOf(1);
+      expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+      expect(simulationResults[0]).to.have.property('id', 'simulation1');
+      expect(simulationResults[0]).to.have.property('pixScore', 111000);
+    });
+  });
+
+  describe('when a simulation does NOT have any simulated level', function () {
     it('should return an error', async function () {
       // given
       const answers = [

--- a/api/tests/integration/domain/usecases/simulate-old-scoring_test.js
+++ b/api/tests/integration/domain/usecases/simulate-old-scoring_test.js
@@ -1,5 +1,5 @@
 const { expect, mockLearningContent, domainBuilder } = require('../../../test-helper');
-const OldScoringSimulation = require('../../../../lib/domain/models/OldScoringSimulation');
+const ScoringSimulation = require('../../../../lib/domain/models/ScoringSimulation');
 const SimulationResult = require('../../../../lib/domain/models/SimulationResult');
 const usecases = require('../../../../lib/domain/usecases/');
 
@@ -72,7 +72,7 @@ describe('Integration | UseCases | simulateOldScoring', function () {
       }),
     ];
 
-    const simulation = new OldScoringSimulation({ answers });
+    const simulation = new ScoringSimulation({ answers });
 
     // when
     const simulationResults = await usecases.simulateOldScoring({ simulations: [simulation] });
@@ -98,7 +98,7 @@ describe('Integration | UseCases | simulateOldScoring', function () {
         }),
       ];
 
-      const simulation = new OldScoringSimulation({ id: 'simulation1', answers });
+      const simulation = new ScoringSimulation({ id: 'simulation1', answers });
 
       // when
       const simulationResults = await usecases.simulateOldScoring({ simulations: [simulation] });
@@ -123,7 +123,7 @@ describe('Integration | UseCases | simulateOldScoring', function () {
         }),
       ];
 
-      const simulation = new OldScoringSimulation({ id: 'simulation1', answers });
+      const simulation = new ScoringSimulation({ id: 'simulation1', answers });
 
       // when
       const simulationResults = await usecases.simulateOldScoring({ simulations: [simulation] });
@@ -148,7 +148,7 @@ describe('Integration | UseCases | simulateOldScoring', function () {
         }),
       ];
 
-      const simulation = new OldScoringSimulation({ answers });
+      const simulation = new ScoringSimulation({ answers });
 
       // when
       const simulationResults = await usecases.simulateOldScoring({ simulations: [simulation] });
@@ -172,7 +172,7 @@ describe('Integration | UseCases | simulateOldScoring', function () {
         }),
       ];
 
-      const simulation = new OldScoringSimulation({ answers });
+      const simulation = new ScoringSimulation({ answers });
 
       // when
       const simulationResults = await usecases.simulateOldScoring({ simulations: [simulation] });


### PR DESCRIPTION
## :christmas_tree: Problème
Le endpoint de simulation du nouveau scoring ne fait rien.

## :gift: Proposition
Faire une première implémentation sans recalcul de la capacité.

## :star2: Remarques
N/A

## :santa: Pour tester
Faire un `curl`.