### PR TITLE
[BUGFIX] Supprimer les divs dans les boutons présents dans la page de détails d'une compétence (PIX-6807).

### DIFF
--- a/mon-pix/app/components/scorecard-details.hbs
+++ b/mon-pix/app/components/scorecard-details.hbs
@@ -88,7 +88,7 @@
             @triggerAction={{this.openModal}}
           >
             {{t "pages.competence-details.actions.reset.label"}}
-            <div class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</div>
+            <span class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</span>
           </PixButton>
         {{/if}}
 
@@ -138,7 +138,7 @@
           class="button button--big button--thin button--round button--link button--green scorecard-details__resume-or-start-button"
         >
           {{t "pages.competence-details.actions.continue.label"}}
-          <div class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</div>
+          <span class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</span>
         </LinkTo>
 
         {{#if this.displayResetButton}}
@@ -151,7 +151,7 @@
             @triggerAction={{this.openModal}}
           >
             {{t "pages.competence-details.actions.reset.label"}}
-            <div class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</div>
+            <span class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</span>
           </PixButton>
         {{/if}}
 
@@ -170,7 +170,7 @@
           class="button button--big button--thin button--round button--link button--green scorecard-details__resume-or-start-button"
         >
           {{t "pages.competence-details.actions.start.label"}}
-          <div class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</div>
+          <span class="sr-only">{{t "pages.competence-details.for-competence" competence=@scorecard.name}}</span>
         </LinkTo>
       {{/if}}
     </div>


### PR DESCRIPTION
## :christmas_tree: Problème
Suite à d'accessibilité, il est conseillé de ne pas avoir de div dans un `<bouton>`

## :gift: Proposition
Remplacer la div avec sr-only par un aria-label sur le bouton

## :star2: Remarques
/

## :santa: Pour tester
- Se connecter à **Pix App** avec un compte ayant déjà des compétences à reprendre.
- Aller sur une compétence à reprendre
- Vérifier que le bouton 'reset' ne comporte plus de Div et que la balise **button** contient l'aria-label.
