### PR TITLE
[BUGFIX] Corriger les seeds : un CDC ne peut pas avoir plusieurs orga SCO rattachées (PIX-6796)

### DIFF
--- a/api/db/seeds/data/certification/certification-centers-builder.js
+++ b/api/db/seeds/data/certification/certification-centers-builder.js
@@ -2,7 +2,10 @@ const _ = require('lodash');
 const { DEFAULT_PASSWORD } = require('../users-builder');
 
 const SCO_COLLEGE_CERTIF_CENTER_ID = 1;
+const GREAT_OAK_CERTIF_CENTER_ID = 23;
 const SCO_COLLEGE_CERTIF_CENTER_NAME = 'Centre SCO Collège des Anne-Étoiles';
+const SCO_COLLEGE_CERTIF_CENTER_WITHOUT_STUDENT_ID = 8;
+const SCO_COLLEGE_CERTIF_CENTER_WITHOUT_STUDENT_NAME = 'Centre SCO Collège sans étudiant';
 const SCO_LYCEE_CERTIF_CENTER_ID = 13;
 const SCO_LYCEE_CERTIF_CENTER_NAME = 'Centre SCO Lycée des Anne-Étoiles';
 const PRO_CERTIF_CENTER_ID = 2;
@@ -14,9 +17,11 @@ const DROIT_CERTIF_CENTER_NAME = 'Centre DROIT des Anne-Étoiles';
 const SCO_NO_MANAGING_STUDENTS_CERTIF_CENTER_ID = 6;
 const SCO_NO_MANAGING_STUDENTS_CERTIF_CENTER_NAME = 'Centre AEFE SCO NO MANAGING STUDENTS des Anne-Étoiles';
 const SCO_COLLEGE_EXTERNAL_ID = '1237457A';
+const SCO_COLLEGE_WITHOUT_STUDENT_EXTERNAL_ID = '1237457G';
 const SCO_LYCEE_EXTERNAL_ID = '1237457B';
 const SCO_AGRI_EXTERNAL_ID = '1237457C';
 const SCO_NO_MANAGING_STUDENTS_EXTERNAL_ID = '1237457E';
+const GREAT_OAK_CERTIF_CENTER_EXTERNAL_ID = '1237457M';
 const AGRI_SCO_MANAGING_STUDENT_ID = 9;
 const AGRI_SCO_MANAGING_STUDENT_NAME = 'Centre AGRI des Anne-Etoiles';
 const CLEA_COMPLEMENTARY_CERTIFICATION_ID = 52;
@@ -210,6 +215,12 @@ function certificationCentersBuilder({ databaseBuilder }) {
     externalId: SCO_COLLEGE_EXTERNAL_ID,
     type: 'SCO',
   });
+  databaseBuilder.factory.buildCertificationCenter({
+    id: SCO_COLLEGE_CERTIF_CENTER_WITHOUT_STUDENT_ID,
+    name: SCO_COLLEGE_CERTIF_CENTER_WITHOUT_STUDENT_NAME,
+    externalId: SCO_COLLEGE_WITHOUT_STUDENT_EXTERNAL_ID,
+    type: 'SCO',
+  });
   databaseBuilder.factory.buildDataProtectionOfficer.withCertificationCenterId({
     firstName: 'Yukiko',
     lastName: 'Tsubaki',
@@ -285,6 +296,7 @@ function certificationCentersBuilder({ databaseBuilder }) {
 
   // Great Oak Certification Center - anonymization purpose
   const greatOakCertificationCenter = databaseBuilder.factory.buildCertificationCenter({
+    id: GREAT_OAK_CERTIF_CENTER_ID,
     name: 'Great Oak Certification Center',
     type: 'SCO',
   });
@@ -326,4 +338,10 @@ module.exports = {
   PIX_CLEA_V3_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
   PIX_DROIT_MAITRE_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
   PIX_EDU_1ER_INITIE_COMPLEMENTARY_CERTIFICATION_BADGE_ID,
+  SCO_COLLEGE_EXTERNAL_ID,
+  SCO_COLLEGE_WITHOUT_STUDENT_EXTERNAL_ID,
+  SCO_LYCEE_EXTERNAL_ID,
+  SCO_AGRI_EXTERNAL_ID,
+  SCO_NO_MANAGING_STUDENTS_EXTERNAL_ID,
+  GREAT_OAK_CERTIF_CENTER_EXTERNAL_ID,
 };

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -2,6 +2,14 @@ const Membership = require('../../../lib/domain/models/Membership');
 const { DEFAULT_PASSWORD, PIX_ALL_ORGA_ID } = require('./users-builder');
 const { SamlIdentityProviders } = require('../../../lib/domain/constants/saml-identity-providers');
 const { ROLES } = require('../../../lib/domain/constants').PIX_ADMIN;
+const {
+  SCO_COLLEGE_EXTERNAL_ID,
+  SCO_LYCEE_EXTERNAL_ID,
+  SCO_AGRI_EXTERNAL_ID,
+  SCO_NO_MANAGING_STUDENTS_EXTERNAL_ID,
+  SCO_COLLEGE_WITHOUT_STUDENT_EXTERNAL_ID,
+  GREAT_OAK_CERTIF_CENTER_EXTERNAL_ID,
+} = require('../data/certification/certification-centers-builder');
 
 const SCO_MIDDLE_SCHOOL_ID = 3;
 const SCO_HIGH_SCHOOL_ID = 6;
@@ -25,8 +33,6 @@ function organizationsScoBuilder({ databaseBuilder }) {
 }
 
 function _buildMiddleSchools({ databaseBuilder }) {
-  const SCO_COLLEGE_EXTERNAL_ID = '1237457A';
-
   databaseBuilder.factory.buildUser.withRawPassword({
     id: SCO_ADMIN_ID,
     firstName: 'Jon',
@@ -74,7 +80,7 @@ function _buildMiddleSchools({ databaseBuilder }) {
     name: 'Collège de la vie',
     isManagingStudents: true,
     email: 'sco.generic.account@example.net',
-    externalId: SCO_COLLEGE_EXTERNAL_ID,
+    externalId: SCO_COLLEGE_WITHOUT_STUDENT_EXTERNAL_ID,
     documentationUrl: 'https://pix.fr/',
     provinceCode: '12',
     identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
@@ -327,7 +333,7 @@ function _buildMiddleSchools({ databaseBuilder }) {
     name: 'Great Oak School',
     isManagingStudents: true,
     email: 'great.oak.school@example.net',
-    externalId: SCO_COLLEGE_EXTERNAL_ID,
+    externalId: GREAT_OAK_CERTIF_CENTER_EXTERNAL_ID,
     documentationUrl: 'https://pix.fr/',
     provinceCode: '12',
     identityProviderForCampaigns: SamlIdentityProviders.GAR.code,
@@ -364,7 +370,6 @@ function _buildMiddleSchools({ databaseBuilder }) {
 }
 
 function _buildHighSchools({ databaseBuilder }) {
-  const SCO_LYCEE_EXTERNAL_ID = '1237457B';
   const highSchoolsCreator = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'France',
     lastName: 'Guernon',
@@ -467,8 +472,6 @@ function _buildHighSchools({ databaseBuilder }) {
 }
 
 function _buildFarmingSchools({ databaseBuilder }) {
-  const SCO_AGRI_EXTERNAL_ID = '1237457C';
-
   const farmingSchoolsCreator = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Maryse',
     lastName: 'Marceau',
@@ -510,8 +513,6 @@ function _buildFarmingSchools({ databaseBuilder }) {
 }
 
 function _buildAEFE({ databaseBuilder }) {
-  const SCO_NO_MANAGING_STUDENTS_EXTERNAL_ID = '1237457E';
-
   const aefeCreator = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Bevis',
     lastName: 'Bellefeuille',


### PR DESCRIPTION
## :christmas_tree: Problème
Une organisation SCO, telle qu’elle est répertoriée dans Pix Orga, dispose d’un identifiant externe (UAI) unique (exception : peut-être partagé dans certains cas par une orga SUP). Cet identifiant externe permet de rattacher cette orga SCO à un centre de certification (CDC) dans Pix Certif.

Autrement dit, un CDC dans Pix Certif ne peut être rattaché qu'à un seul identifiant externe, donc à une seule orga SCO dans Pix Orga.

Dans les seeds, suite à des modifications, certains CDC sont rattachés à plusieurs orga SCO, ce qui dans le cas du ```Centre SCO Collège des Anne-Étoiles (1237457A)``` nous empêche d'acceder à sa liste élèves à ajouter à une session de certification.


## :gift: Proposition
Corriger les seeds pour qu’il n’y ait qu’une seule orga SCO rattachée par CDC.

## :santa: Pour tester
- Se connecter à pix-certif essayer d'ajouter des candidats à une session de certification pour le Centre SCO Collège des Anne-Étoiles (1237457A)
- Constater que l'accès à la liste des élèves est désormais accessible 

![image](https://user-images.githubusercontent.com/37305474/212705785-fa46c485-aa17-4a07-9c6c-d177dbb4f3e6.png)

