### PR TITLE
[CHORE] Changer le nombre de résultats par défaut pour les organisations pro (PIX-6789)

### DIFF
--- a/orga/app/controllers/authenticated/organization-participants/list.js
+++ b/orga/app/controllers/authenticated/organization-participants/list.js
@@ -9,7 +9,7 @@ export default class ListController extends Controller {
   @service router;
 
   @tracked pageNumber = 1;
-  @tracked pageSize = 25;
+  @tracked pageSize = 50;
   @tracked fullName = null;
   @tracked certificability = [];
 

--- a/orga/app/routes/authenticated/organization-participants/list.js
+++ b/orga/app/routes/authenticated/organization-participants/list.js
@@ -29,7 +29,7 @@ export default class ListRoute extends Route {
   resetController(controller, isExiting) {
     if (isExiting) {
       controller.pageNumber = 1;
-      controller.pageSize = 25;
+      controller.pageSize = 50;
       controller.fullName = null;
       controller.certificability = [];
     }


### PR DESCRIPTION
## :christmas_tree: Problème
Retour utilisateurs: Le nombre de résultats à afficher par défaut n'est pas suffisant.

## :gift: Proposition
Passer de 25 à 50 résultats par page

## :star2: Remarques
Alert Datadog pour superviser : [Datadog](https://app.datadoghq.eu/dashboard/uug-ju8-gqg/temps-de-rponses-orga-liste-50-elems?from_ts=1673875573445&to_ts=1673879173445&live=true)

## :santa: Pour tester
1. Se connecter à Pix Orga : [RA](https://orga-pr5506.review.pix.fr)
2. Aller sur les page "Participants" et voir que, pour la pagination, 50 est mis par défaut