### PR TITLE
[FEATURE] Rendre le template de session compatible avec excel (PIX-6658)

### DIFF
--- a/api/lib/infrastructure/files/sessions-import.js
+++ b/api/lib/infrastructure/files/sessions-import.js
@@ -1,5 +1,15 @@
+const { headers } = require('../utils/csv/sessions-import');
+
 function getHeaders() {
-  return '"N° de session";"* Nom du site";"* Nom de la salle";"* Date de début";"* Heure de début (heure locale)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: jj/mm/aaaa)";"* Sexe (M ou F)";"Code Insee";"Code postal";"Nom de la commune";"* Pays";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant local";"Temps majoré ?"';
+  const fields = _getHeadersAsArray();
+
+  return fields;
+}
+
+function _getHeadersAsArray() {
+  return Object.keys(headers)
+    .reduce((arr, key) => [...arr, `"${headers[key]}"`], [])
+    .join(';');
 }
 
 module.exports = { getHeaders };

--- a/api/lib/infrastructure/files/sessions-import.js
+++ b/api/lib/infrastructure/files/sessions-import.js
@@ -1,15 +1,19 @@
+const { Parser } = require('json2csv');
 const { headers } = require('../utils/csv/sessions-import');
 
 function getHeaders() {
   const fields = _getHeadersAsArray();
-
-  return fields;
+  const json2csvParser = new Parser({
+    withBOM: true,
+    includeEmptyRows: false,
+    fields,
+    delimiter: ';',
+  });
+  return json2csvParser.parse();
 }
 
 function _getHeadersAsArray() {
-  return Object.keys(headers)
-    .reduce((arr, key) => [...arr, `"${headers[key]}"`], [])
-    .join(';');
+  return Object.keys(headers).reduce((arr, key) => [...arr, headers[key]], []);
 }
 
 module.exports = { getHeaders };

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -1,6 +1,7 @@
 const logger = require('../../logger');
 const { FileValidationError } = require('../../../../lib/domain/errors');
 const { convertDateValue } = require('../../utils/date-utils');
+const { headers } = require('../../utils/csv/sessions-import');
 
 function _csvFormulaEscapingPrefix(data) {
   const mayBeInterpretedAsFormula = /^[-@=+]/.test(data);
@@ -23,29 +24,6 @@ function _csvSerializeValue(data) {
 }
 
 function deserializeForSessionsImport(parsedCsvData) {
-  const headers = {
-    address: '* Nom du site',
-    room: '* Nom de la salle',
-    date: '* Date de début',
-    time: '* Heure de début (heure locale)',
-    examiner: '* Surveillant(s)',
-    description: 'Observations (optionnel)',
-    lastName: '* Nom de naissance',
-    firstName: '* Prénom',
-    birthdate: '* Date de naissance (format: jj/mm/aaaa)',
-    sex: '* Sexe (M ou F)',
-    birthINSEECode: 'Code Insee',
-    birthPostalCode: 'Code postal',
-    birthCity: 'Nom de la commune',
-    birthCountry: '* Pays',
-    resultRecipientEmail: 'E-mail du destinataire des résultats (formateur, enseignant…)',
-    email: 'E-mail de convocation',
-    externalId: 'Identifiant local',
-    extraTimePercentage: 'Temps majoré ?',
-    billingMode: 'Tarification part Pix',
-    prepaymentCode: 'Code de prépaiement',
-  };
-
   const sessions = [];
   const csvLineKeys = Object.keys(headers);
 

--- a/api/lib/infrastructure/utils/csv/sessions-import.js
+++ b/api/lib/infrastructure/utils/csv/sessions-import.js
@@ -1,0 +1,27 @@
+const headers = {
+  sessionId: 'N° de session',
+  address: '* Nom du site',
+  room: '* Nom de la salle',
+  date: '* Date de début',
+  time: '* Heure de début (heure locale)',
+  examiner: '* Surveillant(s)',
+  description: 'Observations (optionnel)',
+  lastName: '* Nom de naissance',
+  firstName: '* Prénom',
+  birthdate: '* Date de naissance (format: jj/mm/aaaa)',
+  sex: '* Sexe (M ou F)',
+  birthINSEECode: 'Code Insee',
+  birthPostalCode: 'Code postal',
+  birthCity: 'Nom de la commune',
+  birthCountry: '* Pays',
+  resultRecipientEmail: 'E-mail du destinataire des résultats (formateur, enseignant…)',
+  email: 'E-mail de convocation',
+  externalId: 'Identifiant local',
+  extraTimePercentage: 'Temps majoré ?',
+  billingMode: 'Tarification part Pix',
+  prepaymentCode: 'Code de prépaiement',
+};
+
+module.exports = {
+  headers,
+};

--- a/api/tests/integration/infrastructure/utils/csv/sessions-import_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/sessions-import_test.js
@@ -9,7 +9,7 @@ describe('Integration | Infrastructure | Utils | csv | sessions-import', functio
 
       // then
       const expectedResult =
-        '"N° de session";"* Nom du site";"* Nom de la salle";"* Date de début";"* Heure de début (heure locale)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: jj/mm/aaaa)";"* Sexe (M ou F)";"Code Insee";"Code postal";"Nom de la commune";"* Pays";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant local";"Temps majoré ?"';
+        '"N° de session";"* Nom du site";"* Nom de la salle";"* Date de début";"* Heure de début (heure locale)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: jj/mm/aaaa)";"* Sexe (M ou F)";"Code Insee";"Code postal";"Nom de la commune";"* Pays";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant local";"Temps majoré ?";"Tarification part Pix";"Code de prépaiement"';
       expect(result).to.equal(expectedResult);
     });
   });

--- a/api/tests/integration/infrastructure/utils/csv/sessions-import_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/sessions-import_test.js
@@ -1,6 +1,6 @@
 const { expect } = require('../../../../test-helper');
 const { getHeaders } = require('../../../../../lib/infrastructure/files/sessions-import');
-
+const BOM_CHAR = '\ufeff';
 describe('Integration | Infrastructure | Utils | csv | sessions-import', function () {
   context('#getHeaders', function () {
     it('should return the correct values', function () {
@@ -8,8 +8,7 @@ describe('Integration | Infrastructure | Utils | csv | sessions-import', functio
       const result = getHeaders();
 
       // then
-      const expectedResult =
-        '"N° de session";"* Nom du site";"* Nom de la salle";"* Date de début";"* Heure de début (heure locale)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: jj/mm/aaaa)";"* Sexe (M ou F)";"Code Insee";"Code postal";"Nom de la commune";"* Pays";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant local";"Temps majoré ?";"Tarification part Pix";"Code de prépaiement"';
+      const expectedResult = `${BOM_CHAR}"N° de session";"* Nom du site";"* Nom de la salle";"* Date de début";"* Heure de début (heure locale)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: jj/mm/aaaa)";"* Sexe (M ou F)";"Code Insee";"Code postal";"Nom de la commune";"* Pays";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant local";"Temps majoré ?";"Tarification part Pix";"Code de prépaiement"`;
       expect(result).to.equal(expectedResult);
     });
   });

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -318,6 +318,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
 function _lineWithSessionAndNoCandidate(sessionNumber) {
   return {
+    'N° de session': '',
     '* Nom du site': `Site ${sessionNumber}`,
     '* Nom de la salle': `Salle ${sessionNumber}`,
     '* Date de début': '12/05/2023',
@@ -343,6 +344,7 @@ function _lineWithSessionAndNoCandidate(sessionNumber) {
 
 function _lineWithCandidateAndNoSession() {
   return {
+    'N° de session': '',
     '* Nom du site': '',
     '* Nom de la salle': '',
     '* Date de début': '',
@@ -368,6 +370,7 @@ function _lineWithCandidateAndNoSession() {
 
 function _lineWithSessionAndCandidate({ sessionNumber, candidateNumber }) {
   return {
+    'N° de session': '',
     '* Nom du site': `Site ${sessionNumber}`,
     '* Nom de la salle': `Salle ${sessionNumber}`,
     '* Date de début': '12/05/2023',

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -154,6 +154,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
         });
       });
+
       describe('when there is different session information on consecutive lines', function () {
         it('should return a full session object per line', function () {
           // given
@@ -316,82 +317,107 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
   });
 });
 
-function _lineWithSessionAndNoCandidate(sessionNumber) {
+function _line({
+  sessionId = '',
+  address = '',
+  room = '',
+  date = '',
+  time = '',
+  examiner = '',
+  description = '',
+  lastName = '',
+  firstName = '',
+  birthdate = '',
+  sex = '',
+  birthINSEECode = '',
+  birthPostalCode = '',
+  birthCity = '',
+  birthCountry = '',
+  resultRecipientEmail = '',
+  email = '',
+  externalId = '',
+  extraTimePercentage = '',
+  billingMode = '',
+  prepaymentCode = '',
+}) {
   return {
-    'N° de session': '',
-    '* Nom du site': `Site ${sessionNumber}`,
-    '* Nom de la salle': `Salle ${sessionNumber}`,
-    '* Date de début': '12/05/2023',
-    '* Heure de début (heure locale)': '01:00',
-    '* Surveillant(s)': 'Paul',
-    'Observations (optionnel)': '',
-    '* Nom de naissance': '',
-    '* Prénom': '',
-    '* Date de naissance (format: jj/mm/aaaa)': '',
-    '* Sexe (M ou F)': '',
-    'Code Insee': '',
-    'Code postal': '',
-    'Nom de la commune': '',
-    '* Pays': '',
-    'E-mail du destinataire des résultats (formateur, enseignant…)': '',
-    'E-mail de convocation': '',
-    'Identifiant local': '',
-    'Temps majoré ?': '',
-    'Tarification part Pix': '',
-    'Code de prépaiement': '',
+    'N° de session': sessionId,
+    '* Nom du site': address,
+    '* Nom de la salle': room,
+    '* Date de début': date,
+    '* Heure de début (heure locale)': time,
+    '* Surveillant(s)': examiner,
+    'Observations (optionnel)': description,
+    '* Nom de naissance': lastName,
+    '* Prénom': firstName,
+    '* Date de naissance (format: jj/mm/aaaa)': birthdate,
+    '* Sexe (M ou F)': sex,
+    'Code Insee': birthINSEECode,
+    'Code postal': birthPostalCode,
+    'Nom de la commune': birthCity,
+    '* Pays': birthCountry,
+    'E-mail du destinataire des résultats (formateur, enseignant…)': resultRecipientEmail,
+    'E-mail de convocation': email,
+    'Identifiant local': externalId,
+    'Temps majoré ?': extraTimePercentage,
+    'Tarification part Pix': billingMode,
+    'Code de prépaiement': prepaymentCode,
   };
+}
+
+function _lineWithSessionAndNoCandidate(sessionNumber) {
+  return _line({
+    address: `Site ${sessionNumber}`,
+    room: `Salle ${sessionNumber}`,
+    date: '12/05/2023',
+    time: '01:00',
+    examiner: 'Paul',
+    description: '',
+  });
 }
 
 function _lineWithCandidateAndNoSession() {
-  return {
-    'N° de session': '',
-    '* Nom du site': '',
-    '* Nom de la salle': '',
-    '* Date de début': '',
-    '* Heure de début (heure locale)': '',
-    '* Surveillant(s)': '',
-    'Observations (optionnel)': '',
-    '* Nom de naissance': 'Pennyworth',
-    '* Prénom': 'Alfred',
-    '* Date de naissance (format: jj/mm/aaaa)': '02/03/1951',
-    '* Sexe (M ou F)': 'M',
-    'Code Insee': '75015',
-    'Code postal': '',
-    'Nom de la commune': '',
-    '* Pays': 'France',
-    'E-mail du destinataire des résultats (formateur, enseignant…)': 'alfredOfficial@email.fr',
-    'E-mail de convocation': '',
-    'Identifiant local': '',
-    'Temps majoré ?': '',
-    'Tarification part Pix': 'Prépayée',
-    'Code de prépaiement': '43',
-  };
+  return _line({
+    lastName: 'Pennyworth',
+    firstName: 'Alfred',
+    birthdate: '02/03/1951',
+    sex: 'M',
+    birthINSEECode: '75015',
+    birthPostalCode: '',
+    birthCity: '',
+    birthCountry: 'France',
+    resultRecipientEmail: 'alfredOfficial@email.fr',
+    email: '',
+    externalId: '',
+    extraTimePercentage: '',
+    billingMode: 'Prépayée',
+    prepaymentCode: '43',
+  });
 }
 
 function _lineWithSessionAndCandidate({ sessionNumber, candidateNumber }) {
-  return {
-    'N° de session': '',
-    '* Nom du site': `Site ${sessionNumber}`,
-    '* Nom de la salle': `Salle ${sessionNumber}`,
-    '* Date de début': '12/05/2023',
-    '* Heure de début (heure locale)': '01:00',
-    '* Surveillant(s)': 'Paul',
-    'Observations (optionnel)': '',
-    '* Nom de naissance': `Candidat ${candidateNumber}`,
-    '* Prénom': `Candidat ${candidateNumber}`,
-    '* Date de naissance (format: jj/mm/aaaa)': '01/03/1981',
-    '* Sexe (M ou F)': 'M',
-    'Code Insee': '75015',
-    'Code postal': '',
-    'Nom de la commune': '',
-    '* Pays': 'France',
-    'E-mail du destinataire des résultats (formateur, enseignant…)': 'robindahood@email.fr',
-    'E-mail de convocation': '',
-    'Identifiant local': '',
-    'Temps majoré ?': '',
-    'Tarification part Pix': 'Prépayée',
-    'Code de prépaiement': '43',
-  };
+  return _line({
+    address: `Site ${sessionNumber}`,
+    room: `Salle ${sessionNumber}`,
+    date: '12/05/2023',
+    time: '01:00',
+    examiner: 'Paul',
+    description: '',
+    lastName: `Candidat ${candidateNumber}`,
+    firstName: `Candidat ${candidateNumber}`,
+    birthdate: '01/03/1981',
+    sex: 'M',
+    birthINSEECode: '75015',
+    birthPostalCode: '',
+    birthCity: '',
+    birthCountry: 'France',
+    resultRecipientEmail: 'robindahood@email.fr',
+    email: '',
+    externalId: '',
+    extraTimePercentage: '',
+    billingMode: 'Prépayée',
+    prepaymentCode: '43',
+  });
 }
 
 function _omitUniqueKey(result) {


### PR DESCRIPTION
## :christmas_tree: Problème
Le template des imports de session est en csv mais les caracteres speciaux posent probleme sur microsoft excel

## :gift: Proposition
Forcer l'encodage via BOM ?

## :star2: Remarques
Refacto pour reutiliser les headers definit dans l'import

## :santa: Pour tester
Telecharger le template, verifier que les caracteres accentues sont bien pris en compte sur ms excel
