### PR TITLE
[FEATURE][ADMIN] Proposer les tags récemment utilisés lors de l'ajout d'un tag à une organisation (PIX-6740)

### DIFF
--- a/admin/app/adapters/tag.js
+++ b/admin/app/adapters/tag.js
@@ -2,4 +2,16 @@ import ApplicationAdapter from './application';
 
 export default class TagAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
+
+  urlForQuery(query) {
+    const { tagId, recentlyUsedTags } = query;
+    delete query.tagId;
+    delete query.recentlyUsedTags;
+
+    if (recentlyUsedTags) {
+      return `${this.host}/${this.namespace}/tags/${tagId}/recently-used`;
+    }
+
+    return super.urlForQueryRecord(...arguments);
+  }
 }

--- a/admin/app/components/organizations/all-tags.hbs
+++ b/admin/app/components/organizations/all-tags.hbs
@@ -1,5 +1,42 @@
 <section class="page-section">
 
+  {{#if this.recentlyUsedTags}}
+    <h2 class="pix-text--bold pix-text--small">{{t
+        "components.organizations.all-tags.recently-used-tags"
+        tagName=this.selectedTag.name
+      }}</h2>
+    <ul class="organization-recently-used-tags-list">
+      {{#each this.recentlyUsedTags as |tag|}}
+        <li class="organization-recently-used-tags-list__tag">
+
+          {{#if tag.isTagAssignedToOrganization}}
+            <button
+              type="button"
+              onClick={{fn this.removeTagToOrganization tag}}
+              aria-label="Tag {{tag.name}} assigné à l'organisation"
+            >
+              <PixTag @compact="true" @color="purple-light">
+                {{tag.name}}
+              </PixTag>
+            </button>
+          {{else}}
+            <button
+              type="button"
+              onClick={{fn this.addRecentlyUsedTagToOrganization tag}}
+              aria-label="Tag {{tag.name}} non assigné à l'organisation"
+            >
+              <PixTag @compact="true" @color="grey-light">
+                {{tag.name}}
+              </PixTag>
+            </button>
+          {{/if}}
+
+        </li>
+      {{/each}}
+    </ul>
+    <hr class="organization-tags-lists-separator" />
+  {{/if}}
+
   {{#if this.allTags}}
     <ul class="organization-all-tags-list">
       {{#each this.allTags as |tag|}}

--- a/admin/app/components/organizations/all-tags.js
+++ b/admin/app/components/organizations/all-tags.js
@@ -39,5 +39,7 @@ export default class OrganizationAllTags extends Component {
   async removeTagToOrganization(tagToRemove) {
     this.args.model.organization.tags.removeObject(tagToRemove);
     await this.args.model.organization.save();
+    this.selectedTag = null;
+    this.recentlyUsedTags = null;
   }
 }

--- a/admin/app/components/organizations/all-tags.js
+++ b/admin/app/components/organizations/all-tags.js
@@ -2,8 +2,15 @@ import Component from '@glimmer/component';
 import map from 'lodash/map';
 import sortBy from 'lodash/sortBy';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 
 export default class OrganizationAllTags extends Component {
+  @service store;
+
+  @tracked selectedTag = null;
+  @tracked recentlyUsedTags = null;
+
   get allTags() {
     const organizationTagsNames = map(this.args.model.organization.tags.toArray(), 'name');
     const allTags = sortBy(this.args.model.allTags.toArray(), 'name');
@@ -16,6 +23,14 @@ export default class OrganizationAllTags extends Component {
 
   @action
   async addTagToOrganization(tagToAdd) {
+    this.args.model.organization.tags.pushObject(tagToAdd);
+    await this.args.model.organization.save();
+    this.selectedTag = tagToAdd;
+    this.recentlyUsedTags = await this.store.query('tag', { tagId: tagToAdd.id, recentlyUsedTags: true });
+  }
+
+  @action
+  async addRecentlyUsedTagToOrganization(tagToAdd) {
     this.args.model.organization.tags.pushObject(tagToAdd);
     await this.args.model.organization.save();
   }

--- a/admin/app/models/tag.js
+++ b/admin/app/models/tag.js
@@ -1,8 +1,7 @@
 import Model, { attr } from '@ember-data/model';
-import { tracked } from '@glimmer/tracking';
 
 export default class Tag extends Model {
-  @attr('string') name;
+  @attr() name;
 
-  @tracked isTagAssignedToOrganization;
+  @attr() isTagAssignedToOrganization;
 }

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -46,6 +46,7 @@
 @import "components/confirm-popup";
 @import "components/member-item";
 @import "components/menu-bar";
+@import "components/organizations/all-tags";
 @import "components/organizations/archiving-confirmation-modal";
 @import "components/organizations/places";
 @import "components/organizations/places-lot-creation-form";

--- a/admin/app/styles/components/organizations/all-tags.scss
+++ b/admin/app/styles/components/organizations/all-tags.scss
@@ -1,9 +1,10 @@
-.organization-all-tags-list {
+.organization-recently-used-tags-list {
   list-style: none;
   padding: 0;
   display: flex;
   flex-wrap: wrap;
   gap: $spacing-xs;
+  margin-top: $spacing-xs;
 
   &__tag {
 
@@ -14,4 +15,9 @@
       background-color: transparent;
     }
   }
+}
+
+.organization-tags-lists-separator {
+  border: 1px solid $pix-neutral-20;
+  margin: $spacing-m 0;
 }

--- a/admin/tests/integration/components/organizations/all-tags_test.js
+++ b/admin/tests/integration/components/organizations/all-tags_test.js
@@ -59,9 +59,7 @@ module('Integration | Component | organizations/all-tags', function (hooks) {
 
         // then
         assert.ok(save.called);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(this.model.organization.tags.length, 1);
+        assert.strictEqual(this.model.organization.tags.length, 1);
       });
     });
 
@@ -80,9 +78,7 @@ module('Integration | Component | organizations/all-tags', function (hooks) {
 
         // then
         assert.ok(save.called);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(this.model.organization.tags.length, 0);
+        assert.strictEqual(this.model.organization.tags.length, 0);
       });
     });
   });

--- a/admin/tests/integration/components/organizations/all-tags_test.js
+++ b/admin/tests/integration/components/organizations/all-tags_test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { clickByName, render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 import sinon from 'sinon';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | organizations/all-tags', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it should display a list of inactive and active tags', async function (assert) {
     // given
@@ -45,21 +45,33 @@ module('Integration | Component | organizations/all-tags', function (hooks) {
 
   module('when clicking on a tag', () => {
     module('when the tag is not yet associated to the organization', () => {
-      test('it should associate the tag to the organization', async function (assert) {
+      test('it associates the tag to the organization and displays a recently used tags list', async function (assert) {
         // given
-        const tag1 = EmberObject.create({ id: 1, name: 'MEDNUM' });
-        const tag2 = EmberObject.create({ id: 2, name: 'AGRICULTURE' });
-        const save = sinon.stub();
-        const organization = EmberObject.create({ tags: [], save });
+        const store = this.owner.lookup('service:store');
+        const tag1 = store.createRecord('tag', { name: 'MEDNUM' });
+        const tag2 = store.createRecord('tag', { name: 'AGRICULTURE' });
+        const recentlyUsedTag = store.createRecord('tag', { name: 'USED' });
+        const saveStub = sinon.stub().resolves();
+        const organization = store.createRecord('organization', { tags: [], save: saveStub });
+
         this.set('model', { organization, allTags: [tag1, tag2] });
 
+        store.query = sinon.stub().resolves([recentlyUsedTag]);
+
         // when
-        await render(hbs`<Organizations::AllTags @model={{this.model}} />`);
+        const screen = await render(hbs`<Organizations::AllTags @model={{this.model}} />`);
         await clickByName("Tag AGRICULTURE non assigné à l'organisation");
 
         // then
-        assert.ok(save.called);
-        assert.strictEqual(this.model.organization.tags.length, 1);
+        assert.dom(screen.getByRole('button', { name: "Tag AGRICULTURE assigné à l'organisation" })).exists();
+        assert
+          .dom(
+            screen.getByRole('heading', {
+              name: this.intl.t('components.organizations.all-tags.recently-used-tags', { tagName: tag2.name }),
+            })
+          )
+          .exists();
+        assert.dom(screen.getByRole('button', { name: "Tag USED non assigné à l'organisation" })).exists();
       });
     });
 

--- a/admin/tests/unit/components/badges/badge_test.js
+++ b/admin/tests/unit/components/badges/badge_test.js
@@ -8,32 +8,29 @@ module('Unit | Component | Badges | badge', function (hooks) {
 
   module('isCertifiable', function () {
     test('returns color and text when is certifiable', function (assert) {
+      // given & when
       const component = createComponent('component:badges/badge');
       component.args = {
         badge: { isCertifiable: true },
       };
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.isCertifiableColor, 'green');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.isCertifiableText, 'Certifiable');
+      // then
+      assert.strictEqual(component.isCertifiableColor, 'green');
+      assert.strictEqual(component.isCertifiableText, 'Certifiable');
     });
   });
 
   module('isAlwaysVisible', function () {
     test('returns color and text when is always visible', function (assert) {
+      // given & when
       const component = createComponent('component:badges/badge');
       component.args = {
         badge: { isAlwaysVisible: true },
       };
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.isAlwaysVisibleColor, 'green');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.isAlwaysVisibleText, 'Lacunes');
+
+      // then
+      assert.strictEqual(component.isAlwaysVisibleColor, 'green');
+      assert.strictEqual(component.isAlwaysVisibleText, 'Lacunes');
     });
   });
 });

--- a/admin/tests/unit/components/organizations/all-tags_test.js
+++ b/admin/tests/unit/components/organizations/all-tags_test.js
@@ -1,0 +1,41 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit | Component | organizations/all-tags', function (hooks) {
+  setupTest(hooks);
+
+  module('when clicking on a tag', function () {
+    module('when the tag is not yet associated to the organization', function () {
+      test('associates the tag to the organization and show recently used tags', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const tag = store.createRecord('tag', { name: 'TAG1' });
+        const recentlyUsedTag = store.createRecord('tag', { name: 'TAG2' });
+        const saveStub = sinon.stub().resolves();
+        const organization = store.createRecord('organization', { tags: [], save: saveStub });
+        const component = createGlimmerComponent('component:organizations/all-tags', {
+          model: {
+            organization,
+            allTags: [tag, recentlyUsedTag],
+          },
+        });
+
+        store.query = sinon.stub().resolves([recentlyUsedTag]);
+
+        component.store = store;
+
+        // when
+        await component.addTagToOrganization(tag);
+
+        // then
+        sinon.assert.calledOnce(saveStub);
+        assert.strictEqual(component.args.model.organization.tags.length, 1);
+        sinon.assert.calledOnce(store.query);
+        assert.strictEqual(component.selectedTag.name, tag.name);
+        assert.strictEqual(component.recentlyUsedTags.length, 1);
+      });
+    });
+  });
+});

--- a/admin/tests/unit/components/organizations/all-tags_test.js
+++ b/admin/tests/unit/components/organizations/all-tags_test.js
@@ -8,7 +8,7 @@ module('Unit | Component | organizations/all-tags', function (hooks) {
 
   module('when clicking on a tag', function () {
     module('when the tag is not yet associated to the organization', function () {
-      test('associates the tag to the organization and show recently used tags', async function (assert) {
+      test('it associates the tag to the organization and show recently used tags', async function (assert) {
         // given
         const store = this.owner.lookup('service:store');
         const tag = store.createRecord('tag', { name: 'TAG1' });
@@ -35,6 +35,39 @@ module('Unit | Component | organizations/all-tags', function (hooks) {
         sinon.assert.calledOnce(store.query);
         assert.strictEqual(component.selectedTag.name, tag.name);
         assert.strictEqual(component.recentlyUsedTags.length, 1);
+      });
+    });
+
+    module('when the tag is associated to the organization', function () {
+      test('it disassociates the tag from the organization', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const tag1 = store.createRecord('tag', { name: 'TAG1' });
+        const tag2 = store.createRecord('tag', { name: 'TAG2' });
+        const saveStub = sinon.stub().resolves();
+        const organizationTags = [tag1, tag2];
+        const organization = store.createRecord('organization', { tags: organizationTags, save: saveStub });
+        const component = createGlimmerComponent('component:organizations/all-tags', {
+          model: {
+            organization,
+            allTags: [tag1, tag2],
+          },
+        });
+
+        component.store = store;
+        component.selectedTag = tag1;
+        component.recentlyUsedTags = [tag2];
+
+        // when
+        await component.removeTagToOrganization(tag2);
+
+        console.log(component);
+
+        // then
+        sinon.assert.calledOnce(saveStub);
+        assert.strictEqual(component.args.model.organization.tags.length, 1);
+        assert.strictEqual(component.selectedTag, null);
+        assert.strictEqual(component.recentlyUsedTags, null);
       });
     });
   });

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -15,5 +15,12 @@
         "login-no-permission": "You don't have the permission to connect."
       }
     }
+  },
+  "components": {
+    "organizations": {
+      "all-tags": {
+        "recently-used-tags": "List of tags recently used with {tagName}"
+      }
+    }
   }
 }

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -15,5 +15,12 @@
         "login-no-permission": "Vous n'avez pas les droits pour vous connecter."
       }
     }
+  },
+  "components": {
+    "organizations": {
+      "all-tags": {
+        "recently-used-tags": "Liste de tags récemment utilisés avec {tagName}"
+      }
+    }
   }
 }

--- a/api/lib/application/tags/index.js
+++ b/api/lib/application/tags/index.js
@@ -1,6 +1,7 @@
 const securityPreHandlers = require('../security-pre-handlers');
 const tagController = require('./tag-controller');
 const Joi = require('joi');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async (server) => {
   server.route([
@@ -55,6 +56,34 @@ exports.register = async (server) => {
         notes: [
           "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
             '- Renvoie tous les tags.',
+        ],
+        tags: ['api', 'tags'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/admin/tags/{id}/recently-used',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: tagController.getRecentlyUsedTags,
+        validate: {
+          params: Joi.object({
+            id: identifiersType.tagId,
+          }),
+        },
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            '- Renvoie les 10 tags les plus utilisés par rapport au tag sélectionné',
         ],
         tags: ['api', 'tags'],
       },

--- a/api/lib/application/tags/tag-controller.js
+++ b/api/lib/application/tags/tag-controller.js
@@ -12,4 +12,10 @@ module.exports = {
     const organizationsTags = await usecases.findAllTags();
     return tagSerializer.serialize(organizationsTags);
   },
+
+  async getRecentlyUsedTags(request) {
+    const tagId = request.params.id;
+    const recentlyUsedTags = await usecases.getRecentlyUsedTags({ tagId });
+    return tagSerializer.serialize(recentlyUsedTags);
+  },
 };

--- a/api/lib/domain/types/identifiers-type.js
+++ b/api/lib/domain/types/identifiers-type.js
@@ -49,6 +49,7 @@ const typesPositiveInteger32bits = [
   'sessionId',
   'stageId',
   'supervisorAccessesId',
+  'tagId',
   'targetProfileId',
   'targetProfileTemplateId',
   'trainingId',

--- a/api/lib/domain/usecases/get-recently-used-tags.js
+++ b/api/lib/domain/usecases/get-recently-used-tags.js
@@ -1,0 +1,3 @@
+module.exports = async function getRecentlyUsedTags({ tagId, organizationTagRepository }) {
+  return organizationTagRepository.getRecentlyUsedTags({ tagId, numberOfRecentTags: 10 });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -360,6 +360,7 @@ module.exports = injectDependencies(
     getPrescriber: require('./get-prescriber'),
     getPrivateCertificate: require('./certificate/get-private-certificate'),
     getProgression: require('./get-progression'),
+    getRecentlyUsedTags: require('./get-recently-used-tags'),
     getScoCertificationResultsByDivision: require('./get-sco-certification-results-by-division'),
     getScorecard: require('./get-scorecard'),
     getSession: require('./get-session'),

--- a/api/tests/acceptance/application/tags/tag-api_test.js
+++ b/api/tests/acceptance/application/tags/tag-api_test.js
@@ -1,11 +1,12 @@
+const _ = require('lodash');
 const {
   expect,
   generateValidRequestAuthorizationHeader,
   insertUserWithRoleSuperAdmin,
+  insertUserWithRoleCertif,
   databaseBuilder,
   knex,
 } = require('../../../test-helper');
-
 const createServer = require('../../../../server');
 
 describe('Acceptance | Route | tag-router', function () {
@@ -131,4 +132,83 @@ describe('Acceptance | Route | tag-router', function () {
       expect(response.statusCode).to.equal(403);
     });
   });
+
+  describe('GET /api/admin/{id}/recently-used', function () {
+    context('when an admin member with a role "SUPER_ADMIN" tries to access this resource', function () {
+      it('returns a list of recently used tags with a 200 HTTP status code', async function () {
+        // given
+        const server = await createServer();
+
+        const basedTag = databaseBuilder.factory.buildTag({ name: 'konoha' });
+        const mostUsedTag = databaseBuilder.factory.buildTag({ name: 'kumo' });
+        const leastUsedTag = databaseBuilder.factory.buildTag({ name: 'hueco mundo' });
+        const tags = [mostUsedTag, databaseBuilder.factory.buildTag({ name: 'kiri' }), leastUsedTag];
+        const organizations = [];
+
+        _.times(3, () => organizations.push(databaseBuilder.factory.buildOrganization()));
+
+        for (const [index, organization] of organizations.entries()) {
+          const tagIds = tags.slice(0, index + 1).map(({ id }) => id);
+          tagIds.push(basedTag.id);
+          _buildOrganizationTags(organization.id, tagIds);
+        }
+
+        await databaseBuilder.commit();
+
+        const userId = (await insertUserWithRoleSuperAdmin()).id;
+
+        // when
+        const { statusCode, result } = await server.inject({
+          method: 'GET',
+          url: `/api/admin/tags/${basedTag.id}/recently-used`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        });
+
+        // then
+        expect(statusCode).to.equal(200);
+        expect(result.data.length).to.equal(3);
+      });
+    });
+
+    context('when an admin member with a role "CERTIF" tries to access this resource', function () {
+      it('returns an error with a 403 HTTP status code', async function () {
+        // given
+        const server = await createServer();
+
+        const basedTag = databaseBuilder.factory.buildTag({ name: 'konoha' });
+        const mostUsedTag = databaseBuilder.factory.buildTag({ name: 'kumo' });
+        const leastUsedTag = databaseBuilder.factory.buildTag({ name: 'hueco mundo' });
+        const tags = [mostUsedTag, databaseBuilder.factory.buildTag({ name: 'kiri' }), leastUsedTag];
+        const organizations = [];
+
+        _.times(3, () => organizations.push(databaseBuilder.factory.buildOrganization()));
+
+        for (const [index, organization] of organizations.entries()) {
+          const tagIds = tags.slice(0, index + 1).map(({ id }) => id);
+          tagIds.push(basedTag.id);
+          _buildOrganizationTags(organization.id, tagIds);
+        }
+
+        await databaseBuilder.commit();
+
+        const userId = (await insertUserWithRoleCertif()).id;
+
+        // when
+        const { statusCode } = await server.inject({
+          method: 'GET',
+          url: `/api/admin/tags/${basedTag.id}/recently-used`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        });
+
+        // then
+        expect(statusCode).to.equal(403);
+      });
+    });
+  });
 });
+
+function _buildOrganizationTags(organizationId, tagIds) {
+  tagIds.forEach((tagId) => {
+    databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+  });
+}

--- a/api/tests/integration/domain/usecases/get-recently-used-tags_test.js
+++ b/api/tests/integration/domain/usecases/get-recently-used-tags_test.js
@@ -1,0 +1,52 @@
+const _ = require('lodash');
+const { expect, databaseBuilder } = require('../../../test-helper');
+const getRecentlyUsedTags = require('../../../../lib/domain/usecases/get-recently-used-tags');
+const Tag = require('../../../../lib/domain/models/Tag');
+const organizationTagRepository = require('../../../../lib/infrastructure/repositories/organization-tag-repository');
+
+describe('Integration | UseCase | get-recently-used-tags', function () {
+  it('returns 10 recently used tags based on a tag id and ordered by the most used first', async function () {
+    // given
+    const basedTag = databaseBuilder.factory.buildTag({ name: 'konoha' });
+    const mostUsedTag = databaseBuilder.factory.buildTag({ name: 'kumo' });
+    const leastUsedTag = databaseBuilder.factory.buildTag({ name: 'hueco mundo' });
+    const tags = [
+      mostUsedTag,
+      databaseBuilder.factory.buildTag({ name: 'kiri' }),
+      databaseBuilder.factory.buildTag({ name: 'suna' }),
+      databaseBuilder.factory.buildTag({ name: 'oto' }),
+      databaseBuilder.factory.buildTag({ name: 'ame' }),
+      databaseBuilder.factory.buildTag({ name: 'iwa' }),
+      databaseBuilder.factory.buildTag({ name: 'uzushio' }),
+      databaseBuilder.factory.buildTag({ name: 'seireitei' }),
+      databaseBuilder.factory.buildTag({ name: 'karakura' }),
+      leastUsedTag,
+      databaseBuilder.factory.buildTag({ name: 'yuei' }),
+    ];
+    const organizations = [];
+
+    _.times(11, () => organizations.push(databaseBuilder.factory.buildOrganization()));
+
+    for (const [index, organization] of organizations.entries()) {
+      const tagIds = tags.slice(0, index + 1).map(({ id }) => id);
+      tagIds.push(basedTag.id);
+      _buildOrganizationTags(organization.id, tagIds);
+    }
+
+    await databaseBuilder.commit();
+
+    // when
+    const recentlyUsedTags = await getRecentlyUsedTags({ tagId: basedTag.id, organizationTagRepository });
+
+    // then
+    expect(recentlyUsedTags.length).to.equal(10);
+    expect(recentlyUsedTags[0]).to.deepEqualInstance(new Tag(mostUsedTag));
+    expect(recentlyUsedTags[recentlyUsedTags.length - 1]).to.deepEqualInstance(new Tag(leastUsedTag));
+  });
+});
+
+function _buildOrganizationTags(organizationId, tagIds) {
+  tagIds.forEach((tagId) => {
+    databaseBuilder.factory.buildOrganizationTag({ organizationId, tagId });
+  });
+}

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -26,6 +26,8 @@ const tokenService = require('../lib/domain/services/token-service');
 const Membership = require('../lib/domain/models/Membership');
 const EMPTY_BLANK_AND_NULL = ['', '\t \n', null];
 
+const { ROLES } = require('../lib/domain/constants').PIX_ADMIN;
+
 /* eslint-disable mocha/no-top-level-hooks */
 afterEach(function () {
   sinon.restore();
@@ -68,6 +70,21 @@ async function insertUserWithRoleSuperAdmin() {
     lastName: 'Papa',
     email: 'super.papa@example.net',
     password: 'Password123',
+  });
+
+  await databaseBuilder.commit();
+
+  return user;
+}
+
+async function insertUserWithRoleCertif() {
+  const user = databaseBuilder.factory.buildUser.withRole({
+    id: 1234,
+    firstName: 'Certif',
+    lastName: 'Power',
+    email: 'certif.power@example.net',
+    password: 'Pix123',
+    role: ROLES.CERTIF,
   });
 
   await databaseBuilder.commit();
@@ -224,6 +241,7 @@ module.exports = {
   HttpTestServer: require('./tooling/server/http-test-server'),
   insertOrganizationUserWithRoleAdmin,
   insertUserWithRoleSuperAdmin,
+  insertUserWithRoleCertif,
   knex,
   nock,
   sinon,


### PR DESCRIPTION
## :christmas_tree: Problème

Actuellement en production, il y a plus de 100 tags affichés. L'ajout des tags à une organisation peut parfois être compliqué, et pourrait devenir très compliqué si le nombre de tags ne fait qu'augmenter.

## :gift: Proposition

Lors de la sélection d'un tag, une liste des 10 tags récemment utilisés avec le tag sélectionné s'affichera. Cette liste sera ordonnée par ordre décroissant par rapport au nombre de fois que ce tag a été utilisé avec le tag sélectionné.

Lors de la sélection d'un tag dans cette nouvelle liste, cette dernière ne sera pas mise à jour. Cette liste ne se mettra à jour que lorsqu'un autre tag sera sélectionné dans la liste de tous les tags.

## :star2: Remarques

- Les données de seed n'ont pas été mis à jour pour éviter la surcharge de données.
- Pour le test fonctionnel avec plus de tags, il vous faudra en local modifier les seeds pour y ajouter des tags.

## :santa: Pour tester

- Ouvrir l'application Pix Admin
- Se rendre sur la page de détails d'une organisation
- Ouvrir l'onglet Tags
- Sélectionner un tag n'étant pas associé à l'organisation
- Constater que la liste des tags récemment utilisés avec le tag sélectionné s'affiche
- Sélectionner un tag de la liste des tags récemment utilisés
- Constater que le status du tag sélectionné se met à jour, s'affiche comme associé à l'organisation (en haut de la page) et ne rafraîchit pas la liste des tags récemment utilisés.
- Sélectionner un tag dans la liste des tags
- Constater que la liste des tags récemment utilisés s'est mis à jour
