### PR TITLE
[FEATURE] Changement du format de date des sessions pour l'import en masse (PIX-6845).

### DIFF
--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -76,7 +76,7 @@ function deserializeForSessionsImport(parsedCsvData) {
 function getDataFromColumnNames({ csvLineKeys, headers, line }) {
   const data = {};
   csvLineKeys.forEach((key) => {
-    if (key === 'birthdate') {
+    if (key === 'birthdate' || key === 'date') {
       data[key] = convertDateValue({
         dateString: line[headers[key]],
         inputFormat: 'DD/MM/YYYY',

--- a/api/tests/acceptance/application/certification-centers/certification-centers-controller-post-import-sessions_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-centers-controller-post-import-sessions_test.js
@@ -22,7 +22,7 @@ describe('Acceptance | Controller | certification-centers-controller-post-import
         await databaseBuilder.commit();
 
         const newBuffer = `N° de session;* Nom du site;* Nom de la salle;* Date de début;* Heure de début (heure locale);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: jj/mm/aaaa);* Sexe (M ou F);Code Insee;Code postal;Nom de la commune;* Pays;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant local;Temps majoré ?;Tarification part Pix;Code de prépaiement
-        ;site1;salle1;2022-10-19;12:00;surveillant;non;;;;;;;;;;;;;;`;
+        ;site1;salle1;19/10/2022;12:00;surveillant;non;;;;;;;;;;;;;;`;
 
         const options = {
           method: 'POST',

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -320,7 +320,7 @@ function _lineWithSessionAndNoCandidate(sessionNumber) {
   return {
     '* Nom du site': `Site ${sessionNumber}`,
     '* Nom de la salle': `Salle ${sessionNumber}`,
-    '* Date de début': '2023-05-12',
+    '* Date de début': '12/05/2023',
     '* Heure de début (heure locale)': '01:00',
     '* Surveillant(s)': 'Paul',
     'Observations (optionnel)': '',
@@ -370,7 +370,7 @@ function _lineWithSessionAndCandidate({ sessionNumber, candidateNumber }) {
   return {
     '* Nom du site': `Site ${sessionNumber}`,
     '* Nom de la salle': `Salle ${sessionNumber}`,
-    '* Date de début': '2023-05-12',
+    '* Date de début': '12/05/2023',
     '* Heure de début (heure locale)': '01:00',
     '* Surveillant(s)': 'Paul',
     'Observations (optionnel)': '',


### PR DESCRIPTION
## :christmas_tree: Problème

Le format de date des sessions dans le fichier CSV d'import de sessions n'est pas identique à ce qui se fait pour le reste des imports dans Pix-Certif ni au format de date utilisé pour la date de naissance des candidats de ce même fichier.

## :gift: Proposition

- Modifier le format de date (`YYYY-MM-DD` vers `DD/MM/YYYY`)

## :star2: Remarques

N/A

## :santa: Pour tester

Cas passant : 

Importer le CSV suivant grâce au bouton d'import en masse de sessions dans Pix Certif et vérifier que les sessions ont bien été enregistrées (et donc qu'il n'y ait pas eu d'erreur)

```
N° de session;* Nom du site;* Nom de la salle;* Date de début;* Heure de début (heure locale);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: jj/mm/aaaa);* Sexe (M ou F);Code Insee;Code postal;Nom de la commune;* Pays;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant local;Temps majoré ?;Tarification part Pix;Code de prépaiement
;Paris;Pix;01/12/2021;12:00;Surveillant 1;;Testeur;Michel;01/01/2000;M;;75001;Paris;France;;;;;Gratuite;;
;Paris;Pix;08/12/2021;14:00;Surveillant 2;;Testeur;Adam;01/01/2000;M;75101;;;France;;;;;Gratuite;;
;Paris;Pix;01/02/2021;12:00;Surveillant 3;;Testeur;Micheline;01/01/2000;F;;75001;Paris;France;;;;;Gratuite;;
;Paris;Pix;30/10/2021;14:00;Surveillant 4;;Testeur;Eve;01/01/2000;F;75101;;;France;;;;;Gratuite;;
```

Cas d'erreur : Erreur dans la date
Importer le CSV suivant (un `/` a été remplacé par un `-` dans la date de session de la deuxième ligne) grâce au bouton d'import en masse de sessions dans Pix Certif et vérifier que les sessions n'ont pas été enregistrées.

```
N° de session;* Nom du site;* Nom de la salle;* Date de début;* Heure de début (heure locale);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: jj/mm/aaaa);* Sexe (M ou F);Code Insee;Code postal;Nom de la commune;* Pays;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant local;Temps majoré ?;Tarification part Pix;Code de prépaiement
;Paris;Pix;01/12/2021;12:00;Surveillant 1;;Testeur;Michel;01/01/2000;M;;75001;Paris;France;;;;;Gratuite;;
;Paris;Pix;08-12/2021;14:00;Surveillant 2;;Testeur;Adam;01/01/2000;M;75101;;;France;;;;;Gratuite;;
;Paris;Pix;01/02/2021;12:00;Surveillant 3;;Testeur;Micheline;01/01/2000;F;;75001;Paris;France;;;;;Gratuite;;
;Paris;Pix;30/10/2021;14:00;Surveillant 4;;Testeur;Eve;01/01/2000;F;75101;;;France;;;;;Gratuite;;
```
