### PR TITLE
[FEATURE] Simulateur nouveau scoring : Ajouter un flag permettant le recalcul de la capacité (PIX-6832)

### DIFF
--- a/api/lib/application/scoring-simulator/index.js
+++ b/api/lib/application/scoring-simulator/index.js
@@ -62,6 +62,7 @@ exports.register = async (server) => {
           },
           payload: Joi.object({
             successProbabilityThreshold: Joi.number(),
+            calculateEstimatedLevel: Joi.boolean().default(false),
             simulations: Joi.array()
               .required()
               .items(

--- a/api/lib/application/scoring-simulator/scoring-simulator-controller.js
+++ b/api/lib/application/scoring-simulator/scoring-simulator-controller.js
@@ -29,6 +29,7 @@ module.exports = {
 
     const results = await usecases.simulateFlashScoring({
       successProbabilityThreshold: request.payload.successProbabilityThreshold,
+      calculateEstimatedLevel: request.payload.calculateEstimatedLevel,
       simulations,
     });
 

--- a/api/lib/domain/usecases/simulate-flash-scoring.js
+++ b/api/lib/domain/usecases/simulate-flash-scoring.js
@@ -5,24 +5,35 @@ module.exports = async function simulateFlashScoring({
   flashAlgorithmService,
   successProbabilityThreshold,
   simulations,
+  calculateEstimatedLevel = false,
   locale = 'fr',
 }) {
   const challenges = await challengeRepository.findFlashCompatible({ locale, successProbabilityThreshold });
   const challengeIds = new Set(challenges.map(({ id }) => id));
 
-  return simulations.map(({ id, estimatedLevel, answers: allAnswers }) => {
-    if (estimatedLevel == undefined) {
+  return simulations.map(({ id, estimatedLevel: givenEstimatedLevel, answers: allAnswers }) => {
+    let finalEstimatedLevel = givenEstimatedLevel;
+
+    if (!calculateEstimatedLevel && givenEstimatedLevel == undefined) {
       return new SimulationResult({
         id,
         error: 'Simulation should have an estimated level',
       });
     }
 
-    if (!allAnswers || allAnswers.length === 0) {
-      return new SimulationResult({
-        id,
-        error: 'Simulation should have answers in order to calculate estimated level',
+    if (calculateEstimatedLevel) {
+      if (!allAnswers || allAnswers.length === 0) {
+        return new SimulationResult({
+          id,
+          error: 'Simulation should have answers in order to calculate estimated level',
+        });
+      }
+
+      const { estimatedLevel: calculatedEstimatedLevel } = flashAlgorithmService.getEstimatedLevelAndErrorRate({
+        allAnswers,
+        challenges,
       });
+      finalEstimatedLevel = calculatedEstimatedLevel;
     }
 
     for (const answer of allAnswers) {
@@ -36,10 +47,10 @@ module.exports = async function simulateFlashScoring({
 
     const pixScore = flashAlgorithmService.calculateTotalPixScore({
       challenges,
-      estimatedLevel,
+      estimatedLevel: finalEstimatedLevel,
       allAnswers,
     });
 
-    return new SimulationResult({ id, estimatedLevel, pixScore });
+    return new SimulationResult({ id, estimatedLevel: finalEstimatedLevel, pixScore });
   });
 };

--- a/api/lib/domain/usecases/simulate-flash-scoring.js
+++ b/api/lib/domain/usecases/simulate-flash-scoring.js
@@ -21,8 +21,17 @@ module.exports = async function simulateFlashScoring({
       });
     }
 
+    for (const answer of allAnswers) {
+      if (!challengeIds.has(answer.challengeId)) {
+        return new SimulationResult({
+          id,
+          error: `Challenge ID ${answer.challengeId} is unknown or not compatible with flash algorithm`,
+        });
+      }
+    }
+
     if (calculateEstimatedLevel) {
-      if (!allAnswers || allAnswers.length === 0) {
+      if (allAnswers.length === 0) {
         return new SimulationResult({
           id,
           error: 'Simulation should have answers in order to calculate estimated level',
@@ -33,6 +42,7 @@ module.exports = async function simulateFlashScoring({
         allAnswers,
         challenges,
       });
+
       if (givenEstimatedLevel != undefined && calculatedEstimatedLevel !== givenEstimatedLevel) {
         return new SimulationResult({
           id,
@@ -40,16 +50,8 @@ module.exports = async function simulateFlashScoring({
           error: `Calculated estimated level ${calculatedEstimatedLevel} is different from expected given estimated level ${givenEstimatedLevel}`,
         });
       }
-      finalEstimatedLevel = calculatedEstimatedLevel;
-    }
 
-    for (const answer of allAnswers) {
-      if (!challengeIds.has(answer.challengeId)) {
-        return new SimulationResult({
-          id,
-          error: `Challenge ID ${answer.challengeId} is unknown or not compatible with flash algorithm`,
-        });
-      }
+      finalEstimatedLevel = calculatedEstimatedLevel;
     }
 
     const pixScore = flashAlgorithmService.calculateTotalPixScore({

--- a/api/lib/domain/usecases/simulate-flash-scoring.js
+++ b/api/lib/domain/usecases/simulate-flash-scoring.js
@@ -18,6 +18,13 @@ module.exports = async function simulateFlashScoring({
       });
     }
 
+    if (!allAnswers || allAnswers.length === 0) {
+      return new SimulationResult({
+        id,
+        error: 'Simulation should have answers in order to calculate estimated level',
+      });
+    }
+
     for (const answer of allAnswers) {
       if (!challengeIds.has(answer.challengeId)) {
         return new SimulationResult({

--- a/api/lib/domain/usecases/simulate-flash-scoring.js
+++ b/api/lib/domain/usecases/simulate-flash-scoring.js
@@ -33,6 +33,13 @@ module.exports = async function simulateFlashScoring({
         allAnswers,
         challenges,
       });
+      if (givenEstimatedLevel != undefined && calculatedEstimatedLevel !== givenEstimatedLevel) {
+        return new SimulationResult({
+          id,
+          estimatedLevel: calculatedEstimatedLevel,
+          error: `Calculated estimated level ${calculatedEstimatedLevel} is different from expected given estimated level ${givenEstimatedLevel}`,
+        });
+      }
       finalEstimatedLevel = calculatedEstimatedLevel;
     }
 

--- a/api/tests/integration/application/scoring-simulator/scoring-simulator-controller_test.js
+++ b/api/tests/integration/application/scoring-simulator/scoring-simulator-controller_test.js
@@ -32,6 +32,7 @@ describe('Integration | Application | Scoring-simulator | scoring-simulator-cont
         const response = await httpTestServer.request('POST', '/api/scoring-simulator/flash', {
           simulations: [{ estimatedLevel: 2, answers: [{ challengeId: 'okChallengeId', result: 'ok' }] }],
           successProbabilityThreshold: 0.8,
+          calculateEstimatedLevel: true,
         });
 
         // then
@@ -44,6 +45,7 @@ describe('Integration | Application | Scoring-simulator | scoring-simulator-cont
             }),
           ],
           successProbabilityThreshold: 0.8,
+          calculateEstimatedLevel: true,
         });
       });
     });

--- a/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
+++ b/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
@@ -84,6 +84,33 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
         );
       });
     });
+
+    describe('when there are answers AND there is NO estimated level', function () {
+      it('should calculate estimated level AND total score', async function () {
+        // given
+        const answers = [
+          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: 'challenge1' }),
+          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: 'challenge2' }),
+          domainBuilder.buildAnswer({ result: AnswerStatus.KO, challengeId: 'challenge3' }),
+          domainBuilder.buildAnswer({ result: AnswerStatus.SKIPPED, challengeId: 'challenge4' }),
+        ];
+
+        const simulation = new ScoringSimulation({ id: 'simulation1', answers });
+
+        // when
+        const simulationResults = await usecases.simulateFlashScoring({
+          simulations: [simulation],
+          calculateEstimatedLevel,
+        });
+
+        // then
+        expect(simulationResults).to.have.lengthOf(1);
+        expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+        expect(simulationResults[0]).to.have.property('id', 'simulation1');
+        expect(simulationResults[0]).to.have.property('estimatedLevel', 5.309899756825917);
+        expect(simulationResults[0]).to.have.property('pixScore', 110011);
+      });
+    });
   });
 
   describe('when NOT calculating estimated level', function () {

--- a/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
+++ b/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
@@ -111,6 +111,65 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
         expect(simulationResults[0]).to.have.property('pixScore', 110011);
       });
     });
+
+    describe('when there are answers and an estimated level', function () {
+      describe('when the calculated and given estimated levels are the same', function () {
+        it('should calculate estimated level AND total score', async function () {
+          // given
+          const answers = [
+            domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: 'challenge1' }),
+            domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: 'challenge2' }),
+            domainBuilder.buildAnswer({ result: AnswerStatus.KO, challengeId: 'challenge3' }),
+            domainBuilder.buildAnswer({ result: AnswerStatus.SKIPPED, challengeId: 'challenge4' }),
+          ];
+
+          const simulation = new ScoringSimulation({ id: 'simulation1', answers, estimatedLevel: 5.309899756825917 });
+
+          // when
+          const simulationResults = await usecases.simulateFlashScoring({
+            simulations: [simulation],
+            calculateEstimatedLevel,
+          });
+
+          // then
+          expect(simulationResults).to.have.lengthOf(1);
+          expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+          expect(simulationResults[0]).to.have.property('id', 'simulation1');
+          expect(simulationResults[0]).to.have.property('estimatedLevel', 5.309899756825917);
+          expect(simulationResults[0]).to.have.property('pixScore', 110011);
+        });
+      });
+
+      describe('when the calculated and given estimated levels are different', function () {
+        it('should return an error', async function () {
+          // given
+          const answers = [
+            domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: 'challenge1' }),
+            domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: 'challenge2' }),
+            domainBuilder.buildAnswer({ result: AnswerStatus.KO, challengeId: 'challenge3' }),
+            domainBuilder.buildAnswer({ result: AnswerStatus.SKIPPED, challengeId: 'challenge4' }),
+          ];
+
+          const simulation = new ScoringSimulation({ id: 'simulation1', answers, estimatedLevel: 1 });
+
+          // when
+          const simulationResults = await usecases.simulateFlashScoring({
+            simulations: [simulation],
+            calculateEstimatedLevel,
+          });
+
+          // then
+          expect(simulationResults).to.have.lengthOf(1);
+          expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+          expect(simulationResults[0]).to.have.property('id', 'simulation1');
+          expect(simulationResults[0]).to.have.property('estimatedLevel', 5.309899756825917);
+          expect(simulationResults[0]).to.have.property(
+            'error',
+            'Calculated estimated level 5.309899756825917 is different from expected given estimated level 1'
+          );
+        });
+      });
+    });
   });
 
   describe('when NOT calculating estimated level', function () {


### PR DESCRIPTION
## :egg: Problème
Le simulateur de nouveau scoring ne sait pas recalculer/vérifier la capacité.

## :bowl_with_spoon: Proposition
Ajouter un flag `calculateEstimatedLevel` permettant de le faire.

## :milk_glass: Remarques
N/A

## :butter: Pour tester
Faire un `curl` :
```
TOKEN=$(curl 'https://api-pr5511.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin%40example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr5511.review.pix.fr/api/scoring-simulator/flash \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -X POST \
    -d '{ "calculateEstimatedLevel": true, "simulations": [{ "answers": [{ "challengeId": "rec0c55SlcVqmWlA5", "result": "ok" }] }] }'
```