### PR TITLE
[FEATURE] Ajout d'un texte spécifique pour lecteur d'écran sur le bouton de reset des filtres des tutoriels

### DIFF
--- a/mon-pix/app/components/user-tutorials/filters/sidebar.hbs
+++ b/mon-pix/app/components/user-tutorials/filters/sidebar.hbs
@@ -31,6 +31,7 @@
           @size="small"
           @backgroundColor="transparent-light"
           @isBorderVisible={{true}}
+          aria-label={{t "pages.user-tutorials.sidebar.reset-aria-label"}}
         >
           {{t "pages.user-tutorials.sidebar.reset"}}
         </PixButton>

--- a/mon-pix/tests/integration/components/user-tutorials/filters/sidebar_test.js
+++ b/mon-pix/tests/integration/components/user-tutorials/filters/sidebar_test.js
@@ -75,7 +75,9 @@ module('Integration | Component | User-Tutorials | Filters | Sidebar', function 
           await click(checkbox);
 
           // when
-          await click(screen.getByRole('button', { name: 'Réinitialiser' }));
+          await click(
+            screen.getByRole('button', { name: this.intl.t('pages.user-tutorials.sidebar.reset-aria-label') })
+          );
 
           // then
           assert.false(checkbox.checked);

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1576,6 +1576,7 @@
       "filter": "Filter",
       "sidebar": {
         "reset": "Reset",
+        "reset-aria-label": "Reset and deselect all filters",
         "see-results": "See the results"
       },
       "label": "Tutorials",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1577,6 +1577,7 @@
       "label": "tutoriels",
       "sidebar": {
         "reset": "Réinitialiser",
+        "reset-aria-label": "Réinitialiser et désélectionner tous les filtres",
         "see-results": "Voir les résultats"
       },
       "list": {


### PR DESCRIPTION
## :egg: Problème
Le bouton "Réinitialiser" dans le bandeau des filtres était trop générique.

## :bowl_with_spoon: Proposition
En attribut `aria-label` du bouton de réinitialisation, préciser ce qui va être réinitialiser : "Réinitialiser et désélectionner tous les filtres"

## :milk_glass: Remarques
La traduction est aussi faite en anglais.

## :butter: Pour tester
- Visiter la page des tutoriels
- Ouvrir la sidebar des filtres
- Vérifier dans l'inspecteur web que le bouton de réinitialisation a bien un `aria-label` valide.
