### PR TITLE
[CHORE] Mise à jour de pix-ui en version 24.0.2 (PIX-6859)

### DIFF
--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.0",
-        "@1024pix/pix-ui": "^24.0.1",
+        "@1024pix/pix-ui": "^24.0.2",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
         "@ember/optional-features": "^2.0.0",
@@ -1049,9 +1049,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-24.0.1.tgz",
-      "integrity": "sha512-hymu4ttHwswbP/VJTERYyP31nATR4LrG7yaYc7kKz9ztM2IvWs1tJZcXjFTdkvcTlslTJssEhLLvTmuIUd6U2Q==",
+      "version": "24.0.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-24.0.2.tgz",
+      "integrity": "sha512-3SEKidTeBhnu7kW8sz6F1IMbH/nWlhnVLO3LQqe3RL39mlZtx27aFPhnSXOZ34ROb6kjlf8YM+AifLIYj2WULw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -34955,9 +34955,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-24.0.1.tgz",
-      "integrity": "sha512-hymu4ttHwswbP/VJTERYyP31nATR4LrG7yaYc7kKz9ztM2IvWs1tJZcXjFTdkvcTlslTJssEhLLvTmuIUd6U2Q==",
+      "version": "24.0.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-24.0.2.tgz",
+      "integrity": "sha512-3SEKidTeBhnu7kW8sz6F1IMbH/nWlhnVLO3LQqe3RL39mlZtx27aFPhnSXOZ34ROb6kjlf8YM+AifLIYj2WULw==",
       "dev": true,
       "requires": {
         "color": "^4.2.3",

--- a/orga/package.json
+++ b/orga/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.0",
-    "@1024pix/pix-ui": "^24.0.1",
+    "@1024pix/pix-ui": "^24.0.2",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
## :christmas_tree: Problème
Besoin de mettre a jour pix ui dans pix orga pour afficher les cartes de résumé des participations des prescrits telles que sur la maquette.

## :gift: Proposition
Mettre a jour Pix ui a la version 24.0.2

## :santa: Pour tester
Vérifier que la CI passe