### PR TITLE
[FEATURE] Simulateur scoring flash : pouvoir choisir la langue des épreuves utilisées (PIX-6856)

### DIFF
--- a/api/lib/application/scoring-simulator/scoring-simulator-controller.js
+++ b/api/lib/application/scoring-simulator/scoring-simulator-controller.js
@@ -1,6 +1,7 @@
 const ScoringSimulation = require('../../domain/models/ScoringSimulation');
 const Answer = require('../../domain/models/Answer');
 const usecases = require('../../domain/usecases');
+const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
 module.exports = {
   async calculateOldScores(request, h) {
@@ -27,10 +28,13 @@ module.exports = {
         })
     );
 
+    const locale = extractLocaleFromRequest(request);
+
     const results = await usecases.simulateFlashScoring({
       successProbabilityThreshold: request.payload.successProbabilityThreshold,
       calculateEstimatedLevel: request.payload.calculateEstimatedLevel,
       simulations,
+      locale,
     });
 
     return h.response({ results });

--- a/api/lib/domain/usecases/simulate-flash-scoring.js
+++ b/api/lib/domain/usecases/simulate-flash-scoring.js
@@ -6,7 +6,7 @@ module.exports = async function simulateFlashScoring({
   successProbabilityThreshold,
   simulations,
   calculateEstimatedLevel = false,
-  locale = 'fr',
+  locale,
 }) {
   const challenges = await challengeRepository.findFlashCompatible({ locale, successProbabilityThreshold });
   const challengeIds = new Set(challenges.map(({ id }) => id));

--- a/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
@@ -60,12 +60,12 @@ describe('Acceptance | Controller | scoring-simulator-controller', function () {
         { id: 'skill6', status: 'périmé', tubeId: 'recTube2', competenceId: 'rec2', level: 6, pixValue: 100000 },
       ],
       challenges: [
-        { id: 'challenge1', skillId: 'skill1', status: 'validé', alpha: 0.16, delta: -2, locales: ['fr'] },
-        { id: 'challenge2', skillId: 'skill2', status: 'validé', alpha: 3, delta: 6, locales: ['fr'] },
-        { id: 'challenge3', skillId: 'skill3', status: 'validé', alpha: 1.587, delta: 8.5, locales: ['fr'] },
-        { id: 'challenge4', skillId: 'skill4', status: 'validé', alpha: 2.86789, delta: 0.145, locales: ['fr'] },
-        { id: 'challenge5', skillId: 'skill5', status: 'validé', alpha: 3, delta: 1, locales: ['fr'] },
-        { id: 'challenge6', skillId: 'skill5', status: 'validé', alpha: 1.7, delta: -1, locales: ['fr'] },
+        { id: 'challenge1', skillId: 'skill1', status: 'validé', alpha: 0.16, delta: -2, locales: ['fr-fr'] },
+        { id: 'challenge2', skillId: 'skill2', status: 'validé', alpha: 3, delta: 6, locales: ['fr-fr'] },
+        { id: 'challenge3', skillId: 'skill3', status: 'validé', alpha: 1.587, delta: 8.5, locales: ['fr-fr'] },
+        { id: 'challenge4', skillId: 'skill4', status: 'validé', alpha: 2.86789, delta: 0.145, locales: ['fr-fr'] },
+        { id: 'challenge5', skillId: 'skill5', status: 'validé', alpha: 3, delta: 1, locales: ['fr-fr'] },
+        { id: 'challenge6', skillId: 'skill5', status: 'validé', alpha: 1.7, delta: -1, locales: ['fr-fr'] },
       ],
     };
 

--- a/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
+++ b/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
@@ -5,6 +5,8 @@ const usecases = require('../../../../lib/domain/usecases/');
 const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
 
 describe('Integration | UseCases | simulateFlashScoring', function () {
+  const locale = 'fr-fr';
+
   beforeEach(function () {
     const learningContent = {
       competences: [
@@ -45,14 +47,14 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
         { id: 'skill7', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', pixValue: 1000000 },
       ],
       challenges: [
-        { id: 'challenge1', skillId: 'skill1', status: 'validé', alpha: 0.16, delta: -2, locales: ['fr'] },
-        { id: 'challenge2', skillId: 'skill2', status: 'validé', alpha: 3, delta: 6, locales: ['fr'] },
-        { id: 'challenge3', skillId: 'skill3', status: 'validé', alpha: 1.587, delta: 8.5, locales: ['fr'] },
-        { id: 'challenge4', skillId: 'skill4', status: 'validé', alpha: 2.86789, delta: 0.145, locales: ['fr'] },
-        { id: 'challenge5', skillId: 'skill5', status: 'validé', alpha: 3, delta: 1, locales: ['fr'] },
-        { id: 'challenge6', skillId: 'skill6', status: 'validé', alpha: 1.7, delta: -1, locales: ['fr'] },
-        { id: 'challenge7', skillId: 'skill7', status: 'validé', alpha: 2.5, delta: 5, locales: ['fr'] },
-        { id: 'challenge8', skillId: 'skill7', status: 'validé', locales: ['fr'] },
+        { id: 'challenge1', skillId: 'skill1', status: 'validé', alpha: 0.16, delta: -2, locales: [locale] },
+        { id: 'challenge2', skillId: 'skill2', status: 'validé', alpha: 3, delta: 6, locales: [locale] },
+        { id: 'challenge3', skillId: 'skill3', status: 'validé', alpha: 1.587, delta: 8.5, locales: [locale] },
+        { id: 'challenge4', skillId: 'skill4', status: 'validé', alpha: 2.86789, delta: 0.145, locales: [locale] },
+        { id: 'challenge5', skillId: 'skill5', status: 'validé', alpha: 3, delta: 1, locales: [locale] },
+        { id: 'challenge6', skillId: 'skill6', status: 'validé', alpha: 1.7, delta: -1, locales: [locale] },
+        { id: 'challenge7', skillId: 'skill7', status: 'validé', alpha: 2.5, delta: 5, locales: [locale] },
+        { id: 'challenge8', skillId: 'skill7', status: 'validé', locales: [locale] },
       ],
     };
 
@@ -73,6 +75,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
         const simulationResults = await usecases.simulateFlashScoring({
           simulations: [simulation],
           calculateEstimatedLevel,
+          locale,
         });
 
         // then
@@ -101,6 +104,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
         const simulationResults = await usecases.simulateFlashScoring({
           simulations: [simulation],
           calculateEstimatedLevel,
+          locale,
         });
 
         // then
@@ -129,6 +133,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
           const simulationResults = await usecases.simulateFlashScoring({
             simulations: [simulation],
             calculateEstimatedLevel,
+            locale,
           });
 
           // then
@@ -156,6 +161,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
           const simulationResults = await usecases.simulateFlashScoring({
             simulations: [simulation],
             calculateEstimatedLevel,
+            locale,
           });
 
           // then
@@ -198,6 +204,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
         const simulationResults = await usecases.simulateFlashScoring({
           simulations: [simulation],
           calculateEstimatedLevel,
+          locale,
         });
 
         // then
@@ -219,6 +226,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
         const simulationResults = await usecases.simulateFlashScoring({
           simulations: [simulation],
           calculateEstimatedLevel,
+          locale,
         });
 
         // then
@@ -245,6 +253,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
         const simulationResults = await usecases.simulateFlashScoring({
           simulations: [simulation],
           calculateEstimatedLevel,
+          locale,
         });
 
         // then
@@ -266,7 +275,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
         const simulation = new ScoringSimulation({ id: 'simulation1', answers, estimatedLevel });
 
         // when
-        const simulationResults = await usecases.simulateFlashScoring({ simulations: [simulation] });
+        const simulationResults = await usecases.simulateFlashScoring({ simulations: [simulation], locale });
 
         // then
         expect(simulationResults).to.have.lengthOf(1);
@@ -289,7 +298,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
         const simulation = new ScoringSimulation({ answers, estimatedLevel });
 
         // when
-        const simulationResults = await usecases.simulateFlashScoring({ simulations: [simulation] });
+        const simulationResults = await usecases.simulateFlashScoring({ simulations: [simulation], locale });
 
         // then
         expect(simulationResults).to.have.lengthOf(1);
@@ -314,6 +323,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
       const simulationResults = await usecases.simulateFlashScoring({
         simulations: [simulation],
         successProbabilityThreshold,
+        locale,
       });
 
       // then


### PR DESCRIPTION
## :egg: Problème
Il n'est pas possible de choisir la language des épreuves utilisées par le simulateur de scoring flash.

## :bowl_with_spoon: Proposition
Lire le header `Accept-Language` et l'utilser comme `locale` pour les épreuves.

## :milk_glass: Remarques
N/A

## :butter: Pour tester
```
TOKEN=$(curl 'https://api-pr5515.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin%40example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr5515.review.pix.fr/api/scoring-simulator/flash \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept-Language: fr" \
    -X POST \
    -d '{ "calculateEstimatedLevel": true, "simulations": [{ "answers": [{ "challengeId": "rec0c55SlcVqmWlA5", "result": "ok" }] }] }'
```