### PR TITLE
[FEATURE] Simulateur scoring actuel : Calculer le score par compétence (PIX-6768)

### DIFF
--- a/api/lib/domain/models/SimulationResult.js
+++ b/api/lib/domain/models/SimulationResult.js
@@ -1,9 +1,19 @@
 class SimulationResult {
-  constructor({ id, estimatedLevel, pixScore, error } = {}) {
+  constructor({ id, estimatedLevel, pixScore, pixScoreByCompetence = [], error } = {}) {
     this.id = id;
     this.estimatedLevel = estimatedLevel;
     this.pixScore = pixScore;
+    this.pixScoreByCompetence = pixScoreByCompetence.map(
+      (competenceScore) => new SimulationCompetenceResult(competenceScore)
+    );
     this.error = error;
+  }
+}
+
+class SimulationCompetenceResult {
+  constructor({ competenceId, pixScore }) {
+    this.competenceId = competenceId;
+    this.pixScore = pixScore;
   }
 }
 

--- a/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
@@ -111,21 +111,20 @@ describe('Acceptance | Controller | scoring-simulator-controller', function () {
 
       // then
       expect(response).to.have.property('statusCode', 200);
-      expect(response.result).to.deep.equal({
-        results: [
-          {
-            id: undefined,
-            error: undefined,
-            estimatedLevel: undefined,
-            pixScore: 11111,
-          },
-          {
-            id: 'simulationWithError',
-            error: 'Answer for skill skill1 was already given or inferred',
-            estimatedLevel: undefined,
-            pixScore: undefined,
-          },
-        ],
+      expect(response.result.results).to.have.lengthOf(2);
+      expect(response.result.results[0]).to.deep.include({
+        id: undefined,
+        estimatedLevel: undefined,
+        pixScore: 11111,
+        pixScoreByCompetence: [],
+        error: undefined,
+      });
+      expect(response.result.results[1]).to.deep.include({
+        id: 'simulationWithError',
+        estimatedLevel: undefined,
+        pixScore: undefined,
+        pixScoreByCompetence: [],
+        error: 'Answer for skill skill1 was already given or inferred',
       });
     });
 
@@ -237,21 +236,20 @@ describe('Acceptance | Controller | scoring-simulator-controller', function () {
 
       // then
       expect(response).to.have.property('statusCode', 200);
-      expect(response.result).to.deep.equal({
-        results: [
-          {
-            id: 'simulation1',
-            estimatedLevel: 2.5769829347,
-            pixScore: 11110,
-            error: undefined,
-          },
-          {
-            id: 'simulation2',
-            error: 'Simulation should have an estimated level',
-            estimatedLevel: undefined,
-            pixScore: undefined,
-          },
-        ],
+      expect(response.result.results).to.have.lengthOf(2);
+      expect(response.result.results[0]).to.deep.include({
+        id: 'simulation1',
+        estimatedLevel: 2.5769829347,
+        pixScore: 11110,
+        pixScoreByCompetence: [],
+        error: undefined,
+      });
+      expect(response.result.results[1]).to.deep.include({
+        id: 'simulation2',
+        error: 'Simulation should have an estimated level',
+        estimatedLevel: undefined,
+        pixScore: undefined,
+        pixScoreByCompetence: [],
       });
     });
 

--- a/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
@@ -112,20 +112,31 @@ describe('Acceptance | Controller | scoring-simulator-controller', function () {
       // then
       expect(response).to.have.property('statusCode', 200);
       expect(response.result.results).to.have.lengthOf(2);
-      expect(response.result.results[0]).to.deep.include({
-        id: undefined,
-        estimatedLevel: undefined,
-        pixScore: 11111,
-        pixScoreByCompetence: [],
-        error: undefined,
-      });
-      expect(response.result.results[1]).to.deep.include({
-        id: 'simulationWithError',
-        estimatedLevel: undefined,
-        pixScore: undefined,
-        pixScoreByCompetence: [],
-        error: 'Answer for skill skill1 was already given or inferred',
-      });
+      expect(response.result.results).to.exactlyContain([
+        {
+          id: undefined,
+          estimatedLevel: undefined,
+          pixScore: 11111,
+          error: undefined,
+          pixScoreByCompetence: [
+            {
+              competenceId: 'rec1',
+              pixScore: 11,
+            },
+            {
+              competenceId: 'rec2',
+              pixScore: 11100,
+            },
+          ],
+        },
+        {
+          id: 'simulationWithError',
+          estimatedLevel: undefined,
+          pixScore: undefined,
+          pixScoreByCompetence: [],
+          error: 'Answer for skill skill1 was already given or inferred',
+        },
+      ]);
     });
 
     describe('when there is no connected user', function () {

--- a/api/tests/integration/domain/usecases/simulate-old-scoring_test.js
+++ b/api/tests/integration/domain/usecases/simulate-old-scoring_test.js
@@ -81,6 +81,16 @@ describe('Integration | UseCases | simulateOldScoring', function () {
     expect(simulationResults).to.have.lengthOf(1);
     expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
     expect(simulationResults[0]).to.have.property('pixScore', 101);
+    expect(simulationResults[0].pixScoreByCompetence).to.exactlyContain([
+      {
+        competenceId: 'rec1',
+        pixScore: 1,
+      },
+      {
+        competenceId: 'rec2',
+        pixScore: 100,
+      },
+    ]);
   });
 
   describe('when there are many challenges on the same tube', function () {
@@ -108,6 +118,16 @@ describe('Integration | UseCases | simulateOldScoring', function () {
       expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
       expect(simulationResults[0]).to.have.property('id', 'simulation1');
       expect(simulationResults[0]).to.have.property('pixScore', 11111);
+      expect(simulationResults[0].pixScoreByCompetence).to.exactlyContain([
+        {
+          competenceId: 'rec1',
+          pixScore: 11,
+        },
+        {
+          competenceId: 'rec2',
+          pixScore: 11100,
+        },
+      ]);
     });
   });
 


### PR DESCRIPTION
## :egg: Problème
Le simulateur de scoring actuel ne renvoie pas le score par compétence.

## :bowl_with_spoon: Proposition
Calculer et renvoyer le score par compétence.

## :milk_glass: Remarques
N/A

## :butter: Pour tester
```
TOKEN=$(curl 'https://api-pr5517.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin%40example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr5517.review.pix.fr/api/scoring-simulator/old \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -X POST \
    -d '{ "simulations": [{ "answers": [{ "challengeId": "rec3wt8JjOQZMoQav", "result": "ok" }] }] }'
```
