### PR TITLE
[FEATURE][ADMIN] Afficher l'information si le mot de passe est temporaire (PIX-6803)

### DIFF
--- a/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
@@ -19,6 +19,19 @@
       Adresse e-mail non confirmée
     </div>
   {{/if}}
+  {{#if this.hasPixAuthenticationMethod}}
+    <br />
+    <div class="authentication-method__connexions-information">
+      <dt>{{t
+          "components.users.user-detail-personal-information.authentication-method.should-change-password-status"
+        }}</dt>
+      {{#if this.pixAuthenticationMethod.authenticationComplement.shouldChangePassword}}
+        <dd>{{t "common.words.yes"}}</dd>
+      {{else}}
+        <dd>{{t "common.words.no"}}</dd>
+      {{/if}}
+    </div>
+  {{/if}}
 
 </dl>
 

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.hbs
@@ -2,38 +2,36 @@
   <h2 class="page-section__title">Méthodes de connexion</h2>
 </header>
 
-<dl>
-  <div class="authentication-method__connexions-information">
-    <dt>Date de dernière connexion :</dt>
-    {{#if @user.lastLoggedAt}}
-      <dd>{{dayjs-format @user.lastLoggedAt "DD/MM/YYYY"}}</dd>
-    {{/if}}
-  </div>
+<ul>
+  <li class="authentication-method__connexions-information">
+    Date de dernière connexion :
+    {{#if @user.lastLoggedAt}}{{dayjs-format @user.lastLoggedAt "DD/MM/YYYY"}}{{/if}}
+  </li>
   {{#if @user.emailConfirmedAt}}
-    <div class="authentication-method__connexions-information">
-      <dt>Adresse e-mail confirmée le :</dt>
-      <dd>{{dayjs-format @user.emailConfirmedAt "DD/MM/YYYY"}}</dd>
-    </div>
+    <li class="authentication-method__connexions-information">
+      Adresse e-mail confirmée le :
+      {{dayjs-format @user.emailConfirmedAt "DD/MM/YYYY"}}
+    </li>
   {{else}}
-    <div class="authentication-method__connexions-information">
+    <li class="authentication-method__connexions-information">
       Adresse e-mail non confirmée
-    </div>
+    </li>
   {{/if}}
-  {{#if this.hasPixAuthenticationMethod}}
-    <br />
-    <div class="authentication-method__connexions-information">
-      <dt>{{t
-          "components.users.user-detail-personal-information.authentication-method.should-change-password-status"
-        }}</dt>
-      {{#if this.pixAuthenticationMethod.authenticationComplement.shouldChangePassword}}
-        <dd>{{t "common.words.yes"}}</dd>
-      {{else}}
-        <dd>{{t "common.words.no"}}</dd>
-      {{/if}}
-    </div>
-  {{/if}}
+</ul>
 
-</dl>
+{{#if this.hasPixAuthenticationMethod}}
+  <br />
+  <ul>
+    <li class="authentication-method__connexions-information">
+      {{t "components.users.user-detail-personal-information.authentication-method.should-change-password-status"}}
+      {{#if this.pixAuthenticationMethod.authenticationComplement.shouldChangePassword}}{{t
+          "common.words.yes"
+        }}{{else}}{{t "common.words.no"}}{{/if}}
+    </li>
+  </ul>
+{{/if}}
+
+<br />
 
 <table class="authentication-method-table">
 

--- a/admin/app/components/users/user-detail-personal-information/authentication-method.js
+++ b/admin/app/components/users/user-detail-personal-information/authentication-method.js
@@ -22,6 +22,12 @@ export default class AuthenticationMethod extends Component {
     );
   }
 
+  get pixAuthenticationMethod() {
+    return this.args.user.authenticationMethods.find(
+      (authenticationMethod) => authenticationMethod.identityProvider === 'PIX'
+    );
+  }
+
   get hasEmailAuthenticationMethod() {
     return (
       this.args.user.email &&

--- a/admin/app/models/authentication-method.js
+++ b/admin/app/models/authentication-method.js
@@ -2,4 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class AuthenticationMethod extends Model {
   @attr() identityProvider;
+  @attr() authenticationComplement;
 }

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -80,4 +80,4 @@
 @import "components/campaigns/update";
 @import "components/campaigns/participations-section";
 @import "components/stages/view-stage";
-@import "display/footer-modal"
+@import "display/footer-modal";

--- a/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
@@ -26,7 +26,17 @@ module('Integration | Component | users | user-detail-personal-information/authe
           );
 
           // then
-          assert.dom(screen.getByText('30/10/2020')).exists();
+          assert
+            .dom(
+              screen.getAllByRole('listitem').find((listItem) => {
+                const childrenText = listItem.textContent.trim().split('\n');
+                return (
+                  childrenText[0]?.trim() === 'Adresse e-mail confirmée le :' &&
+                  childrenText[1]?.trim() === '30/10/2020'
+                );
+              })
+            )
+            .exists();
         });
       });
 
@@ -42,7 +52,13 @@ module('Integration | Component | users | user-detail-personal-information/authe
           );
 
           // then
-          assert.dom(screen.getByText('Adresse e-mail non confirmée')).exists();
+          assert
+            .dom(
+              screen
+                .getAllByRole('listitem')
+                .find((listItem) => listItem.textContent?.trim() === 'Adresse e-mail non confirmée')
+            )
+            .exists();
         });
       });
 
@@ -58,8 +74,16 @@ module('Integration | Component | users | user-detail-personal-information/authe
           );
 
           // then
-          assert.dom(screen.getByText('Date de dernière connexion :')).exists();
-          assert.dom(screen.getByText('01/07/2022')).exists();
+          assert
+            .dom(
+              screen.getAllByRole('listitem').find((listItem) => {
+                const childrenText = listItem.textContent.trim().split('\n');
+                return (
+                  childrenText[0]?.trim() === 'Date de dernière connexion :' && childrenText[1]?.trim() === '01/07/2022'
+                );
+              })
+            )
+            .exists();
         });
       });
 
@@ -75,8 +99,13 @@ module('Integration | Component | users | user-detail-personal-information/authe
           );
 
           // then
-          assert.dom(screen.getByText('Date de dernière connexion :')).exists();
-          assert.dom(screen.queryByText('Invalid date')).doesNotExist();
+          assert
+            .dom(
+              screen
+                .getAllByRole('listitem')
+                .find((listItem) => listItem.textContent?.trim() === 'Date de dernière connexion :')
+            )
+            .exists();
         });
       });
 
@@ -99,13 +128,18 @@ module('Integration | Component | users | user-detail-personal-information/authe
           );
 
           // then
-          const shouldChangePasswordLabelElement = screen.getByText(
-            `${this.intl.t(
-              'components.users.user-detail-personal-information.authentication-method.should-change-password-status'
-            )}`
+          const expectedLabel = this.intl.t(
+            'components.users.user-detail-personal-information.authentication-method.should-change-password-status'
           );
-          assert.dom(shouldChangePasswordLabelElement).exists();
-          assert.dom(shouldChangePasswordLabelElement.nextElementSibling).hasText(this.intl.t('common.words.yes'));
+          const expectedValue = this.intl.t('common.words.yes');
+          assert
+            .dom(
+              screen.getAllByRole('listitem').find((listItem) => {
+                const childrenText = listItem.textContent.trim().split('\n');
+                return childrenText[0]?.trim() === expectedLabel && childrenText[1]?.trim() === expectedValue;
+              })
+            )
+            .exists();
         });
       });
 

--- a/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
+++ b/admin/tests/integration/components/users/user-detail-personal-information/authentication-method_test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 import { hbs } from 'ember-cli-htmlbars';
 import { render } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
 import sinon from 'sinon';
 
 module('Integration | Component | users | user-detail-personal-information/authentication-method', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   module('When the admin member has access to users actions scope', function () {
     class AccessControlStub extends Service {
@@ -77,6 +77,35 @@ module('Integration | Component | users | user-detail-personal-information/authe
           // then
           assert.dom(screen.getByText('Date de dernière connexion :')).exists();
           assert.dom(screen.queryByText('Invalid date')).doesNotExist();
+        });
+      });
+
+      module('when user has a PIX authentication method', function () {
+        test('it displays the should change password status', async function (assert) {
+          // given
+          this.set('user', {
+            authenticationMethods: [
+              {
+                identityProvider: 'PIX',
+                authenticationComplement: { shouldChangePassword: true },
+              },
+            ],
+          });
+          this.owner.register('service:access-control', AccessControlStub);
+
+          // when
+          const screen = await render(
+            hbs`<Users::UserDetailPersonalInformation::AuthenticationMethod @user={{this.user}} />`
+          );
+
+          // then
+          const shouldChangePasswordLabelElement = screen.getByText(
+            `${this.intl.t(
+              'components.users.user-detail-personal-information.authentication-method.should-change-password-status'
+            )}`
+          );
+          assert.dom(shouldChangePasswordLabelElement).exists();
+          assert.dom(shouldChangePasswordLabelElement.nextElementSibling).hasText(this.intl.t('common.words.yes'));
         });
       });
 

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -7,6 +7,10 @@
       "login-user-blocked-error": "Your account has reached the maximum number of failed login attempts and has been temporarily blocked. Please <a href=\"{url}\">contact us</a> to unblock it.",
     "internal-server-error": "An error occurred, our teams are working on finding a solution. Please try again later.",
       "gateway-timeout-error": "The service is being slow. Please try again later."
+    },
+    "words": {
+      "yes": "Yes",
+      "no": "No"
     }
   },
   "pages": {
@@ -20,6 +24,13 @@
     "organizations": {
       "all-tags": {
         "recently-used-tags": "List of tags recently used with {tagName}"
+      }
+    },
+    "users": {
+      "user-detail-personal-information": {
+        "authentication-method": {
+          "should-change-password-status": "Temporary password :"
+        }
       }
     }
   }

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -7,6 +7,10 @@
       "login-user-blocked-error": "Votre compte est bloqué car vous avez effectué trop de tentatives de connexion. Pour le débloquer, <a href=\"{url}\">contactez-nous</a>.",
     "internal-server-error": "Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.",
       "gateway-timeout-error": "Le service subit des ralentissements. Veuillez réessayer ultérieurement."
+    },
+    "words": {
+      "yes": "Oui",
+      "no": "Non"
     }
   },
   "pages": {
@@ -20,6 +24,13 @@
     "organizations": {
       "all-tags": {
         "recently-used-tags": "Liste de tags récemment utilisés avec {tagName}"
+      }
+    },
+    "users": {
+      "user-detail-personal-information": {
+        "authentication-method": {
+          "should-change-password-status": "Mot de passe temporaire :"
+        }
       }
     }
   }

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -108,7 +108,11 @@ module.exports = {
     }
 
     const authenticationMethodsDTO = await knex('authentication-methods')
-      .select(['authentication-methods.id', 'identityProvider'])
+      .select([
+        'authentication-methods.id',
+        'authentication-methods.identityProvider',
+        'authentication-methods.authenticationComplement',
+      ])
       .join('users', 'users.id', 'authentication-methods.userId')
       .where({ userId });
 
@@ -433,6 +437,16 @@ function _fromKnexDTOToUserDetailsForAdmin({ userDTO, organizationLearnersDTO, a
     temporaryBlockedUntil: userDTO.temporaryBlockedUntil,
     blockedAt: userDTO.blockedAt,
   });
+
+  const authenticationMethods = authenticationMethodsDTO.map((authenticationMethod) => {
+    // eslint-disable-next-line no-unused-vars
+    const { password, ...authenticationComplement } = authenticationMethod.authenticationComplement;
+    return {
+      ...authenticationMethod,
+      authenticationComplement,
+    };
+  });
+
   return new UserDetailsForAdmin({
     id: userDTO.id,
     firstName: userDTO.firstName,
@@ -449,7 +463,7 @@ function _fromKnexDTOToUserDetailsForAdmin({ userDTO, organizationLearnersDTO, a
     lastLoggedAt: userDTO.lastLoggedAt,
     emailConfirmedAt: userDTO.emailConfirmedAt,
     organizationLearners,
-    authenticationMethods: authenticationMethodsDTO,
+    authenticationMethods,
     userLogin,
     hasBeenAnonymised: userDTO.hasBeenAnonymised,
     updatedAt: userDTO.updatedAt,

--- a/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
@@ -56,7 +56,7 @@ module.exports = {
       authenticationMethods: {
         ref: 'id',
         includes: true,
-        attributes: ['identityProvider'],
+        attributes: ['identityProvider', 'authenticationComplement'],
       },
       userLogin: {
         ref: 'id',

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -1119,12 +1119,13 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
       });
 
       context('when user has authentication methods', function () {
-        it('should return the user with his authentication methods', async function () {
+        it('returns the user with his authentication methods', async function () {
           // given
           const userInDB = databaseBuilder.factory.buildUser(userToInsert);
-          databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
-            userId: userInDB.id,
-          });
+          const expectedPixAuthenticationMethod =
+            databaseBuilder.factory.buildAuthenticationMethod.withPixAsIdentityProviderAndHashedPassword({
+              userId: userInDB.id,
+            });
           databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({ userId: userInDB.id });
           await databaseBuilder.commit();
 
@@ -1132,7 +1133,17 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
           const userDetailsForAdmin = await userRepository.getUserDetailsForAdmin(userInDB.id);
 
           // then
+          const pixAuthenticationMethod = userDetailsForAdmin.authenticationMethods.find(
+            ({ identityProvider }) => identityProvider === AuthenticationMethod.identityProviders.PIX
+          );
           expect(userDetailsForAdmin.authenticationMethods.length).to.equal(2);
+          expect(pixAuthenticationMethod).to.deep.equal({
+            authenticationComplement: {
+              shouldChangePassword: false,
+            },
+            id: expectedPixAuthenticationMethod.id,
+            identityProvider: AuthenticationMethod.identityProviders.PIX,
+          });
         });
       });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-details-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-details-for-admin-serializer_test.js
@@ -3,7 +3,7 @@ const serializer = require('../../../../../lib/infrastructure/serializers/jsonap
 
 describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', function () {
   describe('#serialize', function () {
-    it('should serialize user details for Pix Admin', function () {
+    it('serializes user details for Pix Admin', function () {
       // given
       const now = new Date();
       const userDetailsForAdmin = domainBuilder.buildUserDetailsForAdmin({
@@ -17,7 +17,9 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
         hasBeenAnonymised: false,
         anonymisedByFullName: null,
         organizationLearners: [domainBuilder.buildOrganizationLearnerForAdmin()],
-        authenticationMethods: [{ id: 1, identityProvider: 'PIX' }],
+        authenticationMethods: [
+          { id: 1, identityProvider: 'PIX', authenticationComplement: { shouldChangePassword: true } },
+        ],
         userLogin: [{ id: 123, failureCount: 8 }],
       });
 
@@ -115,6 +117,7 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', func
           {
             attributes: {
               'identity-provider': userDetailsForAdmin.authenticationMethods[0].identityProvider,
+              'authentication-complement': { shouldChangePassword: true },
             },
             id: `${userDetailsForAdmin.authenticationMethods[0].id}`,
             type: 'authenticationMethods',


### PR DESCRIPTION
## :egg: Problème

Actuellement, il n'est pas possible de retrouver l'information suivante : le **mot de passe est temporaire** (si l'utilisateur doit changer son mot de passe).

## :bowl_with_spoon: Proposition

Afficher, au niveau du cadre concernant les méthodes d'authentification d'un utilisateur, l'information mentionnée ci-dessus.

## :milk_glass: Remarques

RAS

## :butter: Pour tester

- Se connecter à [Pix Admin](https://admin-pr5519.review.pix.fr/)
- Allez sur la page de détails d'un utilisateur (ex: userpix1@example.net, ou ce [lien](http://admin.dev.pix.fr/users/1))
- Constater, dans le cadre `Méthodes de connexion`, l'affichage du statut du mot de passe (temporaire ou non)
- (en local) Modifier en base de données pour cet utilisateur, dans la table `authentication-methods`, l'attribut `authenticationComplement.shouldChangePassword` dans la méthode d'authentification PIX 
- Constater que le statut du mot de passe a été modifié
- Anonymiser l'utilisateur ce qui entrainera la suppression de la méthode d'authentification PIX
- Constater que le statut du mot de passe n'est plus affiché
