### PR TITLE
[BUGFIX] La pages des résultats dans PixOrga ne s'affiche pas (PIX-6847).

### DIFF
--- a/api/lib/domain/read-models/campaign-results/CampaignAssessmentParticipationResultMinimal.js
+++ b/api/lib/domain/read-models/campaign-results/CampaignAssessmentParticipationResultMinimal.js
@@ -7,7 +7,8 @@ class CampaignAssessmentParticipationResultMinimal {
     this.lastName = lastName;
     this.participantExternalId = participantExternalId;
     this.masteryRate = !_.isNil(masteryRate) ? Number(masteryRate) : null;
-    this.badges = badges;
+    //TODO REMOVE WHEN https://1024pix.atlassian.net/browse/PIX-6849 IS DONE
+    this.badges = _.uniqBy(badges, 'id');
   }
 }
 

--- a/api/tests/unit/domain/read-models/campaign-results/CampaignAssessmentParticipationResultMinimal_test.js
+++ b/api/tests/unit/domain/read-models/campaign-results/CampaignAssessmentParticipationResultMinimal_test.js
@@ -72,4 +72,16 @@ describe('Unit | Domain | Read-Models | CampaignResults | CampaignAssessmentPart
       });
     });
   });
+
+  describe('badges', function () {
+    it('keeps only once each badge', function () {
+      // when
+      const campaignAssessmentParticipationResultMinimal = new CampaignAssessmentParticipationResultMinimal({
+        badges: [{ id: 1 }, { id: 1 }, { id: 2 }, { id: 2 }, { id: 3 }, { id: 3 }, { id: 3 }],
+      });
+
+      // then
+      expect(campaignAssessmentParticipationResultMinimal.badges).to.exactlyContain([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    });
+  });
 });


### PR DESCRIPTION
## :egg: Problème
La pages des résultats dans PIxOrga ne s'affiche pas

## :bowl_with_spoon: Proposition
Les badges sont dupliqués en BDD et Ember n'arrive pas a récupérer les badges d'une participation quand il y a a la fois des badges dupliqués et des badges non dupliqués dans la liste.
Faire un quick fix qui permet d'afficher la page en supprimant les données dupliquées avant de les envoyer au front.



## :milk_glass: Remarques
Solution temporaire en attendant ce ticket https://1024pix.atlassian.net/browse/PIX-6849

## :butter: Pour tester
Rajouter des badges à une participation, il faut que la participation ait des badges dupliqués et des badges non dupliqués.
La pages résultats d'une campagne doit s'afficher correctement
