### PR TITLE
[BUGFIX] Retirer une classe non utilisée après un mise à jour de PixUI (PIX-6636).

### DIFF
--- a/orga/app/styles/pages/authenticated/campaigns/create-form.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/create-form.scss
@@ -17,24 +17,19 @@
   }
 }
 .form__field-with-info {
-  .pix-filterable-and-searchable-select {
-    @include device-is('desktop') {
-      width: 500px;
-    }
-  }
-  
+
   .pix-multi-select {
     @include device-is('desktop') {
       width: 140px;
     }
   }
-  
-  
+
+
   .pix-select {
     @include device-is('desktop') {
       width: 360px !important;
     }
-  
+
     &__dropdown {
       overflow-x: hidden;
     }


### PR DESCRIPTION
## :egg: Problème
Une classe css n'est plus utile après la mise à jour de PixUi

## :bowl_with_spoon: Proposition
Supprimer la classe inutile

## :milk_glass: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :butter: Pour tester
Vérifier que le selecteur de "parcours" s'affiche correctement.
