### PR TITLE
[FEATURE] Ajouter les certifs complémentaires habilitées sur le CSV d'import en masse (PIX-6178).

### DIFF
--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -172,8 +172,12 @@ module.exports = {
     return h.response(serializedCertificationCenterInvitation);
   },
 
-  getSessionsImportTemplate(_, h) {
-    const headers = getHeaders();
+  async getSessionsImportTemplate(request, h) {
+    const certificationCenterId = request.params.certificationCenterId;
+    const habilitationLabels = await usecases.getImportSessionComplementaryCertificationHabilitationsLabels({
+      certificationCenterId,
+    });
+    const headers = getHeaders(habilitationLabels);
     return h
       .response(headers)
       .header('Content-Type', 'text/csv; charset=utf-8')

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -13,6 +13,7 @@ const queryParamsUtils = require('../../infrastructure/utils/query-params-utils'
 const map = require('lodash/map');
 const csvHelpers = require('../../../scripts/helpers/csvHelpers');
 const csvSerializer = require('../../infrastructure/serializers/csv/csv-serializer');
+const { getHeaders } = require('../../infrastructure/files/sessions-import');
 
 module.exports = {
   async saveSession(request) {
@@ -169,6 +170,15 @@ module.exports = {
       return h.response(serializedCertificationCenterInvitation).created();
     }
     return h.response(serializedCertificationCenterInvitation);
+  },
+
+  getSessionsImportTemplate(_, h) {
+    const headers = getHeaders();
+    return h
+      .response(headers)
+      .header('Content-Type', 'text/csv; charset=utf-8')
+      .header('content-disposition', 'filename=import-sessions')
+      .code(200);
   },
 
   async importSessions(request, h) {

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -171,6 +171,18 @@ exports.register = async function (server) {
       },
     },
     {
+      method: 'GET',
+      path: '/api/certification-centers/import',
+      config: {
+        handler: certificationCenterController.getSessionsImportTemplate,
+        tags: ['api', 'sessions'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            '- Elle permet de récupérer le fichier de création de sessions de certification',
+        ],
+      },
+    },
+    {
       method: 'POST',
       path: '/api/certification-centers/{certificationCenterId}/sessions/import',
       config: {

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -172,8 +172,17 @@ exports.register = async function (server) {
     },
     {
       method: 'GET',
-      path: '/api/certification-centers/import',
+      path: '/api/certification-centers/{certificationCenterId}/import',
       config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsMemberOfCertificationCenter,
+            assign: 'isMemberOfCertificationCenter',
+          },
+        ],
+        validate: {
+          params: Joi.object({ certificationCenterId: identifiersType.certificationCenterId }),
+        },
         handler: certificationCenterController.getSessionsImportTemplate,
         tags: ['api', 'sessions'],
         notes: [

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -785,18 +785,6 @@ exports.register = async (server) => {
         ],
       },
     },
-    {
-      method: 'GET',
-      path: '/api/sessions/import',
-      config: {
-        handler: sessionController.getSessionsImportTemplate,
-        tags: ['api', 'sessions'],
-        notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-            '- Elle permet de récupérer le fichier de création de sessions de certification',
-        ],
-      },
-    },
   ]);
 };
 

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -17,7 +17,6 @@ const queryParamsUtils = require('../../infrastructure/utils/query-params-utils'
 const requestResponseUtils = require('../../infrastructure/utils/request-response-utils');
 const certificationResultUtils = require('../../infrastructure/utils/csv/certification-results');
 const fillCandidatesImportSheet = require('../../infrastructure/files/candidates-import/fill-candidates-import-sheet');
-const { getHeaders } = require('../../infrastructure/files/sessions-import');
 const supervisorKitPdf = require('../../infrastructure/utils/pdf/supervisor-kit-pdf');
 const trim = require('lodash/trim');
 const UserLinkedToCertificationCandidate = require('../../domain/events/UserLinkedToCertificationCandidate');
@@ -338,15 +337,6 @@ module.exports = {
     await usecases.deleteSessionJuryComment({ sessionId });
 
     return h.response().code(204);
-  },
-
-  getSessionsImportTemplate(_, h) {
-    const headers = getHeaders();
-    return h
-      .response(headers)
-      .header('Content-Type', 'text/csv; charset=utf-8')
-      .header('content-disposition', 'filename=import-sessions')
-      .code(200);
   },
 };
 

--- a/api/lib/domain/usecases/get-import-session-complementary-certification-habilitations-labels.js
+++ b/api/lib/domain/usecases/get-import-session-complementary-certification-habilitations-labels.js
@@ -1,0 +1,12 @@
+module.exports = async function getImportSessionComplementaryCertificationHabilitationsLabels({
+  certificationCenterId,
+  complementaryCertificationHabilitationRepository,
+}) {
+  const habilitations = await complementaryCertificationHabilitationRepository.findByCertificationCenterId(
+    certificationCenterId
+  );
+
+  const habilitationsLabels = habilitations.map((habilitation) => habilitation.label);
+
+  return habilitationsLabels;
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -335,6 +335,7 @@ module.exports = injectDependencies(
     getExternalAuthenticationRedirectionUrl: require('./get-external-authentication-redirection-url'),
     getFrameworkAreas: require('./get-framework-areas'),
     getFrameworks: require('./get-frameworks'),
+    getImportSessionComplementaryCertificationHabilitationsLabels: require('./get-import-session-complementary-certification-habilitations-labels'),
     getJuryCertification: require('./get-jury-certification'),
     getJurySession: require('./get-jury-session'),
     getLastChallengeIdFromAssessmentId: require('./get-last-challenge-id-from-assessment-id'),

--- a/api/lib/infrastructure/files/sessions-import.js
+++ b/api/lib/infrastructure/files/sessions-import.js
@@ -1,8 +1,9 @@
 const { Parser } = require('json2csv');
 const { headers } = require('../utils/csv/sessions-import');
 
-function getHeaders() {
-  const fields = _getHeadersAsArray();
+function getHeaders(habilitationLabels) {
+  const complementaryCertificationsHeaders = _getComplementaryCertificationsHeaders(habilitationLabels);
+  const fields = _getHeadersAsArray(complementaryCertificationsHeaders);
   const json2csvParser = new Parser({
     withBOM: true,
     includeEmptyRows: false,
@@ -12,8 +13,13 @@ function getHeaders() {
   return json2csvParser.parse();
 }
 
-function _getHeadersAsArray() {
-  return Object.keys(headers).reduce((arr, key) => [...arr, headers[key]], []);
+function _getComplementaryCertificationsHeaders(habilitationLabels) {
+  return habilitationLabels?.map((habilitationLabel) => `${habilitationLabel} ('oui' ou laisser vide)`);
+}
+
+function _getHeadersAsArray(complementaryCertificationsHeaders = []) {
+  const csvHeaders = Object.keys(headers).reduce((arr, key) => [...arr, headers[key]], []);
+  return [...csvHeaders, ...complementaryCertificationsHeaders];
 }
 
 module.exports = { getHeaders };

--- a/api/tests/acceptance/application/certification-centers/certification-center-controller-get-import-template_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-center-controller-get-import-template_test.js
@@ -9,7 +9,7 @@ describe('Acceptance | Controller | certification-center-controller-get-import-t
   });
 
   describe('GET /api/certification-centers/{certificationCenterId}/import', function () {
-    context('when user requests sessions import template', function () {
+    describe('when user requests sessions import template', function () {
       it('should return a csv file', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;

--- a/api/tests/acceptance/application/certification-centers/certification-center-controller-get-import-template_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-center-controller-get-import-template_test.js
@@ -1,14 +1,14 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 const createServer = require('../../../../server');
 
-describe('Acceptance | Controller | session-controller-get-import-template', function () {
+describe('Acceptance | Controller | certification-center-controller-get-import-template', function () {
   let server;
 
   beforeEach(async function () {
     server = await createServer();
   });
 
-  describe('GET /api/sessions/import', function () {
+  describe('GET /api/certification-centers/import', function () {
     context('when user requests sessions import template', function () {
       it('should return a csv file', async function () {
         // given
@@ -18,7 +18,7 @@ describe('Acceptance | Controller | session-controller-get-import-template', fun
         // when
         const response = await server.inject({
           method: 'GET',
-          url: '/api/sessions/import',
+          url: '/api/certification-centers/import',
           payload: {},
           headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
         });

--- a/api/tests/acceptance/application/certification-centers/certification-center-controller-get-import-template_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-center-controller-get-import-template_test.js
@@ -8,17 +8,19 @@ describe('Acceptance | Controller | certification-center-controller-get-import-t
     server = await createServer();
   });
 
-  describe('GET /api/certification-centers/import', function () {
+  describe('GET /api/certification-centers/{certificationCenterId}/import', function () {
     context('when user requests sessions import template', function () {
       it('should return a csv file', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
         await databaseBuilder.commit();
 
         // when
         const response = await server.inject({
           method: 'GET',
-          url: '/api/certification-centers/import',
+          url: `/api/certification-centers/${certificationCenterId}/import`,
           payload: {},
           headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
         });

--- a/api/tests/integration/infrastructure/utils/csv/sessions-import_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/sessions-import_test.js
@@ -3,13 +3,30 @@ const { getHeaders } = require('../../../../../lib/infrastructure/files/sessions
 const BOM_CHAR = '\ufeff';
 describe('Integration | Infrastructure | Utils | csv | sessions-import', function () {
   context('#getHeaders', function () {
-    it('should return the correct values', function () {
-      // when
-      const result = getHeaders();
+    context('when no habilitation labels are passed', function () {
+      it('should return the correct values without complementary certification columns', function () {
+        // when
+        const habilitationLabels = [];
+        const result = getHeaders(habilitationLabels);
 
-      // then
-      const expectedResult = `${BOM_CHAR}"N° de session";"* Nom du site";"* Nom de la salle";"* Date de début";"* Heure de début (heure locale)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: jj/mm/aaaa)";"* Sexe (M ou F)";"Code Insee";"Code postal";"Nom de la commune";"* Pays";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant local";"Temps majoré ?";"Tarification part Pix";"Code de prépaiement"`;
-      expect(result).to.equal(expectedResult);
+        // then
+        const expectedResult = `${BOM_CHAR}"N° de session";"* Nom du site";"* Nom de la salle";"* Date de début";"* Heure de début (heure locale)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: jj/mm/aaaa)";"* Sexe (M ou F)";"Code Insee";"Code postal";"Nom de la commune";"* Pays";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant local";"Temps majoré ?";"Tarification part Pix";"Code de prépaiement"`;
+        expect(result).to.equal(expectedResult);
+      });
+    });
+
+    context('when habilitation labels are passed', function () {
+      it('should return the correct values with complementary certification columns', function () {
+        // given
+        const habilitationLabels = ['Pix 1', 'Pix 2'];
+
+        // when
+        const result = getHeaders(habilitationLabels);
+
+        // then
+        const expectedResult = `${BOM_CHAR}"N° de session";"* Nom du site";"* Nom de la salle";"* Date de début";"* Heure de début (heure locale)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: jj/mm/aaaa)";"* Sexe (M ou F)";"Code Insee";"Code postal";"Nom de la commune";"* Pays";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant local";"Temps majoré ?";"Tarification part Pix";"Code de prépaiement";"Pix 1 ('oui' ou laisser vide)";"Pix 2 ('oui' ou laisser vide)"`;
+        expect(result).to.equal(expectedResult);
+      });
     });
   });
 });

--- a/api/tests/unit/application/certification-centers/index_test.js
+++ b/api/tests/unit/application/certification-centers/index_test.js
@@ -361,4 +361,20 @@ describe('Unit | Router | certification-center-router', function () {
       expect(response.statusCode).to.equal(200);
     });
   });
+
+  describe('GET /api/certification-centers/{certificationCenterId}/import', function () {
+    it('should exist', async function () {
+      // given
+      sinon.stub(securityPreHandlers, 'checkUserIsMemberOfCertificationCenter').callsFake((_, h) => h.response(true));
+      sinon.stub(certificationCenterController, 'getSessionsImportTemplate').returns('ok');
+      const httpTestServer = new HttpTestServer();
+      await httpTestServer.register(moduleUnderTest);
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/certification-centers/123/import');
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
 });

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -1027,18 +1027,4 @@ describe('Unit | Application | Sessions | Routes', function () {
       expect(response.statusCode).to.equal(200);
     });
   });
-
-  describe('GET /api/sessions/import', function () {
-    it('should exist', async function () {
-      // given
-      const httpTestServer = new HttpTestServer();
-      await httpTestServer.register(moduleUnderTest);
-
-      // when
-      const response = await httpTestServer.request('GET', '/api/sessions/import');
-
-      // then
-      expect(response.statusCode).to.equal(200);
-    });
-  });
 });

--- a/api/tests/unit/domain/usecases/get-import-session-complementary-certification-habilitations-labels_test.js
+++ b/api/tests/unit/domain/usecases/get-import-session-complementary-certification-habilitations-labels_test.js
@@ -1,0 +1,27 @@
+const { sinon, expect, domainBuilder } = require('../../../test-helper');
+const getImportSessionComplementaryCertificationHabilitationsLabels = require('../../../../lib/domain/usecases/get-import-session-complementary-certification-habilitations-labels');
+
+describe('Unit | Usecase | get-import-session-complementary-certification-habilitations-labels', function () {
+  it('should return the certification center  habilitations labels', async function () {
+    // given
+    const complementaryCertificationHabilitationRepository = { findByCertificationCenterId: sinon.stub() };
+    complementaryCertificationHabilitationRepository.findByCertificationCenterId.withArgs(123).resolves([
+      domainBuilder.buildComplementaryCertification({
+        label: 'Pix Plus Toto',
+      }),
+      domainBuilder.buildComplementaryCertification({
+        label: 'Pix Plus Tata',
+      }),
+    ]);
+
+    // when
+    const habilitationsLabels = await getImportSessionComplementaryCertificationHabilitationsLabels({
+      certificationCenterId: 123,
+      complementaryCertificationHabilitationRepository,
+    });
+
+    // then
+    const expectedHabilitationsLabels = ['Pix Plus Toto', 'Pix Plus Tata'];
+    expect(habilitationsLabels).to.deepEqualInstance(expectedHabilitationsLabels);
+  });
+});

--- a/certif/app/components/sessions/panel-header.js
+++ b/certif/app/components/sessions/panel-header.js
@@ -17,7 +17,7 @@ export default class PanelHeader extends Component {
 
   @action
   async downloadSessionImportTemplate() {
-    const url = '/api/sessions/import';
+    const url = '/api/certification-centers/import';
     const token = this.session.data.authenticated.access_token;
     try {
       await this.fileSaver.save({ url, token });

--- a/certif/app/components/sessions/panel-header.js
+++ b/certif/app/components/sessions/panel-header.js
@@ -17,7 +17,8 @@ export default class PanelHeader extends Component {
 
   @action
   async downloadSessionImportTemplate() {
-    const url = '/api/certification-centers/import';
+    const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
+    const url = `/api/certification-centers/${certificationCenterId}/import`;
     const token = this.session.data.authenticated.access_token;
     try {
       await this.fileSaver.save({ url, token });

--- a/certif/tests/unit/components/sessions/panel-header_test.js
+++ b/certif/tests/unit/components/sessions/panel-header_test.js
@@ -37,7 +37,7 @@ module('Unit | Component | panel-header', function (hooks) {
       assert.ok(
         component.fileSaver.save.calledWith({
           token,
-          url: `/api/sessions/import`,
+          url: '/api/certification-centers/import',
         })
       );
     });

--- a/certif/tests/unit/components/sessions/panel-header_test.js
+++ b/certif/tests/unit/components/sessions/panel-header_test.js
@@ -13,7 +13,19 @@ module('Unit | Component | panel-header', function (hooks) {
     component = createGlimmerComponent('component:sessions/panel-header');
   });
 
-  module('#downloadSessionImportTemplate', function () {
+  module('#downloadSessionImportTemplate', function (hooks) {
+    hooks.beforeEach(function () {
+      const store = this.owner.lookup('service:store');
+      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+        id: 123,
+      });
+      class CurrentUserStub extends Service {
+        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+    });
+
     test('should call the file-saver service for downloadSessionImportTemplate with the right parameters', async function (assert) {
       // given
       const token = 'a token';
@@ -37,7 +49,7 @@ module('Unit | Component | panel-header', function (hooks) {
       assert.ok(
         component.fileSaver.save.calledWith({
           token,
-          url: '/api/certification-centers/import',
+          url: '/api/certification-centers/123/import',
         })
       );
     });


### PR DESCRIPTION
## :egg: Problème

Le fichier CSV d'import en masse de sessions ne contient actuellement pas les colonnes des certifications complémentaires habilitées pour le centre de certification duquel provient la demande de téléchargement du template.

## :bowl_with_spoon: Proposition

Récupération des certifications complémentaires habilitées pour le centre de certification en question

## :milk_glass: Remarques

- La route de téléchargement du template a été déplacée de `sessions` vers `certification-centers`

## :butter: Pour tester

Dans Pix-Orga, vérifier l'habilitation aux certification complémentaires du centre de certification avec lequel vous allez vous connecter sur Pix-Certif.

Une fois connecté sur Pix-Certif:
- Si le CDC n'a pas d'habilitation à des certifications complémentaires, vérifier que le template CSV d'import de session ne comporte pas de colonnes comportant le nom des certifs complémentaires à la fin du fichier
- Si le CDC a une ou plusieurs habilitations à des certifications complémentaires, vérifier que le template CSV d'import de session comporte la ou les colonnes comportant le nom des certifs complémentaires autorisées à la fin du fichier
