### PR TITLE
[FEATURE] Ajouter une route API pour récupérer un contenu formatif à partir de son ID (PIX-6732)

### DIFF
--- a/api/lib/application/trainings/index.js
+++ b/api/lib/application/trainings/index.js
@@ -39,6 +39,34 @@ exports.register = async (server) => {
       },
     },
     {
+      method: 'GET',
+      path: '/api/admin/trainings/{trainingId}',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            trainingId: identifiersType.trainingId,
+          }),
+        },
+        handler: trainingsController.getById,
+        tags: ['api', 'admin', 'trainings'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            '- Elle permet de récupérer un contenu formatif spécifique',
+        ],
+      },
+    },
+    {
       method: 'POST',
       path: '/api/admin/trainings',
       config: {

--- a/api/lib/application/trainings/training-controller.js
+++ b/api/lib/application/trainings/training-controller.js
@@ -9,6 +9,11 @@ module.exports = {
     const { trainings, meta } = await usecases.findPaginatedTrainingSummaries({ page });
     return trainingSummarySerializer.serialize(trainings, meta);
   },
+  async getById(request) {
+    const { trainingId } = request.params;
+    const training = await usecases.getTraining({ trainingId });
+    return trainingSerializer.serialize(training);
+  },
   async create(request, h) {
     const deserializedTraining = await trainingSerializer.deserialize(request.payload);
     const createdTraining = await usecases.createTraining({ training: deserializedTraining });

--- a/api/lib/domain/usecases/get-training.js
+++ b/api/lib/domain/usecases/get-training.js
@@ -1,0 +1,3 @@
+module.exports = function getTraining({ trainingId, trainingRepository }) {
+  return trainingRepository.get(trainingId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -374,6 +374,7 @@ module.exports = injectDependencies(
     getSupervisorKitSessionInfo: require('./get-supervisor-kit-session-info'),
     getTargetProfileContentAsJson: require('./get-target-profile-content-as-json'),
     getTargetProfileForAdmin: require('./get-target-profile-for-admin'),
+    getTraining: require('./get-training'),
     getUserByResetPasswordDemand: require('./get-user-by-reset-password-demand'),
     getUserCampaignAssessmentResult: require('./get-user-campaign-assessment-result'),
     getUserCampaignParticipationToCampaign: require('./get-user-campaign-participation-to-campaign'),

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -13,6 +13,49 @@ describe('Acceptance | Controller | training-controller', function () {
     server = await createServer();
   });
 
+  describe('GET /api/admin/trainings/{trainingId}', function () {
+    it('should get a training with the specific id', async function () {
+      // given
+      const superAdmin = await insertUserWithRoleSuperAdmin();
+      databaseBuilder.factory.buildTraining();
+      const { id: trainingId, ...trainingAttributes } = databaseBuilder.factory.buildTraining();
+      await databaseBuilder.commit();
+
+      const expectedResponse = {
+        type: 'trainings',
+        id: `${trainingId}`,
+        attributes: {
+          title: trainingAttributes.title,
+          type: trainingAttributes.type,
+          link: trainingAttributes.link,
+          locale: trainingAttributes.locale,
+          duration: {
+            hours: 6,
+          },
+          'editor-logo-url': trainingAttributes.editorLogoUrl,
+          'editor-name': trainingAttributes.editorName,
+          'goal-threshold': trainingAttributes.goalThreshold,
+          'prerequisite-threshold': trainingAttributes.prerequisiteThreshold,
+        },
+      };
+
+      // when
+      const response = await server.inject({
+        method: 'GET',
+        url: `/api/admin/trainings/${trainingId}`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(superAdmin.id),
+        },
+      });
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data.type).to.equal(expectedResponse.type);
+      expect(response.result.data.id).to.equal(expectedResponse.id);
+      expect(response.result.data.attributes).to.deep.equal(expectedResponse.attributes);
+    });
+  });
+
   describe('POST /api/admin/trainings', function () {
     it('should create a new training and response with a 201', async function () {
       // given

--- a/api/tests/unit/application/trainings/training-controller_test.js
+++ b/api/tests/unit/application/trainings/training-controller_test.js
@@ -37,6 +37,30 @@ describe('Unit | Controller | training-controller', function () {
     });
   });
 
+  describe('#getById', function () {
+    it('should get training by id', async function () {
+      // given
+      const expectedResult = Symbol('serialized-trainings');
+      const training = Symbol('training');
+      const trainingId = 1;
+
+      sinon.stub(usecases, 'getTraining').resolves(training);
+      sinon.stub(trainingSerializer, 'serialize').returns(expectedResult);
+
+      // when
+      const response = await trainingController.getById({
+        params: {
+          trainingId,
+        },
+      });
+
+      // then
+      expect(usecases.getTraining).to.have.been.calledWith({ trainingId });
+      expect(trainingSerializer.serialize).to.have.been.calledOnce;
+      expect(response).to.deep.equal(expectedResult);
+    });
+  });
+
   describe('#create', function () {
     const deserializedTraining = {
       title: 'Training title',

--- a/api/tests/unit/domain/usecases/get-training_test.js
+++ b/api/tests/unit/domain/usecases/get-training_test.js
@@ -1,0 +1,42 @@
+const { expect, sinon, catchErr } = require('../../../test-helper');
+const getTraining = require('../../../../lib/domain/usecases/get-training');
+const { NotFoundError } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | get-training', function () {
+  let trainingRepository;
+
+  beforeEach(function () {
+    trainingRepository = {
+      get: sinon.stub(),
+    };
+  });
+
+  context('when the training exists', function () {
+    it('should return an existing training', async function () {
+      // given
+      const trainingId = 1;
+      const trainingToFind = Symbol('existing-training');
+      trainingRepository.get.withArgs(trainingId).resolves(trainingToFind);
+
+      // when
+      const training = await getTraining({ trainingId, trainingRepository });
+
+      // then
+      expect(training).to.equal(trainingToFind);
+    });
+  });
+
+  context('when the training does not exist', function () {
+    it('should throw an error', async function () {
+      // given
+      const trainingId = 123;
+      trainingRepository.get.withArgs(trainingId).rejects(new NotFoundError());
+
+      // when
+      const err = await catchErr(getTraining)({ trainingId, trainingRepository });
+
+      // then
+      expect(err).to.be.an.instanceof(NotFoundError);
+    });
+  });
+});


### PR DESCRIPTION
## :egg: Problème

On souhaite récupérer les informations d'un contenu formatif grâce à son ID.

## :bowl_with_spoon: Proposition

Création de la route API `/api/admin/trainings/{trainingId}`

## :butter: Pour tester

- Se connecter sur Pix Admin en local, avec un compte METIER ou SUPER_ADMIN
- Récupérer le token d'auth
- Lancer l'API en local
- Lancer la requête cURL :

```
TOKEN=$(curl 'https://api-pr5523.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin%40example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl 'https://api-pr5523.review.pix.fr/api/admin/trainings/101034' \
  -H "authorization: Bearer $TOKEN" \
  -H 'content-type: application/json' | jq 
```
