### PR TITLE
[BUGFIX] On ne peut plus choisir la langue du PDF du profil cible sur PixAdmin dans la modale (PIX-6876)

### DIFF
--- a/admin/app/components/target-profiles/pdf-parameters-modal.hbs
+++ b/admin/app/components/target-profiles/pdf-parameters-modal.hbs
@@ -4,7 +4,9 @@
       @value={{this.language}}
       @onChange={{this.onChangeLanguage}}
       @options={{this.options}}
+      @hideDefaultOption={{true}}
       @label="Langue du référentiel (français ou anglais) :"
+      class="pdf-modal--select"
     />
   </:content>
   <:footer>

--- a/admin/app/components/target-profiles/pdf-parameters-modal.js
+++ b/admin/app/components/target-profiles/pdf-parameters-modal.js
@@ -26,8 +26,8 @@ export default class PdfParametersModal extends Component {
   }
 
   @action
-  onChangeLanguage(event) {
-    this.language = event.target.value;
+  onChangeLanguage(language) {
+    this.language = language;
   }
 
   _isInvalid() {

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -73,6 +73,7 @@
 @import "components/target-profiles/organizations";
 @import "components/target-profiles/stages";
 @import "components/target-profiles/stage-form";
+@import "components/target-profiles/pdf-modal";
 @import "components/team/add-member";
 @import "components/team/list";
 @import "components/badges/badge";

--- a/admin/app/styles/components/target-profiles/pdf-modal.css
+++ b/admin/app/styles/components/target-profiles/pdf-modal.css
@@ -1,0 +1,4 @@
+/* stylelint-disable selector-class-pattern */
+.pdf-modal--select {
+  min-width: 100%;
+}


### PR DESCRIPTION
## :egg: Problème
La modale est toute cassée

## :bowl_with_spoon: Proposition
Il faut la réparer.
- Virer le choix vide
- Ajouter une classe pour remettre le label droit
- Appliquer les modifications récentes PixSelect (ne plus passer par event.target mais par la valeur directement transmise)

## :milk_glass: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :butter: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
