### PR TITLE
[TECH] Un test unitaire du "mailer" est échec en local (PIX-6883)

### DIFF
--- a/api/tests/unit/infrastructure/mailers/mailer_test.js
+++ b/api/tests/unit/infrastructure/mailers/mailer_test.js
@@ -5,8 +5,11 @@ const logger = require('../../../../lib/infrastructure/logger');
 const mailer = require('../../../../lib/infrastructure/mailers/mailer');
 const EmailingAttempt = require('../../../../lib/domain/models/EmailingAttempt');
 
+let mailCheckDomainIsValidStub;
+
 describe('Unit | Infrastructure | Mailers | mailer', function () {
   beforeEach(function () {
+    mailCheckDomainIsValidStub = sinon.stub(mailCheck, 'checkDomainIsValid');
     sinon.stub(mailing, 'provider').value('sendinblue');
   });
 
@@ -136,11 +139,11 @@ function _enableMailing() {
 }
 
 function _mailAddressIsValid(recipient) {
-  sinon.stub(mailCheck, 'checkDomainIsValid').withArgs(recipient).resolves();
+  mailCheckDomainIsValidStub.withArgs(recipient).resolves();
 }
 
 function _mailAddressIsInvalid(recipient, expectedError) {
-  sinon.stub(mailCheck, 'checkDomainIsValid').withArgs(recipient).rejects(expectedError);
+  mailCheckDomainIsValidStub.withArgs(recipient).rejects(expectedError);
 }
 
 function _mockMailingProvider() {


### PR DESCRIPTION
## :egg: Problème
Un test unitaire du `mailer` est en échec en local, car une vérification **DNS** est effectuée (et échoue).

## :bowl_with_spoon: Proposition
En contexte unitaire, les actions externes ne devraient pas être appelées en vrai. Il faut s'assurer que le `mailCheck` est bien stubbé pour tout le test unitaire.

## :milk_glass: Remarques
Aucun impact en prod

## :butter: Pour tester
Fichier de test au vert en local
