### PR TITLE
[FEATURE] Améliorer la sémantique des listes de cartes de compétence (PIX-6817).

### DIFF
--- a/mon-pix/app/components/competence-card-default.hbs
+++ b/mon-pix/app/components/competence-card-default.hbs
@@ -3,7 +3,7 @@
     <div class="competence-card__title">
       <div class="competence-card__wrapper competence-card__wrapper--{{@scorecard.area.color}}">
         <div class="competence-card__area-name">{{@scorecard.area.title}}</div>
-        <div class="competence-card__competence-name">{{@scorecard.name}}</div>
+        <h4 class="competence-card__competence-name">{{@scorecard.name}}</h4>
       </div>
     </div>
 

--- a/mon-pix/app/components/competence-card-mobile.hbs
+++ b/mon-pix/app/components/competence-card-mobile.hbs
@@ -3,7 +3,7 @@
     <span class="competence-card__wrapper competence-card__wrapper--{{@scorecard.area.color}}"></span>
     <div class="competence-card__title">
       <span class="competence-card__area-name">{{@scorecard.area.title}}</span>
-      <span class="competence-card__competence-name">{{@scorecard.name}}</span>
+      <h4 class="competence-card__competence-name">{{@scorecard.name}}</h4>
     </div>
     <div class="competence-card__body" role="img" aria-label="{{scorecard-aria-label @scorecard}}">
       {{#if @scorecard.isFinishedWithMaxLevel}}

--- a/mon-pix/app/components/competence-card/list.hbs
+++ b/mon-pix/app/components/competence-card/list.hbs
@@ -1,7 +1,7 @@
-<section class="competence-card-list">
+<ul class="competence-card-list">
   {{#each @scorecards as |scorecard index|}}
-    <div class="competence-card-list__competence-card competence-card-list__competence-card--{{index}}">
+    <li class="competence-card-list__competence-card competence-card-list__competence-card--{{index}}">
       <CompetenceCard @scorecard={{scorecard}} @interactive={{true}} />
-    </div>
+    </li>
   {{/each}}
-</section>
+</ul>

--- a/mon-pix/app/styles/components/_competence-card-mobile.scss
+++ b/mon-pix/app/styles/components/_competence-card-mobile.scss
@@ -34,7 +34,6 @@
 }
 
 .competence-card__wrapper {
-
   &::after {
     position: absolute;
     top: -90px;
@@ -79,8 +78,12 @@
 
 .competence-card__competence-name {
   position: relative;
+  color: inherit;
   font-weight: $font-medium;
   font-size: 1.125rem;
+  font-family: inherit;
+  line-height: inherit;
+  letter-spacing: inherit;
 }
 
 .competence-card__body {

--- a/mon-pix/app/styles/components/competence-card/_list.scss
+++ b/mon-pix/app/styles/components/competence-card/_list.scss
@@ -3,7 +3,9 @@ $scorecard-width: 212px;
 .competence-card-list {
   display: flex;
   flex-direction: column;
+  margin: 0;
   padding: 0;
+  list-style: none;
 
   &__competence-card {
     margin-bottom: 37px;
@@ -28,7 +30,6 @@ $scorecard-width: 212px;
   }
 
   @media (min-width: 1056px) {
-
     &__competence-card,
     &__competence-card:nth-child(3n) {
       margin-right: calc((100% - #{$scorecard-width} * 4) / 3);


### PR DESCRIPTION
## :egg: Problème

- Les listes de cartes de compétences n'étaient pas des listes HTML
- Les titres de ces cartes n'étaient pas des titres HTML

## :bowl_with_spoon: Proposition

Améliorer la structure HTML de ces listes et de ces cartes.

## :butter: Pour tester

- Visiter https://app-pr5526.review.pix.fr/accueil
- Vérifier que :
  - les `.competence-card-list` soient bien des `<ul>`
  - les `.competence-card-list__competence-card` soient bien des `<li>`
  - les `.competence-card__competence-name` soient bien des `<h4>`
- Vérifier que le style n'a pas changé par rapport à https://app.recette.pix.fr/accueil
