### PR TITLE
[FEATURE] Ajouter un lien sur les Parcours dans l'onglet d'une organisation (PIX-6881)

### DIFF
--- a/admin/app/components/organizations/target-profiles-section.hbs
+++ b/admin/app/components/organizations/target-profiles-section.hbs
@@ -34,14 +34,13 @@
         {{#if @organization.targetProfileSummaries}}
           <tbody>
             {{#each @organization.sortedTargetProfileSummaries as |summary|}}
-              {{! template-lint-disable no-invalid-interactive }}
-              <tr
-                aria-label="Profil cible"
-                {{on "click" (fn this.goToTargetProfilePage summary.id)}}
-                class="tr--clickable"
-              >
+              <tr aria-label="Profil cible">
                 <td class="table__column table__column--id">{{summary.id}}</td>
-                <td>{{summary.name}}</td>
+                <td headers="target-profile-name">
+                  <LinkTo @route="authenticated.target-profiles.target-profile" @model={{summary.id}}>
+                    {{summary.name}}
+                  </LinkTo>
+                </td>
               </tr>
             {{/each}}
           </tbody>

--- a/admin/tests/integration/components/organizations/target-profiles-section_test.js
+++ b/admin/tests/integration/components/organizations/target-profiles-section_test.js
@@ -9,12 +9,15 @@ import sinon from 'sinon';
 module('Integration | Component | organizations/target-profiles-section', function (hooks) {
   setupRenderingTest(hooks);
 
+  let store;
+
   module('when user has access', function (hooks) {
     hooks.beforeEach(function () {
       class AccessControlStub extends Service {
         hasAccessToOrganizationActionsScope = true;
       }
       this.owner.register('service:access-control', AccessControlStub);
+      store = this.owner.lookup('service:store');
     });
 
     test('it disables the button when the input is empty', async function (assert) {
@@ -24,6 +27,7 @@ module('Integration | Component | organizations/target-profiles-section', functi
         targetProfiles: [],
         attachTargetProfiles: sinon.stub(),
       });
+
       this.set('organization', organization);
 
       // when
@@ -52,6 +56,27 @@ module('Integration | Component | organizations/target-profiles-section', functi
 
       // then
       assert.ok(organization.attachTargetProfiles.calledWith({ 'target-profile-ids': ['1'] }));
+    });
+
+    test('it should have a link to redirect on target profile page', async function (assert) {
+      const targetProfileSummary = store.createRecord('target-profile-summary', {
+        id: 666,
+        name: 'Number of The Beast',
+      });
+      const organization = store.createRecord('organization', {
+        id: 1,
+        targetProfiles: [],
+        targetProfileSummaries: [targetProfileSummary],
+      });
+
+      this.set('organization', organization);
+
+      // when
+      const screen = await render(hbs`<Organizations::TargetProfilesSection @organization={{this.organization}} />`);
+
+      assert
+        .dom(screen.getByRole('link', { name: 'Number of The Beast' }))
+        .hasAttribute('href', '/target-profiles/666');
     });
   });
 


### PR DESCRIPTION
## :egg: Problème
Le métier, support ne pouvaient pas utiliser la possibilité d'ouvrir dans un nouvel onglet un profil cible a partir d'une organisation

## :bowl_with_spoon: Proposition
changer le clique sur le tableau en un lien qui permet

## :milk_glass: Remarques
RAS

## :butter: Pour tester
Se connecter sur Pix Admin, et vérifier que sur les profiles cible d'une organization nous avons bien un lien. 