### PR TITLE
[TECH] Mise à jour d'Oppsy.

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10320,13 +10320,14 @@
     },
     "node_modules/oppsy": {
       "version": "3.0.0",
-      "resolved": "git+ssh://git@github.com/1024pix/oppsy.git#179016714e55eeb9f13e5bdb8820fbd3076ced08",
+      "resolved": "git+ssh://git@github.com/1024pix/oppsy.git#ca8c3f37989eee9089dd7127e1c5d1c57f827de0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "9.x.x"
       },
       "engines": {
-        "node": "16.14.0"
+        "node": "16",
+        "npm": "8"
       }
     },
     "node_modules/optionator": {
@@ -21883,7 +21884,7 @@
       "peer": true
     },
     "oppsy": {
-      "version": "git+ssh://git@github.com/1024pix/oppsy.git#179016714e55eeb9f13e5bdb8820fbd3076ced08",
+      "version": "git+ssh://git@github.com/1024pix/oppsy.git#ca8c3f37989eee9089dd7127e1c5d1c57f827de0",
       "from": "oppsy@https://github.com/1024pix/oppsy#main",
       "requires": {
         "@hapi/hoek": "9.x.x"


### PR DESCRIPTION
## :egg: Problème
La version d'Oppsy actuelle est plus stricte que l'API sur la version de node et npm

## :bowl_with_spoon: Proposition
Apporter les bénéfices de la PR https://github.com/1024pix/oppsy/pull/4 sur le monorepo

## :butter: Pour tester
Lancer un `npm ci` et vérifier que npm ne renvoie pas une erreur `Unsupported engine`