### PR TITLE
[FEATURE] Prise en compte du type de centre dans la génération du csv: Tarification (PIX-6179)

### DIFF
--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -48,7 +48,7 @@ module.exports = {
   async getCertificationCenterDetails(request) {
     const certificationCenterId = request.params.id;
 
-    const certificationCenterDetails = await usecases.getCertificationCenter({ id: certificationCenterId });
+    const certificationCenterDetails = await usecases.getCertificationCenterForAdmin({ id: certificationCenterId });
     return certificationCenterForAdminSerializer.serialize(certificationCenterDetails);
   },
 

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -177,7 +177,9 @@ module.exports = {
     const habilitationLabels = await usecases.getImportSessionComplementaryCertificationHabilitationsLabels({
       certificationCenterId,
     });
-    const headers = getHeaders(habilitationLabels);
+    const headers = getHeaders({
+      habilitationLabels,
+    });
     return h
       .response(headers)
       .header('Content-Type', 'text/csv; charset=utf-8')

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -177,8 +177,10 @@ module.exports = {
     const habilitationLabels = await usecases.getImportSessionComplementaryCertificationHabilitationsLabels({
       certificationCenterId,
     });
+    const certificationCenter = await usecases.getCertificationCenter({ id: certificationCenterId });
     const headers = getHeaders({
       habilitationLabels,
+      shouldDisplayBillingModeColumns: certificationCenter.hasBillingMode,
     });
     return h
       .response(headers)

--- a/api/lib/domain/models/CertificationCenter.js
+++ b/api/lib/domain/models/CertificationCenter.js
@@ -25,6 +25,10 @@ class CertificationCenter {
     return this.type === CERTIFICATION_CENTER_TYPES.SCO;
   }
 
+  get hasBillingMode() {
+    return this.type !== CERTIFICATION_CENTER_TYPES.SCO;
+  }
+
   isHabilitated(key) {
     return this.habilitations.some((habilitation) => habilitation.key === key);
   }

--- a/api/lib/domain/usecases/get-certification-center-for-admin.js
+++ b/api/lib/domain/usecases/get-certification-center-for-admin.js
@@ -1,0 +1,3 @@
+module.exports = function getCertificationCenterForAdmin({ id, certificationCenterForAdminRepository }) {
+  return certificationCenterForAdminRepository.get(id);
+};

--- a/api/lib/domain/usecases/get-certification-center.js
+++ b/api/lib/domain/usecases/get-certification-center.js
@@ -1,0 +1,3 @@
+module.exports = function getCertificationCenter({ id, certificationCenterRepository }) {
+  return certificationCenterRepository.get(id);
+};

--- a/api/lib/domain/usecases/get-certification-center.js
+++ b/api/lib/domain/usecases/get-certification-center.js
@@ -1,3 +1,0 @@
-module.exports = function getCertificationCenter({ id, certificationCenterForAdminRepository }) {
-  return certificationCenterForAdminRepository.get(id);
-};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -322,7 +322,7 @@ module.exports = injectDependencies(
     getCertificationAttestation: require('./certificate/get-certification-attestation'),
     getCertificationCandidate: require('./get-certification-candidate'),
     getCertificationCandidateSubscription: require('./get-certification-candidate-subscription'),
-    getCertificationCenter: require('./get-certification-center'),
+    getCertificationCenterForAdmin: require('./get-certification-center-for-admin'),
     getCertificationCenterInvitation: require('./get-certification-center-invitation'),
     getCertificationCourse: require('./get-certification-course'),
     getCertificationDetails: require('./get-certification-details'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -322,6 +322,7 @@ module.exports = injectDependencies(
     getCertificationAttestation: require('./certificate/get-certification-attestation'),
     getCertificationCandidate: require('./get-certification-candidate'),
     getCertificationCandidateSubscription: require('./get-certification-candidate-subscription'),
+    getCertificationCenter: require('./get-certification-center'),
     getCertificationCenterForAdmin: require('./get-certification-center-for-admin'),
     getCertificationCenterInvitation: require('./get-certification-center-invitation'),
     getCertificationCourse: require('./get-certification-course'),

--- a/api/lib/infrastructure/files/sessions-import.js
+++ b/api/lib/infrastructure/files/sessions-import.js
@@ -1,9 +1,10 @@
 const { Parser } = require('json2csv');
 const { headers } = require('../utils/csv/sessions-import');
+const omit = require('lodash/omit');
 
-function getHeaders(habilitationLabels) {
+function getHeaders({ habilitationLabels, shouldDisplayBillingModeColumns = true }) {
   const complementaryCertificationsHeaders = _getComplementaryCertificationsHeaders(habilitationLabels);
-  const fields = _getHeadersAsArray(complementaryCertificationsHeaders);
+  const fields = _getHeadersAsArray(complementaryCertificationsHeaders, shouldDisplayBillingModeColumns);
   const json2csvParser = new Parser({
     withBOM: true,
     includeEmptyRows: false,
@@ -17,8 +18,12 @@ function _getComplementaryCertificationsHeaders(habilitationLabels) {
   return habilitationLabels?.map((habilitationLabel) => `${habilitationLabel} ('oui' ou laisser vide)`);
 }
 
-function _getHeadersAsArray(complementaryCertificationsHeaders = []) {
-  const csvHeaders = Object.keys(headers).reduce((arr, key) => [...arr, headers[key]], []);
+function _getHeadersAsArray(complementaryCertificationsHeaders = [], shouldDisplayBillingModeColumns) {
+  const certificationCenterCsvHeaders = shouldDisplayBillingModeColumns
+    ? headers
+    : omit(headers, ['billingMode', 'prepaymentCode']);
+
+  const csvHeaders = Object.keys(certificationCenterCsvHeaders).reduce((arr, key) => [...arr, headers[key]], []);
   return [...csvHeaders, ...complementaryCertificationsHeaders];
 }
 

--- a/api/tests/integration/infrastructure/utils/csv/sessions-import_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/sessions-import_test.js
@@ -3,28 +3,45 @@ const { getHeaders } = require('../../../../../lib/infrastructure/files/sessions
 const BOM_CHAR = '\ufeff';
 describe('Integration | Infrastructure | Utils | csv | sessions-import', function () {
   context('#getHeaders', function () {
-    context('when no habilitation labels are passed', function () {
-      it('should return the correct values without complementary certification columns', function () {
-        // when
-        const habilitationLabels = [];
-        const result = getHeaders(habilitationLabels);
+    context('when should display billing mode', function () {
+      context('when no habilitation labels are passed', function () {
+        it('should return the correct values without complementary certification columns', function () {
+          // when
+          const habilitationLabels = [];
+          const shouldDisplayBillingModeColumns = true;
+          const result = getHeaders({ habilitationLabels, shouldDisplayBillingModeColumns });
 
-        // then
-        const expectedResult = `${BOM_CHAR}"N° de session";"* Nom du site";"* Nom de la salle";"* Date de début";"* Heure de début (heure locale)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: jj/mm/aaaa)";"* Sexe (M ou F)";"Code Insee";"Code postal";"Nom de la commune";"* Pays";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant local";"Temps majoré ?";"Tarification part Pix";"Code de prépaiement"`;
-        expect(result).to.equal(expectedResult);
+          // then
+          const expectedResult = `${BOM_CHAR}"N° de session";"* Nom du site";"* Nom de la salle";"* Date de début";"* Heure de début (heure locale)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: jj/mm/aaaa)";"* Sexe (M ou F)";"Code Insee";"Code postal";"Nom de la commune";"* Pays";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant local";"Temps majoré ?";"Tarification part Pix";"Code de prépaiement"`;
+          expect(result).to.equal(expectedResult);
+        });
+      });
+
+      context('when habilitation labels are passed', function () {
+        it('should return the correct values with complementary certification columns', function () {
+          // given
+          const habilitationLabels = ['Pix 1', 'Pix 2'];
+          const shouldDisplayBillingModeColumns = true;
+
+          // when
+          const result = getHeaders({ habilitationLabels, shouldDisplayBillingModeColumns });
+
+          // then
+          const expectedResult = `${BOM_CHAR}"N° de session";"* Nom du site";"* Nom de la salle";"* Date de début";"* Heure de début (heure locale)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: jj/mm/aaaa)";"* Sexe (M ou F)";"Code Insee";"Code postal";"Nom de la commune";"* Pays";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant local";"Temps majoré ?";"Tarification part Pix";"Code de prépaiement";"Pix 1 ('oui' ou laisser vide)";"Pix 2 ('oui' ou laisser vide)"`;
+          expect(result).to.equal(expectedResult);
+        });
       });
     });
 
-    context('when habilitation labels are passed', function () {
-      it('should return the correct values with complementary certification columns', function () {
-        // given
-        const habilitationLabels = ['Pix 1', 'Pix 2'];
-
+    context('when should not display billing mode', function () {
+      it('should return the correct values without billing mode columns', function () {
         // when
-        const result = getHeaders(habilitationLabels);
+        const habilitationLabels = [];
+        const shouldDisplayBillingModeColumns = false;
+        const result = getHeaders({ habilitationLabels, shouldDisplayBillingModeColumns });
 
         // then
-        const expectedResult = `${BOM_CHAR}"N° de session";"* Nom du site";"* Nom de la salle";"* Date de début";"* Heure de début (heure locale)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: jj/mm/aaaa)";"* Sexe (M ou F)";"Code Insee";"Code postal";"Nom de la commune";"* Pays";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant local";"Temps majoré ?";"Tarification part Pix";"Code de prépaiement";"Pix 1 ('oui' ou laisser vide)";"Pix 2 ('oui' ou laisser vide)"`;
+        const expectedResult = `${BOM_CHAR}"N° de session";"* Nom du site";"* Nom de la salle";"* Date de début";"* Heure de début (heure locale)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: jj/mm/aaaa)";"* Sexe (M ou F)";"Code Insee";"Code postal";"Nom de la commune";"* Pays";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant local";"Temps majoré ?"`;
         expect(result).to.equal(expectedResult);
       });
     });

--- a/api/tests/unit/domain/models/CertificationCenter_test.js
+++ b/api/tests/unit/domain/models/CertificationCenter_test.js
@@ -18,6 +18,23 @@ describe('Unit | Domain | Models | CertificationCenter', function () {
       expect(certificationCenter.isSco).is.false;
     });
   });
+  describe('#hasBillingMode', function () {
+    it('should return false when certification center is of type SCO', function () {
+      // given
+      const certificationCenter = domainBuilder.buildCertificationCenter({ type: 'SCO' });
+
+      // when / then
+      expect(certificationCenter.hasBillingMode).is.false;
+    });
+
+    it('should return true when certification center is not of type SCO', function () {
+      // given
+      const certificationCenter = domainBuilder.buildCertificationCenter({ type: 'SUP' });
+
+      // when / then
+      expect(certificationCenter.hasBillingMode).is.true;
+    });
+  });
   describe('#isHabilitated', function () {
     it('should return false when the certification center does not have the complementary certification', function () {
       // given

--- a/api/tests/unit/domain/usecases/get-certification-center-for-admin_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-center-for-admin_test.js
@@ -1,0 +1,30 @@
+const { expect, domainBuilder, sinon } = require('../../../test-helper');
+const getCertificationCenterForAdmin = require('../../../../lib/domain/usecases/get-certification-center-for-admin');
+const CertificationCenterForAdmin = require('../../../../lib/domain/models/CertificationCenterForAdmin');
+
+describe('Unit | UseCase | get-certification-center-for-admin', function () {
+  let certificationCenterForAdmin;
+  let certificationCenterForAdminRepository;
+
+  beforeEach(function () {
+    certificationCenterForAdmin = domainBuilder.buildCertificationCenterForAdmin({ id: 1234 });
+    certificationCenterForAdminRepository = {
+      get: sinon.stub(),
+    };
+  });
+
+  it('should get the certification center for admin', async function () {
+    // given
+    certificationCenterForAdminRepository.get.withArgs(1234).resolves(certificationCenterForAdmin);
+
+    // when
+    const actualCertificationCourse = await getCertificationCenterForAdmin({
+      id: 1234,
+      certificationCenterForAdminRepository,
+    });
+
+    // then
+    expect(actualCertificationCourse.id).to.equal(1234);
+    expect(actualCertificationCourse).to.be.instanceOf(CertificationCenterForAdmin);
+  });
+});

--- a/api/tests/unit/domain/usecases/get-certification-center_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-center_test.js
@@ -1,0 +1,30 @@
+const { expect, domainBuilder, sinon } = require('../../../test-helper');
+const getCertificationCenter = require('../../../../lib/domain/usecases/get-certification-center');
+const CertificationCenter = require('../../../../lib/domain/models/CertificationCenter');
+
+describe('Unit | UseCase | get-certification-center', function () {
+  let certificationCenter;
+  let certificationCenterRepository;
+
+  beforeEach(function () {
+    certificationCenter = domainBuilder.buildCertificationCenter({ id: 1234 });
+    certificationCenterRepository = {
+      get: sinon.stub(),
+    };
+  });
+
+  it('should get the certification center', async function () {
+    // given
+    certificationCenterRepository.get.withArgs(1234).resolves(certificationCenter);
+
+    // when
+    const actualCertificationCourse = await getCertificationCenter({
+      id: 1234,
+      certificationCenterRepository,
+    });
+
+    // then
+    expect(actualCertificationCourse.id).to.equal(1234);
+    expect(actualCertificationCourse).to.be.instanceOf(CertificationCenter);
+  });
+});


### PR DESCRIPTION
## :egg: Problème

Le fichier CSV d'import en masse de sessions ne tient pas en compte le type de centre de certification pour la tarification.

## :bowl_with_spoon: Proposition

Récupération du type centre de certification et afficher les colonnes de tarification uniquement si le centre n'est pas de type SCO


## :butter: Pour tester

Une fois connecté sur Pix-Certif:
- Si le CDC est SCO, vérifier que le template CSV d'import de session ne comporte pas les colonnes  'Tarification part Pix', 'Code de prépaiement'.

- Si le CDC n'est pas SCO, vérifier que le template CSV d'import de session comporte les colonnes  'Tarification part Pix', 'Code de prépaiement'.