### PR TITLE
[FEATURE] Permettre d'avoir une surveillant par ligne pour une meme session importée (PIX-6727)

### DIFF
--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -42,13 +42,20 @@ function deserializeForSessionsImport(parsedCsvData) {
     } else {
       existingSession = sessions.at(-1);
     }
+    const examiner = data.examiner.trim();
+    if (examiner.length && !existingSession.examiner.includes(examiner)) {
+      existingSession.examiner.push(examiner);
+    }
 
     if (_hasCandidateInformation(data)) {
       existingSession.certificationCandidates.push(_createCandidate(data));
     }
   });
 
-  return sessions;
+  return sessions.map((session) => ({
+    ...session,
+    examiner: session.examiner.join(', '),
+  }));
 }
 
 function getDataFromColumnNames({ csvLineKeys, headers, line }) {
@@ -86,7 +93,7 @@ function _hasCandidateInformation({ lastName }) {
 }
 
 function _createSession({ address, room, date, time, examiner, description }) {
-  const uniqueKey = _generateUniqueKey({ address, room, date, time, examiner });
+  const uniqueKey = _generateUniqueKey({ address, room, date, time });
 
   return {
     uniqueKey,
@@ -94,7 +101,7 @@ function _createSession({ address, room, date, time, examiner, description }) {
     room,
     date,
     time,
-    examiner,
+    examiner: examiner ? [examiner] : [],
     description,
     certificationCandidates: [],
   };
@@ -134,8 +141,8 @@ function _createCandidate({
   };
 }
 
-function _generateUniqueKey({ address, room, date, time, examiner }) {
-  return address + room + date + time + examiner;
+function _generateUniqueKey({ address, room, date, time }) {
+  return address + room + date + time;
 }
 
 module.exports = {

--- a/api/tests/acceptance/application/certification-centers/files/sessions.csv
+++ b/api/tests/acceptance/application/certification-centers/files/sessions.csv
@@ -1,3 +1,0 @@
-N° de session;* Nom du site;* Nom de la salle;* Date de début;* Heure de début (heure locale);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: jj/mm/aaaa);* Sexe (M ou F);Code Insee;Code postal;Nom de la commune;* Pays;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant local;Temps majoré ?
-;site;salle;2022-10-19;12:00;surveillant;non;;;;;;;;;;;;
-;truc;lala;2022-09-18;14:00;nfue;bucdev;;;;;;;;;;;;

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -95,7 +95,10 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
       describe('when session information is identical on consecutive lines', function () {
         it('should return a full session object per line', function () {
           // given
-          const parsedCsvData = [_lineWithSessionAndNoCandidate(1), _lineWithSessionAndNoCandidate(1)];
+          const parsedCsvData = [
+            _lineWithSessionAndNoCandidate({ sessionNumber: 1 }),
+            _lineWithSessionAndNoCandidate({ sessionNumber: 1 }),
+          ];
 
           const expectedResult = [
             {
@@ -121,9 +124,9 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
         it('should return a full session object per line', function () {
           // given
           const parsedCsvData = [
-            _lineWithSessionAndNoCandidate(1),
-            _lineWithSessionAndNoCandidate(2),
-            _lineWithSessionAndNoCandidate(1),
+            _lineWithSessionAndNoCandidate({ sessionNumber: 1 }),
+            _lineWithSessionAndNoCandidate({ sessionNumber: 2 }),
+            _lineWithSessionAndNoCandidate({ sessionNumber: 1 }),
           ];
 
           const expectedResult = [
@@ -247,7 +250,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
     describe('when there is no session information', function () {
       it('should return a full session object with previous session information and current candidate information if any', function () {
         // given
-        const parsedCsvData = [_lineWithSessionAndNoCandidate(1), _lineWithCandidateAndNoSession()];
+        const parsedCsvData = [_lineWithSessionAndNoCandidate({ sessionNumber: 1 }), _lineWithCandidateAndNoSession()];
 
         const expectedResult = [
           {
@@ -291,7 +294,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
     describe('when there is no candidate information', function () {
       it('should return a session object with empty candidate information per csv line', function () {
         // given
-        const parsedCsvData = [_lineWithSessionAndNoCandidate(1)];
+        const parsedCsvData = [_lineWithSessionAndNoCandidate({ sessionNumber: 1 })];
 
         const expectedResult = [
           {
@@ -365,13 +368,13 @@ function _line({
   };
 }
 
-function _lineWithSessionAndNoCandidate(sessionNumber) {
+function _lineWithSessionAndNoCandidate({ sessionNumber, examiner = 'Paul' }) {
   return _line({
     address: `Site ${sessionNumber}`,
     room: `Salle ${sessionNumber}`,
     date: '12/05/2023',
     time: '01:00',
-    examiner: 'Paul',
+    examiner,
     description: '',
   });
 }

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -118,6 +118,34 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           // then
           expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
         });
+
+        describe('when the are multiple different supervisors per session', function () {
+          it('should return the session with an array of supervisors', function () {
+            // given
+            const parsedCsvData = [
+              _lineWithSessionAndNoCandidate({ sessionNumber: 1, examiner: 'Big' }),
+              _lineWithSessionAndNoCandidate({ sessionNumber: 1, examiner: 'Jim' }),
+            ];
+
+            const expectedResult = [
+              {
+                address: 'Site 1',
+                room: 'Salle 1',
+                date: '2023-05-12',
+                time: '01:00',
+                examiner: 'Big, Jim',
+                description: '',
+                certificationCandidates: [],
+              },
+            ];
+
+            // when
+            const result = csvSerializer.deserializeForSessionsImport(parsedCsvData);
+
+            // then
+            expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+          });
+        });
       });
 
       describe('when session information is identical on none consecutive lines', function () {


### PR DESCRIPTION
## :egg: Problème
Lors de l'import de session en masse, on veut pouvoir créer une seule session avec plusieurs surveillants, notamment pour le cas des grandes salles d’examen (notamment amphithéâtres dans le SUP). 

## :bowl_with_spoon: Proposition
Si plusieurs lignes de session ont les même caractéristiques mais pas le même surveillant, alors 1 seule session est créée avec l'ensemble des surveillants.

## :milk_glass: Remarques
La session a une propriété `examiner` qui pourrait être renommer en `supervisors`

## :butter: Pour tester
Importer une session sans surveillant (doit être KO)
Importer une session avec un surveillant (OK)
Importer une session sur 2 lignes avec 2 surveillants (OK)

```
N° de session;* Nom du site;* Nom de la salle;* Date de début;* Heure de début (heure locale);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: jj/mm/aaaa);* Sexe (M ou F);Code Insee;Code postal;Nom de la commune;* Pays;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant local;Temps majoré ?;Tarification part Pix;Code de prépaiement
;site1;salle1;19/10/2022;12:00;Jean Surveillant;non;;;;;;;;;;;;;;
;site1;salle1;19/10/2022;12:00;Hamza Surveillant;non;;;;;;;;;;;;;;
```
