### PR TITLE
[BUGFIX] Réparer le champ pour modifier le SSO d'une organisation sur Pix Admin (PIX-6886).

### DIFF
--- a/admin/app/components/organizations/information-section-edit.hbs
+++ b/admin/app/components/organizations/information-section-edit.hbs
@@ -157,7 +157,6 @@
     <div class="form-field">
       <PixSelect
         @label="SSO"
-        @placeholder="SSO"
         @options={{this.identityProviderOptions}}
         @value={{this.form.identityProviderForCampaigns}}
         @onChange={{this.onChangeIdentityProvider}}

--- a/admin/app/components/organizations/information-section-edit.js
+++ b/admin/app/components/organizations/information-section-edit.js
@@ -154,8 +154,7 @@ export default class OrganizationInformationSectionEditionMode extends Component
 
   @action
   onChangeIdentityProvider(newIdentityProvider) {
-    this.form.identityProviderForCampaigns =
-      newIdentityProvider === this.noIdentityProviderOption.value ? null : newIdentityProvider;
+    this.form.identityProviderForCampaigns = newIdentityProvider;
   }
 
   @action
@@ -171,6 +170,10 @@ export default class OrganizationInformationSectionEditionMode extends Component
     const { validations } = await this.form.validate();
     if (!validations.isValid) {
       return;
+    }
+
+    if (this.form.identityProviderForCampaigns === 'None') {
+      this.form.identityProviderForCampaigns = null;
     }
 
     this.args.organization.set('name', this.form.name);

--- a/admin/app/components/team/add-member.hbs
+++ b/admin/app/components/team/add-member.hbs
@@ -17,10 +17,8 @@
       <PixSelect
         @options={{@roles}}
         @value={{this.role}}
-        @isSearchable={{false}}
         @onChange={{this.roleChanged}}
         @label="Choisir le rôle à assigner au nouveau membre"
-        @placeholder="- Choisissez un rôle -"
         @screenReaderOnly={{true}}
       />
     </section>

--- a/admin/tests/unit/components/organizations/information-section-edit_test.js
+++ b/admin/tests/unit/components/organizations/information-section-edit_test.js
@@ -1,19 +1,31 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+import sinon from 'sinon';
 
 module('Unit | Component | organizations/information-section-edit', function (hooks) {
   setupTest(hooks);
 
-  module('when None is selected as SSO', function () {
+  module('when "Aucun" is selected as SSO', function () {
     test('it should set identityProviderForCampaigns to null', async function (assert) {
       // given
+      const store = this.owner.lookup('service:store');
+      const organization = store.createRecord('organization', { id: 1 });
       const component = createGlimmerComponent('component:organizations/information-section-edit', {
-        organization: { id: 1 },
+        organization,
+        toggleEditMode: sinon.stub(),
+        onSubmit: sinon.stub(),
       });
+      const validations = { isValid: true };
+      component.form.validate = sinon.stub().returns({ validations });
+
+      const event = {
+        preventDefault: sinon.stub(),
+      };
+      component._initForm = sinon.stub();
 
       // when
-      component.onChangeIdentityProvider('None');
+      await component.updateOrganization(event);
 
       // then
       assert.strictEqual(component.form.identityProviderForCampaigns, null);


### PR DESCRIPTION
## :egg: Problème
Actuellement lorsqu'une organisation ne possédant pas de SSO associé est modifié sur Pix Admin, une 500 est retournée.

## :bowl_with_spoon: Proposition
Corriger le champ pour qu'il retourne null si aucun SSO n'est sélectionné 

## :milk_glass: Remarques
Ce bug est apparu suite à la récente montée de version de Pix UI. 

Cette montée de version à également ajouté un placeholder au champ pour ajouter un agent Pix qui n'est pas utile, en plus de ne pas correctement être rendu sur le champ. On le supprime ici.

---

**Autres remarques** : 
- La contrainte ne devrait pas retourner une 500. On devrait avoir la main dessus.
- Le terme SSO est un acronyme et un terme anglais, d'un point de vue a11Y il devrait être défini et traduit en français.

## :butter: Pour tester
Aller sur Pix Admin > Organizations 

Scénario 1 : Le bug trouvé

Cliquer pour éditer une orga qui ne possède pas de SSO (Aucun)
Ne pas modifier ce champ et valider directement le formulaire
Constater que la requête est un succès et que le SSO est toujours en Aucun.

Scénario 2 : Autres manip

Faire des manips de non régression sur le autres SSO et constater qu'ils sont bien modifiés.
❌ Ne pas essayer avec FWB car la requête sera forcément en échec, l'API ne trouvant pas la FWB dans les identity Providers acceptés.
