### PR TITLE
[TECH] Supprimer les relations inexistantes dans le serializer user.

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -16,9 +16,6 @@ module.exports = {
         'pixCertifTermsOfServiceAccepted',
         'lang',
         'isAnonymous',
-        'certificationCenterMemberships',
-        'pixScore',
-        'scorecards',
         'profile',
         'campaignParticipations',
         'hasSeenAssessmentInstructions',
@@ -30,33 +27,6 @@ module.exports = {
         'lastDataProtectionPolicySeenAt',
         'shouldSeeDataProtectionPolicyInformationBanner',
       ],
-      certificationCenterMemberships: {
-        ref: 'id',
-        ignoreRelationshipData: true,
-        relationshipLinks: {
-          related: function (record, current, parent) {
-            return `/api/users/${parent.id}/certification-center-memberships`;
-          },
-        },
-      },
-      pixScore: {
-        ref: 'id',
-        ignoreRelationshipData: true,
-        relationshipLinks: {
-          related: function (record, current, parent) {
-            return `/api/users/${parent.id}/pixscore`;
-          },
-        },
-      },
-      scorecards: {
-        ref: 'id',
-        ignoreRelationshipData: true,
-        relationshipLinks: {
-          related: function (record, current, parent) {
-            return `/api/users/${parent.id}/scorecards`;
-          },
-        },
-      },
       profile: {
         ref: 'id',
         ignoreRelationshipData: true,

--- a/api/lib/infrastructure/serializers/jsonapi/user-with-activity-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-with-activity-serializer.js
@@ -16,9 +16,6 @@ module.exports = {
         'pixCertifTermsOfServiceAccepted',
         'lang',
         'isAnonymous',
-        'certificationCenterMemberships',
-        'pixScore',
-        'scorecards',
         'profile',
         'hasSeenAssessmentInstructions',
         'isCertifiable',
@@ -31,33 +28,6 @@ module.exports = {
         'trainings',
         'shouldSeeDataProtectionPolicyInformationBanner',
       ],
-      certificationCenterMemberships: {
-        ref: 'id',
-        ignoreRelationshipData: true,
-        relationshipLinks: {
-          related: function (record, current, parent) {
-            return `/api/users/${parent.id}/certification-center-memberships`;
-          },
-        },
-      },
-      pixScore: {
-        ref: 'id',
-        ignoreRelationshipData: true,
-        relationshipLinks: {
-          related: function (record, current, parent) {
-            return `/api/users/${parent.id}/pixscore`;
-          },
-        },
-      },
-      scorecards: {
-        ref: 'id',
-        ignoreRelationshipData: true,
-        relationshipLinks: {
-          related: function (record, current, parent) {
-            return `/api/users/${parent.id}/scorecards`;
-          },
-        },
-      },
       profile: {
         ref: 'id',
         ignoreRelationshipData: true,

--- a/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
@@ -67,24 +67,9 @@ describe('Acceptance | Controller | users-controller-get-current-user', function
             'last-data-protection-policy-seen-at': null,
           },
           relationships: {
-            'certification-center-memberships': {
-              links: {
-                related: `/api/users/${user.id}/certification-center-memberships`,
-              },
-            },
-            'pix-score': {
-              links: {
-                related: `/api/users/${user.id}/pixscore`,
-              },
-            },
             profile: {
               links: {
                 related: `/api/users/${user.id}/profile`,
-              },
-            },
-            scorecards: {
-              links: {
-                related: `/api/users/${user.id}/scorecards`,
               },
             },
             'is-certifiable': {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -56,24 +56,9 @@ describe('Unit | Serializer | JSONAPI | user-serializer', function () {
                 userModelObject.shouldSeeDataProtectionPolicyInformationBanner,
             },
             relationships: {
-              'certification-center-memberships': {
-                links: {
-                  related: `/api/users/${userModelObject.id}/certification-center-memberships`,
-                },
-              },
-              'pix-score': {
-                links: {
-                  related: `/api/users/${userModelObject.id}/pixscore`,
-                },
-              },
               profile: {
                 links: {
                   related: `/api/users/${userModelObject.id}/profile`,
-                },
-              },
-              scorecards: {
-                links: {
-                  related: `/api/users/${userModelObject.id}/scorecards`,
                 },
               },
               'campaign-participations': {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-with-activity-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-with-activity-serializer_test.js
@@ -64,24 +64,9 @@ describe('Unit | Serializer | JSONAPI | user-with-activity-serializer', function
                 userModelObject.shouldSeeDataProtectionPolicyInformationBanner,
             },
             relationships: {
-              'certification-center-memberships': {
-                links: {
-                  related: `/api/users/${userModelObject.id}/certification-center-memberships`,
-                },
-              },
-              'pix-score': {
-                links: {
-                  related: `/api/users/${userModelObject.id}/pixscore`,
-                },
-              },
               profile: {
                 links: {
                   related: `/api/users/${userModelObject.id}/profile`,
-                },
-              },
-              scorecards: {
-                links: {
-                  related: `/api/users/${userModelObject.id}/scorecards`,
                 },
               },
               'is-certifiable': {

--- a/mon-pix/mirage/serializers/user.js
+++ b/mon-pix/mirage/serializers/user.js
@@ -22,12 +22,6 @@ export default ApplicationSerializer.extend({
       isCertifiable: {
         related: `${userBaseUrl}/is-certifiable`,
       },
-      pixScore: {
-        related: `${userBaseUrl}/pixscore`,
-      },
-      scorecards: {
-        related: `${userBaseUrl}/scorecards`,
-      },
       profile: {
         related: `${userBaseUrl}/profile`,
       },
@@ -36,9 +30,6 @@ export default ApplicationSerializer.extend({
       },
       campaignParticipationOverviews: {
         related: `${userBaseUrl}/campaign-participation-overviews`,
-      },
-      certificationCenterMemberships: {
-        related: `${userBaseUrl}/certification-center-memberships`,
       },
       memberships: {
         related: `${userBaseUrl}/memberships`,


### PR DESCRIPTION
## :egg: Problème
Actuellement, les serializers `user` et `user-with-activity` retournent des liens de relations qui n'existent pas.

## :bowl_with_spoon: Proposition
Supprimer ces liens inutiles. 

## :milk_glass: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :butter: Pour tester
## Impact sur les apps 
Les liens ne fonctionnant pas de base, le comportement de l'application devrait être inchangé. 

## Vérifier que les liens n'existent pas : 
- `/api/users/:id/pixscore`
- `/api/users/:id/scorecards`
- `/api/users/:id/certification-center-memberships`