### PR TITLE
[FEATURE] Mettre en place la gestion des erreurs à la connexion aussi sur la double mire invitation Pix Orga (PIX-6823)

### DIFF
--- a/orga/app/components/auth/login-form.hbs
+++ b/orga/app/components/auth/login-form.hbs
@@ -12,7 +12,7 @@
     <p class="login-form__invitation-error">{{t "pages.login-form.invitation-was-cancelled"}}</p>
   {{/if}}
 
-  {{#if this.isErrorMessagePresent}}
+  {{#if this.errorMessage}}
     <div id="login-form-error-message" class="login-form__error-message error-message" role="alert">
       {{this.errorMessage}}
     </div>

--- a/orga/app/components/auth/login-form.js
+++ b/orga/app/components/auth/login-form.js
@@ -14,7 +14,6 @@ export default class LoginForm extends Component {
   @service store;
 
   @tracked errorMessage = null;
-  @tracked isErrorMessagePresent = false;
   @tracked isLoading = false;
   @tracked password = null;
   @tracked email = null;
@@ -95,13 +94,10 @@ export default class LoginForm extends Component {
   async _authenticate(password, email) {
     const scope = 'pix-orga';
 
-    this.isErrorMessagePresent = false;
-    this.errorMessage = '';
-
+    this.errorMessage = null;
     try {
       await this.session.authenticate('authenticator:oauth2', email, password, scope);
     } catch (responseError) {
-      this.isErrorMessagePresent = true;
       this._handleApiError(responseError);
     } finally {
       this.isLoading = false;

--- a/orga/app/components/auth/login-form.js
+++ b/orga/app/components/auth/login-form.js
@@ -48,14 +48,14 @@ export default class LoginForm extends Component {
           email
         );
       } catch (err) {
-        const error = Array.isArray(err.errors) && err.errors.length > 0 && err.errors[0];
-        const isInvitationAlreadyAcceptedByAnotherUser = error && error.status === '409';
+        const error = err.errors[0];
+        const isInvitationAlreadyAcceptedByAnotherUser = error.status === '409';
         if (isInvitationAlreadyAcceptedByAnotherUser) {
           this.errorMessage = this.intl.t('pages.login-form.errors.status.409');
           this.isLoading = false;
           return;
         }
-        const isUserAlreadyOrganizationMember = error && error.status === '412';
+        const isUserAlreadyOrganizationMember = error.status === '412';
         if (!isUserAlreadyOrganizationMember) {
           this.errorMessage = this.intl.t(this._getI18nKeyByStatus(error.status));
           this.isLoading = false;

--- a/orga/tests/integration/components/auth/login-form_test.js
+++ b/orga/tests/integration/components/auth/login-form_test.js
@@ -87,6 +87,9 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
 
   module('When there is an invitation', function (hooks) {
     hooks.beforeEach(function () {
+      StoreStub.prototype.peekRecord = () => {
+        return null;
+      };
       StoreStub.prototype.createRecord = () => {
         return EmberObject.create({
           save() {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -597,7 +597,7 @@
         "should-change-password": "You currently have a temporary password. <a href=\"{url}\">Reset your password here</a>.",
         "status": {
           "403": "Access to this Pix Orga space is limited to invited members. Each Pix Orga space is managed by an administrator specific to the organisation using it. Please contact your administrator to get invited.",
-          "409": "This invitation has been already accepted by another account or it has been cancelled."
+          "409": "This invitation has been already accepted or cancelled."
         }
       },
       "forgot-password": "Forgot your password?",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -596,7 +596,8 @@
         "empty-password": "Your password can't be empty.",
         "should-change-password": "You currently have a temporary password. <a href=\"{url}\">Reset your password here</a>.",
         "status": {
-          "403": "Access to this Pix Orga space is limited to invited members. Each Pix Orga space is managed by an administrator specific to the organisation using it. Please contact your administrator to get invited."
+          "403": "Access to this Pix Orga space is limited to invited members. Each Pix Orga space is managed by an administrator specific to the organisation using it. Please contact your administrator to get invited.",
+          "409": "This invitation has been already accepted by another account or it has been cancelled."
         }
       },
       "forgot-password": "Forgot your password?",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -596,7 +596,8 @@
         "empty-password": "Le champ mot de passe est obligatoire.",
         "should-change-password": "Vous avez actuellement un mot de passe temporaire. Cliquez sur <a href=\"{url}\">mot de passe oublié</a> pour le réinitialiser.",
         "status": {
-          "403": "L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite."
+          "403": "L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite.",
+          "409": "Cette invitation a déjà été acceptée par un autre compte ou elle a été annulée."
         }
       },
       "forgot-password": "Mot de passe oublié ?",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -597,7 +597,7 @@
         "should-change-password": "Vous avez actuellement un mot de passe temporaire. Cliquez sur <a href=\"{url}\">mot de passe oublié</a> pour le réinitialiser.",
         "status": {
           "403": "L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite.",
-          "409": "Cette invitation a déjà été acceptée par un autre compte ou elle a été annulée."
+          "409": "Cette invitation a déjà été acceptée ou annulée."
         }
       },
       "forgot-password": "Mot de passe oublié ?",


### PR DESCRIPTION
## :egg: Problème

Dans Pix Orga, plusieurs cas ne sont pas pris en compte dans le formulaire sur lequel un utilisateur se rend quand il suit le lien d'une invitation : 
* le cas où l'utilisateur soumet plusieurs fois le formulaire d'authentification avec un couple login+mot de passe invalide
* le cas d'une invitation déjà acceptée par un autre utilisateur

## :bowl_with_spoon: Proposition

* Ajouter une vérification dans `login-form.js` pour savoir si l'invitation est déjà présente dans le store local d'Ember (avec `peekRecord`) pour que cela ne génère pas une erreur impossible à discriminer. Un autre ticket déjà prévu a pour objectif de retravailler sur la logique d'acceptation des invitations, mais ce n'est pas le but de ce ticket-ci qui ne fait que des corrections.
* Faire évoluer le join test en y faisant cliquer plusieurs fois le bouton login
* Augmenter le join test avec le cas (`409`) de l'invitation déjà acceptée par un autre utilisateur

## :milk_glass: Remarques

RAS

## :butter: Pour tester

1. Créer une invitation pour un utilisateur u1 et avec cet utilisateur u1 entrer à plusieurs reprises un couple login+mot de passe invalide jusqu'à bloquer le compte temporairement puis définitivement. Tous les bons messages liés au blocage doivent s'afficher.
2. Créer une autre invitation pour un utilisateur u1
3. Aller sur le lien de cette invitation avec un utilisateur u1 mais sans rien remplir
3. Dans un autre navigateur aller sur le lien de cette invitation avec un utilisateur u2 mais sans rien remplir
4. Avec l'utilisateur u2 s'authentifier avec succès
5. Avec l'utilisateur u1 s'authentifier avec succès et observer l'affichage du message `Cette invitation a déjà été acceptée par un autre compte ou elle a été annulée.`
