### PR TITLE
[TECH] Supprime la colonne des centres end-test-screen-removal (PIX-6612)

### DIFF
--- a/api/db/migrations/20230112224527_drop-column-end-test-screen-removal.js
+++ b/api/db/migrations/20230112224527_drop-column-end-test-screen-removal.js
@@ -1,0 +1,10 @@
+const TABLE_NAME = 'certification-centers';
+const COLUMN_NAME = 'isSupervisorAccessEnabled';
+
+exports.up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+exports.down = async function () {};


### PR DESCRIPTION
## :egg: Problème
On a supprimé la possibilité de desactiver l'espace surveillant mais il reste la colonne dans la table des centres de certification

## :bowl_with_spoon: Proposition
Supprimer la colonne

## :milk_glass: Remarques
Mettre sur une release après celle incluant https://github.com/1024pix/pix/pull/5500 

## :butter: Pour tester
/
