### PR TITLE
[FEATURE] Permettre d'associer le SSO FWB à une organisation (PIX-6893)

### DIFF
--- a/api/db/migrations/20230124090916_add-fwb-identity-provider-to-organization-table.js
+++ b/api/db/migrations/20230124090916_add-fwb-identity-provider-to-organization-table.js
@@ -1,0 +1,13 @@
+exports.up = async function (knex) {
+  await knex.raw('ALTER TABLE "organizations" DROP CONSTRAINT "organizations_identityProviderForCampaigns_check" ');
+  return knex.raw(
+    "ALTER TABLE \"organizations\" ADD CONSTRAINT \"organizations_identityProviderForCampaigns_check\" CHECK ( \"identityProviderForCampaigns\" IN ('POLE_EMPLOI', 'CNAV', 'GAR', 'FWB') )"
+  );
+};
+
+exports.down = async function (knex) {
+  await knex.raw('ALTER TABLE "organizations" DROP CONSTRAINT "organizations_identityProviderForCampaigns_check" ');
+  return knex.raw(
+    'ALTER TABLE "organizations" ADD CONSTRAINT "organizations_identityProviderForCampaigns_check" CHECK ( "identityProviderForCampaigns" IN (\'POLE_EMPLOI\', \'CNAV\', \'GAR\') )'
+  );
+};


### PR DESCRIPTION
## :egg: Problème

Lorsqu’on associe une organisation au SSO FWB dans Pix Admin, l’api répond par une erreur 500.
La raison est qu’il existe une contrainte sur la valeur du champ identityProviderForCampaigns  dans la table organizations et que FWB ne fait pas partie des valeurs possibles.

## :bowl_with_spoon: Proposition

Ajouter la FWB aux valeurs possibles pour le champ organizations.identityProviderForCampaigns.

## :milk_glass: Remarques

RAS

## :butter: Pour tester

- Exécuter la commande `npm run db:migrate`
- Constater en base de données, au niveau de la table Organizations que la contrainte sur la colonne identityProviderFroCampaigns prend en compte la valeur FWB
- Exécuter la commande `npm run db:rollback:latest`
- Constater en base de données, que la valeur FWB n'est plus prise en compte
