### PR TITLE
[TECH] Avoir un nommage cohérent pour le filtre des types de connexion dans l'API (Pix-6712)

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -810,7 +810,7 @@ exports.register = async (server) => {
             'page[size]': Joi.number().integer().empty(''),
             'page[number]': Joi.number().integer().empty(''),
             'filter[divisions][]': [Joi.string(), Joi.array().items(Joi.string())],
-            'filter[connexionType][]': [Joi.string(), Joi.array().items(Joi.string())],
+            'filter[connectionTypes][]': [Joi.string(), Joi.array().items(Joi.string())],
             'filter[search]': Joi.string().empty(''),
             'filter[certificability][]': [Joi.string(), Joi.array().items(Joi.string())],
           }),

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -237,8 +237,8 @@ module.exports = {
     if (filter.divisions && !Array.isArray(filter.divisions)) {
       filter.divisions = [filter.divisions];
     }
-    if (filter.connexionType && !Array.isArray(filter.connexionType)) {
-      filter.connexionType = [filter.connexionType];
+    if (filter.connectionTypes && !Array.isArray(filter.connectionTypes)) {
+      filter.connectionTypes = [filter.connectionTypes];
     }
     if (filter.certificability) {
       filter.certificability = mapCertificabilityByLabel(filter.certificability);

--- a/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
@@ -8,16 +8,16 @@ const ScoOrganizationParticipant = require('../../domain/read-models/ScoOrganiza
 const CampaignTypes = require('../../domain/models/CampaignTypes');
 const CampaignParticipationStatuses = require('../../domain/models/CampaignParticipationStatuses');
 
-function _setFilters(qb, { search, divisions, connexionType, certificability } = {}) {
+function _setFilters(qb, { search, divisions, connectionTypes, certificability } = {}) {
   if (search) {
     filterByFullName(qb, search, 'organization-learners.firstName', 'organization-learners.lastName');
   }
   if (!_.isEmpty(divisions)) {
     qb.whereIn('division', divisions);
   }
-  if (!_.isEmpty(connexionType)) {
+  if (!_.isEmpty(connectionTypes)) {
     qb.where(function () {
-      if (connexionType.includes('none')) {
+      if (connectionTypes.includes('none')) {
         this.orWhere(function () {
           this.whereRaw('"users"."username" IS NULL');
           this.whereRaw('"users"."email" IS NULL');
@@ -25,13 +25,13 @@ function _setFilters(qb, { search, divisions, connexionType, certificability } =
           this.whereRaw('"authentication-methods"."externalIdentifier" IS NULL');
         });
       }
-      if (connexionType.includes('identifiant')) {
+      if (connectionTypes.includes('identifiant')) {
         this.orWhereRaw('"users"."username" IS NOT NULL');
       }
-      if (connexionType.includes('email')) {
+      if (connectionTypes.includes('email')) {
         this.orWhereRaw('"users"."email" IS NOT NULL');
       }
-      if (connexionType.includes('mediacentre')) {
+      if (connectionTypes.includes('mediacentre')) {
         // we only retrieve GAR authentication method in join clause
         this.orWhereRaw('"authentication-methods"."externalIdentifier" IS NOT NULL');
       }

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1119,7 +1119,7 @@ describe('Acceptance | Application | organization-controller', function () {
           // given
           options = {
             method: 'GET',
-            url: `/api/organizations/${organization.id}/sco-participants?filter[connexionType][]=none`,
+            url: `/api/organizations/${organization.id}/sco-participants?filter[connectionTypes][]=none`,
             headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
           };
 
@@ -1134,7 +1134,7 @@ describe('Acceptance | Application | organization-controller', function () {
           // given
           options = {
             method: 'GET',
-            url: `/api/organizations/${organization.id}/sco-participants?filter[connexionType][]=none&filter[connexionType][]=email`,
+            url: `/api/organizations/${organization.id}/sco-participants?filter[connectionTypes][]=none&filter[connectionTypes][]=email`,
             headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
           };
 

--- a/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
@@ -260,7 +260,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
             data: [{ lastName }],
           } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
             organizationId,
-            filter: { connexionType: ['none'] },
+            filter: { connectionTypes: ['none'] },
           });
 
           // then
@@ -273,7 +273,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
             data: [{ lastName }],
           } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
             organizationId,
-            filter: { connexionType: ['identifiant'] },
+            filter: { connectionTypes: ['identifiant'] },
           });
 
           // then
@@ -286,7 +286,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
             data: [{ lastName }],
           } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
             organizationId,
-            filter: { connexionType: ['email'] },
+            filter: { connectionTypes: ['email'] },
           });
 
           // then
@@ -299,7 +299,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
             data: [{ lastName }],
           } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
             organizationId,
-            filter: { connexionType: ['mediacentre'] },
+            filter: { connectionTypes: ['mediacentre'] },
           });
 
           // then
@@ -309,7 +309,7 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
           // when
           const { data } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
             organizationId,
-            filter: { connexionType: ['mediacentre', 'none'] },
+            filter: { connectionTypes: ['mediacentre', 'none'] },
           });
 
           // then

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -645,7 +645,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
         query: {
           'filter[lastName]': 'Bob',
           'filter[firstName]': 'Tom',
-          'filter[connexionType]': 'email',
+          'filter[connectionTypes]': 'email',
           'filter[divisions][]': 'D1',
         },
       };
@@ -657,7 +657,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       // then
       expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWith({
         organizationId,
-        filter: { lastName: 'Bob', firstName: 'Tom', connexionType: ['email'], divisions: ['D1'] },
+        filter: { lastName: 'Bob', firstName: 'Tom', connectionTypes: ['email'], divisions: ['D1'] },
         page: {},
       });
     });

--- a/orga/app/routes/authenticated/sco-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sco-organization-participants/list.js
@@ -22,7 +22,7 @@ export default class ListRoute extends Route {
         organizationId: this.currentUser.organization.id,
         search: params.search,
         divisions: params.divisions,
-        connexionType: params.connectionTypes,
+        connectionTypes: params.connectionTypes,
         certificability: params.certificability,
       },
       page: {

--- a/orga/mirage/handlers/find-filtered-paginated-sco-organization-participants.js
+++ b/orga/mirage/handlers/find-filtered-paginated-sco-organization-participants.js
@@ -34,13 +34,14 @@ function _filtersFromQueryParams(schema, organizationId, queryParams) {
     return schema.scoOrganizationParticipants.where(({ firstName }) => firstName.includes(firstNameFilter));
   }
 
-  const connexionTypeFilter = queryParams['filter[connexionType]'];
-  if (connexionTypeFilter) {
+  const connectionTypeFilter = queryParams['filter[connectionTypes]'];
+  if (connectionTypeFilter) {
     return schema.scoOrganizationParticipants.where((scoOrganizationParticipant) => {
-      if (connexionTypeFilter === '') return true;
-      if (connexionTypeFilter.includes('identifiant') && scoOrganizationParticipant.hasUsername) return true;
-      if (connexionTypeFilter.includes('email') && scoOrganizationParticipant.hasEmail) return true;
-      if (connexionTypeFilter.includes('mediacentre') && scoOrganizationParticipant.isAuthenticatedFromGar) return true;
+      if (connectionTypeFilter === '') return true;
+      if (connectionTypeFilter.includes('identifiant') && scoOrganizationParticipant.hasUsername) return true;
+      if (connectionTypeFilter.includes('email') && scoOrganizationParticipant.hasEmail) return true;
+      if (connectionTypeFilter.includes('mediacentre') && scoOrganizationParticipant.isAuthenticatedFromGar)
+        return true;
       return false;
     });
   }


### PR DESCRIPTION
## :egg: Problème
Un incohérence de nommage avec du franglais c'était glissé dans le filtre des type de connexion

## :bowl_with_spoon: Proposition
Avoir un nommage cohérent en anglais, mais garder en conduite du changement l'ancien nom afin que les frontaux pas à jour continue de fonctionner

## :milk_glass: Remarques
RAS

## :butter: Pour tester
Se connecter sur une orga sco est vérifier que le filtre par type de connexion fonctionne