### PR TITLE
[FEATURE] Afficher les heures au format 24 au lieu de 12 dans les exports des résultats  (PIX-6898)

### DIFF
--- a/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -1,6 +1,11 @@
 const _ = require('lodash');
-const moment = require('moment');
 const bluebird = require('bluebird');
+
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 const constants = require('../../infrastructure/constants');
 const { UserNotAuthorizedToGetCampaignResultsError, CampaignTypeError } = require('../errors');
@@ -134,7 +139,7 @@ module.exports = async function startWritingCampaignAssessmentResultsToStream({
   const fileName = translate('campaign-export.common.file-name', {
     name: campaign.name,
     id: campaign.id,
-    date: moment.utc().format('YYYY-MM-DD-hhmm'),
+    date: dayjs().tz('Europe/Berlin').format('YYYY-MM-DD-HHmm'),
   });
   return { fileName };
 };

--- a/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -1,4 +1,9 @@
-const moment = require('moment');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
 const { UserNotAuthorizedToGetCampaignResultsError, CampaignTypeError } = require('../errors');
 const CampaignProfilesCollectionExport = require('../../infrastructure/serializers/csv/campaign-profiles-collection-export');
 
@@ -64,7 +69,7 @@ module.exports = async function startWritingCampaignProfilesCollectionResultsToS
   const fileName = translate('campaign-export.common.file-name', {
     name: campaign.name,
     id: campaign.id,
-    date: moment.utc().format('YYYY-MM-DD-hhmm'),
+    date: dayjs().tz('Europe/Berlin').format('YYYY-MM-DD-HHmm'),
   });
 
   return { fileName };


### PR DESCRIPTION
## :egg: Problème
Lors des exports CSV des résultats d' évaluation / collecte de profil, l'heure dans le nom du fichier etait sous la format 00-12 au lieu de 00-23.

## :bowl_with_spoon: Proposition
Remplacer le format des heures par celui voulu en intégrant la timezone

## :milk_glass: Remarques
RAS

## :butter: Pour tester
Se connecter sur Pix Orga et vérifier qu'a l'export des résultats l'heure sur le nom du fichier soit au bons format