### PR TITLE
[TECH] La catégorie CONNECTION_OR_END_SCREEN devrait être dépréciée (PIX-6582)

### DIFF
--- a/api/db/migrations/20230124103059_update-connection-or-end-screen-category-to-deprecated.js
+++ b/api/db/migrations/20230124103059_update-connection-or-end-screen-category-to-deprecated.js
@@ -1,0 +1,9 @@
+const TABLE_NAME = 'issue-report-categories';
+
+exports.up = function (knex) {
+  return knex(TABLE_NAME).update({ isDeprecated: true }).where('name', 'CONNECTION_OR_END_SCREEN');
+};
+
+exports.down = function (knex) {
+  return knex(TABLE_NAME).update({ isDeprecated: false }).where('name', 'CONNECTION_OR_END_SCREEN');
+};

--- a/api/db/seeds/data/certification/certification-courses-builder.js
+++ b/api/db/seeds/data/certification/certification-courses-builder.js
@@ -198,7 +198,7 @@ async function _buildCertificationCourse(databaseBuilder, {
     });
     databaseBuilder.factory.buildCertificationIssueReport({
       certificationCourseId,
-      category: CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN,
+      category: CertificationIssueReportCategories.SIGNATURE_ISSUE,
       description: examinerComment,
     });
   }

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -113,17 +113,12 @@ class CertificationIssueReport {
 
     if (
       [
-        CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN,
         CertificationIssueReportCategories.NON_BLOCKING_CANDIDATE_ISSUE,
         CertificationIssueReportCategories.NON_BLOCKING_TECHNICAL_ISSUE,
         CertificationIssueReportCategories.SIGNATURE_ISSUE,
       ].includes(this.category)
     ) {
       this.subcategory = null;
-    }
-
-    if (this.category === CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN) {
-      this.description = null;
     }
 
     if (this.category !== CertificationIssueReportCategories.IN_CHALLENGE) {

--- a/api/lib/domain/models/CertificationIssueReportCategory.js
+++ b/api/lib/domain/models/CertificationIssueReportCategory.js
@@ -50,16 +50,17 @@ const ImpactfulSubcategories = [
   CertificationIssueReportSubcategories.ACCESSIBILITY_ISSUE,
 ];
 
-const DeprecatedSubcategories = [
-  CertificationIssueReportSubcategories.LINK_NOT_WORKING,
-  CertificationIssueReportSubcategories.OTHER,
-  CertificationIssueReportSubcategories.LEFT_EXAM_ROOM,
-];
-
 const DeprecatedCategories = [
   CertificationIssueReportCategories.TECHNICAL_PROBLEM,
   CertificationIssueReportCategories.OTHER,
   CertificationIssueReportCategories.LATE_OR_LEAVING,
+  CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN,
+];
+
+const DeprecatedSubcategories = [
+  CertificationIssueReportSubcategories.LINK_NOT_WORKING,
+  CertificationIssueReportSubcategories.OTHER,
+  CertificationIssueReportSubcategories.LEFT_EXAM_ROOM,
 ];
 
 module.exports = {

--- a/api/tests/tooling/domain-builder/factory/build-certification-issue-report.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-issue-report.js
@@ -72,7 +72,7 @@ buildCertificationIssueReport.notImpactful = function ({
     resolvedAt,
     resolution,
     categoryId,
-    category: CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN,
+    category: CertificationIssueReportCategories.SIGNATURE_ISSUE,
     subcategory: null,
     hasBeenAutomaticallyResolved,
   });

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -389,7 +389,9 @@ describe('Unit | Domain | Models | CertificationIssueReport', function () {
             description: 'toto',
           },
           { certificationCourseId: 42, category: 'SIGNATURE_ISSUE' },
-          { certificationCourseId: 42, category: 'CONNECTION_OR_END_SCREEN' },
+          { certificationCourseId: 42, category: 'IN_CHALLENGE' },
+          { certificationCourseId: 42, category: 'NON_BLOCKING_CANDIDATE_ISSUE' },
+          { certificationCourseId: 42, category: 'NON_BLOCKING_TECHNICAL_ISSUE' },
         ].forEach((certificationIssueReportDTO) => {
           it(`for ${certificationIssueReportDTO.category} ${
             certificationIssueReportDTO.subcategory ? certificationIssueReportDTO.subcategory : ''


### PR DESCRIPTION
## :egg: Problème
la catégorie #4 CONNECTION_OR_END_SCREEN est actuellement non dépréciée alors qu’elle n’est plus affichée ni dans le PV d’incident, ni sur la page de finalisation d’une session car elle n’est plus utilisée.

## :bowl_with_spoon: Proposition
passer la catégorie CONNECTION_OR_END_SCREEN a “true” pour le champ “isDeprecated”

## :butter: Pour tester
Lancer la commande npm run db:migrate et voir que la valeur isDeprecated de CONNECTION_OR_END_SCREEN est bien a true
OU
regarder la table ```issue-report-categories``` sur la RA et observer le changement de valeur