### PR TITLE
[FEATURE] Retirer le message d'inscription/connexion lorsque l'utilisateur est connecté sur la page d'envoi de profil sur PixAPP (PIX-6163)

### DIFF
--- a/mon-pix/app/components/campaign-start-block.hbs
+++ b/mon-pix/app/components/campaign-start-block.hbs
@@ -18,7 +18,9 @@
   <form {{on "submit" this.start}}>
     <div class="campaign-landing-page__start__text">
       <h1 class="campaign-landing-page__start__text__title">{{this.titleText}}</h1>
-      <h2 class="campaign-landing-page__start__text__announcement">{{{this.announcementText}}}</h2>
+      {{#unless this.session.isAuthenticated}}
+        <h2 class="campaign-landing-page__start__text__announcement">{{{this.announcementText}}}</h2>
+      {{/unless}}
       <PixButton
         @type="submit"
         class="campaign-landing-page__start-button"

--- a/mon-pix/tests/integration/components/campaign-start-block_test.js
+++ b/mon-pix/tests/integration/components/campaign-start-block_test.js
@@ -29,6 +29,7 @@ module('Integration | Component | campaign-start-block', function (hooks) {
 
       // then
       assert.dom('[src="http://orga.com/logo.png"][alt="My organisation"]').exists();
+      assert.ok(contains(this.intl.t('pages.campaign-landing.profiles-collection.announcement')));
       assert.ok(contains('My campaign text'));
     });
   });
@@ -101,7 +102,7 @@ module('Integration | Component | campaign-start-block', function (hooks) {
             @startCampaignParticipation={{this.startCampaignParticipation}}
           />`);
         // then
-        assert.ok(contains(this.intl.t('pages.campaign-landing.profiles-collection.announcement')));
+        assert.notOk(contains(this.intl.t('pages.campaign-landing.profiles-collection.announcement')));
         assert.ok(contains(this.intl.t('pages.campaign-landing.profiles-collection.action')));
         assert.ok(contains(this.intl.t('pages.campaign-landing.profiles-collection.legal')));
       });
@@ -132,7 +133,7 @@ module('Integration | Component | campaign-start-block', function (hooks) {
             @startCampaignParticipation={{this.startCampaignParticipation}}
           />`);
         // then
-        assert.ok(contains(this.intl.t('pages.campaign-landing.assessment.announcement')));
+        assert.notOk(contains(this.intl.t('pages.campaign-landing.profiles-collection.announcement')));
         assert.ok(contains(this.intl.t('pages.campaign-landing.assessment.action')));
         assert.ok(contains(this.intl.t('pages.campaign-landing.assessment.legal')));
       });


### PR DESCRIPTION
## :egg: Problème
Un message incitant l'utilisateur à se connecter / s'inscrire était affiché au moment d'envoyer son résultat de collecte de profil, même quand l'utilisateur était connecté

## :bowl_with_spoon: Proposition
N'afficher ce message seulement quand l'utilisateur n'est pas connecté

## :milk_glass: Remarques
RAS

## :butter: Pour tester
Aller sur Pix APP /campagnes/PROCOLEC  sans être connecté et vérifier la présence du message incitant l'utilisateur à se connecter/créer un compte si besoin.

Se connecter sur Pix APP avec superadmin par example. lancer une campagne de collecte de profil PROCOLEC et vérifier l'absence de ce message