### PR TITLE
[FEATURE] Ajouter le score par compétence dans le simulateur nouveau scoring (PIX-6769)

### DIFF
--- a/api/lib/domain/models/ScoringSimulationResult.js
+++ b/api/lib/domain/models/ScoringSimulationResult.js
@@ -1,4 +1,4 @@
-class SimulationResult {
+class ScoringSimulationResult {
   constructor({ id, estimatedLevel, pixScore, pixScoreByCompetence = [], error } = {}) {
     this.id = id;
     this.estimatedLevel = estimatedLevel;
@@ -17,4 +17,4 @@ class SimulationCompetenceResult {
   }
 }
 
-module.exports = SimulationResult;
+module.exports = ScoringSimulationResult;

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -127,7 +127,9 @@ function calculateTotalPixScore({ allAnswers, challenges, estimatedLevel }) {
     estimatedLevel,
   });
 
-  return _sumSkillsChallengesPixScore([...succeededChallenges, ...inferredChallenges]);
+  const pixScore = _sumSkillsChallengesPixScore([...succeededChallenges, ...inferredChallenges]);
+
+  return { pixScore };
 }
 
 function _getDirectSucceededChallenges({ allAnswers, challenges }) {

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -127,9 +127,12 @@ function calculateTotalPixScore({ allAnswers, challenges, estimatedLevel }) {
     estimatedLevel,
   });
 
-  const pixScore = _sumSkillsChallengesPixScore([...succeededChallenges, ...inferredChallenges]);
+  const pixScoreAndScoreByCompetence = _sumPixScoreAndScoreByCompetence([
+    ...succeededChallenges,
+    ...inferredChallenges,
+  ]);
 
-  return { pixScore };
+  return pixScoreAndScoreByCompetence;
 }
 
 function _getDirectSucceededChallenges({ allAnswers, challenges }) {
@@ -160,17 +163,39 @@ function _findChallengeForAnswer(challenges, answer) {
   return challenges.find((challenge) => challenge.id === answer.challengeId);
 }
 
-function _sumSkillsChallengesPixScore(challenges) {
-  const scoreBySkillId = challenges.reduce((acc, challenge) => {
-    if (acc[challenge.skill.id]) return acc;
+function _sumPixScoreAndScoreByCompetence(challenges) {
+  const { scoreBySkillId, scoreByCompetenceId } = challenges.reduce(
+    (acc, challenge) => {
+      const skillId = challenge.skill.id;
+      const competenceId = challenge.skill.competenceId;
+      if (acc.scoreBySkillId[skillId]) return acc;
 
-    return {
-      ...acc,
-      [challenge.skill.id]: challenge.skill.pixValue,
-    };
-  }, {});
+      const scoreBySkillId = {
+        ...acc.scoreBySkillId,
+        [skillId]: challenge.skill.pixValue,
+      };
 
-  return Object.values(scoreBySkillId).reduce((sum, pixValue) => sum + pixValue, 0);
+      const previousCompetenceScore = acc.scoreByCompetenceId[competenceId] ?? 0;
+      const scoreByCompetenceId = {
+        ...acc.scoreByCompetenceId,
+        [competenceId]: challenge.skill.pixValue + previousCompetenceScore,
+      };
+
+      return { scoreBySkillId, scoreByCompetenceId };
+    },
+    { scoreBySkillId: {}, scoreByCompetenceId: {} }
+  );
+
+  const pixScore = Object.values(scoreBySkillId).reduce((sum, pixValue) => sum + pixValue, 0);
+  const pixScoreByCompetence = _.sortBy(
+    Object.entries(scoreByCompetenceId).map(([competenceId, pixScore]) => ({
+      competenceId,
+      pixScore,
+    })),
+    'competenceId'
+  );
+
+  return { pixScore, pixScoreByCompetence };
 }
 
 function _getReward({ estimatedLevel, discriminant, difficulty }) {

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -15,7 +15,7 @@ module.exports = {
   getPossibleNextChallenges,
   getEstimatedLevelAndErrorRate,
   getChallengesForNonAnsweredSkills,
-  calculateTotalPixScore,
+  calculateTotalPixScoreAndScoreByCompetence,
 };
 
 function getPossibleNextChallenges({ allAnswers, challenges, estimatedLevel = DEFAULT_ESTIMATED_LEVEL } = {}) {
@@ -119,7 +119,7 @@ function getChallengesForNonAnsweredSkills({ allAnswers, challenges }) {
   return challengesForNonAnsweredSkills;
 }
 
-function calculateTotalPixScore({ allAnswers, challenges, estimatedLevel }) {
+function calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges, estimatedLevel }) {
   const succeededChallenges = _getDirectSucceededChallenges({ allAnswers, challenges });
 
   const inferredChallenges = _getInferredChallenges({

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -120,32 +120,24 @@ function getChallengesForNonAnsweredSkills({ allAnswers, challenges }) {
 }
 
 function calculateTotalPixScore({ allAnswers, challenges, estimatedLevel }) {
-  const directPixScore = _getDirectPixScore({ allAnswers, challenges });
+  const succeededChallenges = _getDirectSucceededChallenges({ allAnswers, challenges });
 
-  const inferredPixScore = _getInferredPixScore({
+  const inferredChallenges = _getInferredChallenges({
     challenges: getChallengesForNonAnsweredSkills({ allAnswers, challenges }),
     estimatedLevel,
   });
 
-  const totalPixScore = directPixScore + inferredPixScore;
-
-  return totalPixScore;
+  return _sumSkillsChallengesPixScore([...succeededChallenges, ...inferredChallenges]);
 }
 
-function _getDirectPixScore({ allAnswers, challenges }) {
+function _getDirectSucceededChallenges({ allAnswers, challenges }) {
   const correctAnswers = allAnswers.filter((answer) => answer.isOk());
-  const succeededChallenges = correctAnswers.map((answer) => _findChallengeForAnswer(challenges, answer));
-  const directPixScore = _sumSkillsChallengesPixScore(succeededChallenges);
-  return directPixScore;
+  return correctAnswers.map((answer) => _findChallengeForAnswer(challenges, answer));
 }
 
-function _getInferredPixScore({ challenges, estimatedLevel }) {
+function _getInferredChallenges({ challenges, estimatedLevel }) {
   const lowestCapabilityChallengesBySkill = _findLowestCapabilityChallengesBySkill(challenges);
-  const inferredChallenges = lowestCapabilityChallengesBySkill.filter(
-    (challenge) => estimatedLevel >= challenge.minimumCapability
-  );
-  const inferredPixScore = _sumSkillsChallengesPixScore(inferredChallenges);
-  return inferredPixScore;
+  return lowestCapabilityChallengesBySkill.filter((challenge) => estimatedLevel >= challenge.minimumCapability);
 }
 
 function _findLowestCapabilityChallengesBySkill(challenges) {

--- a/api/lib/domain/services/algorithm-methods/flash.js
+++ b/api/lib/domain/services/algorithm-methods/flash.js
@@ -164,27 +164,20 @@ function _findChallengeForAnswer(challenges, answer) {
 }
 
 function _sumPixScoreAndScoreByCompetence(challenges) {
-  const { scoreBySkillId, scoreByCompetenceId } = challenges.reduce(
-    (acc, challenge) => {
-      const skillId = challenge.skill.id;
-      const competenceId = challenge.skill.competenceId;
-      if (acc.scoreBySkillId[skillId]) return acc;
+  const scoreBySkillId = {};
+  const scoreByCompetenceId = {};
 
-      const scoreBySkillId = {
-        ...acc.scoreBySkillId,
-        [skillId]: challenge.skill.pixValue,
-      };
+  for (const challenge of challenges) {
+    const { id: skillId, competenceId, pixValue } = challenge.skill;
 
-      const previousCompetenceScore = acc.scoreByCompetenceId[competenceId] ?? 0;
-      const scoreByCompetenceId = {
-        ...acc.scoreByCompetenceId,
-        [competenceId]: challenge.skill.pixValue + previousCompetenceScore,
-      };
+    if (scoreBySkillId[skillId]) continue;
 
-      return { scoreBySkillId, scoreByCompetenceId };
-    },
-    { scoreBySkillId: {}, scoreByCompetenceId: {} }
-  );
+    scoreBySkillId[skillId] = pixValue;
+
+    const previousCompetenceScore = scoreByCompetenceId[competenceId] ?? 0;
+
+    scoreByCompetenceId[competenceId] = pixValue + previousCompetenceScore;
+  }
 
   const pixScore = Object.values(scoreBySkillId).reduce((sum, pixValue) => sum + pixValue, 0);
   const pixScoreByCompetence = _.sortBy(

--- a/api/lib/domain/usecases/simulate-flash-scoring.js
+++ b/api/lib/domain/usecases/simulate-flash-scoring.js
@@ -53,7 +53,7 @@ module.exports = async function simulateFlashScoring({
       finalEstimatedLevel = calculatedEstimatedLevel;
     }
 
-    const { pixScore, pixScoreByCompetence } = flashAlgorithmService.calculateTotalPixScore({
+    const { pixScore, pixScoreByCompetence } = flashAlgorithmService.calculateTotalPixScoreAndScoreByCompetence({
       challenges,
       estimatedLevel: finalEstimatedLevel,
       allAnswers,

--- a/api/lib/domain/usecases/simulate-flash-scoring.js
+++ b/api/lib/domain/usecases/simulate-flash-scoring.js
@@ -53,31 +53,12 @@ module.exports = async function simulateFlashScoring({
       finalEstimatedLevel = calculatedEstimatedLevel;
     }
 
-    const { pixScore } = flashAlgorithmService.calculateTotalPixScore({
+    const { pixScore, pixScoreByCompetence } = flashAlgorithmService.calculateTotalPixScore({
       challenges,
       estimatedLevel: finalEstimatedLevel,
       allAnswers,
     });
 
-    return new ScoringSimulationResult({ id, estimatedLevel: finalEstimatedLevel, pixScore });
+    return new ScoringSimulationResult({ id, estimatedLevel: finalEstimatedLevel, pixScore, pixScoreByCompetence });
   });
 };
-
-// "results": [
-//   {
-//     "id": "simulation1",
-//     "pixScore": 11111,
-//     "estimatedLevel": -2.5769829347,
-//     "pixScoreByCompetence": [
-//       {
-//         "competenceId": "competence1",
-//         "pixScore": 11100
-//       },
-//       {
-//         "competenceId": "competence2",
-//         "pixScore": 11
-//       }
-//     ],
-//     "error": undefined
-//   },
-// }

--- a/api/lib/domain/usecases/simulate-flash-scoring.js
+++ b/api/lib/domain/usecases/simulate-flash-scoring.js
@@ -1,4 +1,4 @@
-const SimulationResult = require('../models/SimulationResult');
+const ScoringSimulationResult = require('../models/ScoringSimulationResult');
 
 module.exports = async function simulateFlashScoring({
   challengeRepository,
@@ -14,7 +14,7 @@ module.exports = async function simulateFlashScoring({
     let finalEstimatedLevel = givenEstimatedLevel;
 
     if (!calculateEstimatedLevel && givenEstimatedLevel == undefined) {
-      return new SimulationResult({
+      return new ScoringSimulationResult({
         id,
         error: 'Simulation should have an estimated level',
       });
@@ -22,7 +22,7 @@ module.exports = async function simulateFlashScoring({
 
     for (const answer of allAnswers) {
       if (!challengeIds.has(answer.challengeId)) {
-        return new SimulationResult({
+        return new ScoringSimulationResult({
           id,
           error: `Challenge ID ${answer.challengeId} is unknown or not compatible with flash algorithm`,
         });
@@ -31,7 +31,7 @@ module.exports = async function simulateFlashScoring({
 
     if (calculateEstimatedLevel) {
       if (allAnswers.length === 0) {
-        return new SimulationResult({
+        return new ScoringSimulationResult({
           id,
           error: 'Simulation should have answers in order to calculate estimated level',
         });
@@ -43,7 +43,7 @@ module.exports = async function simulateFlashScoring({
       });
 
       if (givenEstimatedLevel != undefined && calculatedEstimatedLevel !== givenEstimatedLevel) {
-        return new SimulationResult({
+        return new ScoringSimulationResult({
           id,
           estimatedLevel: calculatedEstimatedLevel,
           error: `Calculated estimated level ${calculatedEstimatedLevel} is different from expected given estimated level ${givenEstimatedLevel}`,
@@ -59,6 +59,6 @@ module.exports = async function simulateFlashScoring({
       allAnswers,
     });
 
-    return new SimulationResult({ id, estimatedLevel: finalEstimatedLevel, pixScore });
+    return new ScoringSimulationResult({ id, estimatedLevel: finalEstimatedLevel, pixScore });
   });
 };

--- a/api/lib/domain/usecases/simulate-flash-scoring.js
+++ b/api/lib/domain/usecases/simulate-flash-scoring.js
@@ -53,7 +53,7 @@ module.exports = async function simulateFlashScoring({
       finalEstimatedLevel = calculatedEstimatedLevel;
     }
 
-    const pixScore = flashAlgorithmService.calculateTotalPixScore({
+    const { pixScore } = flashAlgorithmService.calculateTotalPixScore({
       challenges,
       estimatedLevel: finalEstimatedLevel,
       allAnswers,
@@ -62,3 +62,22 @@ module.exports = async function simulateFlashScoring({
     return new ScoringSimulationResult({ id, estimatedLevel: finalEstimatedLevel, pixScore });
   });
 };
+
+// "results": [
+//   {
+//     "id": "simulation1",
+//     "pixScore": 11111,
+//     "estimatedLevel": -2.5769829347,
+//     "pixScoreByCompetence": [
+//       {
+//         "competenceId": "competence1",
+//         "pixScore": 11100
+//       },
+//       {
+//         "competenceId": "competence2",
+//         "pixScore": 11
+//       }
+//     ],
+//     "error": undefined
+//   },
+// }

--- a/api/lib/domain/usecases/simulate-old-scoring.js
+++ b/api/lib/domain/usecases/simulate-old-scoring.js
@@ -1,4 +1,4 @@
-const SimulationResult = require('../models/SimulationResult');
+const ScoringSimulationResult = require('../models/ScoringSimulationResult');
 const fp = require('lodash/fp');
 const { sortBy } = require('lodash');
 
@@ -24,7 +24,7 @@ module.exports = async function simulateOldScoring({ challengeRepository, simula
       const { skill: answeredSkill } = challengesById.get(answer.challengeId);
 
       if (isSkillAnswered(answeredSkill)) {
-        return new SimulationResult({
+        return new ScoringSimulationResult({
           id,
           error: `Answer for skill ${answeredSkill.id} was already given or inferred`,
         });
@@ -63,7 +63,7 @@ module.exports = async function simulateOldScoring({ challengeRepository, simula
       'competenceId'
     );
 
-    return new SimulationResult({ id, pixScore, pixScoreByCompetence });
+    return new ScoringSimulationResult({ id, pixScore, pixScoreByCompetence });
   });
 
   return simulationResults;

--- a/api/lib/infrastructure/repositories/participant-result-repository.js
+++ b/api/lib/infrastructure/repositories/participant-result-repository.js
@@ -62,7 +62,7 @@ async function _getParticipationResults(userId, campaignId, locale) {
       flashAssessmentResultRepository,
     });
     estimatedFlashLevel = estimatedLevel;
-    flashPixScore = flash.calculateTotalPixScore({ allAnswers, challenges, estimatedLevel });
+    flashPixScore = flash.calculateTotalPixScore({ allAnswers, challenges, estimatedLevel }).pixScore;
   }
 
   return {

--- a/api/lib/infrastructure/repositories/participant-result-repository.js
+++ b/api/lib/infrastructure/repositories/participant-result-repository.js
@@ -62,7 +62,11 @@ async function _getParticipationResults(userId, campaignId, locale) {
       flashAssessmentResultRepository,
     });
     estimatedFlashLevel = estimatedLevel;
-    flashPixScore = flash.calculateTotalPixScore({ allAnswers, challenges, estimatedLevel }).pixScore;
+    flashPixScore = flash.calculateTotalPixScoreAndScoreByCompetence({
+      allAnswers,
+      challenges,
+      estimatedLevel,
+    }).pixScore;
   }
 
   return {

--- a/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
+++ b/api/tests/acceptance/application/scoring-simulator/scoring-simulator-controller_test.js
@@ -269,7 +269,10 @@ describe('Acceptance | Controller | scoring-simulator-controller', function () {
           id: 'simulation1',
           estimatedLevel: 2.5769829347,
           pixScore: 11110,
-          pixScoreByCompetence: [],
+          pixScoreByCompetence: [
+            { competenceId: 'rec1', pixScore: 10 },
+            { competenceId: 'rec2', pixScore: 11100 },
+          ],
           error: undefined,
         },
         {

--- a/api/tests/integration/application/scoring-simulator/scoring-simulator-controller_test.js
+++ b/api/tests/integration/application/scoring-simulator/scoring-simulator-controller_test.js
@@ -1,5 +1,5 @@
 const { expect, sinon, HttpTestServer } = require('../../../test-helper');
-const SimulationResult = require('../../../../lib/domain/models/SimulationResult');
+const ScoringSimulationResult = require('../../../../lib/domain/models/ScoringSimulationResult');
 const ScoringSimulation = require('../../../../lib/domain/models/ScoringSimulation');
 const Answer = require('../../../../lib/domain/models/Answer');
 const ScoringSimulationContext = require('../../../../lib/domain/models/ScoringSimulationContext');
@@ -23,7 +23,7 @@ describe('Integration | Application | Scoring-simulator | scoring-simulator-cont
     describe('#post', function () {
       beforeEach(async function () {
         simulationResults = [
-          new SimulationResult({
+          new ScoringSimulationResult({
             id: 'resultId',
             pixScore: 123,
             pixScoreByCompetence: [
@@ -72,7 +72,7 @@ describe('Integration | Application | Scoring-simulator | scoring-simulator-cont
     describe('#post', function () {
       beforeEach(async function () {
         simulationResults = [
-          new SimulationResult({
+          new ScoringSimulationResult({
             id: 'resultId',
             estimatedLevel: 2.2498723,
             pixScore: 123,

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -684,7 +684,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
     });
   });
 
-  describe('#calculateTotalPixScore', function () {
+  describe('#calculateTotalPixScoreAndScoreByCompetence', function () {
     describe('when there is no answer', function () {
       it('should return a total score with only inferred challenges scores', function () {
         // given
@@ -751,7 +751,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const allAnswers = [];
 
         // when
-        const result = flash.calculateTotalPixScore({ allAnswers, challenges, estimatedLevel });
+        const result = flash.calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges, estimatedLevel });
 
         // then
         expect(result).to.deep.equal({
@@ -827,7 +827,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const allAnswers = [];
 
         // when
-        const result = flash.calculateTotalPixScore({ allAnswers, challenges, estimatedLevel });
+        const result = flash.calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges, estimatedLevel });
 
         // then
         expect(result).to.deep.equal({
@@ -939,7 +939,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const estimatedLevel = 2;
 
         // when
-        const result = flash.calculateTotalPixScore({ allAnswers, challenges, estimatedLevel });
+        const result = flash.calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges, estimatedLevel });
 
         // then
         expect(result).to.deep.equal({
@@ -986,7 +986,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         ];
 
         // when
-        const result = flash.calculateTotalPixScore({ allAnswers, challenges });
+        const result = flash.calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges });
 
         // then
         expect(result).to.deep.equal({

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -754,7 +754,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const result = flash.calculateTotalPixScore({ allAnswers, challenges, estimatedLevel });
 
         // then
-        expect(result).to.equal(101);
+        expect(result).to.deep.equal({ pixScore: 101 });
       });
       it("should not count a skill's score more than once", function () {
         // given
@@ -817,7 +817,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const result = flash.calculateTotalPixScore({ allAnswers, challenges, estimatedLevel });
 
         // then
-        expect(result).to.equal(101);
+        expect(result).to.deep.equal({ pixScore: 101 });
       });
     });
 
@@ -917,7 +917,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const result = flash.calculateTotalPixScore({ allAnswers, challenges, estimatedLevel });
 
         // then
-        expect(result).to.equal(110011);
+        expect(result).to.deep.equal({ pixScore: 110011 });
       });
 
       it('should not count a skill more than once in direct score', function () {
@@ -952,7 +952,7 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const result = flash.calculateTotalPixScore({ allAnswers, challenges });
 
         // then
-        expect(result).to.equal(1);
+        expect(result).to.deep.equal({ pixScore: 1 });
       });
     });
   });

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -689,9 +689,9 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
       it('should return a total score with only inferred challenges scores', function () {
         // given
         const skills = [
-          domainBuilder.buildSkill({ id: 'Skill1', pixValue: 1 }),
-          domainBuilder.buildSkill({ id: 'Skill2', pixValue: 10 }),
-          domainBuilder.buildSkill({ id: 'Skill3', pixValue: 100 }),
+          domainBuilder.buildSkill({ id: 'Skill1', pixValue: 1, competenceId: 'FirstCompetence' }),
+          domainBuilder.buildSkill({ id: 'Skill2', pixValue: 10, competenceId: 'FirstCompetence' }),
+          domainBuilder.buildSkill({ id: 'Skill3', pixValue: 100, competenceId: 'SecondCompetence' }),
         ];
 
         const successProbabilityThreshold = 0.95;
@@ -754,14 +754,27 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const result = flash.calculateTotalPixScore({ allAnswers, challenges, estimatedLevel });
 
         // then
-        expect(result).to.deep.equal({ pixScore: 101 });
+        expect(result).to.deep.equal({
+          pixScore: 101,
+          pixScoreByCompetence: [
+            {
+              competenceId: 'FirstCompetence',
+              pixScore: 1,
+            },
+            {
+              competenceId: 'SecondCompetence',
+              pixScore: 100,
+            },
+          ],
+        });
       });
+
       it("should not count a skill's score more than once", function () {
         // given
         const skills = [
-          domainBuilder.buildSkill({ id: 'Skill1', pixValue: 1 }),
-          domainBuilder.buildSkill({ id: 'Skill2', pixValue: 10 }),
-          domainBuilder.buildSkill({ id: 'Skill3', pixValue: 100 }),
+          domainBuilder.buildSkill({ id: 'Skill1', pixValue: 1, competenceId: 'FirstCompetence' }),
+          domainBuilder.buildSkill({ id: 'Skill2', pixValue: 10, competenceId: 'FirstCompetence' }),
+          domainBuilder.buildSkill({ id: 'Skill3', pixValue: 100, competenceId: 'SecondCompetence' }),
         ];
 
         const successProbabilityThreshold = 0.95;
@@ -817,7 +830,19 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const result = flash.calculateTotalPixScore({ allAnswers, challenges, estimatedLevel });
 
         // then
-        expect(result).to.deep.equal({ pixScore: 101 });
+        expect(result).to.deep.equal({
+          pixScore: 101,
+          pixScoreByCompetence: [
+            {
+              competenceId: 'FirstCompetence',
+              pixScore: 1,
+            },
+            {
+              competenceId: 'SecondCompetence',
+              pixScore: 100,
+            },
+          ],
+        });
       });
     });
 
@@ -825,13 +850,13 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
       it('should return a total score that combines inferred and direct challenges values', function () {
         // given
         const skills = [
-          domainBuilder.buildSkill({ id: 'FirstSkill', pixValue: 1 }),
-          domainBuilder.buildSkill({ id: 'SecondSkill', pixValue: 10 }),
-          domainBuilder.buildSkill({ id: 'ThirdSkill', pixValue: 100 }),
-          domainBuilder.buildSkill({ id: 'FourthSkill', pixValue: 1000 }),
-          domainBuilder.buildSkill({ id: 'FifthSkill', pixValue: 10000 }),
-          domainBuilder.buildSkill({ id: 'SixthSkill', pixValue: 100000 }),
-          domainBuilder.buildSkill({ id: 'SeventhSkill', pixValue: 1000000 }),
+          domainBuilder.buildSkill({ id: 'FirstSkill', pixValue: 1, competenceId: 'FirstCompetence' }),
+          domainBuilder.buildSkill({ id: 'SecondSkill', pixValue: 10, competenceId: 'FirstCompetence' }),
+          domainBuilder.buildSkill({ id: 'ThirdSkill', pixValue: 100, competenceId: 'FirstCompetence' }),
+          domainBuilder.buildSkill({ id: 'FourthSkill', pixValue: 1000, competenceId: 'SecondCompetence' }),
+          domainBuilder.buildSkill({ id: 'FifthSkill', pixValue: 10000, competenceId: 'SecondCompetence' }),
+          domainBuilder.buildSkill({ id: 'SixthSkill', pixValue: 100000, competenceId: 'SecondCompetence' }),
+          domainBuilder.buildSkill({ id: 'SeventhSkill', pixValue: 1000000, competenceId: 'SecondCompetence' }),
         ];
 
         const successProbabilityThreshold = 0.95;
@@ -917,12 +942,24 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const result = flash.calculateTotalPixScore({ allAnswers, challenges, estimatedLevel });
 
         // then
-        expect(result).to.deep.equal({ pixScore: 110011 });
+        expect(result).to.deep.equal({
+          pixScore: 110011,
+          pixScoreByCompetence: [
+            {
+              competenceId: 'FirstCompetence',
+              pixScore: 11,
+            },
+            {
+              competenceId: 'SecondCompetence',
+              pixScore: 110000,
+            },
+          ],
+        });
       });
 
       it('should not count a skill more than once in direct score', function () {
         // given
-        const skill = domainBuilder.buildSkill({ id: 'FirstSkill', pixValue: 1 });
+        const skill = domainBuilder.buildSkill({ id: 'FirstSkill', pixValue: 1, competenceId: 'FirstCompetence' });
 
         const successProbabilityThreshold = 0.95;
 
@@ -952,7 +989,15 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
         const result = flash.calculateTotalPixScore({ allAnswers, challenges });
 
         // then
-        expect(result).to.deep.equal({ pixScore: 1 });
+        expect(result).to.deep.equal({
+          pixScore: 1,
+          pixScoreByCompetence: [
+            {
+              competenceId: 'FirstCompetence',
+              pixScore: 1,
+            },
+          ],
+        });
       });
     });
   });

--- a/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
+++ b/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
@@ -114,6 +114,10 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
         expect(simulationResults[0]).to.have.property('id', 'simulation1');
         expect(simulationResults[0]).to.have.property('estimatedLevel', 5.309899756825917);
         expect(simulationResults[0]).to.have.property('pixScore', 110011);
+        expect(simulationResults[0].pixScoreByCompetence).to.deep.equal([
+          { competenceId: 'rec1', pixScore: 11 },
+          { competenceId: 'rec2', pixScore: 110000 },
+        ]);
       });
     });
 
@@ -143,6 +147,10 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
           expect(simulationResults[0]).to.have.property('id', 'simulation1');
           expect(simulationResults[0]).to.have.property('estimatedLevel', 5.309899756825917);
           expect(simulationResults[0]).to.have.property('pixScore', 110011);
+          expect(simulationResults[0].pixScoreByCompetence).to.deep.equal([
+            { competenceId: 'rec1', pixScore: 11 },
+            { competenceId: 'rec2', pixScore: 110000 },
+          ]);
         });
       });
 
@@ -212,6 +220,10 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
         expect(simulationResults[0]).to.be.instanceOf(ScoringSimulationResult);
         expect(simulationResults[0]).to.have.property('id', 'simulation1');
         expect(simulationResults[0]).to.have.property('pixScore', 110011);
+        expect(simulationResults[0].pixScoreByCompetence).to.deep.equal([
+          { competenceId: 'rec1', pixScore: 11 },
+          { competenceId: 'rec2', pixScore: 110000 },
+        ]);
       });
     });
 
@@ -234,6 +246,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
         expect(simulationResults[0]).to.be.instanceOf(ScoringSimulationResult);
         expect(simulationResults[0]).to.have.property('id', 'simulation1');
         expect(simulationResults[0]).to.have.property('pixScore', 111000);
+        expect(simulationResults[0].pixScoreByCompetence).to.deep.equal([{ competenceId: 'rec2', pixScore: 111000 }]);
       });
     });
 
@@ -339,6 +352,10 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
       expect(simulationResults[0]).to.be.instanceOf(ScoringSimulationResult);
       expect(simulationResults[0]).to.have.property('id', 'simulation1');
       expect(simulationResults[0]).to.have.property('pixScore', 111001);
+      expect(simulationResults[0].pixScoreByCompetence).to.deep.equal([
+        { competenceId: 'rec1', pixScore: 1 },
+        { competenceId: 'rec2', pixScore: 111000 },
+      ]);
     });
   });
 });

--- a/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
+++ b/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
@@ -1,7 +1,7 @@
 const { expect, mockLearningContent, domainBuilder } = require('../../../test-helper');
 const ScoringSimulationContext = require('../../../../lib/domain/models/ScoringSimulationContext');
 const ScoringSimulation = require('../../../../lib/domain/models/ScoringSimulation');
-const SimulationResult = require('../../../../lib/domain/models/SimulationResult');
+const ScoringSimulationResult = require('../../../../lib/domain/models/ScoringSimulationResult');
 const usecases = require('../../../../lib/domain/usecases/');
 const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
 
@@ -81,7 +81,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
 
         // then
         expect(simulationResults).to.have.lengthOf(1);
-        expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+        expect(simulationResults[0]).to.be.instanceOf(ScoringSimulationResult);
         expect(simulationResults[0]).to.have.property(
           'error',
           'Simulation should have answers in order to calculate estimated level'
@@ -110,7 +110,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
 
         // then
         expect(simulationResults).to.have.lengthOf(1);
-        expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+        expect(simulationResults[0]).to.be.instanceOf(ScoringSimulationResult);
         expect(simulationResults[0]).to.have.property('id', 'simulation1');
         expect(simulationResults[0]).to.have.property('estimatedLevel', 5.309899756825917);
         expect(simulationResults[0]).to.have.property('pixScore', 110011);
@@ -139,7 +139,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
 
           // then
           expect(simulationResults).to.have.lengthOf(1);
-          expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+          expect(simulationResults[0]).to.be.instanceOf(ScoringSimulationResult);
           expect(simulationResults[0]).to.have.property('id', 'simulation1');
           expect(simulationResults[0]).to.have.property('estimatedLevel', 5.309899756825917);
           expect(simulationResults[0]).to.have.property('pixScore', 110011);
@@ -167,7 +167,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
 
           // then
           expect(simulationResults).to.have.lengthOf(1);
-          expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+          expect(simulationResults[0]).to.be.instanceOf(ScoringSimulationResult);
           expect(simulationResults[0]).to.have.property('id', 'simulation1');
           expect(simulationResults[0]).to.have.property('estimatedLevel', 5.309899756825917);
           expect(simulationResults[0]).to.have.property(
@@ -209,7 +209,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
 
         // then
         expect(simulationResults).to.have.lengthOf(1);
-        expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+        expect(simulationResults[0]).to.be.instanceOf(ScoringSimulationResult);
         expect(simulationResults[0]).to.have.property('id', 'simulation1');
         expect(simulationResults[0]).to.have.property('pixScore', 110011);
       });
@@ -231,7 +231,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
 
         // then
         expect(simulationResults).to.have.lengthOf(1);
-        expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+        expect(simulationResults[0]).to.be.instanceOf(ScoringSimulationResult);
         expect(simulationResults[0]).to.have.property('id', 'simulation1');
         expect(simulationResults[0]).to.have.property('pixScore', 111000);
       });
@@ -258,7 +258,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
 
         // then
         expect(simulationResults).to.have.lengthOf(1);
-        expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+        expect(simulationResults[0]).to.be.instanceOf(ScoringSimulationResult);
         expect(simulationResults[0]).to.have.property('error', 'Simulation should have an estimated level');
       });
     });
@@ -283,7 +283,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
 
         // then
         expect(simulationResults).to.have.lengthOf(1);
-        expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+        expect(simulationResults[0]).to.be.instanceOf(ScoringSimulationResult);
         expect(simulationResults[0]).to.have.property('id', 'simulation1');
         expect(simulationResults[0]).to.have.property(
           'error',
@@ -310,7 +310,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
 
         // then
         expect(simulationResults).to.have.lengthOf(1);
-        expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+        expect(simulationResults[0]).to.be.instanceOf(ScoringSimulationResult);
         expect(simulationResults[0]).to.have.property(
           'error',
           'Challenge ID challenge8 is unknown or not compatible with flash algorithm'
@@ -336,7 +336,7 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
 
       // then
       expect(simulationResults).to.have.lengthOf(1);
-      expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+      expect(simulationResults[0]).to.be.instanceOf(ScoringSimulationResult);
       expect(simulationResults[0]).to.have.property('id', 'simulation1');
       expect(simulationResults[0]).to.have.property('pixScore', 111001);
     });

--- a/api/tests/integration/domain/usecases/simulate-old-scoring_test.js
+++ b/api/tests/integration/domain/usecases/simulate-old-scoring_test.js
@@ -1,6 +1,6 @@
 const { expect, mockLearningContent, domainBuilder } = require('../../../test-helper');
 const ScoringSimulation = require('../../../../lib/domain/models/ScoringSimulation');
-const SimulationResult = require('../../../../lib/domain/models/SimulationResult');
+const ScoringSimulationResult = require('../../../../lib/domain/models/ScoringSimulationResult');
 const usecases = require('../../../../lib/domain/usecases/');
 
 describe('Integration | UseCases | simulateOldScoring', function () {
@@ -79,7 +79,7 @@ describe('Integration | UseCases | simulateOldScoring', function () {
 
     // then
     expect(simulationResults).to.have.lengthOf(1);
-    expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+    expect(simulationResults[0]).to.be.instanceOf(ScoringSimulationResult);
     expect(simulationResults[0]).to.have.property('pixScore', 101);
     expect(simulationResults[0].pixScoreByCompetence).to.exactlyContain([
       {
@@ -115,7 +115,7 @@ describe('Integration | UseCases | simulateOldScoring', function () {
 
       // then
       expect(simulationResults).to.have.lengthOf(1);
-      expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+      expect(simulationResults[0]).to.be.instanceOf(ScoringSimulationResult);
       expect(simulationResults[0]).to.have.property('id', 'simulation1');
       expect(simulationResults[0]).to.have.property('pixScore', 11111);
       expect(simulationResults[0].pixScoreByCompetence).to.exactlyContain([
@@ -150,7 +150,7 @@ describe('Integration | UseCases | simulateOldScoring', function () {
 
       // then
       expect(simulationResults).to.have.lengthOf(1);
-      expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+      expect(simulationResults[0]).to.be.instanceOf(ScoringSimulationResult);
       expect(simulationResults[0]).to.have.property('id', 'simulation1');
       expect(simulationResults[0]).to.have.property('error', 'Answer for skill skill5 was already given or inferred');
     });
@@ -175,7 +175,7 @@ describe('Integration | UseCases | simulateOldScoring', function () {
 
       // then
       expect(simulationResults).to.have.lengthOf(1);
-      expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+      expect(simulationResults[0]).to.be.instanceOf(ScoringSimulationResult);
       expect(simulationResults[0]).to.have.property('error', 'Answer for skill skill2 was already given or inferred');
     });
   });
@@ -199,7 +199,7 @@ describe('Integration | UseCases | simulateOldScoring', function () {
 
       // then
       expect(simulationResults).to.have.lengthOf(1);
-      expect(simulationResults[0]).to.be.instanceOf(SimulationResult);
+      expect(simulationResults[0]).to.be.instanceOf(ScoringSimulationResult);
       expect(simulationResults[0]).to.have.property('error', 'Answer for skill skill1 was already given or inferred');
     });
   });


### PR DESCRIPTION
## :egg: Problème
Le simulateur du nouveau scoring ne renvoie pas le score par compétence.

## :bowl_with_spoon: Proposition
Calculer et renvoyer le score par compétence dans le simulateur du nouveau scoring.

## :milk_glass: Remarques
N/A

## :butter: Pour tester
```
TOKEN=$(curl 'https://api-pr5545.review.pix.fr/api/token' --data-raw 'grant_type=password&username=superadmin%40example.net&password=pix123&scope=pix-admin' | jq -r .access_token)
curl https://api-pr5545.review.pix.fr/api/scoring-simulator/flash \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -X POST \
    -d '{ "context": { "id": "context123", "calculateEstimatedLevel": true }, "dataset": { "id": "dataset456", "simulations": [{ "answers": [{ "challengeId": "rec0c55SlcVqmWlA5", "result": "ok" }] }] } }'
```