### PR TITLE
[FEATURE] Aligner graphiquement les pages de résultats de collecte d eprofils avec celle des évaluations dans Pix APP (PIX-6165)

### DIFF
--- a/mon-pix/app/components/campaign-share-button.hbs
+++ b/mon-pix/app/components/campaign-share-button.hbs
@@ -4,12 +4,7 @@
       <span><FaIcon @icon="circle-check" class="badge-card-status__acquired-icon" /></span>
       {{t "pages.skill-review.already-shared"}}
     </div>
-    <a
-      href="#"
-      {{on "click" @redirectToSignupIfUserIsAnonymous}}
-      class="skill-review-share__back-to-home link"
-      data-link-to-continue-pix
-    >
+    <a href="#" {{on "click" @redirectToSignupIfUserIsAnonymous}} class="skill-review-share__back-to-home link">
       <FaIcon @icon="arrow-right" aria-hidden="true" />
       {{t "pages.skill-review.actions.continue"}}
     </a>

--- a/mon-pix/app/components/profile-sharing-form.hbs
+++ b/mon-pix/app/components/profile-sharing-form.hbs
@@ -1,5 +1,4 @@
-{{! template-lint-disable no-action }}
-<form {{action @sendProfile on="submit"}} class="send-profile-header__form">
+<form {{on "submit" @sendProfile}} class="send-profile-header__form">
   <p class="send-profile-header__recipient">
     {{t "pages.send-profile.form.recipient" recipient=@campaign.organizationName}}
   </p>
@@ -9,6 +8,7 @@
       {{t "pages.send-profile.form.shared"}}
     </p>
     <LinkTo @route="authenticated" class="skill-review-share__back-to-home link">
+      <FaIcon @icon="arrow-right" aria-hidden="true" />
       {{t "pages.send-profile.form.continue"}}
     </LinkTo>
   {{else if @errorMessage}}
@@ -21,5 +21,4 @@
       {{t "pages.send-profile.form.send"}}
     </PixButton>
   {{/if}}
-
 </form>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -94,8 +94,8 @@
                   href="#"
                   {{on "click" this.redirectToSignupIfUserIsAnonymous}}
                   class="skill-review-share__back-to-home link"
-                  data-link-to-continue-pix
                 >
+                  <FaIcon @icon="arrow-right" aria-hidden="true" />
                   {{t "pages.skill-review.actions.continue"}}
                 </a>
               {{else}}

--- a/mon-pix/app/controllers/campaigns/profiles-collection/send-profile.js
+++ b/mon-pix/app/controllers/campaigns/profiles-collection/send-profile.js
@@ -14,7 +14,8 @@ export default class SendProfileController extends Controller {
   }
 
   @action
-  async sendProfile() {
+  async sendProfile(event) {
+    event.preventDefault();
     this.errorMessage = null;
 
     const campaignParticipation = this.model.campaignParticipation;

--- a/mon-pix/tests/unit/controllers/campaigns/profiles-collection/send-profile_test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/profiles-collection/send-profile_test.js
@@ -63,17 +63,25 @@ module('Unit | Controller | campaigns/profiles-collection/send-profile', functio
   });
 
   module('#sendProfile', function () {
-    test('should set isShared to true', function (assert) {
+    test('should set isShared to true', async function (assert) {
+      const event = {
+        preventDefault: () => {},
+      };
+
       // when
-      controller.actions.sendProfile.call(controller);
+      await controller.actions.sendProfile.call(controller, event);
 
       // then
       assert.true(controller.model.campaignParticipation.isShared);
     });
 
     test('should call load from currentUser', async function (assert) {
+      const event = {
+        preventDefault: () => {},
+      };
+
       // when
-      await controller.actions.sendProfile.call(controller);
+      await controller.actions.sendProfile.call(controller, event);
 
       // then
       sinon.assert.called(currentUserStub.load);
@@ -81,13 +89,15 @@ module('Unit | Controller | campaigns/profiles-collection/send-profile', functio
     });
 
     test('should not be loading nor in error', async function (assert) {
+      const event = {
+        preventDefault: () => {},
+      };
+
       // when
-      await controller.actions.sendProfile.call(controller);
+      await controller.actions.sendProfile.call(controller, event);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.errorMessage, null);
+      assert.strictEqual(controller.errorMessage, null);
     });
   });
 });


### PR DESCRIPTION
## :egg: Problème
Les pages de résultats de campagne ne sont pas identiques.

## :bowl_with_spoon: Proposition
Aligner l'affichage de ces deux pages

## :milk_glass: Remarques
Il y a un problème d'harmonisation sur les pages, bloc gris pour la collecte, fond blanc sur l'évaluation. il faudra puet être revoir ça. et utiliser des composants commun pour garantir l'affichage partout pareil

## :butter: Pour tester
Vérifier que l'affichage d'une page de collecte partagé PROCOLMUL, à le même espacement entre les message de succes et le bouton continuer sur Pix