### PR TITLE
[FEATURE] Création de(s) candidat(s) depuis l'import du fichier csv sessions en masse (PIX-6176)

### DIFF
--- a/api/lib/infrastructure/files/sessions-import.js
+++ b/api/lib/infrastructure/files/sessions-import.js
@@ -1,5 +1,5 @@
 const { Parser } = require('json2csv');
-const { headers } = require('../utils/csv/sessions-import');
+const { headers, COMPLEMENTARY_CERTIFICATION_SUFFIX } = require('../utils/csv/sessions-import');
 const omit = require('lodash/omit');
 
 function getHeaders({ habilitationLabels, shouldDisplayBillingModeColumns = true }) {
@@ -15,7 +15,7 @@ function getHeaders({ habilitationLabels, shouldDisplayBillingModeColumns = true
 }
 
 function _getComplementaryCertificationsHeaders(habilitationLabels) {
-  return habilitationLabels?.map((habilitationLabel) => `${habilitationLabel} ('oui' ou laisser vide)`);
+  return habilitationLabels?.map((habilitationLabel) => `${habilitationLabel} ${COMPLEMENTARY_CERTIFICATION_SUFFIX}`);
 }
 
 function _getHeadersAsArray(complementaryCertificationsHeaders = [], shouldDisplayBillingModeColumns) {

--- a/api/lib/infrastructure/repositories/complementary-certification-repository.js
+++ b/api/lib/infrastructure/repositories/complementary-certification-repository.js
@@ -13,4 +13,10 @@ module.exports = {
 
     return result.map(_toDomain);
   },
+
+  async getByLabel({ label }) {
+    const result = await knex.from('complementary-certifications').where({ label }).first();
+
+    return _toDomain(result);
+  },
 };

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -30,7 +30,7 @@ function deserializeForSessionsImport(parsedCsvData) {
   _verifyHeaders({ csvLineKeys, headers, parsedCsvLine: parsedCsvData[0] });
 
   parsedCsvData.forEach((line) => {
-    const data = getDataFromColumnNames({ csvLineKeys, headers, line });
+    const data = _getDataFromColumnNames({ csvLineKeys, headers, line });
 
     let existingSession;
     if (_hasSessionInformation(data)) {
@@ -58,7 +58,7 @@ function deserializeForSessionsImport(parsedCsvData) {
   }));
 }
 
-function getDataFromColumnNames({ csvLineKeys, headers, line }) {
+function _getDataFromColumnNames({ csvLineKeys, headers, line }) {
   const data = {};
   data.complementaryCertifications = _extractComplementaryCertificationLabelsFromLine(line);
 

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -63,18 +63,19 @@ function _getDataFromColumnNames({ csvLineKeys, headers, line }) {
   data.complementaryCertifications = _extractComplementaryCertificationLabelsFromLine(line);
 
   csvLineKeys.forEach((key) => {
+    const headerKeyInCurrentLine = line[headers[key]];
     if (key === 'birthdate' || key === 'date') {
       data[key] = convertDateValue({
-        dateString: line[headers[key]],
+        dateString: headerKeyInCurrentLine,
         inputFormat: 'DD/MM/YYYY',
         outputFormat: 'YYYY-MM-DD',
       });
     } else if (key === 'extraTimePercentage') {
-      data[key] = line[headers[key]] !== '' ? parseInt(line[headers[key]]) : null;
+      data[key] = headerKeyInCurrentLine !== '' ? parseInt(headerKeyInCurrentLine) : null;
     } else if (key === 'prepaymentCode') {
-      data[key] = line[headers[key]] !== '' ? line[headers[key]] : null;
+      data[key] = headerKeyInCurrentLine !== '' ? headerKeyInCurrentLine : null;
     } else {
-      data[key] = line[headers[key]];
+      data[key] = headerKeyInCurrentLine;
     }
   });
   return data;

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -71,6 +71,8 @@ function _getDataFromColumnNames({ csvLineKeys, headers, line }) {
       });
     } else if (key === 'extraTimePercentage') {
       data[key] = line[headers[key]] !== '' ? parseInt(line[headers[key]]) : null;
+    } else if (key === 'prepaymentCode') {
+      data[key] = line[headers[key]] !== '' ? line[headers[key]] : null;
     } else {
       data[key] = line[headers[key]];
     }

--- a/api/lib/infrastructure/utils/csv/sessions-import.js
+++ b/api/lib/infrastructure/utils/csv/sessions-import.js
@@ -22,6 +22,9 @@ const headers = {
   prepaymentCode: 'Code de prépaiement',
 };
 
+const COMPLEMENTARY_CERTIFICATION_SUFFIX = "('oui' ou laisser vide)";
+
 module.exports = {
   headers,
+  COMPLEMENTARY_CERTIFICATION_SUFFIX,
 };

--- a/api/tests/integration/infrastructure/repositories/complementary-certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/complementary-certification-repository_test.js
@@ -70,4 +70,35 @@ describe('Integration | Repository | complementary-certification-repository', fu
       });
     });
   });
+
+  describe('#getByLabel', function () {
+    it('should return the complementary certification by its label', async function () {
+      // given
+      const label = 'Pix+ Édu 1er degré';
+      databaseBuilder.factory.buildComplementaryCertification({
+        id: 1,
+        key: 'EDU_1ER_DEGRE',
+        label,
+      });
+
+      databaseBuilder.factory.buildComplementaryCertification({
+        id: 3,
+        key: 'EDU_2ND_DEGRE',
+        label: 'Pix+ Édu 2nd degré',
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const complementaryCertification = await complementaryCertificationRepository.getByLabel({ label });
+
+      // then
+      const expectedComplementaryCertification = domainBuilder.buildComplementaryCertification({
+        id: 1,
+        key: 'EDU_1ER_DEGRE',
+        label: 'Pix+ Édu 1er degré',
+      });
+      expect(complementaryCertification).to.deep.equal(expectedComplementaryCertification);
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -219,6 +219,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   extraTimePercentage: null,
                   billingMode: 'Prépayée',
                   prepaymentCode: '43',
+                  complementaryCertifications: [],
                 },
                 {
                   lastName: 'Candidat 2',
@@ -235,6 +236,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   extraTimePercentage: null,
                   billingMode: 'Prépayée',
                   prepaymentCode: '43',
+                  complementaryCertifications: [],
                 },
               ],
             },
@@ -261,6 +263,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   extraTimePercentage: null,
                   billingMode: 'Prépayée',
                   prepaymentCode: '43',
+                  complementaryCertifications: [],
                 },
               ],
             },
@@ -304,6 +307,58 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                 extraTimePercentage: null,
                 billingMode: 'Prépayée',
                 prepaymentCode: '43',
+                complementaryCertifications: [],
+              },
+            ],
+          },
+        ];
+
+        // when
+        const result = csvSerializer
+          .deserializeForSessionsImport(parsedCsvData)
+          .map((session) => _.omit(session, 'uniqueKey'));
+
+        // then
+        expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+      });
+    });
+
+    describe('when there is candidate information', function () {
+      it('should return a session object with candidate information per csv line', function () {
+        // given
+        const parsedCsvData = [
+          _lineWithSessionAndCandidateWithComplementaryCertification({
+            sessionNumber: 1,
+            candidateNumber: 1,
+            complementaryCertifications: ['Pix Toto', 'Pix Tata'],
+          }),
+        ];
+
+        const expectedResult = [
+          {
+            address: 'Site 1',
+            room: 'Salle 1',
+            date: '2023-05-12',
+            time: '01:00',
+            examiner: 'Paul',
+            description: '',
+            certificationCandidates: [
+              {
+                lastName: 'Candidat 1',
+                firstName: 'Candidat 1',
+                birthdate: '1981-03-01',
+                birthINSEECode: '75015',
+                birthPostalCode: '',
+                billingMode: 'Prépayée',
+                birthCity: '',
+                birthCountry: 'France',
+                email: '',
+                externalId: '',
+                extraTimePercentage: null,
+                prepaymentCode: '43',
+                resultRecipientEmail: 'robindahood@email.fr',
+                sex: 'M',
+                complementaryCertifications: ['Pix Toto', 'Pix Tata'],
               },
             ],
           },
@@ -370,7 +425,14 @@ function _line({
   extraTimePercentage = '',
   billingMode = '',
   prepaymentCode = '',
+  complementaryCertifications = [],
 }) {
+  const candidateComplementaryCertifications = {};
+
+  complementaryCertifications.forEach((cc) => {
+    candidateComplementaryCertifications[`${cc} ('oui' ou laisser vide)`] = 'oui';
+  });
+
   return {
     'N° de session': sessionId,
     '* Nom du site': address,
@@ -393,6 +455,7 @@ function _line({
     'Temps majoré ?': extraTimePercentage,
     'Tarification part Pix': billingMode,
     'Code de prépaiement': prepaymentCode,
+    ...candidateComplementaryCertifications,
   };
 }
 
@@ -448,6 +511,36 @@ function _lineWithSessionAndCandidate({ sessionNumber, candidateNumber }) {
     extraTimePercentage: '',
     billingMode: 'Prépayée',
     prepaymentCode: '43',
+  });
+}
+
+function _lineWithSessionAndCandidateWithComplementaryCertification({
+  sessionNumber,
+  candidateNumber,
+  complementaryCertifications,
+}) {
+  return _line({
+    address: `Site ${sessionNumber}`,
+    room: `Salle ${sessionNumber}`,
+    date: '12/05/2023',
+    time: '01:00',
+    examiner: 'Paul',
+    description: '',
+    lastName: `Candidat ${candidateNumber}`,
+    firstName: `Candidat ${candidateNumber}`,
+    birthdate: '01/03/1981',
+    sex: 'M',
+    birthINSEECode: '75015',
+    birthPostalCode: '',
+    birthCity: '',
+    birthCountry: 'France',
+    resultRecipientEmail: 'robindahood@email.fr',
+    email: '',
+    externalId: '',
+    extraTimePercentage: '',
+    billingMode: 'Prépayée',
+    prepaymentCode: '43',
+    complementaryCertifications,
   });
 }
 

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -324,6 +324,56 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
     });
 
     describe('when there is candidate information', function () {
+      describe('when there is prepayment code information', function () {
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        [
+          { prepaymentCode: '', expectedParsedPrepaymentCode: null },
+          { prepaymentCode: '1234', expectedParsedPrepaymentCode: '1234' },
+        ].forEach(({ prepaymentCode, expectedParsedPrepaymentCode }) => {
+          it(`should return ${expectedParsedPrepaymentCode} when prepaymenCode is ${prepaymentCode}`, function () {
+            // given
+            const csvLine = [_lineWithCandidateAndBillingInformation({ prepaymentCode })];
+
+            // when
+            const result = csvSerializer
+              .deserializeForSessionsImport(csvLine)
+              .map((session) => _.omit(session, 'uniqueKey'));
+
+            // then
+            const expectedResult = [
+              {
+                address: 'Site toto',
+                room: 'Salle toto',
+                date: '2023-05-12',
+                time: '01:00',
+                examiner: '',
+                description: '',
+                certificationCandidates: [
+                  {
+                    lastName: 'Pennyworth',
+                    firstName: 'Alfred',
+                    birthdate: '1951-03-02',
+                    birthINSEECode: '',
+                    birthPostalCode: '',
+                    birthCity: '',
+                    birthCountry: '',
+                    resultRecipientEmail: '',
+                    email: '',
+                    externalId: '',
+                    extraTimePercentage: null,
+                    billingMode: '',
+                    prepaymentCode: expectedParsedPrepaymentCode,
+                    sex: '',
+                    complementaryCertifications: [],
+                  },
+                ],
+              },
+            ];
+            expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+          });
+        });
+      });
+
       it('should return a session object with candidate information per csv line', function () {
         // given
         const parsedCsvData = [
@@ -467,6 +517,19 @@ function _lineWithSessionAndNoCandidate({ sessionNumber, examiner = 'Paul' }) {
     time: '01:00',
     examiner,
     description: '',
+  });
+}
+
+function _lineWithCandidateAndBillingInformation({ prepaymentCode }) {
+  return _line({
+    address: `Site toto`,
+    room: `Salle toto`,
+    date: '12/05/2023',
+    time: '01:00',
+    lastName: 'Pennyworth',
+    firstName: 'Alfred',
+    birthdate: '02/03/1951',
+    prepaymentCode,
   });
 }
 


### PR DESCRIPTION
## :egg: Problème

L'import en masse de sessions n'enregistre à l'heure actuelle que les sessions sans les candidats (dont la validation a été effectuée dans la PR #5438 

## :bowl_with_spoon: Proposition

Enregistrer les candidats

## :milk_glass: Remarques

N/A

## :butter: Pour tester

Tester l'intégralité des cas suivants:

Cas passant 1 : Ajout d'un candidat avec des informations de session

```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
,lkjlk,sale3,01/01/2024,12:00,mlk,,candidat,1,01/01/2000,M,75115,,,France,,,,,Gratuite,,oui,
```

Cas passant 2: Ajout de plusieurs candidats avec les informations de sessions répétées pour chacun des candidats 

```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
,lkjlk,payéeprépayée,01/01/2024,12:00,mlk,,candidat,1,01/01/2000,M,75115,,,France,,,,,Prépayée,1234,oui,
,lkjlk,payéeprépayée,01/01/2024,12:00,mlk,,candidat,2,01/01/2000,M,75115,,,France,,,,,Payante,,,oui
```

Cas passant 3 : Ajout de plusieurs candidats avec les informations de sessions non répétées pour l'ensemble des candidats 

```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
,lkjlk,sale3,01/01/2024,12:00,mlk,,candidat,1,01/01/2000,M,75115,,,France,,,,,Gratuite,,oui,
,,,,,,,candidat_2,2,02/02/2001,M,,75000,Paris,France,,,,,Prépayée,1234,oui,
```

Cas d'erreur 1 : Erreur sur les informations de facturation (`billingMode` et/ou `prepaymentCode`)

```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
,lkjlk,sale3,01/01/2024,12:00,mlk,,candidat,1,01/01/2000,M,75115,,,France,,,,,Gratuite,1234,oui,
```

Possibilité de tester l'intégralité des combinaisons de facturation.

Cas d'erreur 2 : Erreur sur des informations autres du(des) candidat(s)

```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
,lkjlk,sale3,01/01/2024,12:00,mlk,,candidat_1,1,01/01/2000,M,75115,,,France,,,,,Gratuite,,oui,
,lkjlk,sale3,01/01/2024,12:00,mlk,,candidat_2,2,02/02/2001,H,,75000,Paris,France,,,,,Gratuite,oui,
``` 
(Le sexe du deuxième candidat a été remplacé par une lettre non connue (H))

Cas d'erreur 3 : Ajout d'une seule ligne avec informations de candidat mais pas de sessions

```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
,,,,,,,candidat,1,01/01/2000,M,75115,,,France,,,,,Gratuite,,oui,
```
