### PR TITLE
[FEATURE] Séparer les résultats Flash des Participant Results (PIX-6746).

### DIFF
--- a/api/lib/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/lib/domain/read-models/participant-results/AssessmentResult.js
@@ -13,6 +13,7 @@ class AssessmentResult {
     competences,
     badgeResultsDTO,
     stages,
+    flashScoringResults,
   }) {
     const { knowledgeElements, sharedAt, assessmentCreatedAt } = participationResults;
 
@@ -20,9 +21,6 @@ class AssessmentResult {
     this.isCompleted = participationResults.isCompleted;
     this.isShared = Boolean(participationResults.sharedAt);
     this.participantExternalId = participationResults.participantExternalId;
-    this.estimatedFlashLevel = participationResults.estimatedFlashLevel;
-    this.flashPixScore = participationResults.flashPixScore;
-
     this.totalSkillsCount = competences.flatMap(({ skillIds }) => skillIds).length;
     this.testedSkillsCount = knowledgeElements.length;
     this.validatedSkillsCount = knowledgeElements.filter(({ isValidated }) => isValidated).length;
@@ -49,6 +47,9 @@ class AssessmentResult {
       this.masteryRate,
       this.isDisabled
     );
+
+    this.estimatedFlashLevel = flashScoringResults?.estimatedFlashLevel;
+    this.flashPixScore = flashScoringResults?.flashPixScore;
   }
 
   _computeMasteryRate(masteryRate, isShared, totalSkillsCount, validatedSkillsCount) {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -32,8 +32,6 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
         acquiredBadgeIds: [3],
         participantExternalId: 'greg@lafleche.fr',
         masteryRate: 0.5,
-        estimatedFlashLevel: -2.4672347856,
-        flashPixScore: 374.3438957781,
         isDeleted: false,
       };
 
@@ -68,6 +66,11 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
         },
       ];
 
+      const flashScoringResults = {
+        estimatedFlashLevel: -2.4672347856,
+        flashPixScore: 374.3438957781,
+      };
+
       assessmentResult = new AssessmentResult({
         participationResults,
         competences,
@@ -76,6 +79,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
         isCampaignMultipleSendings,
         isOrganizationLearnerActive,
         isCampaignArchived,
+        flashScoringResults,
       });
     });
 


### PR DESCRIPTION
## :egg: Problème
Lorsqu'on avait ajouté la remontée du score Pix dans le participant result pour l'afficher dans l'écran de fin de campagne, on avait jugé que trop de logique/intelligence se trouvait dans le repository et que notre ajout créait de la dette technique. On s'était donc dit qu'on repasserait sur ce repository quand on en aurait l'occasion et une vision plus claire. 

## :bowl_with_spoon: Proposition
Sortir l'intelligence et la logique du repository vers un usecase nous semble trop compliqué et hétérogène par rapport aux traitements déjà réalisés dans ce repository. On souhaite donc isoler notre ajout du Pix Score et du niveau estimé dans une fonction privée. 

## :milk_glass: Remarques
Nous avons cherché à mieux délimiter le code se rapportant au nouveau scoring. 

## :butter: Pour tester
C'est un refacto, les tests doivent toujours passer. L'affichage du score Pix en fin de campagne flash doit toujours fonctionner. 
