### PR TITLE
[FEATURE] Améliorer le contraste du texte au survol du menu utilisateur sur Pix App (PIX-6814).

### DIFF
--- a/mon-pix/app/styles/components/_user-logged-menu.scss
+++ b/mon-pix/app/styles/components/_user-logged-menu.scss
@@ -27,11 +27,11 @@
   }
 
   &:hover {
-    color: $pix-primary-40;
+    color: $pix-primary-60;
     text-decoration: none;
 
     > .caret {
-      border-color: $pix-primary-40 transparent transparent transparent;
+      border-color: $pix-primary-60 transparent transparent transparent;
     }
   }
 }


### PR DESCRIPTION
## :egg: Problème
Sur Pix App, le texte du bouton permettant d'accéder au compte de l'utilisateur présente un ratio de contraste insuffisant au hover (survol) (2.95:1).

<img width="231" alt="Capture d’écran 2023-01-25 à 15 17 20" src="https://user-images.githubusercontent.com/58915422/214587687-cb33c1db-6993-4dae-84a1-a24370c7aa91.png">


## :bowl_with_spoon: Proposition
Modifier la couleur au survol pour qu'il atteigne à minima un ratio de 4.5:1

## :milk_glass: Remarques
Les outils permettant de vérifier ce ratio : 

- Wave
- WCAG color contrast checker

## :butter: Pour tester

- Se connecter sur Pix App
- Ouvrir sa console et forcer le hover sur le bouton du menu utilisateur
<img width="324" alt="Capture d’écran 2023-01-25 à 15 14 31" src="https://user-images.githubusercontent.com/58915422/214586476-731ffc4d-be45-423d-82fb-8aae0d03dc66.png">
- Lancer Wave ou WCAG CCC et constater que l'extension ne revoie plus d'erreur.

