### PR TITLE
[FEATURE] Renvoyer le score Pix par compétence dans la route `assessment-result` (PIX-6901)

### DIFF
--- a/api/lib/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/lib/domain/read-models/participant-results/AssessmentResult.js
@@ -21,7 +21,7 @@ class AssessmentResult {
     this.isCompleted = participationResults.isCompleted;
     this.isShared = Boolean(participationResults.sharedAt);
     this.participantExternalId = participationResults.participantExternalId;
-    this.totalSkillsCount = competences.flatMap(({ skillIds }) => skillIds).length;
+    this.totalSkillsCount = competences.flatMap(({ targetedSkillIds }) => targetedSkillIds).length;
     this.testedSkillsCount = knowledgeElements.length;
     this.validatedSkillsCount = knowledgeElements.filter(({ isValidated }) => isValidated).length;
     this.masteryRate = this._computeMasteryRate(
@@ -31,7 +31,9 @@ class AssessmentResult {
       this.validatedSkillsCount
     );
 
-    this.competenceResults = competences.map((competence) => _buildCompetenceResults(competence, knowledgeElements));
+    this.competenceResults = competences.map(({ competence, area, targetedSkillIds }) =>
+      _buildCompetenceResult({ competence, area, targetedSkillIds, knowledgeElements })
+    );
     this.badgeResults = badgeResultsDTO.map((badge) => new BadgeResult(badge, participationResults));
 
     this.stageCount = stages.length;
@@ -95,10 +97,12 @@ class AssessmentResult {
   }
 }
 
-function _buildCompetenceResults(competence, knowledgeElements) {
-  const competenceKnowledgeElements = knowledgeElements.filter(({ skillId }) => competence.skillIds.includes(skillId));
+function _buildCompetenceResult({ competence, area, targetedSkillIds, knowledgeElements }) {
+  const competenceKnowledgeElements = knowledgeElements.filter(({ skillId }) => targetedSkillIds.includes(skillId));
   return new CompetenceResult({
     competence,
+    area,
+    totalSkillsCount: targetedSkillIds.length,
     knowledgeElements: competenceKnowledgeElements,
   });
 }

--- a/api/lib/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/lib/domain/read-models/participant-results/AssessmentResult.js
@@ -97,7 +97,10 @@ class AssessmentResult {
 
 function _buildCompetenceResults(competence, knowledgeElements) {
   const competenceKnowledgeElements = knowledgeElements.filter(({ skillId }) => competence.skillIds.includes(skillId));
-  return new CompetenceResult(competence, competenceKnowledgeElements);
+  return new CompetenceResult({
+    competence,
+    knowledgeElements: competenceKnowledgeElements,
+  });
 }
 
 module.exports = AssessmentResult;

--- a/api/lib/domain/read-models/participant-results/AssessmentResult.js
+++ b/api/lib/domain/read-models/participant-results/AssessmentResult.js
@@ -50,8 +50,20 @@ class AssessmentResult {
       this.isDisabled
     );
 
-    this.estimatedFlashLevel = flashScoringResults?.estimatedFlashLevel;
-    this.flashPixScore = flashScoringResults?.flashPixScore;
+    if (flashScoringResults) {
+      this.estimatedFlashLevel = flashScoringResults.estimatedLevel;
+      this.flashPixScore = flashScoringResults.pixScore;
+      this.competenceResults = flashScoringResults.competencesWithPixScore.map(
+        ({ competence, area, pixScore }) =>
+          new CompetenceResult({
+            competence,
+            area,
+            totalSkillsCount: competence.skillIds.length,
+            knowledgeElements: [],
+            flashPixScore: pixScore,
+          })
+      );
+    }
   }
 
   _computeMasteryRate(masteryRate, isShared, totalSkillsCount, validatedSkillsCount) {

--- a/api/lib/domain/read-models/participant-results/BadgeResult.js
+++ b/api/lib/domain/read-models/participant-results/BadgeResult.js
@@ -14,13 +14,13 @@ class BadgeResult {
     this.isCertifiable = badge.isCertifiable;
     this.isValid = badge.isValid;
 
-    this.skillSetResults = badge.badgeCompetences.map((competence) =>
-      _buildCompetenceResults(competence, knowledgeElements)
+    this.skillSetResults = badge.badgeCompetences.map((badgeCompetence) =>
+      _buildSkillSetResult(badgeCompetence, knowledgeElements)
     );
   }
 }
 
-function _buildCompetenceResults(badgeCompetence, knowledgeElements) {
+function _buildSkillSetResult(badgeCompetence, knowledgeElements) {
   const skillIds = badgeCompetence.skillIds;
   const competenceKnowledgeElements = knowledgeElements.filter(({ skillId }) => skillIds.includes(skillId));
 

--- a/api/lib/domain/read-models/participant-results/CompetenceResult.js
+++ b/api/lib/domain/read-models/participant-results/CompetenceResult.js
@@ -1,5 +1,5 @@
 class CompetenceResult {
-  constructor(competence, knowledgeElements) {
+  constructor({ competence, knowledgeElements }) {
     const totalSkillsCount = competence.skillIds.length;
     const validatedSkillsCount = knowledgeElements.filter(({ isValidated }) => isValidated).length;
 

--- a/api/lib/domain/read-models/participant-results/CompetenceResult.js
+++ b/api/lib/domain/read-models/participant-results/CompetenceResult.js
@@ -1,13 +1,12 @@
 class CompetenceResult {
-  constructor({ competence, knowledgeElements }) {
-    const totalSkillsCount = competence.skillIds.length;
+  constructor({ competence, area, totalSkillsCount, knowledgeElements }) {
     const validatedSkillsCount = knowledgeElements.filter(({ isValidated }) => isValidated).length;
 
     this.id = competence.id;
     this.name = competence.name;
     this.index = competence.index;
-    this.areaName = competence.areaName;
-    this.areaColor = competence.areaColor;
+    this.areaName = area.name;
+    this.areaColor = area.color;
     this.totalSkillsCount = totalSkillsCount;
     this.testedSkillsCount = knowledgeElements.length;
     this.validatedSkillsCount = validatedSkillsCount;

--- a/api/lib/domain/read-models/participant-results/CompetenceResult.js
+++ b/api/lib/domain/read-models/participant-results/CompetenceResult.js
@@ -1,5 +1,5 @@
 class CompetenceResult {
-  constructor({ competence, area, totalSkillsCount, knowledgeElements }) {
+  constructor({ competence, area, totalSkillsCount, knowledgeElements, flashPixScore }) {
     const validatedSkillsCount = knowledgeElements.filter(({ isValidated }) => isValidated).length;
 
     this.id = competence.id;
@@ -11,6 +11,7 @@ class CompetenceResult {
     this.testedSkillsCount = knowledgeElements.length;
     this.validatedSkillsCount = validatedSkillsCount;
     this.masteryPercentage = Math.round((validatedSkillsCount / totalSkillsCount) * 100);
+    this.flashPixScore = flashPixScore;
   }
 }
 

--- a/api/lib/infrastructure/repositories/participant-result-repository.js
+++ b/api/lib/infrastructure/repositories/participant-result-repository.js
@@ -178,16 +178,13 @@ async function _findTargetedCompetences(campaignId, locale) {
   const targetedCompetences = [];
 
   for (const competence of competences) {
-    const matchingSkills = _.intersection(competence.skillIds, skillIds);
+    const targetedSkillIds = _.intersection(competence.skillIds, skillIds);
     const area = await areaRepository.get({ id: competence.areaId, locale });
-    if (matchingSkills.length > 0) {
+    if (targetedSkillIds.length > 0) {
       targetedCompetences.push({
-        id: competence.id,
-        name: competence.name,
-        index: competence.index,
-        areaName: area.name,
-        areaColor: area.color,
-        skillIds: matchingSkills,
+        competence,
+        area,
+        targetedSkillIds,
       });
     }
   }

--- a/api/lib/infrastructure/repositories/participant-result-repository.js
+++ b/api/lib/infrastructure/repositories/participant-result-repository.js
@@ -80,14 +80,35 @@ async function _getFlashScoringResults(assessmentId, locale) {
     challengeRepository,
     flashAssessmentResultRepository,
   });
-  const estimatedFlashLevel = estimatedLevel;
-  const flashPixScore = flash.calculateTotalPixScoreAndScoreByCompetence({
+
+  const { pixScore, pixScoreByCompetence } = flash.calculateTotalPixScoreAndScoreByCompetence({
     allAnswers,
     challenges,
     estimatedLevel,
-  }).pixScore;
+  });
 
-  return { estimatedFlashLevel, flashPixScore };
+  const competences = await competenceRepository.findByRecordIds({
+    competenceIds: pixScoreByCompetence.map(({ competenceId }) => competenceId),
+    locale,
+  });
+
+  const areas = await areaRepository.list({ locale });
+
+  const competencesWithPixScore = _.sortBy(
+    pixScoreByCompetence.map(({ competenceId, pixScore }) => {
+      const competence = competences.find(({ id }) => id === competenceId);
+      const area = areas.find(({ id }) => id === competence.areaId);
+
+      return {
+        competence,
+        area,
+        pixScore,
+      };
+    }),
+    'competence.index'
+  );
+
+  return { estimatedLevel, pixScore, competencesWithPixScore };
 }
 
 async function _getParticipationAttributes(userId, campaignId) {

--- a/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
@@ -74,6 +74,7 @@ module.exports = {
           'totalSkillsCount',
           'testedSkillsCount',
           'validatedSkillsCount',
+          'flashPixScore',
         ],
       },
       reachedStage: {

--- a/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
+++ b/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
@@ -203,8 +203,6 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
             'can-improve': false,
             'is-disabled': false,
             'participant-external-id': 'participantExternalId',
-            'estimated-flash-level': undefined,
-            'flash-pix-score': undefined,
           },
           relationships: {
             'campaign-participation-badges': {
@@ -308,6 +306,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
               'tested-skills-count': 0,
               'validated-skills-count': 0,
               'area-color': JAFFA_COLOR,
+              'flash-pix-score': undefined,
             },
           },
           {
@@ -321,6 +320,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
               'tested-skills-count': 2,
               'validated-skills-count': 2,
               'area-color': EMERALD_COLOR,
+              'flash-pix-score': undefined,
             },
           },
           {
@@ -334,6 +334,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
               'tested-skills-count': 3,
               'validated-skills-count': 1,
               'area-color': EMERALD_COLOR,
+              'flash-pix-score': undefined,
             },
           },
           {

--- a/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
@@ -545,6 +545,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         totalSkillsCount: 2,
         validatedSkillsCount: 2,
         masteryPercentage: 100,
+        flashPixScore: undefined,
       });
       expect(competenceResult2).to.deep.equal({
         id: 'rec2',
@@ -556,6 +557,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         totalSkillsCount: 2,
         validatedSkillsCount: 1,
         masteryPercentage: 50,
+        flashPixScore: undefined,
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
@@ -1034,13 +1034,12 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
     });
 
     context('when campaign is flash', function () {
-      it('returns the estimated flash level and calculated pix score', async function () {
+      it('returns the estimated flash level and calculated pix score (total and by competence)', async function () {
         // given
         const { id: userId } = databaseBuilder.factory.buildUser();
         const { id: campaignId } = databaseBuilder.factory.buildCampaign({
           assessmentMethod: Assessment.methods.FLASH,
         });
-        _buildCampaignSkills(campaignId);
         const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
           userId,
           campaignId,
@@ -1077,6 +1076,33 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
           estimatedFlashLevel: estimatedLevel,
           flashPixScore: 202,
         });
+
+        expect(participantResult.competenceResults).to.deep.equal([
+          {
+            id: 'rec1',
+            name: 'comp1Fr',
+            index: '1.1',
+            areaName: 'area1',
+            areaColor: 'colorArea1',
+            testedSkillsCount: 0,
+            totalSkillsCount: 2,
+            validatedSkillsCount: 0,
+            masteryPercentage: 0,
+            flashPixScore: 2,
+          },
+          {
+            id: 'rec2',
+            name: 'comp2Fr',
+            index: '2.1',
+            areaName: 'area2',
+            areaColor: 'colorArea2',
+            testedSkillsCount: 0,
+            totalSkillsCount: 3,
+            validatedSkillsCount: 0,
+            masteryPercentage: 0,
+            flashPixScore: 200,
+          },
+        ]);
       });
     });
   });

--- a/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/AssessmentResult_test.js
@@ -7,20 +7,28 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
   it('computes the number of skills, the number of skill tested and the number of skill validated', function () {
     const competences = [
       {
-        id: 'rec1',
-        name: 'C1',
-        index: '1.1',
-        areaName: 'Domaine1',
-        areaColor: 'Couleur1',
-        skillIds: ['skill1', 'skill2'],
+        competence: domainBuilder.buildCompetence({
+          id: 'rec1',
+          name: 'C1',
+          index: '1.1',
+        }),
+        area: domainBuilder.buildArea({
+          name: 'Domaine1',
+          color: 'Couleur1',
+        }),
+        targetedSkillIds: ['skill1', 'skill2'],
       },
       {
-        id: 'rec2',
-        name: 'C2',
-        index: '2.1',
-        areaName: 'Domaine2',
-        areaColor: 'Couleur2',
-        skillIds: ['skill3', 'skill4'],
+        competence: domainBuilder.buildCompetence({
+          id: 'rec2',
+          name: 'C2',
+          index: '2.1',
+        }),
+        area: domainBuilder.buildArea({
+          name: 'Domaine2',
+          color: 'Couleur2',
+        }),
+        targetedSkillIds: ['skill3', 'skill4'],
       },
     ];
 
@@ -65,20 +73,28 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
         it('computes the mastery rate using knowledge elements', function () {
           const competences = [
             {
-              id: 'rec1',
-              name: 'C1',
-              index: '1.1',
-              areaName: 'Domaine1',
-              areaColor: 'Couleur1',
-              skillIds: ['skill1', 'skill2', 'skill3'],
+              competence: domainBuilder.buildCompetence({
+                id: 'rec1',
+                name: 'C1',
+                index: '1.1',
+              }),
+              area: domainBuilder.buildArea({
+                name: 'Domaine1',
+                color: 'Couleur1',
+              }),
+              targetedSkillIds: ['skill1', 'skill2', 'skill3'],
             },
             {
-              id: 'rec2',
-              name: 'C2',
-              index: '2.1',
-              areaName: 'Domaine2',
-              areaColor: 'Couleur2',
-              skillIds: ['skill4', 'skill5', 'skill6'],
+              competence: domainBuilder.buildCompetence({
+                id: 'rec2',
+                name: 'C2',
+                index: '2.1',
+              }),
+              area: domainBuilder.buildArea({
+                name: 'Domaine2',
+                color: 'Couleur2',
+              }),
+              targetedSkillIds: ['skill4', 'skill5', 'skill6'],
             },
           ];
 
@@ -149,12 +165,16 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
       it('return the mastery rate of the participation', function () {
         const competences = [
           {
-            id: 'rec1',
-            name: 'C1',
-            index: '1.1',
-            areaName: 'Domaine1',
-            areaColor: 'Couleur1',
-            skillIds: ['skill1', 'skill2', 'skill2'],
+            competence: domainBuilder.buildCompetence({
+              id: 'rec1',
+              name: 'C1',
+              index: '1.1',
+            }),
+            area: domainBuilder.buildArea({
+              name: 'Domaine1',
+              color: 'Couleur1',
+            }),
+            targetedSkillIds: ['skill1', 'skill2', 'skill2'],
           },
         ];
 
@@ -184,14 +204,29 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
   it('computes the result by competences', function () {
     const competences = [
       {
-        id: 'rec1',
-        name: 'C1',
-        index: '1.1',
-        areaName: 'Domaine1',
-        areaColor: 'Couleur1',
-        skillIds: ['skill1', 'skill2', 'skill3'],
+        competence: domainBuilder.buildCompetence({
+          id: 'rec1',
+          name: 'C1',
+          index: '1.1',
+        }),
+        area: domainBuilder.buildArea({
+          name: 'Domaine1',
+          color: 'Couleur1',
+        }),
+        targetedSkillIds: ['skill1', 'skill2', 'skill3'],
       },
-      { id: 'rec2', name: 'C2', index: '2.1', areaName: 'Domaine2', areaColor: 'Couleur2', skillIds: ['skill4'] },
+      {
+        competence: domainBuilder.buildCompetence({
+          id: 'rec2',
+          name: 'C2',
+          index: '2.1',
+        }),
+        area: domainBuilder.buildArea({
+          name: 'Domaine2',
+          color: 'Couleur2',
+        }),
+        targetedSkillIds: ['skill4'],
+      },
     ];
 
     const knowledgeElements = [
@@ -212,8 +247,8 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
       isCampaignArchived: false,
     });
 
-    const competenceResults1 = assessmentResult.competenceResults.find(({ id }) => competences[0].id === id);
-    const competenceResults2 = assessmentResult.competenceResults.find(({ id }) => competences[1].id === id);
+    const competenceResults1 = assessmentResult.competenceResults.find(({ id }) => competences[0].competence.id === id);
+    const competenceResults2 = assessmentResult.competenceResults.find(({ id }) => competences[1].competence.id === id);
 
     expect(competenceResults1).to.deep.include({ name: 'C1', masteryPercentage: 33 });
     expect(competenceResults2).to.deep.include({ name: 'C2', masteryPercentage: 100 });
@@ -223,12 +258,16 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
     it('gives the reached stage', function () {
       const competences = [
         {
-          id: 'rec1',
-          name: 'C1',
-          index: '1.1',
-          areaName: 'Domaine1',
-          areaColor: 'Couleur1',
-          skillIds: ['skill1', 'skill2', 'skill3'],
+          competence: domainBuilder.buildCompetence({
+            id: 'rec1',
+            name: 'C1',
+            index: '1.1',
+          }),
+          area: domainBuilder.buildArea({
+            name: 'Domaine1',
+            color: 'Couleur1',
+          }),
+          targetedSkillIds: ['skill1', 'skill2', 'skill3'],
         },
       ];
 
@@ -263,12 +302,16 @@ describe('Unit | Domain | Read-Models | ParticipantResult | AssessmentResult', f
     it('computes results for each badge', function () {
       const competences = [
         {
-          id: 'rec1',
-          name: 'C1',
-          index: '1.1',
-          areaName: 'Domaine1',
-          areaColor: 'Couleur1',
-          skillIds: ['skill1', 'skill2', 'skill3'],
+          competence: domainBuilder.buildCompetence({
+            id: 'rec1',
+            name: 'C1',
+            index: '1.1',
+          }),
+          area: domainBuilder.buildArea({
+            name: 'Domaine1',
+            color: 'Couleur1',
+          }),
+          targetedSkillIds: ['skill1', 'skill2', 'skill3'],
         },
       ];
       const participationResults = { knowledgeElements: [], acquiredBadgeIds: [1] };

--- a/api/tests/unit/domain/read-models/participant-results/CompetenceResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/CompetenceResult_test.js
@@ -18,7 +18,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | CompetenceResult', f
       domainBuilder.buildKnowledgeElement({ status: KnowledgeElement.StatusType.INVALIDATED }),
     ];
 
-    const competenceResult = new CompetenceResult(competence, knowledgeElements);
+    const competenceResult = new CompetenceResult({ competence, knowledgeElements });
 
     expect(competenceResult).to.deep.equal({
       id: 'rec1',

--- a/api/tests/unit/domain/read-models/participant-results/CompetenceResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/CompetenceResult_test.js
@@ -4,21 +4,25 @@ const KnowledgeElement = require('../../../../../lib/domain/models/KnowledgeElem
 
 describe('Unit | Domain | Read-Models | ParticipantResult | CompetenceResult', function () {
   it('computes the result for the given competence', function () {
-    const competence = {
+    const competence = domainBuilder.buildCompetence({
       id: 'rec1',
       name: 'C1',
       index: '1.1',
-      areaName: 'Domaine1',
-      areaColor: 'Couleur1',
-      skillIds: ['skill1', 'skill2', 'skill3'],
-    };
+    });
+
+    const area = domainBuilder.buildArea({
+      name: 'Domaine1',
+      color: 'Couleur1',
+    });
+
+    const totalSkillsCount = 3;
 
     const knowledgeElements = [
       domainBuilder.buildKnowledgeElement({ status: KnowledgeElement.StatusType.VALIDATED }),
       domainBuilder.buildKnowledgeElement({ status: KnowledgeElement.StatusType.INVALIDATED }),
     ];
 
-    const competenceResult = new CompetenceResult({ competence, knowledgeElements });
+    const competenceResult = new CompetenceResult({ competence, area, totalSkillsCount, knowledgeElements });
 
     expect(competenceResult).to.deep.equal({
       id: 'rec1',

--- a/api/tests/unit/domain/read-models/participant-results/CompetenceResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/CompetenceResult_test.js
@@ -22,7 +22,15 @@ describe('Unit | Domain | Read-Models | ParticipantResult | CompetenceResult', f
       domainBuilder.buildKnowledgeElement({ status: KnowledgeElement.StatusType.INVALIDATED }),
     ];
 
-    const competenceResult = new CompetenceResult({ competence, area, totalSkillsCount, knowledgeElements });
+    const flashPixScore = 123.456;
+
+    const competenceResult = new CompetenceResult({
+      competence,
+      area,
+      totalSkillsCount,
+      knowledgeElements,
+      flashPixScore,
+    });
 
     expect(competenceResult).to.deep.equal({
       id: 'rec1',
@@ -34,6 +42,7 @@ describe('Unit | Domain | Read-Models | ParticipantResult | CompetenceResult', f
       totalSkillsCount: 3,
       validatedSkillsCount: 1,
       masteryPercentage: 33,
+      flashPixScore: 123.456,
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -5,12 +5,15 @@ const KnowledgeElement = require('../../../../../lib/domain/models/KnowledgeElem
 
 describe('Unit | Serializer | JSON API | participant-result-serializer', function () {
   describe('#serialize', function () {
-    let assessmentResult;
+    const isCampaignMultipleSendings = true;
+    const isOrganizationLearnerActive = true;
+    const isCampaignArchived = false;
+    let participationResults;
+    let competences;
+    let stages;
+    let badgeResultsDTO;
 
     beforeEach(function () {
-      const isCampaignMultipleSendings = true;
-      const isOrganizationLearnerActive = true;
-      const isCampaignArchived = false;
       const knowledgeElements = [
         domainBuilder.buildKnowledgeElement({
           skillId: 'skill1',
@@ -24,7 +27,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
         }),
       ];
 
-      const participationResults = {
+      participationResults = {
         campaignParticipationId: 1,
         isCompleted: true,
         sharedAt: new Date('2020-01-01'),
@@ -35,7 +38,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
         isDeleted: false,
       };
 
-      const competences = [
+      competences = [
         {
           competence: domainBuilder.buildCompetence({
             id: 'C1',
@@ -50,12 +53,13 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
         },
       ];
 
-      const stages = [
+      stages = [
         { id: 2, title: 'Stage1', message: 'Message1', threshold: 0 },
         { id: 3, title: 'Stage2', message: 'Message2', threshold: 50 },
         { id: 4, title: 'Stage1', message: 'Message1', threshold: 100 },
       ];
-      const badgeResultsDTO = [
+
+      badgeResultsDTO = [
         {
           id: 3,
           altMessage: 'Badge2 AltMessage',
@@ -69,13 +73,11 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
           isValid: true,
         },
       ];
+    });
 
-      const flashScoringResults = {
-        estimatedFlashLevel: -2.4672347856,
-        flashPixScore: 374.3438957781,
-      };
-
-      assessmentResult = new AssessmentResult({
+    it('should convert a CampaignParticipationResult model object into JSON API data', function () {
+      // given
+      const assessmentResult = new AssessmentResult({
         participationResults,
         competences,
         stages,
@@ -83,11 +85,8 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
         isCampaignMultipleSendings,
         isOrganizationLearnerActive,
         isCampaignArchived,
-        flashScoringResults,
       });
-    });
 
-    it('should convert a CampaignParticipationResult model object into JSON API data', function () {
       const expectedSerializedCampaignParticipationResult = {
         data: {
           attributes: {
@@ -102,8 +101,6 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
             'can-improve': false,
             'is-disabled': false,
             'participant-external-id': 'greg@lafleche.fr',
-            'estimated-flash-level': -2.4672347856,
-            'flash-pix-score': 374.3438957781,
           },
           id: '1',
           relationships: {
@@ -218,8 +215,38 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
 
       // when
       const json = serializer.serialize(assessmentResult);
+
       // then
       expect(json).to.deep.equal(expectedSerializedCampaignParticipationResult);
+    });
+
+    context('when campaign is FLASH', function () {
+      it('should return flash results', async function () {
+        // given
+        const flashScoringResults = {
+          estimatedLevel: -2.4672347856,
+          pixScore: 374.3438957781,
+          competencesWithPixScore: [],
+        };
+
+        const assessmentResult = new AssessmentResult({
+          participationResults,
+          competences: [],
+          stages,
+          badgeResultsDTO,
+          isCampaignMultipleSendings,
+          isOrganizationLearnerActive,
+          isCampaignArchived,
+          flashScoringResults,
+        });
+
+        // when
+        const json = serializer.serialize(assessmentResult);
+
+        // then
+        expect(json.data.attributes).to.have.property('estimated-flash-level', -2.4672347856);
+        expect(json.data.attributes).to.have.property('flash-pix-score', 374.3438957781);
+      });
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -196,6 +196,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
               'tested-skills-count': 2,
               'total-skills-count': 2,
               'validated-skills-count': 1,
+              'flash-pix-score': undefined,
             },
             id: 'C1',
             type: 'competenceResults',
@@ -226,7 +227,34 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
         const flashScoringResults = {
           estimatedLevel: -2.4672347856,
           pixScore: 374.3438957781,
-          competencesWithPixScore: [],
+          competencesWithPixScore: [
+            {
+              competence: domainBuilder.buildCompetence({
+                id: 'rec1',
+                index: '1.1',
+                name: 'competence 1',
+                skillIds: ['recSkill1'],
+              }),
+              area: domainBuilder.buildArea({
+                id: 'area1',
+                color: 'area1Color',
+              }),
+              pixScore: 300.3438957781,
+            },
+            {
+              competence: domainBuilder.buildCompetence({
+                id: 'rec2',
+                index: '2.1',
+                name: 'competence 2',
+                skillIds: ['recSkill2', 'recSkill3'],
+              }),
+              area: domainBuilder.buildArea({
+                id: 'area2',
+                color: 'area2Color',
+              }),
+              pixScore: 74,
+            },
+          ],
         };
 
         const assessmentResult = new AssessmentResult({
@@ -246,6 +274,34 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
         // then
         expect(json.data.attributes).to.have.property('estimated-flash-level', -2.4672347856);
         expect(json.data.attributes).to.have.property('flash-pix-score', 374.3438957781);
+        expect(json.included).to.deep.include({
+          type: 'competenceResults',
+          id: 'rec1',
+          attributes: {
+            name: 'competence 1',
+            index: '1.1',
+            'area-color': 'area1Color',
+            'mastery-percentage': 0,
+            'total-skills-count': 1,
+            'tested-skills-count': 0,
+            'validated-skills-count': 0,
+            'flash-pix-score': 300.3438957781,
+          },
+        });
+        expect(json.included).to.deep.include({
+          type: 'competenceResults',
+          id: 'rec2',
+          attributes: {
+            name: 'competence 2',
+            index: '2.1',
+            'area-color': 'area2Color',
+            'mastery-percentage': 0,
+            'total-skills-count': 2,
+            'tested-skills-count': 0,
+            'validated-skills-count': 0,
+            'flash-pix-score': 74,
+          },
+        });
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -37,12 +37,16 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
 
       const competences = [
         {
-          id: 'C1',
-          name: 'Competence1',
-          index: '1.1',
-          areaName: 'AreaName',
-          areaColor: 'AreaColor',
-          skillIds: ['skill1', 'skill2'],
+          competence: domainBuilder.buildCompetence({
+            id: 'C1',
+            name: 'Competence1',
+            index: '1.1',
+          }),
+          area: domainBuilder.buildArea({
+            name: 'AreaName',
+            color: 'AreaColor',
+          }),
+          targetedSkillIds: ['skill1', 'skill2'],
         },
       ];
 


### PR DESCRIPTION
## :egg: Problème
On souhaite afficher le score par compétence sur l'écran de fin de campagne flash, mais cette information n'est pas renvoyée par la route `assessment-result`.

## :bowl_with_spoon: Proposition
Ajouter un champ `flash-pix-score` sur les entités `CompetenceResult` renvoyées par la route `assessment-result`.

## :milk_glass: Remarques
N/A

## :butter: Pour tester
```
TOKEN=$(curl 'https://api-pr5556.review.pix.fr/api/token' --data-raw 'grant_type=password&username=userpix1%40example.net&password=pix123&scope=pix-app' | jq -r .access_token)
curl https://api-pr5556.review.pix.fr/api/users/1/campaigns/19/assessment-result -H "Authorization: Bearer $TOKEN" | jq
```