### PR TITLE
[FEATURE] Définir la pagination par défaut des pages à 50 éléments (PIX-6908)

### DIFF
--- a/orga/app/controllers/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/activity.js
@@ -9,7 +9,7 @@ export default class ActivityController extends Controller {
   @service intl;
 
   @tracked pageNumber = 1;
-  @tracked pageSize = 25;
+  @tracked pageSize = 50;
   @tracked divisions = [];
   @tracked status = null;
   @tracked groups = [];

--- a/orga/app/controllers/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/assessment-results.js
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 
 export default class AssessmentResultsController extends Controller {
   @tracked pageNumber = 1;
-  @tracked pageSize = 25;
+  @tracked pageSize = 50;
   @tracked divisions = [];
   @tracked groups = [];
   @tracked badges = [];

--- a/orga/app/controllers/authenticated/campaigns/campaign/profile-results.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/profile-results.js
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 
 export default class ProfilesController extends Controller {
   @tracked pageNumber = 1;
-  @tracked pageSize = 25;
+  @tracked pageSize = 50;
   @tracked divisions = [];
   @tracked groups = [];
   @tracked search = null;

--- a/orga/app/routes/authenticated/campaigns/campaign/activity.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/activity.js
@@ -61,7 +61,7 @@ export default class ActivityRoute extends Route {
   resetController(controller, isExiting) {
     if (isExiting) {
       controller.pageNumber = 1;
-      controller.pageSize = 25;
+      controller.pageSize = 50;
       controller.divisions = [];
       controller.status = null;
       controller.groups = [];

--- a/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/assessment-results.js
@@ -64,7 +64,7 @@ export default class AssessmentResultsRoute extends Route {
   resetController(controller, isExiting) {
     if (isExiting) {
       controller.pageNumber = 1;
-      controller.pageSize = 25;
+      controller.pageSize = 50;
       controller.divisions = [];
       controller.groups = [];
       controller.badges = [];

--- a/orga/app/routes/authenticated/campaigns/campaign/profile-results.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/profile-results.js
@@ -57,7 +57,7 @@ export default class ProfilesRoute extends Route {
   resetController(controller, isExiting) {
     if (isExiting) {
       controller.pageNumber = 1;
-      controller.pageSize = 25;
+      controller.pageSize = 50;
       controller.divisions = [];
       controller.groups = [];
       controller.search = null;

--- a/orga/tests/acceptance/campaign-assessment-results_test.js
+++ b/orga/tests/acceptance/campaign-assessment-results_test.js
@@ -10,7 +10,7 @@ import setupIntl from '../helpers/setup-intl';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-const pageSize = 25;
+const pageSize = 50;
 const rowCount = 100;
 
 module('Acceptance | Campaign Assessment Results', function (hooks) {
@@ -42,8 +42,8 @@ module('Acceptance | Campaign Assessment Results', function (hooks) {
 
       // then
       assert.dom(`[aria-label="${this.intl.t('pages.campaign-results.table.row-title')}"]`).exists({ count: pageSize });
-      assert.contains('Page 1 / 4');
-      assert.dom(screen.getByLabelText(this.intl.t('common.pagination.action.select-page-size'))).hasText('25');
+      assert.contains('Page 1 / 2');
+      assert.dom(screen.getByLabelText(this.intl.t('common.pagination.action.select-page-size'))).hasText('50');
     });
 
     test('it should display participant list with settings in url for pagination', async function (assert) {
@@ -117,11 +117,12 @@ module('Acceptance | Campaign Assessment Results', function (hooks) {
 
     test('it should go back to first page when user changes page size', async function (assert) {
       // given
-      const changedPageSize = 50;
-      const startPage = 3;
+      const changedPageSize = 25;
+      const startPage = 2;
 
       // when
       const screen = await visit(`/campagnes/1/resultats-evaluation?pageNumber=${startPage}`);
+
       await click(screen.getByLabelText(this.intl.t('common.pagination.action.select-page-size')));
       await click(await screen.findByRole('option', { name: changedPageSize }));
 
@@ -129,7 +130,7 @@ module('Acceptance | Campaign Assessment Results', function (hooks) {
       assert
         .dom(`[aria-label="${this.intl.t('pages.campaign-results.table.row-title')}"]`)
         .exists({ count: changedPageSize });
-      assert.contains('Page 1 / 2');
+      assert.contains('Page 1 / 4');
       assert
         .dom(screen.getByLabelText(this.intl.t('common.pagination.action.select-page-size')))
         .hasText(changedPageSize.toString());

--- a/orga/tests/acceptance/campaign-profiles_test.js
+++ b/orga/tests/acceptance/campaign-profiles_test.js
@@ -15,7 +15,7 @@ module('Acceptance | Campaign Profiles', function (hooks) {
 
   let user;
 
-  const pageSize = 25;
+  const pageSize = 50;
   const rowCount = 100;
   hooks.beforeEach(async () => {
     user = createUserWithMembershipAndTermsOfServiceAccepted();
@@ -33,8 +33,8 @@ module('Acceptance | Campaign Profiles', function (hooks) {
 
       // then
       assert.dom('table tbody tr').exists({ count: pageSize });
-      assert.contains('Page 1 / 4');
-      assert.dom(screen.getByLabelText(this.intl.t('common.pagination.action.select-page-size'))).hasText('25');
+      assert.contains('Page 1 / 2');
+      assert.dom(screen.getByLabelText(this.intl.t('common.pagination.action.select-page-size'))).hasText('50');
     });
 
     test('it should display profile list with settings in url for pagination', async function (assert) {

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results_test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/assessment-results_test.js
@@ -69,7 +69,7 @@ module('Unit | Route | authenticated/campaigns/campaign/assessment-results', fun
       test('it reset pageSize', function (assert) {
         const controller = { pageSize: 10 };
         route.resetController(controller, true);
-        assert.strictEqual(controller.pageSize, 25);
+        assert.strictEqual(controller.pageSize, 50);
       });
 
       test('it reset divisions', function (assert) {


### PR DESCRIPTION
## :egg: Problème
Certaines page de Pix Orga n'avait pas encore un affichage a 50 par défaut

## :bowl_with_spoon: Proposition
Mettre 50 pour le default PageSize

## :milk_glass: Remarques
RAS

## :butter: Pour tester
Vérifier qui sur les pages campagnes, onglet activité ET resultats, des campagnes de collectes et d'évaluation  soient bien sur une pageSize à 50 pour les orga pro sup sco.