### PR TITLE
[ADR] Stockage du token d'accès de l'utilisateur côté client (PIX-6923)

### DIFF
--- a/docs/adr/0041-stockage-de-l-access-token-cote-client.md
+++ b/docs/adr/0041-stockage-de-l-access-token-cote-client.md
@@ -12,7 +12,7 @@ Dans le cadre de l'augmentation globale de la sécurité, nous avons cherché à
 
 Par défaut, EmberSimpleAuth utilise le localStorage pour gérer la session de l'utilisateur via la classe [AdaptiveStore](https://ember-simple-auth.com/api/classes/AdaptiveStore.html).
 
-Nous utilisons le flow OAuth2 (custom) pour l'authentification des utilisateurs.
+Nous utilisons le flow OAuth2 (custom) pour l'authentification des utilisateurs. Ce flow nous permet de définir des endpoints différents de ceux par défaut fourni par ESA (Ember Simple Auth). La subtilité sur PixApp, c'est que nous devons également gérer les connexions via le GAR. 
 
 Il existe une liaison assez forte entre le stockage de la session et le flow d'authentification utilisé.
 

--- a/docs/adr/0041-stockage-de-l-access-token-cote-client.md
+++ b/docs/adr/0041-stockage-de-l-access-token-cote-client.md
@@ -8,18 +8,16 @@ Confirmé
 
 ## Contexte
 
-Dans le cadre de l'augmentation globale de la sécurité, nous avons cherché à améliorer la sécurité 
-du stockage de l'access token conformément aux bonnes pratiques en remplaçant l'usage du 
-localStorage par le cookieStorage (voir lien : https://dev.to/rdegges/please-stop-using-local-storage-1i04).
+Dans le cadre de l'augmentation globale de la sécurité, nous avons cherché à améliorer la sécurité du stockage de l'access token conformément aux bonnes pratiques en remplaçant l'usage du LocalStorage par le CookieStorage (voir lien : https://dev.to/rdegges/please-stop-using-local-storage-1i04).
 
-De base EmberSimpleAuth utilise le localstorage pour gérer la session de l'utilisateur.
+Par défaut, EmberSimpleAuth utilise le Localstorage pour gérer la session de l'utilisateur via la classe [AdaptiveStore](https://ember-simple-auth.com/api/classes/AdaptiveStore.html).
 
 Nous utilisons le flow OAuth2 (custom) pour l'authentification des utilisateurs.
 
-Cet authenticator est fortement lié à la gestion de la session par EmberSimpleAuth.
+Il existe une liaison assez forte entre le stockage de la session et le flow d'authentification utilisé.
 
-Ce dernier utilise les informations stockées dans la session pour gérer le rafraichissement
-de l'access token avant expiration (expires_in, refresh_token)
+L'authenticator utilise les informations stockées dans la session pour gérer le rafraichissement
+de l'access token avant expiration (expires_in, refresh_token).
 
 ## Solution : Cookie
 
@@ -35,10 +33,10 @@ Configurer EmberSimpleAuth pour utiliser le CookieStorage à la place du LocalSt
 
 **Inconvénient(s) :**
 
-- Incompatibilité entre l'utilisation des cookies et du flow OAuth2 par le fonctionnement d'EmberSimpleAuth. Ce qui nous pousserait à ne plus utiliser le flow OAuth2 (voir https://github.com/mainmatter/ember-simple-auth/issues/1907).
+- Incompatibilité entre l'utilisation des cookies et du flow OAuth2 par le fonctionnement d'EmberSimpleAuth. Ce qui nous pousserait à ne plus utiliser le flow OAuth2 (voir lien : https://github.com/mainmatter/ember-simple-auth/issues/1907).
 - Tout l'objet de session EmberSimpleAuth sera ajouté sur toutes les requêtes
 
 ## Décision
 
-En l'état on garde ce l'on a.
-Pas de solutions qui changerait le flow d'authentification OAuth2
+Aucune solution a été trouvée qui éviterait le changement du flow d'authentification actuellement utilisé (OAuth2 custom).
+Nous gardons la solution actuelle, c'est-à-dire l'utilisation du LocalStorage.

--- a/docs/adr/0041-stockage-de-l-access-token-cote-client.md
+++ b/docs/adr/0041-stockage-de-l-access-token-cote-client.md
@@ -38,5 +38,6 @@ Configurer EmberSimpleAuth pour utiliser un cookie à la place du localStorage q
 
 ## Décision
 
-Aucune solution n'a été trouvée qui éviterait le changement du flow d'authentification actuellement utilisé (OAuth2 custom).
-Nous gardons la solution actuelle, c'est-à-dire l'utilisation du localStorage.
+Aucune solution n'a été trouvée qui éviterait le changement du flow d'authentification actuellement utilisé (OAuth2 custom) tout en gardant EmberSimpleAuth qui automatise pour nous toute la gestion des refresh tokens.
+Aussi nous gardons pour l'instant la solution actuelle, c'est-à-dire l'utilisation du localStorage.
+Une potentielle solution à plus long terme serait de faire une contribution à EmberSimpleAuth faisant l'utilisation de cookie pour le stockage de l'access token, mais il faudrait déjà réaliser ce développement puis qu'il soit accepté ce qui n'a rien de certain.

--- a/docs/adr/0041-stockage-de-l-access-token-cote-client.md
+++ b/docs/adr/0041-stockage-de-l-access-token-cote-client.md
@@ -41,3 +41,5 @@ Configurer EmberSimpleAuth pour utiliser un cookie à la place du localStorage q
 Aucune solution n'a été trouvée qui éviterait le changement du flow d'authentification actuellement utilisé (OAuth2 custom) tout en gardant EmberSimpleAuth qui automatise pour nous toute la gestion des refresh tokens.
 Aussi nous gardons pour l'instant la solution actuelle, c'est-à-dire l'utilisation du localStorage.
 Une potentielle solution à plus long terme serait de faire une contribution à EmberSimpleAuth faisant l'utilisation de cookie pour le stockage de l'access token, mais il faudrait déjà réaliser ce développement puis qu'il soit accepté ce qui n'a rien de certain.
+
+Nous avons choisi d'entériner cette non décision par une ADR pour sauvegarder le fruit de nos réflexions au cas où, à l'avenir, d'autres développeurs considérait la possibilité d'utiliser un cookie plutôt que le localStorage pour stocker le token d'accès.

--- a/docs/adr/0041-stockage-de-l-access-token-cote-client.md
+++ b/docs/adr/0041-stockage-de-l-access-token-cote-client.md
@@ -1,0 +1,41 @@
+# Stockage de l'access token côté client
+
+Date : 2023-01-26
+
+## État
+
+Confirmé
+
+## Contexte
+
+Dans le cadre de l'augmentation globale de la sécurité, nous avons cherché à améliorer la sécurité 
+du stockage de l'access token conformément aux bonnes pratiques en remplaçant l'usage du 
+localStorage par le cookieStorage (voir lien : https://dev.to/rdegges/please-stop-using-local-storage-1i04).
+
+De base EmberSimpleAuth utilise le localstorage pour gérer la session de l'utilisateur.
+
+Nous utilisons le flow OAuth2 (custom) pour l'authentification des utilisateurs.
+
+Cet authenticator est fortement lié à la gestion de la session par EmberSimpleAuth.
+
+Ce dernier utilise les informations stockées dans la session pour gérer le rafraichissement
+de l'access token avant expiration (expires_in, refresh_token)
+
+## Solution : Cookie
+
+**Description :**
+
+Utilisation du store CookieStore de EmberSimpleAuth à la place de AdaptiveStore
+
+**Avantage(s) :**
+
+- Stockage de l'access token dans un cookie sécurisé (httpOnly, isSecure)
+
+**Inconvénient(s) :**
+
+- Quitter le flow OAuth 2 : https://github.com/mainmatter/ember-simple-auth/issues/1907
+
+## Décision
+
+En l'état on garde ce l'on a.
+Pas de solutions qui changerait le flow d'authentification OAuth2

--- a/docs/adr/0041-stockage-de-l-access-token-cote-client.md
+++ b/docs/adr/0041-stockage-de-l-access-token-cote-client.md
@@ -12,7 +12,7 @@ Dans le cadre de l'augmentation globale de la sécurité, nous avons cherché à
 
 Par défaut, EmberSimpleAuth utilise le localStorage pour gérer la session de l'utilisateur via la classe [AdaptiveStore](https://ember-simple-auth.com/api/classes/AdaptiveStore.html).
 
-Nous utilisons le flow OAuth2 (custom) pour l'authentification des utilisateurs. Ce flow nous permet de définir des endpoints différents de ceux par défaut fourni par ESA (Ember Simple Auth). La subtilité sur PixApp, c'est que nous devons également gérer les connexions via le GAR. 
+Nous utilisons le flow OAuth2 (custom) pour l'authentification des utilisateurs. Ce flow nous permet de définir des endpoints différents de ceux par défaut fournis par ESA (Ember Simple Auth). La subtilité sur PixApp, c'est que nous devons également gérer les connexions via le GAR. 
 
 Il existe une liaison assez forte entre le stockage de la session et le flow d'authentification utilisé.
 

--- a/docs/adr/0041-stockage-de-l-access-token-cote-client.md
+++ b/docs/adr/0041-stockage-de-l-access-token-cote-client.md
@@ -25,15 +25,18 @@ de l'access token avant expiration (expires_in, refresh_token)
 
 **Description :**
 
-Utilisation du store CookieStore de EmberSimpleAuth à la place de AdaptiveStore
+Configurer EmberSimpleAuth pour utiliser le CookieStorage à la place du LocalStorage qui est le stockage par défaut.
 
 **Avantage(s) :**
 
-- Stockage de l'access token dans un cookie sécurisé (httpOnly, isSecure)
+- Stockage de l'access token dans un cookie sécurisé (httpOnly, isSecure), donc non visible par du code JavaScript.
+- Le navigateur gère automatiquement l'envoi des cookies dans chacune des requêtes.
+- Le back sera la seule entité à pouvoir utiliser les informations du cookie
 
 **Inconvénient(s) :**
 
-- Quitter le flow OAuth 2 : https://github.com/mainmatter/ember-simple-auth/issues/1907
+- Incompatibilité entre l'utilisation des cookies et du flow OAuth2 par le fonctionnement d'EmberSimpleAuth. Ce qui nous pousserait à ne plus utiliser le flow OAuth2 (voir https://github.com/mainmatter/ember-simple-auth/issues/1907).
+- Tout l'objet de session EmberSimpleAuth sera ajouté sur toutes les requêtes
 
 ## Décision
 

--- a/docs/adr/0041-stockage-de-l-access-token-cote-client.md
+++ b/docs/adr/0041-stockage-de-l-access-token-cote-client.md
@@ -8,9 +8,9 @@ Confirmé
 
 ## Contexte
 
-Dans le cadre de l'augmentation globale de la sécurité, nous avons cherché à améliorer la sécurité du stockage de l'access token conformément aux bonnes pratiques en remplaçant l'usage du LocalStorage par le CookieStorage (voir lien : https://dev.to/rdegges/please-stop-using-local-storage-1i04).
+Dans le cadre de l'augmentation globale de la sécurité, nous avons cherché à améliorer la sécurité du stockage de l'access token conformément aux bonnes pratiques en remplaçant l'usage du [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) par l'utilisation d'un [cookie](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie) (voir lien : https://dev.to/rdegges/please-stop-using-local-storage-1i04).
 
-Par défaut, EmberSimpleAuth utilise le Localstorage pour gérer la session de l'utilisateur via la classe [AdaptiveStore](https://ember-simple-auth.com/api/classes/AdaptiveStore.html).
+Par défaut, EmberSimpleAuth utilise le localStorage pour gérer la session de l'utilisateur via la classe [AdaptiveStore](https://ember-simple-auth.com/api/classes/AdaptiveStore.html).
 
 Nous utilisons le flow OAuth2 (custom) pour l'authentification des utilisateurs.
 
@@ -23,12 +23,12 @@ de l'access token avant expiration (expires_in, refresh_token).
 
 **Description :**
 
-Configurer EmberSimpleAuth pour utiliser le CookieStorage à la place du LocalStorage qui est le stockage par défaut.
+Configurer EmberSimpleAuth pour utiliser un cookie à la place du localStorage qui est le stockage par défaut.
 
 **Avantage(s) :**
 
-- Stockage de l'access token dans un cookie sécurisé (httpOnly, isSecure), donc non visible par du code JavaScript.
-- Le navigateur gère automatiquement l'envoi des cookies dans chacune des requêtes.
+- Stockage de l'access token dans un cookie sécurisé (httpOnly, isSecure), donc non visible par du code JavaScript
+- Le navigateur gère automatiquement l'envoi des cookies dans chacune des requêtes
 - Le back sera la seule entité à pouvoir utiliser les informations du cookie
 
 **Inconvénient(s) :**
@@ -38,5 +38,5 @@ Configurer EmberSimpleAuth pour utiliser le CookieStorage à la place du LocalSt
 
 ## Décision
 
-Aucune solution a été trouvée qui éviterait le changement du flow d'authentification actuellement utilisé (OAuth2 custom).
-Nous gardons la solution actuelle, c'est-à-dire l'utilisation du LocalStorage.
+Aucune solution n'a été trouvée qui éviterait le changement du flow d'authentification actuellement utilisé (OAuth2 custom).
+Nous gardons la solution actuelle, c'est-à-dire l'utilisation du localStorage.


### PR DESCRIPTION
## :egg: Problème

Actuellement, le token d'accès des utilisateurs se trouvent dans le `localStorage` du navigateur et donc accessible et lisible par tout code JavaScript. Il faudrait utiliser un stockage plus sécurisé par le biais d'un cookie.

## :bowl_with_spoon: Proposition
> _Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés._

## :milk_glass: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :butter: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
