### PR TITLE
[FEATURE] Ajout de candidats à partir d'un id de session dans le csv d'import en masse (PIX-6180).

### DIFF
--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -26,60 +26,99 @@ module.exports = async function createSessions({
 
   await DomainTransaction.execute(async (domainTransaction) => {
     await bluebird.mapSeries(sessions, async (session) => {
-      const accessCode = sessionCodeService.getNewSessionCodeWithoutAvailabilityCheck();
-      const domainSession = new Session({
-        ...session,
-        certificationCenterId,
-        certificationCenter,
-        accessCode,
-      });
-
-      domainSession.generateSupervisorPassword();
-      sessionValidator.validate(domainSession);
-      const savedSession = await sessionRepository.save(domainSession, domainTransaction);
-
-      await bluebird.mapSeries(domainSession.certificationCandidates, async (certificationCandidate) => {
-        const billingMode = CertificationCandidate.translateBillingMode(certificationCandidate.billingMode);
-
-        const domainCertificationCandidate = new CertificationCandidate({
-          ...certificationCandidate,
-          sessionId: savedSession.id,
-          billingMode,
+      let sessionId;
+      let domainSession;
+      if (!session.sessionId) {
+        const accessCode = sessionCodeService.getNewSessionCodeWithoutAvailabilityCheck();
+        domainSession = new Session({
+          ...session,
+          certificationCenterId,
+          certificationCenter,
+          accessCode,
         });
 
-        domainCertificationCandidate.validate(isSco);
+        domainSession.generateSupervisorPassword();
+        sessionValidator.validate(domainSession);
+        const { id } = await sessionRepository.save(domainSession, domainTransaction);
+        sessionId = id;
+      }
 
-        const cpfBirthInformation = await certificationCpfService.getBirthInformation({
-          birthCountry: domainCertificationCandidate.birthCountry,
-          birthCity: domainCertificationCandidate.birthCity,
-          birthPostalCode: domainCertificationCandidate.birthPostalCode,
-          birthINSEECode: domainCertificationCandidate.birthINSEECode,
+      if (session.sessionId) {
+        sessionId = session.sessionId;
+        domainSession = new Session({
+          ...session,
+          certificationCenterId,
+          certificationCenter,
+        });
+
+        await certificationCandidateRepository.deleteBySessionId({ sessionId });
+      }
+
+      if (domainSession.certificationCandidates.length) {
+        await _createCertificationCandidates({
+          domainSession,
+          sessionId,
+          isSco,
           certificationCpfCountryRepository,
           certificationCpfCityRepository,
-        });
-
-        if (cpfBirthInformation.hasFailed()) {
-          throw new InvalidCertificationCandidate({ message: cpfBirthInformation.message, error: {} });
-        }
-
-        domainCertificationCandidate.updateBirthInformation(cpfBirthInformation);
-
-        if (domainCertificationCandidate.complementaryCertifications.length) {
-          const complementaryCertification = await complementaryCertificationRepository.getByLabel({
-            label: domainCertificationCandidate.complementaryCertifications[0],
-          });
-
-          domainCertificationCandidate.complementaryCertifications = [complementaryCertification];
-        }
-
-        await certificationCandidateRepository.saveInSession({
-          sessionId: savedSession.id,
-          certificationCandidate: domainCertificationCandidate,
+          complementaryCertificationRepository,
+          certificationCandidateRepository,
           domainTransaction,
         });
-      });
+      }
 
-      return savedSession;
+      return true;
     });
   });
 };
+async function _createCertificationCandidates({
+  domainSession,
+  sessionId,
+  isSco,
+  certificationCpfCountryRepository,
+  certificationCpfCityRepository,
+  complementaryCertificationRepository,
+  certificationCandidateRepository,
+  domainTransaction,
+}) {
+  await bluebird.mapSeries(domainSession.certificationCandidates, async (certificationCandidate) => {
+    const billingMode = CertificationCandidate.translateBillingMode(certificationCandidate.billingMode);
+
+    const domainCertificationCandidate = new CertificationCandidate({
+      ...certificationCandidate,
+      sessionId,
+      billingMode,
+    });
+
+    domainCertificationCandidate.validate(isSco);
+
+    const cpfBirthInformation = await certificationCpfService.getBirthInformation({
+      birthCountry: domainCertificationCandidate.birthCountry,
+      birthCity: domainCertificationCandidate.birthCity,
+      birthPostalCode: domainCertificationCandidate.birthPostalCode,
+      birthINSEECode: domainCertificationCandidate.birthINSEECode,
+      certificationCpfCountryRepository,
+      certificationCpfCityRepository,
+    });
+
+    if (cpfBirthInformation.hasFailed()) {
+      throw new InvalidCertificationCandidate({ message: cpfBirthInformation.message, error: {} });
+    }
+
+    domainCertificationCandidate.updateBirthInformation(cpfBirthInformation);
+
+    if (domainCertificationCandidate.complementaryCertifications.length) {
+      const complementaryCertification = await complementaryCertificationRepository.getByLabel({
+        label: domainCertificationCandidate.complementaryCertifications[0],
+      });
+
+      domainCertificationCandidate.complementaryCertifications = [complementaryCertification];
+    }
+
+    await certificationCandidateRepository.saveInSession({
+      sessionId,
+      certificationCandidate: domainCertificationCandidate,
+      domainTransaction,
+    });
+  });
+}

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -278,48 +278,101 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
       });
     });
 
+    describe('when there is a sessionId', function () {
+      context('when there is certification candidate information', function () {
+        it('should return data', function () {
+          // given
+          const parsedCsvData = [
+            _lineWithSessionIdAndCandidate({
+              sessionId: 1,
+              candidateNumber: 1,
+            }),
+          ];
+
+          const expectedResult = [
+            {
+              sessionId: 1,
+              examiner: undefined,
+              certificationCandidates: [
+                {
+                  lastName: 'Candidat 1',
+                  firstName: 'Candidat 1',
+                  birthdate: '1981-03-01',
+                  birthINSEECode: '75015',
+                  birthPostalCode: '',
+                  billingMode: 'Prépayée',
+                  birthCity: '',
+                  birthCountry: 'France',
+                  email: '',
+                  externalId: '',
+                  extraTimePercentage: null,
+                  prepaymentCode: '43',
+                  resultRecipientEmail: 'robindahood@email.fr',
+                  sex: 'M',
+                  complementaryCertifications: [],
+                },
+              ],
+            },
+          ];
+
+          // when
+          const result = csvSerializer
+            .deserializeForSessionsImport(parsedCsvData)
+            .map((session) => _.omit(session, 'uniqueKey'));
+
+          // then
+          expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+        });
+      });
+    });
+
     describe('when there is no session information', function () {
-      it('should return a full session object with previous session information and current candidate information if any', function () {
-        // given
-        const parsedCsvData = [_lineWithSessionAndNoCandidate({ sessionNumber: 1 }), _lineWithCandidateAndNoSession()];
+      context('when there is a previous session line in csv', function () {
+        it('should return a full session object with previous session information and current candidate information if any', function () {
+          // given
+          const parsedCsvData = [
+            _lineWithSessionAndNoCandidate({ sessionNumber: 1 }),
+            _lineWithCandidateAndNoSession(),
+          ];
 
-        const expectedResult = [
-          {
-            address: 'Site 1',
-            room: 'Salle 1',
-            date: '2023-05-12',
-            time: '01:00',
-            examiner: 'Paul',
-            description: '',
-            certificationCandidates: [
-              {
-                lastName: 'Pennyworth',
-                firstName: 'Alfred',
-                birthdate: '1951-03-02',
-                sex: 'M',
-                birthINSEECode: '75015',
-                birthPostalCode: '',
-                birthCity: '',
-                birthCountry: 'France',
-                resultRecipientEmail: 'alfredOfficial@email.fr',
-                email: '',
-                externalId: '',
-                extraTimePercentage: null,
-                billingMode: 'Prépayée',
-                prepaymentCode: '43',
-                complementaryCertifications: [],
-              },
-            ],
-          },
-        ];
+          const expectedResult = [
+            {
+              address: 'Site 1',
+              room: 'Salle 1',
+              date: '2023-05-12',
+              time: '01:00',
+              examiner: 'Paul',
+              description: '',
+              certificationCandidates: [
+                {
+                  lastName: 'Pennyworth',
+                  firstName: 'Alfred',
+                  birthdate: '1951-03-02',
+                  sex: 'M',
+                  birthINSEECode: '75015',
+                  birthPostalCode: '',
+                  birthCity: '',
+                  birthCountry: 'France',
+                  resultRecipientEmail: 'alfredOfficial@email.fr',
+                  email: '',
+                  externalId: '',
+                  extraTimePercentage: null,
+                  billingMode: 'Prépayée',
+                  prepaymentCode: '43',
+                  complementaryCertifications: [],
+                },
+              ],
+            },
+          ];
 
-        // when
-        const result = csvSerializer
-          .deserializeForSessionsImport(parsedCsvData)
-          .map((session) => _.omit(session, 'uniqueKey'));
+          // when
+          const result = csvSerializer
+            .deserializeForSessionsImport(parsedCsvData)
+            .map((session) => _.omit(session, 'uniqueKey'));
 
-        // then
-        expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+          // then
+          expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+        });
       });
     });
 
@@ -559,6 +612,26 @@ function _lineWithSessionAndCandidate({ sessionNumber, candidateNumber }) {
     date: '12/05/2023',
     time: '01:00',
     examiner: 'Paul',
+    description: '',
+    lastName: `Candidat ${candidateNumber}`,
+    firstName: `Candidat ${candidateNumber}`,
+    birthdate: '01/03/1981',
+    sex: 'M',
+    birthINSEECode: '75015',
+    birthPostalCode: '',
+    birthCity: '',
+    birthCountry: 'France',
+    resultRecipientEmail: 'robindahood@email.fr',
+    email: '',
+    externalId: '',
+    extraTimePercentage: '',
+    billingMode: 'Prépayée',
+    prepaymentCode: '43',
+  });
+}
+function _lineWithSessionIdAndCandidate({ sessionId, candidateNumber }) {
+  return _line({
+    sessionId,
     description: '',
     lastName: `Candidat ${candidateNumber}`,
     firstName: `Candidat ${candidateNumber}`,


### PR DESCRIPTION
## :egg: Problème

Nous ne pouvons pas créer ajouter des candidats à partir d'un numéro de session existante

## :bowl_with_spoon: Proposition
Entrer un numéro de session sur une ligne de candidat pour l'inscrire à cette même session

## :milk_glass: Remarques
Cette PR dépend de #5548

## :butter: Pour tester
- Depuis pix-certif, importer des candidats avec le csv en ajoutant le N° de session d'une session existante

```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
NUMERO DE SESSION EXISTANTE,,,,,,,Candidat 1,1,01/01/2000,M,75115,,,France,,,,,Gratuite,,oui,
NUMERO DE SESSION EXISTANTE,,,,,,,Candidat 2,2,01/01/2000,M,75115,,,France,,,,,Payante,,,oui
```

- Constater que "Candidat 1" et "Candidat 2" ont bien été ajoutés à la session
- Si la session comportait déjà des candidats: 
  - Constater que les anciens candidats ont été remplacés par les nouveaux