### PR TITLE
[FEATURE] Ajouter un titre dans la carte de tutoriel (PIX-6810)

### DIFF
--- a/mon-pix/app/components/scorecard-details.hbs
+++ b/mon-pix/app/components/scorecard-details.hbs
@@ -179,13 +179,13 @@
     <div class="scorecard-details__content">
       <div class="tutorials">
         <div class="tutorials__header">
-          <h3 class="tutorials-header__title">{{t "pages.competence-details.tutorials.title"}}</h3>
+          <h2 class="tutorials-header__title">{{t "pages.competence-details.tutorials.title"}}</h2>
           <p class="tutorials-header__description">{{t "pages.competence-details.tutorials.description"}}</p>
         </div>
         <div>
           {{#each this.tutorialsGroupedByTubeName as |tube|}}
             <div class="tube">
-              <h4 class="tube__title">{{tube.practicalTitle}}</h4>
+              <h3 class="tube__title">{{tube.practicalTitle}}</h3>
               <ul class="tube__content">
                 {{#each tube.tutorials as |tutorial|}}
                   <Tutorials::Card @tutorial={{tutorial}} />

--- a/mon-pix/app/components/tutorials/card.hbs
+++ b/mon-pix/app/components/tutorials/card.hbs
@@ -1,15 +1,11 @@
 <li>
   <article class="tutorial-card" role="article">
     <div class="tutorial-card__content">
-      <a
-        target="_blank"
-        rel="noopener noreferrer"
-        href="{{@tutorial.link}}"
-        class="tutorial-card-content__link"
-        title="{{@tutorial.title}}"
-      >
-        {{@tutorial.title}}
-      </a>
+      <h4 class="tutorial-card-content__title">
+        <a target="_blank" rel="noopener noreferrer" href="{{@tutorial.link}}" title="{{@tutorial.title}}">
+          {{@tutorial.title}}
+        </a>
+      </h4>
       <p class="tutorial-card-content__details">
         {{@tutorial.source}}
         •

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -8,8 +8,9 @@
 }
 
 .tutorials-header {
-
   &__title {
+    @extend h3;
+
     margin-bottom: 4px;
   }
 
@@ -33,6 +34,7 @@
     font-size: 1.25rem;
     font-family: $font-open-sans;
     line-height: 2.125rem;
+    letter-spacing: 0;
   }
 
   &__content {
@@ -47,7 +49,6 @@
 }
 
 .scorecard-details {
-
   &__content {
     display: flex;
     flex-direction: column;
@@ -101,7 +102,6 @@
 }
 
 .scorecard-details-content {
-
   &__left {
     display: flex;
     flex-direction: column;
@@ -133,7 +133,6 @@
 }
 
 .scorecard-details-content-left {
-
   &__area {
     font-size: 0.875rem;
     letter-spacing: 0.125rem;
@@ -175,7 +174,6 @@
 }
 
 .scorecard-details-content-right {
-
   &__score-container {
     display: flex;
     flex-direction: row;
@@ -200,7 +198,6 @@
 }
 
 .scorecard-details-content-right-score-container {
-
   &__pix-earned {
     display: flex;
     flex-direction: column;
@@ -212,7 +209,6 @@
 }
 
 .scorecard-details-reset-modal {
-
   &__important-message {
     margin-bottom: $spacing-s;
     color: $pix-neutral-110;
@@ -249,7 +245,6 @@
 }
 
 .scorecard-details-improvement-countdown {
-
   &__label {
     color: $pix-neutral-60;
     font-size: 0.6875rem;

--- a/mon-pix/app/styles/components/_tutorial-card.scss
+++ b/mon-pix/app/styles/components/_tutorial-card.scss
@@ -15,13 +15,10 @@
 }
 
 .tutorial-card-content {
-
-  &__link {
+  &__title {
     display: -webkit-box;
-    width: 100%;
     margin-bottom: 4px;
     overflow: hidden;
-    color: $pix-neutral-90;
     font-weight: $font-semi-bold;
     font-size: 1.25rem;
     font-family: $font-open-sans;
@@ -30,9 +27,13 @@
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
 
-    &:hover,
-    &:focus {
-      color: $pix-primary;
+    a {
+      color: $pix-neutral-90;
+
+      &:hover,
+      &:focus {
+        color: $pix-primary;
+      }
     }
   }
 

--- a/mon-pix/tests/integration/components/tutorials/card_test.js
+++ b/mon-pix/tests/integration/components/tutorials/card_test.js
@@ -35,8 +35,8 @@ module('Integration | Component | Tutorials | Card', function (hooks) {
       // then
       assert.dom('.tutorial-card').exists();
       assert.dom('.tutorial-card__content').exists();
-      assert.ok(find('.tutorial-card-content__link').textContent.includes('Mon super tutoriel'));
-      assert.strictEqual(find('.tutorial-card-content__link').href, 'https://exemple.net/');
+      assert.ok(find('.tutorial-card-content__title a').textContent.includes('Mon super tutoriel'));
+      assert.strictEqual(find('.tutorial-card-content__title a').href, 'https://exemple.net/');
       assert.ok(find('.tutorial-card-content__details').textContent.includes('mon-tuto'));
       assert.ok(find('.tutorial-card-content__details').textContent.includes('vidéo'));
       assert.ok(find('.tutorial-card-content__details').textContent.includes('une minute'));
@@ -75,8 +75,8 @@ module('Integration | Component | Tutorials | Card', function (hooks) {
       // then
       assert.dom('.tutorial-card').exists();
       assert.dom('.tutorial-card__content').exists();
-      assert.ok(find('.tutorial-card-content__link').textContent.includes('Mon super tutoriel'));
-      assert.strictEqual(find('.tutorial-card-content__link').href, 'https://exemple.net/');
+      assert.ok(find('.tutorial-card-content__title a').textContent.includes('Mon super tutoriel'));
+      assert.strictEqual(find('.tutorial-card-content__title a').href, 'https://exemple.net/');
       assert.ok(find('.tutorial-card-content__details').textContent.includes('mon-tuto'));
       assert.ok(find('.tutorial-card-content__details').textContent.includes('vidéo'));
       assert.ok(find('.tutorial-card-content__details').textContent.includes('une minute'));


### PR DESCRIPTION
## :egg: Problème
Mauvaise accessibilité : la carte des tutoriels n'avait pas de titre.

## :bowl_with_spoon: Proposition
Ajouter un titre de niveau 4 dans ces cartes.

## :milk_glass: Remarques
Ces cartes sont présentes dans 4 pages différentes :

- Page /mes-tutos/recommandes
- Modale “Tuto et réponse” dans un checkpoint : bloc “Pour en apprendre d’avantage“
- Bloc “Cultivez vos compétences” de la page de détails d'une compétence
- Bloc “Cultivez vos compétences” de la page de résultats d'une compétence

Pour ces deux derniers blocs, une amélioration a été faite sur le niveau de titres des pages (on passait du H1 au H3, sans H2 hormis celui de la modale, mais qui est donc hors de contexte).

## :butter: Pour tester
Se connecter sur la RA avec UserPix1 et vérifier les titres des cartes de tuto et que le style des autres titres des pages n'ont pas changé :

- https://app-pr5560.review.pix.fr/mes-tutos/recommandes
- Bloc "Pour réussir la prochaine fois" de la modale : https://app-pr5560.review.pix.fr/assessments/108581/checkpoint?finalCheckpoint=false
- Bloc "Cultivez vos compétences" : https://app-pr5560.review.pix.fr/competences/recsvLz0W2ShyfD63/details
- Bloc "Cultivez vos compétences" : https://app-pr5560.review.pix.fr/competences/recgxqQfz3BqEbtzh/resultats/108582
