### PR TITLE
[FEATURE] Simulateur nouveau scoring : Utiliser les challenges archivés (PIX-6920)

### DIFF
--- a/api/lib/domain/services/algorithm-methods/data-fetcher.js
+++ b/api/lib/domain/services/algorithm-methods/data-fetcher.js
@@ -85,7 +85,7 @@ async function fetchForFlashCampaigns({
 }) {
   const [allAnswers, challenges, { estimatedLevel } = {}] = await Promise.all([
     answerRepository.findByAssessment(assessmentId),
-    challengeRepository.findFlashCompatible({ locale }),
+    challengeRepository.findActiveFlashCompatible({ locale }),
     flashAssessmentResultRepository.getLatestByAssessmentId(assessmentId),
   ]);
 

--- a/api/lib/domain/usecases/simulate-flash-scoring.js
+++ b/api/lib/domain/usecases/simulate-flash-scoring.js
@@ -7,7 +7,7 @@ module.exports = async function simulateFlashScoring({
   locale,
   context: { calculateEstimatedLevel, successProbabilityThreshold },
 }) {
-  const challenges = await challengeRepository.findActiveFlashCompatible({ locale, successProbabilityThreshold });
+  const challenges = await challengeRepository.findOperativeFlashCompatible({ locale, successProbabilityThreshold });
   const challengeIds = new Set(challenges.map(({ id }) => id));
 
   return simulations.map(({ id, user: { estimatedLevel: givenEstimatedLevel }, answers: allAnswers }) => {

--- a/api/lib/domain/usecases/simulate-flash-scoring.js
+++ b/api/lib/domain/usecases/simulate-flash-scoring.js
@@ -7,7 +7,7 @@ module.exports = async function simulateFlashScoring({
   locale,
   context: { calculateEstimatedLevel, successProbabilityThreshold },
 }) {
-  const challenges = await challengeRepository.findFlashCompatible({ locale, successProbabilityThreshold });
+  const challenges = await challengeRepository.findActiveFlashCompatible({ locale, successProbabilityThreshold });
   const challengeIds = new Set(challenges.map(({ id }) => id));
 
   return simulations.map(({ id, user: { estimatedLevel: givenEstimatedLevel }, answers: allAnswers }) => {

--- a/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
@@ -40,7 +40,7 @@ module.exports = datasource.extend({
     return validatedChallenges.filter((challenge) => challenge.skillId === id);
   },
 
-  async findFlashCompatible(locale) {
+  async findActiveFlashCompatible(locale) {
     const challenges = await this.list();
     return challenges.filter(
       (challengeData) =>

--- a/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/learning-content/challenge-datasource.js
@@ -51,4 +51,16 @@ module.exports = datasource.extend({
         challengeData.delta != null
     );
   },
+
+  async findOperativeFlashCompatible(locale) {
+    const challenges = await this.list();
+    return challenges.filter(
+      (challengeData) =>
+        _.includes(OPERATIVE_CHALLENGES, challengeData.status) &&
+        challengeData.skillId &&
+        _.includes(challengeData.locales, locale) &&
+        challengeData.alpha != null &&
+        challengeData.delta != null
+    );
+  },
 });

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -73,11 +73,11 @@ module.exports = {
     return _toDomainCollection({ challengeDataObjects, skills: operativeSkills });
   },
 
-  async findFlashCompatible({
+  async findActiveFlashCompatible({
     locale,
     successProbabilityThreshold = config.features.successProbabilityThreshold,
   } = {}) {
-    const challengeDataObjects = await challengeDatasource.findFlashCompatible(locale);
+    const challengeDataObjects = await challengeDatasource.findActiveFlashCompatible(locale);
     const activeSkills = await skillDatasource.findActive();
     return _toDomainCollection({ challengeDataObjects, skills: activeSkills, successProbabilityThreshold });
   },

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -82,6 +82,15 @@ module.exports = {
     return _toDomainCollection({ challengeDataObjects, skills: activeSkills, successProbabilityThreshold });
   },
 
+  async findOperativeFlashCompatible({
+    locale,
+    successProbabilityThreshold = config.features.successProbabilityThreshold,
+  } = {}) {
+    const challengeDataObjects = await challengeDatasource.findOperativeFlashCompatible(locale);
+    const skills = await skillDatasource.list();
+    return _toDomainCollection({ challengeDataObjects, skills, successProbabilityThreshold });
+  },
+
   async findValidatedBySkillId(skillId) {
     const challengeDataObjects = await challengeDatasource.findValidatedBySkillId(skillId);
     const activeSkills = await skillDatasource.findActive();

--- a/api/tests/integration/domain/services/algorithm-methods/flash_test.js
+++ b/api/tests/integration/domain/services/algorithm-methods/flash_test.js
@@ -768,82 +768,6 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
           ],
         });
       });
-
-      it("should not count a skill's score more than once", function () {
-        // given
-        const skills = [
-          domainBuilder.buildSkill({ id: 'Skill1', pixValue: 1, competenceId: 'FirstCompetence' }),
-          domainBuilder.buildSkill({ id: 'Skill2', pixValue: 10, competenceId: 'FirstCompetence' }),
-          domainBuilder.buildSkill({ id: 'Skill3', pixValue: 100, competenceId: 'SecondCompetence' }),
-        ];
-
-        const successProbabilityThreshold = 0.95;
-
-        const inferredChallenges = [
-          domainBuilder.buildChallenge({
-            id: 'Skill1Challenge',
-            skill: skills[0],
-            discriminant: 1.86350005965093,
-            difficulty: 0.194712138508747,
-            successProbabilityThreshold,
-          }), // minimumCapability: 1.7747705688358126
-          domainBuilder.buildChallenge({
-            id: 'Skill3LowestChallenge',
-            skill: skills[2],
-            discriminant: 2.65,
-            difficulty: -1.2,
-            successProbabilityThreshold,
-          }), // minimumCapability: -0.08889095125794655
-          domainBuilder.buildChallenge({
-            id: 'Skill3MediumChallenge',
-            skill: skills[2],
-            discriminant: 2.65,
-            difficulty: 0.9,
-            successProbabilityThreshold,
-          }), // minimumCapability: 1.9111090487420535
-        ];
-
-        const notInferredChallenges = [
-          domainBuilder.buildChallenge({
-            id: 'Skill2Challenge',
-            skill: skills[1],
-            discriminant: 2.25422414740233,
-            difficulty: 0.823376599163319,
-            successProbabilityThreshold,
-          }), // minimumCapability: 2.1295639109084643
-          domainBuilder.buildChallenge({
-            id: 'Skill3HighestChallenge1',
-            skill: skills[2],
-            discriminant: 1.4,
-            difficulty: 0.9,
-            successProbabilityThreshold,
-          }), // minimumCapability: 3.0031706994046012
-        ];
-
-        const challenges = [...inferredChallenges, ...notInferredChallenges];
-
-        const estimatedLevel = 2;
-
-        const allAnswers = [];
-
-        // when
-        const result = flash.calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges, estimatedLevel });
-
-        // then
-        expect(result).to.deep.equal({
-          pixScore: 101,
-          pixScoreByCompetence: [
-            {
-              competenceId: 'FirstCompetence',
-              pixScore: 1,
-            },
-            {
-              competenceId: 'SecondCompetence',
-              pixScore: 100,
-            },
-          ],
-        });
-      });
     });
 
     describe('when there are answers', function () {
@@ -956,47 +880,141 @@ describe('Integration | Domain | Algorithm-methods | Flash', function () {
           ],
         });
       });
+    });
 
-      it('should not count a skill more than once in direct score', function () {
+    describe('when there are several challenges for the same skill', function () {
+      it("should not count a skill's score more than once", function () {
         // given
-        const skill = domainBuilder.buildSkill({ id: 'FirstSkill', pixValue: 1, competenceId: 'FirstCompetence' });
+        const skills = [
+          domainBuilder.buildSkill({ id: 'Skill1', pixValue: 1, competenceId: 'FirstCompetence' }),
+          domainBuilder.buildSkill({ id: 'Skill2', pixValue: 10, competenceId: 'FirstCompetence' }),
+          domainBuilder.buildSkill({ id: 'Skill3', pixValue: 100, competenceId: 'SecondCompetence' }),
+        ];
 
         const successProbabilityThreshold = 0.95;
 
-        const challenges = [
+        const succeededChallenges = [
           domainBuilder.buildChallenge({
-            id: 'First',
-            skill,
-            discriminant: 0.16,
-            difficulty: -2,
+            id: 'Skill1Challenge1',
+            skill: skills[0],
+            discriminant: 1.86350005965093,
+            difficulty: 0.194712138508747,
             successProbabilityThreshold,
-          }),
+          }), // minimumCapability: 1.7747705688358126
           domainBuilder.buildChallenge({
-            id: 'Second',
-            skill,
-            discriminant: 3,
-            difficulty: 6,
+            id: 'Skill1Challenge2',
+            skill: skills[0],
+            discriminant: 1.86350005965093,
+            difficulty: 0.194712138508747,
             successProbabilityThreshold,
-          }),
+          }), // minimumCapability: 1.7747705688358126
+          domainBuilder.buildChallenge({
+            id: 'Skill1Challenge3',
+            skill: skills[0],
+            discriminant: 1.86350005965093,
+            difficulty: 0.194712138508747,
+            successProbabilityThreshold,
+          }), // minimumCapability: 1.7747705688358126
         ];
 
+        const inferredChallenges = [
+          domainBuilder.buildChallenge({
+            id: 'Skill3LowestChallenge',
+            skill: skills[2],
+            discriminant: 2.65,
+            difficulty: -1.2,
+            successProbabilityThreshold,
+          }), // minimumCapability: -0.08889095125794655
+          domainBuilder.buildChallenge({
+            id: 'Skill3MediumChallenge',
+            skill: skills[2],
+            discriminant: 2.65,
+            difficulty: 0.9,
+            successProbabilityThreshold,
+          }), // minimumCapability: 1.9111090487420535
+        ];
+
+        const notInferredChallenges = [
+          domainBuilder.buildChallenge({
+            id: 'Skill2Challenge',
+            skill: skills[1],
+            discriminant: 2.25422414740233,
+            difficulty: 0.823376599163319,
+            successProbabilityThreshold,
+          }), // minimumCapability: 2.1295639109084643
+          domainBuilder.buildChallenge({
+            id: 'Skill3HighestChallenge1',
+            skill: skills[2],
+            discriminant: 1.4,
+            difficulty: 0.9,
+            successProbabilityThreshold,
+          }), // minimumCapability: 3.0031706994046012
+        ];
+
+        const challenges = [...succeededChallenges, ...inferredChallenges, ...notInferredChallenges];
+
+        const estimatedLevel = 2;
+
         const allAnswers = [
-          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[0].id }),
-          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: challenges[1].id }),
+          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: succeededChallenges[0].id }),
+          domainBuilder.buildAnswer({ result: AnswerStatus.OK, challengeId: succeededChallenges[1].id }),
         ];
 
         // when
-        const result = flash.calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges });
+        const result = flash.calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges, estimatedLevel });
 
         // then
         expect(result).to.deep.equal({
-          pixScore: 1,
+          pixScore: 101,
           pixScoreByCompetence: [
             {
               competenceId: 'FirstCompetence',
               pixScore: 1,
             },
+            {
+              competenceId: 'SecondCompetence',
+              pixScore: 100,
+            },
           ],
+        });
+      });
+
+      it('should prioritize validated challenges for inferrence', async function () {
+        // given
+        const skills = [domainBuilder.buildSkill({ id: 'Skill1', pixValue: 1, competenceId: 'FirstCompetence' })];
+
+        const successProbabilityThreshold = 0.95;
+
+        const challenges = [
+          domainBuilder.buildChallenge({
+            id: 'ArchivedChallenge',
+            status: 'archivé',
+            skill: skills[0],
+            discriminant: 1.86350005965093,
+            difficulty: 0.194712138508747,
+            successProbabilityThreshold,
+          }), // minimumCapability: 1.7747705688358126
+          domainBuilder.buildChallenge({
+            id: 'ValidatedChallenge',
+            status: 'validé',
+            skill: skills[0],
+            discriminant: 2.25422414740233,
+            difficulty: 0.823376599163319,
+            successProbabilityThreshold,
+          }), // minimumCapability: 2.1295639109084643
+        ];
+
+        const estimatedLevel = 2;
+
+        const allAnswers = [];
+
+        // when
+        const result = flash.calculateTotalPixScoreAndScoreByCompetence({ allAnswers, challenges, estimatedLevel });
+
+        // then
+        expect(result).to.deep.equal({
+          pixScore: 0,
+          pixScoreByCompetence: [],
         });
       });
     });

--- a/api/tests/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -178,7 +178,7 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
 
       answerRepository = { findByAssessment: sinon.stub().resolves([lastAnswer]) };
       challenges = [];
-      challengeRepository = { findFlashCompatible: sinon.stub().resolves(challenges) };
+      challengeRepository = { findActiveFlashCompatible: sinon.stub().resolves(challenges) };
       const campaign = domainBuilder.buildCampaign({ assessmentMethod: 'FLASH' });
       domainBuilder.buildCampaignParticipation({ campaign, id: campaignParticipationId });
       assessment = domainBuilder.buildAssessment.ofTypeCampaign({
@@ -237,7 +237,7 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
 
     it('should have fetched the challenges', function () {
       // then
-      expect(challengeRepository.findFlashCompatible).to.have.been.called;
+      expect(challengeRepository.findActiveFlashCompatible).to.have.been.called;
     });
 
     it('should have fetched the next challenge with only most recent knowledge elements', function () {

--- a/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
+++ b/api/tests/integration/domain/usecases/simulate-flash-scoring_test.js
@@ -7,6 +7,7 @@ const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
 
 describe('Integration | UseCases | simulateFlashScoring', function () {
   const locale = 'fr-fr';
+  const locales = [locale];
 
   beforeEach(function () {
     const learningContent = {
@@ -48,14 +49,15 @@ describe('Integration | UseCases | simulateFlashScoring', function () {
         { id: 'skill7', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2', pixValue: 1000000 },
       ],
       challenges: [
-        { id: 'challenge1', skillId: 'skill1', status: 'validé', alpha: 0.16, delta: -2, locales: [locale] },
-        { id: 'challenge2', skillId: 'skill2', status: 'validé', alpha: 3, delta: 6, locales: [locale] },
-        { id: 'challenge3', skillId: 'skill3', status: 'validé', alpha: 1.587, delta: 8.5, locales: [locale] },
-        { id: 'challenge4', skillId: 'skill4', status: 'validé', alpha: 2.86789, delta: 0.145, locales: [locale] },
-        { id: 'challenge5', skillId: 'skill5', status: 'validé', alpha: 3, delta: 1, locales: [locale] },
-        { id: 'challenge6', skillId: 'skill6', status: 'validé', alpha: 1.7, delta: -1, locales: [locale] },
-        { id: 'challenge7', skillId: 'skill7', status: 'validé', alpha: 2.5, delta: 5, locales: [locale] },
-        { id: 'challenge8', skillId: 'skill7', status: 'validé', locales: [locale] },
+        { id: 'challenge1', skillId: 'skill1', status: 'validé', alpha: 0.16, delta: -2, locales },
+        { id: 'challenge2', skillId: 'skill2', status: 'validé', alpha: 3, delta: 6, locales },
+        { id: 'challenge3', skillId: 'skill3', status: 'validé', alpha: 1.587, delta: 8.5, locales },
+        { id: 'challenge4', skillId: 'skill4', status: 'validé', alpha: 2.86789, delta: 0.145, locales },
+        { id: 'challenge5', skillId: 'skill5', status: 'validé', alpha: 3, delta: 1, locales },
+        { id: 'challenge6', skillId: 'skill6', status: 'archivé', alpha: 1.7, delta: -1, locales },
+        { id: 'challenge7', skillId: 'skill7', status: 'validé', alpha: 2.5, delta: 5, locales },
+        { id: 'challenge8', skillId: 'skill7', status: 'validé', locales },
+        { id: 'challenge9', skillId: 'skill7', status: 'périmé', alpha: 1.7, delta: -1, locales },
       ],
     };
 

--- a/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/challenge-repository_test.js
@@ -445,7 +445,7 @@ describe('Integration | Repository | challenge-repository', function () {
     });
   });
 
-  describe('#findFlashCompatible', function () {
+  describe('#findActiveFlashCompatible', function () {
     beforeEach(function () {
       // given
       const skill = domainBuilder.buildSkill({ id: 'recSkill1' });
@@ -467,7 +467,7 @@ describe('Integration | Repository | challenge-repository', function () {
 
     it('should return only flash compatible challenges with skills', async function () {
       // when
-      const actualChallenges = await challengeRepository.findFlashCompatible({ locale: 'fr-fr' });
+      const actualChallenges = await challengeRepository.findActiveFlashCompatible({ locale: 'fr-fr' });
 
       // then
       expect(actualChallenges).to.have.lengthOf(1);
@@ -490,7 +490,7 @@ describe('Integration | Repository | challenge-repository', function () {
       const successProbabilityThreshold = 0.75;
 
       // when
-      const actualChallenges = await challengeRepository.findFlashCompatible({
+      const actualChallenges = await challengeRepository.findActiveFlashCompatible({
         locale: 'fr-fr',
         successProbabilityThreshold,
       });

--- a/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
+++ b/api/tests/unit/domain/services/smart-random/data-fetcher_test.js
@@ -160,7 +160,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
         findByAssessment: sinon.stub(),
       };
       challengeRepository = {
-        findFlashCompatible: sinon.stub(),
+        findActiveFlashCompatible: sinon.stub(),
       };
       flashAssessmentResultRepository = {
         getLatestByAssessmentId: sinon.stub(),
@@ -180,7 +180,7 @@ describe('Unit | Domain | services | smart-random | dataFetcher', function () {
       const estimatedLevel = Symbol('estimatedLevel');
 
       answerRepository.findByAssessment.withArgs(assessmentId).resolves([answer]);
-      challengeRepository.findFlashCompatible.withArgs().resolves(challenges);
+      challengeRepository.findActiveFlashCompatible.withArgs().resolves(challenges);
       flashAssessmentResultRepository.getLatestByAssessmentId.withArgs(assessmentId).resolves({ estimatedLevel });
 
       // when

--- a/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
@@ -208,7 +208,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
     });
   });
 
-  describe('#findFlashCompatible', function () {
+  describe('#findActiveFlashCompatible', function () {
     beforeEach(function () {
       sinon.stub(lcms, 'getLatestRelease').resolves({
         challenges: [
@@ -227,7 +227,7 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
     it('should resolve an array of matching Challenges from learning content', async function () {
       // when
       const locale = 'fr-fr';
-      const result = await challengeDatasource.findFlashCompatible(locale);
+      const result = await challengeDatasource.findActiveFlashCompatible(locale);
 
       // then
       expect(lcms.getLatestRelease).to.have.been.called;

--- a/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/learning-content/challenge-datasource_test.js
@@ -74,16 +74,12 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
       skillId: web1.id,
       status: 'proposé',
       locales: ['fr', 'fr-fr'],
-      alpha: -1.9,
-      delta: 2.34,
     };
     challenge_web1_archived = {
       id: 'challenge_web1_archived',
       skillId: web1.id,
       status: 'archivé',
       locales: ['fr', 'fr-fr'],
-      alpha: -1.9,
-      delta: 2.34,
     };
     challenge_web2_en = {
       id: 'challenge-web2',
@@ -231,7 +227,43 @@ describe('Unit | Infrastructure | Datasource | Learning Content | ChallengeDatas
 
       // then
       expect(lcms.getLatestRelease).to.have.been.called;
-      expect(_.map(result, 'id')).to.deep.equal(['challenge-competence1', 'challenge-competence2', 'challenge-web3']);
+      expect(_.map(result, 'id')).to.deep.equal([
+        challenge_competence1.id,
+        challenge_competence2.id,
+        challenge_web3.id,
+      ]);
+    });
+  });
+
+  describe('#findOperativeFlashCompatible', function () {
+    beforeEach(function () {
+      sinon.stub(lcms, 'getLatestRelease').resolves({
+        challenges: [
+          challenge_competence1,
+          challenge_competence1_noSkills,
+          challenge_competence2,
+          challenge_web1,
+          challenge_web1_notValidated,
+          challenge_web2_en,
+          challenge_web3,
+          challenge_web3_archived,
+        ],
+      });
+    });
+
+    it('should resolve an array of matching Challenges from learning content', async function () {
+      // when
+      const locale = 'fr-fr';
+      const result = await challengeDatasource.findOperativeFlashCompatible(locale);
+
+      // then
+      expect(lcms.getLatestRelease).to.have.been.called;
+      expect(_.map(result, 'id')).to.deep.equal([
+        challenge_competence1.id,
+        challenge_competence2.id,
+        challenge_web3.id,
+        challenge_web3_archived.id,
+      ]);
     });
   });
 


### PR DESCRIPTION
## :egg: Problème
Le simulateur de nouveau scoring n'utilise que les challenges à l'état "Validé", mais cela réduit les possibilités d'utilisation de ce simulateur.

## :bowl_with_spoon: Proposition
Élargir également aux challenges à l'état "Archivé".

## :milk_glass: Remarques
Est-ce qu'on veut vraiment prioriser les challenges validés dans l'inférence ?

## :butter: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
