### PR TITLE
[TECH] Amélioration de l’accessibilité sur Pix Orga (PIX-6853).

### DIFF
--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -87,7 +87,9 @@
             />
           </div>
         </Table::Header>
-        <Table::Header @size="small" class="hide-on-mobile" />
+        <Table::Header @size="small" class="hide-on-mobile">
+          <span>{{t "common.actions.global"}}</span>
+        </Table::Header>
       </tr>
     </thead>
 

--- a/orga/app/components/team/invitations-list.hbs
+++ b/orga/app/components/team/invitations-list.hbs
@@ -7,7 +7,7 @@
             "pages.team-invitations.table.column.pending-invitation"
           }}</Table::Header>
         <Table::Header @size="wide" class="hide-on-mobile">
-          <span class="screen-reader-only">{{t "common.actions.global"}}</span>
+          <span>{{t "common.actions.global"}}</span>
         </Table::Header>
       </tr>
     </thead>

--- a/orga/app/components/team/members-list.hbs
+++ b/orga/app/components/team/members-list.hbs
@@ -9,8 +9,8 @@
               "pages.team-members.table.column.organization-membership-role"
             }}</Table::Header>
           {{#if this.displayManagingColumn}}
-            <Table::Header @size="wide" class="hide-on-mobile">
-              <span class="screen-reader-only">{{t "common.actions.global"}}</span>
+            <Table::Header @size="medium" class="hide-on-mobile">
+              <span>{{t "common.actions.global"}}</span>
             </Table::Header>
           {{/if}}
         </tr>

--- a/orga/app/styles/pages/authenticated/team/list.scss
+++ b/orga/app/styles/pages/authenticated/team/list.scss
@@ -33,12 +33,6 @@ $margin-right: 32px;
 }
 
 .zone-edit-role {
-  align-items: center;
-  box-sizing: border-box;
-  display: flex;
-  height: inherit;
-  justify-content: flex-end;
-  padding-right: 25px;
 
   &__dropdown-button {
     margin-right: $margin-right;

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -32,16 +32,16 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
     this.set('students', []);
 
     // when
-    await render(
+    const screen = await render(
       hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}}/>`
     );
 
     // then
-    assert.contains('Nom');
-    assert.contains('Prénom');
-    assert.contains('Date de naissance');
-    assert.contains('Classe');
-    assert.contains('Méthode(s) de connexion');
+    assert.dom(screen.getByRole('columnheader', { name: 'Nom' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Prénom' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Date de naissance' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Méthode(s) de connexion' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Actions' })).exists();
   });
 
   test('it should display a list of students', async function (assert) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -919,7 +919,7 @@
           "login-method": "Log in method(s)",
           "participation-count": "Number of participations"
         },
-        "description": "Table of students, sorted by name. For students who have provided an email address or a username, you can manage the allowed login modes and reset the student's password through a menu in an additional column",
+        "description": "Table of students, sorted by name. For students who have provided an authentication method, you can manage the allowed login modes and reset the student's password through a menu in 'Actions' column",
         "empty": "No students.",
         "row-title": "Student"
       }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -919,7 +919,7 @@
           "login-method": "Méthode(s) de connexion",
           "participation-count": "Nombre de participations"
         },
-        "description": "Tableau des élèves trié par nom. Pour les élèves ayant fourni une adresse e-mail ou un identifiant, vous pouvez, via un menu situé dans une colonne supplémentaire, gérer les modes de connexion autorisés et réinitialiser le mot de passe de l'élève",
+        "description": "Tableau des élèves trié par nom. Pour les élèves ayant fourni une méthode de connexion, vous pouvez, via un menu situé dans la colonne 'Actions', gérer les modes de connexion autorisés et réinitialiser le mot de passe de l'élève",
         "empty": "Aucun élève.",
         "row-title": "Élève"
       }


### PR DESCRIPTION
## :egg: Problème
Actuellement sur Pix Orga, le tableau des élèves comporte un résumé qui est restitué par les lecteurs d'écran. 
Ce résumé a été ajouté car à l'époque le tableau était considéré comme "complexe" : il possèdait des fonctionnalités internes, sur certaines colonnes uniquement. 
Or on a constaté que ce résumé manquait de précision.

Le résumé était le suivant : "`Tableau des élèves trié par nom. Pour les élèves ayant fourni une adresse e-mail ou un identifiant, vous pouvez, via un menu situé dans une colonne supplémentaire, gérer les modes de connexion autorisés et réinitialiser le mot de passe de l'élève`"

`Pour les élèves ayant fourni une adresse e-mail ou un identifiant` : en réalité ça fonctionne également pour les méthodes de connexion GAR.

`situé dans une colonne supplémentaire` : peu clair mais c'est parce que la colonne en question n'a pas de nom.

## :bowl_with_spoon: Proposition
Corriger le résumé du tableau et ajouter un nom, Actions, à la dernière colonne du tableau.

A la demande d'Antoine et Emmy, les noms des colonnes Actions présentes dans deux autres tableaux seront visuellement affichés.

## :milk_glass: Remarques
Cette PR devait initialement supprimer le résumé de ce tableau, n'étant plus un tableau dit "complexe". Cependant nous souhaitons le garder pour aider à la compréhension de ce bouton d'action qui est disponible uniquement selon un cas particulier.

## :butter: Pour tester
Aller sur Pix Orga (sco.admin@example.net)
Constater que la dernière colonne possède bien une colonne nommé Actions
Accéder au tableau Equipe, constater que la dernière colonne est nommé Actions
Pareil pour le tableau des invitations.
