### PR TITLE
[FEATURE] Afficher le score par compétence sur la page de fin de campagne Flash (PIX-6902).

### DIFF
--- a/mon-pix/app/components/campaign-skill-review-competence-result.hbs
+++ b/mon-pix/app/components/campaign-skill-review-competence-result.hbs
@@ -30,10 +30,14 @@
             <span>{{competence.name}}</span>
           </th>
           <td>
-            <PixProgressGauge
-              @value={{competence.masteryPercentage}}
-              @tooltipText="{{competence.masteryPercentage}}%"
-            />
+            {{#if competence.flashPixScore}}
+              {{t "pages.skill-review.details.flash-pix-score" score=competence.flashPixScore}}
+            {{else}}
+              <PixProgressGauge
+                @value={{competence.masteryPercentage}}
+                @tooltipText="{{competence.masteryPercentage}}%"
+              />
+            {{/if}}
           </td>
         </tr>
       {{/each}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -225,53 +225,53 @@
     </PixBlock>
   {{/if}}
 
-  {{#if this.showDetail}}
-    <PixBlock @shadow="heavy" class="skill-review__result-detail-container">
+  <PixBlock @shadow="heavy" class="skill-review__result-detail-container">
 
-      {{#if this.showCertifiableBadges}}
-        <div class="badge-certifiable-container">
-          {{#each this.certifiableBadgesOrderedByValidity as |badge|}}
-            <BadgeCardCertifiable
-              @title={{badge.title}}
-              @message={{badge.message}}
-              @imageUrl={{badge.imageUrl}}
-              @altMessage={{badge.altMessage}}
-              @isAcquired={{badge.isAcquired}}
-              @isValid={{badge.isValid}}
-              @isCertifiable={{badge.isCertifiable}}
-            />
-          {{/each}}
-        </div>
-      {{/if}}
+    {{#if this.showCertifiableBadges}}
+      <div class="badge-certifiable-container">
+        {{#each this.certifiableBadgesOrderedByValidity as |badge|}}
+          <BadgeCardCertifiable
+            @title={{badge.title}}
+            @message={{badge.message}}
+            @imageUrl={{badge.imageUrl}}
+            @altMessage={{badge.altMessage}}
+            @isAcquired={{badge.isAcquired}}
+            @isValid={{badge.isValid}}
+            @isCertifiable={{badge.isCertifiable}}
+          />
+        {{/each}}
+      </div>
+    {{/if}}
 
-      {{#if this.showNotCertifiableBadges}}
-        <h2 class="skill-review-result-detail__badge-subtitle">
-          {{t "pages.skill-review.badges-title"}}
-        </h2>
-        <div class="badge-container">
-          {{#each this.acquiredNotCertifiableBadges as |badge|}}
-            <BadgeCard
-              @title={{badge.title}}
-              @message={{badge.message}}
-              @imageUrl={{badge.imageUrl}}
-              @altMessage={{badge.altMessage}}
-              @isAcquired={{badge.isAcquired}}
-            />
-          {{/each}}
-        </div>
-      {{/if}}
+    {{#if this.showNotCertifiableBadges}}
+      <h2 class="skill-review-result-detail__badge-subtitle">
+        {{t "pages.skill-review.badges-title"}}
+      </h2>
+      <div class="badge-container">
+        {{#each this.acquiredNotCertifiableBadges as |badge|}}
+          <BadgeCard
+            @title={{badge.title}}
+            @message={{badge.message}}
+            @imageUrl={{badge.imageUrl}}
+            @altMessage={{badge.altMessage}}
+            @isAcquired={{badge.isAcquired}}
+          />
+        {{/each}}
+      </div>
+    {{/if}}
 
-      {{#if this.showImproveButton}}
-        <SkillReviewImprove @improve={{this.improve}} />
-      {{/if}}
+    {{#if this.showImproveButton}}
+      <SkillReviewImprove @improve={{this.improve}} />
+    {{/if}}
 
-      {{#unless @model.campaign.isForAbsoluteNovice}}
+    {{#unless @model.campaign.isForAbsoluteNovice}}
 
-        <section class="skill-review-result-detail__content">
-          <div class="skill-review-result-detail__table-header">
-            <h2 class="skill-review-result-detail__subtitle">
-              {{t "pages.skill-review.details.title"}}
-            </h2>
+      <section class="skill-review-result-detail__content">
+        <div class="skill-review-result-detail__table-header">
+          <h2 class="skill-review-result-detail__subtitle">
+            {{t "pages.skill-review.details.title"}}
+          </h2>
+          {{#unless this.isFlashCampaign}}
             <CircleChart @value={{this.masteryPercentage}}>
               <span
                 aria-label="{{t 'pages.skill-review.details.result'}}"
@@ -280,15 +280,17 @@
                 {{t "pages.skill-review.details.percentage" rate=this.masteryRate}}
               </span>
             </CircleChart>
-          </div>
+          {{/unless}}
+        </div>
 
-          <CampaignSkillReviewCompetenceResult
-            @showCleaCompetences={{this.showCleaCompetences}}
-            @competenceResults={{@model.campaignParticipationResult.competenceResults}}
-            @skillSetResults={{@model.campaignParticipationResult.cleaBadge.skillSetResults}}
-          />
-        </section>
+        <CampaignSkillReviewCompetenceResult
+          @showCleaCompetences={{this.showCleaCompetences}}
+          @competenceResults={{@model.campaignParticipationResult.competenceResults}}
+          @skillSetResults={{@model.campaignParticipationResult.cleaBadge.skillSetResults}}
+        />
+      </section>
 
+      {{#unless this.isFlashCampaign}}
         <div class="skill-review-result-detail__information">
           <FaIcon @icon="circle-info" class="skill-review-information__info-icon" aria-hidden="true" />
           <div class="skill-review-information__text">
@@ -296,6 +298,6 @@
           </div>
         </div>
       {{/unless}}
-    </PixBlock>
-  {{/if}}
+    {{/unless}}
+  </PixBlock>
 </main>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -112,10 +112,6 @@ export default class SkillReview extends Component {
     return this.args.model.campaign.isFlash;
   }
 
-  get showDetail() {
-    return !this.isFlashCampaign;
-  }
-
   get masteryRate() {
     return this.args.model.campaignParticipationResult.masteryRate;
   }

--- a/mon-pix/app/models/competence-result.js
+++ b/mon-pix/app/models/competence-result.js
@@ -9,6 +9,7 @@ export default class CompetenceResult extends Model {
   @attr('number') totalSkillsCount;
   @attr('number') testedSkillsCount;
   @attr('number') validatedSkillsCount;
+  @attr('number') flashPixScore;
 
   // includes
   @belongsTo('campaignParticipationResult') campaignParticipationResult;

--- a/mon-pix/tests/integration/components/campaign/skill-review_test.js
+++ b/mon-pix/tests/integration/components/campaign/skill-review_test.js
@@ -1,0 +1,41 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { render } from '@1024pix/ember-testing-library';
+import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
+
+module('Integration | Component | Campaign | skill-review', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  test('it should display a list of competences and their scores', async function (assert) {
+    // given
+    const competenceResults = [
+      {
+        name: 'Faire des câlins',
+        flashPixScore: 23,
+        areaColor: 'jaffa',
+      },
+    ];
+    const model = {
+      campaign: EmberObject.create({
+        isFlash: true,
+      }),
+      campaignParticipationResult: EmberObject.create({
+        id: 12345,
+        flashPixScore: 122,
+        competenceResults,
+        campaignParticipationBadges: [],
+      }),
+    };
+
+    this.set('model', model);
+
+    // when
+    const screen = await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{this.model}} />`);
+
+    // then
+    assert.dom(screen.getByText('Compétences testées')).exists();
+    assert.dom(screen.getByRole('rowheader', { name: 'Faire des câlins' })).exists();
+    assert.dom(screen.getByRole('cell', { name: '23 Pix' })).exists();
+  });
+});

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -755,22 +755,4 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
       assert.ok(true);
     });
   });
-
-  module('#showDetail', function () {
-    test('should be true when campaign is not FLASH', async function (assert) {
-      // given
-      component.args.model.campaign.isFlash = false;
-
-      // then
-      assert.true(component.showDetail);
-    });
-
-    test('should be false when campaign is FLASH', async function (assert) {
-      // given
-      component.args.model.campaign.isFlash = true;
-
-      // then
-      assert.false(component.showDetail);
-    });
-  });
 });

--- a/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
@@ -756,22 +756,4 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
       assert.ok(true);
     });
   });
-
-  module('#showDetail', function () {
-    test('should be true when campaign is not FLASH', async function (assert) {
-      // given
-      component.args.model.campaign.isFlash = false;
-
-      // then
-      assert.true(component.showDetail);
-    });
-
-    test('should be false when campaign is FLASH', async function (assert) {
-      // given
-      component.args.model.campaign.isFlash = true;
-
-      // then
-      assert.false(component.showDetail);
-    });
-  });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1341,6 +1341,7 @@
       "badges-title": "Your thematic results",
       "details": {
         "title": "Your results by competence",
+        "flash-pix-score": "{score, number, ::.} Pix",
         "header-result": "Results",
         "header-skill": "Competences tested",
         "result": "Overall result",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1341,6 +1341,7 @@
       "badges-title": "Vos résultats thématiques",
       "details": {
         "title": "Vos résultats par compétence",
+        "flash-pix-score": "{score, number, ::.} Pix",
         "header-result": "Résultats",
         "header-skill": "Compétences testées",
         "result": "Résultat global",


### PR DESCRIPTION
## :egg: Problème
On souhaite afficher sur la page de fin de campagne Flash le score total et le score par compétence avec les intitulés de compétence. 

## :bowl_with_spoon: Proposition
Afficher le libellé de la compétence ainsi qu'un arrondi du score Pix pour cette compétence.

## :milk_glass: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :butter: Pour tester
- Se connecter à Pix App avec n'importe quel compte.
- Cliquer sur j'ai un code, renseigner le code `FLASH1234` et démarrer la campagne Flash.
- Répondre aux questions du parcours jusqu'à la fin.
- une fois sur la page de fin de campagne, constater l'affichage du score total en Pix et le détail de ce score par compétence avec la couleur du thème de la compétence, l'intitulé de la compétence et son score.