### PR TITLE
[BUGFIX] Réparer les select qui ont été cassés suite à la montée de version de pix ui (PIX-6909)

### DIFF
--- a/admin/app/components/trainings/create-training-form.hbs
+++ b/admin/app/components/trainings/create-training-form.hbs
@@ -28,7 +28,7 @@
         @options={{this.optionsTypeList}}
         required={{true}}
         aria-required={{true}}
-        {{on "change" (fn this.updateForm "type")}}
+        @onChange={{(fn this.updateSelect "type")}}
       />
       <div class="create-training-form-card__duration">
         <PixInput
@@ -70,12 +70,12 @@
       <PixSelect
         @id="trainingLocale"
         @label="Langue localisée"
-        @emptyOptionLabel={{"-- Sélectionnez une langue --"}}
-        @selectedOption={{this.form.locale}}
+        @placeholder={{"-- Sélectionnez une langue --"}}
         @options={{this.optionsLocaleList}}
+        @value={{this.form.locale}}
+        @onChange={{(fn this.updateSelect "locale")}}
         required={{true}}
         aria-required={{true}}
-        {{on "change" (fn this.updateForm "locale")}}
       />
       <div class="training-editor-logo-url-input">
         <label for="trainingEditorLogoUrl-name">Nom du fichier du logo éditeur (.svg)
@@ -96,7 +96,7 @@
           @ariaLabel="Nom du fichier du logo éditeur"
           placeholder="logo-ministere-education-nationale-et-jeunesse.svg"
           @value={{this.form.editorLogoUrl}}
-          {{on "change" this.updateEditorLogoUrl}}
+          {{on "change" (fn this.updateForm "editorLogoUrl")}}
         />
       </div>
       <PixInput

--- a/admin/app/components/trainings/create-training-form.js
+++ b/admin/app/components/trainings/create-training-form.js
@@ -5,33 +5,56 @@ import { optionsLocaleList, optionsTypeList } from '../../models/training';
 import { tracked } from '@glimmer/tracking';
 import set from 'lodash/set';
 
+class Form {
+  @tracked title;
+  @tracked link;
+  @tracked type;
+  @tracked duration = {
+    days: 0,
+    hours: 0,
+    minutes: 0,
+  };
+  @tracked locale;
+  @tracked editorLogoUrl;
+  @tracked editorName;
+}
+
 export default class CreateTrainingForm extends Component {
   @service notifications;
 
   @tracked submitting = false;
 
-  @tracked form = { duration: { days: 0, hours: 0, minutes: 0 } };
-
   constructor() {
     super(...arguments);
     this.optionsTypeList = optionsTypeList;
     this.optionsLocaleList = optionsLocaleList;
+    this.form = new Form();
   }
 
   @action
   updateForm(key, event) {
-    set(this.form, key, event.target.value);
+    set(this.form, key, event.target.value.trim());
   }
 
   @action
-  updateEditorLogoUrl(event) {
-    this.form.editorLogoUrl = `https://images.pix.fr/contenu-formatif/editeur/${event.target.value}`;
+  updateSelect(key, value) {
+    set(this.form, key, value);
   }
 
   @action
   async onSubmit(event) {
     event.preventDefault();
-    const training = { ...this.form };
+
+    const training = {
+      title: this.form.title,
+      link: this.form.link,
+      type: this.form.type,
+      duration: this.form.duration,
+      locale: this.form.locale,
+      editorName: this.form.editorName,
+    };
+    training.editorLogoUrl = `https://images.pix.fr/contenu-formatif/editeur/${this.form.editorLogoUrl}`;
+
     try {
       this.submitting = true;
       await this.args.onSubmit(training);

--- a/admin/tests/unit/components/trainings/create-training-form_test.js
+++ b/admin/tests/unit/components/trainings/create-training-form_test.js
@@ -28,33 +28,36 @@ module('Unit | Component | Trainings | CreateTrainingForm', function (hooks) {
     });
   });
 
-  module('#updateEditorLogoUrl', function () {
-    test('it should update EditorLogoUrl form attribute with appropriate base URL', function (assert) {
+  module('#onSubmit', function (hooks) {
+    let submitEvent;
+
+    hooks.beforeEach(function () {
       // given
-      const baseURL = 'https://images.pix.fr/contenu-formatif/editeur/';
-      const formEvent = { target: { value: 'new-logo.svg' } };
-
-      // when
-      component.updateEditorLogoUrl(formEvent);
-
-      // then
-      assert.strictEqual(component.form.editorLogoUrl, `${baseURL}new-logo.svg`);
-    });
-  });
-
-  module('#onSubmit', function () {
-    test('is should call the onSubmit method', function (assert) {
-      // given
-      const submitEvent = {
+      submitEvent = {
         preventDefault: sinon.stub(),
       };
+    });
 
+    test('is should call the onSubmit method', async function (assert) {
       // when
-      component.onSubmit(submitEvent);
+      await component.onSubmit(submitEvent);
 
       // then
       assert.ok(submitEvent.preventDefault.called);
       assert.ok(component.args.onSubmit.called);
+    });
+
+    test('it should update EditorLogoUrl form attribute with appropriate base URL', async function (assert) {
+      // given
+      const baseURL = 'https://images.pix.fr/contenu-formatif/editeur/';
+      const formEvent = { target: { value: 'new-logo.svg' } };
+      component.updateForm('editorLogoUrl', formEvent);
+
+      // when
+      await component.onSubmit(submitEvent);
+
+      // then
+      assert.deepEqual(component.args.onSubmit.getCall(0).firstArg.editorLogoUrl, `${baseURL}new-logo.svg`);
     });
   });
 });


### PR DESCRIPTION
## :egg: Problème
Les selects présent sur la page de création d'un contenu formatif ont été cassés par la montée de version qui a été effectuée dans la PR #5492. Le formulaire n'est plus utilisable actuellement pour créer des contenus formatifs.

## :bowl_with_spoon: Proposition
Il faut ajuster l'utilisation du composant PixSelect afin de "coller" à la nouvelle interface du composant, car les paramètres d'entrée et de sortie ont été modifiés suite à la montée de version.

## :milk_glass: Remarques
On a commencé avec un `EmberObject` afin d'être iso par rapport aux autres formulaires présent dans pix admin. Cela permet de créer des propriétés trackées dans un objet, et si on le souhaite de lui associer des validateurs.

Puis nous avons revue notre copie en utilisant une classe native, car c'est maintenant [la manière conseillée par Ember](https://guides.emberjs.com/release/upgrading/current-edition/native-classes/#toc_cheatsheet).

## :butter: Pour tester
- Se rendre sur pix admin
- Aller sur la page des contenus formatifs
- Créer un contenu formatif
- Vérifier que tout se passe bien (le contenu formatif est présent dans la page de détail)