### PR TITLE
[BUGFIX] Corriger l'erreur rendant impossible la lecture des détails utilisateur sur Pix Admin (PIX-6941).

### DIFF
--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -439,12 +439,10 @@ function _fromKnexDTOToUserDetailsForAdmin({ userDTO, organizationLearnersDTO, a
   });
 
   const authenticationMethods = authenticationMethodsDTO.map((authenticationMethod) => {
-    // eslint-disable-next-line no-unused-vars
-    const { password, ...authenticationComplement } = authenticationMethod.authenticationComplement;
-    return {
-      ...authenticationMethod,
-      authenticationComplement,
-    };
+    if (authenticationMethod.identityProvider === AuthenticationMethod.identityProviders.PIX) {
+      delete authenticationMethod.authenticationComplement.password;
+    }
+    return authenticationMethod;
   });
 
   return new UserDetailsForAdmin({


### PR DESCRIPTION
## :egg: Problème
Actuellement sur Pix Admin, il n'est plus possible d'accéder aux informations des utilisateurs.
L'erreur retournée est la suivante : `Cannot destructure property 'password' of 'authenticationMethod.authenticationComplement' as it is null.`

## :bowl_with_spoon: Proposition
Corriger l'erreur se produisant dans le repository, lors de la récupération des infos utilisateur.

## :milk_glass: Remarques
Cette erreur a été introduite dans la PR suivante : https://github.com/1024pix/pix/pull/5519

## :butter: Pour tester
Se connecter avec Pix Admin
Se rendre sur la page de détails d'un utilisateur et constater que les infos sont bien retournées.