### PR TITLE
[TECH] Affichage des liens sur la page de finalisation de session (PIX-6907)

### DIFF
--- a/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.hbs
@@ -14,7 +14,12 @@
     <div class="fraud-certification-issue-report-fields__details">
       <p>Merci de transmettre le procès-verbal de fraude rempli pendant la session de certification en utilisant
         <span>
-          <a href="https://form-eu.123formbuilder.com/41052/form" target="_blank" rel="noreferrer noopener">
+          <a
+            class="link"
+            href="https://form-eu.123formbuilder.com/41052/form"
+            target="_blank"
+            rel="noreferrer noopener"
+          >
             ce formulaire</a>
         </span>
       </p>

--- a/certif/app/components/session-finalization/complementary-information-step.hbs
+++ b/certif/app/components/session-finalization/complementary-information-step.hbs
@@ -25,6 +25,7 @@
       <PixMessage @type="info" @withIcon={{true}}>
         Vous trouverez
         <a
+          class="link"
           href="https://cloud.pix.fr/s/zf3fGimWwPQCeWF/download/Probl%C3%A8mes%20d%27acc%C3%A8s%20en%20session.pdf"
           target="_blank"
           rel="noreferrer noopener"

--- a/certif/app/styles/globals/texts.scss
+++ b/certif/app/styles/globals/texts.scss
@@ -36,13 +36,12 @@
   outline: none;
   border: none;
   background-color: inherit;
-  color: $pix-primary;
-  text-decoration: none;
+  color: $pix-primary-60;
+  text-decoration: underline;
 
   &:hover,
   &:focus,
   &:active {
-    text-decoration: underline;
-    color: $pix-primary-60;
+    color: $pix-tertiary-80;
   }
 }


### PR DESCRIPTION
## :egg: Problème
Suite à la montée en version Pix UI, l’affichage des liens a été modifié.

## :bowl_with_spoon: Proposition
Utiliser la class link lorsque l'on a besoin de mettre en valeur un lien

## :butter: Pour tester
Aller sur une session de certif sco et passer à l;étape de finalisation, vérifier les liens suivants :


Situation 1 : Lors de la finalisation d’une session, l’utilisateur peut remonter un signalement C6 Suspicion de fraude en utilisant un formulaire accessible par un lien sur les mots “ce formulaire”.

Situation 2 : Lors de la finalisation d’une session, l’utilisateur peut préciser qu’un ou plusieurs candidats étaient présents mais n’ont pas pu rejoindre la session. On propose alors un document d’aide à la connexion accessible via un lien sur les mots “ici un document pour vous aider à résoudre ce type de problème de connexion pour les prochaines sessions. (PDF. 131ko)”