### PR TITLE
[BUGFIX] corriger une régression visuelle des intitulées de réponse dans les QCM et SCU

### DIFF
--- a/mon-pix/app/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/components/challenge-item-qcm.hbs
@@ -1,8 +1,8 @@
 <form {{on "submit" this.validateAnswer}}>
 
   <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}">
-    <h2 class="challenge-response__instructions">{{t "pages.challenge.parts.answer-instructions.qcm"}}</h2>
     <h2 class="sr-only">{{t "pages.challenge.parts.answer-input"}}</h2>
+    <p class="challenge-response__instructions">{{t "pages.challenge.parts.answer-instructions.qcm"}}</p>
     <div class="challenge-proposals">
       <QcmProposals
         @answer={{@answer}}

--- a/mon-pix/app/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/components/challenge-item-qcu.hbs
@@ -1,8 +1,8 @@
 <form {{on "submit" this.validateAnswer}}>
 
   <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}">
-    <h2 class="challenge-response__instructions">{{t "pages.challenge.parts.answer-instructions.qcu"}}</h2>
     <h2 class="sr-only">{{t "pages.challenge.parts.answer-input"}}</h2>
+    <p class="challenge-response__instructions">{{t "pages.challenge.parts.answer-instructions.qcu"}}</p>
     <div class="challenge-proposals">
       <QcuProposals
         @answer={{@answer}}

--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -40,11 +40,6 @@
     }
   }
 
-  &__instructions {
-    font-weight: $font-normal;
-    font-size: 1rem;
-  }
-
   &__proposal {
     margin-top: 10px;
     margin-bottom: 10px;
@@ -91,7 +86,6 @@
 }
 
 form .challenge-response {
-
   &--locked {
     position: relative;
   }
@@ -102,6 +96,12 @@ form .challenge-response {
     left: 50%;
     transform: translate(-50%, -50%);
     opacity: 0;
+  }
+
+  .challenge-response__instructions {
+    margin-top: 0;
+    font-weight: $font-normal;
+    font-size: 1rem;
   }
 
   .qroc-proposal {
@@ -123,9 +123,7 @@ form .challenge-response {
 }
 
 form .challenge-response.challenge-response--locked {
-
   &:hover {
-
     .challenge-response__locked-overlay {
       opacity: 1;
       transition: 0.9s ease;
@@ -134,7 +132,6 @@ form .challenge-response.challenge-response--locked {
 }
 
 form .challenge-response-locked {
-
   &__icon {
     font-size: 3.125rem;
     opacity: 1;


### PR DESCRIPTION
## :egg: Problème
Régression visuelle suite à l'import du reset / normalize et du correctif associé.

![image](https://user-images.githubusercontent.com/7335131/215448354-63dc486d-c9f6-43b8-8113-0b94b8d7e874.png)


## :bowl_with_spoon: Proposition

Passer le `.challenge-response__instructions` de `h2` à `p`, car un autre `h2` (.sr-only) existe + petit ajout CSS pour supprimer la marge-top.

## :butter: Pour tester

- Aller sur la RA
- Visiter les épreuves https://app.recette.pix.fr/challenges/recRPcaiXk8ggWMSB/preview et https://app.recette.pix.fr/challenges/rec25g8nc1SC2Wd60/preview
- Vérifier que le style est bon
