### PR TITLE
[BUGFIX] Raccourcir le placeholder du champs certificabilité (PIX-6926)

### DIFF
--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -19,8 +19,7 @@
     @onSelect={{@triggerFiltering}}
     @selectedOption={{@certificabilityFilter}}
     @options={{@certificabilityOptions}}
-    @placeholder={{t "pages.organization-participants.filters.type.certificability.label"}}
-    @ariaLabel={{t "pages.organization-participants.filters.type.certificability.aria-label"}}
+    @placeholder={{t "pages.organization-participants.filters.type.certificability.placeholder"}}
     @emptyMessage=""
   />
 </PixFilterBanner>

--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -41,8 +41,7 @@
     @onSelect={{@onFilter}}
     @selectedOption={{@certificabilityFilter}}
     @options={{this.certificabilityOptions}}
-    @placeholder={{t "pages.sco-organization-participants.filter.certificability.label"}}
-    @ariaLabel={{t "pages.sco-organization-participants.filter.certificability.aria-label"}}
+    @placeholder={{t "pages.sco-organization-participants.filter.certificability.placeholder"}}
     @emptyMessage=""
   />
 </PixFilterBanner>

--- a/orga/app/components/sup-organization-participant/list.hbs
+++ b/orga/app/components/sup-organization-participant/list.hbs
@@ -38,8 +38,7 @@
     @onSelect={{@onFilter}}
     @selectedOption={{@certificabilityFilter}}
     @options={{this.certificabilityOptions}}
-    @placeholder={{t "pages.sup-organization-participants.filter.certificability.label"}}
-    @ariaLabel={{t "pages.sup-organization-participants.filter.certificability.aria-label"}}
+    @placeholder={{t "pages.sup-organization-participants.filter.certificability.placeholder"}}
     @emptyMessage=""
   />
 </PixFilterBanner>

--- a/orga/tests/acceptance/organization-participant-list_test.js
+++ b/orga/tests/acceptance/organization-participant-list_test.js
@@ -55,10 +55,10 @@ module('Acceptance | Organization Participant List', function (hooks) {
         server.create('organization-participant', { organizationId, firstName: 'Jean', lastName: 'Charles' });
 
         await authenticateSession(user.id);
-        const { getByPlaceholderText } = await visit('/participants');
+        const { getByLabelText } = await visit('/participants');
 
         // when
-        const select = getByPlaceholderText(
+        const select = getByLabelText(
           this.intl.t('pages.organization-participants.filters.type.certificability.label')
         );
         await click(select);

--- a/orga/tests/acceptance/sup-organization-participant-list_test.js
+++ b/orga/tests/acceptance/sup-organization-participant-list_test.js
@@ -75,12 +75,10 @@ module('Acceptance | Sup Organization Participant List', function (hooks) {
         server.create('organization-participant', { organizationId, firstName: 'Jean', lastName: 'Charles' });
 
         await authenticateSession(user.id);
-        const { getByPlaceholderText } = await visit('/etudiants');
+        const { getByLabelText } = await visit('/etudiants');
 
         // when
-        const select = getByPlaceholderText(
-          this.intl.t('pages.sup-organization-participants.filter.certificability.label')
-        );
+        const select = getByLabelText(this.intl.t('pages.sup-organization-participants.filter.certificability.label'));
         await click(select);
         await clickByText(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible'));
 

--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -230,12 +230,12 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     this.set('certificabilityOptions', [{ value: 'eligible', label: 'Certifiable' }]);
     this.set('certificability', []);
 
-    const { getByPlaceholderText, findByRole } = await render(
+    const { getByLabelText, findByRole } = await render(
       hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.triggerFiltering}} @certificabilityOptions={{this.certificabilityOptions}} @certificability={{this.certificability}} @onClickLearner={{this.noop}}/>`
     );
 
     // when
-    const select = await getByPlaceholderText(
+    const select = await getByLabelText(
       this.intl.t('pages.organization-participants.filters.type.certificability.label')
     );
     await click(select);

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -226,12 +226,12 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('students', []);
       this.set('certificability', []);
 
-      const { getByPlaceholderText, findByRole } = await render(
+      const { getByLabelText, findByRole } = await render(
         hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}} @certificability={{this.certificability}} @onClickLearner={{this.noop}}/>`
       );
 
       // when
-      const select = await getByPlaceholderText('Rechercher par certificabilité');
+      const select = await getByLabelText('Rechercher par certificabilité');
       await click(select);
 
       await findByRole('menu');

--- a/orga/tests/integration/components/sup-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list_test.js
@@ -285,12 +285,12 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
       this.set('students', []);
       this.set('certificability', []);
 
-      const { getByPlaceholderText, findByRole } = await render(
+      const { getByLabelText, findByRole } = await render(
         hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.triggerFiltering}} @certificability={{this.certificability}} @onClickLearner={{this.noop}}/>`
       );
 
       // when
-      const select = await getByPlaceholderText('Rechercher par certificabilité');
+      const select = await getByLabelText('Rechercher par certificabilité');
       await click(select);
 
       await findByRole('menu');

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -704,7 +704,7 @@
         "participations-count": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count} participants}}",
         "type": {
           "certificability": {
-            "aria-label": "Enter a status for certificability",
+            "placeholder": "Search by certificability",
             "label": "Search by certificability"
           },
           "fullName": {
@@ -868,7 +868,7 @@
       "no-participants-action": "The administrator must import the students database by clicking on the import button.",
       "filter": {
         "certificability": {
-          "aria-label": "Enter a status for certificability",
+          "placeholder": "Search by certificability",
           "label": "Search by certificability"
         },
         "division": {
@@ -976,7 +976,7 @@
         },
         "aria-label": "Filters on students",
         "certificability": {
-          "aria-label": "Enter a status for certificability",
+          "placeholder": "Search by certificability",
           "label": "Search by certificability"
         },
         "group": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -704,7 +704,7 @@
         "title": "Filtres",
         "type": {
           "certificability": {
-            "aria-label": "Enter un statut de certification",
+            "placeholder": "Certificabilité",
             "label": "Rechercher par certificabilité"
           },
           "fullName": {
@@ -868,7 +868,7 @@
       "no-participants-action": "L’administrateur doit importer la base élèves en cliquant sur le bouton importer.",
       "filter": {
         "certificability": {
-          "aria-label": "Enter un statut de certification",
+          "placeholder": "Certificabilité",
           "label": "Rechercher par certificabilité"
         },
         "division": {
@@ -976,7 +976,7 @@
           "clear": "Effacer les filtres"
         },
         "certificability": {
-          "aria-label": "Enter un statut de certification",
+          "placeholder": "Certificabilité",
           "label": "Rechercher par certificabilité"
         },
         "group": {


### PR DESCRIPTION
## :egg: Problème
Le placeholder du champs certificabilité est un peu trop long, donc tronqué

## :bowl_with_spoon: Proposition
Le raccourcir afin qu'il soit lisible

## :milk_glass: Remarques
RAS

## :butter: Pour tester
Se connecter sur Pix Orga et vérifier que le placeholder s'affiche entiètrement