### PR TITLE
[FEATURE] Empêcher l'enregistrement de sessions déjà existantes (PIX-6954).

### DIFF
--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -24,6 +24,13 @@ module.exports = async function createSessions({
 
   const { name: certificationCenter, isSco } = await certificationCenterRepository.get(certificationCenterId);
 
+  for (const session of sessions) {
+    const sessionAlreadyExisting = await sessionRepository.getExistingSessionByInformation({ ...session });
+    if (sessionAlreadyExisting) {
+      throw new UnprocessableEntityError(`Session happening on ${session.date} at ${session.time} already exists`);
+    }
+  }
+
   await DomainTransaction.execute(async (domainTransaction) => {
     await bluebird.mapSeries(sessions, async (session) => {
       let { sessionId } = session;

--- a/api/lib/infrastructure/repositories/sessions/session-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-repository.js
@@ -45,6 +45,11 @@ module.exports = {
     }
   },
 
+  async getExistingSessionByInformation({ address, room, date, time }) {
+    const sessions = await knex('sessions').where({ address, room, date, time });
+    return sessions.length > 0;
+  },
+
   async getWithCertificationCandidates(sessionId) {
     const session = await knex.from('sessions').where({ 'sessions.id': sessionId }).first();
 

--- a/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
@@ -901,4 +901,43 @@ describe('Integration | Repository | Session', function () {
       });
     });
   });
+
+  describe('#getExistingSessionByInformation', function () {
+    it('should return true if the session already exists', async function () {
+      // given
+      const session = {
+        address: 'rue de Bercy',
+        room: 'Salle A',
+        examiner: 'madame examinatrice',
+        date: '2018-02-23',
+        time: '12:00:00',
+      };
+      databaseBuilder.factory.buildSession({ ...session, examiner: 'Monsieur Examinateur, Madame Examinatrice' });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await sessionRepository.getExistingSessionByInformation({ ...session });
+
+      // then
+      expect(result).to.equal(true);
+    });
+
+    it('should return false if the session does not already exist', async function () {
+      // given
+      const session = {
+        address: 'rue de Bercy',
+        room: 'Salle A',
+        examiner: 'Monsieur Examinateur',
+        date: '2018-02-23',
+        time: '12:00:00',
+      };
+
+      // when
+      const result = await sessionRepository.getExistingSessionByInformation({ ...session });
+
+      // then
+      expect(result).to.equal(false);
+    });
+  });
 });


### PR DESCRIPTION
## :egg: Problème

A l'heure actuelle, une session est enregistrée autant de fois que le CSV sur lequel elle est inscrite est importée. Nous voulons empêcher un second import d'une session existante d'arriver.

## :bowl_with_spoon: Proposition

Comparaison des données des sessions déjà sauvegardées avec les données des sessions présentes sur un CSV.
Si l'ensemble des critères obligatoires d'une session.


## :milk_glass: Remarques

Pas convaincu par la gestion de la comparaison du/des examinateur(s).
Il y probablement moyen de faire bien mieux. (exporter la méthode de comparaison pour la tester en profondeur  ? Sortir cette comparaison du domaine ?)

## :butter: Pour tester

Essayer d'importer le fichier CSV suivant et vérifier qu'une erreur apparait et que la session n'est pas ré-enregistrée.

```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
,3 rue des églantines,B315,31/01/2020,15:00,Ginette,,,,,,,,,,,,,,,,