### PR TITLE
[TECH] Réduire la largeur de plusieurs colonnes sur la table des élèves sur Pix Orga (PIX-6971).

### DIFF
--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -67,11 +67,11 @@
         <Table::Header @size="medium" @align="center">
           {{t "pages.sco-organization-participants.table.column.date-of-birth"}}
         </Table::Header>
-        <Table::Header @size="wide">{{t "pages.sco-organization-participants.table.column.division"}}</Table::Header>
-        <Table::Header @size="wide">
+        <Table::Header @size="medium">{{t "pages.sco-organization-participants.table.column.division"}}</Table::Header>
+        <Table::Header @size="medium">
           {{t "pages.sco-organization-participants.table.column.login-method"}}
         </Table::Header>
-        <Table::Header @size="medium" @align="right">
+        <Table::Header @size="medium" @align="right" class="organization-participant-list-page__participant-count">
           {{t "pages.sco-organization-participants.table.column.participation-count"}}
         </Table::Header>
         <Table::Header @size="medium" @align="center">
@@ -86,8 +86,8 @@
             />
           </div>
         </Table::Header>
-        <Table::Header @size="small" class="hide-on-mobile">
-          <span>{{t "common.actions.global"}}</span>
+        <Table::Header class="hide-on-mobile organization-participant-list-page__actions-header">
+          {{t "common.actions.global"}}
         </Table::Header>
       </tr>
     </thead>
@@ -116,7 +116,9 @@
                 <p>{{t authenticationMethod}}</p>
               {{/each}}
             </td>
-            <td class="table__column--right">{{student.participationCount}}</td>
+            <td
+              class="table__column--right organization-participant-list-page__participant-count"
+            >{{student.participationCount}}</td>
             <td class="table__column--center">
               {{#if student.lastParticipationDate}}
                 <div class="organization-participant-list-page__last-participation">

--- a/orga/app/components/sup-organization-participant/list.hbs
+++ b/orga/app/components/sup-organization-participant/list.hbs
@@ -71,7 +71,9 @@
             />
           </div>
         </Table::Header>
-        <Table::Header @size="medium" class="hide-on-mobile" />
+        <Table::Header class="hide-on-mobile organization-participant-list-page__actions-header">
+          {{t "common.actions.global"}}
+        </Table::Header>
       </tr>
     </thead>
 

--- a/orga/app/components/sup-organization-participant/list.hbs
+++ b/orga/app/components/sup-organization-participant/list.hbs
@@ -56,7 +56,7 @@
           {{t "pages.sup-organization-participants.table.column.date-of-birth"}}
         </Table::Header>
         <Table::Header @size="wide">{{t "pages.sup-organization-participants.table.column.group"}}</Table::Header>
-        <Table::Header @size="medium" @align="right">
+        <Table::Header @size="medium" @align="right" class="organization-participant-list-page__participant-count">
           {{t "pages.sup-organization-participants.table.column.participation-count"}}
         </Table::Header>
         <Table::Header @size="medium" @align="center">
@@ -97,7 +97,9 @@
             <td class="ellipsis">{{student.firstName}}</td>
             <td class="table__column--center">{{dayjs-format student.birthdate "DD/MM/YYYY"}}</td>
             <td class="ellipsis">{{student.group}}</td>
-            <td class="table__column--right">{{student.participationCount}}</td>
+            <td
+              class="table__column--right organization-participant-list-page__participant-count"
+            >{{student.participationCount}}</td>
             <td class="table__column--center">
               {{#if student.lastParticipationDate}}
                 <div class="organization-participant-list-page__last-participation">

--- a/orga/app/components/ui/is-certifiable.hbs
+++ b/orga/app/components/ui/is-certifiable.hbs
@@ -5,7 +5,7 @@
     {{t "pages.sco-organization-participants.table.column.is-certifiable.eligible"}}
   </PixTag>
 {{else}}
-  <PixTag @color="yellow-light">
+  <PixTag @color="yellow-light organization-participant-list-page__tag">
     {{t "pages.sco-organization-participants.table.column.is-certifiable.non-eligible"}}
   </PixTag>
 {{/if}}

--- a/orga/app/styles/pages/authenticated/organization-participants.scss
+++ b/orga/app/styles/pages/authenticated/organization-participants.scss
@@ -17,6 +17,20 @@ $margin-right: 32px;
     justify-content: center;
   }
 
+  &__actions-header {
+    width: 10%;
+
+    @include device-is('tablet') {
+      text-align: right;
+      padding-right: 12px;
+      padding-left: 0;
+    }
+  }
+
+  &__participant-count {
+    padding-left: 0;
+  }
+
   &__certifiable-at {
     display: block;
     margin-top: $spacing-xxs;
@@ -47,10 +61,18 @@ $margin-right: 32px;
 
   &__dropdown-button {
     margin-right: $margin-right;
+
+    @include device-is('tablet') {
+      margin-right: 12px;
+    }
   }
 
   &__dropdown-content {
     width: 200px;
     right: $margin-right;
+  }
+
+  &__tag {
+    white-space: normal;
   }
 }

--- a/orga/app/styles/pages/authenticated/sco-organization-participants/list.scss
+++ b/orga/app/styles/pages/authenticated/sco-organization-participants/list.scss
@@ -7,6 +7,7 @@
   }
   &__certificability-header {
     display: flex;
+    flex-wrap: wrap;
   }
 }
 

--- a/orga/app/styles/pages/authenticated/sup-organization-participants/list.scss
+++ b/orga/app/styles/pages/authenticated/sup-organization-participants/list.scss
@@ -1,6 +1,7 @@
 .sup-organization-participant-list-page {
   &__certificability-header {
     display: flex;
+    flex-wrap: wrap;
   }
 }
 

--- a/orga/tests/integration/components/sup-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list_test.js
@@ -26,16 +26,17 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
     this.set('groups', []);
 
     // when
-    await render(
+    const screen = await render(
       hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @groups={{this.groups}} @onClickLearner={{this.noop}}/>`
     );
 
     // then
-    assert.contains('Numéro étudiant');
-    assert.contains('Nom');
-    assert.contains('Prénom');
-    assert.contains('Date de naissance');
-    assert.contains('Groupes');
+    assert.dom(screen.getByRole('columnheader', { name: 'Numéro étudiant' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Nom' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Prénom' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Date de naissance' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Groupes' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Actions' })).exists();
   });
 
   test('it should display a list of students', async function (assert) {


### PR DESCRIPTION
## :egg: Problème
Sur Pix Orga, dans le tableau des élèves, on a récemment ajouté un nom à la dernière colonne : Actions.
Or ce tableau ayant beaucoup de colonnes, le nom Actions sort visuellement du tableau sur Firefox.

## :bowl_with_spoon: Proposition
Réduire la largeur de plusieurs colonnes sur le tableau.

On ajoute le nom de la colonne Actions également sur le tableau des Etudiants.

## :butter: Pour tester
Se connecter sur Pix Orga
Aller sur le menu > Eleves
Constater que le tableau rend correctement toutes les colonnes (Sur Chrome et Firefox)

Pour le tableau des Etudiants, se connecter avec sup.admin@example.net