### PR TITLE
[BUGFIX] Corriger les tests flakys aléatoires `An error occurred while fetching https://lcms-test.pix.fr/api`

### DIFF
--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -68,6 +68,7 @@ class OidcAuthenticationService {
       url: this.tokenUrl,
       payload: querystring.stringify(data),
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      timeout: settings.partner.fetchTimeOut,
     });
 
     if (!response.isSuccessful) {
@@ -108,6 +109,7 @@ class OidcAuthenticationService {
     const response = await httpAgent.get({
       url: userInfoUrl,
       headers: { Authorization: `Bearer ${accessToken}` },
+      timeout: settings.partner.fetchTimeOut,
     });
 
     if (!response.isSuccessful) {

--- a/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
+++ b/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
@@ -48,6 +48,7 @@ module.exports = {
         url: settings.poleEmploi.tokenUrl,
         payload: querystring.stringify(data),
         headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        timeout: settings.partner.fetchTimeOut,
       });
 
       if (!tokenResponse.isSuccessful) {
@@ -85,7 +86,12 @@ module.exports = {
       'Service-source': 'Pix',
     };
 
-    const httpResponse = await httpAgent.post({ url, payload, headers });
+    const httpResponse = await httpAgent.post({
+      url,
+      payload,
+      headers,
+      timeout: settings.partner.fetchTimeOut,
+    });
 
     if (!httpResponse.isSuccessful) {
       const serializedError = httpErrorsHelper.serializeHttpErrorResponse(httpResponse);

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -2,11 +2,7 @@
 const axios = require('axios');
 const { performance } = require('perf_hooks');
 
-const config = require('../../config');
-
 const monitoringTools = require('../monitoring-tools');
-
-const TIMEOUT_MILLISECONDS = config.partner.fetchTimeOut;
 
 class HttpResponse {
   constructor({ code, data, isSuccessful }) {
@@ -17,14 +13,17 @@ class HttpResponse {
 }
 
 module.exports = {
-  async post({ url, payload, headers }) {
+  async post({ url, payload, headers, timeout }) {
     const startTime = performance.now();
     let responseTime = null;
     try {
-      const httpResponse = await axios.post(url, payload, {
+      const config = {
         headers,
-        timeout: TIMEOUT_MILLISECONDS,
-      });
+      };
+      if (timeout != undefined) {
+        config.timeout = timeout;
+      }
+      const httpResponse = await axios.post(url, payload, config);
       responseTime = performance.now() - startTime;
       monitoringTools.logInfoWithCorrelationIds({
         metrics: { responseTime },
@@ -63,11 +62,17 @@ module.exports = {
       });
     }
   },
-  async get({ url, payload, headers }) {
+  async get({ url, payload, headers, timeout }) {
     const startTime = performance.now();
     let responseTime = null;
     try {
-      const config = { data: payload, headers, timeout: TIMEOUT_MILLISECONDS };
+      const config = {
+        data: payload,
+        headers,
+      };
+      if (timeout != undefined) {
+        config.timeout = timeout;
+      }
       const httpResponse = await axios.get(url, config);
       responseTime = performance.now() - startTime;
       monitoringTools.logInfoWithCorrelationIds({

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -143,6 +143,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         url: 'http://oidc.net/api/token',
         payload: expectedData,
         headers: expectedHeaders,
+        timeout: settings.partner.fetchTimeOut,
       });
       expect(result).to.be.an.instanceOf(AuthenticationSessionContent);
       expect(result).to.deep.equal(oidcAuthenticationSessionContent);
@@ -307,7 +308,11 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       // given
       sinon
         .stub(httpAgent, 'get')
-        .withArgs({ url: userInfoUrl, headers: { Authorization: `Bearer ${accessToken}` } })
+        .withArgs({
+          url: userInfoUrl,
+          headers: { Authorization: `Bearer ${accessToken}` },
+          timeout: settings.partner.fetchTimeOut,
+        })
         .resolves({
           isSuccessful: true,
           data: {
@@ -350,7 +355,11 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         };
         sinon
           .stub(httpAgent, 'get')
-          .withArgs({ url: userInfoUrl, headers: { Authorization: `Bearer ${accessToken}` } })
+          .withArgs({
+            url: userInfoUrl,
+            headers: { Authorization: `Bearer ${accessToken}` },
+            timeout: settings.partner.fetchTimeOut,
+          })
           .resolves({ isSuccessful: false, code: axiosError.response.status, data: axiosError.response.data });
         // See api/lib/infrastructure/http/http-agent.js to understand, axios can throw an error but httpAgent.get map it into an http response
         const oidcAuthenticationService = new OidcAuthenticationService({ userInfoUrl, accessToken });
@@ -386,7 +395,11 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
         sinon
           .stub(httpAgent, 'get')
-          .withArgs({ url: userInfoUrl, headers: { Authorization: `Bearer ${accessToken}` } })
+          .withArgs({
+            url: userInfoUrl,
+            headers: { Authorization: `Bearer ${accessToken}` },
+            timeout: settings.partner.fetchTimeOut,
+          })
           .resolves({
             isSuccessful: true,
             data: '',
@@ -418,7 +431,11 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         sinon.stub(monitoringTools, 'logErrorWithCorrelationIds');
         sinon
           .stub(httpAgent, 'get')
-          .withArgs({ url: userInfoUrl, headers: { Authorization: `Bearer ${accessToken}` } })
+          .withArgs({
+            url: userInfoUrl,
+            headers: { Authorization: `Bearer ${accessToken}` },
+            timeout: settings.partner.fetchTimeOut,
+          })
           .resolves({
             isSuccessful: true,
             data: {

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -102,6 +102,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
           url: settings.poleEmploi.sendingUrl,
           payload,
           headers: expectedHearders,
+          timeout: settings.partner.fetchTimeOut,
         });
       });
 
@@ -150,6 +151,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
           url: settings.poleEmploi.tokenUrl,
           payload: querystring.stringify(params),
           headers: expectedHeaders,
+          timeout: settings.partner.fetchTimeOut,
         });
       });
 
@@ -235,6 +237,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
             url: settings.poleEmploi.sendingUrl,
             payload,
             headers: expectedHeaders,
+            timeout: settings.partner.fetchTimeOut,
           });
         });
       });
@@ -259,6 +262,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
               url: settings.poleEmploi.tokenUrl,
               headers: sinon.match.any,
               payload: sinon.match.any,
+              timeout: settings.partner.fetchTimeOut,
             })
             .resolves(tokenResponse);
 
@@ -307,12 +311,14 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
               url: settings.poleEmploi.tokenUrl,
               headers: sinon.match.any,
               payload: sinon.match.any,
+              timeout: settings.partner.fetchTimeOut,
             })
             .resolves(tokenResponse)
             .withArgs({
               url: settings.poleEmploi.sendingUrl,
               headers: sinon.match.any,
               payload: sinon.match.any,
+              timeout: settings.partner.fetchTimeOut,
             })
             .resolves(httpResponse);
 

--- a/api/tests/unit/infrastructure/http/http-agent_test.js
+++ b/api/tests/unit/infrastructure/http/http-agent_test.js
@@ -3,9 +3,6 @@ const axios = require('axios');
 const { post, get } = require('../../../../lib/infrastructure/http/http-agent');
 const monitoringTools = require('../../../../lib/infrastructure/monitoring-tools');
 
-const config = require('../../../../lib/config');
-const TIMEOUT_MILLISECONDS = config.partner.fetchTimeOut;
-
 describe('Unit | Infrastructure | http | http-agent', function () {
   describe('#post', function () {
     afterEach(function () {
@@ -21,16 +18,17 @@ describe('Unit | Infrastructure | http | http-agent', function () {
         data: Symbol('data'),
         status: 'someStatus',
       };
+      const timeout = 'someTimeout';
       sinon
         .stub(axios, 'post')
         .withArgs(url, payload, {
           headers,
-          timeout: TIMEOUT_MILLISECONDS,
+          timeout,
         })
         .resolves(axiosResponse);
 
       // when
-      const actualResponse = await post({ url, payload, headers });
+      const actualResponse = await post({ url, payload, headers, timeout });
 
       // then
       expect(actualResponse).to.deep.equal({
@@ -55,10 +53,7 @@ describe('Unit | Infrastructure | http | http-agent', function () {
             status: 400,
           },
         };
-        sinon
-          .stub(axios, 'post')
-          .withArgs(url, payload, { headers, timeout: TIMEOUT_MILLISECONDS })
-          .rejects(axiosError);
+        sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
 
         // when
         await post({ url, payload, headers });
@@ -82,13 +77,7 @@ describe('Unit | Infrastructure | http | http-agent', function () {
               status: 'someStatus',
             },
           };
-          sinon
-            .stub(axios, 'post')
-            .withArgs(url, payload, {
-              headers,
-              timeout: TIMEOUT_MILLISECONDS,
-            })
-            .rejects(axiosError);
+          sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
 
           // when
           const actualResponse = await post({ url, payload, headers });
@@ -115,13 +104,7 @@ describe('Unit | Infrastructure | http | http-agent', function () {
               status: 400,
             },
           };
-          sinon
-            .stub(axios, 'post')
-            .withArgs(url, payload, {
-              headers,
-              timeout: TIMEOUT_MILLISECONDS,
-            })
-            .rejects(axiosError);
+          sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
 
           const expectedResponse = {
             isSuccessful: false,
@@ -151,10 +134,7 @@ describe('Unit | Infrastructure | http | http-agent', function () {
         data: Symbol('data'),
         status: 'someStatus',
       };
-      sinon
-        .stub(axios, 'get')
-        .withArgs(url, { data: payload, headers, timeout: TIMEOUT_MILLISECONDS })
-        .resolves(axiosResponse);
+      sinon.stub(axios, 'get').withArgs(url, { data: payload, headers }).resolves(axiosResponse);
 
       // when
       const actualResponse = await get({ url, payload, headers });
@@ -182,10 +162,7 @@ describe('Unit | Infrastructure | http | http-agent', function () {
             status: 400,
           },
         };
-        sinon
-          .stub(axios, 'get')
-          .withArgs(url, { data: payload, headers, timeout: TIMEOUT_MILLISECONDS })
-          .rejects(axiosError);
+        sinon.stub(axios, 'get').withArgs(url, { data: payload, headers }).rejects(axiosError);
 
         // when
         await get({ url, payload, headers });
@@ -209,10 +186,7 @@ describe('Unit | Infrastructure | http | http-agent', function () {
               status: 'someStatus',
             },
           };
-          sinon
-            .stub(axios, 'get')
-            .withArgs(url, { data: payload, headers, timeout: TIMEOUT_MILLISECONDS })
-            .rejects(axiosError);
+          sinon.stub(axios, 'get').withArgs(url, { data: payload, headers }).rejects(axiosError);
 
           // when
           const actualResponse = await get({ url, payload, headers });


### PR DESCRIPTION
## :egg: Problème
Dans la PR #5097, un timeout a été mis en place pour les appels HTTP vers des services externes de partenaires.

Ce timeout a été mis en place pour tous les appels HTTP (dans `http-agent`), et est aussi utilisé lors des appels à l'API LCMS qui n'est pas un service partenaire, mais un service Pix.

Pour les environnements de test, ce timeout a été fixé à 5ms, ce qui est parfois trop court pour que `nock` puisse répondre dans les temps, et provoque donc les tests flaky.

Exemples de flakys sur une journée de builds :
 - https://app.circleci.com/pipelines/github/1024pix/pix/51065/workflows/f69c3bfe-22a0-4c2f-9a3e-488d4c2c297e/jobs/405013#failed-test-1
 - https://app.circleci.com/pipelines/github/1024pix/pix/51064/workflows/490d7ae0-3c13-46fd-8925-5e231d7a0daa/jobs/405005
 - https://app.circleci.com/pipelines/github/1024pix/pix/51090/workflows/3df890d4-c15a-45b8-aeac-987f8749998f/jobs/405166/tests
 - https://app.circleci.com/pipelines/github/1024pix/pix/51091/workflows/63bbf166-9365-4af7-9415-ab4c088f10fa/jobs/405177
 - https://app.circleci.com/pipelines/github/1024pix/pix/51102/workflows/dd41911b-0f44-44fc-841f-b9f077f8c2ec/jobs/405306#failed-test-0

## :bowl_with_spoon: Proposition

 - Ne pas mettre en place le timeout directement dans `http-agent`, mais lui envoyer en paramètre.
 - Envoyer le timeout pour les services externes partenaires au `http-agent` uniquement lorsque cela est pertinent.

## :milk_glass: Remarques

Si un timeout doit être mis en place pour l'appel à l'API LCMS, cela sera fait dans une PR ultérieure.

## :butter: Pour tester

Pas testable en dehors de la CI.
