### PR TITLE
[TECH] Utiliser les mêmes règles de lint CSS dans les front

### DIFF
--- a/admin/.stylelintrc.json
+++ b/admin/.stylelintrc.json
@@ -1,22 +1,12 @@
 {
-  "extends": ["stylelint-config-standard-scss", "stylelint-config-prettier"],
+  "extends": ["@1024pix/stylelint-config"],
   "rules": {
     "scss/no-global-function-names": null,
     "scss/at-mixin-pattern": null,
-    "selector-class-pattern": null,
-    "at-rule-no-unknown": [true, { "ignoreAtRules": ["else", "extend", "if", "include", "mixin", "warn"] }],
-    "color-hex-case": "upper",
-    "color-hex-length": "long",
-    "indentation": [2, { "indentInsideParens": "once-at-root-twice-in-block" }],
+    "import-notation": "string",
     "rule-empty-line-before": [
       "always-multi-line",
       { "except": ["after-single-line-comment"], "ignore": ["first-nested"] }
-    ],
-    "value-keyword-case": ["lower", { "ignoreKeywords": ["Arial"] }],
-    "import-notation": "string",
-    "declaration-colon-space-after": "always-single-line",
-    "declaration-colon-space-before": "never",
-    "declaration-block-semicolon-space-before": "never",
-    "block-opening-brace-space-before": "always"
+      ]
   }
 }

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.0",
         "@1024pix/pix-ui": "^24.1.0",
+        "@1024pix/stylelint-config": "^1.0.1",
         "@babel/eslint-parser": "^7.19.1",
         "@ember/optional-features": "^2.0.0",
         "@ember/test-helpers": "^2.8.1",
@@ -1223,6 +1224,17 @@
       "engines": {
         "node": "16",
         "npm": ">=8.13.2 <9"
+      }
+    },
+    "node_modules/@1024pix/stylelint-config": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/stylelint-config/-/stylelint-config-1.0.1.tgz",
+      "integrity": "sha512-8+4DpyS6BLGhMQNl0c1Te3vsOTXzdB5KhdGwOX/L+4EY1Fb7RsMYWfINwuyGBJAZvY8RReKj7RKvW/BmkHS0HQ==",
+      "dev": true,
+      "peerDependencies": {
+        "stylelint": ">=14.4.0",
+        "stylelint-config-prettier": ">=9.0.4",
+        "stylelint-config-standard-scss": ">=6.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -40874,6 +40886,13 @@
         "ember-truth-helpers": "^3.1.1",
         "lodash.debounce": "^4.0.8"
       }
+    },
+    "@1024pix/stylelint-config": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/stylelint-config/-/stylelint-config-1.0.1.tgz",
+      "integrity": "sha512-8+4DpyS6BLGhMQNl0c1Te3vsOTXzdB5KhdGwOX/L+4EY1Fb7RsMYWfINwuyGBJAZvY8RReKj7RKvW/BmkHS0HQ==",
+      "dev": true,
+      "requires": {}
     },
     "@ampproject/remapping": {
       "version": "2.2.0",

--- a/admin/package.json
+++ b/admin/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.0",
     "@1024pix/pix-ui": "^24.1.0",
+    "@1024pix/stylelint-config": "^1.0.1",
     "@babel/eslint-parser": "^7.19.1",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.8.1",

--- a/certif/.stylelintrc.json
+++ b/certif/.stylelintrc.json
@@ -1,16 +1,4 @@
 {
-  "extends": ["stylelint-config-standard-scss", "stylelint-config-prettier"],
-  "rules": {
-    "at-rule-no-unknown": [true, { "ignoreAtRules": ["else", "extend", "if", "include", "mixin", "warn"] }],
-    "color-hex-case": "upper",
-    "color-hex-length": "long",
-    "indentation": [2, { "indentInsideParens": "once-at-root-twice-in-block" }],
-    "rule-empty-line-before": ["always-multi-line", { "ignore": ["after-comment", "first-nested"] }],
-    "value-keyword-case": ["lower", { "ignoreKeywords": ["Arial"] }],
-    "selector-class-pattern": null,
-    "declaration-colon-space-after": "always-single-line",
-    "declaration-colon-space-before": "never",
-    "declaration-block-semicolon-space-before": "never",
-    "block-opening-brace-space-before": "always"
-  }
+  "extends": ["@1024pix/stylelint-config"],
+  "rules": {}
 }

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -12,6 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
         "@1024pix/pix-ui": "^24.0.1",
+        "@1024pix/stylelint-config": "^1.0.1",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.5",
         "@ember/optional-features": "^2.0.0",
@@ -1021,6 +1022,17 @@
       "engines": {
         "node": "16",
         "npm": ">=8.13.2 <9"
+      }
+    },
+    "node_modules/@1024pix/stylelint-config": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/stylelint-config/-/stylelint-config-1.0.1.tgz",
+      "integrity": "sha512-8+4DpyS6BLGhMQNl0c1Te3vsOTXzdB5KhdGwOX/L+4EY1Fb7RsMYWfINwuyGBJAZvY8RReKj7RKvW/BmkHS0HQ==",
+      "dev": true,
+      "peerDependencies": {
+        "stylelint": ">=14.4.0",
+        "stylelint-config-prettier": ">=9.0.4",
+        "stylelint-config-standard-scss": ">=6.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -36012,6 +36024,13 @@
         "ember-prop-modifier": "^1.0.1",
         "ember-truth-helpers": "^3.1.1"
       }
+    },
+    "@1024pix/stylelint-config": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/stylelint-config/-/stylelint-config-1.0.1.tgz",
+      "integrity": "sha512-8+4DpyS6BLGhMQNl0c1Te3vsOTXzdB5KhdGwOX/L+4EY1Fb7RsMYWfINwuyGBJAZvY8RReKj7RKvW/BmkHS0HQ==",
+      "dev": true,
+      "requires": {}
     },
     "@ampproject/remapping": {
       "version": "2.2.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
     "@1024pix/pix-ui": "^24.0.1",
+    "@1024pix/stylelint-config": "^1.0.1",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.5",
     "@ember/optional-features": "^2.0.0",

--- a/mon-pix/.stylelintrc.json
+++ b/mon-pix/.stylelintrc.json
@@ -1,8 +1,7 @@
 {
-  "extends": ["stylelint-config-standard-scss", "stylelint-config-rational-order", "stylelint-config-prettier"],
+  "extends": ["@1024pix/stylelint-config", "stylelint-config-rational-order"],
   "rules": {
     "scss/operator-no-unspaced": null,
-    "selector-class-pattern": null,
     "scss/no-global-function-names": null,
     "declaration-block-no-redundant-longhand-properties": null,
     "scss/at-mixin-pattern": null,
@@ -11,16 +10,6 @@
     "selector-pseudo-class-no-unknown": null,
     "scss/double-slash-comment-whitespace-inside": null,
     "scss/double-slash-comment-empty-line-before": null,
-    "at-rule-no-unknown": [true, { "ignoreAtRules": ["else", "extend", "if", "include", "mixin", "warn"] }],
-    "color-hex-case": "upper",
-    "color-hex-length": "long",
-    "indentation": [2, { "indentInsideParens": "once-at-root-twice-in-block" }],
-    "rule-empty-line-before": ["always-multi-line", { "ignore": ["after-comment", "first-nested"] }],
-    "value-keyword-case": ["lower", { "ignoreKeywords": ["Arial"] }],
-    "string-quotes": "single",
-    "declaration-colon-space-after": "always-single-line",
-    "declaration-colon-space-before": "never",
-    "declaration-block-semicolon-space-before": "never",
-    "block-opening-brace-space-before": "always"
+    "string-quotes": "single"
   }
 }

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -12,6 +12,7 @@
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.5.0",
         "@1024pix/pix-ui": "^24.0.1",
+        "@1024pix/stylelint-config": "^1.0.1",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
         "@ember/optional-features": "^2.0.0",
@@ -1154,6 +1155,17 @@
       "engines": {
         "node": "16",
         "npm": ">=8.13.2 <9"
+      }
+    },
+    "node_modules/@1024pix/stylelint-config": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/stylelint-config/-/stylelint-config-1.0.1.tgz",
+      "integrity": "sha512-8+4DpyS6BLGhMQNl0c1Te3vsOTXzdB5KhdGwOX/L+4EY1Fb7RsMYWfINwuyGBJAZvY8RReKj7RKvW/BmkHS0HQ==",
+      "dev": true,
+      "peerDependencies": {
+        "stylelint": ">=14.4.0",
+        "stylelint-config-prettier": ">=9.0.4",
+        "stylelint-config-standard-scss": ">=6.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -42679,6 +42691,13 @@
         "ember-prop-modifier": "^1.0.1",
         "ember-truth-helpers": "^3.1.1"
       }
+    },
+    "@1024pix/stylelint-config": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/stylelint-config/-/stylelint-config-1.0.1.tgz",
+      "integrity": "sha512-8+4DpyS6BLGhMQNl0c1Te3vsOTXzdB5KhdGwOX/L+4EY1Fb7RsMYWfINwuyGBJAZvY8RReKj7RKvW/BmkHS0HQ==",
+      "dev": true,
+      "requires": {}
     },
     "@ampproject/remapping": {
       "version": "2.1.2",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.5.0",
     "@1024pix/pix-ui": "^24.0.1",
+    "@1024pix/stylelint-config": "^1.0.1",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
## :egg: Problème
Les règles de stylelint ne sont pas toutes les mêmes sur les différentes applications.

## :bowl_with_spoon: Proposition
Mettre en commun toutes les règles utilisées dans les apps à l'aide du package npm @1024pix/stylelint-config 
https://github.com/1024pix/stylelint-config

## :milk_glass: Remarques
Il n'y a pas de lint CSS sur pix-orga.
Par la suite un ménage serait de mise sur certaines règles redondantes avec les extends.

## :butter: Pour tester
Lancer la commande ```npm run lint:scss ``` et s'assurer qu'aucunes erreurs n'est retourné.