### PR TITLE
[TECH] Améliorer l’accessibilité de la page Connexion sur Pix App (PIX-6913). 

### DIFF
--- a/mon-pix/tests/integration/components/signin-form_test.js
+++ b/mon-pix/tests/integration/components/signin-form_test.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 import { module, test } from 'qunit';
-import { fillIn } from '@ember/test-helpers';
+import { fillIn, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { render, clickByName } from '@1024pix/ember-testing-library';
 
@@ -271,6 +271,25 @@ module('Integration | Component | signin form', function (hooks) {
       // Then
       sinon.assert.calledOnce(session.authenticateUser);
       assert.ok(true);
+    });
+  });
+
+  module('when the password visibility button is clicked', function () {
+    test('it should focus on input', async function (assert) {
+      // given
+      const screen = await render(hbs`<SigninForm />`);
+
+      // when
+      await click(screen.getByRole('button', { name: this.intl.t('common.form.visible-password') }));
+
+      // then
+      assert
+        .dom(
+          screen.getByRole('textbox', {
+            name: `${this.intl.t('pages.sign-in.fields.password.label')}`,
+          })
+        )
+        .isFocused();
     });
   });
 });


### PR DESCRIPTION
## :egg: Problème
Suite à l'audit d’accessibilité, plusieurs pages de l'application nécessitent des améliorations dont la page `/connexion`.

## :bowl_with_spoon: Proposition
Prendre les retours de l'audit pour améliorer l'a11y de la page /inscription.

Le tableau d'audit sera mis à jour lors du merge de ce ticket.

## :milk_glass: Remarques

Les critères invalidés sur cette page ont été corrigés grâce à la PR #5486 :

**Critère 7.3 : Chaque script est-il contrôlable par le clavier et par tout dispositif de pointage (hors cas particuliers) ?**
Pour corriger : Donner le focus au champ mot de passe quand on clique sur le bouton pour afficher ou masquer celui-ci.

**Critère 10.5 : Dans chaque page web, les déclarations CSS de couleurs de fond d'élément et de police sont-elles correctement utilisées ?**
Pas de déclaration de couleur de police par défaut qui puisse être héritée tout au long du document.
Pour corriger : en plus de la couleur de fond par défaut, déclarer une couleur de police par défaut.

## :butter: Pour tester
Sur Pix App, aller sur la page de connexion :

1. **Critère 7.3** Aller sur le champ mot de passe, constater qu'au click sur le bouton pour masquer/afficher un mot de passe, le focus repasse sur le champ de texte (tester en navigation clavier également).
2. **Critère 10.5** Le screen suivant montre en rouge le texte qui ne possédait pas de couleur par défaut.
<img width="450" alt="Capture d’écran 2023-01-31 à 17 32 47" src="https://user-images.githubusercontent.com/82950611/215822161-85d32d04-e2ea-4f8c-9698-371b5f6a16e0.png">

