### PR TITLE
[TECH] Amélioration de la gestion des erreurs lors d'une erreur 500 pendant la réconciliation(PIX-6371)

### DIFF
--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -75,6 +75,9 @@ module.exports = {
       ACCOUNT_BELONGING_TO_ANOTHER_USER: { shortCode: 'R90', code: 'ACCOUNT_SEEMS_TO_BELONGS_TO_ANOTHER_USER' },
     },
     LOGIN_OR_REGISTER: {
+      IN_DB: {
+        username: { shortCode: 'S50', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_IN_DB' },
+      },
       IN_SAME_ORGANIZATION: {
         email: { shortCode: 'S51', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
         username: { shortCode: 'S52', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },

--- a/api/lib/domain/usecases/create-and-reconcile-user-to-organization-learner.js
+++ b/api/lib/domain/usecases/create-and-reconcile-user-to-organization-learner.js
@@ -14,6 +14,7 @@ const passwordValidator = require('../validators/password-validator');
 const userValidator = require('../validators/user-validator');
 
 const { getCampaignUrl } = require('../../infrastructure/utils/url-builder');
+const { STUDENT_RECONCILIATION_ERRORS } = require('../constants');
 
 function _encryptPassword(userPassword, encryptionService) {
   const encryptedPassword = encryptionService.hashPassword(userPassword);
@@ -137,10 +138,14 @@ module.exports = async function createAndReconcileUserToOrganizationLearner({
       obfuscationService,
     });
 
-  if (!isNil(matchedOrganizationLearner.userId)) {
-    throw new OrganizationLearnerAlreadyLinkedToUserError(
-      'Un compte existe déjà pour l‘élève dans le même établissement.'
-    );
+  const organizationLearnerFound = !isNil(matchedOrganizationLearner.userId);
+  if (organizationLearnerFound) {
+    const detail = 'Un compte existe déjà pour l‘élève dans le même établissement.';
+    const error = STUDENT_RECONCILIATION_ERRORS.LOGIN_OR_REGISTER.IN_SAME_ORGANIZATION.username;
+    const meta = {
+      shortCode: error.shortCode,
+    };
+    throw new OrganizationLearnerAlreadyLinkedToUserError(detail, error.code, meta);
   }
 
   const isUsernameMode = userAttributes.withUsername;

--- a/api/tests/integration/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
+++ b/api/tests/integration/domain/usecases/create-and-reconcile-user-to-organization-learner_test.js
@@ -13,6 +13,7 @@ const mailService = require('../../../../lib/domain/services/mail-service');
 const obfuscationService = require('../../../../lib/domain/services/obfuscation-service');
 const userReconciliationService = require('../../../../lib/domain/services/user-reconciliation-service');
 const userService = require('../../../../lib/domain/services/user-service');
+const createAndReconcileUserToOrganizationLearner = require('../../../../lib/domain/usecases/create-and-reconcile-user-to-organization-learner');
 
 const {
   CampaignCodeError,
@@ -20,8 +21,6 @@ const {
   NotFoundError,
   OrganizationLearnerAlreadyLinkedToUserError,
 } = require('../../../../lib/domain/errors');
-
-const createAndReconcileUserToOrganizationLearner = require('../../../../lib/domain/usecases/create-and-reconcile-user-to-organization-learner');
 
 describe('Integration | UseCases | create-and-reconcile-user-to-organization-learner', function () {
   const pickUserAttributes = ['firstName', 'lastName', 'email', 'username', 'cgu'];
@@ -143,6 +142,8 @@ describe('Integration | UseCases | create-and-reconcile-user-to-organization-lea
 
         // then
         expect(error).to.be.instanceOf(OrganizationLearnerAlreadyLinkedToUserError);
+        expect(error.code).to.equal('ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION');
+        expect(error.meta.shortCode).to.equal('S52');
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/user-to-create-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-to-create-repository_test.js
@@ -1,6 +1,6 @@
 const { expect, knex, databaseBuilder, catchErr } = require('../../../test-helper');
 
-const { AlreadyRegisteredUsernameError } = require('../../../../lib/domain/errors');
+const { OrganizationLearnerAlreadyLinkedToUserError } = require('../../../../lib/domain/errors');
 
 const User = require('../../../../lib/domain/models/User');
 const UserToCreateRepository = require('../../../../lib/infrastructure/repositories/user-to-create-repository');
@@ -70,7 +70,7 @@ describe('Integration | Infrastructure | Repository | UserToCreateRepository', f
       const error = await catchErr(UserToCreateRepository.create)({ user });
 
       // then
-      expect(error).to.be.instanceOf(AlreadyRegisteredUsernameError);
+      expect(error).to.be.instanceOf(OrganizationLearnerAlreadyLinkedToUserError);
     });
   });
 });

--- a/mon-pix/app/components/routes/register-form.hbs
+++ b/mon-pix/app/components/routes/register-form.hbs
@@ -126,9 +126,8 @@
       </div>
 
       {{#if this.displayRegisterErrorMessage}}
-        <div class="register-form__error" aria-live="polite" id="register-display-error-message">{{t
-            "pages.login-or-register.register-form.error"
-          }}
+        <div class="register-form__error" aria-live="polite" id="register-display-error-message">
+          {{{this.registerErrorMessage}}}
         </div>
       {{/if}}
 

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -277,6 +277,7 @@ export default class RegisterForm extends Component {
     this.matchingStudentFound = false;
     this.loginWithUsername = true;
     this.validation = new FormValidation();
+    this.errorMessage = null;
   }
 
   _executeFieldValidation(key, value, isValid) {

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -171,17 +171,13 @@ export default class RegisterForm extends Component {
             const message = this._showErrorMessageByShortCode(error.meta);
             return (this.errorMessage = message);
           }
+          if (error.status === '500') {
+            return (this.errorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY));
+          }
           const defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY);
           return (this.errorMessage = error.detail ? error.detail : defaultMessage);
         });
       }
-    );
-  }
-
-  _showErrorMessageByShortCode(meta) {
-    const defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY);
-    return (
-      this.intl.t(getRegisterErrorsMessageByShortCode(meta), { value: meta.value, htlmSafe: true }) || defaultMessage
     );
   }
 
@@ -195,6 +191,7 @@ export default class RegisterForm extends Component {
     if (this.isCreationFormNotValid) {
       return (this.isLoading = false);
     }
+
     try {
       this.dependentUser.password = this.password;
       this.dependentUser.withUsername = this.loginWithUsername;
@@ -206,15 +203,25 @@ export default class RegisterForm extends Component {
         this.dependentUser.username = undefined;
       }
       await this.dependentUser.save();
-    } catch (error) {
-      this.isLoading = false;
-      return this._updateInputsStatus();
-    }
 
-    if (this.loginWithUsername) {
-      await this._authenticate(this.dependentUser.username, this.dependentUser.password);
-    } else {
-      await this._authenticate(this.dependentUser.email, this.dependentUser.password);
+      const userLogin = this.loginWithUsername ? this.dependentUser.username : this.dependentUser.email;
+      await this._authenticate(userLogin, this.dependentUser.password);
+    } catch (responseError) {
+      this.isLoading = false;
+      responseError.errors.forEach((error) => {
+        let defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY);
+        if (error.status === '422') {
+          return this._displayErrorsRelatedToInputs();
+        }
+
+        if (error.status === '500' || error.status === '400' || error.status === '404' || error.status === '409') {
+          if (error.status === '409') {
+            defaultMessage = this._showErrorMessageByShortCode(error.meta);
+          }
+        }
+        this.displayRegisterErrorMessage = true;
+        this.registerErrorMessage = defaultMessage;
+      });
     }
 
     this.dependentUser.password = null;
@@ -224,6 +231,7 @@ export default class RegisterForm extends Component {
   @action
   onToggle(data) {
     this.loginWithUsername = data;
+    this.displayRegisterErrorMessage = false;
   }
 
   @action
@@ -289,9 +297,8 @@ export default class RegisterForm extends Component {
     this.validation[key].message = message;
   }
 
-  _updateInputsStatus() {
+  _displayErrorsRelatedToInputs() {
     const errors = this.dependentUser.errors;
-
     if (errors) {
       errors.forEach(({ attribute, message }) => {
         this.validation[attribute].status = 'error';
@@ -335,5 +342,12 @@ export default class RegisterForm extends Component {
   _authenticate(login, password) {
     const scope = 'mon-pix';
     return this.session.authenticate('authenticator:oauth2', { login, password, scope });
+  }
+
+  _showErrorMessageByShortCode(meta) {
+    const defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY);
+    return (
+      this.intl.t(getRegisterErrorsMessageByShortCode(meta), { value: meta.value, htlmSafe: true }) || defaultMessage
+    );
   }
 }

--- a/mon-pix/app/utils/errors-messages.js
+++ b/mon-pix/app/utils/errors-messages.js
@@ -38,6 +38,11 @@ const JOIN_ERRORS = [
 
 const REGISTER_ERRORS = [
   {
+    shortCode: 'S50',
+    message: 'api-error-messages.register-error.s50',
+    code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_IN_DB',
+  },
+  {
     shortCode: 'S51',
     message: 'api-error-messages.register-error.s51',
     code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_SAME_ORGANIZATION',

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -65,9 +65,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await click('.fill-in-campaign-code__start-button');
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
           });
 
           module('When user create its account', function () {
@@ -95,13 +93,17 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
               const screen = await visit('/campagnes');
               await fillIn('#campaign-code', campaign.code);
               await click('.fill-in-campaign-code__start-button');
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line qunit/no-assert-equal
-              assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+
+              // then
+              assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
+
+              // when
               await click('.campaign-landing-page__start-button');
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line qunit/no-assert-equal
-              assert.equal(currentURL(), '/inscription');
+
+              // then
+              assert.strictEqual(currentURL(), '/inscription');
+
+              // when
               await fillIn('#firstName', prescritUser.firstName);
               await fillIn('#lastName', prescritUser.lastName);
               await fillIn('#email', prescritUser.email);
@@ -112,9 +114,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
               await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
 
               // then
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line qunit/no-assert-equal
-              assert.equal(sentCampaignCode, campaign.code);
+              assert.strictEqual(sentCampaignCode, campaign.code);
             });
           });
         });
@@ -139,9 +139,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
               await click('#submit-connexion');
 
               // then
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line qunit/no-assert-equal
-              assert.equal(currentURL(), `/campagnes/${campaign.code}/prescrit/eleve`);
+              assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/prescrit/eleve`);
             });
 
             module('When student is reconciled in another organization', function () {
@@ -165,14 +163,11 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
                 await click('#submit-connexion');
 
                 // then
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line qunit/no-assert-equal
-                assert.equal(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+                assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
               });
             });
           });
 
-          // TODO: Fix this the next time the file is edited.
           // eslint-disable-next-line qunit/no-async-module-callbacks
           module('When user must accept Pix last terms of service', async function () {
             test('should redirect to invited sco student page after accept terms of service', async function (assert) {
@@ -192,9 +187,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
               await clickByLabel(this.intl.t('pages.terms-of-service.form.button'));
 
               // then
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line qunit/no-assert-equal
-              assert.equal(currentURL(), `/campagnes/${campaign.code}/prescrit/eleve`);
+              assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/prescrit/eleve`);
             });
           });
 
@@ -203,9 +196,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await visit(`/campagnes/${campaign.code}`);
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
           });
 
           test('should redirect to login-or-register page when landing page has been seen', async function (assert) {
@@ -216,9 +207,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await clickByLabel('Je commence');
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/rejoindre/identification`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/rejoindre/identification`);
           });
 
           test('should not alter inputs(username,password,email) when email already exists', async function (assert) {
@@ -271,37 +260,26 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await fillIn('#email', prescritUser.email);
             await fillIn('#password', 'pix123');
             await click('#submit-registration');
+
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/rejoindre/identification`);
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(find('#firstName').value, prescritUser.firstName);
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(find('#email').value, prescritUser.email);
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(find('#password').value, 'pix123');
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/rejoindre/identification`);
+            assert.strictEqual(find('#firstName').value, prescritUser.firstName);
+            assert.strictEqual(find('#email').value, prescritUser.email);
+            assert.strictEqual(find('#password').value, 'pix123');
 
             //go to username-based authentication window
             await click('.pix-toggle-deprecated__off');
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(find('span[data-test-username]').textContent, 'first.last1010');
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(find('#password').value, 'pix123');
+            assert.strictEqual(find('span[data-test-username]').textContent, 'first.last1010');
+            assert.strictEqual(find('#password').value, 'pix123');
           });
 
           test('should redirect to student sco invited page when connection is done', async function (assert) {
             // given
             await visit(`/campagnes/${campaign.code}`);
             await clickByLabel('Je commence');
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/rejoindre/identification`);
+
+            // then
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/rejoindre/identification`);
 
             // when
             await click('#login-button');
@@ -310,27 +288,25 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await click('#submit-connexion');
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/prescrit/eleve`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/prescrit/eleve`);
           });
 
           test('should begin campaign participation when fields are filled in and associate button is clicked', async function (assert) {
             // given
             await visit(`/campagnes/${campaign.code}`);
             await clickByLabel('Je commence');
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/rejoindre/identification`);
 
+            // then
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/rejoindre/identification`);
+
+            // when
             await click('#login-button');
             await fillIn('#login', prescritUser.email);
             await fillIn('#password', prescritUser.password);
             await click('#submit-connexion');
 
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/prescrit/eleve`);
+            // then
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/prescrit/eleve`);
 
             // when
             await fillIn('#firstName', 'Jane');
@@ -343,9 +319,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await clickByLabel(this.intl.t('pages.join.sco.associate'));
 
             //then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
           });
         });
 
@@ -363,9 +337,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
           });
 
           test('should redirect to simple login page when landing page has been seen', async function (assert) {
@@ -376,9 +348,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await clickByLabel('Je commence');
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), '/inscription');
+            assert.strictEqual(currentURL(), '/inscription');
           });
 
           test('should redirect to invited sup student page after login', async function (assert) {
@@ -394,9 +364,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await clickByLabel('Je me connecte');
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/prescrit/etudiant`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/prescrit/etudiant`);
           });
         });
 
@@ -410,9 +378,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await visit(`/campagnes/${campaign.code}`);
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
           });
 
           test('should redirect to tutorial page after starting campaign', async function (assert) {
@@ -423,9 +389,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await click('button[type="submit"]');
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
           });
         });
       });
@@ -441,9 +405,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
           await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), '/campagnes');
+          assert.strictEqual(currentURL(), '/campagnes');
           assert.ok(
             find('.fill-in-campaign-code__error').textContent.includes(
               'Votre code est erroné, veuillez vérifier ou contacter l’organisateur.'
@@ -461,9 +423,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
           await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), '/campagnes');
+          assert.strictEqual(currentURL(), '/campagnes');
           assert.ok(find('.fill-in-campaign-code__error').textContent.includes('Veuillez saisir un code.'));
         });
       });
@@ -476,9 +436,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
 
         test('should redirect to signin page', async function (assert) {
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), '/inscription');
+          assert.strictEqual(currentURL(), '/inscription');
         });
       });
 
@@ -489,9 +447,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
           await visit(`/campagnes/${campaign.code}`);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
         });
 
         module('When campaign has custom text for the landing page', function () {
@@ -537,9 +493,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
           await visit(`/campagnes/${campaign.code}`);
 
           //then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
         });
       });
 
@@ -558,9 +512,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
             //then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
           });
 
           test('should try to reconcile automatically before redirect to invited sco student page', async function (assert) {
@@ -577,9 +529,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await clickByLabel('Je commence');
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
           });
 
           test('should redirect to invited sco student page when landing page has been seen', async function (assert) {
@@ -590,9 +540,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await clickByLabel('Je commence');
 
             //then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/prescrit/eleve`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/prescrit/eleve`);
           });
 
           test('should not set any field by default', async function (assert) {
@@ -601,12 +549,8 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await clickByLabel('Je commence');
 
             //then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(find('#firstName').value, '');
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(find('#lastName').value, '');
+            assert.strictEqual(find('#firstName').value, '');
+            assert.strictEqual(find('#lastName').value, '');
           });
 
           test('should begin campaign participation when fields are filled in and associate button is clicked', async function (assert) {
@@ -624,9 +568,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await clickByLabel(this.intl.t('pages.join.sco.associate'));
 
             //then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
           });
         });
 
@@ -642,9 +584,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await visit(`/campagnes/${campaign.code}`);
 
             //then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
           });
 
           test('should begin campaign participation when landing page has been seen', async function (assert) {
@@ -655,9 +595,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await clickByLabel('Je commence');
 
             //then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
           });
         });
       });
@@ -676,9 +614,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
           await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
           //then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
         });
 
         test('should redirect to invited sup student page when landing page has been seen', async function (assert) {
@@ -689,9 +625,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
           await clickByLabel('Je commence');
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/campagnes/${campaign.code}/prescrit/etudiant`);
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/prescrit/etudiant`);
         });
 
         test('should begin campaign participation when association is done', async function (assert) {
@@ -709,9 +643,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
           await clickByLabel("C'est parti !");
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
         });
       });
 
@@ -723,9 +655,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
           });
 
           test('should show the identifiant page after clicking on start button in landing page', function (assert) {
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/prescrit/identifiant`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/prescrit/identifiant`);
           });
         });
 
@@ -736,9 +666,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
           });
 
           test('should begin campaign participation', function (assert) {
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
           });
         });
       });
@@ -750,9 +678,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
         });
 
         test('should begin campaign participation', function (assert) {
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
         });
       });
 
@@ -765,9 +691,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
           });
 
           test('should begin campaign participation', function (assert) {
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
           });
         }
       );
@@ -782,9 +706,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
           await visit(`/campagnes/${campaign.code}`);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
         });
 
         test('should show an error message when user starts the campaign', async function (assert) {
@@ -804,9 +726,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
 
         test('should show an error message', async function (assert) {
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), '/campagnes/codefaux');
+          assert.strictEqual(currentURL(), '/campagnes/codefaux');
           assert.ok(find('.title').textContent.includes('Oups, la page demandée n’est pas accessible.'));
         });
       });
@@ -821,9 +741,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
           await visit(`/campagnes/${campaign.code}`);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
         });
 
         test('should redirect to tutorial page after starting campaign', async function (assert) {
@@ -834,9 +752,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
           await click('button[type="submit"]');
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
         });
       });
     });
@@ -889,9 +805,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
           });
 
           test('should redirect to reconciliation form when landing page has been seen', async function (assert) {
@@ -901,9 +815,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await clickByLabel('Je commence');
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/rejoindre/mediacentre`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/rejoindre/mediacentre`);
           });
 
           test('should set by default firstName and lastName', async function (assert) {
@@ -913,12 +825,8 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await clickByLabel('Je commence');
 
             //then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(find('#firstName').value, 'JeanPrescrit');
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(find('#lastName').value, 'Campagne');
+            assert.strictEqual(find('#firstName').value, 'JeanPrescrit');
+            assert.strictEqual(find('#lastName').value, 'Campagne');
           });
 
           test('should begin campaign participation when reconciliation is done', async function (assert) {
@@ -934,9 +842,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await clickByLabel(this.intl.t('pages.join.button'));
 
             //then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
           });
         });
 
@@ -956,12 +862,9 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await visit(`/campagnes/${campaign.code}`);
 
             //then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
           });
 
-          // TODO: Fix this the next time the file is edited.
           // eslint-disable-next-line qunit/no-async-module-callbacks
           module('When user is already reconciled in another organization', async function () {
             test('should reconcile and redirect to landing-page', async function (assert) {
@@ -979,9 +882,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
               await clickByLabel(t('pages.fill-in-campaign-code.start'));
 
               // then
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line qunit/no-assert-equal
-              assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+              assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
             });
           });
         });
@@ -1041,14 +942,10 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             await click('#submit-connexion');
 
             const session = currentSession();
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(session.data.authenticated.source, AUTHENTICATED_SOURCE_FROM_GAR);
+            assert.strictEqual(session.data.authenticated.source, AUTHENTICATED_SOURCE_FROM_GAR);
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
           });
 
           test('should display an specific error message if GAR authentication method adding has failed with http statusCode 4xx', async function (assert) {
@@ -1080,9 +977,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
 
             // then
             assert.ok(currentURL().includes(`/campagnes/${campaign.code}/rejoindre/identification`));
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(find('#update-form-error-message').textContent, expectedErrorMessage);
+            assert.strictEqual(find('#update-form-error-message').textContent, expectedErrorMessage);
           });
 
           test('should display an specific error message if GAR authentication method adding has failed due to wrong connected account', async function (assert) {
@@ -1122,9 +1017,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
 
             // then
             assert.ok(currentURL().includes(`/campagnes/${campaign.code}/rejoindre/identification`));
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(
+            assert.strictEqual(
               find('#update-form-error-message').textContent,
               expectedErrorMessage + expectedObfuscatedConnectionMethod
             );
@@ -1153,9 +1046,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
 
             // then
             assert.ok(currentURL().includes(`/campagnes/${campaign.code}/rejoindre/identification`));
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(find('#update-form-error-message').textContent, expectedErrorMessage);
+            assert.strictEqual(find('#update-form-error-message').textContent, expectedErrorMessage);
           });
 
           module('When user should change password', function () {
@@ -1204,18 +1095,14 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
               await click('#submit-connexion');
 
               // then
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line qunit/no-assert-equal
-              assert.equal(currentURL(), '/mise-a-jour-mot-de-passe-expire');
+              assert.strictEqual(currentURL(), '/mise-a-jour-mot-de-passe-expire');
 
               // when
               await fillIn('#password', 'newPass12345!');
               await clickByLabel(this.intl.t('pages.update-expired-password.button'));
 
               // then
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line qunit/no-assert-equal
-              assert.equal(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+              assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
             });
           });
         });

--- a/mon-pix/tests/integration/components/routes/register-form_test.js
+++ b/mon-pix/tests/integration/components/routes/register-form_test.js
@@ -9,6 +9,8 @@ import sinon from 'sinon';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { clickByLabel } from '../../../helpers/click-by-label';
 
+import ENV from '../../../../config/environment';
+
 const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'Votre prénom n’est pas renseigné.';
 const EMPTY_LASTNAME_ERROR_MESSAGE = 'Votre nom n’est pas renseigné.';
 const INVALID_DAY_OF_BIRTH_ERROR_MESSAGE = 'Votre jour de naissance n’est pas valide.';
@@ -122,149 +124,166 @@ module('Integration | Component | routes/register-form', function (hooks) {
   });
 
   module('errors management', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('When authentication service fails', async function () {
-      test('Should display registerErrorMessage when authentication service fails with username error', async function (assert) {
-        // given
-        const expectedRegisterErrorMessage = this.intl.t('pages.login-or-register.register-form.error');
-        saveDependentUserStub.rejects({ errors: [{ status: '400' }] });
-        // when
-        const screen = await render(hbs`<Routes::RegisterForm />`);
+    module('input errors on reconciliation form', function () {
+      [{ stringFilledIn: '' }, { stringFilledIn: ' ' }].forEach(function ({ stringFilledIn }) {
+        test(`should display an error message on firstName field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
+          // given
+          await render(hbs`<Routes::RegisterForm />`);
 
-        await fillInputReconciliationForm({ screen, intl: this.intl });
-        await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+          // when
+          await fillIn('#firstName', stringFilledIn);
+          await triggerEvent('#firstName', 'focusout');
 
-        await fillIn('#password', 'Mypassword1');
-        await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
-        // then
-        assert.dom('div[id="register-display-error-message"').exists();
-        assert.ok(find('div[id="register-display-error-message"').innerHTML.includes(expectedRegisterErrorMessage));
+          // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
+          assert.equal(
+            find('#register-firstName-container #validationMessage-firstName').textContent,
+            EMPTY_FIRSTNAME_ERROR_MESSAGE
+          );
+          assert.dom('#register-firstName-container .form-textfield__input-container--error').exists();
+        });
+      });
+
+      [{ stringFilledIn: '' }, { stringFilledIn: ' ' }].forEach(function ({ stringFilledIn }) {
+        test(`should display an error message on lastName field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
+          // given
+          await render(hbs`<Routes::RegisterForm />`);
+
+          // when
+          await fillIn('#lastName', stringFilledIn);
+          await triggerEvent('#lastName', 'focusout');
+
+          // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
+          assert.equal(
+            find('#register-lastName-container #validationMessage-lastName').textContent,
+            EMPTY_LASTNAME_ERROR_MESSAGE
+          );
+          assert.dom('#register-lastName-container .form-textfield__input-container--error').exists();
+        });
+      });
+
+      [{ stringFilledIn: '' }, { stringFilledIn: 'a' }, { stringFilledIn: '32' }].forEach(function ({
+        stringFilledIn,
+      }) {
+        test(`should display an error message on dayOfBirth field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
+          // given
+          await render(hbs`<Routes::RegisterForm />`);
+
+          // when
+          await fillIn('#dayOfBirth', stringFilledIn);
+          await triggerEvent('#dayOfBirth', 'focusout');
+
+          // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
+          assert.equal(
+            find('#register-birthdate-container #dayValidationMessage').textContent,
+            INVALID_DAY_OF_BIRTH_ERROR_MESSAGE
+          );
+          assert.dom('#register-birthdate-container .form-textfield__input-container--error').exists();
+        });
+      });
+
+      [{ stringFilledIn: '' }, { stringFilledIn: 'a' }, { stringFilledIn: '13' }].forEach(function ({
+        stringFilledIn,
+      }) {
+        test(`should display an error message on monthOfBirth field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
+          // given
+          await render(hbs`<Routes::RegisterForm />`);
+
+          // when
+          await fillIn('#monthOfBirth', stringFilledIn);
+          await triggerEvent('#monthOfBirth', 'focusout');
+
+          // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
+          assert.equal(
+            find('#register-birthdate-container #monthValidationMessage').textContent,
+            INVALID_MONTH_OF_BIRTH_ERROR_MESSAGE
+          );
+          assert.dom('#register-birthdate-container .form-textfield__input-container--error').exists();
+        });
+      });
+
+      [{ stringFilledIn: '' }, { stringFilledIn: 'a' }, { stringFilledIn: '10000' }].forEach(function ({
+        stringFilledIn,
+      }) {
+        test(`should display an error message on yearOfBirth field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
+          // given
+          await render(hbs`<Routes::RegisterForm />`);
+
+          // when
+          await fillIn('#yearOfBirth', stringFilledIn);
+          await triggerEvent('#yearOfBirth', 'focusout');
+
+          // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
+          assert.equal(
+            find('#register-birthdate-container #yearValidationMessage').textContent,
+            INVALID_YEAR_OF_BIRTH_ERROR_MESSAGE
+          );
+          assert.dom('#register-birthdate-container .form-textfield__input-container--error').exists();
+        });
+      });
+
+      [{ stringFilledIn: ' ' }, { stringFilledIn: 'a' }, { stringFilledIn: 'shi.fu' }].forEach(function ({
+        stringFilledIn,
+      }) {
+        test(`should display an error message on email field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
+          // given
+          const screen = await render(hbs`<Routes::RegisterForm /> `);
+
+          await fillInputReconciliationForm({ screen, intl: this.intl });
+          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+
+          // when
+          await click('.pix-toggle-deprecated__off');
+          await fillIn('#email', stringFilledIn);
+          await triggerEvent('#email', 'focusout');
+
+          // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
+          assert.equal(
+            find('#register-email-container #validationMessage-email').textContent,
+            EMPTY_EMAIL_ERROR_MESSAGE
+          );
+          assert.dom('#register-email-container .form-textfield__input-container--error').exists();
+        });
       });
     });
+    module('input errors on create account form', function () {
+      [
+        { stringFilledIn: ' ' },
+        { stringFilledIn: 'password' },
+        { stringFilledIn: 'password1' },
+        { stringFilledIn: 'Password' },
+      ].forEach(function ({ stringFilledIn }) {
+        test(`should display an error message on password field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
+          // given
+          const screen = await render(hbs`<Routes::RegisterForm /> `);
 
-    [{ stringFilledIn: '' }, { stringFilledIn: ' ' }].forEach(function ({ stringFilledIn }) {
-      test(`should display an error message on firstName field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
-        // given
-        await render(hbs`<Routes::RegisterForm />`);
+          await fillInputReconciliationForm({ screen, intl: this.intl });
+          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
-        // when
-        await fillIn('#firstName', stringFilledIn);
-        await triggerEvent('#firstName', 'focusout');
+          // when
+          await fillIn('#password', stringFilledIn);
+          await triggerEvent('#password', 'focusout');
 
-        // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
-          find('#register-firstName-container #validationMessage-firstName').textContent,
-          EMPTY_FIRSTNAME_ERROR_MESSAGE
-        );
-        assert.dom('#register-firstName-container .form-textfield__input-container--error').exists();
-      });
-    });
-
-    [{ stringFilledIn: '' }, { stringFilledIn: ' ' }].forEach(function ({ stringFilledIn }) {
-      test(`should display an error message on lastName field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
-        // given
-        await render(hbs`<Routes::RegisterForm />`);
-
-        // when
-        await fillIn('#lastName', stringFilledIn);
-        await triggerEvent('#lastName', 'focusout');
-
-        // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
-          find('#register-lastName-container #validationMessage-lastName').textContent,
-          EMPTY_LASTNAME_ERROR_MESSAGE
-        );
-        assert.dom('#register-lastName-container .form-textfield__input-container--error').exists();
-      });
-    });
-
-    [{ stringFilledIn: '' }, { stringFilledIn: 'a' }, { stringFilledIn: '32' }].forEach(function ({ stringFilledIn }) {
-      test(`should display an error message on dayOfBirth field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
-        // given
-        await render(hbs`<Routes::RegisterForm />`);
-
-        // when
-        await fillIn('#dayOfBirth', stringFilledIn);
-        await triggerEvent('#dayOfBirth', 'focusout');
-
-        // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
-          find('#register-birthdate-container #dayValidationMessage').textContent,
-          INVALID_DAY_OF_BIRTH_ERROR_MESSAGE
-        );
-        assert.dom('#register-birthdate-container .form-textfield__input-container--error').exists();
-      });
-    });
-
-    [{ stringFilledIn: '' }, { stringFilledIn: 'a' }, { stringFilledIn: '13' }].forEach(function ({ stringFilledIn }) {
-      test(`should display an error message on monthOfBirth field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
-        // given
-        await render(hbs`<Routes::RegisterForm />`);
-
-        // when
-        await fillIn('#monthOfBirth', stringFilledIn);
-        await triggerEvent('#monthOfBirth', 'focusout');
-
-        // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
-          find('#register-birthdate-container #monthValidationMessage').textContent,
-          INVALID_MONTH_OF_BIRTH_ERROR_MESSAGE
-        );
-        assert.dom('#register-birthdate-container .form-textfield__input-container--error').exists();
-      });
-    });
-
-    [{ stringFilledIn: '' }, { stringFilledIn: 'a' }, { stringFilledIn: '10000' }].forEach(function ({
-      stringFilledIn,
-    }) {
-      test(`should display an error message on yearOfBirth field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
-        // given
-        await render(hbs`<Routes::RegisterForm />`);
-
-        // when
-        await fillIn('#yearOfBirth', stringFilledIn);
-        await triggerEvent('#yearOfBirth', 'focusout');
-
-        // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
-          find('#register-birthdate-container #yearValidationMessage').textContent,
-          INVALID_YEAR_OF_BIRTH_ERROR_MESSAGE
-        );
-        assert.dom('#register-birthdate-container .form-textfield__input-container--error').exists();
-      });
-    });
-
-    [{ stringFilledIn: ' ' }, { stringFilledIn: 'a' }, { stringFilledIn: 'shi.fu' }].forEach(function ({
-      stringFilledIn,
-    }) {
-      test(`should display an error message on email field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
-        // given
-        const screen = await render(hbs`<Routes::RegisterForm /> `);
-
-        await fillInputReconciliationForm({ screen, intl: this.intl });
-        await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
-
-        // when
-        await click('.pix-toggle-deprecated__off');
-        await fillIn('#email', stringFilledIn);
-        await triggerEvent('#email', 'focusout');
-
-        // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('#register-email-container #validationMessage-email').textContent, EMPTY_EMAIL_ERROR_MESSAGE);
-        assert.dom('#register-email-container .form-textfield__input-container--error').exists();
+          // then
+          // TODO: Fix this the next time the file is edited.
+          // eslint-disable-next-line qunit/no-assert-equal
+          assert.equal(
+            find('#register-password-container #validationMessage-password').textContent,
+            INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE
+          );
+          assert.dom('#register-password-container .form-textfield__input-container--error').exists();
+        });
       });
     });
 
@@ -290,31 +309,57 @@ module('Integration | Component | routes/register-form', function (hooks) {
       assert.ok(true);
     });
 
-    [
-      { stringFilledIn: ' ' },
-      { stringFilledIn: 'password' },
-      { stringFilledIn: 'password1' },
-      { stringFilledIn: 'Password' },
-    ].forEach(function ({ stringFilledIn }) {
-      test(`should display an error message on password field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
+    // TODO: Fix this the next time the file is edited.
+    // eslint-disable-next-line qunit/no-async-module-callbacks
+    module('When create and reconcile service fails', async function () {
+      test('Should display registerErrorMessage when authentication service fails with error', async function (assert) {
         // given
-        const screen = await render(hbs`<Routes::RegisterForm /> `);
+        const expectedRegisterErrorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY);
+        saveDependentUserStub.rejects({ errors: [{ status: '400' }] });
+
+        // when
+        const screen = await render(hbs`<Routes::RegisterForm />`);
 
         await fillInputReconciliationForm({ screen, intl: this.intl });
         await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
-        // when
-        await fillIn('#password', stringFilledIn);
-        await triggerEvent('#password', 'focusout');
+        await fillIn('#password', 'Mypassword1');
+        await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
-          find('#register-password-container #validationMessage-password').textContent,
-          INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE
-        );
-        assert.dom('#register-password-container .form-textfield__input-container--error').exists();
+        assert.dom('div[id="register-display-error-message"').exists();
+        assert.ok(find('div[id="register-display-error-message"').innerHTML.includes(expectedRegisterErrorMessage));
+      });
+
+      test('Should display username specific errors when authentication service fails with username error', async function (assert) {
+        // given
+        const expectedRegisterErrorMessage = this.intl.t('api-error-messages.register-error.s50');
+        saveDependentUserStub.rejects({
+          errors: [
+            {
+              status: '409',
+              code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_IN_DB',
+              title: 'Conflict',
+              detail: 'Un compte avec cet identifiant existe déjà.',
+              meta: {
+                shortCode: 'S50',
+              },
+            },
+          ],
+        });
+
+        // when
+        const screen = await render(hbs`<Routes::RegisterForm />`);
+
+        await fillInputReconciliationForm({ screen, intl: this.intl });
+        await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+
+        await fillIn('#password', 'Mypassword1');
+        await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+
+        // then
+        assert.dom('div[id="register-display-error-message"').exists();
+        assert.ok(find('div[id="register-display-error-message"').innerHTML.includes(expectedRegisterErrorMessage));
       });
     });
 
@@ -331,9 +376,7 @@ module('Integration | Component | routes/register-form', function (hooks) {
       await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(
+      assert.strictEqual(
         find('#register-password-container #validationMessage-password').textContent,
         INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE
       );

--- a/mon-pix/tests/unit/components/register-form_test.js
+++ b/mon-pix/tests/unit/components/register-form_test.js
@@ -37,6 +37,7 @@ module('Unit | Component | register-form', function (hooks) {
         assert.strictEqual(component.email, null);
         assert.strictEqual(component.username, null);
         assert.strictEqual(component.password, null);
+        assert.strictEqual(component.errorMessage, null);
         assert.false(component.matchingStudentFound);
         assert.true(component.loginWithUsername);
       });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -23,6 +23,7 @@
       }
     },
     "register-error": {
+      "s50": "This username already exists.",
       "s51": "{ value }",
       "s52": "You already have a Pix account under the username '<br>'{ value }.'<br>'To continue, log in with this account or ask for help from a teacher.'<br>'(Code S52)",
       "s53": "You already have a Pix account through your virtual learning environment (\"ENT\"). Log in with this account to take your customised test.",
@@ -906,7 +907,6 @@
         "title": "Sign up",
         "button": "Sign up",
         "button-form": "Sign up",
-        "error": "An error has occured. Please try again or contact the support.",
         "fields": {
           "birthdate": {
             "label": "Date of birth (DD/MM/YYYY)",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -23,6 +23,7 @@
       }
     },
     "register-error": {
+      "s50": "Cet identifiant existe déjà",
       "s51": "Vous possédez déjà un compte Pix avec l’adresse e-mail'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R51)",
       "s52": "Vous possédez déjà un compte Pix utilisé avec l’identifiant sous la forme prénom.nom suivi de 4 chiffres:'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R52)",
       "s53": "Vous possédez déjà un compte Pix via l’ENT.'<br>'Utilisez-le pour rejoindre le parcours.",
@@ -906,7 +907,6 @@
         "title": "Je m’inscris sur Pix",
         "button": "S'inscrire",
         "button-form": "Je m'inscris",
-        "error": "Une erreur est survenue. Veuillez recommencer ou contacter le support.",
         "fields": {
           "birthdate": {
             "label": "Date de naissance (JJ/MM/AAAA)",


### PR DESCRIPTION
## :egg: Problème
On a de temps en temps des erreurs 500 sur l'endpoint POST /api/sco-organization-learners/dependent
D'après nos investigations, cela serait du à un souci côté infra, car de nombreuses vérifications sont faites concernant le code campagne, l'organisation, l'existence d'un compte pour l'organisation learner que l'on souhaite réconcilier.
Le bug n'a pu être reproduit sans commenter un nombre important de ces vérifications pour arriver au cas observé en prod : Erreur  **duplicate key value violates unique constraint** "users_username_unique" sur la requête qui ne devrait pas retourner d’erreur due à la contrainte d’unicité du username dans la table user



## :bowl_with_spoon: Proposition

Ajouter une gestion des erreurs API sur le register form.
Une autre proposition serait de gérer l'erreur au niveau du repository comme dans par exemple
```
function isUniqConstraintViolated(err) {
  const PGSQL_UNIQ_CONSTRAINT = '23505';

  return err.code === PGSQL_UNIQ_CONSTRAINT;
}
```
utilisé ici https://github.com/1024pix/pix/blob/775972b117fdc47a88f6e9508dec240b46eb810c/api/lib/infrastructure/repositories/tag-repository.js#L13

Mais ce n'est pas ce qui est actuellement fait sur Pix.


Ce qui a été observé sur cette PR :
- les erreurs ne sont pas toujours renvoyée au même format
- une erreur 422 (email déjà utilisée) est affichée au niveau du champ email lorsque l'utilisateur se créé un compte avec une adresse e-mail
- la gestion des erreurs a donc du être différenciée pour
    -  errreur lors de la réconciliation /possibilities
    - erreur lors de la création (avec réconciliation) /dependent


## :milk_glass: Remarques
Une meilleure gestion des erreurs de l'endpoint POST /api/sco-organization-learners/dependent en suivant ce qui a été fait pour la réconciliation, cf l'ADR https://github.com/1024pix/pix/blob/dev/docs/adr/0013-gestion-erreurs-api-ihm.md

## :butter: Pour tester
Le dernier commit commente du code pour produire l'exception observée en prod

- Aller sur http://localhost:4200/campagnes/SCOBADGE1/rejoindre/identification
- Se connecter avec Brother Little né le 10/10/2010 et essayer de créer un compte.
- On récupère bien ses informations avec un user name brother.little1010
- Créer cet utilisateur en ajoutant un mot de passe en en cliquant sur 'Je m'inscris'

- Recommencer
- On passe dans l'erreur db apparaît dans les logs de l’api  **duplicate key value violates unique constraint** "users_username_unique"
- Elle est bien catch et la route renvoie une 409

```
{
    "errors": [
        {
            "status": "409",
            "code": "23505",
            "title": "Conflict",
            "detail": "Un compte avec cet identifiant existe déjà.",
            "meta": {
                "shortCode": "S50"
            }
        }
    ]
}
```

- L’erreur apparaît dans les logs de l’api et on ne voit plus le username de l'utilisateur #RGPD

![Capture d’écran 2023-02-13 à 10 29 49](https://user-images.githubusercontent.com/7688741/218421150-b5cdef81-cc4e-4955-b825-44d66f97b822.png)

### Autre cas de tests (non regression)
- Cliquer sur l'onglet email et renseigner un e-mail existant en base, ex sco.admin@example.net
- Observer que l'erreur **'Cette adresse e-mail est déjà enregistrée, connectez-vous.'**  s'affiche toujours sous le champ e-mail
![Capture d’écran 2023-02-01 à 08 47 41](https://user-images.githubusercontent.com/7688741/215994910-2f12b7bd-da56-4827-95b0-3402e6f7ea0b.png)


### Correction en mode SR
- Dans api/lib/domain/usecases/generate-username.js  ajouter une erreur 500 en écrivant `throw new Error()`
- Observez que lors du premier appel, on voit bien une erreur 
- Sur dev on verrait [Object][Object]


- [x] supprimer le dernier commit avant le merge

