### PR TITLE
[BUGFIX]  Corriger l'affichage du nombre 0 dans la dropdown de palier de type niveau (PIX-6951)

### DIFF
--- a/admin/app/components/stages/stage-level-select.js
+++ b/admin/app/components/stages/stage-level-select.js
@@ -4,8 +4,8 @@ import range from 'lodash/range';
 export default class StageLevelSelect extends Component {
   get levelOptions() {
     return range(this.args.maxLevel + 1).map((level) => ({
-      value: level,
-      label: level,
+      value: level.toString(),
+      label: level.toString(),
     }));
   }
 }

--- a/admin/app/components/stages/update-stage.js
+++ b/admin/app/components/stages/update-stage.js
@@ -16,7 +16,7 @@ export default class UpdateStage extends Component {
   constructor() {
     super(...arguments);
     this.threshold = this.args.stage.threshold;
-    this.level = this.args.stage.level;
+    this.level = this.args.stage.level?.toString();
     this.title = this.args.stage.title;
     this.message = this.args.stage.message;
     this.prescriberTitle = this.args.stage.prescriberTitle;


### PR DESCRIPTION
## :egg: Problème
Pour reproduire :

- Créer un profil cible
- Aller dans les clés de lecture
- Créer des paliers de type "niveau"
- Sélectionner le niveau 0

## :bowl_with_spoon: Proposition


## :milk_glass: Remarques

- [x]  : Corriger le fait qu'on ne voit pas le 0 dans la dropdown

## :butter: Pour tester
Essayer de reproduire le bug
