### PR TITLE
[TECH] Améliorer la pertinence de l'alternative textuelle de l'image de la Marianne dans le menu de navigation et du pied de page sur Pix App (PIX-6806).

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -69,7 +69,7 @@
       "success": "success",
       "visible-password": "Show password"
     },
-    "french-republic": "French Republic",
+    "french-republic": "French Republic. Liberty, equality, fraternity.",
     "french-education-ministry": "Ministry of national education and youth",
     "level": "level",
     "loading": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -69,7 +69,7 @@
       "success": "correct",
       "visible-password": "afficher le mot de passe"
     },
-    "french-republic": "République française",
+    "french-republic": "République française. Liberté, égalité, fraternité.",
     "french-education-ministry": "Ministère de l'éducation nationale et de la jeunesse",
     "level": "niveau",
     "loading": {


### PR DESCRIPTION
## :egg: Problème
Suite à l'audit d’accessibilité, plusieurs pages de l'application nécessitent des améliorations dont celles où sont présents la navbar et le footer.

## :bowl_with_spoon: Proposition
Prendre les retours de l'audit pour améliorer le texte de l'image de la Marianne.

Le tableau d'audit sera mis à jour lors du merge de ce ticket.

## :milk_glass: Remarques
**Critères 1.3 : Pour chaque image porteuse d'information ayant une alternative textuelle, cette alternative est-elle pertinente (hors cas particuliers) ?**
Pour corriger : Expliciter le `alt` du logo de la Marianne de la République Française en ajoutant "Liberté, égalité, fraternité".

## :butter: Pour tester
Se connecter sur Pix App et vérifier sur les pages suivantes que le logo de la Marianne présent dans la navbar et le footer dispose d'un attribut `alt` complet : 
- /mon-compte/methodes-de-connexion
- /competences/recMiZPNl7V1hyE1d/details
- /campagnes
- /accueil
- /mes-tutos/recommandes
- /plan-du-site
- /mes-formations
- voir une page de résultats de campagne 
