### PR TITLE
[BUGFIX] Import candidats avec numéro de session avec informations de session (PIX-6981)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -332,6 +332,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.SessionWithoutStartedCertificationError) {
     return new HttpErrors.BadRequestError(error.message);
   }
+  if (error instanceof DomainErrors.SessionWithIdAndInformationOnMassImportError) {
+    return new HttpErrors.BadRequestError(error.message);
+  }
   if (error instanceof DomainErrors.SessionWithAbortReasonOnCompletedCertificationCourseError) {
     return new HttpErrors.ConflictError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -888,6 +888,12 @@ class SessionAlreadyFinalizedError extends DomainError {
   }
 }
 
+class SessionWithIdAndInformationOnMassImportError extends DomainError {
+  constructor(message = 'Merci de ne pas renseigner les informations de session') {
+    super(message);
+  }
+}
+
 class SessionWithoutStartedCertificationError extends DomainError {
   constructor(
     message = "Cette session n'a pas débuté, vous ne pouvez pas la finaliser. Vous pouvez néanmoins la supprimer."
@@ -1382,6 +1388,7 @@ module.exports = {
   SessionStartedDeletionError,
   SessionWithoutStartedCertificationError,
   SessionWithAbortReasonOnCompletedCertificationCourseError,
+  SessionWithIdAndInformationOnMassImportError,
   SessionWithMissingAbortReasonError,
   SiecleXmlImportError,
   SupervisorAccessNotAuthorizedError,

--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -41,7 +41,7 @@ module.exports = async function createSessions({
             certificationCenter,
           });
 
-          await _deleteExistingCandidatesInSession(certificationCandidateRepository, sessionId);
+          await _deleteExistingCandidatesInSession({ certificationCandidateRepository, sessionId, domainTransaction });
         }
       }
 
@@ -96,8 +96,8 @@ function _createAndValidateNewSessionToSave(session, certificationCenterId, cert
   return domainSession;
 }
 
-async function _deleteExistingCandidatesInSession(certificationCandidateRepository, sessionId) {
-  await certificationCandidateRepository.deleteBySessionId({ sessionId });
+async function _deleteExistingCandidatesInSession({ certificationCandidateRepository, sessionId, domainTransaction }) {
+  await certificationCandidateRepository.deleteBySessionId({ sessionId, domainTransaction });
 }
 
 async function _createCertificationCandidates({

--- a/api/lib/infrastructure/repositories/certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/certification-candidate-repository.js
@@ -179,12 +179,13 @@ module.exports = {
     }
   },
 
-  async deleteBySessionId({ sessionId }) {
-    await knex('complementary-certification-subscriptions')
-      .whereIn('certificationCandidateId', knex.select('id').from('certification-candidates').where({ sessionId }))
+  async deleteBySessionId({ sessionId, domainTransaction = DomainTransaction.emptyTransaction() }) {
+    const knexConn = domainTransaction.knexTransaction ?? knex;
+    await knexConn('complementary-certification-subscriptions')
+      .whereIn('certificationCandidateId', knexConn.select('id').from('certification-candidates').where({ sessionId }))
       .del();
 
-    await knex('certification-candidates').where({ sessionId }).del();
+    await knexConn('certification-candidates').where({ sessionId }).del();
   },
 
   async getWithComplementaryCertifications(id) {

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -213,10 +213,11 @@ function _hasCandidateInformation({ lastName }) {
   return Boolean(lastName);
 }
 
-function _createSession({ address, room, date, time, examiner, description }) {
+function _createSession({ sessionId, address, room, date, time, examiner, description }) {
   const uniqueKey = _generateUniqueKey({ address, room, date, time });
 
   return {
+    sessionId: sessionId ? sessionId : undefined,
     uniqueKey,
     address,
     room,

--- a/api/tests/acceptance/application/certification-centers/certification-centers-controller-post-import-sessions_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-centers-controller-post-import-sessions_test.js
@@ -9,6 +9,9 @@ describe('Acceptance | Controller | certification-centers-controller-post-import
   });
 
   afterEach(async function () {
+    await knex('certification-cpf-cities').delete();
+    await knex('certification-cpf-countries').delete();
+    await knex('certification-candidates').delete();
     return knex('sessions').delete();
   });
 
@@ -39,6 +42,55 @@ describe('Acceptance | Controller | certification-centers-controller-post-import
         // then
         expect(response.statusCode).to.equal(200);
         expect(await knex('sessions')).to.have.length(1);
+      });
+    });
+
+    context('when user imports candidates on existing session with candidates', function () {
+      context('when csv first line has sessionId and no session information', function () {
+        context('when csv last line has sessionId and session information', function () {
+          it('should throw and do nothing', async function () {
+            // given
+            const userId = databaseBuilder.factory.buildUser().id;
+            const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+            databaseBuilder.factory.buildCertificationCpfCountry({
+              commonName: 'FRANCE',
+              matcher: 'ACEFNR',
+              code: '99100',
+            });
+            databaseBuilder.factory.buildCertificationCpfCity({
+              INSEECode: '75115',
+              name: 'Paris',
+              isActualName: true,
+            });
+            databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
+            const sessionId = databaseBuilder.factory.buildSession({ id: 1234 }).id;
+            databaseBuilder.factory.buildCertificationCandidate({ sessionId, lastName: 'Toto' });
+            databaseBuilder.factory.buildCertificationCandidate({ sessionId, lastName: 'Foo' });
+            databaseBuilder.factory.buildCertificationCandidate({ sessionId, lastName: 'Bar' });
+            await databaseBuilder.commit();
+
+            const newBuffer = `N° de session;* Nom du site;* Nom de la salle;* Date de début;* Heure de début (heure locale);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: jj/mm/aaaa);* Sexe (M ou F);Code Insee;Code postal;Nom de la commune;* Pays;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant local;Temps majoré ?;Tarification part Pix;Code de prépaiement
+          ${sessionId};;;;;;;Tutu;Jean-Paul;01/01/2000;M;75115;;;FRANCE;;;;;Gratuite;;
+          ${sessionId};site1;salle1;19/10/2022;12:00;surveillant;non;Tata;Corinne;01/01/2000;M;75115;;;FRANCE;;;;;Gratuite;;`;
+
+            const options = {
+              method: 'POST',
+              url: `/api/certification-centers/${certificationCenterId}/sessions/import`,
+              headers: {
+                authorization: generateValidRequestAuthorizationHeader(userId),
+              },
+              payload: newBuffer,
+            };
+
+            // when
+            const response = await server.inject(options);
+
+            // then
+            expect(response.statusCode).to.equal(400);
+            expect(await knex('sessions')).to.have.length(1);
+            expect(await knex('certification-candidates').where({ sessionId })).to.have.length(3);
+          });
+        });
       });
     });
   });

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -594,6 +594,14 @@ describe('Integration | API | Controller Error', function () {
         'Erreur lors de la création des paramètres utilisateur relatifs à Pix Orga.'
       );
     });
+
+    it('responds Bad Request when a SessionWithIdAndInformationOnMassImportError error occurs', async function () {
+      routeHandler.throws(new DomainErrors.SessionWithIdAndInformationOnMassImportError());
+      const response = await server.requestObject(request);
+
+      expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
+      expect(responseDetail(response)).to.equal('Merci de ne pas renseigner les informations de session');
+    });
   });
 
   context('422 Unprocessable Entity', function () {

--- a/api/tests/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/unit/domain/usecases/create-sessions_test.js
@@ -101,8 +101,8 @@ describe('Unit | UseCase | create-sessions', function () {
           const candidate2 = createValidCandidateData(2);
           const sessions = [
             {
-              sessionId: 1234,
               ...createValidSessionData(),
+              sessionId: 1234,
 
               certificationCandidates: [candidate1, candidate2],
             },
@@ -427,6 +427,7 @@ describe('Unit | UseCase | create-sessions', function () {
 
 function createValidSessionData() {
   return {
+    sessionId: undefined,
     address: 'Site 1',
     room: 'Salle 1',
     date: '2022-03-12',

--- a/api/tests/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/unit/domain/usecases/create-sessions_test.js
@@ -162,6 +162,7 @@ describe('Unit | UseCase | create-sessions', function () {
           expect(sessionRepository.save).to.not.have.been.called;
           expect(certificationCandidateRepository.deleteBySessionId).to.have.been.calledOnceWithExactly({
             sessionId: 1234,
+            domainTransaction,
           });
           expect(certificationCandidateRepository.saveInSession).to.have.been.calledTwice;
         });

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -102,6 +102,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
           const expectedResult = [
             {
+              sessionId: undefined,
               address: 'Site 1',
               room: 'Salle 1',
               date: '2023-05-12',
@@ -129,6 +130,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
             const expectedResult = [
               {
+                sessionId: undefined,
                 address: 'Site 1',
                 room: 'Salle 1',
                 date: '2023-05-12',
@@ -159,6 +161,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
           const expectedResult = [
             {
+              sessionId: undefined,
               address: 'Site 1',
               room: 'Salle 1',
               date: '2023-05-12',
@@ -168,6 +171,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
               certificationCandidates: [],
             },
             {
+              sessionId: undefined,
               address: 'Site 2',
               room: 'Salle 2',
               date: '2023-05-12',
@@ -197,6 +201,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
           const expectedResult = [
             {
+              sessionId: undefined,
               address: 'Site 1',
               room: 'Salle 1',
               date: '2023-05-12',
@@ -241,6 +246,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
               ],
             },
             {
+              sessionId: undefined,
               address: 'Site 2',
               room: 'Salle 2',
               date: '2023-05-12',
@@ -337,6 +343,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
           const expectedResult = [
             {
+              sessionId: undefined,
               address: 'Site 1',
               room: 'Salle 1',
               date: '2023-05-12',
@@ -395,6 +402,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
             // then
             const expectedResult = [
               {
+                sessionId: undefined,
                 address: 'Site toto',
                 room: 'Salle toto',
                 date: '2023-05-12',
@@ -439,6 +447,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
         const expectedResult = [
           {
+            sessionId: undefined,
             address: 'Site 1',
             room: 'Salle 1',
             date: '2023-05-12',
@@ -484,6 +493,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
         const expectedResult = [
           {
+            sessionId: undefined,
             address: 'Site 1',
             room: 'Salle 1',
             date: '2023-05-12',


### PR DESCRIPTION
## :egg: Problème
### **BUG n°1 :**  

Lors de l’import du fichier d’import en masse de sessions, utilisation d’un fichier csv rempli avec un numéro de session pré-existant :

 - Sur une ligne, complété uniquement avec données d’un candidat 1
 - Sur une deuxième ligne, complété avec des informations de session en plus du numéro de session et des informations d’un candidat 2

**Résultat obtenu :**

Import fichier réussi avec message « La liste des sessions a été importée avec succès »

- Candidat 1 ajouté
- Candidat 2 pas ajouté sans message d’erreur


**Résultat attendu :**

L’import doit échouer avec une erreur pour indiquer à l’utilisateur de modifier son fichier avant de le réimporter (cf atelier à venir sur l’affichage des erreurs)

### **BUG n°2 :**

 Retour sur le ticket [PIX-6954: Ne pas recréer une session existante à la suite d'un nouvel importDEPLOYED IN PROD](https://1024pix.atlassian.net/browse/PIX-6954) 

- Lors de l’import du fichier d’import en masse de sessions, utilisation d’un fichier csv rempli avec un numéro de session pré-existant et les données d’au moins un candidat


**Résultat obtenu :**

Import fichier échoue avec message “Aucune session n’a été importée”

**Résultat attendu :**

L’import des candidats doit réussir et la liste des candidats de la session préexitante doit être mise à jour.

### **BUG n°3 :** 

Suite à une création de session avec une liste de candidats A, on souhaite la remplacer en important une nouvelle liste de candidats B. Le fichier est rempli avec un numéro de session pré-existant :

- Sur une première ligne, complété uniquement avec le numéro de session et les données d’un candidat 1

- Sur une deuxième ligne, complété avec des informations de session en plus du numéro de session et des informations d’un candidat 2

Le bug 3 ne se produit que si la ligne en erreur n’est pas la première du csv.


**Résultat obtenu :**

Import fichier échoue mais l’ancienne liste de candidats A est effacée

**Résultat attendu :**

 L’import doit échouer mais sans effacer l’ancienne liste de candidats A.


## :bowl_with_spoon: Proposition
Jeter une erreur et bloquer l'import si le sessionId est indiqué en plus des informations de session

## :milk_glass: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :butter: Pour tester

BUG n°1:

- Essayer d'importer le fichier CSV suivant et vérifier qu'une erreur apparait et que le candidat n'est pas enregistré.

```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
NUMERO DE SESSION EXISTANTE,Site1,Salle 1,03/05/2023,12:00,Jean-claude,,Candidat 1,1,01/01/2000,M,75115,,,France,,,,,Gratuite,,oui,
```

- Enlever les infos de session et constater que le candidat a bien été inscrit à la session dont l'id est passé dans le csv

BUG n°2:

- Essayer d'importer le fichier CSV suivant et vérifier que le candidat est enregistré sans affichage d'erreur.

```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
NUMERO DE SESSION EXISTANTE,,,,,,,Candidat 1,1,01/01/2000,M,75115,,,France,,,,,Gratuite,,oui,
```

BUG n°3:

- Pour un session existante comportant déjà au moins 1 candidat:
  - Essayer d'importer le fichier CSV suivant et vérifier  l'affichage d'une erreur et que la liste des candidats de la session n'a pas été effacée.

```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
NUMERO DE SESSION EXISTANTE,,,,,,,Candidat 1,1,01/01/2000,M,75115,,,France,,,,,Gratuite,,oui,
NUMERO DE SESSION EXISTANTE,Site1,Salle 1,03/05/2023,12:00,Jean-claude,,Candidat 2,2,01/01/2000,M,75115,,,France,,,,,Gratuite,,oui,
```