### PR TITLE
[FEATURE] Création de la nouvelle page d'import de sessions en masse (PIX-6947).

### DIFF
--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -25,7 +25,7 @@ module.exports = async function createSessions({
   const { name: certificationCenter, isSco } = await certificationCenterRepository.get(certificationCenterId);
 
   for (const session of sessions) {
-    const sessionAlreadyExisting = await sessionRepository.getExistingSessionByInformation({ ...session });
+    const sessionAlreadyExisting = await sessionRepository.isSessionExisting({ ...session });
     if (sessionAlreadyExisting) {
       throw new UnprocessableEntityError(`Session happening on ${session.date} at ${session.time} already exists`);
     }

--- a/api/lib/infrastructure/repositories/sessions/session-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-repository.js
@@ -37,7 +37,7 @@ module.exports = {
     return new Session({ ...foundSession });
   },
 
-  async getExistingSessionByInformation({ address, room, date, time }) {
+  async isSessionExisting({ address, room, date, time }) {
     const sessions = await knex('sessions').where({ address, room, date, time });
     return sessions.length > 0;
   },

--- a/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
@@ -863,7 +863,7 @@ describe('Integration | Repository | Session', function () {
     });
   });
 
-  describe('#getExistingSessionByInformation', function () {
+  describe('#isSessionsExisting', function () {
     it('should return true if the session already exists', async function () {
       // given
       const session = {
@@ -878,7 +878,7 @@ describe('Integration | Repository | Session', function () {
       await databaseBuilder.commit();
 
       // when
-      const result = await sessionRepository.getExistingSessionByInformation({ ...session });
+      const result = await sessionRepository.isSessionExisting({ ...session });
 
       // then
       expect(result).to.equal(true);
@@ -895,7 +895,7 @@ describe('Integration | Repository | Session', function () {
       };
 
       // when
-      const result = await sessionRepository.getExistingSessionByInformation({ ...session });
+      const result = await sessionRepository.isSessionExisting({ ...session });
 
       // then
       expect(result).to.equal(false);

--- a/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
@@ -863,7 +863,7 @@ describe('Integration | Repository | Session', function () {
     });
   });
 
-  describe('#isSessionsExisting', function () {
+  describe('#isSessionExisting', function () {
     it('should return true if the session already exists', async function () {
       // given
       const session = {

--- a/api/tests/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/unit/domain/usecases/create-sessions_test.js
@@ -30,7 +30,7 @@ describe('Unit | UseCase | create-sessions', function () {
     certificationCenterRepository = { get: sinon.stub() };
     certificationCandidateRepository = { saveInSession: sinon.stub(), deleteBySessionId: sinon.stub() };
     complementaryCertificationRepository = { getByLabel: sinon.stub() };
-    sessionRepository = { save: sinon.stub(), isSessionsExisting: sinon.stub() };
+    sessionRepository = { save: sinon.stub(), isSessionExisting: sinon.stub() };
     sinon.stub(sessionCodeService, 'getNewSessionCodeWithoutAvailabilityCheck');
     sinon.stub(certificationCpfService, 'getBirthInformation');
     sessionCodeService.getNewSessionCodeWithoutAvailabilityCheck.returns(accessCode);
@@ -367,7 +367,7 @@ describe('Unit | UseCase | create-sessions', function () {
     it('should throw an error', async function () {
       // given
       const sessions = [{ ...createValidSessionData(), examiner: 'Paul' }];
-      sessionRepository.isSessionsExisting.withArgs({ ...sessions[0] }).resolves(true);
+      sessionRepository.isSessionExisting.withArgs({ ...sessions[0] }).resolves(true);
 
       const domainTransaction = Symbol('trx');
       sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));

--- a/api/tests/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/unit/domain/usecases/create-sessions_test.js
@@ -31,9 +31,9 @@ describe('Unit | UseCase | create-sessions', function () {
     certificationCandidateRepository = { saveInSession: sinon.stub(), deleteBySessionId: sinon.stub() };
     complementaryCertificationRepository = { getByLabel: sinon.stub() };
     sessionRepository = { save: sinon.stub(), isSessionExisting: sinon.stub() };
-    sinon.stub(sessionCodeService, 'getNewSessionCodeWithoutAvailabilityCheck');
+    sinon.stub(sessionCodeService, 'getNewSessionCode');
     sinon.stub(certificationCpfService, 'getBirthInformation');
-    sessionCodeService.getNewSessionCodeWithoutAvailabilityCheck.returns(accessCode);
+    sessionCodeService.getNewSessionCode.returns(accessCode);
     certificationCenterRepository.get.withArgs(certificationCenterId).resolves(certificationCenter);
   });
 

--- a/api/tests/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/unit/domain/usecases/create-sessions_test.js
@@ -30,10 +30,10 @@ describe('Unit | UseCase | create-sessions', function () {
     certificationCenterRepository = { get: sinon.stub() };
     certificationCandidateRepository = { saveInSession: sinon.stub(), deleteBySessionId: sinon.stub() };
     complementaryCertificationRepository = { getByLabel: sinon.stub() };
-    sessionRepository = { save: sinon.stub(), getExistingSessionByInformation: sinon.stub() };
-    sinon.stub(sessionCodeService, 'getNewSessionCode');
+    sessionRepository = { save: sinon.stub(), isSessionsExisting: sinon.stub() };
+    sinon.stub(sessionCodeService, 'getNewSessionCodeWithoutAvailabilityCheck');
     sinon.stub(certificationCpfService, 'getBirthInformation');
-    sessionCodeService.getNewSessionCode.returns(accessCode);
+    sessionCodeService.getNewSessionCodeWithoutAvailabilityCheck.returns(accessCode);
     certificationCenterRepository.get.withArgs(certificationCenterId).resolves(certificationCenter);
   });
 
@@ -367,7 +367,7 @@ describe('Unit | UseCase | create-sessions', function () {
     it('should throw an error', async function () {
       // given
       const sessions = [{ ...createValidSessionData(), examiner: 'Paul' }];
-      sessionRepository.getExistingSessionByInformation.withArgs({ ...sessions[0] }).resolves(true);
+      sessionRepository.isSessionsExisting.withArgs({ ...sessions[0] }).resolves(true);
 
       const domainTransaction = Symbol('trx');
       sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));

--- a/certif/app/components/sessions/panel-header.hbs
+++ b/certif/app/components/sessions/panel-header.hbs
@@ -13,6 +13,10 @@
         {{t "pages.sessions.list.header.session-import-upload"}}
       </PixButtonUpload>
 
+      <PixButtonLink>
+        {{t "pages.sessions.list.header.session-multiple-creation-edition"}}
+      </PixButtonLink>
+
     {{/if}}
     <PixButtonLink @route="authenticated.sessions.new">
       {{t "pages.sessions.list.header.session-creation"}}

--- a/certif/app/components/sessions/panel-header.hbs
+++ b/certif/app/components/sessions/panel-header.hbs
@@ -1,26 +1,14 @@
 <div class="session-list__header">
   <h1 class="page-title">{{t "pages.sessions.list.header.title"}}</h1>
   <div class="session-list-header__actions">
-    {{#if this.shouldRenderImportTemplateButton}}
-      <PixButton
-        aria-label={{t "pages.sessions.list.header.session-import-template-label"}}
-        @triggerAction={{this.downloadSessionImportTemplate}}
-      >
-        {{t "pages.sessions.list.header.session-import-template"}}
-      </PixButton>
-
-      <PixButtonUpload @id="file-upload" @onChange={{this.importSessions}} accept=".csv">
-        {{t "pages.sessions.list.header.session-import-upload"}}
-      </PixButtonUpload>
-
-      <PixButtonLink>
-        {{t "pages.sessions.list.header.session-multiple-creation-edition"}}
-      </PixButtonLink>
-
-    {{/if}}
     <PixButtonLink @route="authenticated.sessions.new">
       {{t "pages.sessions.list.header.session-creation"}}
       <FaIcon @icon="plus" class="new-session-icon" />
     </PixButtonLink>
+    {{#if this.shouldRenderImportTemplateButton}}
+      <PixButtonLink @route="authenticated.sessions.import">
+        {{t "pages.sessions.list.header.session-multiple-creation-edition"}}
+      </PixButtonLink>
+    {{/if}}
   </div>
 </div>

--- a/certif/app/components/sessions/panel-header.js
+++ b/certif/app/components/sessions/panel-header.js
@@ -1,43 +1,10 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { action } from '@ember/object';
 
 export default class PanelHeader extends Component {
-  @service fileSaver;
-  @service session;
   @service featureToggles;
-  @service notifications;
-  @service intl;
-  @service currentUser;
-  @service store;
 
   get shouldRenderImportTemplateButton() {
     return this.featureToggles.featureToggles.isMassiveSessionManagementEnabled;
-  }
-
-  @action
-  async downloadSessionImportTemplate() {
-    const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
-    const url = `/api/certification-centers/${certificationCenterId}/import`;
-    const token = this.session.data.authenticated.access_token;
-    try {
-      await this.fileSaver.save({ url, token });
-    } catch (e) {
-      this.notifications.error(this.intl.t('pages.sessions.list.header.session-import-template-dl-error'));
-    }
-  }
-
-  @action
-  async importSessions(files) {
-    const adapter = this.store.adapterFor('sessions-import');
-    const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
-    this.notifications.clearAll();
-    try {
-      await adapter.importSessions(files, certificationCenterId);
-      await this.args.reloadSessionSummaries();
-      this.notifications.success('La liste des sessions a été importée avec succès.');
-    } catch (err) {
-      this.notifications.error("Aucune session n'a été importée");
-    }
   }
 }

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -19,7 +19,7 @@ export default class ImportController extends Controller {
     try {
       await this.fileSaver.save({ url, token });
     } catch (e) {
-      this.notifications.error(this.intl.t('pages.sessions.list.header.session-import-template-dl-error'));
+      this.notifications.error(this.intl.t('pages.sessions.sessions.session-import-template-dl-error'));
     }
   }
 

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -1,0 +1,38 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+
+export default class ImportController extends Controller {
+  @service fileSaver;
+  @service session;
+  @service featureToggles;
+  @service notifications;
+  @service intl;
+  @service currentUser;
+  @service store;
+
+  @action
+  async downloadSessionImportTemplate() {
+    const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
+    const url = `/api/certification-centers/${certificationCenterId}/import`;
+    const token = this.session.data.authenticated.access_token;
+    try {
+      await this.fileSaver.save({ url, token });
+    } catch (e) {
+      this.notifications.error(this.intl.t('pages.sessions.list.header.session-import-template-dl-error'));
+    }
+  }
+
+  @action
+  async importSessions(files) {
+    const adapter = this.store.adapterFor('sessions-import');
+    const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
+    this.notifications.clearAll();
+    try {
+      await adapter.importSessions(files, certificationCenterId);
+      this.notifications.success('La liste des sessions a été importée avec succès.');
+    } catch (err) {
+      this.notifications.error("Aucune session n'a été importée");
+    }
+  }
+}

--- a/certif/app/router.js
+++ b/certif/app/router.js
@@ -26,6 +26,7 @@ Router.map(function () {
     this.route('sessions', function () {
       this.route('list', { path: '/liste' });
       this.route('new', { path: '/creation' });
+      this.route('import');
       this.route('update', { path: '/:session_id/modification' });
       this.route('finalize', { path: '/:session_id/finalisation' });
       this.route('details', { path: '/:session_id' }, function () {

--- a/certif/app/routes/authenticated/sessions/list.js
+++ b/certif/app/routes/authenticated/sessions/list.js
@@ -30,13 +30,8 @@ export default class ListRoute extends Route {
       { reload: true }
     );
 
-    const refreshModel = () => {
-      this.refresh();
-    };
-
     return {
       sessionSummaries,
-      refreshModel,
     };
   }
 

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -20,6 +20,7 @@ $navbar-height: 60px;
 @import "pages/authenticated/sessions";
 @import "pages/authenticated/sessions/add-student";
 @import "pages/authenticated/sessions/details";
+@import "pages/authenticated/sessions/import";
 @import "pages/authenticated/sessions/list-items";
 @import "pages/authenticated/sessions/no-session-panel";
 @import "pages/authenticated/sessions/details/certification-candidates";

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -1,0 +1,41 @@
+.import-page {
+  &__section--download {
+    display: flex;
+    flex-direction: column;
+    padding: 24px;
+  }
+
+  &__section--download__button {
+    align-items: center;
+    background-color: $pix-neutral-5;
+    border: 1px solid $pix-neutral-10;
+    border-radius: 8px;
+    display: flex;
+    justify-content: space-between;
+    padding: 24px 16px;
+  }
+
+  &__section--download__button:first-of-type {
+    margin-bottom: 16px;
+  }
+
+  &__section--download__button p {
+    align-items: center;
+    color: $pix-neutral-90;
+    display: flex;
+  }
+
+  &__section--download__button .download-icon {
+    color: $pix-neutral-25;
+    margin-right: 24px;
+  }
+
+  &__section--link-buttons {
+    display: flex;
+    margin-top: 24px;
+  }
+
+  &__section--link-buttons a:first-of-type {
+    margin-right: 16px;
+  }
+}

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -10,24 +10,19 @@
     background-color: $pix-neutral-5;
     border: 1px solid $pix-neutral-10;
     border-radius: 8px;
-    display: flex;
-    justify-content: space-between;
-    padding: 24px 16px;
+    color: $pix-neutral-90;
+    display: grid;
+    grid-template-columns: 1fr 10fr 2fr;
+    padding: 24px 16px 24px 0;
   }
 
   &__section--download__button:first-of-type {
     margin-bottom: 16px;
   }
 
-  &__section--download__button p {
-    align-items: center;
-    color: $pix-neutral-90;
-    display: flex;
-  }
-
   &__section--download__button .download-icon {
     color: $pix-neutral-25;
-    margin-right: 24px;
+    margin: auto;
   }
 
   &__section--link-buttons {

--- a/certif/app/styles/pages/authenticated/sessions/list-items.scss
+++ b/certif/app/styles/pages/authenticated/sessions/list-items.scss
@@ -30,7 +30,7 @@
 .session-list-header__actions {
   display: flex;
 
-  & button {
+  & .pix-button:not(:last-child) {
     margin-right: 12px;
   }
 }

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -1,34 +1,36 @@
+{{page-title (t "pages.sessions.import.title")}}
 <main class="import-page">
-  <h1 class="page-title">Créer/éditer plusieurs sessions</h1>
+  <h1 class="page-title">{{t "pages.sessions.import.title"}}</h1>
   <section class="import-page__section--download panel">
     <div class="import-page__section--download__button">
       <p>
         <FaIcon @icon="file-arrow-down" class="fa-2x download-icon" />
-        Télécharger le modèle vierge
+        {{t "pages.sessions.import.session-import-template-label"}}
       </p>
       <PixButton
         @backgroundColor="transparent-light"
         @isBorderVisible="{{true}}"
-        aria-label={{t "pages.sessions.list.header.session-import-template-label"}}
+        aria-label={{t "pages.sessions.import.session-import-template-label"}}
         @triggerAction={{this.downloadSessionImportTemplate}}
       >
-        {{t "pages.sessions.list.header.session-import-template"}}
+        {{t "pages.sessions.import.session-import-template"}}
       </PixButton>
     </div>
 
     <div class="import-page__section--download__button">
       <p>
         <FaIcon @icon="cloud-arrow-up" class="fa-2x download-icon" />
-        Importer le modèle complété
+        {{t "pages.sessions.import.session-import-upload-label"}}
       </p>
       <PixButtonUpload
         @backgroundColor="transparent-light"
         @isBorderVisible="{{true}}"
         @id="file-upload"
         @onChange={{this.importSessions}}
+        aria-label={{t "pages.sessions.import.session-import-upload-label"}}
         accept=".csv"
       >
-        {{t "pages.sessions.list.header.session-import-upload"}}
+        {{t "pages.sessions.import.session-import-upload"}}
       </PixButtonUpload>
     </div>
 

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -3,43 +3,23 @@
   <h1 class="page-title">{{t "pages.sessions.import.title"}}</h1>
   <section class="import-page__section--download panel">
     <div class="import-page__section--download__button">
-      <p>
-        <FaIcon @icon="file-arrow-down" class="fa-2x download-icon" />
-        {{t "pages.sessions.import.session-import-template-label"}}
-      </p>
-      <PixButton
-        @backgroundColor="transparent-light"
-        @isBorderVisible="{{true}}"
-        aria-label={{t "pages.sessions.import.session-import-template-label"}}
-        @triggerAction={{this.downloadSessionImportTemplate}}
-      >
+      <FaIcon @icon="file-arrow-down" class="fa-2x download-icon" />
+      {{t "pages.sessions.import.session-import-template-label"}}
+      <PixButton @backgroundColor="transparent-light" @isBorderVisible="{{true}}" aria-label={{t "pages.sessions.import.session-import-template-label"}} @triggerAction={{this.downloadSessionImportTemplate}}>
         {{t "pages.sessions.import.session-import-template"}}
       </PixButton>
     </div>
 
     <div class="import-page__section--download__button">
-      <p>
-        <FaIcon @icon="cloud-arrow-up" class="fa-2x download-icon" />
-        {{t "pages.sessions.import.session-import-upload-label"}}
-      </p>
-      <PixButtonUpload
-        @backgroundColor="transparent-light"
-        @isBorderVisible="{{true}}"
-        @id="file-upload"
-        @onChange={{this.importSessions}}
-        aria-label={{t "pages.sessions.import.session-import-upload-label"}}
-        accept=".csv"
-      >
+      <FaIcon @icon="cloud-arrow-up" class="fa-2x download-icon" />
+      {{t "pages.sessions.import.session-import-upload-label"}}
+      <PixButtonUpload @backgroundColor="transparent-light" @isBorderVisible="{{true}}" @id="file-upload" @onChange={{this.importSessions}} aria-label={{t "pages.sessions.import.session-import-upload-label"}} accept=".csv">
         {{t "pages.sessions.import.session-import-upload"}}
       </PixButtonUpload>
     </div>
 
     <div class="import-page__section--link-buttons">
-      <PixButtonLink
-        @route="authenticated.sessions.list"
-        @backgroundColor="transparent-light"
-        @isBorderVisible={{true}}
-      >
+      <PixButtonLink @route="authenticated.sessions.list" @backgroundColor="transparent-light" @isBorderVisible={{true}}>
         {{t "common.actions.cancel"}}
       </PixButtonLink>
       <PixButtonLink>

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -1,9 +1,14 @@
-<main>
-  <h1>Créer/éditer plusieurs sessions</h1>
-  <section>
-    <div>
-      <p>Télécharger le modèle vierge</p>
+<main class="import-page">
+  <h1 class="page-title">Créer/éditer plusieurs sessions</h1>
+  <section class="import-page__section--download panel">
+    <div class="import-page__section--download__button">
+      <p>
+        <FaIcon @icon="file-arrow-down" class="fa-2x download-icon" />
+        Télécharger le modèle vierge
+      </p>
       <PixButton
+        @backgroundColor="transparent-light"
+        @isBorderVisible="{{true}}"
         aria-label={{t "pages.sessions.list.header.session-import-template-label"}}
         @triggerAction={{this.downloadSessionImportTemplate}}
       >
@@ -11,11 +16,33 @@
       </PixButton>
     </div>
 
-    <div>
-      <p>Importer le modèle <complété></complété></p>
-      <PixButtonUpload @id="file-upload" @onChange={{this.importSessions}} accept=".csv">
+    <div class="import-page__section--download__button">
+      <p>
+        <FaIcon @icon="cloud-arrow-up" class="fa-2x download-icon" />
+        Importer le modèle complété
+      </p>
+      <PixButtonUpload
+        @backgroundColor="transparent-light"
+        @isBorderVisible="{{true}}"
+        @id="file-upload"
+        @onChange={{this.importSessions}}
+        accept=".csv"
+      >
         {{t "pages.sessions.list.header.session-import-upload"}}
       </PixButtonUpload>
+    </div>
+
+    <div class="import-page__section--link-buttons">
+      <PixButtonLink
+        @route="authenticated.sessions.list"
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
+      >
+        {{t "common.actions.cancel"}}
+      </PixButtonLink>
+      <PixButtonLink>
+        {{t "common.actions.continue"}}
+      </PixButtonLink>
     </div>
   </section>
 </main>

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -1,0 +1,21 @@
+<main>
+  <h1>Créer/éditer plusieurs sessions</h1>
+  <section>
+    <div>
+      <p>Télécharger le modèle vierge</p>
+      <PixButton
+        aria-label={{t "pages.sessions.list.header.session-import-template-label"}}
+        @triggerAction={{this.downloadSessionImportTemplate}}
+      >
+        {{t "pages.sessions.list.header.session-import-template"}}
+      </PixButton>
+    </div>
+
+    <div>
+      <p>Importer le modèle <complété></complété></p>
+      <PixButtonUpload @id="file-upload" @onChange={{this.importSessions}} accept=".csv">
+        {{t "pages.sessions.list.header.session-import-upload"}}
+      </PixButtonUpload>
+    </div>
+  </section>
+</main>

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -5,7 +5,12 @@
     <div class="import-page__section--download__button">
       <FaIcon @icon="file-arrow-down" class="fa-2x download-icon" />
       {{t "pages.sessions.import.session-import-template-label"}}
-      <PixButton @backgroundColor="transparent-light" @isBorderVisible="{{true}}" aria-label={{t "pages.sessions.import.session-import-template-label"}} @triggerAction={{this.downloadSessionImportTemplate}}>
+      <PixButton
+        @backgroundColor="transparent-light"
+        @isBorderVisible="{{true}}"
+        aria-label={{t "pages.sessions.import.session-import-template-label"}}
+        @triggerAction={{this.downloadSessionImportTemplate}}
+      >
         {{t "pages.sessions.import.session-import-template"}}
       </PixButton>
     </div>
@@ -13,13 +18,24 @@
     <div class="import-page__section--download__button">
       <FaIcon @icon="cloud-arrow-up" class="fa-2x download-icon" />
       {{t "pages.sessions.import.session-import-upload-label"}}
-      <PixButtonUpload @backgroundColor="transparent-light" @isBorderVisible="{{true}}" @id="file-upload" @onChange={{this.importSessions}} aria-label={{t "pages.sessions.import.session-import-upload-label"}} accept=".csv">
+      <PixButtonUpload
+        @backgroundColor="transparent-light"
+        @isBorderVisible="{{true}}"
+        @id="file-upload"
+        @onChange={{this.importSessions}}
+        aria-label={{t "pages.sessions.import.session-import-upload-label"}}
+        accept=".csv"
+      >
         {{t "pages.sessions.import.session-import-upload"}}
       </PixButtonUpload>
     </div>
 
     <div class="import-page__section--link-buttons">
-      <PixButtonLink @route="authenticated.sessions.list" @backgroundColor="transparent-light" @isBorderVisible={{true}}>
+      <PixButtonLink
+        @route="authenticated.sessions.list"
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
+      >
         {{t "common.actions.cancel"}}
       </PixButtonLink>
       <PixButtonLink>

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -62,7 +62,6 @@ module('Acceptance | Session Import', function (hooks) {
         await authenticateSession(certificationPointOfContact.id);
         server.create('session-summary', { certificationCenterId: certificationCenter.id });
         server.create('feature-toggle', { id: 0, isMassiveSessionManagementEnabled: true });
-        screen = await visit('/sessions/import');
       });
 
       module('when the file is valid', function () {
@@ -71,6 +70,7 @@ module('Acceptance | Session Import', function (hooks) {
           const file = new Blob(['foo'], { type: 'valid-file' });
 
           // when
+          screen = await visit('/sessions/import');
           const input = await screen.findByLabelText('Importer le modèle complété');
           await triggerEvent(input, 'change', { files: [file] });
 
@@ -87,6 +87,7 @@ module('Acceptance | Session Import', function (hooks) {
           const file = new Blob(['foo'], { type: 'invalid-file' });
 
           // when
+          screen = await visit('/sessions/import');
           const input = await screen.findByLabelText('Importer le modèle complété');
           await triggerEvent(input, 'change', { files: [file] });
 

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -71,7 +71,7 @@ module('Acceptance | Session Import', function (hooks) {
           const file = new Blob(['foo'], { type: 'valid-file' });
 
           // when
-          const input = await screen.findByLabelText('Importer en masse');
+          const input = await screen.findByLabelText('Importer le modèle complété');
           await triggerEvent(input, 'change', { files: [file] });
 
           // then
@@ -87,7 +87,7 @@ module('Acceptance | Session Import', function (hooks) {
           const file = new Blob(['foo'], { type: 'invalid-file' });
 
           // when
-          const input = await screen.findByLabelText('Importer en masse');
+          const input = await screen.findByLabelText('Importer le modèle complété');
           await triggerEvent(input, 'change', { files: [file] });
 
           // then

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -1,0 +1,99 @@
+import { module, test } from 'qunit';
+import { currentURL, triggerEvent } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
+import { setupApplicationTest } from 'ember-qunit';
+import {
+  createCertificationPointOfContactWithCustomCenters,
+  createAllowedCertificationCenterAccess,
+  authenticateSession,
+} from '../helpers/test-init';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | Session Import', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  let certificationPointOfContact;
+
+  module('When certificationPointOfContact is not authenticated', function () {
+    test('it should not be accessible', async function (assert) {
+      // when
+      await visit('/sessions/import');
+
+      // then
+      assert.strictEqual(currentURL(), '/connexion');
+    });
+  });
+
+  module('When certificationPointOfContact is authenticated', function (hooks) {
+    let allowedCertificationCenterAccess;
+
+    hooks.beforeEach(async function () {
+      allowedCertificationCenterAccess = server.create('allowed-certification-center-access', {
+        id: 123,
+        isAccessBlockedCollege: false,
+        isAccessBlockedLycee: false,
+        isAccessBlockedAEFE: false,
+        isAccessBlockedAgri: false,
+      });
+      certificationPointOfContact = server.create('certification-point-of-contact', {
+        firstName: 'Buffy',
+        lastName: 'Summers',
+        pixCertifTermsOfServiceAccepted: true,
+        allowedCertificationCenterAccesses: [allowedCertificationCenterAccess],
+      });
+
+      await authenticateSession(certificationPointOfContact.id);
+    });
+
+    module('when importing multiple sessions', function (hooks) {
+      let screen;
+
+      hooks.beforeEach(async function () {
+        const certificationCenter = createAllowedCertificationCenterAccess({
+          certificationCenterName: 'Centre SUP',
+          certificationCenterType: 'SUP',
+        });
+        certificationPointOfContact = createCertificationPointOfContactWithCustomCenters({
+          pixCertifTermsOfServiceAccepted: true,
+          allowedCertificationCenterAccesses: [certificationCenter],
+        });
+        await authenticateSession(certificationPointOfContact.id);
+        server.create('session-summary', { certificationCenterId: certificationCenter.id });
+        server.create('feature-toggle', { id: 0, isMassiveSessionManagementEnabled: true });
+        screen = await visit('/sessions/import');
+      });
+
+      module('when the file is valid', function () {
+        test('it should display success message and reload sessions', async function (assert) {
+          // given
+          const file = new Blob(['foo'], { type: 'valid-file' });
+
+          // when
+          const input = await screen.findByLabelText('Importer en masse');
+          await triggerEvent(input, 'change', { files: [file] });
+
+          // then
+          assert
+            .dom('[data-test-notification-message="success"]')
+            .hasText('La liste des sessions a été importée avec succès.');
+        });
+      });
+
+      module('when the file is not valid', function () {
+        test('it should display an error message and not upload any session', async function (assert) {
+          //given
+          const file = new Blob(['foo'], { type: 'invalid-file' });
+
+          // when
+          const input = await screen.findByLabelText('Importer en masse');
+          await triggerEvent(input, 'change', { files: [file] });
+
+          // then
+          assert.dom('[data-test-notification-message="error"]').hasText("Aucune session n'a été importée");
+        });
+      });
+    });
+  });
+});

--- a/certif/tests/acceptance/session-list_test.js
+++ b/certif/tests/acceptance/session-list_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { click, currentURL, triggerEvent } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import {
@@ -299,59 +299,6 @@ module('Acceptance | Session List', function (hooks) {
         // then
         assert.contains('Page 2 / 2');
         assert.strictEqual(currentURL(), '/sessions/liste?pageNumber=2');
-      });
-    });
-
-    module('when importing multiple sessions', function (hooks) {
-      let screen;
-
-      hooks.beforeEach(async function () {
-        const certificationCenter = createAllowedCertificationCenterAccess({
-          certificationCenterName: 'Centre SUP',
-          certificationCenterType: 'SUP',
-        });
-        certificationPointOfContact = createCertificationPointOfContactWithCustomCenters({
-          pixCertifTermsOfServiceAccepted: true,
-          allowedCertificationCenterAccesses: [certificationCenter],
-        });
-        await authenticateSession(certificationPointOfContact.id);
-        server.create('session-summary', { certificationCenterId: certificationCenter.id });
-        server.create('feature-toggle', { id: 0, isMassiveSessionManagementEnabled: true });
-        screen = await visit('/sessions/liste');
-      });
-
-      module('when the file is valid', function () {
-        test('it should display success message and reload sessions', async function (assert) {
-          // given
-          const file = new Blob(['foo'], { type: 'valid-file' });
-
-          // when
-          const input = await screen.findByLabelText('Importer en masse');
-          await triggerEvent(input, 'change', { files: [file] });
-
-          // then
-          const sessionSummariesCount = await screen.findAllByLabelText('Session de certification');
-          assert
-            .dom('[data-test-notification-message="success"]')
-            .hasText('La liste des sessions a été importée avec succès.');
-          assert.strictEqual(sessionSummariesCount.length, 3);
-        });
-      });
-
-      module('when the file is not valid', function () {
-        test('it should display an error message and not upload any session', async function (assert) {
-          //given
-          const file = new Blob(['foo'], { type: 'invalid-file' });
-
-          // when
-          const input = await screen.findByLabelText('Importer en masse');
-          await triggerEvent(input, 'change', { files: [file] });
-
-          // then
-          const sessionSummariesCount = await screen.findAllByLabelText('Session de certification');
-          assert.dom('[data-test-notification-message="error"]').hasText("Aucune session n'a été importée");
-          assert.strictEqual(sessionSummariesCount.length, 1);
-        });
       });
     });
   });

--- a/certif/tests/integration/components/sessions/panel-header_test.js
+++ b/certif/tests/integration/components/sessions/panel-header_test.js
@@ -23,7 +23,7 @@ module('Integration | Component | panel-header', function (hooks) {
 
   module('isMassiveSessionManagementEnabled feature toggle', function () {
     module('isMassiveSessionManagementEnabled feature toggle is true', function () {
-      test('it renders a download button for the mass import template', async function (assert) {
+      test('it renders a link to the session import page', async function (assert) {
         // given
         class FeatureTogglesStub extends Service {
           featureToggles = { isMassiveSessionManagementEnabled: true };
@@ -31,29 +31,15 @@ module('Integration | Component | panel-header', function (hooks) {
         this.owner.register('service:featureToggles', FeatureTogglesStub);
 
         // when
-        const { getByLabelText } = await render(hbs`<Sessions::PanelHeader />`);
+        const { getByRole } = await render(hbs`<Sessions::PanelHeader />`);
 
         // then
-        assert.dom(getByLabelText("Télécharger le template d'import en masse")).exists();
-      });
-
-      test('it renders an import button for the session mass import', async function (assert) {
-        // given
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isMassiveSessionManagementEnabled: true };
-        }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
-
-        // when
-        const screen = await render(hbs`<Sessions::PanelHeader />`);
-
-        // then
-        assert.dom(screen.getByRole('button', { name: 'Importer en masse' })).exists();
+        assert.dom(getByRole('link', { name: 'Créer/éditer plusieurs sessions' })).exists();
       });
     });
 
     module('isMassiveSessionManagementEnabled feature toggle is false', function () {
-      test('it does not render a download button for the mass import template', async function (assert) {
+      test('it does not render a link to the session import page', async function (assert) {
         // given
         class FeatureTogglesStub extends Service {
           featureToggles = { isMassiveSessionManagementEnabled: false };
@@ -61,24 +47,10 @@ module('Integration | Component | panel-header', function (hooks) {
         this.owner.register('service:featureToggles', FeatureTogglesStub);
 
         // when
-        const { queryByLabelText } = await render(hbs`<Sessions::PanelHeader />`);
+        const { queryByRole } = await render(hbs`<Sessions::PanelHeader />`);
 
         // then
-        assert.dom(queryByLabelText("Télécharger le template d'import en masse")).doesNotExist();
-      });
-
-      test('it does not render an import button for the session mass import', async function (assert) {
-        // given
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isMassiveSessionManagementEnabled: false };
-        }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
-
-        // when
-        const { queryByLabelText } = await render(hbs`<Sessions::PanelHeader />`);
-
-        // then
-        assert.dom(queryByLabelText('Importer en masse')).doesNotExist();
+        assert.dom(queryByRole('link', { name: 'Créer/éditer plusieurs sessions' })).doesNotExist();
       });
     });
   });

--- a/certif/tests/unit/controllers/authenticated/sessions/import_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/import_test.js
@@ -1,16 +1,15 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 import sinon from 'sinon';
 import Service from '@ember/service';
 
-module('Unit | Component | panel-header', function (hooks) {
+module('Unit | Controller | authenticated/sessions/import', function (hooks) {
   setupTest(hooks);
 
-  let component;
+  let controller;
 
   hooks.beforeEach(function () {
-    component = createGlimmerComponent('component:sessions/panel-header');
+    controller = this.owner.lookup('controller:authenticated/sessions/import');
   });
 
   module('#downloadSessionImportTemplate', function (hooks) {
@@ -30,7 +29,7 @@ module('Unit | Component | panel-header', function (hooks) {
       // given
       const token = 'a token';
 
-      component.session = {
+      controller.session = {
         isAuthenticated: true,
         data: {
           authenticated: {
@@ -38,16 +37,16 @@ module('Unit | Component | panel-header', function (hooks) {
           },
         },
       };
-      component.fileSaver = {
+      controller.fileSaver = {
         save: sinon.stub(),
       };
 
       // when
-      await component.downloadSessionImportTemplate(event);
+      await controller.downloadSessionImportTemplate(event);
 
       // then
       assert.ok(
-        component.fileSaver.save.calledWith({
+        controller.fileSaver.save.calledWith({
           token,
           url: '/api/certification-centers/123/import',
         })
@@ -56,7 +55,7 @@ module('Unit | Component | panel-header', function (hooks) {
 
     test('should call the notifications service in case of an error', async function (assert) {
       // given
-      component.session = {
+      controller.session = {
         isAuthenticated: true,
         data: {
           authenticated: {
@@ -64,15 +63,15 @@ module('Unit | Component | panel-header', function (hooks) {
           },
         },
       };
-      component.fileSaver = { save: sinon.stub().rejects() };
-      component.notifications = { error: sinon.spy() };
+      controller.fileSaver = { save: sinon.stub().rejects() };
+      controller.notifications = { error: sinon.spy() };
 
       // when
-      await component.downloadSessionImportTemplate(event);
+      await controller.downloadSessionImportTemplate(event);
 
       // then
-      sinon.assert.calledOnce(component.notifications.error);
-      assert.ok(component);
+      sinon.assert.calledOnce(controller.notifications.error);
+      assert.ok(controller);
     });
   });
 
@@ -94,7 +93,7 @@ module('Unit | Component | panel-header', function (hooks) {
       this.owner.register('service:current-user', CurrentUserStub);
       const token = 'a token';
 
-      component.session = {
+      controller.session = {
         isAuthenticated: true,
         data: {
           authenticated: {
@@ -103,17 +102,13 @@ module('Unit | Component | panel-header', function (hooks) {
         },
       };
 
-      component.args = {
-        reloadSessionSummaries: sinon.stub(),
-      };
-      component.notifications = { success: sinon.stub(), clearAll: sinon.stub() };
+      controller.notifications = { success: sinon.stub(), clearAll: sinon.stub() };
 
       // when
-      await component.importSessions(files);
+      await controller.importSessions(files);
 
       // then
-      sinon.assert.calledOnce(component.notifications.success);
-      sinon.assert.calledOnce(component.args.reloadSessionSummaries);
+      sinon.assert.calledOnce(controller.notifications.success);
       assert.ok(sessionsImportStub.calledWith(files, currentAllowedCertificationCenterAccess.id));
     });
 
@@ -135,7 +130,7 @@ module('Unit | Component | panel-header', function (hooks) {
       this.owner.register('service:current-user', CurrentUserStub);
       const token = 'a token';
 
-      component.session = {
+      controller.session = {
         isAuthenticated: true,
         data: {
           authenticated: {
@@ -144,14 +139,14 @@ module('Unit | Component | panel-header', function (hooks) {
         },
       };
 
-      component.notifications = { error: sinon.stub(), clearAll: sinon.stub() };
+      controller.notifications = { error: sinon.stub(), clearAll: sinon.stub() };
 
       // when
-      await component.importSessions(files);
+      await controller.importSessions(files);
 
       // then
-      sinon.assert.calledOnce(component.notifications.error);
-      assert.ok(component);
+      sinon.assert.calledOnce(controller.notifications.error);
+      assert.ok(controller);
     });
   });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -3,6 +3,7 @@
     "actions": {
       "cancel": "Annuler",
       "close": "Fermer",
+      "continue": "Continuer",
       "delete": "Supprimer",
       "quit": "Quitter",
       "update": "Modifier"
@@ -108,6 +109,14 @@
       "finalize": {
         "finished-test-list-description": "Liste des candidats qui ont fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.",
         "unfinished-test-list-description": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon."
+      },
+      "import": {
+        "title": "Créer/éditer plusieurs sessions",
+        "session-import-template": "Télécharger (.csv)",
+        "session-import-template-dl-error": "Une erreur s'est produite pendant le téléchargement",
+        "session-import-template-label": "Télécharger le modèle vierge",
+        "session-import-upload": "Importer (.csv)",
+        "session-import-upload-label": "Importer le modèle complété"
       },
       "list": {
         "header": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -113,6 +113,7 @@
         "header": {
           "title": "Sessions de certification",
           "session-creation": "Créer une session",
+          "session-multiple-creation-edition": "Créer/éditer plusieurs sessions",
           "session-import-template": "Template d'import de sessions",
           "session-import-template-dl-error": "Une erreur s'est produite pendant le téléchargement",
           "session-import-template-label": "Télécharger le template d'import en masse",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -113,6 +113,7 @@
         "header": {
           "title": "Sessions de certification",
           "session-creation": "Créer une session",
+          "session-multiple-creation-edition": "Créer/éditer plusieurs sessions",
           "session-import-template": "Template d'import de sessions",
           "session-import-template-dl-error": "Une erreur s'est produite pendant le téléchargement",
           "session-import-template-label": "Télécharger le template d'import en masse",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -3,6 +3,7 @@
     "actions": {
       "cancel": "Annuler",
       "close": "Fermer",
+      "continue": "Continuer",
       "delete": "Supprimer",
       "quit": "Quitter",
       "update": "Modifier"
@@ -109,15 +110,19 @@
         "finished-test-list-description": "Liste des candidats qui ont fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.",
         "unfinished-test-list-description": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon."
       },
+      "import": {
+        "title": "Créer/éditer plusieurs sessions",
+        "session-import-template": "Télécharger (.csv)",
+        "session-import-template-dl-error": "Une erreur s'est produite pendant le téléchargement",
+        "session-import-template-label": "Télécharger le modèle vierge",
+        "session-import-upload": "Importer (.csv)",
+        "session-import-upload-label": "Importer le modèle complété"
+      },
       "list": {
         "header": {
           "title": "Sessions de certification",
           "session-creation": "Créer une session",
-          "session-multiple-creation-edition": "Créer/éditer plusieurs sessions",
-          "session-import-template": "Template d'import de sessions",
-          "session-import-template-dl-error": "Une erreur s'est produite pendant le téléchargement",
-          "session-import-template-label": "Télécharger le template d'import en masse",
-          "session-import-upload": "Importer en masse"
+          "session-multiple-creation-edition": "Créer/éditer plusieurs sessions"
         },
         "delete-modal": {
           "title": "Supprimer la session",


### PR DESCRIPTION
## :egg: Problème

Les boutons de téléchargement du template CSV ainsi que de l'import en masse des sessions sont actuellement situés sur la page de listing des sessions `/sessions`.
Ceux-ci doivent apparaître sur une nouvelle page dédiée afin de correspondre aux maquettes

## :bowl_with_spoon: Proposition

- Création d'une nouvelle page `/import` (nom challengeable) accessible sous le FT
- Déplacement des boutons mentionnés précédemment sur cette nouvelle page
- Ajout du style de la section dédiée afin de correspondre aux maquettes
- Mise à jour des différents tests afin d'attester de la non régression.

Maquette : [Figma](https://www.figma.com/file/IWVcwbasXoFUQPhIG097XT/Pix-Certif?node-id=1350%3A26895&t=ysMwxoL9nF8bIeFv-0)

## :milk_glass: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :butter: Pour tester

Dans pix-certif, sur la page de listing des sessions, aller sur la nouvelle page `/import` via le bouton `Créer/éditer des sessions`

Vérifier du bon fonctionnement des téléchargement du template et de l'import du fichier CSV complété.

Exemple de CSV : 
```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
,6 rue des églantines,B315,31/01/2020,15:00,José,,,,,,,,,,,,,,,,
```
