### PR TITLE
[FEATURE] Ne pas obliger la création de clés de traduction en anglais pour PixAdmin (PIX-7001)

### DIFF
--- a/admin/config/ember-intl.js
+++ b/admin/config/ember-intl.js
@@ -12,7 +12,7 @@ module.exports = function (/* environment */) {
      * @type {String?}
      * @default "null"
      */
-    fallbackLocale: null,
+    fallbackLocale: 'fr',
 
     /**
      * Path where translations are kept.  This is relative to the project root.
@@ -67,7 +67,12 @@ module.exports = function (/* environment */) {
      * @type {Function}
      * @default "function(key,locale){return true}"
      */
-    requiresTranslation(/* key, locale */) {
+    requiresTranslation(key, locale) {
+      if (locale !== 'fr') {
+        // Ignore any non-French missing translations while Admin is not used in other languages than French
+        return false;
+      }
+
       return true;
     },
 


### PR DESCRIPTION
## :egg: Problème
Lors de la #5433, le support de l'internationalisation a été ajouté sur Pix Admin. Cette application est pour le moment (et probablement pour longtemps) seulement utilisée en Français.

Lorsque l'on veut utiliser des clés de traduction, on est pour le moment obligé de traduire en Français et en Anglais alors que cette dernière langue n'est pas du tout accessible par l'utilisateur.

## :bowl_with_spoon: Proposition
Utiliser des clés de traduction a plusieurs avantages comme précisé dans la #5433. En particulier permettre de tester des clés de traductions plutôt que des libellés en dur permet de garder plus de liberté sur la modification de wordings (pas besoin de modifier un test quand on modifie un libellé 😄). Exemple : 
```javascript
const triggersTabName = this.intl.t('pages.trainings.training.triggers.tabName');
assert.dom(screen.getByRole('link', { name: triggersTabName })).exists();
// On peut modifier la valeur du libellé quand on veut !
```

La proposition est de permettre d'utiliser les clés de traduction sans avoir besoin d'attendre la traduction en Anglais. Ainsi, il suffit de créer la clé de traduction dans le fichier `translations/fr.json` qui sert de `fallback` si la clé n'est pas définie dans son équivalent anglophone. **C'est la version Française qui sera donc servie à l'utilisateur même si un jour l'Anglais est disponible.**

Indirectement, la traduction de l'application (quelque soit la locale) sera rendue plus simple car ça ne sera (presque) pas un sujet technique.

## :milk_glass: Remarques
J'avais commencé en surchargeant la configuration d'`ember-intl` avec `errorOnMissingTranslations: false,`, mais cela produisait des logs de warning pour les clés de traductions manquantes dans une locale. D'ici quelques mois ça pourrait devenir coûteux si on utilise vraiment les traductions.

La méthode `requiresTranslation` est plus intelligente et permet de ne pas générer de logs supplémentaires.

## :butter: Pour tester
Dans le fichier `admin/app/routes/application.js`, si on remplace la `defaultLocale` par `en` et qu'on supprime des clés `en`, la version Française devrait être servie.

Sinon rien ne change.