### PR TITLE
[TECH] Améliorer l'accessibilité de Pix App en déclarant une couleur de police par défaut (PIX-6867).

### DIFF
--- a/mon-pix/app/styles/globals/_layout.scss
+++ b/mon-pix/app/styles/globals/_layout.scss
@@ -1,4 +1,5 @@
 body {
+  color: $pix-neutral-70;
   background-color: $pix-neutral-10;
 }
 

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -27,7 +27,6 @@
     max-width: 609px;
     margin: 0 auto;
     padding: 20px 10px;
-    color: $pix-neutral-70;
     background-color: $pix-neutral-0;
     border-radius: 10px;
 


### PR DESCRIPTION
## :egg: Problème
Suite à l'audit d’accessibilité, plusieurs pages de l'application Pix App nécessitent des améliorations.
Le critère 10.5 n'est pas validé car nous ne possédons pas de couleur de police par défaut. 

On peut s'en apercevoir en plaçant une couleur rouge par défaut.
<img width="794" alt="Capture d’écran 2023-02-02 à 16 25 29" src="https://user-images.githubusercontent.com/58915422/216370400-c9031c56-aafe-47f8-a7f4-fbbdd8e3dde8.png">
<img width="705" alt="Capture d’écran 2023-02-02 à 16 26 31" src="https://user-images.githubusercontent.com/58915422/216370408-7e49c3cf-6eae-4428-82c0-9278e9af964e.png">
<img width="705" alt="Capture d’écran 2023-02-02 à 16 26 40" src="https://user-images.githubusercontent.com/58915422/216370411-4fac758e-93b8-4740-bc6b-89556fcb4f9a.png">
<img width="705" alt="Capture d’écran 2023-02-02 à 16 26 56" src="https://user-images.githubusercontent.com/58915422/216370414-f0b1aefd-3d95-463b-a297-01464523b44b.png">

## :bowl_with_spoon: Proposition
Ajouter une couleur par défaut sur le body de l'application

## :milk_glass: Remarques
**Critère 10.5 : Dans chaque page web, les déclarations CSS de couleurs de fond d'élément et de police sont-elles correctement utilisées ?**

Pas de déclaration de couleur de police par défaut qui puisse être héritée tout au long du document.
Pour corriger : en plus de la couleur de fond par défaut, déclarer une couleur de police par défaut.

<img width="629" alt="Capture d’écran 2023-01-11 à 16 08 40" src="https://user-images.githubusercontent.com/58915422/211841724-fed0921a-32fe-4108-b76c-b97a6926613e.png">


Je supprime sur sign-form la couleur par défaut qui avait été ajouté pour corriger ce critère mais seulement au niveau de la page inscription/connexion
Ajouté ici : https://github.com/1024pix/pix/pull/5486/commits/a64423213117b2ed2d50e88b100df3b8fc1c7f06

## :butter: Pour tester
Se balader dans l'application et vérifier que ça n'apporte aucune régression sur un élément textuel.
