### PR TITLE
[BUGFIX] Cacher correctement le liens d'évitement lorsqu'une bannière de com est active (PIX-7006)

### DIFF
--- a/mon-pix/app/components/sitemap/content.hbs
+++ b/mon-pix/app/components/sitemap/content.hbs
@@ -1,4 +1,4 @@
-<main class="sitemap" role="main">
+<main id="main" class="sitemap" role="main">
   <div class="sitemap__content">
     <h1 class="sitemap-content__title">{{t "pages.sitemap.title"}}</h1>
 

--- a/mon-pix/app/styles/components/_skip-link.scss
+++ b/mon-pix/app/styles/components/_skip-link.scss
@@ -5,7 +5,7 @@
   padding: 0.5em;
   color: $pix-neutral-0;
   background-color: $pix-primary;
-  transform: translateY(calc(-100% - 8px));
+  transform: translateY(calc(-100% - 16px));
   transition: transform 0.3s;
 
   &:focus,

--- a/mon-pix/app/templates/authenticated/user-trainings.hbs
+++ b/mon-pix/app/templates/authenticated/user-trainings.hbs
@@ -24,3 +24,5 @@
     {{/if}}
   </div>
 </main>
+
+<Footer />

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -9,7 +9,7 @@
   <NavbarHeader />
 </header>
 
-<main class="main" role="main">
+<main id="main" class="main" role="main">
   <PixBackgroundHeader>
     <PixBlock class="fill-in-campaign-code__container">
       <h1 class="fill-in-campaign-code__title rounded-panel-title">


### PR DESCRIPTION
## :egg: Problème

<img width="435" alt="image" src="https://user-images.githubusercontent.com/7335131/216383202-e2efcb01-7716-4dba-a12c-d9e77fa80330.png">

Rien de grave, mais sur Chrome, on discerne les liens d'évitement derrière la bannière de com.

## :bowl_with_spoon: Proposition

Remonter les liens lorsqu'ils ne sont pas actifs.

## :milk_glass: Remarques

Ce changement CSS a permis de lancer les tests E2E d'accessibilité qui ont permis de déceler des liens d'évitement qui n'avaient pas de target dans certaines pages.

Ces problèmes ont été fix dans le [deuxième commit](https://github.com/1024pix/pix/pull/5597/commits/cfe5151ad6c720d721107a7b0d4e55d3dc0ec94e).

## :butter: Pour tester

- [Aller sur la RA](https://app-pr5597.review.pix.fr/)
- S'assurer que les liens d'évitement ne sont plus visibles
- Essayer leur comportement initial
