### PR TITLE
[FEATURE] Ajout d'un tri sur le tableau de participants par nombre de participations (PIX-6627)

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -848,6 +848,7 @@ exports.register = async (server) => {
             'filter[connectionTypes][]': [Joi.string(), Joi.array().items(Joi.string())],
             'filter[search]': Joi.string().empty(''),
             'filter[certificability][]': [Joi.string(), Joi.array().items(Joi.string())],
+            'sort[participationCount]': Joi.string().empty(''),
           }),
         },
         handler: organizationController.findPaginatedFilteredScoParticipants,

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -1010,6 +1010,7 @@ exports.register = async (server) => {
             'page[number]': Joi.number().integer().empty(''),
             'filter[fullName]': Joi.string().empty(''),
             'filter[certificability][]': [Joi.string(), Joi.array().items(Joi.string())],
+            'sort[participationCount]': Joi.string().empty(''),
           }),
         },
         handler: organizationController.getPaginatedParticipantsForAnOrganization,

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -816,6 +816,7 @@ exports.register = async (server) => {
             'filter[groups][]': [Joi.string(), Joi.array().items(Joi.string())],
             'filter[search]': Joi.string().empty(''),
             'filter[studentNumber]': Joi.string().empty(''),
+            'sort[participationCount]': Joi.string().empty(''),
           }),
         },
         handler: organizationController.findPaginatedFilteredSupParticipants,

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -265,7 +265,7 @@ module.exports = {
 
   async findPaginatedFilteredSupParticipants(request) {
     const organizationId = request.params.id;
-    const { filter, page } = queryParamsUtils.extractParameters(request.query);
+    const { filter, page, sort } = queryParamsUtils.extractParameters(request.query);
     if (filter.groups && !Array.isArray(filter.groups)) {
       filter.groups = [filter.groups];
     }
@@ -278,6 +278,7 @@ module.exports = {
       organizationId,
       filter,
       page,
+      sort,
     });
     return supOrganizationParticipantsSerializer.serialize({ supOrganizationParticipants, meta });
   },

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -242,7 +242,7 @@ module.exports = {
 
   async findPaginatedFilteredScoParticipants(request) {
     const organizationId = request.params.id;
-    const { filter, page } = queryParamsUtils.extractParameters(request.query);
+    const { filter, page, sort } = queryParamsUtils.extractParameters(request.query);
     if (filter.divisions && !Array.isArray(filter.divisions)) {
       filter.divisions = [filter.divisions];
     }
@@ -256,6 +256,7 @@ module.exports = {
       organizationId,
       filter,
       page,
+      sort,
     });
     return scoOrganizationParticipantsSerializer.serialize({
       scoOrganizationParticipants,

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -394,7 +394,7 @@ module.exports = {
 
   async getPaginatedParticipantsForAnOrganization(request) {
     const organizationId = request.params.id;
-    const { page, filter: filters } = queryParamsUtils.extractParameters(request.query);
+    const { page, filter: filters, sort } = queryParamsUtils.extractParameters(request.query);
 
     if (filters.certificability) {
       filters.certificability = mapCertificabilityByLabel(filters.certificability);
@@ -404,6 +404,7 @@ module.exports = {
       organizationId,
       page,
       filters,
+      sort,
     });
 
     return organizationParticipantsSerializer.serialize(results);

--- a/api/lib/domain/usecases/find-paginated-filtered-sco-participants.js
+++ b/api/lib/domain/usecases/find-paginated-filtered-sco-participants.js
@@ -3,10 +3,12 @@ module.exports = function findPaginatedFilteredScoParticipants({
   filter,
   page,
   scoOrganizationParticipantRepository,
+  sort,
 }) {
   return scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
     organizationId,
     filter,
     page,
+    sort,
   });
 };

--- a/api/lib/domain/usecases/find-paginated-filtered-sup-participants.js
+++ b/api/lib/domain/usecases/find-paginated-filtered-sup-participants.js
@@ -2,11 +2,13 @@ module.exports = function findPaginatedFilteredSupParticipants({
   organizationId,
   filter,
   page,
+  sort,
   supOrganizationParticipantRepository,
 }) {
   return supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
     organizationId,
     filter,
     page,
+    sort,
   });
 };

--- a/api/lib/domain/usecases/get-paginated-participants-for-an-organization.js
+++ b/api/lib/domain/usecases/get-paginated-participants-for-an-organization.js
@@ -2,11 +2,13 @@ module.exports = function getPaginatedParticipantsForAnOrganization({
   organizationId,
   filters,
   page,
+  sort,
   organizationParticipantRepository,
 }) {
   return organizationParticipantRepository.getParticipantsByOrganizationId({
     organizationId,
     filters,
+    sort,
     page,
   });
 };

--- a/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
+++ b/api/lib/infrastructure/repositories/sco-organization-participant-repository.js
@@ -70,12 +70,24 @@ function _buildIsCertifiable(queryBuilder, organizationId) {
 }
 
 module.exports = {
-  async findPaginatedFilteredScoParticipants({ organizationId, filter, page = {} }) {
+  async findPaginatedFilteredScoParticipants({ organizationId, filter, page = {}, sort = {} }) {
     const { totalScoParticipants } = await knex
       .count('id', { as: 'totalScoParticipants' })
       .from('organization-learners')
       .where({ organizationId: organizationId, isDisabled: false })
       .first();
+
+    const orderByClause = [
+      'organization-learners.lastName',
+      'organization-learners.firstName',
+      'organization-learners.id',
+    ];
+    if (sort?.participationCount) {
+      orderByClause.unshift({
+        column: 'participationCount',
+        order: sort.participationCount == 'desc' ? 'desc' : 'asc',
+      });
+    }
 
     const query = knex
       .with('subquery', (qb) => _buildIsCertifiable(qb, organizationId))
@@ -134,7 +146,7 @@ module.exports = {
       .where('organization-learners.isDisabled', false)
       .where('organization-learners.organizationId', organizationId)
       .modify(_setFilters, filter)
-      .orderByRaw('?? ASC, ?? ASC', ['lowerLastName', 'lowerFirstName']);
+      .orderBy(orderByClause);
 
     const { results, pagination } = await fetchPage(query, page);
 

--- a/api/lib/infrastructure/utils/query-params-utils.js
+++ b/api/lib/infrastructure/utils/query-params-utils.js
@@ -2,18 +2,24 @@ const _ = require('lodash');
 
 module.exports = { extractParameters };
 
-// query example : 'filter[organizationId]=4&page[size]=30$page[number]=3&sort=-createdAt,name&include=user'
+// query example: 'filter[organizationId]=4&page[size]=30$page[number]=3&sort=createdAt[desc]&include=user'
+// Warning: there is not any order between sort parameters
 function extractParameters(query) {
   return {
     filter: _extractFilter(query),
     page: _extractPage(query),
-    sort: _extractArrayParameter(query, 'sort'),
+    sort: _extractSort(query, 'sort'),
     include: _extractArrayParameter(query, 'include'),
   };
 }
 
 function _extractFilter(query) {
   const regex = /filter\[([a-zA-Z]*)\]/;
+  return _extractObjectParameter(query, regex);
+}
+
+function _extractSort(query) {
+  const regex = /sort\[([a-zA-Z]*)\]/;
   return _extractObjectParameter(query, regex);
 }
 

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -501,7 +501,7 @@ describe('Integration | Application | Organizations | organization-controller', 
       it('returns organization participants', async function () {
         const organizationId = 5678;
         usecases.getPaginatedParticipantsForAnOrganization
-          .withArgs({ organizationId, page: {}, filters: {} })
+          .withArgs({ organizationId, page: {}, filters: {}, sort: {} })
           .resolves({
             organizationParticipants: [
               {

--- a/api/tests/integration/domain/usecases/get-paginated-participants-for-an-organization_test.js
+++ b/api/tests/integration/domain/usecases/get-paginated-participants-for-an-organization_test.js
@@ -23,6 +23,7 @@ describe('Integration | UseCases | get-paginated-participants-for-an-organizatio
       organizationId,
       filters: { fullName: 'Ah' },
       page: { number: 1, size: 10 },
+      sort: { participationCount: 'asc' },
       organizationParticipantRepository,
     });
 

--- a/api/tests/integration/infrastructure/repositories/organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-participant-repository_test.js
@@ -352,6 +352,155 @@ describe('Integration | Infrastructure | Repository | OrganizationParticipant', 
           expect(organizationParticipants.map(({ id }) => id)).to.exactlyContainInOrder([1, 2]);
         });
       });
+
+      context('When participants are sorted', function () {
+        it('should return participants sorted by ascendant participation count', async function () {
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          const campaignId1 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+          const campaignId2 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+          const campaignId3 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+          const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+          const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+          const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId1,
+            organizationLearnerId: organizationLearnerId1,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId2,
+            organizationLearnerId: organizationLearnerId1,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId3,
+            organizationLearnerId: organizationLearnerId1,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId1,
+            organizationLearnerId: organizationLearnerId3,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId2,
+            organizationLearnerId: organizationLearnerId3,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId1,
+            organizationLearnerId: organizationLearnerId2,
+          });
+          await databaseBuilder.commit();
+          // when
+          const { organizationParticipants } = await organizationParticipantRepository.getParticipantsByOrganizationId({
+            organizationId,
+            sort: {
+              participationCount: 'asc',
+            },
+          });
+
+          // then
+          expect(organizationParticipants.length).to.equal(3);
+          expect(organizationParticipants[0].id).to.equal(organizationLearnerId2);
+          expect(organizationParticipants[1].id).to.equal(organizationLearnerId3);
+          expect(organizationParticipants[2].id).to.equal(organizationLearnerId1);
+        });
+
+        it('should return participants sorted by descendant participation count', async function () {
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          const campaignId1 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+          const campaignId2 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+          const campaignId3 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+          const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+          const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+          const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId1,
+            organizationLearnerId: organizationLearnerId1,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId2,
+            organizationLearnerId: organizationLearnerId1,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId3,
+            organizationLearnerId: organizationLearnerId1,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId1,
+            organizationLearnerId: organizationLearnerId3,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId2,
+            organizationLearnerId: organizationLearnerId3,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId1,
+            organizationLearnerId: organizationLearnerId2,
+          });
+          await databaseBuilder.commit();
+          // when
+          const { organizationParticipants } = await organizationParticipantRepository.getParticipantsByOrganizationId({
+            organizationId,
+            sort: {
+              participationCount: 'desc',
+            },
+          });
+
+          // then
+          expect(organizationParticipants.length).to.equal(3);
+          expect(organizationParticipants[0].id).to.equal(organizationLearnerId1);
+          expect(organizationParticipants[1].id).to.equal(organizationLearnerId3);
+          expect(organizationParticipants[2].id).to.equal(organizationLearnerId2);
+        });
+
+        it('should return participants sorted by name if participation count are identical', async function () {
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          const campaignId1 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+          const campaignId2 = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+          const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Aaaah',
+          }).id;
+          const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Dupont',
+          }).id;
+          const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({
+            organizationId,
+            lastName: 'Dupond',
+          }).id;
+
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId1,
+            organizationLearnerId: organizationLearnerId1,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId2,
+            organizationLearnerId: organizationLearnerId1,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId1,
+            organizationLearnerId: organizationLearnerId2,
+          });
+          databaseBuilder.factory.buildCampaignParticipation({
+            campaignId: campaignId1,
+            organizationLearnerId: organizationLearnerId3,
+          });
+          await databaseBuilder.commit();
+          // when
+          const { organizationParticipants } = await organizationParticipantRepository.getParticipantsByOrganizationId({
+            organizationId,
+            sort: {
+              participationCount: 'asc',
+            },
+          });
+
+          // then
+          expect(organizationParticipants.length).to.equal(3);
+          expect(organizationParticipants[0].id).to.equal(organizationLearnerId3);
+          expect(organizationParticipants[1].id).to.equal(organizationLearnerId2);
+          expect(organizationParticipants[2].id).to.equal(organizationLearnerId1);
+        });
+      });
     });
 
     context('meta', function () {

--- a/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sco-organization-participant-repository_test.js
@@ -834,6 +834,116 @@ describe('Integration | Infrastructure | Repository | sco-organization-participa
       });
     });
 
+    describe('When sco participants are sorted', function () {
+      it('should return sco participants sorted by ascendant participation count', async function () {
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+        const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+        const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId,
+          organizationLearnerId: organizationLearnerId1,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: otherCampaignId,
+          organizationLearnerId: organizationLearnerId1,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId,
+          organizationLearnerId: organizationLearnerId3,
+        });
+        await databaseBuilder.commit();
+        // when
+        const { data: participants } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+          organizationId,
+          sort: {
+            participationCount: 'asc',
+          },
+        });
+
+        // then
+        expect(participants.length).to.equal(3);
+        expect(participants[0].id).to.equal(organizationLearnerId2);
+        expect(participants[1].id).to.equal(organizationLearnerId3);
+        expect(participants[2].id).to.equal(organizationLearnerId1);
+      });
+
+      it('should return sco participants sorted by descendant participation count', async function () {
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+        const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+        const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId,
+          organizationLearnerId: organizationLearnerId1,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: otherCampaignId,
+          organizationLearnerId: organizationLearnerId1,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId,
+          organizationLearnerId: organizationLearnerId3,
+        });
+        await databaseBuilder.commit();
+        // when
+        const { data: participants } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+          organizationId,
+          sort: {
+            participationCount: 'desc',
+          },
+        });
+
+        // then
+        expect(participants.length).to.equal(3);
+        expect(participants[0].id).to.equal(organizationLearnerId1);
+        expect(participants[1].id).to.equal(organizationLearnerId3);
+        expect(participants[2].id).to.equal(organizationLearnerId2);
+      });
+
+      it('should return sco participants sorted by name if participation count are identical', async function () {
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+        const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          lastName: 'Aaaah',
+        }).id;
+        const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          lastName: 'Dupont',
+        }).id;
+        const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          lastName: 'Dupond',
+        }).id;
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId,
+          organizationLearnerId: organizationLearnerId1,
+        });
+        await databaseBuilder.commit();
+        // when
+        const { data: participants } = await scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants({
+          organizationId,
+          sort: {
+            participationCount: 'asc',
+          },
+        });
+
+        // then
+        expect(participants.length).to.equal(3);
+        expect(participants[0].id).to.equal(organizationLearnerId3);
+        expect(participants[1].id).to.equal(organizationLearnerId2);
+        expect(participants[2].id).to.equal(organizationLearnerId1);
+      });
+    });
+
     context('#lastParticipationDate', function () {
       it('should take the last participation date', async function () {
         // given

--- a/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sup-organization-participant-repository_test.js
@@ -608,6 +608,115 @@ describe('Integration | Infrastructure | Repository | sup-organization-participa
       });
     });
 
+    describe('When sup participants are sorted', function () {
+      it('should return sup participants sorted by ascendant participation count', async function () {
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+        const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+        const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId,
+          organizationLearnerId: organizationLearnerId1,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: otherCampaignId,
+          organizationLearnerId: organizationLearnerId1,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId,
+          organizationLearnerId: organizationLearnerId3,
+        });
+        await databaseBuilder.commit();
+        // when
+        const { data: participants } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+          organizationId,
+          sort: {
+            participationCount: 'asc',
+          },
+        });
+
+        // then
+        expect(participants.length).to.equal(3);
+        expect(participants[0].id).to.equal(organizationLearnerId2);
+        expect(participants[1].id).to.equal(organizationLearnerId3);
+        expect(participants[2].id).to.equal(organizationLearnerId1);
+      });
+      it('should return sup participants sorted by descendant participation count', async function () {
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+        const otherCampaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+        const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+        const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({ organizationId }).id;
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId,
+          organizationLearnerId: organizationLearnerId1,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: otherCampaignId,
+          organizationLearnerId: organizationLearnerId1,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId,
+          organizationLearnerId: organizationLearnerId3,
+        });
+        await databaseBuilder.commit();
+        // when
+        const { data: participants } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+          organizationId,
+          sort: {
+            participationCount: 'desc',
+          },
+        });
+
+        // then
+        expect(participants.length).to.equal(3);
+        expect(participants[0].id).to.equal(organizationLearnerId1);
+        expect(participants[1].id).to.equal(organizationLearnerId3);
+        expect(participants[2].id).to.equal(organizationLearnerId2);
+      });
+
+      it('should return sup participants sorted by name if participation count are identical', async function () {
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+        const organizationLearnerId1 = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          lastName: 'Aaaah',
+        }).id;
+        const organizationLearnerId2 = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          lastName: 'Dupont',
+        }).id;
+        const organizationLearnerId3 = databaseBuilder.factory.buildOrganizationLearner({
+          organizationId,
+          lastName: 'Dupond',
+        }).id;
+
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaignId,
+          organizationLearnerId: organizationLearnerId1,
+        });
+        await databaseBuilder.commit();
+        // when
+        const { data: participants } = await supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants({
+          organizationId,
+          sort: {
+            participationCount: 'asc',
+          },
+        });
+
+        // then
+        expect(participants.length).to.equal(3);
+        expect(participants[0].id).to.equal(organizationLearnerId3);
+        expect(participants[1].id).to.equal(organizationLearnerId2);
+        expect(participants[2].id).to.equal(organizationLearnerId1);
+      });
+    });
+
     context('#participantCount', function () {
       it('should only count SUP participants in currentOrganization', async function () {
         // given

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -635,6 +635,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
         organizationId,
         filter: {},
         page: {},
+        sort: {},
       });
     });
 
@@ -659,6 +660,30 @@ describe('Unit | Application | Organizations | organization-controller', functio
         organizationId,
         filter: { lastName: 'Bob', firstName: 'Tom', connectionTypes: ['email'], divisions: ['D1'] },
         page: {},
+        sort: {},
+      });
+    });
+    it('should call the usecase to find sco participants with users infos related to sort', async function () {
+      // given
+      request = {
+        ...request,
+        query: {
+          'sort[participationCount]': 'asc',
+        },
+      };
+      usecases.findPaginatedFilteredScoParticipants.resolves({});
+
+      // when
+      await organizationController.findPaginatedFilteredScoParticipants(request, hFake);
+
+      // then
+      expect(usecases.findPaginatedFilteredScoParticipants).to.have.been.calledWith({
+        organizationId,
+        filter: {},
+        page: {},
+        sort: {
+          participationCount: 'asc',
+        },
       });
     });
 
@@ -675,6 +700,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
         organizationId,
         filter: {},
         page: { size: 10, number: 1 },
+        sort: {},
       });
     });
 
@@ -713,6 +739,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
         organizationId,
         filter: { certificability: [true, false, null] },
         page: {},
+        sort: {},
       });
     });
   });

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -757,6 +757,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
         organizationId,
         filter: {},
         page: {},
+        sort: {},
       });
     });
 
@@ -780,9 +781,33 @@ describe('Unit | Application | Organizations | organization-controller', functio
         organizationId,
         filter: { lastName: 'Bob', firstName: 'Tom', group: 'L1' },
         page: {},
+        sort: {},
       });
     });
 
+    it('should call the usecase to find sup participants with users infos related to sort', async function () {
+      // given
+      request = {
+        ...request,
+        query: {
+          'sort[participationCount]': 'asc',
+        },
+      };
+      usecases.findPaginatedFilteredSupParticipants.resolves({});
+
+      // when
+      await organizationController.findPaginatedFilteredSupParticipants(request, hFake);
+
+      // then
+      expect(usecases.findPaginatedFilteredSupParticipants).to.have.been.calledWith({
+        organizationId,
+        filter: {},
+        page: {},
+        sort: {
+          participationCount: 'asc',
+        },
+      });
+    });
     it('should call the usecase to find sup participants with users infos related to pagination', async function () {
       // given
       request = { ...request, query: { 'page[size]': 10, 'page[number]': 1 } };
@@ -796,6 +821,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
         organizationId,
         filter: {},
         page: { size: 10, number: 1 },
+        sort: {},
       });
     });
 
@@ -835,6 +861,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
         organizationId,
         filter: { certificability: [true, false, null] },
         page: {},
+        sort: {},
       });
     });
   });

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -1277,7 +1277,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
     });
 
     it('should call the usecase to get the participants of the organization', async function () {
-      const parameters = { page: 2, filter: { fullName: 'name' } };
+      const parameters = { page: 2, filter: { fullName: 'name' }, sort: {} };
       const organizationLearner = domainBuilder.buildOrganizationLearner();
       domainBuilder.buildCampaignParticipation({ organizationLearnerId: organizationLearner.id });
 
@@ -1302,7 +1302,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
       sinon.stub(queryParamsUtils, 'extractParameters').withArgs(request.query).returns(parameters);
 
       usecases.getPaginatedParticipantsForAnOrganization
-        .withArgs({ organizationId, page: 2, filters: parameters.filter })
+        .withArgs({ organizationId, page: 2, filters: parameters.filter, sort: {} })
         .returns({
           organizationParticipants: [participant],
           pagination: expectedPagination,
@@ -1321,6 +1321,29 @@ describe('Unit | Application | Organizations | organization-controller', functio
       expect(response).to.deep.equal(expectedResponse);
     });
 
+    it('should call the usecase to find sco participants with users infos related to sort', async function () {
+      // given
+      request = {
+        ...request,
+        query: {
+          'sort[participationCount]': 'asc',
+        },
+      };
+      usecases.getPaginatedParticipantsForAnOrganization.resolves({});
+
+      // when
+      await organizationController.getPaginatedParticipantsForAnOrganization(request, hFake);
+
+      // then
+      expect(usecases.getPaginatedParticipantsForAnOrganization).to.have.been.calledWith({
+        organizationId,
+        filters: {},
+        page: {},
+        sort: {
+          participationCount: 'asc',
+        },
+      });
+    });
     it('map all certificability values', async function () {
       // given
       request = {
@@ -1341,6 +1364,7 @@ describe('Unit | Application | Organizations | organization-controller', functio
         organizationId,
         filters: { certificability: [true, false, null] },
         page: {},
+        sort: {},
       });
     });
   });

--- a/api/tests/unit/domain/usecases/find-paginated-filtered-sco-participants_test.js
+++ b/api/tests/unit/domain/usecases/find-paginated-filtered-sco-participants_test.js
@@ -33,6 +33,7 @@ describe('Unit | UseCase | findPaginatedFilteredScoParticipants', function () {
     foundScoParticipants = await findPaginatedFilteredScoParticipants({
       organizationId,
       filter: { division: '4A', search: 'A' },
+      sort: { participationCount: 'asc' },
       page: { size: 10, number: 1 },
       scoOrganizationParticipantRepository,
     });
@@ -40,6 +41,7 @@ describe('Unit | UseCase | findPaginatedFilteredScoParticipants', function () {
     expect(scoOrganizationParticipantRepository.findPaginatedFilteredScoParticipants).to.have.been.calledWithExactly({
       organizationId,
       filter: { division: '4A', search: 'A' },
+      sort: { participationCount: 'asc' },
       page: { size: 10, number: 1 },
     });
     expect(foundScoParticipants).to.deep.equal(expectedScoParticipants);

--- a/api/tests/unit/domain/usecases/find-paginated-filtered-sup-participants_test.js
+++ b/api/tests/unit/domain/usecases/find-paginated-filtered-sup-participants_test.js
@@ -20,6 +20,7 @@ describe('Unit | UseCase | findPaginatedFilteredSupParticipants', function () {
     foundSupParticipants = await findPaginatedFilteredSupParticipants({
       organizationId,
       filter: { search: 'Arm', group: 'L1' },
+      sort: { participationCount: 'asc' },
       page: { size: 10, number: 1 },
       supOrganizationParticipantRepository,
     });
@@ -27,6 +28,7 @@ describe('Unit | UseCase | findPaginatedFilteredSupParticipants', function () {
     expect(supOrganizationParticipantRepository.findPaginatedFilteredSupParticipants).to.have.been.calledWithExactly({
       organizationId,
       filter: { search: 'Arm', group: 'L1' },
+      sort: { participationCount: 'asc' },
       page: { size: 10, number: 1 },
     });
     expect(foundSupParticipants).to.deep.equal(expectedSupParticipants);

--- a/api/tests/unit/domain/usecases/get-paginated-participants-for-an-organization_test.js
+++ b/api/tests/unit/domain/usecases/get-paginated-participants-for-an-organization_test.js
@@ -6,6 +6,7 @@ describe('Unit | UseCase | get-participants-by-organization-id', function () {
     // given
     const organizationId = 90000;
     const page = {};
+    const sort = { participationCount: 'asc' };
     const organizationParticipantRepository = {
       getParticipantsByOrganizationId: sinon.stub(),
     };
@@ -18,6 +19,7 @@ describe('Unit | UseCase | get-participants-by-organization-id', function () {
       organizationId,
       filters,
       page,
+      sort,
       organizationParticipantRepository,
     });
 
@@ -25,6 +27,7 @@ describe('Unit | UseCase | get-participants-by-organization-id', function () {
     expect(organizationParticipantRepository.getParticipantsByOrganizationId).to.have.been.calledWithExactly({
       organizationId,
       page,
+      sort,
       filters,
     });
   });

--- a/api/tests/unit/infrastructure/utils/query-params-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/query-params-utils_test.js
@@ -10,7 +10,7 @@ describe('Unit | Utils | Query Params Utils', function () {
         'filter[userId]': '1',
         'page[number]': '1',
         'page[size]': '200',
-        sort: '-createdAt,id',
+        'sort[participationCount]': 'asc',
         include: 'user,organization',
       };
 
@@ -27,7 +27,9 @@ describe('Unit | Utils | Query Params Utils', function () {
           number: 1,
           size: 200,
         },
-        sort: ['-createdAt', 'id'],
+        sort: {
+          participationCount: 'asc',
+        },
         include: ['user', 'organization'],
       });
     });
@@ -46,7 +48,7 @@ describe('Unit | Utils | Query Params Utils', function () {
       expect(result).to.deep.equal({
         filter: {},
         page: {},
-        sort: [],
+        sort: {},
         include: [],
       });
     });

--- a/orga/app/components/campaign/analysis/recommendations.hbs
+++ b/orga/app/components/campaign/analysis/recommendations.hbs
@@ -21,9 +21,11 @@
           @align="center"
           @onSort={{this.sortRecommendationOrder}}
           @isDisabled={{not @displayAnalysis}}
-          @ariaLabel={{t "pages.campaign-review.table.analysis.sort.relevance"}}
+          @ariaLabelDefaultSort={{t "pages.campaign-review.table.analysis.column.relevance.ariaLabelDefaultSort"}}
+          @ariaLabelSortUp={{t "pages.campaign-review.table.analysis.column.relevance.ariaLabelSortUp"}}
+          @ariaLabelSortDown={{t "pages.campaign-review.table.analysis.column.relevance.ariaLabelSortDown"}}
         >
-          {{t "pages.campaign-review.table.analysis.column.relevance"}}
+          {{t "pages.campaign-review.table.analysis.column.relevance.label"}}
         </Table::HeaderSort>
         <Table::Header
           @size="small"

--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -29,12 +29,21 @@
       <tr>
         <Table::Header>{{t "pages.organization-participants.table.column.last-name"}}</Table::Header>
         <Table::Header>{{t "pages.organization-participants.table.column.first-name"}}</Table::Header>
-        <Table::Header @size="medium" @align="right">{{t
-            "pages.organization-participants.table.column.participation-count"
-          }}</Table::Header>
-        <Table::Header @size="medium">{{t
-            "pages.organization-participants.table.column.lastest-participation"
-          }}</Table::Header>
+        <Table::HeaderSort
+          @size="medium"
+          @onSort={{@sortByParticipationCount}}
+          @defaultOrder={{@participationCountOrder}}
+          @ariaLabelDefaultSort={{t
+            "pages.organization-participants.table.column.participation-count.ariaLabelDefaultSort"
+          }}
+          @ariaLabelSortUp={{t "pages.organization-participants.table.column.participation-count.ariaLabelSortUp"}}
+          @ariaLabelSortDown={{t "pages.organization-participants.table.column.participation-count.ariaLabelSortDown"}}
+        >
+          {{t "pages.organization-participants.table.column.participation-count.label"}}
+        </Table::HeaderSort>
+        <Table::Header @size="medium" @align="right">
+          {{t "pages.organization-participants.table.column.latest-participation"}}
+        </Table::Header>
         <Table::Header @size="medium" @align="center">
           <div class="organization-participant-list-page__certificability-header">
             {{t "pages.organization-participants.table.column.is-certifiable.label"}}

--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -71,9 +71,21 @@
         <Table::Header @size="medium">
           {{t "pages.sco-organization-participants.table.column.login-method"}}
         </Table::Header>
-        <Table::Header @size="medium" @align="right" class="organization-participant-list-page__participant-count">
-          {{t "pages.sco-organization-participants.table.column.participation-count"}}
-        </Table::Header>
+        <Table::HeaderSort
+          @size="medium"
+          @onSort={{@sortByParticipationCount}}
+          @defaultOrder={{@participationCountOrder}}
+          @ariaLabelDefaultSort={{t
+            "pages.sco-organization-participants.table.column.participation-count.ariaLabelDefaultSort"
+          }}
+          @ariaLabelSortUp={{t "pages.sco-organization-participants.table.column.participation-count.ariaLabelSortUp"}}
+          @ariaLabelSortDown={{t
+            "pages.sco-organization-participants.table.column.participation-count.ariaLabelSortDown"
+          }}
+          class="organization-participant-list-page__participant-count"
+        >
+          {{t "pages.sco-organization-participants.table.column.participation-count.label"}}
+        </Table::HeaderSort>
         <Table::Header @size="medium" @align="center">
           {{t "pages.sco-organization-participants.table.column.last-participation-date"}}
         </Table::Header>

--- a/orga/app/components/sup-organization-participant/list.hbs
+++ b/orga/app/components/sup-organization-participant/list.hbs
@@ -56,9 +56,21 @@
           {{t "pages.sup-organization-participants.table.column.date-of-birth"}}
         </Table::Header>
         <Table::Header @size="wide">{{t "pages.sup-organization-participants.table.column.group"}}</Table::Header>
-        <Table::Header @size="medium" @align="right" class="organization-participant-list-page__participant-count">
-          {{t "pages.sup-organization-participants.table.column.participation-count"}}
-        </Table::Header>
+        <Table::HeaderSort
+          @size="medium"
+          @onSort={{@sortByParticipationCount}}
+          @defaultOrder={{@participationCountOrder}}
+          @ariaLabelDefaultSort={{t
+            "pages.sup-organization-participants.table.column.participation-count.ariaLabelDefaultSort"
+          }}
+          @ariaLabelSortUp={{t "pages.sup-organization-participants.table.column.participation-count.ariaLabelSortUp"}}
+          @ariaLabelSortDown={{t
+            "pages.sup-organization-participants.table.column.participation-count.ariaLabelSortDown"
+          }}
+          class="organization-participant-list-page__participant-count"
+        >
+          {{t "pages.sup-organization-participants.table.column.participation-count.label"}}
+        </Table::HeaderSort>
         <Table::Header @size="medium" @align="center">
           {{t "pages.sup-organization-participants.table.column.last-participation-date"}}
         </Table::Header>

--- a/orga/app/components/table/header-sort.hbs
+++ b/orga/app/components/table/header-sort.hbs
@@ -3,12 +3,12 @@
     {{yield}}
     {{#unless @isDisabled}}
       <PixIconButton
-        @icon="{{if (eq this.order 'asc') 'arrow-up' 'arrow-down'}}"
+        @icon={{this.icon}}
         @triggerAction={{this.toggleSort}}
         @withBackground={{false}}
         @size="small"
         @color="dark-grey"
-        aria-label={{@ariaLabel}}
+        aria-label={{this.ariaLabel}}
       />
     {{/unless}}
   </span>

--- a/orga/app/components/table/header-sort.js
+++ b/orga/app/components/table/header-sort.js
@@ -3,15 +3,46 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 export default class HeaderSort extends Component {
-  @tracked order = this.args.defaultOrder || 'desc';
+  @tracked order;
+  @tracked icon;
+  @tracked ariaLabel;
+
+  constructor(...args) {
+    super(...args);
+    if (this.args.defaultOrder === 'desc') {
+      this._setDescendantSort();
+    } else if (this.args.defaultOrder === 'asc') {
+      this._setAscendantSort();
+    } else {
+      this._setDefaultSort();
+    }
+  }
 
   @action
   toggleSort() {
-    if (this.order === 'desc') {
-      this.order = 'asc';
+    if (this.order === 'asc') {
+      this._setDescendantSort();
     } else {
-      this.order = 'desc';
+      this._setAscendantSort();
     }
     this.args.onSort(this.order);
+  }
+
+  _setDefaultSort() {
+    this.order = null;
+    this.icon = 'sort';
+    this.ariaLabel = this.args.ariaLabelDefaultSort;
+  }
+
+  _setAscendantSort() {
+    this.order = 'asc';
+    this.icon = 'sort-up';
+    this.ariaLabel = this.args.ariaLabelSortUp;
+  }
+
+  _setDescendantSort() {
+    this.order = 'desc';
+    this.icon = 'sort-down';
+    this.ariaLabel = this.args.ariaLabelSortDown;
   }
 }

--- a/orga/app/controllers/authenticated/organization-participants/list.js
+++ b/orga/app/controllers/authenticated/organization-participants/list.js
@@ -12,10 +12,17 @@ export default class ListController extends Controller {
   @tracked pageSize = 50;
   @tracked fullName = null;
   @tracked certificability = [];
+  @tracked participationCountOrder = null;
 
   @action
   triggerFiltering(fieldName, value) {
     this[fieldName] = value || undefined;
+    this.pageNumber = null;
+  }
+
+  @action
+  sortByParticipationCount(value) {
+    this.participationCountOrder = value || null;
     this.pageNumber = null;
   }
 

--- a/orga/app/controllers/authenticated/sco-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sco-organization-participants/list.js
@@ -18,11 +18,18 @@ export default class ListController extends Controller {
   @tracked certificability = [];
   @tracked pageNumber = null;
   @tracked pageSize = 50;
+  @tracked participationCountOrder = null;
 
   @action
   goToLearnerPage(learnerId, event) {
     event.preventDefault();
     this.router.transitionTo('authenticated.sco-organization-participants.sco-organization-participant', learnerId);
+  }
+
+  @action
+  sortByParticipationCount(value) {
+    this.participationCountOrder = value || null;
+    this.pageNumber = null;
   }
 
   @action

--- a/orga/app/controllers/authenticated/sup-organization-participants/list.js
+++ b/orga/app/controllers/authenticated/sup-organization-participants/list.js
@@ -11,11 +11,18 @@ export default class ListController extends Controller {
   @tracked certificability = [];
   @tracked pageNumber = null;
   @tracked pageSize = 50;
+  @tracked participationCountOrder = null;
 
   @action
   goToLearnerPage(learnerId, event) {
     event.preventDefault();
     this.router.transitionTo('authenticated.sup-organization-participants.sup-organization-participant', learnerId);
+  }
+
+  @action
+  sortByParticipationCount(value) {
+    this.participationCountOrder = value || null;
+    this.pageNumber = null;
   }
 
   @action

--- a/orga/app/routes/authenticated/organization-participants/list.js
+++ b/orga/app/routes/authenticated/organization-participants/list.js
@@ -7,6 +7,7 @@ export default class ListRoute extends Route {
     pageSize: { refreshModel: true },
     fullName: { refreshModel: true },
     certificability: { refreshModel: true },
+    participationCountOrder: { refreshModel: true },
   };
 
   @service currentUser;
@@ -18,6 +19,9 @@ export default class ListRoute extends Route {
         organizationId: this.currentUser.organization.id,
         fullName: params.fullName,
         certificability: params.certificability,
+      },
+      sort: {
+        participationCount: params.participationCountOrder,
       },
       page: {
         number: params.pageNumber,
@@ -32,6 +36,7 @@ export default class ListRoute extends Route {
       controller.pageSize = 50;
       controller.fullName = null;
       controller.certificability = [];
+      controller.participationCountOrder = null;
     }
   }
 }

--- a/orga/app/routes/authenticated/sco-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sco-organization-participants/list.js
@@ -11,6 +11,7 @@ export default class ListRoute extends Route {
     certificability: { refreshModel: true },
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
+    participationCountOrder: { refreshModel: true },
   };
 
   @service currentUser;
@@ -24,6 +25,9 @@ export default class ListRoute extends Route {
         divisions: params.divisions,
         connectionTypes: params.connectionTypes,
         certificability: params.certificability,
+      },
+      sort: {
+        participationCount: params.participationCountOrder,
       },
       page: {
         number: params.pageNumber,
@@ -40,6 +44,7 @@ export default class ListRoute extends Route {
       controller.certificability = [];
       controller.pageNumber = null;
       controller.pageSize = 50;
+      controller.participationCountOrder = null;
     }
   }
 

--- a/orga/app/routes/authenticated/sup-organization-participants/list.js
+++ b/orga/app/routes/authenticated/sup-organization-participants/list.js
@@ -11,6 +11,7 @@ export default class ListRoute extends Route {
     certificability: { refreshModel: true },
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
+    participationCountOrder: { refreshModel: true },
   };
 
   @service currentUser;
@@ -25,6 +26,9 @@ export default class ListRoute extends Route {
         studentNumber: params.studentNumber,
         groups: params.groups,
         certificability: params.certificability,
+      },
+      sort: {
+        participationCount: params.participationCountOrder,
       },
       page: {
         number: params.pageNumber,
@@ -41,6 +45,7 @@ export default class ListRoute extends Route {
       controller.certificability = [];
       controller.pageNumber = null;
       controller.pageSize = 50;
+      controller.participationCountOrder = null;
     }
   }
 

--- a/orga/app/templates/authenticated/organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/organization-participants/list.hbs
@@ -11,6 +11,8 @@
       @onClickLearner={{this.goToLearnerPage}}
       @certificabilityFilter={{this.certificability}}
       @certificabilityOptions={{this.certificabilityOptions}}
+      @participationCountOrder={{this.participationCountOrder}}
+      @sortByParticipationCount={{this.sortByParticipationCount}}
     />
   {{else}}
     <OrganizationParticipant::NoParticipantPanel />

--- a/orga/app/templates/authenticated/sco-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sco-organization-participants/list.hbs
@@ -14,6 +14,8 @@
     @onFilter={{this.triggerFiltering}}
     @onClickLearner={{this.goToLearnerPage}}
     @onResetFilter={{this.resetFiltering}}
+    @participationCountOrder={{this.participationCountOrder}}
+    @sortByParticipationCount={{this.sortByParticipationCount}}
   />
 
   {{#if this.isLoading}}

--- a/orga/app/templates/authenticated/sup-organization-participants/list.hbs
+++ b/orga/app/templates/authenticated/sup-organization-participants/list.hbs
@@ -11,5 +11,7 @@
     @onFilter={{this.triggerFiltering}}
     @onClickLearner={{this.goToLearnerPage}}
     @onResetFilter={{this.onResetFilter}}
+    @participationCountOrder={{this.participationCountOrder}}
+    @sortByParticipationCount={{this.sortByParticipationCount}}
   />
 </div>

--- a/orga/config/icons.js
+++ b/orga/config/icons.js
@@ -2,10 +2,8 @@ module.exports = function () {
   return {
     'free-solid-svg-icons': [
       'box-archive',
-      'arrow-down',
       'arrow-left',
       'arrow-right',
-      'arrow-up',
       'award',
       'book',
       'bullhorn',
@@ -30,6 +28,9 @@ module.exports = function () {
       'magnifying-glass',
       'share',
       'slash',
+      'sort',
+      'sort-up',
+      'sort-down',
       'star',
       'tablet-screen-button',
       'xmark',

--- a/orga/tests/integration/components/campaign/analysis/recommendations_test.js
+++ b/orga/tests/integration/components/campaign/analysis/recommendations_test.js
@@ -59,14 +59,24 @@ module('Integration | Component | Campaign::Analysis::Recommendations', function
     });
 
     test('it should order by recommendation asc', async function (assert) {
-      await click(screen.getByLabelText('Trier par pertinence'));
+      await click(
+        screen.getByLabelText(
+          "Le tableau n'est actuellement pas trié par pertinence. Cliquez pour trier par ordre croissant."
+        )
+      );
 
       assert.dom(screen.getAllByLabelText('Sujet')[0]).containsText('Tube B');
     });
 
     test('it should order by recommendation desc', async function (assert) {
-      await click(screen.getByLabelText('Trier par pertinence'));
-      await click(screen.getByLabelText('Trier par pertinence'));
+      await click(
+        screen.getByLabelText(
+          "Le tableau n'est actuellement pas trié par pertinence. Cliquez pour trier par ordre croissant."
+        )
+      );
+      await click(
+        screen.getByLabelText('Le tableau est trié par pertinence croissante. Cliquez pour trier en ordre décroissant.')
+      );
 
       assert.dom(screen.getAllByLabelText('Sujet')[0]).containsText('Tube A');
     });

--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -300,7 +300,15 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
       this.set('sortByParticipationCount', sortByParticipationCount);
 
       const screen = await render(
-        hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.triggerFiltering}} @certificabilityOptions={{this.certificabilityOptions}} @certificability={{this.certificability}} @onClickLearner={{this.noop}} @participationCountOrder={{this.participationCountOrder}} @sortByParticipationCount={{this.sortByParticipationCount}}/>`
+        hbs`<OrganizationParticipant::List
+  @participants={{this.participants}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @certificabilityOptions={{this.certificabilityOptions}}
+  @certificability={{this.certificability}}
+  @onClickLearner={{this.noop}}
+  @participationCountOrder={{this.participationCountOrder}}
+  @sortByParticipationCount={{this.sortByParticipationCount}}
+/>`
       );
 
       // when
@@ -326,7 +334,15 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
       const sortByParticipationCount = sinon.spy();
       this.set('sortByParticipationCount', sortByParticipationCount);
       const screen = await render(
-        hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.triggerFiltering}} @certificabilityOptions={{this.certificabilityOptions}} @certificability={{this.certificability}} @onClickLearner={{this.noop}} @participationCountOrder={{this.participationCountOrder}} @sortByParticipationCount={{this.sortByParticipationCount}}/>`
+        hbs`<OrganizationParticipant::List
+  @participants={{this.participants}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @certificabilityOptions={{this.certificabilityOptions}}
+  @certificability={{this.certificability}}
+  @onClickLearner={{this.noop}}
+  @participationCountOrder={{this.participationCountOrder}}
+  @sortByParticipationCount={{this.sortByParticipationCount}}
+/>`
       );
 
       // when
@@ -353,7 +369,15 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
       this.set('sortByParticipationCount', sortByParticipationCount);
 
       const screen = await render(
-        hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.triggerFiltering}} @certificabilityOptions={{this.certificabilityOptions}} @certificability={{this.certificability}} @onClickLearner={{this.noop}} @participationCountOrder={{this.participationCountOrder}} @sortByParticipationCount={{this.sortByParticipationCount}}/>`
+        hbs`<OrganizationParticipant::List
+  @participants={{this.participants}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @certificabilityOptions={{this.certificabilityOptions}}
+  @certificability={{this.certificability}}
+  @onClickLearner={{this.noop}}
+  @participationCountOrder={{this.participationCountOrder}}
+  @sortByParticipationCount={{this.sortByParticipationCount}}
+/>`
       );
 
       // when

--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -16,6 +16,7 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     class CurrentUserStub extends Service {
       organization = organization;
     }
+
     this.owner.register('service:current-user', CurrentUserStub);
     this.set('noop', sinon.stub());
   });
@@ -283,6 +284,89 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     // then
     sinon.assert.calledWithExactly(triggerFiltering, 'certificability', ['eligible']);
     assert.ok(true);
+  });
+
+  module('when user is sorting the table', function () {
+    test('it should trigger ascending sort on participation count column', async function (assert) {
+      // given
+      this.set('triggerFiltering', () => {});
+      this.set('participants', []);
+      this.set('certificabilityOptions', [{ value: 'eligible', label: 'Certifiable' }]);
+      this.set('certificability', []);
+      this.set('participationCountOrder', null);
+
+      const sortByParticipationCount = sinon.spy();
+
+      this.set('sortByParticipationCount', sortByParticipationCount);
+
+      const screen = await render(
+        hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.triggerFiltering}} @certificabilityOptions={{this.certificabilityOptions}} @certificability={{this.certificability}} @onClickLearner={{this.noop}} @participationCountOrder={{this.participationCountOrder}} @sortByParticipationCount={{this.sortByParticipationCount}}/>`
+      );
+
+      // when
+      await click(
+        screen.getByLabelText(
+          this.intl.t('pages.organization-participants.table.column.participation-count.ariaLabelDefaultSort')
+        )
+      );
+
+      // then
+      sinon.assert.calledWithExactly(sortByParticipationCount, 'asc');
+      assert.ok(true);
+    });
+
+    test('it should trigger ascending sort on participation count column when it is already sort descending', async function (assert) {
+      // given
+      this.set('triggerFiltering', () => {});
+      this.set('participants', []);
+      this.set('certificabilityOptions', [{ value: 'eligible', label: 'Certifiable' }]);
+      this.set('certificability', []);
+
+      this.set('participationCountOrder', 'desc');
+      const sortByParticipationCount = sinon.spy();
+      this.set('sortByParticipationCount', sortByParticipationCount);
+      const screen = await render(
+        hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.triggerFiltering}} @certificabilityOptions={{this.certificabilityOptions}} @certificability={{this.certificability}} @onClickLearner={{this.noop}} @participationCountOrder={{this.participationCountOrder}} @sortByParticipationCount={{this.sortByParticipationCount}}/>`
+      );
+
+      // when
+      await click(
+        screen.getByLabelText(
+          this.intl.t('pages.organization-participants.table.column.participation-count.ariaLabelSortDown')
+        )
+      );
+
+      // then
+      sinon.assert.calledWithExactly(sortByParticipationCount, 'asc');
+      assert.ok(true);
+    });
+
+    test('it should trigger descending sort on participation count column when it is already sort ascending', async function (assert) {
+      // given
+      this.set('triggerFiltering', () => {});
+      this.set('participants', []);
+      this.set('certificabilityOptions', [{ value: 'eligible', label: 'Certifiable' }]);
+      this.set('certificability', []);
+
+      this.set('participationCountOrder', 'asc');
+      const sortByParticipationCount = sinon.spy();
+      this.set('sortByParticipationCount', sortByParticipationCount);
+
+      const screen = await render(
+        hbs`<OrganizationParticipant::List @participants={{this.participants}} @triggerFiltering={{this.triggerFiltering}} @certificabilityOptions={{this.certificabilityOptions}} @certificability={{this.certificability}} @onClickLearner={{this.noop}} @participationCountOrder={{this.participationCountOrder}} @sortByParticipationCount={{this.sortByParticipationCount}}/>`
+      );
+
+      // when
+      await click(
+        screen.getByLabelText(
+          this.intl.t('pages.organization-participants.table.column.participation-count.ariaLabelSortUp')
+        )
+      );
+
+      // then
+      sinon.assert.calledWithExactly(sortByParticipationCount, 'desc');
+      assert.ok(true);
+    });
   });
 
   test('it should display the empty state when no participants', async function (assert) {

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -306,7 +306,13 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('sortByParticipationCount', sortByParticipationCount);
 
       const screen = await render(
-        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}} @participationCountOrder={{this.participationCountOrder}} @sortByParticipationCount={{this.sortByParticipationCount}}/>`
+        hbs`<ScoOrganizationParticipant::List
+  @students={{this.students}}
+  @onFilter={{this.noop}}
+  @onClickLearner={{this.noop}}
+  @participationCountOrder={{this.participationCountOrder}}
+  @sortByParticipationCount={{this.sortByParticipationCount}}
+/>`
       );
 
       // when
@@ -334,7 +340,13 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('sortByParticipationCount', sortByParticipationCount);
 
       const screen = await render(
-        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}} @participationCountOrder={{this.participationCountOrder}} @sortByParticipationCount={{this.sortByParticipationCount}}/>`
+        hbs`<ScoOrganizationParticipant::List
+  @students={{this.students}}
+  @onFilter={{this.noop}}
+  @onClickLearner={{this.noop}}
+  @participationCountOrder={{this.participationCountOrder}}
+  @sortByParticipationCount={{this.sortByParticipationCount}}
+/>`
       );
 
       // when
@@ -362,7 +374,13 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
       this.set('sortByParticipationCount', sortByParticipationCount);
 
       const screen = await render(
-        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}} @participationCountOrder={{this.participationCountOrder}} @sortByParticipationCount={{this.sortByParticipationCount}}/>`
+        hbs`<ScoOrganizationParticipant::List
+  @students={{this.students}}
+  @onFilter={{this.noop}}
+  @onClickLearner={{this.noop}}
+  @participationCountOrder={{this.participationCountOrder}}
+  @sortByParticipationCount={{this.sortByParticipationCount}}
+/>`
       );
 
       // when

--- a/orga/tests/integration/components/sco-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sco-organization-participant/list_test.js
@@ -16,6 +16,7 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
     store = this.owner.lookup('service:store');
 
     const division = store.createRecord('division', { id: '3A', name: '3A' });
+
     class CurrentUserStub extends Service {
       isSCOManagingStudents = true;
       organization = store.createRecord('organization', {
@@ -41,6 +42,9 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
     assert.dom(screen.getByRole('columnheader', { name: 'Prénom' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'Date de naissance' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'Méthode(s) de connexion' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Nombre de participations' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Dernière participation' })).exists();
+    assert.dom(screen.getByRole('columnheader', { name: 'Certificabilité' })).exists();
     assert.dom(screen.getByRole('columnheader', { name: 'Actions' })).exists();
   });
 
@@ -284,6 +288,92 @@ module('Integration | Component | ScoOrganizationParticipant::List', function (h
 
       // then
       sinon.assert.called(resetFiltered);
+      assert.ok(true);
+    });
+  });
+
+  module('when user is sorting the table', function () {
+    test('it should trigger ascending sort on participation count column', async function (assert) {
+      // given
+      this.set('triggerFiltering', () => {});
+      this.set('participants', []);
+      this.set('certificabilityOptions', [{ value: 'eligible', label: 'Certifiable' }]);
+      this.set('certificability', []);
+      this.set('participationCountOrder', null);
+
+      const sortByParticipationCount = sinon.spy();
+
+      this.set('sortByParticipationCount', sortByParticipationCount);
+
+      const screen = await render(
+        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}} @participationCountOrder={{this.participationCountOrder}} @sortByParticipationCount={{this.sortByParticipationCount}}/>`
+      );
+
+      // when
+      await click(
+        screen.getByLabelText(
+          this.intl.t('pages.sco-organization-participants.table.column.participation-count.ariaLabelDefaultSort')
+        )
+      );
+
+      // then
+      sinon.assert.calledWithExactly(sortByParticipationCount, 'asc');
+      assert.ok(true);
+    });
+
+    test('it should trigger ascending sort on participation count column when it is already sort descending', async function (assert) {
+      // given
+      this.set('triggerFiltering', () => {});
+      this.set('participants', []);
+      this.set('certificabilityOptions', [{ value: 'eligible', label: 'Certifiable' }]);
+      this.set('certificability', []);
+      this.set('participationCountOrder', 'desc');
+
+      const sortByParticipationCount = sinon.spy();
+
+      this.set('sortByParticipationCount', sortByParticipationCount);
+
+      const screen = await render(
+        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}} @participationCountOrder={{this.participationCountOrder}} @sortByParticipationCount={{this.sortByParticipationCount}}/>`
+      );
+
+      // when
+      await click(
+        screen.getByLabelText(
+          this.intl.t('pages.sco-organization-participants.table.column.participation-count.ariaLabelSortDown')
+        )
+      );
+
+      // then
+      sinon.assert.calledWithExactly(sortByParticipationCount, 'asc');
+      assert.ok(true);
+    });
+
+    test('it should trigger descending sort on participation count column when it is already sort ascending', async function (assert) {
+      // given
+      this.set('triggerFiltering', () => {});
+      this.set('participants', []);
+      this.set('certificabilityOptions', [{ value: 'eligible', label: 'Certifiable' }]);
+      this.set('certificability', []);
+      this.set('participationCountOrder', 'asc');
+
+      const sortByParticipationCount = sinon.spy();
+
+      this.set('sortByParticipationCount', sortByParticipationCount);
+
+      const screen = await render(
+        hbs`<ScoOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}} @participationCountOrder={{this.participationCountOrder}} @sortByParticipationCount={{this.sortByParticipationCount}}/>`
+      );
+
+      // when
+      await click(
+        screen.getByLabelText(
+          this.intl.t('pages.sco-organization-participants.table.column.participation-count.ariaLabelSortUp')
+        )
+      );
+
+      // then
+      sinon.assert.calledWithExactly(sortByParticipationCount, 'desc');
       assert.ok(true);
     });
   });

--- a/orga/tests/integration/components/sup-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list_test.js
@@ -359,7 +359,13 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
       this.set('sortByParticipationCount', sortByParticipationCount);
 
       const screen = await render(
-        hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}} @participationCountOrder={{this.participationCountOrder}} @sortByParticipationCount={{this.sortByParticipationCount}}/>`
+        hbs`<SupOrganizationParticipant::List
+  @students={{this.students}}
+  @onFilter={{this.noop}}
+  @onClickLearner={{this.noop}}
+  @participationCountOrder={{this.participationCountOrder}}
+  @sortByParticipationCount={{this.sortByParticipationCount}}
+/>`
       );
 
       // when
@@ -387,7 +393,13 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
       this.set('sortByParticipationCount', sortByParticipationCount);
 
       const screen = await render(
-        hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}} @participationCountOrder={{this.participationCountOrder}} @sortByParticipationCount={{this.sortByParticipationCount}}/>`
+        hbs`<SupOrganizationParticipant::List
+  @students={{this.students}}
+  @onFilter={{this.noop}}
+  @onClickLearner={{this.noop}}
+  @participationCountOrder={{this.participationCountOrder}}
+  @sortByParticipationCount={{this.sortByParticipationCount}}
+/>`
       );
       // when
       await click(
@@ -414,7 +426,13 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
       this.set('sortByParticipationCount', sortByParticipationCount);
 
       const screen = await render(
-        hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}} @participationCountOrder={{this.participationCountOrder}} @sortByParticipationCount={{this.sortByParticipationCount}}/>`
+        hbs`<SupOrganizationParticipant::List
+  @students={{this.students}}
+  @onFilter={{this.noop}}
+  @onClickLearner={{this.noop}}
+  @participationCountOrder={{this.participationCountOrder}}
+  @sortByParticipationCount={{this.sortByParticipationCount}}
+/>`
       );
 
       // when

--- a/orga/tests/integration/components/sup-organization-participant/list_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/list_test.js
@@ -14,9 +14,11 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
     const group = store.createRecord('group', { name: 'L1' });
     const organization = store.createRecord('organization', { groups: [group] });
     this.set('noop', sinon.stub());
+
     class CurrentUserStub extends Service {
       organization = organization;
     }
+
     this.owner.register('service:current-user', CurrentUserStub);
   });
 
@@ -339,6 +341,91 @@ module('Integration | Component | SupOrganizationParticipant::List', function (h
 
       // then
       sinon.assert.calledWithExactly(triggerFiltering, 'certificability', ['eligible']);
+      assert.ok(true);
+    });
+  });
+
+  module('when user is sorting the table', function () {
+    test('it should trigger ascending sort on participation count column', async function (assert) {
+      // given
+      this.set('triggerFiltering', () => {});
+      this.set('students', []);
+      this.set('certificabilityOptions', [{ value: 'eligible', label: 'Certifiable' }]);
+      this.set('certificability', []);
+      this.set('participationCountOrder', null);
+
+      const sortByParticipationCount = sinon.spy();
+
+      this.set('sortByParticipationCount', sortByParticipationCount);
+
+      const screen = await render(
+        hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}} @participationCountOrder={{this.participationCountOrder}} @sortByParticipationCount={{this.sortByParticipationCount}}/>`
+      );
+
+      // when
+      await click(
+        screen.getByLabelText(
+          this.intl.t('pages.sup-organization-participants.table.column.participation-count.ariaLabelDefaultSort')
+        )
+      );
+
+      // then
+      sinon.assert.calledWithExactly(sortByParticipationCount, 'asc');
+      assert.ok(true);
+    });
+
+    test('it should trigger ascending sort on participation count column when it is already sort descending', async function (assert) {
+      // given
+      this.set('triggerFiltering', () => {});
+      this.set('students', []);
+      this.set('certificabilityOptions', [{ value: 'eligible', label: 'Certifiable' }]);
+      this.set('certificability', []);
+      this.set('participationCountOrder', 'desc');
+
+      const sortByParticipationCount = sinon.spy();
+
+      this.set('sortByParticipationCount', sortByParticipationCount);
+
+      const screen = await render(
+        hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}} @participationCountOrder={{this.participationCountOrder}} @sortByParticipationCount={{this.sortByParticipationCount}}/>`
+      );
+      // when
+      await click(
+        screen.getByLabelText(
+          this.intl.t('pages.sup-organization-participants.table.column.participation-count.ariaLabelSortDown')
+        )
+      );
+
+      // then
+      sinon.assert.calledWithExactly(sortByParticipationCount, 'asc');
+      assert.ok(true);
+    });
+
+    test('it should trigger descending sort on participation count column when it is already sort ascending', async function (assert) {
+      // given
+      this.set('triggerFiltering', () => {});
+      this.set('students', []);
+      this.set('certificabilityOptions', [{ value: 'eligible', label: 'Certifiable' }]);
+      this.set('certificability', []);
+      this.set('participationCountOrder', 'asc');
+
+      const sortByParticipationCount = sinon.spy();
+
+      this.set('sortByParticipationCount', sortByParticipationCount);
+
+      const screen = await render(
+        hbs`<SupOrganizationParticipant::List @students={{this.students}} @onFilter={{this.noop}} @onClickLearner={{this.noop}} @participationCountOrder={{this.participationCountOrder}} @sortByParticipationCount={{this.sortByParticipationCount}}/>`
+      );
+
+      // when
+      await click(
+        screen.getByLabelText(
+          this.intl.t('pages.sup-organization-participants.table.column.participation-count.ariaLabelSortUp')
+        )
+      );
+
+      // then
+      sinon.assert.calledWithExactly(sortByParticipationCount, 'desc');
       assert.ok(true);
     });
   });

--- a/orga/tests/integration/components/tables/header-sort_test.js
+++ b/orga/tests/integration/components/tables/header-sort_test.js
@@ -23,28 +23,39 @@ module('Integration | Component | Tables | header-sort', function (hooks) {
   });
 
   module('When header sort is enabled', function () {
-    test('should display arrow', async function (assert) {
+    test('should display sort-icon', async function (assert) {
       // when
       await render(hbs`<Table::HeaderSort @isDisabled={{false}}>Header</Table::HeaderSort>`);
 
       // then
-      assert.dom('[data-icon="arrow-down"]').exists();
+      assert.dom('[data-icon="sort"]').exists();
     });
 
-    test('should inverse arrow on click', async function (assert) {
+    test('should display asc arrow on click', async function (assert) {
       // when
       await render(
-        hbs`<Table::HeaderSort
-  @isDisabled={{false}}
-  @onSort={{this.onSort}}
-  @ariaLabel='Trier par pertinence'
->Header</Table::HeaderSort>`
+        hbs`<Table::HeaderSort @isDisabled={{false}} @onSort={{this.onSort}} @ariaLabelDefaultSort="Trier par pertinence" @ariaLabelSortUp="Trié par ordre croissant" @ariaLabelSortDown="Trié par ordre décroissant">Header</Table::HeaderSort>`
       );
       await click('[aria-label="Trier par pertinence"]');
 
       // then
       assert.ok(onSortStub.calledWith('asc'));
-      assert.dom('[data-icon="arrow-up"]').exists();
+      assert.dom('[data-icon="sort-up"]').exists();
+      assert.dom('[aria-label="Trié par ordre croissant"]').exists();
+    });
+
+    test('should display down arrow on double click', async function (assert) {
+      // when
+      await render(
+        hbs`<Table::HeaderSort @isDisabled={{false}} @onSort={{this.onSort}} @ariaLabelDefaultSort="Trier par pertinence" @ariaLabelSortUp="Trié par ordre croissant" @ariaLabelSortDown="Trié par ordre décroissant">Header</Table::HeaderSort>`
+      );
+      await click('[aria-label="Trier par pertinence"]');
+      await click('[aria-label="Trié par ordre croissant"]');
+
+      // then
+      assert.ok(onSortStub.calledWith('desc'));
+      assert.dom('[data-icon="sort-down"]').exists();
+      assert.dom('[aria-label="Trié par ordre décroissant"]').exists();
     });
   });
 

--- a/orga/tests/integration/components/tables/header-sort_test.js
+++ b/orga/tests/integration/components/tables/header-sort_test.js
@@ -34,7 +34,13 @@ module('Integration | Component | Tables | header-sort', function (hooks) {
     test('should display asc arrow on click', async function (assert) {
       // when
       await render(
-        hbs`<Table::HeaderSort @isDisabled={{false}} @onSort={{this.onSort}} @ariaLabelDefaultSort="Trier par pertinence" @ariaLabelSortUp="Trié par ordre croissant" @ariaLabelSortDown="Trié par ordre décroissant">Header</Table::HeaderSort>`
+        hbs`<Table::HeaderSort
+  @isDisabled={{false}}
+  @onSort={{this.onSort}}
+  @ariaLabelDefaultSort='Trier par pertinence'
+  @ariaLabelSortUp='Trié par ordre croissant'
+  @ariaLabelSortDown='Trié par ordre décroissant'
+>Header</Table::HeaderSort>`
       );
       await click('[aria-label="Trier par pertinence"]');
 
@@ -47,7 +53,13 @@ module('Integration | Component | Tables | header-sort', function (hooks) {
     test('should display down arrow on double click', async function (assert) {
       // when
       await render(
-        hbs`<Table::HeaderSort @isDisabled={{false}} @onSort={{this.onSort}} @ariaLabelDefaultSort="Trier par pertinence" @ariaLabelSortUp="Trié par ordre croissant" @ariaLabelSortDown="Trié par ordre décroissant">Header</Table::HeaderSort>`
+        hbs`<Table::HeaderSort
+  @isDisabled={{false}}
+  @onSort={{this.onSort}}
+  @ariaLabelDefaultSort='Trier par pertinence'
+  @ariaLabelSortUp='Trié par ordre croissant'
+  @ariaLabelSortDown='Trié par ordre décroissant'
+>Header</Table::HeaderSort>`
       );
       await click('[aria-label="Trier par pertinence"]');
       await click('[aria-label="Trié par ordre croissant"]');

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -959,7 +959,12 @@
           "group": "Groups",
           "last-name": "Last name",
           "last-participation-date": "Latest participation",
-          "participation-count": "Number of participations",
+          "participation-count": {
+            "label": "Number of participations",
+            "ariaLabelDefaultSort": "The array is not yet sorted by number of participations. Click to sort ascending.",
+            "ariaLabelSortUp": "The array is sorted by ascending number of participations. Click to sort descending.",
+            "ariaLabelSortDown": "The array is sorted by descending number of participations. Click to sort ascending."
+          },
           "student-number": "Student number",
           "is-certifiable": {
             "label": "Certificabilité",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -497,7 +497,12 @@
           "caption": "Table of topics to work on, sorted by relevance. Some have additional columns showing the number of tutorials that exist related to the topic and how to access these tutorials",
           "title": "Review by topic",
           "column": {
-            "relevance": "Relevance",
+            "relevance": {
+              "label": "Relevance",
+              "ariaLabelDefaultSort": "The array is not yet sorted by relevance. Click to sort ascending.",
+              "ariaLabelSortUp": "The array is sorted by ascending relevance. Click to sort descending.",
+              "ariaLabelSortDown": "The array is sorted by descending relevance. Click to sort ascending."
+            },
             "subjects": "Topics ({count, plural, =0 {-} other {{count}}})",
             "tutorial": {
               "aria-label": "Show all tutorials"
@@ -513,10 +518,7 @@
             "strongly-recommended": "Strongly recommended",
             "very-strongly-recommended": "Very strongly recommended"
           },
-          "row-title": "Topic",
-          "sort": {
-            "relevance": "Sort by relevance"
-          }
+          "row-title": "Topic"
         },
         "competences": {
           "title": "Results by competence",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -920,7 +920,12 @@
           "last-name": "Last name",
           "last-participation-date": "Latest participation",
           "login-method": "Log in method(s)",
-          "participation-count": "Number of participations"
+          "participation-count": {
+            "label": "Number of participations",
+            "ariaLabelDefaultSort": "The array is not yet sorted by number of participations. Click to sort ascending.",
+            "ariaLabelSortUp": "The array is sorted by ascending number of participations. Click to sort descending.",
+            "ariaLabelSortDown": "The array is sorted by descending number of participations. Click to sort ascending."
+          }
         },
         "description": "Table of students, sorted by name. For students who have provided an authentication method, you can manage the allowed login modes and reset the student's password through a menu in 'Actions' column",
         "empty": "No students.",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -720,8 +720,13 @@
         "column": {
           "first-name": "First name",
           "last-name": "Last name",
-          "lastest-participation": "Lastest participation",
-          "participation-count": "Number of participations",
+          "latest-participation": "Latest participation",
+          "participation-count": {
+            "label": "Number of participations",
+            "ariaLabelDefaultSort": "The array is not yet sorted by number of participations. Click to sort ascending.",
+            "ariaLabelSortUp": "The array is sorted by ascending number of participations. Click to sort descending.",
+            "ariaLabelSortDown": "The array is sorted by descending number of participations. Click to sort ascending."
+          },
           "is-certifiable": {
             "label": "Eligibility for certification",
             "tooltip": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -920,7 +920,12 @@
           "last-name": "Nom",
           "last-participation-date": "Dernière participation",
           "login-method": "Méthode(s) de connexion",
-          "participation-count": "Nombre de participations"
+          "participation-count": {
+            "label": "Nombre de participations",
+            "ariaLabelDefaultSort": "Le tableau n'est actuellement pas trié par nombre de participations. Cliquez pour trier par ordre croissant.",
+            "ariaLabelSortUp": "Le tableau est trié par nombre de participation croissant. Cliquez pour trier en ordre décroissant.",
+            "ariaLabelSortDown": "Le tableau est trié par nombre de participation décroissant. Cliquez pour trier en ordre croissant."
+          }
         },
         "description": "Tableau des élèves trié par nom. Pour les élèves ayant fourni une méthode de connexion, vous pouvez, via un menu situé dans la colonne 'Actions', gérer les modes de connexion autorisés et réinitialiser le mot de passe de l'élève",
         "empty": "Aucun élève.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -720,8 +720,13 @@
         "column": {
           "first-name": "Prénom",
           "last-name": "Nom",
-          "lastest-participation": "Dernière participation",
-          "participation-count": "Nombre de participations",
+          "latest-participation": "Dernière participation",
+          "participation-count": {
+            "label": "Nombre de participations",
+            "ariaLabelDefaultSort": "Le tableau n'est actuellement pas trié par nombre de participations. Cliquez pour trier par ordre croissant.",
+            "ariaLabelSortUp": "Le tableau est trié par nombre de participation croissant. Cliquez pour trier en ordre décroissant.",
+            "ariaLabelSortDown": "Le tableau est trié par nombre de participation décroissant. Cliquez pour trier en ordre croissant."
+          },
           "is-certifiable": {
             "label": "Certificabilité",
             "tooltip": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -959,7 +959,12 @@
           "group": "Groupes",
           "last-name": "Nom",
           "last-participation-date": "Dernière participation",
-          "participation-count": "Nombre de participations",
+          "participation-count": {
+            "label": "Nombre de participations",
+            "ariaLabelDefaultSort": "Le tableau n'est actuellement pas trié par nombre de participations. Cliquez pour trier par ordre croissant.",
+            "ariaLabelSortUp": "Le tableau est trié par nombre de participation croissant. Cliquez pour trier en ordre décroissant.",
+            "ariaLabelSortDown": "Le tableau est trié par nombre de participation décroissant. Cliquez pour trier en ordre croissant."
+          },
           "student-number": "Numéro étudiant",
           "is-certifiable": {
             "label": "Certificabilité",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -497,7 +497,12 @@
           "caption": "Tableau des sujets à travailler, certains présentent des colonnes supplémentaires indiquant le nombre de tutoriels existant en lien avec le sujet et un accès à ces tutoriels",
           "title": "Analyse par sujet",
           "column": {
-            "relevance": "Pertinence",
+            "relevance": {
+              "label": "Pertinence",
+              "ariaLabelDefaultSort": "Le tableau n'est actuellement pas trié par pertinence. Cliquez pour trier par ordre croissant.",
+              "ariaLabelSortUp": "Le tableau est trié par pertinence croissante. Cliquez pour trier en ordre décroissant.",
+              "ariaLabelSortDown": "Le tableau est trié par pertinence décroissante. Cliquez pour trier en ordre croissant."
+            },
             "subjects": "Sujets ({count, plural, =0 {-} other {{count}}})",
             "tutorial": {
               "aria-label": "Afficher la liste des tutos"
@@ -513,10 +518,7 @@
             "strongly-recommended": "Fortement recommandé",
             "very-strongly-recommended": "Très recommandé"
           },
-          "row-title": "Sujet",
-          "sort": {
-            "relevance": "Trier par pertinence"
-          }
+          "row-title": "Sujet"
         },
         "competences": {
           "title": "Résultats par compétence",


### PR DESCRIPTION
## :egg: Problème

Dans Pix Orga, sco sup ou pro, on peut filtrer les prescrits selon certains critères (nom/prénom etc.), mais pas les trier. Or le besoin est fort de pouvoir trier les prescrits selon leur nombre de participations, notamment afin de faire facilement ressortir ceux qui n’ont pas encore participé aux campagnes dans le cas des orgas avec import ou ceux qui n’ont pas beaucoup participé en général. Cela permettra notamment aux prescripteurs de mieux suivre leurs prescrits et leur activité, pour les relancer.

## :bowl_with_spoon: Proposition

Ajouter la possibilité de trier sur la colonne du nombre de participations de la liste des élèves/étudiants/participants par ordre croissant ou décroissant.

## :milk_glass: Remarques

Quand le nombre de colonnes dans le tableau est trop important, le focus du picto "sort" dans l'entête de colonne est déformé (aplati dans la largeur). Une solution doit être trouvée avec le design pour résoudre ce problème dans un 2ème temps. En attente d'intégration de la nouvelle version de [Pix-ui](https://1024pix.atlassian.net/jira/software/c/projects/PIX/boards/93?modal=detail&selectedIssue=PIX-6844).

## :butter: Pour tester

Depuis [Orga]([Orga](https://orga-pr5599.review.pix.fr/)) : 

- se connecter sur les 3 types d'organisation (pro / sco / sup)
- accéder à la liste des participants / élèves / étudiants
- cliquer sur l'icône de tri sur la colonne du nombre de participations.
↪️ Après un clic, le tri est ascendant. Sur le second clic, le tri est descendant. 
Remarque : le tri est réinitialisé lorsque l'on quitte la page.