### PR TITLE
[FEATURE] Activer/désactiver le champ `isForAbsoluteNovice` d'une campagne grâce à un script (PIX-6998).

### DIFF
--- a/api/scripts/toggle-is-for-absolute-novice-campaign-attribute.js
+++ b/api/scripts/toggle-is-for-absolute-novice-campaign-attribute.js
@@ -1,0 +1,41 @@
+require('dotenv').config();
+const { performance } = require('perf_hooks');
+const logger = require('../lib/infrastructure/logger');
+const cache = require('../lib/infrastructure/caches/learning-content-cache');
+const { knex, disconnect } = require('../db/knex-database-connection');
+
+async function toggleIsForAbsoluteNoviceCampaignAttribute(campaignId) {
+  const campaign = await knex.select('isForAbsoluteNovice').from('campaigns').where({ id: campaignId }).first();
+  if (!campaign) {
+    return logger.error(`Campaign not found for id ${campaignId}`);
+  }
+  await knex('campaigns').update({ isForAbsoluteNovice: !campaign.isForAbsoluteNovice }).where({ id: campaignId });
+}
+
+const isLaunchedFromCommandLine = require.main === module;
+
+async function main() {
+  const startTime = performance.now();
+  logger.info(`Script ${__filename} has started`);
+  const campaignId = process.argv[2];
+  await toggleIsForAbsoluteNoviceCampaignAttribute(campaignId);
+  const endTime = performance.now();
+  const duration = Math.round(endTime - startTime);
+  logger.info(`Script has ended: took ${duration} milliseconds`);
+}
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await main();
+    } catch (error) {
+      logger.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+      await cache.quit();
+    }
+  }
+})();
+
+module.exports = { toggleIsForAbsoluteNoviceCampaignAttribute };

--- a/api/tests/integration/scripts/toggle-is-for-absolute-novice-campaign-attribute_test.js
+++ b/api/tests/integration/scripts/toggle-is-for-absolute-novice-campaign-attribute_test.js
@@ -1,0 +1,62 @@
+const { expect, sinon, databaseBuilder, knex } = require('../../test-helper');
+const logger = require('../../../lib/infrastructure/logger');
+const {
+  toggleIsForAbsoluteNoviceCampaignAttribute,
+} = require('../../../scripts/toggle-is-for-absolute-novice-campaign-attribute');
+
+describe('Toggle isForAbsoluteNovice campaign attribute', function () {
+  describe('#toggleIsForAbsoluteNoviceCampaignAttribute', function () {
+    context('when campaign does not exist', function () {
+      it('should log an error', async function () {
+        // given
+        sinon.stub(logger, 'error');
+
+        // when
+        await toggleIsForAbsoluteNoviceCampaignAttribute(1234);
+
+        // then
+        expect(logger.error).to.have.been.calledWith('Campaign not found for id 1234');
+      });
+    });
+
+    context('when campaign exists', function () {
+      context('when isForAbsoluteNovice is true', function () {
+        it('should disable isForAbsoluteNovice', async function () {
+          // given
+          const campaign = databaseBuilder.factory.buildCampaign({ isForAbsoluteNovice: true });
+          await databaseBuilder.commit();
+
+          // when
+          await toggleIsForAbsoluteNoviceCampaignAttribute(campaign.id);
+
+          // then
+          const updatedCampaign = await knex
+            .select('isForAbsoluteNovice')
+            .from('campaigns')
+            .where({ id: campaign.id })
+            .first();
+          expect(updatedCampaign.isForAbsoluteNovice).to.be.false;
+        });
+      });
+
+      context('when isForAbsoluteNovice is false', function () {
+        it('should enable isForAbsoluteNovice', async function () {
+          // given
+          const campaign = databaseBuilder.factory.buildCampaign({ isForAbsoluteNovice: false });
+          await databaseBuilder.commit();
+
+          // when
+          await toggleIsForAbsoluteNoviceCampaignAttribute(campaign.id);
+
+          // then
+          const updatedCampaign = await knex
+            .select('isForAbsoluteNovice')
+            .from('campaigns')
+            .where({ id: campaign.id })
+            .first();
+          expect(updatedCampaign.isForAbsoluteNovice).to.be.true;
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :egg: Problème
Nous devons passer le champ `isForAbsoluteNovice` à `true` d'une campagne, mais il n'existe pas de moyen de le faire

## :bowl_with_spoon: Proposition
Permettre de controler ce champ à l'aide d'un script. 

## :milk_glass: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :butter: Pour tester
Dans un terminal : 
Regarder la valeur d'une campagne dans la RA : 
```
scalingo --region osc-fr1 --app pix-api-review-pr5600 pgsql-console

select "isForAbsoluteNovice" from campaigns where id = 107708;
```

Dans un autre terminal : 
Lancer le script 
```
scalingo -a pix-api-review-pr5600 run node scripts/toggle-is-for-absolute-novice-campaign-attribute 107708
```

Regarder à nouveau la valeur du champ