### PR TITLE
[FEATURE] Améliorer l'export JSON proposé au niveau de la page de sélection des sujets (PIX-6993)

### DIFF
--- a/orga/app/components/tube/list.hbs
+++ b/orga/app/components/tube/list.hbs
@@ -52,78 +52,21 @@
             <tbody>
               {{#each competence.sortedThematics as |thematic|}}
                 {{#each thematic.tubes as |tube index|}}
-                  <tr
-                    {{on "click" this.toggleTubeInput}}
-                    class="row-tube"
-                    aria-label={{t "pages.preselect-target-profile.table.row-title"}}
-                  >
+                  <tr class="row-tube" aria-label={{t "pages.preselect-target-profile.table.row-title"}}>
                     {{#if (eq index 0)}}
-                      <th
-                        scope="row"
-                        class="th--clickable"
-                        rowspan={{thematic.tubes.length}}
-                        {{on "click" this.toggleThematicInput}}
-                      >
-                        <Input
-                          {{on "input" (fn this.updateSelectedThematics thematic.id)}}
-                          id="thematic-{{thematic.id}}"
-                          @type="checkbox"
-                        />
-                        <label for="thematic-{{thematic.id}}">
-                          {{thematic.name}}
-                        </label>
-                      </th>
-                    {{/if}}
-                    <td class="table__column--center">
-                      <Input
-                        {{on "input" (fn this.updateSelectedTubes tube.id)}}
-                        data-thematic={{thematic.id}}
-                        data-tube={{tube.id}}
-                        id="tube-{{tube.id}}"
-                        @type="checkbox"
+                      <Tube::Thematic
+                        @thematic={{thematic}}
+                        @getThematicState={{this.getThematicState}}
+                        @selectThematic={{this.selectThematic}}
+                        @unselectThematic={{this.unselectThematic}}
                       />
-                    </td>
-                    <td>
-                      <label for="tube-{{tube.id}}">
-                        {{tube.practicalTitle}}
-                        :
-                        {{tube.practicalDescription}}
-                      </label>
-                    </td>
-                    <td class="table__column--center">
-                      <div
-                        aria-label="{{if
-                          tube.isMobileCompliant
-                          (t 'pages.preselect-target-profile.table.is-responsive')
-                          (t 'pages.preselect-target-profile.table.not-responsive')
-                        }}"
-                      >
-                        <FaIcon
-                          @icon="mobile-screen-button"
-                          class="fa-2x {{if tube.isMobileCompliant 'is-responsive'}}"
-                        />
-                        {{#unless tube.isMobileCompliant}}
-                          <FaIcon @icon="slash" class="fa-2x not-responsive" />
-                        {{/unless}}
-                      </div>
-                    </td>
-                    <td class="table__column--center">
-                      <div
-                        aria-label="{{if
-                          tube.isTabletCompliant
-                          (t 'pages.preselect-target-profile.table.is-responsive')
-                          (t 'pages.preselect-target-profile.table.not-responsive')
-                        }}"
-                      >
-                        <FaIcon
-                          @icon="tablet-screen-button"
-                          class="fa-2x {{if tube.isTabletCompliant 'is-responsive'}}"
-                        />
-                        {{#unless tube.isTabletCompliant}}
-                          <FaIcon @icon="slash" class="fa-2x not-responsive" />
-                        {{/unless}}
-                      </div>
-                    </td>
+                    {{/if}}
+                    <Tube::Tube
+                      @tube={{tube}}
+                      @isTubeSelected={{this.isTubeSelected}}
+                      @selectTube={{this.selectTube}}
+                      @unselectTube={{this.unselectTube}}
+                    />
                   </tr>
                 {{/each}}
               {{/each}}

--- a/orga/app/components/tube/list.js
+++ b/orga/app/components/tube/list.js
@@ -53,6 +53,13 @@ export default class TubeList extends Component {
     return this.selectedTubeIds.includes(tube.id);
   };
 
+  get sortedAreas() {
+    return this.args.frameworks
+      .map((framework) => framework.areas.toArray())
+      .flat()
+      .sortBy('code');
+  }
+
   get haveNoTubeSelected() {
     return this.selectedTubeIds.length === 0;
   }
@@ -62,7 +69,21 @@ export default class TubeList extends Component {
   }
 
   get file() {
-    const json = JSON.stringify(this.selectedTubeIds);
+    const selectedTubes = this.args.frameworks.toArray().flatMap((framework) => {
+      return framework.areas.toArray().flatMap((area) => {
+        return area.competences.toArray().flatMap((competence) => {
+          return competence.thematics.toArray().flatMap((thematic) => {
+            return thematic.tubes
+              .filter((tube) => this.isTubeSelected(tube))
+              .map((tube) => ({
+                id: tube.id,
+                frameworkId: framework.id,
+              }));
+          });
+        });
+      });
+    });
+    const json = JSON.stringify(selectedTubes);
     return new Blob([json], { type: 'application/json' });
   }
 
@@ -76,9 +97,5 @@ export default class TubeList extends Component {
 
   get downloadURL() {
     return URL.createObjectURL(this.file);
-  }
-
-  get sortedAreas() {
-    return this.args.areas.sortBy('code');
   }
 }

--- a/orga/app/components/tube/list.js
+++ b/orga/app/components/tube/list.js
@@ -5,20 +5,64 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 
 export default class TubeList extends Component {
-  @tracked tubesSelected = A();
+  @tracked selectedTubeIds = A();
 
   @service dayjs;
 
+  @action
+  selectThematic(thematic) {
+    thematic.tubes.forEach((tube) => {
+      this.selectTube(tube);
+    });
+  }
+
+  @action
+  unselectThematic(thematic) {
+    thematic.tubes.forEach((tube) => {
+      this.unselectTube(tube);
+    });
+  }
+
+  @action
+  selectTube(tube) {
+    if (this.isTubeSelected(tube)) return;
+    this.selectedTubeIds.pushObject(tube.id);
+  }
+
+  @action
+  unselectTube(tube) {
+    const index = this.selectedTubeIds.indexOf(tube.id);
+    if (index === -1) return;
+    this.selectedTubeIds.removeAt(index);
+  }
+
+  getThematicState = (thematic) => {
+    let every = true;
+    let some = false;
+    thematic.tubes.forEach((tube) => {
+      if (this.isTubeSelected(tube)) {
+        some = true;
+      } else {
+        every = false;
+      }
+    });
+    return every ? 'checked' : some ? 'indeterminate' : 'unchecked';
+  };
+
+  isTubeSelected = (tube) => {
+    return this.selectedTubeIds.includes(tube.id);
+  };
+
   get haveNoTubeSelected() {
-    return this.tubesSelected.length === 0;
+    return this.selectedTubeIds.length === 0;
   }
 
   get numberOfTubesSelected() {
-    return this.tubesSelected.length;
+    return this.selectedTubeIds.length;
   }
 
   get file() {
-    const json = JSON.stringify(this.tubesSelected);
+    const json = JSON.stringify(this.selectedTubeIds);
     return new Blob([json], { type: 'application/json' });
   }
 
@@ -36,77 +80,5 @@ export default class TubeList extends Component {
 
   get sortedAreas() {
     return this.args.areas.sortBy('code');
-  }
-
-  @action
-  toggleTubeInput(event) {
-    const checkbox = event.currentTarget.querySelector('[data-tube]');
-    if (event.target.nodeName === 'TD') {
-      checkbox.checked = !checkbox.checked;
-      const evt = document.createEvent('HTMLEvents');
-      evt.initEvent('input', false, true);
-      checkbox.dispatchEvent(evt);
-    }
-  }
-
-  @action
-  toggleThematicInput(event) {
-    const checkbox = event.currentTarget.querySelector('input');
-    if (event.target.nodeName === 'TH') {
-      checkbox.checked = !checkbox.checked;
-      const evt = document.createEvent('HTMLEvents');
-      evt.initEvent('input', false, true);
-      checkbox.dispatchEvent(evt);
-    }
-  }
-
-  _toggleCheckboxThematicByTubes(tube) {
-    const thematicId = tube.getAttribute('data-thematic');
-    const thematic = document.getElementById(`thematic-${thematicId}`);
-    const tubes = document.querySelectorAll(`[data-thematic="${thematicId}"]`);
-
-    if (Array.from(tubes).every((element) => element.checked)) {
-      thematic.indeterminate = false;
-      thematic.checked = true;
-    } else if (Array.from(tubes).some((element) => element.checked)) {
-      thematic.indeterminate = true;
-    } else {
-      thematic.indeterminate = false;
-      thematic.checked = false;
-    }
-  }
-
-  @action
-  updateSelectedTubes(tubeId, event) {
-    const tube = event.currentTarget;
-    this._toggleCheckboxThematicByTubes(tube);
-    if (tube.checked) {
-      this.tubesSelected.pushObject(tubeId);
-    } else {
-      this.tubesSelected.removeObject(tubeId);
-    }
-  }
-
-  @action
-  updateSelectedThematics(thematicId, event) {
-    const el = event.currentTarget;
-    const tubes = document.querySelectorAll(`[data-thematic="${thematicId}"]`);
-    const uniqueTubesSelected = new Set(this.tubesSelected);
-
-    if (el.checked) {
-      for (let i = 0; i < tubes.length; i++) {
-        const tubeId = tubes[i].getAttribute('data-tube');
-        tubes[i].checked = true;
-        uniqueTubesSelected.add(tubeId);
-      }
-    } else {
-      for (let i = 0; i < tubes.length; i++) {
-        const tubeId = tubes[i].getAttribute('data-tube');
-        tubes[i].checked = false;
-        uniqueTubesSelected.delete(tubeId);
-      }
-    }
-
-    this.tubesSelected = A([...new Set(uniqueTubesSelected)]);
   }
 }

--- a/orga/app/components/tube/thematic.hbs
+++ b/orga/app/components/tube/thematic.hbs
@@ -1,0 +1,12 @@
+<th scope="row" rowspan={{@thematic.tubes.length}}>
+  <Input
+    {{did-insert this.updateState}}
+    {{did-update this.updateState this.state}}
+    id="thematic-{{@thematic.id}}"
+    @type="checkbox"
+    @checked={{this.checked}}
+  />
+  <label for="thematic-{{@thematic.id}}">
+    {{@thematic.name}}
+  </label>
+</th>

--- a/orga/app/components/tube/thematic.js
+++ b/orga/app/components/tube/thematic.js
@@ -1,0 +1,25 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class Thematic extends Component {
+  @action
+  updateState(element) {
+    element.indeterminate = this.state === 'indeterminate';
+  }
+
+  get state() {
+    return this.args.getThematicState(this.args.thematic);
+  }
+
+  get checked() {
+    return this.state === 'checked';
+  }
+
+  set checked(checked) {
+    if (checked) {
+      this.args.selectThematic(this.args.thematic);
+    } else {
+      this.args.unselectThematic(this.args.thematic);
+    }
+  }
+}

--- a/orga/app/components/tube/tube.hbs
+++ b/orga/app/components/tube/tube.hbs
@@ -1,0 +1,38 @@
+<td class="table__column--center">
+  <Input id="tube-{{@tube.id}}" @type="checkbox" @checked={{this.checked}} />
+</td>
+<td>
+  <label for="tube-{{@tube.id}}">
+    {{@tube.practicalTitle}}
+    :
+    {{@tube.practicalDescription}}
+  </label>
+</td>
+<td class="table__column--center">
+  <div
+    aria-label="{{if
+      @tube.isMobileCompliant
+      (t 'pages.preselect-target-profile.table.is-responsive')
+      (t 'pages.preselect-target-profile.table.not-responsive')
+    }}"
+  >
+    <FaIcon @icon="mobile-screen-button" class="fa-2x {{if @tube.isMobileCompliant 'is-responsive'}}" />
+    {{#unless @tube.isMobileCompliant}}
+      <FaIcon @icon="slash" class="fa-2x not-responsive" />
+    {{/unless}}
+  </div>
+</td>
+<td class="table__column--center">
+  <div
+    aria-label="{{if
+      @tube.isTabletCompliant
+      (t 'pages.preselect-target-profile.table.is-responsive')
+      (t 'pages.preselect-target-profile.table.not-responsive')
+    }}"
+  >
+    <FaIcon @icon="tablet-screen-button" class="fa-2x {{if @tube.isTabletCompliant 'is-responsive'}}" />
+    {{#unless @tube.isTabletCompliant}}
+      <FaIcon @icon="slash" class="fa-2x not-responsive" />
+    {{/unless}}
+  </div>
+</td>

--- a/orga/app/components/tube/tube.js
+++ b/orga/app/components/tube/tube.js
@@ -1,0 +1,15 @@
+import Component from '@glimmer/component';
+
+export default class Tube extends Component {
+  get checked() {
+    return this.args.isTubeSelected(this.args.tube);
+  }
+
+  set checked(checked) {
+    if (checked) {
+      this.args.selectTube(this.args.tube);
+    } else {
+      this.args.unselectTube(this.args.tube);
+    }
+  }
+}

--- a/orga/app/routes/authenticated/preselect-target-profile.js
+++ b/orga/app/routes/authenticated/preselect-target-profile.js
@@ -8,13 +8,9 @@ export default class PreselectTargetProfileRoute extends Route {
   async model() {
     const organization = this.currentUser.organization;
     const frameworks = await this.store.query('framework', {});
-    const sortedAreas = frameworks
-      .map((framework) => framework.areas.toArray())
-      .flat()
-      .sortBy('code');
     return {
       organization,
-      sortedAreas,
+      frameworks,
     };
   }
 }

--- a/orga/app/templates/authenticated/preselect-target-profile.hbs
+++ b/orga/app/templates/authenticated/preselect-target-profile.hbs
@@ -2,5 +2,5 @@
 
 <article class="preselect-target-profile">
   <h1 class="page__title page-title">{{t "pages.preselect-target-profile.title"}}</h1>
-  <Tube::List @areas={{this.model.sortedAreas}} @organization={{this.model.organization}} />
+  <Tube::List @frameworks={{this.model.frameworks}} @organization={{this.model.organization}} />
 </article>

--- a/orga/tests/integration/components/tube/list_test.js
+++ b/orga/tests/integration/components/tube/list_test.js
@@ -1,17 +1,18 @@
 import { module, test } from 'qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { clickByName, render } from '@1024pix/ember-testing-library';
+import { A } from '@ember/array';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import sinon from 'sinon';
 
 module('Integration | Component | tube:list', function (hooks) {
   setupIntlRenderingTest(hooks);
-  let areas;
+  let frameworks;
   const MOCK_TODAY = '2020-08-05-1152';
   let dayjs;
 
   hooks.beforeEach(function () {
-    const tubes = [
+    const tubes = A([
       {
         id: 'tubeId1',
         practicalTitle: 'Titre 1',
@@ -22,22 +23,30 @@ module('Integration | Component | tube:list', function (hooks) {
         practicalTitle: 'Titre 2',
         practicalDescription: 'Description 2',
       },
-    ];
-    const thematics = [{ id: 'thematicId', name: 'thematic1', tubes }];
-    const competences = [
+    ]);
+    const thematics = A([{ id: 'thematicId', name: 'thematic1', tubes }]);
+    const competences = A([
       {
+        thematics,
         get sortedThematics() {
           return thematics;
         },
       },
-    ];
-    areas = [
+    ]);
+    const areas = A([
       {
         title: 'Titre domaine',
         code: 1,
+        competences,
         get sortedCompetences() {
           return competences;
         },
+      },
+    ]);
+    frameworks = [
+      {
+        id: 'fmkId',
+        areas,
       },
     ];
     dayjs = this.owner.lookup('service:dayjs');
@@ -50,10 +59,10 @@ module('Integration | Component | tube:list', function (hooks) {
 
   test('it should display a list of tubes', async function (assert) {
     // given
-    this.set('areas', areas);
+    this.set('frameworks', frameworks);
 
     // when
-    const screen = await render(hbs`<Tube::list @areas={{this.areas}} />`);
+    const screen = await render(hbs`<Tube::list @frameworks={{this.frameworks}} />`);
     await clickByName('1 · Titre domaine');
     // then
 
@@ -63,10 +72,10 @@ module('Integration | Component | tube:list', function (hooks) {
 
   test('it should disable the download button if not tube is selected', async function (assert) {
     // given
-    this.set('areas', areas);
+    this.set('frameworks', frameworks);
 
     // when
-    const screen = await render(hbs`<Tube::list @areas={{this.areas}} />`);
+    const screen = await render(hbs`<Tube::list @frameworks={{this.frameworks}} />`);
 
     // then
     assert.dom(screen.getByText('Télécharger la sélection des sujets (JSON, 0.00ko)')).hasClass('pix-button--disabled');
@@ -74,31 +83,33 @@ module('Integration | Component | tube:list', function (hooks) {
 
   test('it should enable the download button if a tube is selected', async function (assert) {
     const expectedAttr = `selection-sujets-mon orga-${MOCK_TODAY}.json`;
-    this.set('areas', areas);
+    this.set('frameworks', frameworks);
     this.set('organization', { name: 'mon orga' });
 
     // when
-    const screen = await render(hbs`<Tube::list @areas={{this.areas}} @organization={{this.organization}} />`);
+    const screen = await render(
+      hbs`<Tube::list @frameworks={{this.frameworks}} @organization={{this.organization}} />`
+    );
 
     await clickByName('1 · Titre domaine');
     await clickByName('Titre 1 : Description 1');
 
     // then
     assert
-      .dom(screen.getByText('Télécharger la sélection des sujets (1) (JSON, 0.01ko)'))
+      .dom(screen.getByText('Télécharger la sélection des sujets (1) (JSON, 0.04ko)'))
       .doesNotHaveClass('pix-button--disabled');
 
     assert
-      .dom(screen.getByText('Télécharger la sélection des sujets (1) (JSON, 0.01ko)'))
+      .dom(screen.getByText('Télécharger la sélection des sujets (1) (JSON, 0.04ko)'))
       .hasAttribute('download', expectedAttr);
   });
 
   test('Enable the download button if a thematic is selected', async function (assert) {
     // given
-    this.set('areas', areas);
+    this.set('frameworks', frameworks);
 
     // when
-    await render(hbs`<Tube::list @areas={{this.areas}} />`);
+    await render(hbs`<Tube::list @frameworks={{this.frameworks}} />`);
 
     await clickByName('1 · Titre domaine');
     await clickByName('thematic1');
@@ -109,10 +120,10 @@ module('Integration | Component | tube:list', function (hooks) {
 
   test('Should check all tubes corresponding to the thematics if a thematic is selected', async function (assert) {
     // given
-    this.set('areas', areas);
+    this.set('frameworks', frameworks);
 
     // when
-    const screen = await render(hbs`<Tube::list @areas={{this.areas}} />`);
+    const screen = await render(hbs`<Tube::list @frameworks={{this.frameworks}} />`);
 
     await clickByName('1 · Titre domaine');
     await clickByName('thematic1');
@@ -124,10 +135,10 @@ module('Integration | Component | tube:list', function (hooks) {
 
   test('Should check the thematics if all corresponding tubes are selected', async function (assert) {
     // given
-    this.set('areas', areas);
+    this.set('frameworks', frameworks);
 
     // when
-    const screen = await render(hbs`<Tube::list @areas={{this.areas}} />`);
+    const screen = await render(hbs`<Tube::list @frameworks={{this.frameworks}} />`);
 
     await clickByName('1 · Titre domaine');
     await clickByName('Titre 1 : Description 1');

--- a/orga/tests/unit/components/tube/list_test.js
+++ b/orga/tests/unit/components/tube/list_test.js
@@ -9,12 +9,12 @@ module('Unit | Component | Tube::List', function (hooks) {
     // given
     const component = await createGlimmerComponent('component:tube/list');
     const expectedFile = JSON.stringify(['tubeId1']);
+    component.selectedTubeIds = ['tubeId1'];
 
     // when
-    component.tubesSelected = ['tubeId1'];
+    const text = await component.file.text();
 
     // then
-    const text = await component.file.text();
     assert.strictEqual(text, expectedFile);
   });
 });

--- a/orga/tests/unit/components/tube/list_test.js
+++ b/orga/tests/unit/components/tube/list_test.js
@@ -1,4 +1,5 @@
 import { module, test } from 'qunit';
+import { A } from '@ember/array';
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 import { setupTest } from 'ember-qunit';
 
@@ -7,9 +8,46 @@ module('Unit | Component | Tube::List', function (hooks) {
 
   test('should generate a file with selected tubes', async function (assert) {
     // given
-    const component = await createGlimmerComponent('component:tube/list');
-    const expectedFile = JSON.stringify(['tubeId1']);
-    component.selectedTubeIds = ['tubeId1'];
+    const frameworks = [
+      {
+        id: 'fmkId1',
+        areas: A([
+          {
+            competences: A([
+              {
+                thematics: A([
+                  {
+                    tubes: A([{ id: 'tubeId1' }, { id: 'tubeId2' }]),
+                  },
+                ]),
+              },
+            ]),
+          },
+        ]),
+      },
+      {
+        id: 'fmkId2',
+        areas: A([
+          {
+            competences: A([
+              {
+                thematics: A([
+                  {
+                    tubes: A([{ id: 'tubeId3' }, { id: 'tubeId4' }]),
+                  },
+                ]),
+              },
+            ]),
+          },
+        ]),
+      },
+    ];
+    const component = await createGlimmerComponent('component:tube/list', { frameworks });
+    const expectedFile = JSON.stringify([
+      { id: 'tubeId1', frameworkId: 'fmkId1' },
+      { id: 'tubeId4', frameworkId: 'fmkId2' },
+    ]);
+    component.selectedTubeIds = ['tubeId1', 'tubeId4'];
 
     // when
     const text = await component.file.text();


### PR DESCRIPTION
## :egg: Problème
L'export JSON du profil cible dans PixOrga ne comporte pas l'identifiant du référentiel auquel le sujet sélectionné appartient, ce qui ne facilite pas l'import dans PixAdmin quand on utilise dans référentiels complémentaires.

## :bowl_with_spoon: Proposition
Changer le format de l'export pour ajouter l'identifiant du référentiel.

## :milk_glass: Remarques
N/A

## :butter: Pour tester
Aller sur https://orga-pr5601.review.pix.fr/selection-sujets sélectionner des sujets hors référentiel coeur, exporter le fichier et le vérifier.
Éventuellement, importer le fichier dans PixAdmin :star_struck: 