### PR TITLE
[BUGFIX] Corriger les URL des CGU et de la Politique de confidentialité sur la page d'inscription de Pix App (PIX-6989)

### DIFF
--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -24,19 +24,26 @@ export default class Url extends Service {
   }
 
   get cguUrl() {
+    const tld = this.currentDomain.getExtension();
     const currentLanguage = this.intl.t('current-lang');
-    if (currentLanguage === 'en') {
-      return 'https://pix.org/en-gb/terms-and-conditions';
+    if (tld === 'fr') {
+      return `https://pix.fr/conditions-generales-d-utilisation`;
     }
-    return `https://pix.${this.currentDomain.getExtension()}/conditions-generales-d-utilisation`;
+    return currentLanguage === 'fr'
+      ? 'https://pix.org/fr/conditions-generales-d-utilisation'
+      : 'https://pix.org/en-gb/terms-and-conditions';
   }
 
   get dataProtectionPolicyUrl() {
+    const tld = this.currentDomain.getExtension();
     const currentLanguage = this.intl.t('current-lang');
-    if (currentLanguage === 'en') {
-      return 'https://pix.org/en-gb/personal-data-protection-policy';
+    if (tld === 'fr') {
+      return `https://pix.fr/politique-protection-donnees-personnelles-app`;
     }
-    return `https://pix.${this.currentDomain.getExtension()}/politique-protection-donnees-personnelles-app`;
+
+    return currentLanguage === 'fr'
+      ? 'https://pix.org/fr/politique-protection-donnees-personnelles-app'
+      : 'https://pix.org/en-gb/personal-data-protection-policy';
   }
 
   get _showcaseWebsiteUrl() {

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -102,88 +102,136 @@ module('Unit | Service | locale', function (hooks) {
   });
 
   module('#cguUrl', function () {
-    test('should get "pix.fr" url when current domain contains pix.fr', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
-      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+    module('when website is pix.fr', function () {
+      test('returns the French page URL', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url');
+        const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
+        service.currentDomain = { getExtension: sinon.stub().returns('fr') };
 
-      // when
-      const cguUrl = service.cguUrl;
+        // when
+        const cguUrl = service.cguUrl;
 
-      // then
-      assert.strictEqual(cguUrl, expectedCguUrl);
+        // then
+        assert.strictEqual(cguUrl, expectedCguUrl);
+      });
+
+      module('when current language is "en"', function () {
+        test('returns the French page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
+          service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+          service.intl = { t: sinon.stub().returns('en') };
+
+          // when
+          const cguUrl = service.cguUrl;
+
+          // then
+          assert.strictEqual(cguUrl, expectedCguUrl);
+        });
+      });
     });
 
-    test('should get "pix.org" english url when current language is en', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.org/en-gb/terms-and-conditions';
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
-      service.intl = { t: sinon.stub().returns('en') };
+    module('when website is pix.org', function () {
+      module('when current language is "fr"', function () {
+        test('returns the French page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          const expectedCguUrl = 'https://pix.org/fr/conditions-generales-d-utilisation';
+          service.currentDomain = { getExtension: sinon.stub().returns('org') };
+          service.intl = { t: sinon.stub().returns('fr') };
 
-      // when
-      const cguUrl = service.cguUrl;
+          // when
+          const cguUrl = service.cguUrl;
 
-      // then
-      assert.strictEqual(cguUrl, expectedCguUrl);
-    });
+          // then
+          assert.strictEqual(cguUrl, expectedCguUrl);
+        });
+      });
 
-    test('should get "pix.org" french url when current language is fr', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.org/conditions-generales-d-utilisation';
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
-      service.intl = { t: sinon.stub().returns('fr') };
+      module('when current language is "en"', function () {
+        test('returns the English page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          const expectedCguUrl = 'https://pix.org/en-gb/terms-and-conditions';
+          service.currentDomain = { getExtension: sinon.stub().returns('org') };
+          service.intl = { t: sinon.stub().returns('en') };
 
-      // when
-      const cguUrl = service.cguUrl;
+          // when
+          const cguUrl = service.cguUrl;
 
-      // then
-      assert.strictEqual(cguUrl, expectedCguUrl);
+          // then
+          assert.strictEqual(cguUrl, expectedCguUrl);
+        });
+      });
     });
   });
 
   module('#dataProtectionPolicyUrl', function () {
-    test('should get "pix.fr" url when current domain contains pix.fr', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
-      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+    module('when website is pix.fr', function () {
+      test('returns the French page URL', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url');
+        const expectedCguUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
+        service.currentDomain = { getExtension: sinon.stub().returns('fr') };
 
-      // when
-      const cguUrl = service.dataProtectionPolicyUrl;
+        // when
+        const cguUrl = service.dataProtectionPolicyUrl;
 
-      // then
-      assert.strictEqual(cguUrl, expectedCguUrl);
+        // then
+        assert.strictEqual(cguUrl, expectedCguUrl);
+      });
+
+      module('when current language is "en"', function () {
+        test('returns the French page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          const expectedCguUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
+          service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+          service.intl = { t: sinon.stub().returns('en') };
+
+          // when
+          const cguUrl = service.dataProtectionPolicyUrl;
+
+          // then
+          assert.strictEqual(cguUrl, expectedCguUrl);
+        });
+      });
     });
 
-    test('should get "pix.org" english url when current language is en', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
-      service.intl = { t: sinon.stub().returns('en') };
+    module('when website is pix.org', function () {
+      module('when current language is "fr"', function () {
+        test('returns the French page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          const expectedCguUrl = 'https://pix.org/fr/politique-protection-donnees-personnelles-app';
+          service.currentDomain = { getExtension: sinon.stub().returns('org') };
+          service.intl = { t: sinon.stub().returns('fr') };
 
-      // when
-      const cguUrl = service.dataProtectionPolicyUrl;
+          // when
+          const cguUrl = service.dataProtectionPolicyUrl;
 
-      // then
-      assert.strictEqual(cguUrl, expectedCguUrl);
-    });
+          // then
+          assert.strictEqual(cguUrl, expectedCguUrl);
+        });
+      });
 
-    test('should get "pix.org" french url when current language is fr', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.org/politique-protection-donnees-personnelles-app';
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
-      service.intl = { t: sinon.stub().returns('fr') };
+      module('when current language is "en"', function () {
+        test('returns the English page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          const expectedCguUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
+          service.currentDomain = { getExtension: sinon.stub().returns('org') };
+          service.intl = { t: sinon.stub().returns('en') };
 
-      // when
-      const cguUrl = service.dataProtectionPolicyUrl;
+          // when
+          const cguUrl = service.dataProtectionPolicyUrl;
 
-      // then
-      assert.strictEqual(cguUrl, expectedCguUrl);
+          // then
+          assert.strictEqual(cguUrl, expectedCguUrl);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## :egg: Problème

Sur la page d’inscription de app.pix.org les liens des CGU et de la Politique de confidentialité ne fonctionnent plus depuis l’ajout de la page de sélection de locale car les URL utilisés sont génériques et ne contiennent pas de locale, ce qui n’est plus géré par pix-site.

## :bowl_with_spoon: Proposition

Dans l'URL service de Pix App :
* Gérer les différents URL en fonction du [top-level domain, ou TLD](https://fr.wikipedia.org/wiki/Domaine_de_premier_niveau)
*  Ajouter la locale `/fr` dans l'URL pour app.pix.org lorsque la langue active est le français

## :milk_glass: Remarques

RAS

## :butter: Pour tester

Aller sur les pages suivantes et vérifier que pour chacune le lien des CGU et le lien de la Politique de confidentialité mènent bien sur la page attendue, c'est à dire une page existante (et non une `404`) et dans la locale attendue : 
* https://app-pr5603.review.pix.fr/inscription
   * CGU : https://pix.fr/conditions-generales-d-utilisation/
   * Politique de confidentialité : https://pix.fr/politique-protection-donnees-personnelles-app/
* https://app-pr5603.review.pix.org/inscription
   * CGU : https://pix.fr/conditions-generales-d-utilisation/
   * Politique de confidentialité : https://pix.fr/politique-protection-donnees-personnelles-app/
* https://app-pr5603.review.pix.org/inscription?lang=en
   * CGU : https://pix.org/en-gb/terms-and-conditions/
   * Politique de confidentialité : https://pix.org/en-gb/personal-data-protection-policy/

Et pour pouvoir comparer/tester avec la prod, en prod ces URL sont :
* https://app.pix.fr/inscription
   * CGU : https://pix.fr/conditions-generales-d-utilisation/
   * Politique de confidentialité : https://pix.fr/politique-protection-donnees-personnelles-app/
* https://app.pix.org/inscription
   * CGU : https://pix.fr/conditions-generales-d-utilisation/
   * Politique de confidentialité : https://pix.fr/politique-protection-donnees-personnelles-app/
* https://app.pix.org/inscription?lang=en
   * CGU : https://pix.org/en-gb/terms-and-conditions/
   * Politique de confidentialité : https://pix.org/en-gb/personal-data-protection-policy/
