### PR TITLE
[FEATURE] Traduire en anglais la page de connexion à Pix Certif (PIX-6661).

### DIFF
--- a/certif/app/components/login-form.hbs
+++ b/certif/app/components/login-form.hbs
@@ -3,10 +3,10 @@
   <header class="login__header">
     <img src="/pix-certif-logo.svg" alt="Pix Certif" />
 
-    <h1 class="login-header__title">Connectez-vous</h1>
+    <h1 class="login-header__title">{{t "pages.login.login"}}</h1>
 
     <p class="login-header__information paragraph">
-      L'accès à Pix Certif est limité aux centres de certification Pix.
+      {{t "pages.login.accessible-to"}}
     </p>
 
     {{#if @hasInvitationAlreadyBeenAccepted}}
@@ -23,13 +23,13 @@
     <form class="login-main__form" {{on "submit" this.authenticate}}>
 
       <p class="login-main-form__mandatory-information paragraph">
-        Tous les champs sont obligatoires.
+        {{t "pages.login.form.mandatory-fields"}}
       </p>
 
       <PixInput
         @id="login-email"
         name="login"
-        @label="Adresse e-mail"
+        @label={{t "pages.login.form.email-address"}}
         autocomplete="email"
         type="email"
         required="true"
@@ -39,7 +39,7 @@
       <PixInputPassword
         @id="login-password"
         name="password"
-        @label="Mot de passe"
+        @label={{t "pages.login.form.password"}}
         autocomplete="current-password"
         required="true"
         {{on "input" this.setPassword}}
@@ -52,11 +52,13 @@
       {{/if}}
 
       <PixButton @type="submit">
-        Je me connecte
+        {{t "pages.login.form.button"}}
       </PixButton>
 
       <div class="login-main-form__forgotten-password">
-        <a href="https://app.pix.fr/mot-de-passe-oublie" target="_blank" rel="noopener noreferrer">Mot de passe oublié ?</a>
+        <a href="https://app.pix.fr/mot-de-passe-oublie" target="_blank" rel="noopener noreferrer">{{t
+            "pages.login.form.forgotten-password"
+          }}</a>
       </div>
     </form>
   </main>

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -35,6 +35,15 @@
         "should-change-password": "You currently have a temporary password. <a href=\"{url}\">Reset your password here</a>.",
         "invitation-was-cancelled": "This invitation is no longer valid.<br/>Please contact the administrator of your Pix Certif space.",
         "invitation-already-accepted": "This invitation has already been accepted.<br/>Please log in or contact the administrator of your Pix Certif space."
+      },
+      "login": "Log in",
+      "accessible-to": "Pix Certif is only accessible to Pix certification centres.",
+      "form": {
+        "mandatory-fields": "All fields are required.",
+        "email-address": "Email address",
+        "password": "Password",
+        "button": "Log in",
+        "forgotten-password": "Forgot your password?"
       }
     },
     "login-or-register": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -35,6 +35,15 @@
         "should-change-password": "Vous avez actuellement un mot de passe temporaire. Cliquez sur <a href=\"{url}\">mot de passe oublié</a> pour le réinitialiser.",
         "invitation-was-cancelled": "Cette invitation n’est plus valide.<br/>Contactez l’administrateur de votre espace Pix Certif.",
         "invitation-already-accepted": "Cette invitation a déjà été acceptée.<br/>Connectez-vous ou contactez l’administrateur de votre espace Pix Certif."
+      },
+      "login": "Connectez-vous",
+      "accessible-to": "L'accès à Pix Certif est limité aux centres de certification Pix.",
+      "form": {
+        "mandatory-fields": "Tous les champs sont obligatoires.",
+        "email-address": "Adresse e-mail",
+        "password": "Mot de passe",
+        "button": "Je me connecte",
+        "forgotten-password": "Mot de passe oublié ?"
       }
     },
     "login-or-register": {


### PR DESCRIPTION
## :egg: Problème
Afin d'élargir le champ de prospection et de développement de Pix, et plus précisément de sa certification, à l’international, il nous faut permettre une utilisation de Pix Certif par un utilisateur anglophone.

## :bowl_with_spoon: Proposition
Traduire la page de connexion :

Connectez-vous : Log in
L'accès à Pix Certif est limité aux centres de certification Pix. : Pix Certif is only accessible to Pix certification centres.
Tous les champs sont obligatoires. : All fields are required.
Adresse e-mail : Email address
Mot de passe : Password
Je me connecte : Log in
Mot de passe oublié ? : Forgot your password ?

## :milk_glass: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :butter: Pour tester
- Lancer Pix Certif
- Vérifier que les champs de la page de connexion en français sont les bons
- Passer en anglais en ajoutant ?lang=en à la fin de l'URL (https://app-pr5607.review.pix.org/connexion?lang=en)
- Vérifier que les champs de la page de connexion en anglais sont les bons