### PR TITLE
[FEATURE] Ajout des instructions et du fil d'Ariane sur la page d'import des sessions (PIX-6949).

### DIFF
--- a/certif/app/routes/authenticated/sessions/import.js
+++ b/certif/app/routes/authenticated/sessions/import.js
@@ -1,0 +1,15 @@
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
+
+export default class ImportRoute extends Route {
+  @service featureToggles;
+  @service router;
+
+  beforeModel() {
+    const { isMassiveSessionManagementEnabled } = this.featureToggles.featureToggles;
+
+    if (!isMassiveSessionManagementEnabled) {
+      return this.router.replaceWith('authenticated.sessions.list');
+    }
+  }
+}

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -21,6 +21,10 @@
     font-weight: $font-light;
   }
 
+  .pix-collapsible__title:not(.pix-collapsible__title--uncollapsed):focus {
+    background-color: inherit;
+  }
+
   .pix-collapsible__title--uncollapsed {
     border-radius: 8px 8px 0 0;
   }

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -1,7 +1,48 @@
 .import-page {
+  > p {
+    color: $pix-neutral-60;
+    font-weight: 300;
+    margin-bottom: 8px;
+  }
+
+  .pix-collapsible {
+    margin-bottom: 8px;
+  }
+
+  .pix-collapsible,
+  .pix-collapsible__title {
+    border-radius: 8px;
+    color: $pix-neutral-70;
+    font-size: 14px;
+    font-weight: 300;
+  }
+
+  .pix-collapsible__title--uncollapsed {
+    border-radius: 8px 8px 0 0;
+  }
+
+  .pix-collapsible__content {
+    line-height: 20px;
+    padding: 14px 16px;
+  }
+
+  .pix-collapsible ul {
+    list-style: disc;
+    margin-top: 6px;
+    margin-left: 24px;
+  }
+
+  .pix-collapsible .pix-banner {
+    border-radius: 4px;
+    box-shadow: none;
+    margin-top: 8px;
+    padding: 12px 16px;
+  }
+
   &__section--download {
     display: flex;
     flex-direction: column;
+    margin-top: 2rem;
     padding: 24px;
   }
 

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -36,11 +36,9 @@
     margin-left: 24px;
   }
 
-  .pix-collapsible .pix-banner {
+  .pix-collapsible .pix-message {
     border-radius: 4px;
-    box-shadow: none;
     margin-top: 8px;
-    padding: 12px 16px;
   }
 
   &__section--breadcrumb {

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -5,7 +5,7 @@
 
   > p {
     color: $pix-neutral-60;
-    font-weight: 300;
+    font-weight: $font-light;
     margin-bottom: 8px;
   }
 
@@ -18,7 +18,7 @@
     border-radius: 8px;
     color: $pix-neutral-70;
     font-size: 14px;
-    font-weight: 300;
+    font-weight: $font-light;
   }
 
   .pix-collapsible__title--uncollapsed {
@@ -77,7 +77,7 @@
       color: $pix-neutral-0;
       content: "" counter(import-breadcrumb);
       font-size: 1.1rem;
-      font-weight: 500;
+      font-weight: $font-medium;
       display: flex;
       height: 30px;
       justify-content: center;

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -1,11 +1,15 @@
 .import-page {
+  .panel {
+    border-radius: 8px;
+  }
+
   > p {
     color: $pix-neutral-60;
     font-weight: 300;
     margin-bottom: 8px;
   }
 
-  .pix-collapsible {
+  .pix-collapsible:not(:last-child) {
     margin-bottom: 8px;
   }
 
@@ -39,10 +43,61 @@
     padding: 12px 16px;
   }
 
+  &__section--breadcrumb {
+    background-color: $pix-neutral-5;
+    border: 1px solid $pix-neutral-15;
+    box-shadow: none;
+    margin: 24px 0 16px;
+    padding: 16px;
+
+    .breadcrumb-icon {
+      color: $pix-neutral-40;
+      margin: 0 24px;
+    }
+
+    ol {
+      align-items: center;
+      counter-reset: import-breadcrumb;
+      display: flex;
+      justify-content: center;
+      list-style: none;
+    }
+
+    ol li {
+      align-items: center;
+      color: $pix-neutral_50;
+      counter-increment: import-breadcrumb;
+      display: flex;
+    }
+
+    ol li::before {
+      align-items: center;
+      background-color: $pix-neutral-25;
+      border-radius: 50%;
+      color: $pix-neutral-0;
+      content: "" counter(import-breadcrumb);
+      font-size: 1.1rem;
+      font-weight: 500;
+      display: flex;
+      height: 30px;
+      justify-content: center;
+      margin-right: 16px;
+      width: 30px;
+    }
+
+    ol li.active {
+      color: $pix-neutral_90;
+    }
+
+    ol li.active::before {
+      background-color: $pix-success-60;
+    }
+
+  }
+
   &__section--download {
     display: flex;
     flex-direction: column;
-    margin-top: 2rem;
     padding: 24px;
   }
 

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -22,7 +22,9 @@
       <li>{{t "pages.sessions.import.instructions-edition-replace" htmlSafe=true}}</li>
       <li>{{t "pages.sessions.import.instructions-edition-subscription" htmlSafe=true}}</li>
     </ul>
-    <PixBanner @type="warning">{{t "pages.sessions.import.instructions-edition-warning"}}</PixBanner>
+    <PixMessage @type="warning" @withIcon={{true}}>
+      {{t "pages.sessions.import.instructions-edition-warning"}}
+    </PixMessage>
   </PixCollapsible>
   <nav aria-label="Fil d'Ariane" class="import-page__section--breadcrumb panel">
     <ol>

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -24,6 +24,21 @@
     </ul>
     <PixBanner @type="warning">{{t "pages.sessions.import.instructions-edition-warning"}}</PixBanner>
   </PixCollapsible>
+  <nav aria-label="Fil d'Ariane" class="import-page__section--breadcrumb panel">
+    <ol>
+      <li class="active">
+        <a href="">
+          Import du modèle
+        </a>
+      </li>
+      <FaIcon @icon="chevron-right" class="breadcrumb-icon" />
+      <li>
+        <a href="">
+          Récapitulatif
+        </a>
+      </li>
+    </ol>
+  </nav>
   <section class="import-page__section--download panel">
     <div class="import-page__section--download__button">
       <FaIcon @icon="file-arrow-down" class="fa-2x download-icon" />

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -2,24 +2,27 @@
 <main class="import-page">
   <h1 class="page-title">{{t "pages.sessions.import.title"}}</h1>
   <p>Comment ça marche ?</p>
-  <PixCollapsible @title="Pour créer des sessions ?" @iconTitle="plus" class="import-page_section--instructions">
-    Vous pouvez créer des sessions
+  <PixCollapsible
+    @title={{t "pages.sessions.import.instructions-creation-title"}}
+    @iconTitle="plus"
+    class="import-page_section--instructions"
+  >
+    {{t "pages.sessions.import.instructions-creation-list"}}
     <ul>
-      <li><strong>Avec candidats</strong>, complétez le modèle dans son intégralité,</li>
-      <li><strong>Sans candidat</strong>, complétez uniquement les informations des sessions.</li>
+      <li>{{t "pages.sessions.import.instructions-creation-list-with-candidates" htmlSafe=true}}</li>
+      <li>{{t "pages.sessions.import.instructions-creation-list-without-candidates" htmlSafe=true}}</li>
     </ul>
   </PixCollapsible>
   <PixCollapsible
-    @title="Pour éditer la liste des candidats de sessions déjà créées ?"
+    @title={{t "pages.sessions.import.instructions-edition-title"}}
     @iconTitle="plus"
     class="import-page__section--instructions"
   >
     <ul>
-      <li><strong>Pour remplacer</strong> une liste pré-existante dans le fichier modèle,</li>
-      <li><strong>Pour inscrire</strong> des candidats dans une session vide.</li>
+      <li>{{t "pages.sessions.import.instructions-edition-replace" htmlSafe=true}}</li>
+      <li>{{t "pages.sessions.import.instructions-edition-subscription" htmlSafe=true}}</li>
     </ul>
-    <PixBanner @type="warning">Attention à renseigner le numéro de session sans les autres informations de sessions (ex
-      : date, heure, etc.) pour éviter les doublons lors de la création.</PixBanner>
+    <PixBanner @type="warning">{{t "pages.sessions.import.instructions-edition-warning"}}</PixBanner>
   </PixCollapsible>
   <section class="import-page__section--download panel">
     <div class="import-page__section--download__button">

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -1,6 +1,26 @@
 {{page-title (t "pages.sessions.import.title")}}
 <main class="import-page">
   <h1 class="page-title">{{t "pages.sessions.import.title"}}</h1>
+  <p>Comment ça marche ?</p>
+  <PixCollapsible @title="Pour créer des sessions ?" @iconTitle="plus" class="import-page_section--instructions">
+    Vous pouvez créer des sessions
+    <ul>
+      <li><strong>Avec candidats</strong>, complétez le modèle dans son intégralité,</li>
+      <li><strong>Sans candidat</strong>, complétez uniquement les informations des sessions.</li>
+    </ul>
+  </PixCollapsible>
+  <PixCollapsible
+    @title="Pour éditer la liste des candidats de sessions déjà créées ?"
+    @iconTitle="plus"
+    class="import-page__section--instructions"
+  >
+    <ul>
+      <li><strong>Pour remplacer</strong> une liste pré-existante dans le fichier modèle,</li>
+      <li><strong>Pour inscrire</strong> des candidats dans une session vide.</li>
+    </ul>
+    <PixBanner @type="warning">Attention à renseigner le numéro de session sans les autres informations de sessions (ex
+      : date, heure, etc.) pour éviter les doublons lors de la création.</PixBanner>
+  </PixCollapsible>
   <section class="import-page__section--download panel">
     <div class="import-page__section--download__button">
       <FaIcon @icon="file-arrow-down" class="fa-2x download-icon" />

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -28,13 +28,13 @@
     <ol>
       <li class="active">
         <a href="">
-          Import du modèle
+          {{t "pages.sessions.import.breadcrumb-import"}}
         </a>
       </li>
       <FaIcon @icon="chevron-right" class="breadcrumb-icon" />
       <li>
         <a href="">
-          Récapitulatif
+          {{t "pages.sessions.import.breadcrumb-summary"}}
         </a>
       </li>
     </ol>

--- a/certif/tests/acceptance/routes/authenticated/sessions/import_test.js
+++ b/certif/tests/acceptance/routes/authenticated/sessions/import_test.js
@@ -1,0 +1,71 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
+import {
+  authenticateSession,
+  createAllowedCertificationCenterAccess,
+  createCertificationPointOfContactWithCustomCenters,
+} from '../../../../helpers/test-init';
+
+module('Acceptance | Routes | Authenticated | Sessions | import', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  let certificationPointOfContact;
+
+  module('When a user tries to go on the multiple sessions import page', function (hooks) {
+    hooks.beforeEach(async function () {
+      certificationPointOfContact = server.create('certification-point-of-contact', {
+        firstName: 'Buffy',
+        lastName: 'Summers',
+      });
+
+      const certificationCenter = createAllowedCertificationCenterAccess({
+        certificationCenterName: 'Centre SUP',
+        certificationCenterType: 'SUP',
+      });
+      certificationPointOfContact = createCertificationPointOfContactWithCustomCenters({
+        pixCertifTermsOfServiceAccepted: true,
+        allowedCertificationCenterAccesses: [certificationCenter],
+      });
+      await authenticateSession(certificationPointOfContact.id);
+      server.create('session-summary', { certificationCenterId: certificationCenter.id });
+    });
+
+    module('without feature toggle authorization', function (hooks) {
+      let screen;
+
+      hooks.beforeEach(async function () {
+        server.create('feature-toggle', { id: 0, isMassiveSessionManagementEnabled: false });
+      });
+
+      test('it should redirect the user to the sessions list page', async function (assert) {
+        // when
+        screen = await visit(`/sessions/import`);
+
+        // then
+        assert.strictEqual(currentURL(), '/sessions/liste');
+        assert.dom(screen.getByText('Sessions de certification')).exists();
+      });
+    });
+
+    module('with feature toggle authorization', function (hooks) {
+      let screen;
+
+      hooks.beforeEach(async function () {
+        server.create('feature-toggle', { id: 0, isMassiveSessionManagementEnabled: true });
+      });
+
+      test('it should redirect the user to the sessions list page', async function (assert) {
+        // when
+        screen = await visit(`/sessions/import`);
+
+        // then
+        assert.strictEqual(currentURL(), '/sessions/import');
+        assert.dom(screen.getByText('Créer/éditer plusieurs sessions')).exists();
+      });
+    });
+  });
+});

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -128,7 +128,7 @@
         "session-import-upload": "Importer (.csv)",
         "session-import-upload-label": "Importer le modèle complété",
         "instructions-creation-title": "Pour créer des sessions ?",
-        "instructions-creation-list": "Vous pouvez créer des sessions",
+        "instructions-creation-list": "Vous pouvez créer des sessions :",
         "instructions-creation-list-with-candidates": "<strong>Avec candidats</strong>, complétez le modèle dans son intégralité,",
         "instructions-creation-list-without-candidates": "<strong>Sans candidat</strong>, complétez uniquement les informations des sessions.",
         "instructions-edition-title": "Pour éditer la liste des candidats de sessions déjà créées ?",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -126,7 +126,15 @@
         "session-import-template-dl-error": "Une erreur s'est produite pendant le téléchargement",
         "session-import-template-label": "Télécharger le modèle vierge",
         "session-import-upload": "Importer (.csv)",
-        "session-import-upload-label": "Importer le modèle complété"
+        "session-import-upload-label": "Importer le modèle complété",
+        "instructions-creation-title": "Pour créer des sessions ?",
+        "instructions-creation-list": "Vous pouvez créer des sessions",
+        "instructions-creation-list-with-candidates": "<strong>Avec candidats</strong>, complétez le modèle dans son intégralité,",
+        "instructions-creation-list-without-candidates": "<strong>Sans candidat</strong>, complétez uniquement les informations des sessions.",
+        "instructions-edition-title": "Pour éditer la liste des candidats de sessions déjà créées ?",
+        "instructions-edition-replace": "<strong>Pour remplacer</strong> une liste pré-existante dans le fichier modèle,",
+        "instructions-edition-subscription": "<strong>Pour inscrire</strong> des candidats dans une session vide.",
+        "instructions-edition-warning": "Attention à renseigner le numéro de session sans les autres informations de sessions (ex: date, heure, etc.) pour éviter les doublons lors de la création."
       },
       "list": {
         "header": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -134,7 +134,9 @@
         "instructions-edition-title": "Pour éditer la liste des candidats de sessions déjà créées ?",
         "instructions-edition-replace": "<strong>Pour remplacer</strong> une liste pré-existante dans le fichier modèle,",
         "instructions-edition-subscription": "<strong>Pour inscrire</strong> des candidats dans une session vide.",
-        "instructions-edition-warning": "Attention à renseigner le numéro de session sans les autres informations de sessions (ex: date, heure, etc.) pour éviter les doublons lors de la création."
+        "instructions-edition-warning": "Attention à renseigner le numéro de session sans les autres informations de sessions (ex: date, heure, etc.) pour éviter les doublons lors de la création.",
+        "breadcrumb-import": "Import du modèle",
+        "breadcrumb-summary": "Récapitulatif"
       },
       "list": {
         "header": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -128,7 +128,7 @@
         "session-import-upload": "Importer (.csv)",
         "session-import-upload-label": "Importer le modèle complété",
         "instructions-creation-title": "Pour créer des sessions ?",
-        "instructions-creation-list": "Vous pouvez créer des sessions",
+        "instructions-creation-list": "Vous pouvez créer des sessions :",
         "instructions-creation-list-with-candidates": "<strong>Avec candidats</strong>, complétez le modèle dans son intégralité,",
         "instructions-creation-list-without-candidates": "<strong>Sans candidat</strong>, complétez uniquement les informations des sessions.",
         "instructions-edition-title": "Pour éditer la liste des candidats de sessions déjà créées ?",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -126,7 +126,15 @@
         "session-import-template-dl-error": "Une erreur s'est produite pendant le téléchargement",
         "session-import-template-label": "Télécharger le modèle vierge",
         "session-import-upload": "Importer (.csv)",
-        "session-import-upload-label": "Importer le modèle complété"
+        "session-import-upload-label": "Importer le modèle complété",
+        "instructions-creation-title": "Pour créer des sessions ?",
+        "instructions-creation-list": "Vous pouvez créer des sessions",
+        "instructions-creation-list-with-candidates": "<strong>Avec candidats</strong>, complétez le modèle dans son intégralité,",
+        "instructions-creation-list-without-candidates": "<strong>Sans candidat</strong>, complétez uniquement les informations des sessions.",
+        "instructions-edition-title": "Pour éditer la liste des candidats de sessions déjà créées ?",
+        "instructions-edition-replace": "<strong>Pour remplacer</strong> une liste pré-existante dans le fichier modèle,",
+        "instructions-edition-subscription": "<strong>Pour inscrire</strong> des candidats dans une session vide.",
+        "instructions-edition-warning": "Attention à renseigner le numéro de session sans les autres informations de sessions (ex: date, heure, etc.) pour éviter les doublons lors de la création."
       },
       "list": {
         "header": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -134,7 +134,9 @@
         "instructions-edition-title": "Pour éditer la liste des candidats de sessions déjà créées ?",
         "instructions-edition-replace": "<strong>Pour remplacer</strong> une liste pré-existante dans le fichier modèle,",
         "instructions-edition-subscription": "<strong>Pour inscrire</strong> des candidats dans une session vide.",
-        "instructions-edition-warning": "Attention à renseigner le numéro de session sans les autres informations de sessions (ex: date, heure, etc.) pour éviter les doublons lors de la création."
+        "instructions-edition-warning": "Attention à renseigner le numéro de session sans les autres informations de sessions (ex: date, heure, etc.) pour éviter les doublons lors de la création.",
+        "breadcrumb-import": "Import du modèle",
+        "breadcrumb-summary": "Récapitulatif"
       },
       "list": {
         "header": {


### PR DESCRIPTION
## :egg: Problème
L’utilisateur Pix Certif n’est pas guidé pendant sa saisie pour limiter le risque d’erreur et lui faire gagner du temps.

## :bowl_with_spoon: Proposition
- Préciser à l’utilisateur pendant sa saisie comment marche la création de plusieurs sessions ou encore l’import de candidats dans plusieurs sessions

- Aider l’utilisateur à mieux visualiser les étapes qu’il lui reste à accomplir grâce à un fil d’Ariane

## :milk_glass: Remarques
Pour la personnalisation de la balise `ol` : https://css-tricks.com/almanac/properties/c/counter-reset/

Lien vers la maquette : https://www.figma.com/file/IWVcwbasXoFUQPhIG097XT/Pix-Certif?node-id=1350%3A26895&t=ysMwxoL9nF8bIeFv-0

Rendu :
![Screenshot 2023-02-06 at 14-38-54 Créer_éditer plusieurs sessions Sessions de certification Pix Certif](https://user-images.githubusercontent.com/11388201/216986139-4b6beb3f-938b-4fe1-8305-57749e61ae4a.png)

## :100: Pour tester
- Sur la page de liste des sessions, cliquer sur "Créer/Éditer plusieurs sessions"
