### PR TITLE
[TECH] Ne plus utiliser la variable `MAX_REACHABLE_LEVEL` dans Pix App (PIX-7009).

### DIFF
--- a/mon-pix/app/components/dashboard/content.hbs
+++ b/mon-pix/app/components/dashboard/content.hbs
@@ -13,7 +13,11 @@
 
   <section class="dashboard-content__score">
     <div class="dashboard-content-score__wrapper">
-      <HexagonScore @pixScore={{this.userScore}} />
+      <HexagonScore
+        @pixScore={{this.userScore}}
+        @maxReachablePixScore={{this.maxReachablePixScore}}
+        @maxReachableLevel={{this.maxReachableLevel}}
+      />
       <LinkTo @route="authenticated.profile" class="dashboard-content-score-wrapper__button">{{t
           "pages.dashboard.score.profile-link"
         }}</LinkTo>

--- a/mon-pix/app/components/dashboard/content.js
+++ b/mon-pix/app/components/dashboard/content.js
@@ -73,6 +73,14 @@ export default class Content extends Component {
     return this.currentUser.user.profile.get('pixScore');
   }
 
+  get maxReachablePixScore() {
+    return this.currentUser.user.profile.get('maxReachablePixScore');
+  }
+
+  get maxReachableLevel() {
+    return this.currentUser.user.profile.get('maxReachableLevel');
+  }
+
   @action
   async closeInformationAboutNewDashboard() {
     await this.currentUser.user.save({ adapterOptions: { rememberUserHasSeenNewDashboardInfo: true } });

--- a/mon-pix/app/components/hexagon-score.hbs
+++ b/mon-pix/app/components/hexagon-score.hbs
@@ -3,7 +3,7 @@
     <div class="hexagon-score-content__title">{{t "common.pix"}}</div>
     <div class="hexagon-score-content__pix-score">{{this.score}}</div>
     <div class="hexagon-score-content__pix-total">
-      1024
+      {{@maxReachablePixScore}}
       <PixTooltip @isLight={{true}} @isWide={{true}} @position="bottom" @id="hexagon-score-tooltip">
         <:triggerElement>
           <button
@@ -18,12 +18,12 @@
         <:tooltip>
           <div class="hexagon-score__information hexagon-score-information__text">
             <p class="hexagon-score-information__text--strong">
-              {{t "pages.profile.total-score-helper.title"}}
+              {{t "pages.profile.total-score-helper.title" maxReachablePixScore=@maxReachablePixScore}}
             </p>
             {{t
               "pages.profile.total-score-helper.explanation"
-              maxReachablePixCount=this.maxReachablePixCount
-              maxReachableLevel=this.maxReachableLevel
+              maxReachablePixScore=@maxReachablePixScore
+              maxReachableLevel=@maxReachableLevel
               htmlSafe=true
             }}
           </div>

--- a/mon-pix/app/components/hexagon-score.js
+++ b/mon-pix/app/components/hexagon-score.js
@@ -1,18 +1,9 @@
 import { isNone } from '@ember/utils';
 import Component from '@glimmer/component';
-import ENV from 'mon-pix/config/environment';
 
 export default class HexagonScore extends Component {
   get score() {
     const score = this.args.pixScore;
     return isNone(score) || score === 0 ? '–' : Math.floor(score);
-  }
-
-  get maxReachablePixCount() {
-    return ENV.APP.MAX_REACHABLE_LEVEL * 8 * 16;
-  }
-
-  get maxReachableLevel() {
-    return ENV.APP.MAX_REACHABLE_LEVEL;
   }
 }

--- a/mon-pix/app/components/profile-content.hbs
+++ b/mon-pix/app/components/profile-content.hbs
@@ -14,7 +14,11 @@
       </div>
       <div class="rounded-panel-header__right-wrapper">
         <h2 class="sr-only">{{t "pages.profile.accessibility.user-score"}}</h2>
-        <HexagonScore @pixScore={{@model.profile.pixScore}} />
+        <HexagonScore
+          @pixScore={{@model.profile.pixScore}}
+          @maxReachablePixScore={{this.model.profile.maxReachablePixScore}}
+          @maxReachableLevel={{this.model.profile.maxReachableLevel}}
+        />
       </div>
     </div>
 

--- a/mon-pix/app/components/routes/campaigns/profiles-collection/send-profile.hbs
+++ b/mon-pix/app/components/routes/campaigns/profiles-collection/send-profile.hbs
@@ -13,7 +13,11 @@
     </LinkTo>
   </div>
   <div class="send-profile-header__profile send-profile-header__profile--with-border-bottom">
-    <HexagonScore @pixScore={{@user.profile.pixScore}} />
+    <HexagonScore
+      @pixScore={{@user.profile.pixScore}}
+      @maxReachablePixScore={{@user.profile.maxReachablePixScore}}
+      @maxReachableLevel={{@user.profile.maxReachableLevel}}
+    />
     <div class="send-profile-header__profile__cards">
       <ProfileScorecards
         @interactive={{false}}
@@ -39,7 +43,11 @@
     @errorMessage={{@errorMessage}}
   />
   <div class="send-profile-header__profile send-profile-header__profile--with-border-bottom">
-    <HexagonScore @pixScore={{@user.profile.pixScore}} />
+    <HexagonScore
+      @pixScore={{@user.profile.pixScore}}
+      @maxReachablePixScore={{@user.profile.maxReachablePixScore}}
+      @maxReachableLevel={{@user.profile.maxReachableLevel}}
+    />
     <div class="send-profile-header__profile__cards">
       <ProfileScorecards
         @interactive={{false}}

--- a/mon-pix/app/models/profile.js
+++ b/mon-pix/app/models/profile.js
@@ -2,6 +2,8 @@ import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class Profile extends Model {
   @attr('number') pixScore;
+  @attr('number') maxReachablePixScore;
+  @attr('number') maxReachableLevel;
 
   @hasMany('scorecard') scorecards;
 

--- a/mon-pix/app/models/shared-profile-for-campaign.js
+++ b/mon-pix/app/models/shared-profile-for-campaign.js
@@ -5,6 +5,8 @@ import { computed } from '@ember/object';
 
 export default class SharedProfileForCampaign extends Model {
   @attr('number') pixScore;
+  @attr('number') maxReachablePixScore;
+  @attr('number') maxReachableLevel;
   @attr('date') sharedAt;
   @attr('boolean') canRetry;
   @hasMany('scorecard') scorecards;

--- a/mon-pix/app/templates/campaigns/profiles-collection/profile-already-shared.hbs
+++ b/mon-pix/app/templates/campaigns/profiles-collection/profile-already-shared.hbs
@@ -39,7 +39,11 @@
       </div>
     {{/if}}
     <div class="send-profile-header__profile">
-      <HexagonScore @pixScore={{this.model.sharedProfile.pixScore}} />
+      <HexagonScore
+        @pixScore={{this.model.sharedProfile.pixScore}}
+        @maxReachablePixScore={{this.model.sharedProfile.maxReachablePixScore}}
+        @maxReachableLevel={{this.model.sharedProfile.maxReachableLevel}}
+      />
       <div class="send-profile-header__profile__cards">
         <ProfileScorecards
           class="send-profile-header__profile__cards"

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -65,11 +65,6 @@ module.exports = function (environment) {
       FRENCH_NEW_LEVEL_MESSAGE: process.env.FRENCH_NEW_LEVEL_MESSAGE || '',
       ENGLISH_NEW_LEVEL_MESSAGE: process.env.ENGLISH_NEW_LEVEL_MESSAGE || '',
       IS_PROD_ENVIRONMENT: (process.env.REVIEW_APP === 'false' && environment === 'production') || false,
-      MAX_REACHABLE_LEVEL: _getEnvironmentVariableAsNumber({
-        environmentVariableName: 'MAX_REACHABLE_LEVEL',
-        defaultValue: 5,
-        minValue: 5,
-      }),
       EMBED_ALLOWED_ORIGINS: (
         process.env.EMBED_ALLOWED_ORIGINS || 'https://epreuves.pix.fr,https://1024pix.github.io'
       ).split(','),

--- a/mon-pix/tests/integration/components/hexagon-score_test.js
+++ b/mon-pix/tests/integration/components/hexagon-score_test.js
@@ -8,8 +8,16 @@ module('Integration | Component | hexagon-score', function (hooks) {
 
   module('Component rendering', function () {
     test('should display two dashes, when no pixScore provided', async function (assert) {
-      // given & when
-      const screen = await render(hbs`<HexagonScore />`);
+      // given
+      const maxReachablePixScore = 100;
+      const maxReachableLevel = 5;
+      this.set('maxReachablePixScore', maxReachablePixScore);
+      this.set('maxReachableLevel', maxReachableLevel);
+
+      // when
+      const screen = await render(
+        hbs`<HexagonScore @maxReachablePixScore={{this.maxReachablePixScore}} @maxReachableLevel={{this.maxReachableLevel}} />`
+      );
 
       // then
       assert.ok(screen.getByText('–'));
@@ -21,18 +29,44 @@ module('Integration | Component | hexagon-score', function (hooks) {
       this.set('pixScore', pixScore);
 
       // when
-      const screen = await render(hbs`<HexagonScore @pixScore={{this.pixScore}} />`);
+      const screen = await render(
+        hbs`<HexagonScore @pixScore={{this.pixScore}} @maxReachablePixScore={{this.maxReachablePixScore}} @maxReachableLevel={{this.maxReachableLevel}} />`
+      );
 
       // then
       assert.ok(screen.getByText(pixScore));
     });
 
     test('should display an information tooltip', async function (assert) {
-      // given & when
-      const screen = await render(hbs`<HexagonScore />`);
+      // given
+      const maxReachablePixScore = 100;
+      const maxReachableLevel = 5;
+      this.set('maxReachablePixScore', maxReachablePixScore);
+      this.set('maxReachableLevel', maxReachableLevel);
+
+      // when
+      const screen = await render(
+        hbs`<HexagonScore @maxReachablePixScore={{this.maxReachablePixScore}} @maxReachableLevel={{this.maxReachableLevel}} />`
+      );
 
       // then
       assert.ok(screen.getByRole('button', { name: this.intl.t('pages.profile.total-score-helper.label') }));
+    });
+
+    test('should display maxReachablePixScore', async function (assert) {
+      // given
+      const maxReachablePixScore = 100;
+      const maxReachableLevel = 5;
+      this.set('maxReachablePixScore', maxReachablePixScore);
+      this.set('maxReachableLevel', maxReachableLevel);
+
+      // when
+      const screen = await render(
+        hbs`<HexagonScore @maxReachableLevel={{this.maxReachableLevel}} @maxReachablePixScore={{this.maxReachablePixScore}}/>`
+      );
+
+      // then
+      assert.ok(screen.getByText(maxReachablePixScore));
     });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1062,8 +1062,8 @@
       "total-score-helper": {
         "label": "Open tooltip",
         "icon": "Pix information",
-        "title": "Why 1,024 pix?",
-        "explanation": "<p>That’s the maximum number of pix you can get when the 8 levels of the Pix framework will be available.'</p><p>'Today, '<span class=\"hexagon-score-information__text--strong\">'the maximum number available is {maxReachablePixCount} pix'</span>', corresponding to level {maxReachableLevel}.'</p>'"
+        "title": "Why {maxReachablePixScore} pix?",
+        "explanation": "<p>That’s the maximum number of pix you can get when the 8 levels of the Pix framework will be available.'</p><p>'Today, '<span class=\"hexagon-score-information__text--strong\">'the maximum number available is {maxReachablePixScore} pix'</span>', corresponding to level {maxReachableLevel}.'</p>'"
       }
     },
     "profile-already-shared": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1062,8 +1062,8 @@
       "total-score-helper": {
         "label": "Ouvrir l'infobulle",
         "icon": "Information sur les pix",
-        "title": "Pourquoi 1024 pix ?",
-        "explanation": "<p>C’est le nombre maximum de pix qu’on pourra atteindre lorsque les 8 niveaux du référentiel Pix seront disponibles.'</p><p>'Aujourd’hui, '<span class=\"hexagon-score-information__text--strong\">'le maximum est de {maxReachablePixCount} pix'</span>', correspondant au niveau {maxReachableLevel}.'</p>'"
+        "title": "Pourquoi {maxReachablePixScore} pix ?",
+        "explanation": "<p>C’est le nombre maximum de pix qu’on pourra atteindre lorsque les 8 niveaux du référentiel Pix seront disponibles.'</p><p>'Aujourd’hui, '<span class=\"hexagon-score-information__text--strong\">'le maximum est de {maxReachablePixScore} pix'</span>', correspondant au niveau {maxReachableLevel}.'</p>'"
       }
     },
     "profile-already-shared": {


### PR DESCRIPTION
## :egg: Problème
Actuellement Pix App, contient une variable d'env `MAX_REACHABLE_LEVEL` qui est lié au référentiel. 
Le front ne devrait pas avoir connaissance de ce genre d'information et devrait faire uniquement de l'affichage. 
Pour aller dans ce sens une première PR #5585 a fait en sorte que l'API retourne les champs : `maxReachableLevel` et `maxReachablePixScore`. 

## :bowl_with_spoon: Proposition
Utiliser les nouveaux champs retournés par l'API et supprimer la variable d'environnement du front. 

## :milk_glass: Remarques
Je n'ai pas réussi à tester le contenu de la tooltip, ni à tester simplement le contenu de la traduction comme il s'agit d'HTML. :/ 

Il faudra penser à supprimer cette variable une fois la PR en prod sur ces apps : 
- pix-front-review
- pix-app-integration
- pix-app-recette
- pix-app-production

## :butter: Pour tester
- Se connecter sur Pix App 
- Constater que la tooltip de l'hexagon score contient bien les informations fournis par l'API
- Rejoindre la campagne `PROCOLECT`
- Constater la tooltip
- Envoyer son profil 
- Revenir sur la campagne
- Constater la tooltip