### PR TITLE
[BUGFIX][MON-PIX] Rediriger l'utilisateur vers la page de connexion si un identity provider n'est pas configuré (PIX-6997)

### DIFF
--- a/api/db/database-builder/factory/build-authentication-method.js
+++ b/api/db/database-builder/factory/build-authentication-method.js
@@ -113,7 +113,7 @@ buildAuthenticationMethod.withPoleEmploiAsIdentityProvider = function ({
   }
   const values = {
     id,
-    identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+    identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
     authenticationComplement: new AuthenticationMethod.OidcAuthenticationComplement({
       accessToken,
       refreshToken,

--- a/api/db/seeds/data/organizations-pro-builder.js
+++ b/api/db/seeds/data/organizations-pro-builder.js
@@ -130,7 +130,7 @@ function organizationsProBuilder({ databaseBuilder }) {
     provinceCode: null,
     email: null,
     createdBy: poleEmploiCreator.id,
-    identityProviderForCampaigns: OidcIdentityProviders.POLE_EMPLOI.code,
+    identityProviderForCampaigns: OidcIdentityProviders.POLE_EMPLOI.service.code,
   });
   databaseBuilder.factory.buildOrganizationTag({ organizationId: PRO_POLE_EMPLOI_ID, tagId: 4 });
 
@@ -157,7 +157,7 @@ function organizationsProBuilder({ databaseBuilder }) {
     provinceCode: null,
     email: null,
     createdBy: cnavCreator.id,
-    identityProviderForCampaigns: OidcIdentityProviders.CNAV.code,
+    identityProviderForCampaigns: OidcIdentityProviders.CNAV.service.code,
   });
 
   databaseBuilder.factory.buildMembership({

--- a/api/db/seeds/data/users-builder.js
+++ b/api/db/seeds/data/users-builder.js
@@ -123,7 +123,7 @@ function usersBuilder({ databaseBuilder }) {
   });
   databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
     userId: pixUserWithPoleEmploiAuthenticationMethod.id,
-    identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+    identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
   });
 
   const userWithPoleEmploiAuthenticationMethod = databaseBuilder.factory.buildUser.withoutPixAuthenticationMethod({
@@ -133,7 +133,7 @@ function usersBuilder({ databaseBuilder }) {
   });
   databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
     userId: userWithPoleEmploiAuthenticationMethod.id,
-    identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+    identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
   });
 
   const pixUserWithCnavAuthenticationMethod = databaseBuilder.factory.buildUser.withRawPassword({
@@ -146,7 +146,7 @@ function usersBuilder({ databaseBuilder }) {
   });
   databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
     userId: pixUserWithCnavAuthenticationMethod.id,
-    identityProvider: OidcIdentityProviders.CNAV.code,
+    identityProvider: OidcIdentityProviders.CNAV.service.code,
   });
 
   const userWithCnavAuthenticationMethod = databaseBuilder.factory.buildUser.withoutPixAuthenticationMethod({
@@ -156,7 +156,7 @@ function usersBuilder({ databaseBuilder }) {
   });
   databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
     userId: userWithCnavAuthenticationMethod.id,
-    identityProvider: OidcIdentityProviders.CNAV.code,
+    identityProvider: OidcIdentityProviders.CNAV.service.code,
   });
 
   const userWithMultiplesAuthenticationMethods = databaseBuilder.factory.buildUser.withRawPassword({
@@ -169,11 +169,11 @@ function usersBuilder({ databaseBuilder }) {
   });
   databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
     userId: userWithMultiplesAuthenticationMethods.id,
-    identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+    identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
   });
   databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
     userId: userWithMultiplesAuthenticationMethods.id,
-    identityProvider: OidcIdentityProviders.CNAV.code,
+    identityProvider: OidcIdentityProviders.CNAV.service.code,
   });
   databaseBuilder.factory.buildAuthenticationMethod.withGarAsIdentityProvider({
     externalIdentifier: `${userWithMultiplesAuthenticationMethods.firstName}.${userWithMultiplesAuthenticationMethods.lastName}.${userWithMultiplesAuthenticationMethods.id}`,

--- a/api/lib/application/authentication/oidc/index.js
+++ b/api/lib/application/authentication/oidc/index.js
@@ -2,7 +2,7 @@ const Joi = require('joi');
 const OidcIdentityProviders = require('../../../domain/constants/oidc-identity-providers');
 const oidcController = require('./oidc-controller');
 
-const validProviders = Object.values(OidcIdentityProviders).map((provider) => provider.code);
+const validProviders = Object.values(OidcIdentityProviders).map((provider) => provider.service.code);
 
 exports.register = async (server) => {
   server.route([
@@ -24,7 +24,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           query: Joi.object({
-            identity_provider: Joi.string().required().valid(OidcIdentityProviders.POLE_EMPLOI.code),
+            identity_provider: Joi.string().required().valid(OidcIdentityProviders.POLE_EMPLOI.service.code),
             logout_url_uuid: Joi.string()
               .regex(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i)
               .required(),

--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -1,14 +1,14 @@
 const authenticationServiceRegistry = require('../../../domain/services/authentication/authentication-service-registry');
 const authenticationRegistry = require('../../../domain/services/authentication/authentication-service-registry');
 const serializer = require('../../../infrastructure/serializers/jsonapi/oidc-identity-providers-serializer');
-const OidcIdentityProviders = require('../../../domain/constants/oidc-identity-providers');
 const usecases = require('../../../domain/usecases');
 const { UnauthorizedError } = require('../../http-errors');
 const oidcSerializer = require('../../../infrastructure/serializers/jsonapi/oidc-serializer');
 
 module.exports = {
   async getIdentityProviders(request, h) {
-    return h.response(serializer.serialize(Object.values(OidcIdentityProviders))).code(200);
+    const identityProviders = usecases.getIdentityProviders();
+    return h.response(serializer.serialize(identityProviders)).code(200);
   },
 
   async getRedirectLogoutUrl(request, h) {

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -158,7 +158,9 @@ exports.register = async function (server) {
             data: {
               attributes: {
                 'user-id': identifiersType.userId,
-                'identity-provider': Joi.string().valid('GAR', OidcIdentityProviders.POLE_EMPLOI.code).required(),
+                'identity-provider': Joi.string()
+                  .valid('GAR', OidcIdentityProviders.POLE_EMPLOI.service.code)
+                  .required(),
               },
             },
           }),
@@ -202,8 +204,8 @@ exports.register = async function (server) {
                     'GAR',
                     'EMAIL',
                     'USERNAME',
-                    OidcIdentityProviders.POLE_EMPLOI.code,
-                    OidcIdentityProviders.CNAV.code
+                    OidcIdentityProviders.POLE_EMPLOI.service.code,
+                    OidcIdentityProviders.CNAV.service.code
                   )
                   .required(),
               },

--- a/api/lib/domain/constants/oidc-identity-providers.js
+++ b/api/lib/domain/constants/oidc-identity-providers.js
@@ -2,8 +2,22 @@ const PoleEmploiOidcAuthenticationService = require('../services/authentication/
 const CnavOidcAuthenticationService = require('../services/authentication/cnav-oidc-authentication-service');
 const FwbOidcAuthenticationService = require('../services/authentication/fwb-oidc-authentication-service');
 
+const DEFAULT_PROPERTY_PATHS_TO_PICK = ['clientId', 'authenticationUrl', 'userInfoUrl', 'tokenUrl', 'clientSecret'];
+
 module.exports = {
-  POLE_EMPLOI: new PoleEmploiOidcAuthenticationService(),
-  CNAV: new CnavOidcAuthenticationService(),
-  FWB: new FwbOidcAuthenticationService(),
+  POLE_EMPLOI: {
+    configKey: 'poleEmploi',
+    propertyPathsToPick: [...DEFAULT_PROPERTY_PATHS_TO_PICK, 'sendingUrl', 'logoutUrl', 'afterLogoutUrl'],
+    service: new PoleEmploiOidcAuthenticationService(),
+  },
+  CNAV: {
+    configKey: 'cnav',
+    propertyPathsToPick: DEFAULT_PROPERTY_PATHS_TO_PICK,
+    service: new CnavOidcAuthenticationService(),
+  },
+  FWB: {
+    configKey: 'fwb',
+    propertyPathsToPick: DEFAULT_PROPERTY_PATHS_TO_PICK,
+    service: new FwbOidcAuthenticationService(),
+  },
 };

--- a/api/lib/domain/services/authentication/authentication-service-registry.js
+++ b/api/lib/domain/services/authentication/authentication-service-registry.js
@@ -3,12 +3,12 @@ const { InvalidIdentityProviderError } = require('../../errors');
 
 function lookupAuthenticationService(identityProvider) {
   const identityProviderService = Object.values(OidcIdentityProviders).find(
-    (oidcIdentityProvider) => oidcIdentityProvider.code === identityProvider
+    (oidcIdentityProvider) => oidcIdentityProvider.service.code === identityProvider
   );
 
   if (!identityProviderService) throw new InvalidIdentityProviderError(identityProvider);
 
-  return identityProviderService;
+  return identityProviderService.service;
 }
 
 module.exports = {

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -1,13 +1,14 @@
 const jsonwebtoken = require('jsonwebtoken');
+const querystring = require('querystring');
+const { v4: uuidv4 } = require('uuid');
+
+const { InvalidExternalAPIResponseError } = require('../../errors');
+const AuthenticationMethod = require('../../models/AuthenticationMethod');
+const AuthenticationSessionContent = require('../../models/AuthenticationSessionContent');
 const settings = require('../../../config');
 const httpAgent = require('../../../infrastructure/http/http-agent');
 const httpErrorsHelper = require('../../../infrastructure/http/errors-helper');
-const querystring = require('querystring');
-const { InvalidExternalAPIResponseError } = require('../../errors');
-const AuthenticationSessionContent = require('../../models/AuthenticationSessionContent');
-const { v4: uuidv4 } = require('uuid');
 const DomainTransaction = require('../../../infrastructure/DomainTransaction');
-const AuthenticationMethod = require('../../models/AuthenticationMethod');
 const monitoringTools = require('../../../infrastructure/monitoring-tools');
 
 class OidcAuthenticationService {

--- a/api/lib/domain/usecases/get-identity-providers.js
+++ b/api/lib/domain/usecases/get-identity-providers.js
@@ -1,0 +1,26 @@
+const { isEmpty, isNil, pick } = require('lodash');
+const OidcIdentityProviders = require('../constants/oidc-identity-providers');
+const config = require('../../config');
+
+module.exports = function getIdentityProviders() {
+  return Object.keys(OidcIdentityProviders)
+    .map((oidcIdentityProviderKey) => {
+      const { configKey, propertyPathsToPick, service } = OidcIdentityProviders[oidcIdentityProviderKey];
+
+      const providerConfig = pick(config[configKey], propertyPathsToPick);
+      const providerConfigKeys = Object.keys(providerConfig);
+
+      if (providerConfigKeys.length === 0) {
+        return;
+      }
+
+      const providerConfigExists = propertyPathsToPick.every(
+        (providerConfigKey) => !isNil(providerConfig[providerConfigKey])
+      );
+
+      if (providerConfigExists) {
+        return service;
+      }
+    })
+    .filter((identityProvider) => !isEmpty(identityProvider));
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -342,6 +342,7 @@ module.exports = injectDependencies(
     getExternalAuthenticationRedirectionUrl: require('./get-external-authentication-redirection-url'),
     getFrameworkAreas: require('./get-framework-areas'),
     getFrameworks: require('./get-frameworks'),
+    getIdentityProviders: require('./get-identity-providers'),
     getImportSessionComplementaryCertificationHabilitationsLabels: require('./get-import-session-complementary-certification-habilitations-labels'),
     getJuryCertification: require('./get-jury-certification'),
     getJurySession: require('./get-jury-session'),

--- a/api/lib/domain/usecases/remove-authentication-method.js
+++ b/api/lib/domain/usecases/remove-authentication-method.js
@@ -40,12 +40,16 @@ module.exports = async function removeAuthenticationMethod({
     );
   }
 
-  if (type === OidcIdentityProviders.POLE_EMPLOI.code) {
-    await _removeAuthenticationMethod(userId, OidcIdentityProviders.POLE_EMPLOI.code, authenticationMethodRepository);
+  if (type === OidcIdentityProviders.POLE_EMPLOI.service.code) {
+    await _removeAuthenticationMethod(
+      userId,
+      OidcIdentityProviders.POLE_EMPLOI.service.code,
+      authenticationMethodRepository
+    );
   }
 
-  if (type === OidcIdentityProviders.CNAV.code) {
-    await _removeAuthenticationMethod(userId, OidcIdentityProviders.CNAV.code, authenticationMethodRepository);
+  if (type === OidcIdentityProviders.CNAV.service.code) {
+    await _removeAuthenticationMethod(userId, OidcIdentityProviders.CNAV.service.code, authenticationMethodRepository);
   }
 };
 

--- a/api/lib/domain/validators/organization-with-tags-and-target-profiles-script.js
+++ b/api/lib/domain/validators/organization-with-tags-and-target-profiles-script.js
@@ -4,7 +4,7 @@ const Organization = require('../models/Organization');
 const Membership = require('../models/Membership');
 const OidcIdentityProviders = require('../../../lib/domain/constants/oidc-identity-providers');
 
-const validProviders = Object.values(OidcIdentityProviders).map((provider) => provider.code);
+const validProviders = Object.values(OidcIdentityProviders).map((provider) => provider.service.code);
 
 const schema = Joi.object({
   type: Joi.string()

--- a/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
+++ b/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
@@ -19,7 +19,7 @@ module.exports = {
     });
     const authenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
       userId,
-      identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+      identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
     });
     let accessToken = get(authenticationMethod, 'authenticationComplement.accessToken');
     if (!accessToken) {
@@ -74,7 +74,7 @@ module.exports = {
       await authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider({
         authenticationComplement,
         userId,
-        identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+        identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
       });
     }
 

--- a/api/lib/infrastructure/repositories/authentication-method-repository.js
+++ b/api/lib/infrastructure/repositories/authentication-method-repository.js
@@ -26,7 +26,7 @@ function _toAuthenticationComplement(identityProvider, bookshelfAuthenticationCo
     return new AuthenticationMethod.PixAuthenticationComplement(bookshelfAuthenticationComplement);
   }
 
-  if (identityProvider === OidcIdentityProviders.POLE_EMPLOI.code) {
+  if (identityProvider === OidcIdentityProviders.POLE_EMPLOI.service.code) {
     return new AuthenticationMethod.OidcAuthenticationComplement(bookshelfAuthenticationComplement);
   }
 

--- a/api/lib/infrastructure/repositories/pole-emploi-sending-repository.js
+++ b/api/lib/infrastructure/repositories/pole-emploi-sending-repository.js
@@ -19,7 +19,7 @@ module.exports = {
       )
       .join('campaign-participations', 'campaign-participations.id', 'pole-emploi-sendings.campaignParticipationId')
       .join('authentication-methods', 'authentication-methods.userId', 'campaign-participations.userId')
-      .where('authentication-methods.identityProvider', OidcIdentityProviders.POLE_EMPLOI.code)
+      .where('authentication-methods.identityProvider', OidcIdentityProviders.POLE_EMPLOI.service.code)
       .modify(_olderThan, sending)
       .modify(_filterByStatus, filters)
       .orderBy([

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -520,7 +520,7 @@ function _getAuthenticationComplementAndExternalIdentifier(authenticationMethodB
       shouldChangePassword: Boolean(authenticationComplement.shouldChangePassword),
     });
     externalIdentifier = undefined;
-  } else if (identityProvider === OidcIdentityProviders.POLE_EMPLOI.code) {
+  } else if (identityProvider === OidcIdentityProviders.POLE_EMPLOI.service.code) {
     authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement({
       accessToken: authenticationComplement.accessToken,
       refreshToken: authenticationComplement.refreshToken,

--- a/api/tests/acceptance/application/authentication/oidc/authentication-url-route-get_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/authentication-url-route-get_test.js
@@ -15,7 +15,7 @@ describe('Acceptance | Route | oidc authentication url', function () {
       it('should return the authentication url for cnav', async function () {
         // given
         const query = querystring.stringify({
-          identity_provider: OidcIdentityProviders.CNAV.code,
+          identity_provider: OidcIdentityProviders.CNAV.service.code,
           redirect_uri: 'http://app.pix.fr/connexion/cnav',
         });
 
@@ -48,7 +48,7 @@ describe('Acceptance | Route | oidc authentication url', function () {
       it('should return the authentication url for pole emploi', async function () {
         // given
         const query = querystring.stringify({
-          identity_provider: OidcIdentityProviders.POLE_EMPLOI.code,
+          identity_provider: OidcIdentityProviders.POLE_EMPLOI.service.code,
           redirect_uri: 'http://app.pix.fr/connexion/pole-emploi',
         });
 

--- a/api/tests/acceptance/application/authentication/oidc/reconcile-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/reconcile-route-post_test.js
@@ -47,7 +47,7 @@ describe('Acceptance | Application | Oidc | Routes', function () {
         payload: {
           data: {
             attributes: {
-              identity_provider: OidcIdentityProviders.CNAV.code,
+              identity_provider: OidcIdentityProviders.CNAV.service.code,
               authentication_key: userAuthenticationKey,
             },
           },

--- a/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/token-route-post_test.js
@@ -29,7 +29,7 @@ describe('Acceptance | Route | oidc | token', function () {
       payload = {
         data: {
           attributes: {
-            identity_provider: OidcIdentityProviders.POLE_EMPLOI.code,
+            identity_provider: OidcIdentityProviders.POLE_EMPLOI.service.code,
             code: 'code',
             redirect_uri: 'redirect_uri',
             state_sent: 'state',
@@ -110,7 +110,7 @@ describe('Acceptance | Route | oidc | token', function () {
       }).id;
 
       databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
-        identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+        identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
         externalIdentifier,
         accessToken: 'access_token',
         refreshToken: 'refresh_token',
@@ -164,7 +164,7 @@ describe('Acceptance | Route | oidc | token', function () {
         }).id;
 
         databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
-          identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+          identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
           externalIdentifier,
           accessToken: 'access_token',
           refreshToken: 'refresh_token',
@@ -258,7 +258,7 @@ describe('Acceptance | Route | oidc | token', function () {
             }).id;
 
             databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
-              identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+              identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
               externalIdentifier,
               accessToken: 'access_token',
               refreshToken: 'refresh_token',

--- a/api/tests/acceptance/application/authentication/oidc/users-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/users-route-post_test.js
@@ -52,7 +52,7 @@ describe('Acceptance | Route | oidc users', function () {
         payload: {
           data: {
             attributes: {
-              identity_provider: OidcIdentityProviders.CNAV.code,
+              identity_provider: OidcIdentityProviders.CNAV.service.code,
               authentication_key: userAuthenticationKey,
             },
           },
@@ -85,7 +85,7 @@ describe('Acceptance | Route | oidc users', function () {
           payload: {
             data: {
               attributes: {
-                identity_provider: OidcIdentityProviders.CNAV.code,
+                identity_provider: OidcIdentityProviders.CNAV.service.code,
                 authentication_key: userAuthenticationKey,
               },
             },

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -352,7 +352,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         // when
         const pixAuthenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
           userId: user.id,
-          identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+          identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
         });
 
         // then
@@ -794,7 +794,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         const userId = databaseBuilder.factory.buildUser().id;
         authenticationMethod = databaseBuilder.factory.buildAuthenticationMethod.withIdentityProvider({
           id: 123,
-          identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+          identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
           externalIdentifier: 'identifier',
           accessToken: 'to_be_updated',
           refreshToken: 'to_be_updated',
@@ -822,7 +822,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         await authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider({
           authenticationComplement,
           userId,
-          identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+          identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
         });
 
         // then
@@ -849,7 +849,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
           await authenticationMethodRepository.updateAuthenticationComplementByUserIdAndIdentityProvider({
             authenticationComplement,
             userId,
-            identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+            identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
           });
 
         // then
@@ -878,7 +878,7 @@ describe('Integration | Repository | AuthenticationMethod', function () {
         )({
           authenticationComplement,
           userId,
-          identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+          identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
         });
 
         // then

--- a/api/tests/integration/infrastructure/repositories/campaign-to-join-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-to-join-repository_test.js
@@ -70,7 +70,7 @@ describe('Integration | Repository | CampaignToJoin', function () {
       const code = 'LAURA123';
       const targetProfile = databaseBuilder.factory.buildTargetProfile();
       const organization = databaseBuilder.factory.buildOrganization({
-        identityProviderForCampaigns: OidcIdentityProviders.POLE_EMPLOI.code,
+        identityProviderForCampaigns: OidcIdentityProviders.POLE_EMPLOI.service.code,
       });
       const expectedCampaign = databaseBuilder.factory.buildCampaign({
         code,
@@ -106,7 +106,7 @@ describe('Integration | Repository | CampaignToJoin', function () {
       expect(actualCampaign.targetProfileName).to.equal(targetProfile.name);
       expect(actualCampaign.targetProfileImageUrl).to.equal(targetProfile.imageUrl);
       expect(actualCampaign.isSimplifiedAccess).to.equal(targetProfile.isSimplifiedAccess);
-      expect(actualCampaign.identityProvider).to.equal(OidcIdentityProviders.POLE_EMPLOI.code);
+      expect(actualCampaign.identityProvider).to.equal(OidcIdentityProviders.POLE_EMPLOI.service.code);
     });
 
     it('should throw a NotFoundError when no campaign exists with given code', async function () {

--- a/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-for-admin-repository_test.js
@@ -38,7 +38,7 @@ describe('Integration | Repository | Organization-for-admin', function () {
         showNPS: true,
         formNPSUrl: 'https://pix.fr/',
         showSkills: false,
-        identityProviderForCampaigns: OidcIdentityProviders.CNAV.code,
+        identityProviderForCampaigns: OidcIdentityProviders.CNAV.service.code,
       });
 
       databaseBuilder.factory.buildDataProtectionOfficer.withOrganizationId({
@@ -82,7 +82,7 @@ describe('Integration | Repository | Organization-for-admin', function () {
         dataProtectionOfficerEmail: 'justin.ptipeu@example.net',
         creatorFirstName: 'Cécile',
         creatorLastName: 'Encieux',
-        identityProviderForCampaigns: OidcIdentityProviders.CNAV.code,
+        identityProviderForCampaigns: OidcIdentityProviders.CNAV.service.code,
       });
       expect(foundOrganizationForAdmin).to.deepEqualInstance(expectedOrganizationForAdmin);
     });

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -103,7 +103,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
         // when
         const foundUser = await userRepository.findByExternalIdentifier({
           externalIdentityId,
-          identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+          identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
         });
 
         // then
@@ -118,7 +118,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
         // when
         const foundUser = await userRepository.findByExternalIdentifier({
           externalIdentityId: badId,
-          identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+          identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
         });
 
         // then

--- a/api/tests/tooling/domain-builder/factory/build-authentication-method.js
+++ b/api/tests/tooling/domain-builder/factory/build-authentication-method.js
@@ -107,7 +107,7 @@ buildAuthenticationMethod.withPoleEmploiAsIdentityProvider = function ({
 
   return new AuthenticationMethod({
     id,
-    identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+    identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
     authenticationComplement: new AuthenticationMethod.OidcAuthenticationComplement({
       accessToken,
       refreshToken,

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -933,65 +933,69 @@ describe('Unit | Router | user-router', function () {
 
     describe('POST /api/admin/users/{id}/remove-authentication', function () {
       // eslint-disable-next-line mocha/no-setup-in-describe
-      ['GAR', 'EMAIL', 'USERNAME', OidcIdentityProviders.POLE_EMPLOI.code, OidcIdentityProviders.CNAV.code].forEach(
-        (type) => {
-          it(`should return 200 when user is "SUPER_ADMIN" and type is ${type}`, async function () {
-            // given
-            sinon.stub(userController, 'removeAuthenticationMethod').returns('ok');
-            sinon
-              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-              .callsFake((request, h) => h.response(true));
-            sinon
-              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-              .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-            const httpTestServer = new HttpTestServer();
-            await httpTestServer.register(moduleUnderTest);
+      [
+        'GAR',
+        'EMAIL',
+        'USERNAME',
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        OidcIdentityProviders.POLE_EMPLOI.service.code,
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        OidcIdentityProviders.CNAV.service.code,
+      ].forEach((type) => {
+        it(`should return 200 when user is "SUPER_ADMIN" and type is ${type}`, async function () {
+          // given
+          sinon.stub(userController, 'removeAuthenticationMethod').returns('ok');
+          sinon
+            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+            .callsFake((request, h) => h.response(true));
+          sinon
+            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
+            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
 
-            // when
-            const result = await httpTestServer.request('POST', '/api/admin/users/1/remove-authentication', {
-              data: {
-                attributes: {
-                  type,
-                },
+          // when
+          const result = await httpTestServer.request('POST', '/api/admin/users/1/remove-authentication', {
+            data: {
+              attributes: {
+                type,
               },
-            });
-
-            // then
-            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
-            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
-            sinon.assert.calledOnce(userController.removeAuthenticationMethod);
-            expect(result.statusCode).to.equal(200);
+            },
           });
 
-          it(`should return 200 when user is "SUPPORT" and type is ${type}`, async function () {
-            // given
-            sinon.stub(userController, 'removeAuthenticationMethod').returns('ok');
-            sinon
-              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
-              .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
-            sinon
-              .stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport')
-              .callsFake((request, h) => h.response(true));
-            const httpTestServer = new HttpTestServer();
-            await httpTestServer.register(moduleUnderTest);
+          // then
+          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
+          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
+          sinon.assert.calledOnce(userController.removeAuthenticationMethod);
+          expect(result.statusCode).to.equal(200);
+        });
 
-            // when
-            const result = await httpTestServer.request('POST', '/api/admin/users/1/remove-authentication', {
-              data: {
-                attributes: {
-                  type,
-                },
+        it(`should return 200 when user is "SUPPORT" and type is ${type}`, async function () {
+          // given
+          sinon.stub(userController, 'removeAuthenticationMethod').returns('ok');
+          sinon
+            .stub(securityPreHandlers, 'checkAdminMemberHasRoleSuperAdmin')
+            .callsFake((request, h) => h.response({ errors: new Error('forbidden') }).code(403));
+          sinon.stub(securityPreHandlers, 'checkAdminMemberHasRoleSupport').callsFake((request, h) => h.response(true));
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const result = await httpTestServer.request('POST', '/api/admin/users/1/remove-authentication', {
+            data: {
+              attributes: {
+                type,
               },
-            });
-
-            // then
-            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
-            sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
-            sinon.assert.calledOnce(userController.removeAuthenticationMethod);
-            expect(result.statusCode).to.equal(200);
+            },
           });
-        }
-      );
+
+          // then
+          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSuperAdmin);
+          sinon.assert.calledOnce(securityPreHandlers.checkAdminMemberHasRoleSupport);
+          sinon.assert.calledOnce(userController.removeAuthenticationMethod);
+          expect(result.statusCode).to.equal(200);
+        });
+      });
 
       it('should return 400 when id is not a number', async function () {
         // given
@@ -1045,7 +1049,7 @@ describe('Unit | Router | user-router', function () {
         const result = await httpTestServer.request('POST', '/api/admin/users/1/remove-authentication', {
           data: {
             attributes: {
-              type: OidcIdentityProviders.POLE_EMPLOI.code,
+              type: OidcIdentityProviders.POLE_EMPLOI.service.code,
             },
           },
         });
@@ -1060,7 +1064,7 @@ describe('Unit | Router | user-router', function () {
 
     describe('POST /api/admin/users/{userId}/authentication-methods/{authenticationMethodId}', function () {
       // eslint-disable-next-line mocha/no-setup-in-describe
-      ['GAR', OidcIdentityProviders.POLE_EMPLOI.code].forEach((identityProvider) => {
+      ['GAR', OidcIdentityProviders.POLE_EMPLOI.service.code].forEach((identityProvider) => {
         it(`should return 200 when user role is "SUPER_ADMIN" and identity provider is "${identityProvider}"`, async function () {
           // given
           sinon

--- a/api/tests/unit/domain/models/AuthenticationMethod_test.js
+++ b/api/tests/unit/domain/models/AuthenticationMethod_test.js
@@ -68,7 +68,7 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
       expect(
         () =>
           new AuthenticationMethod({
-            identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+            identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
             externalIdentifier: 'externalIdentifier',
             authenticationComplement,
             userId: 1,
@@ -81,7 +81,7 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
       expect(
         () =>
           new AuthenticationMethod({
-            identityProvider: OidcIdentityProviders.CNAV.code,
+            identityProvider: OidcIdentityProviders.CNAV.service.code,
             externalIdentifier: 'externalIdentifier',
             userId: 1,
           })
@@ -117,7 +117,7 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
       expect(
         () =>
           new AuthenticationMethod({
-            identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+            identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
             externalIdentifier: undefined,
             userId: 1,
           })
@@ -125,7 +125,7 @@ describe('Unit | Domain | Models | AuthenticationMethod', function () {
       expect(
         () =>
           new AuthenticationMethod({
-            identityProvider: OidcIdentityProviders.CNAV.code,
+            identityProvider: OidcIdentityProviders.CNAV.service.code,
             externalIdentifier: undefined,
             userId: 1,
           })

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -497,7 +497,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
         const userId = 1;
         userToCreateRepository.create.withArgs({ user, domainTransaction }).resolves({ id: userId });
 
-        const identityProvider = OidcIdentityProviders.CNAV.code;
+        const identityProvider = OidcIdentityProviders.CNAV.service.code;
         const expectedAuthenticationMethod = new AuthenticationMethod({
           identityProvider,
           externalIdentifier: externalIdentityId,

--- a/api/tests/unit/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/pole-emploi-oidc-authentication-service_test.js
@@ -52,7 +52,7 @@ describe('Unit | Domain | Services | pole-emploi-oidc-authentication-service', f
       userToCreateRepository.create.withArgs({ user, domainTransaction }).resolves({ id: userId });
 
       const expectedAuthenticationMethod = new AuthenticationMethod({
-        identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+        identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
         externalIdentifier: externalIdentityId,
         authenticationComplement: new AuthenticationMethod.OidcAuthenticationComplement({
           accessToken: sessionContent.accessToken,

--- a/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/authentication/authenticate-oidc-user_test.js
@@ -16,7 +16,7 @@ describe('Unit | UseCase | authenticate-oidc-user', function () {
 
   beforeEach(function () {
     oidcAuthenticationService = {
-      identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+      identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
       createAccessToken: sinon.stub(),
       saveIdToken: sinon.stub(),
       createAuthenticationComplement: sinon.stub(),

--- a/api/tests/unit/domain/usecases/get-identity-providers_test.js
+++ b/api/tests/unit/domain/usecases/get-identity-providers_test.js
@@ -1,0 +1,57 @@
+const { expect, sinon } = require('../../../test-helper');
+const getIdentityProviders = require('../../../../lib/domain/usecases/get-identity-providers');
+const OidcIdentityProviders = require('../../../../lib/domain/constants/oidc-identity-providers');
+const config = require('../../../../lib/config');
+
+describe('Unit | UseCase | get-identity-providers', function () {
+  beforeEach(function () {
+    sinon.stub(config, 'poleEmploi').value({
+      clientId: 'client id pole emploi',
+      clientSecret: 'client secret pole emploi',
+      tokenUrl: 'http://token.url',
+      sendingUrl: 'http://sending.url',
+      userInfoUrl: 'http://user.info.url',
+      authenticationUrl: 'http://authentication.url',
+      logoutUrl: 'http://logout.url',
+      afterLogoutUrl: 'http://after.logout.url',
+    });
+    sinon.stub(config, 'cnav').value({
+      clientId: 'client id cnav',
+      authenticationUrl: 'http://authentication.url',
+      userInfoUrl: 'http://user.info.url',
+      tokenUrl: 'http://token.url',
+      clientSecret: 'client secret cnav',
+      accessTokenLifespanMs: 1000,
+    });
+    sinon.stub(config, 'fwb').value({});
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it('returns all identity providers', async function () {
+    // given & when
+    const identityProviders = getIdentityProviders();
+
+    // then
+    const expectedIdentityProviders = [OidcIdentityProviders.POLE_EMPLOI.service, OidcIdentityProviders.CNAV.service];
+    expect(identityProviders.length).to.equal(2);
+    expect(identityProviders).to.deep.equal(expectedIdentityProviders);
+  });
+
+  context('when an identity provider is not configured', function () {
+    it('returns only configured identity providers', function () {
+      // given
+      sinon.stub(config, 'cnav').value({});
+
+      // when
+      const identityProviders = getIdentityProviders();
+
+      // then
+      const expectedIdentityProviders = [OidcIdentityProviders.POLE_EMPLOI.service];
+      expect(identityProviders.length).to.equal(1);
+      expect(identityProviders).to.deep.equal(expectedIdentityProviders);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/reassign-authentication-method-to-another-user_test.js
+++ b/api/tests/unit/domain/usecases/reassign-authentication-method-to-another-user_test.js
@@ -147,7 +147,7 @@ describe('Unit | UseCase | reassign-authentication-method-to-another-user', func
     // then
     expect(authenticationMethodRepository.updateAuthenticationMethodUserId).to.have.been.calledOnceWith({
       originUserId,
-      identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+      identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
       targetUserId,
     });
   });

--- a/api/tests/unit/domain/usecases/remove-authentication-method_test.js
+++ b/api/tests/unit/domain/usecases/remove-authentication-method_test.js
@@ -26,7 +26,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
       domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({ userId }),
       domainBuilder.buildAuthenticationMethod.withIdentityProvider({
         userId,
-        identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+        identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
       }),
     ];
   }
@@ -37,11 +37,11 @@ describe('Unit | UseCase | remove-authentication-method', function () {
       domainBuilder.buildAuthenticationMethod.withGarAsIdentityProvider({ userId }),
       domainBuilder.buildAuthenticationMethod.withIdentityProvider({
         userId,
-        identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+        identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
       }),
       domainBuilder.buildAuthenticationMethod.withIdentityProvider({
         userId,
-        identityProvider: OidcIdentityProviders.CNAV.code,
+        identityProvider: OidcIdentityProviders.CNAV.service.code,
       }),
     ];
   }
@@ -176,7 +176,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
   context('When type is POLE_EMPLOI', function () {
     it('should remove POLE_EMPLOI authentication method', async function () {
       // given
-      const type = OidcIdentityProviders.POLE_EMPLOI.code;
+      const type = OidcIdentityProviders.POLE_EMPLOI.service.code;
       const user = domainBuilder.buildUser();
       userRepository.get.resolves(user);
       const authenticationMethods = buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
@@ -188,7 +188,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
       // then
       expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
         userId: user.id,
-        identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+        identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
       });
     });
   });
@@ -196,7 +196,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
   context('When type is CNAV', function () {
     it('should remove CNAV authentication method', async function () {
       // given
-      const type = OidcIdentityProviders.CNAV.code;
+      const type = OidcIdentityProviders.CNAV.service.code;
       const user = domainBuilder.buildUser();
       userRepository.get.resolves(user);
       const authenticationMethods = buildAllAuthenticationMethodsForUser(user.id);
@@ -208,7 +208,7 @@ describe('Unit | UseCase | remove-authentication-method', function () {
       // then
       expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
         userId: user.id,
-        identityProvider: OidcIdentityProviders.CNAV.code,
+        identityProvider: OidcIdentityProviders.CNAV.service.code,
       });
     });
   });

--- a/api/tests/unit/domain/usecases/update-organization-information_test.js
+++ b/api/tests/unit/domain/usecases/update-organization-information_test.js
@@ -40,7 +40,7 @@ describe('Unit | UseCase | update-organization-information', function () {
       const givenOrganization = _buildOrganizationWithNullAttributes({
         id: organizationId,
         name: newName,
-        identityProviderForCampaigns: OidcIdentityProviders.CNAV.code,
+        identityProviderForCampaigns: OidcIdentityProviders.CNAV.service.code,
       });
       const originalOrganization = _buildOriginalOrganization(organizationId);
 
@@ -60,7 +60,7 @@ describe('Unit | UseCase | update-organization-information', function () {
       expect(organizationForAdminRepository.update).to.have.been.calledWithMatch({
         ...originalOrganization,
         name: newName,
-        identityProviderForCampaigns: OidcIdentityProviders.CNAV.code,
+        identityProviderForCampaigns: OidcIdentityProviders.CNAV.service.code,
       });
     });
 

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -65,7 +65,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
     it('should throw an error if the user is not known as PoleEmploi user', async function () {
       // given
       authenticationMethodRepository.findOneByUserIdAndIdentityProvider
-        .withArgs({ userId, identityProvider: OidcIdentityProviders.POLE_EMPLOI.code })
+        .withArgs({ userId, identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code })
         .resolves(null);
 
       // when
@@ -90,7 +90,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
         };
 
         authenticationMethodRepository.findOneByUserIdAndIdentityProvider
-          .withArgs({ userId, identityProvider: OidcIdentityProviders.POLE_EMPLOI.code })
+          .withArgs({ userId, identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code })
           .resolves(authenticationMethod);
         httpAgent.post.resolves({ isSuccessful: true, code });
 
@@ -113,7 +113,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
         const authenticationMethod = { authenticationComplement: { accessToken, expiredDate, refreshToken } };
 
         authenticationMethodRepository.findOneByUserIdAndIdentityProvider
-          .withArgs({ userId, identityProvider: OidcIdentityProviders.POLE_EMPLOI.code })
+          .withArgs({ userId, identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code })
           .resolves(authenticationMethod);
         httpAgent.post.resolves({ isSuccessful: true, code });
         // when
@@ -133,7 +133,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
         // given
         const expectedHeaders = { 'content-type': 'application/x-www-form-urlencoded' };
         authenticationMethodRepository.findOneByUserIdAndIdentityProvider
-          .withArgs({ userId, identityProvider: OidcIdentityProviders.POLE_EMPLOI.code })
+          .withArgs({ userId, identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code })
           .resolves(authenticationMethod);
         const params = {
           grant_type: 'refresh_token',
@@ -158,7 +158,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
       it('logs the attempt to refresh the access token', async function () {
         // given
         authenticationMethodRepository.findOneByUserIdAndIdentityProvider
-          .withArgs({ userId, identityProvider: OidcIdentityProviders.POLE_EMPLOI.code })
+          .withArgs({ userId, identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code })
           .resolves(authenticationMethod);
         httpAgent.post.resolves({ isSuccessful: true, code, data });
 
@@ -178,7 +178,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
         it('should update the authentication method', async function () {
           // given
           authenticationMethodRepository.findOneByUserIdAndIdentityProvider
-            .withArgs({ userId, identityProvider: OidcIdentityProviders.POLE_EMPLOI.code })
+            .withArgs({ userId, identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code })
             .resolves(authenticationMethod);
           httpAgent.post.resolves({ isSuccessful: true, code, data });
           const authenticationComplement = new AuthenticationMethod.OidcAuthenticationComplement({
@@ -196,7 +196,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
           ).to.have.been.calledWith({
             authenticationComplement,
             userId,
-            identityProvider: OidcIdentityProviders.POLE_EMPLOI.code,
+            identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code,
           });
         });
 
@@ -220,7 +220,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
             .resolves();
 
           authenticationMethodRepository.findOneByUserIdAndIdentityProvider
-            .withArgs({ userId, identityProvider: OidcIdentityProviders.POLE_EMPLOI.code })
+            .withArgs({ userId, identityProvider: OidcIdentityProviders.POLE_EMPLOI.service.code })
             .resolves(authenticationMethod);
 
           httpAgent.post

--- a/api/tests/unit/infrastructure/serializers/jsonapi/authentication-methods-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/authentication-methods-serializer_test.js
@@ -20,7 +20,7 @@ describe('Unit | Serializer | JSONAPI | authentication-methods-serializer', func
           {
             type: 'authentication-methods',
             attributes: {
-              'identity-provider': OidcIdentityProviders.POLE_EMPLOI.code,
+              'identity-provider': OidcIdentityProviders.POLE_EMPLOI.service.code,
             },
           },
         ],


### PR DESCRIPTION
## :egg: Problème

Si un utilisateur accède aujourd’hui à https://app.pix.org/connexion/fwb, cela déclenche une erreur 500.

C’est (probablement) dû au fait que les variables ne sont pas encore renseignés (à confirmer).

## :bowl_with_spoon: Proposition

Lorsqu’on appelle l’url de connexion oidc avec un identity provider qui n’est pas configuré, réagir comme si l’idp n’existait pas en redirigant l’utilisateur vers la page de connexion standard.

## :milk_glass: Remarques

RAS

## :butter: Pour tester

- En local retirer les configurations d'un identity provider (Pole Emploi, CNAV ou FWB) dans votre fichier `.env` de l'api
- Démarrer l'api ainsi que l'application mon-pix
- Tenter une connexion via l'url associée à l'identity provider que vous avez retiré (ex: `/connexion/pole-emploi`)
- Constater que vous arrivez sur la page de connexion de Pix