### PR TITLE
[TECH] Affichage bandeau téléchargement résultats CléA numérique (PIX-6988)

### DIFF
--- a/certif/app/components/session-clea-results-download.hbs
+++ b/certif/app/components/session-clea-results-download.hbs
@@ -7,9 +7,9 @@
       <h1 class="session-details__clea-results-download-title">
         {{t "pages.sessions.detail.panel-clea.title"}}
       </h1>
-      <p class="&__clea-results-download-description">
+      <p class="session-details__clea-results-download-description">
         {{t "pages.sessions.detail.panel-clea.description"}}
-        <a href="https://cleanumerique.org/" target="_blank" rel="noopener noreferrer">
+        <a class="link" href="https://cleanumerique.org/" target="_blank" rel="noopener noreferrer">
           {{t "pages.sessions.detail.panel-clea.link-text"}}
           <FaIcon @icon="link" /></a>
       </p>

--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -157,11 +157,14 @@
     font-weight: 500;
     font-size: 20px;
     color: $pix-neutral-90;
-    margin: 0 0 4px;
+    margin: 0 0 8px;
+    font-family: $font-open-sans;
   }
 
   &__clea-results-download-description {
-    color: $pix-neutral-50;
+    color: $pix-neutral-60;
+    font-size: 0.875rem;
+    margin-bottom: 12px;
   }
 
   &__clea-results-download-icon {
@@ -174,7 +177,7 @@
 
     svg {
       font-size: 40px;
-      color: $pix-neutral-50;
+      color: $pix-neutral-40;
     }
   }
 


### PR DESCRIPTION
## :egg: Problème
Le design du bandeau Clea a été cassé avec la montée de version de Pix UI

## :bowl_with_spoon: Proposition
Le réparer

## :butter: Pour tester
Se connecter avec le compte certifsup@example.net
Verifier le bandeau sur la session #108714
https://certif-pr5611.review.pix.fr/sessions/108714
