### PR TITLE
[BUFGIX] Renommer userInfoContentContainsMissingFields en userInfoMissingField (PIX-7018)

### DIFF
--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -136,12 +136,12 @@ class OidcAuthenticationService {
       throw new InvalidExternalAPIResponseError(message);
     }
 
-    const userInfoContentContainsMissingFields = this.isUserInfoContentContainsMissingFields({ userInfoContent });
+    const userInfoMissingFields = this.userInfoMissingFields({ userInfoContent });
 
-    if (userInfoContentContainsMissingFields) {
+    if (userInfoMissingFields) {
       monitoringTools.logErrorWithCorrelationIds({
         message: "Un des champs obligatoires n'a pas été renvoyé",
-        missingFields: userInfoContentContainsMissingFields,
+        missingFields: userInfoMissingFields,
       });
       throw new InvalidExternalAPIResponseError('Les informations utilisateurs récupérées sont incorrectes.');
     }
@@ -154,7 +154,7 @@ class OidcAuthenticationService {
     };
   }
 
-  isUserInfoContentContainsMissingFields({ userInfoContent }) {
+  userInfoMissingFields({ userInfoContent }) {
     const missingFields = [];
     if (!userInfoContent.family_name) {
       missingFields.push('family_name');

--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -60,13 +60,13 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
     });
   });
 
-  describe('#isUserInfoContentContainsMissingFields', function () {
+  describe('#userInfoMissingFields', function () {
     it('should return a message with missing fields list', async function () {
       // given
       const oidcAuthenticationService = new OidcAuthenticationService({});
 
       // when
-      const response = await oidcAuthenticationService.isUserInfoContentContainsMissingFields({
+      const response = await oidcAuthenticationService.userInfoMissingFields({
         userInfoContent: {
           given_name: 'givenName',
           family_name: undefined,
@@ -84,7 +84,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       const oidcAuthenticationService = new OidcAuthenticationService({});
 
       // when
-      const response = await oidcAuthenticationService.isUserInfoContentContainsMissingFields({
+      const response = await oidcAuthenticationService.userInfoMissingFields({
         userInfoContent: {
           given_name: 'givenName',
           family_name: 'familyName',
@@ -275,6 +275,7 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
             'secret'
           );
         }
+
         const idToken = generateIdToken({
           nonce: 'bb041272-d6e6-457c-99fb-ff1aa02217fd',
           sub: '094b83ac-2e20-4aa8-b438-0bc91748e4a6',


### PR DESCRIPTION
## :egg: Problème
[Voir ](https://github.com/1024pix/pix/pull/5068#discussion_r1093330370)

## :bowl_with_spoon: Proposition
Renommer `userInfoContentContainsMissingFields` en `userInfoMissingField`

## :butter: Pour tester
Vérifier que la CI passe
