### PR TITLE
[TECH] Utiliser la version 16.19 Node.js dans les test E2E de la CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ workflows:
 jobs:
   checkout:
     docker:
-      - image: cimg/node:16.18.1
+      - image: cimg/node:16.19.0
     resource_class: small
     working_directory: ~/pix
     steps:
@@ -90,7 +90,7 @@ jobs:
 
   api_build_and_test:
     docker:
-      - image: cimg/node:16.18.1
+      - image: cimg/node:16.19.0
       - image: postgres:14.6-alpine
         environment:
           POSTGRES_USER: circleci
@@ -133,7 +133,7 @@ jobs:
 
   mon_pix_build_and_test:
     docker:
-      - image: cimg/node:16.18.1-browsers
+      - image: cimg/node:16.19.0-browsers
         environment:
           # See https://git.io/vdao3 for details.
           JOBS: 2
@@ -161,7 +161,7 @@ jobs:
 
   orga_build_and_test:
     docker:
-      - image: cimg/node:16.18.1-browsers
+      - image: cimg/node:16.19.0-browsers
         environment:
           JOBS: 2
     resource_class: small
@@ -188,7 +188,7 @@ jobs:
 
   certif_build_and_test:
     docker:
-      - image: cimg/node:16.18.1-browsers
+      - image: cimg/node:16.19.0-browsers
         environment:
           JOBS: 2
     resource_class: small
@@ -215,7 +215,7 @@ jobs:
 
   admin_build_and_test:
     docker:
-      - image: cimg/node:16.18.1-browsers
+      - image: cimg/node:16.19.0-browsers
         environment:
           JOBS: 2
     resource_class: small
@@ -242,7 +242,7 @@ jobs:
 
   e2e_test:
     docker:
-      - image: cimg/node:16.18.1-browsers
+      - image: cimg/node:16.19.0-browsers
       - image: postgres:14.6-alpine
         environment:
           POSTGRES_USER: circleci
@@ -340,7 +340,7 @@ jobs:
 
   algo_test:
     docker:
-      - image: cimg/node:16.18.1
+      - image: cimg/node:16.19.0
     resource_class: small
     parallelism: 1
     working_directory: ~/pix/high-level-tests/test-algo


### PR DESCRIPTION
## :christmas_tree: Problème
La version de Node.js que nous utilisons sur les tests E2E CircleCI n'est pas celle que l'on utilise en production.

## :gift: Solution
Monter cette version en v16.19.0 (elle est dispo depuis 29/12/2022).

## :star2: Remarques
On fixe la version de Circle CI comme précisé dans [cet ADR](https://github.com/1024pix/pix/blob/dev/docs/adr/0018-specifier-version-nodejs.md#d%C3%A9cision).

## :santa: Pour tester
Vérifier que la CI passe toujours.