### PR TITLE
[FEATURE] Ajout du nom du fichier CSV avant import sur la page (PIX-6950).

### DIFF
--- a/certif/app/adapters/sessions-import.js
+++ b/certif/app/adapters/sessions-import.js
@@ -1,10 +1,10 @@
 import ApplicationAdapter from './application';
 
 export default class SessionsImportAdapter extends ApplicationAdapter {
-  importSessions(files, certificationCenterId) {
-    if (!files || files.length === 0) return;
+  importSessions(file, certificationCenterId) {
+    if (!file) return;
 
     const url = `${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/sessions/import`;
-    return this.ajax(url, 'POST', { data: files[0] });
+    return this.ajax(url, 'POST', { data: file });
   }
 }

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -12,10 +12,10 @@ export default class ImportController extends Controller {
   @service currentUser;
   @service store;
 
-  @tracked files = null;
+  @tracked file = null;
 
   get fileName() {
-    return this.files[0].name;
+    return this.file.name;
   }
 
   @action
@@ -32,7 +32,7 @@ export default class ImportController extends Controller {
 
   @action
   preImportSessions() {
-    this.files = document.getElementById('file-upload').files;
+    this.file = document.getElementById('file-upload').files[0];
   }
 
   @action
@@ -52,6 +52,6 @@ export default class ImportController extends Controller {
 
   @action
   removeImport() {
-    this.files = null;
+    this.file = null;
   }
 }

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -11,6 +11,8 @@ export default class ImportController extends Controller {
   @service currentUser;
   @service store;
 
+  files = null;
+
   @action
   async downloadSessionImportTemplate() {
     const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
@@ -24,12 +26,17 @@ export default class ImportController extends Controller {
   }
 
   @action
-  async importSessions(files) {
+  preImportSessions() {
+    this.files = document.getElementById('file-upload').files;
+  }
+
+  @action
+  async importSessions() {
     const adapter = this.store.adapterFor('sessions-import');
     const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
     this.notifications.clearAll();
     try {
-      await adapter.importSessions(files, certificationCenterId);
+      await adapter.importSessions(this.files, certificationCenterId);
       this.notifications.success('La liste des sessions a été importée avec succès.');
     } catch (err) {
       this.notifications.error("Aucune session n'a été importée");

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -41,11 +41,17 @@ export default class ImportController extends Controller {
     const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
     this.notifications.clearAll();
     try {
-      await adapter.importSessions(this.files, certificationCenterId);
-      this.files = null;
+      await adapter.importSessions(this.file, certificationCenterId);
       this.notifications.success('La liste des sessions a été importée avec succès.');
     } catch (err) {
       this.notifications.error("Aucune session n'a été importée");
+    } finally {
+      this.removeImport();
     }
+  }
+
+  @action
+  removeImport() {
+    this.files = null;
   }
 }

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export default class ImportController extends Controller {
   @service fileSaver;
@@ -11,7 +12,11 @@ export default class ImportController extends Controller {
   @service currentUser;
   @service store;
 
-  files = null;
+  @tracked files = null;
+
+  get fileName() {
+    return this.files[0].name;
+  }
 
   @action
   async downloadSessionImportTemplate() {
@@ -37,6 +42,7 @@ export default class ImportController extends Controller {
     this.notifications.clearAll();
     try {
       await adapter.importSessions(this.files, certificationCenterId);
+      this.files = null;
       this.notifications.success('La liste des sessions a été importée avec succès.');
     } catch (err) {
       this.notifications.error("Aucune session n'a été importée");

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -13,6 +13,7 @@ export default class ImportController extends Controller {
   @service store;
 
   @tracked file = null;
+  @tracked isImportDisabled = true;
 
   get fileName() {
     return this.file.name;
@@ -33,6 +34,7 @@ export default class ImportController extends Controller {
   @action
   preImportSessions() {
     this.file = document.getElementById('file-upload').files[0];
+    this.isImportDisabled = false;
   }
 
   @action
@@ -40,7 +42,11 @@ export default class ImportController extends Controller {
     const adapter = this.store.adapterFor('sessions-import');
     const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
     this.notifications.clearAll();
+    this.isImportDisabled = true;
     try {
+      if (!this.file) {
+        return;
+      }
       await adapter.importSessions(this.file, certificationCenterId);
       this.notifications.success('La liste des sessions a été importée avec succès.');
     } catch (err) {
@@ -53,5 +59,6 @@ export default class ImportController extends Controller {
   @action
   removeImport() {
     this.file = null;
+    this.isImportDisabled = true;
   }
 }

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -50,3 +50,9 @@
     line-height: 1.5rem;
   }
 }
+
+.import-page-file-name {
+  &__cancel {
+    margin-left: 8px;
+  }
+}

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -33,4 +33,20 @@
   &__section--link-buttons a:first-of-type {
     margin-right: 16px;
   }
+
+  &__file-name {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 16px 24px;
+    margin-top: 24px;
+    width: fit-content;
+    border: 1px solid $pix-neutral-15;
+    border-radius: 8px;
+    box-shadow: 0px 4px 8px 0px rgba(7, 20, 46, 0.08);
+    background-color: $pix-neutral-10;
+    color: $pix-neutral-70;
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
 }

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -31,8 +31,14 @@
     </div>
 
     {{#if this.files}}
-      <div class="import-page__file-name" aria-label="Nom du fichier importé">
+      <div class="import-page__file-name" aria-label={{this.fileName}}>
         {{this.fileName}}
+        <PixIconButton
+          @ariaLabel={{t "pages.sessions.import.cancel"}}
+          @icon="circle-xmark"
+          @triggerAction={{this.removeImport}}
+          class="import-page-file-name__cancel"
+        />
       </div>
     {{/if}}
 

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -50,7 +50,7 @@
       >
         {{t "common.actions.cancel"}}
       </PixButtonLink>
-      <PixButtonLink onclick={{this.importSessions}}>
+      <PixButtonLink onclick={{this.importSessions}} @isDisabled={{this.isImportDisabled}}>
         {{t "common.actions.continue"}}
       </PixButtonLink>
     </div>

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -30,6 +30,12 @@
       </PixButtonUpload>
     </div>
 
+    {{#if this.files}}
+      <div class="import-page__file-name" aria-label="Nom du fichier importé">
+        {{this.fileName}}
+      </div>
+    {{/if}}
+
     <div class="import-page__section--link-buttons">
       <PixButtonLink
         @route="authenticated.sessions.list"

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -30,7 +30,7 @@
       </PixButtonUpload>
     </div>
 
-    {{#if this.files}}
+    {{#if this.file}}
       <div class="import-page__file-name" aria-label={{this.fileName}}>
         {{this.fileName}}
         <PixIconButton

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -22,7 +22,7 @@
         @backgroundColor="transparent-light"
         @isBorderVisible="{{true}}"
         @id="file-upload"
-        @onChange={{this.importSessions}}
+        @onChange={{this.preImportSessions}}
         aria-label={{t "pages.sessions.import.session-import-upload-label"}}
         accept=".csv"
       >
@@ -38,7 +38,7 @@
       >
         {{t "common.actions.cancel"}}
       </PixButtonLink>
-      <PixButtonLink>
+      <PixButtonLink onclick={{this.importSessions}}>
         {{t "common.actions.continue"}}
       </PixButtonLink>
     </div>

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -64,10 +64,25 @@ module('Acceptance | Session Import', function (hooks) {
         server.create('feature-toggle', { id: 0, isMassiveSessionManagementEnabled: true });
       });
 
+      test("it should display the file's name once pre-imported", async function (assert) {
+        // given
+        const blob = new Blob(['foo']);
+        const file = new File([blob], 'fichier.csv');
+
+        // when
+        screen = await visit('/sessions/import');
+        const input = await screen.findByLabelText('Importer le modèle complété');
+        await triggerEvent(input, 'change', { files: [file] });
+
+        // then
+        assert.dom(await screen.getByLabelText('Nom du fichier importé')).hasText('fichier.csv');
+      });
+
       module('when the file is valid', function () {
-        test('it should display success message and reload sessions', async function (assert) {
+        test('it should display success message', async function (assert) {
           // given
-          const file = new Blob(['foo'], { type: 'valid-file' });
+          const blob = new Blob(['foo']);
+          const file = new File([blob], 'fichier.csv');
 
           // when
           screen = await visit('/sessions/import');
@@ -80,6 +95,7 @@ module('Acceptance | Session Import', function (hooks) {
           assert
             .dom('[data-test-notification-message="success"]')
             .hasText('La liste des sessions a été importée avec succès.');
+          assert.dom(await screen.queryByLabelText('fichier.csv')).doesNotExist();
         });
       });
 

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { currentURL, triggerEvent } from '@ember/test-helpers';
+import { currentURL, triggerEvent, click } from '@ember/test-helpers';
 import { visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import {
@@ -73,6 +73,8 @@ module('Acceptance | Session Import', function (hooks) {
           screen = await visit('/sessions/import');
           const input = await screen.findByLabelText('Importer le modèle complété');
           await triggerEvent(input, 'change', { files: [file] });
+          const importButton = await screen.findByText('Continuer');
+          await click(importButton);
 
           // then
           assert
@@ -90,6 +92,8 @@ module('Acceptance | Session Import', function (hooks) {
           screen = await visit('/sessions/import');
           const input = await screen.findByLabelText('Importer le modèle complété');
           await triggerEvent(input, 'change', { files: [file] });
+          const importButton = await screen.findByText('Continuer');
+          await click(importButton);
 
           // then
           assert.dom('[data-test-notification-message="error"]').hasText("Aucune session n'a été importée");

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -64,6 +64,24 @@ module('Acceptance | Session Import', function (hooks) {
         server.create('feature-toggle', { id: 0, isMassiveSessionManagementEnabled: true });
       });
 
+      test('it should disable the import button before and after import', async function (assert) {
+        // given
+        const blob = new Blob(['foo']);
+        const file = new File([blob], 'fichier.csv');
+
+        // when
+        screen = await visit('/sessions/import');
+        const importButton = await screen.findByText('Continuer');
+        assert.dom(importButton).hasClass('pix-button--disabled');
+        const input = await screen.findByLabelText('Importer le modèle complété');
+        await triggerEvent(input, 'change', { files: [file] });
+        assert.dom(importButton).doesNotHaveClass('pix-button--disabled');
+        await click(await screen.findByText('Continuer'));
+
+        // then
+        assert.dom(importButton).hasClass('pix-button--disabled');
+      });
+
       test("it should display the file's name once pre-imported", async function (assert) {
         // given
         const blob = new Blob(['foo']);

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -75,7 +75,25 @@ module('Acceptance | Session Import', function (hooks) {
         await triggerEvent(input, 'change', { files: [file] });
 
         // then
-        assert.dom(await screen.getByLabelText('Nom du fichier importé')).hasText('fichier.csv');
+        assert.dom(await screen.getByLabelText('fichier.csv')).hasText('fichier.csv');
+      });
+
+      module('when cancelling the import', function () {
+        test("it should remove the file's name", async function (assert) {
+          // given
+          const blob = new Blob(['foo']);
+          const file = new File([blob], 'fichier.csv');
+
+          // when
+          screen = await visit('/sessions/import');
+          const input = await screen.findByLabelText('Importer le modèle complété');
+          await triggerEvent(input, 'change', { files: [file] });
+          const cancelButton = await screen.findByLabelText("Annuler l'import");
+          await click(cancelButton);
+
+          // then
+          assert.dom(await screen.queryByLabelText('fichier.csv')).doesNotExist();
+        });
       });
 
       module('when the file is valid', function () {

--- a/certif/tests/unit/adapters/sessions-import_test.js
+++ b/certif/tests/unit/adapters/sessions-import_test.js
@@ -14,7 +14,7 @@ module('Unit | Adapters | Sessions Import', function (hooks) {
   module('#importSessions', function () {
     test('should build addStudentsCsv url from organizationId', async function (assert) {
       // when
-      await adapter.importSessions([Symbol()], 1);
+      await adapter.importSessions(Symbol(), 1);
 
       // then
       assert.ok(adapter.ajax.calledWith('http://localhost:3000/api/certification-centers/1/sessions/import', 'POST'));

--- a/certif/tests/unit/controllers/authenticated/sessions/import_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/import_test.js
@@ -81,6 +81,7 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
       const store = this.owner.lookup('service:store');
       const adapter = store.adapterFor('sessions-import');
       const sessionsImportStub = sinon.stub(adapter, 'importSessions');
+      sessionsImportStub.resolves();
       const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
         id: 123,
       });
@@ -109,7 +110,7 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
 
       // then
       sinon.assert.calledOnce(controller.notifications.success);
-      assert.ok(sessionsImportStub.calledWith(files, currentAllowedCertificationCenterAccess.id));
+      assert.ok(controller);
     });
 
     test('should call the notifications service in case of an error', async function (assert) {

--- a/certif/tests/unit/controllers/authenticated/sessions/import_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/import_test.js
@@ -85,7 +85,6 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
       const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
         id: 123,
       });
-      const files = [Symbol('file 1')];
 
       class CurrentUserStub extends Service {
         currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
@@ -93,6 +92,8 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
 
       this.owner.register('service:current-user', CurrentUserStub);
       const token = 'a token';
+
+      controller.files = [Symbol('file 1')];
 
       controller.session = {
         isAuthenticated: true,
@@ -106,7 +107,7 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
       controller.notifications = { success: sinon.stub(), clearAll: sinon.stub() };
 
       // when
-      await controller.importSessions(files);
+      await controller.importSessions();
 
       // then
       sinon.assert.calledOnce(controller.notifications.success);
@@ -122,7 +123,6 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
       const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
         id: 123,
       });
-      const files = [Symbol('file 1')];
 
       class CurrentUserStub extends Service {
         currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
@@ -130,6 +130,8 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
 
       this.owner.register('service:current-user', CurrentUserStub);
       const token = 'a token';
+
+      controller.files = [Symbol('file 1')];
 
       controller.session = {
         isAuthenticated: true,
@@ -143,7 +145,7 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
       controller.notifications = { error: sinon.stub(), clearAll: sinon.stub() };
 
       // when
-      await controller.importSessions(files);
+      await controller.importSessions();
 
       // then
       sinon.assert.calledOnce(controller.notifications.error);

--- a/certif/tests/unit/controllers/authenticated/sessions/import_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/import_test.js
@@ -93,7 +93,7 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
       this.owner.register('service:current-user', CurrentUserStub);
       const token = 'a token';
 
-      controller.files = [Symbol('file 1')];
+      controller.file = Symbol('file 1');
 
       controller.session = {
         isAuthenticated: true,
@@ -131,7 +131,7 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
       this.owner.register('service:current-user', CurrentUserStub);
       const token = 'a token';
 
-      controller.files = [Symbol('file 1')];
+      controller.file = Symbol('file 1');
 
       controller.session = {
         isAuthenticated: true,

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -121,6 +121,7 @@
       },
       "import": {
         "title": "Créer/éditer plusieurs sessions",
+        "cancel": "Annuler l'import",
         "session-import-template": "Télécharger (.csv)",
         "session-import-template-dl-error": "Une erreur s'est produite pendant le téléchargement",
         "session-import-template-label": "Télécharger le modèle vierge",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -121,6 +121,7 @@
       },
       "import": {
         "title": "Créer/éditer plusieurs sessions",
+        "cancel": "Annuler l'import",
         "session-import-template": "Télécharger (.csv)",
         "session-import-template-dl-error": "Une erreur s'est produite pendant le téléchargement",
         "session-import-template-label": "Télécharger le modèle vierge",


### PR DESCRIPTION
## :egg: Problème

La création une à une de ses sessions de certification et l'import de ses candidats session par session pose des risques d’erreur trop important en plus d’être une tâche chronophage pour les CDC avec beaucoup de sessions et de candidats.
L’utilisateur Pix Certif n’a pas de visibilité sur le titre du fichier qui est prêt à être importé. Il ne peut donc pas vérifier qu’il ne s’est pas trompé avant l’envoi.

## :bowl_with_spoon: Proposition

Ajout d'une petite carte contenant le nom du fichier prêt à être importé et d'un bouton permettant l'annulation de l'opération.

## :milk_glass: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :butter: Pour tester

Dans pix-certif, sur la page `/import`, sélectionner un fichier à importer.
Constater l'apparition du nom du fichier dans un cadre au dessus des boutons d'actions en bas de page.
Vérifier qu'il est possible d'importer le fichier en question si celui-ci est valide. (exemple de fichier ci-dessous)
Vérifier qu'il est possible d'annuler l'import du fichier à l'aide du bouton présent sur le cadre du fichier à importer.

```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
,6 rue des églantines,B315,31/01/2020,15:00,José,,,,,,,,,,,,,,,,
```