### PR TITLE
[BUGFIX] Eviter les doublons de candidat lors d'import sessions en masse (PIX-7008)

### DIFF
--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -42,11 +42,14 @@ function deserializeForSessionsImport(parsedCsvData) {
         sessions.push(currentParsedSession);
       }
     } else if (_hasSessionIdAndCandidateInformation(data)) {
-      currentParsedSession = {
-        sessionId: data.sessionId,
-        certificationCandidates: [],
-      };
-      sessions.push(currentParsedSession);
+      currentParsedSession = sessions.find((session) => session.sessionId === data.sessionId);
+      if (!currentParsedSession) {
+        currentParsedSession = {
+          sessionId: data.sessionId,
+          certificationCandidates: [],
+        };
+        sessions.push(currentParsedSession);
+      }
     } else {
       currentParsedSession = sessions.at(-1);
     }

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -293,6 +293,10 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
               sessionId: 1,
               candidateNumber: 1,
             }),
+            _lineWithSessionIdAndCandidate({
+              sessionId: 1,
+              candidateNumber: 2,
+            }),
           ];
 
           const expectedResult = [
@@ -303,6 +307,23 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                 {
                   lastName: 'Candidat 1',
                   firstName: 'Candidat 1',
+                  birthdate: '1981-03-01',
+                  birthINSEECode: '75015',
+                  birthPostalCode: '',
+                  billingMode: 'Prépayée',
+                  birthCity: '',
+                  birthCountry: 'France',
+                  email: '',
+                  externalId: '',
+                  extraTimePercentage: null,
+                  prepaymentCode: '43',
+                  resultRecipientEmail: 'robindahood@email.fr',
+                  sex: 'M',
+                  complementaryCertifications: [],
+                },
+                {
+                  lastName: 'Candidat 2',
+                  firstName: 'Candidat 2',
                   birthdate: '1981-03-01',
                   birthINSEECode: '75015',
                   birthPostalCode: '',


### PR DESCRIPTION
## :egg: Problème
Lors de la création de plusieurs sessions à la fois avec des candidats ou bien lors de l’import de listes de candidats dans des sessions pré-existante, l’utilisateur rempli les informations des candidats dans le fichier csv d’import en masse.

Il peut faire l’erreur d’inscrire les mêmes informations pour le même candidat sur plusieurs lignes différentes qui correspondent à la même session.

Le candidat est rajouté autant de fois que de lignes remplies avec ses informations.

## :bowl_with_spoon: Proposition
L’import devrait être rejeté et l'utilisateur devrait avoir une erreur pour l’avertir qu’il doit corriger son fichier avant de le réimporter de nouveau.


## :butter: Pour tester
- Depuis pix-certif: 
  - Tenter d'importer plusieurs fois le même candidat dans une session
  - Constater que l'import est impossible
  - Retirer les doublons et constater que l'import est traité avec succès