### PR TITLE
[FEATURE] Modification du design de bouton de création de session (PIX-7031).

### DIFF
--- a/certif/app/components/sessions/panel-header.hbs
+++ b/certif/app/components/sessions/panel-header.hbs
@@ -3,7 +3,6 @@
   <div class="session-list-header__actions">
     <PixButtonLink @route="authenticated.sessions.new">
       {{t "pages.sessions.list.header.session-creation"}}
-      <FaIcon @icon="plus" class="new-session-icon" />
     </PixButtonLink>
     {{#if this.shouldRenderImportTemplateButton}}
       <PixButtonLink @route="authenticated.sessions.import">


### PR DESCRIPTION
## :egg: Problème

Dans le cadre de l'épix Gestion massive des sessions, un nouveau bouton a été rajouté sur la page de listing des sessions qui permet de Créer ou éditer plusieurs sessions.
Afin d'équilibrer le design des deux boutons, le bouton préexistant qui permet de créer une seule session a été modifié 

## :bowl_with_spoon: Proposition

Supprimer le `+` : intitulé du bouton devient `Créer une session` au lieu de `Créer une session +`

## :milk_glass: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :butter: Pour tester

Sur pix-certif, vérifier que le bouton de création de session ne contienne plus le `+`
Voir la [maquette](https://www.figma.com/file/IWVcwbasXoFUQPhIG097XT/Pix-Certif?node-id=1350%3A26895&t=NBnVucSFUZMu6QOf-0)
