### PR TITLE
[TECH] Mettre à jour `ember-cli-mirage` dans Pix Admin (PIX-7042).

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -36,7 +36,7 @@
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-inject-live-reload": "^2.1.0",
         "ember-cli-matomo-tag-manager": "^1.3.1",
-        "ember-cli-mirage": "^1.1.8",
+        "ember-cli-mirage": "^2.4.0",
         "ember-cli-notifications": "^8.0.0",
         "ember-cli-sass": "^11.0.1",
         "ember-cli-showdown": "^6.0.1",
@@ -5222,20 +5222,6 @@
       },
       "engines": {
         "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@ember/test-helpers/node_modules/ember-destroyable-polyfill": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.3.tgz",
-      "integrity": "sha512-TovtNqCumzyAiW0/OisSkkVK93xnVF4NRU6+FN0ubpfwEOpRrmM2RqDwXI6YAChCgSHON1cz0DfQStpA1Gjuuw==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.22.1",
-        "ember-cli-version-checker": "^5.1.1",
-        "ember-compatibility-helpers": "^1.2.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
       }
     },
     "node_modules/@ember/test-helpers/node_modules/fs-tree-diff": {
@@ -15195,23 +15181,100 @@
       }
     },
     "node_modules/ember-cli-mirage": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ember-cli-mirage/-/ember-cli-mirage-1.1.8.tgz",
-      "integrity": "sha512-i0/CNwdyza+o+0RW92i/dEhAqTcyoAJ9jGKKiOLK74RwDG0Bgt5w/CdqKfIFBf/lIGPXHPveneWsyckeSiVr4A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-mirage/-/ember-cli-mirage-2.4.0.tgz",
+      "integrity": "sha512-cy8B+IZV07V6xgnFzktKUsntTQvIqPSS3u4+XaLdNW91yOowLsN2BsuQldN3eCnwswgE3a9eGNGS4I0BD4llNA==",
       "dev": true,
       "dependencies": {
+        "@embroider/macros": "^0.41.0",
         "broccoli-file-creator": "^2.1.1",
-        "broccoli-funnel": "^2.0.2",
-        "broccoli-merge-trees": "^3.0.2",
-        "ember-auto-import": "^1.2.19",
-        "ember-cli-babel": "^7.5.0",
-        "ember-get-config": "^0.2.2",
-        "ember-inflector": "^2.0.0 || ^3.0.0",
+        "broccoli-funnel": "^3.0.3",
+        "broccoli-merge-trees": "^4.2.0",
+        "ember-auto-import": "^1.12.0",
+        "ember-cli-babel": "^7.26.6",
+        "ember-destroyable-polyfill": "^2.0.3",
+        "ember-get-config": "0.2.4 - 0.5.0",
+        "ember-inflector": "^2.0.0 || ^3.0.0 || ^4.0.2",
         "lodash-es": "^4.17.11",
-        "miragejs": "^0.1.31"
+        "miragejs": "^0.1.43"
       },
       "engines": {
-        "node": "6.* || 8.* || >= 10.*"
+        "node": ">= 10.*"
+      },
+      "peerDependencies": {
+        "@ember/test-helpers": "*",
+        "ember-data": "*",
+        "ember-qunit": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ember/test-helpers": {
+          "optional": true
+        },
+        "ember-data": {
+          "optional": true
+        },
+        "ember-qunit": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ember-cli-mirage/node_modules/@embroider/macros": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-0.41.0.tgz",
+      "integrity": "sha512-QISzwEEfLsskZeL0jyZDs1RoQSotwBWj+4upTogNHuxQP5j/9H3IMG/3QB1gh8GEpbudATb/cS4NDYK3UBxufw==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/shared-internals": "0.41.0",
+        "assert-never": "^1.1.0",
+        "ember-cli-babel": "^7.23.0",
+        "lodash": "^4.17.10",
+        "resolve": "^1.8.1",
+        "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": "10.* || 12.* || >= 14"
+      }
+    },
+    "node_modules/ember-cli-mirage/node_modules/@embroider/macros/node_modules/@embroider/shared-internals": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-0.41.0.tgz",
+      "integrity": "sha512-fiqUVB6cfh2UBEFE4yhT5EzagkZ1Q26+OhBV0nJszFEJZx4DqVIb3pxSSZ8P+HhpxuJsQ2XpMA/j02ZPFZfbdQ==",
+      "dev": true,
+      "dependencies": {
+        "ember-rfc176-data": "^0.3.17",
+        "fs-extra": "^7.0.1",
+        "lodash": "^4.17.10",
+        "pkg-up": "^3.1.0",
+        "resolve-package-path": "^1.2.2",
+        "semver": "^7.3.2",
+        "typescript-memoize": "^1.0.0-alpha.3"
+      },
+      "engines": {
+        "node": "10.* || 12.* || >= 14"
+      }
+    },
+    "node_modules/ember-cli-mirage/node_modules/@embroider/macros/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/ember-cli-mirage/node_modules/@embroider/macros/node_modules/resolve-package-path": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-1.2.7.tgz",
+      "integrity": "sha512-fVEKHGeK85bGbVFuwO9o1aU0n3vqQGrezPc51JGu9UTXpFQfWq5qCeKxyaRUSvephs+06c5j5rPq/dzHGEo8+Q==",
+      "dev": true,
+      "dependencies": {
+        "path-root": "^0.1.1",
+        "resolve": "^1.10.0"
       }
     },
     "node_modules/ember-cli-mirage/node_modules/@embroider/shared-internals": {
@@ -15455,6 +15518,75 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ember-cli-mirage/node_modules/broccoli-funnel": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz",
+      "integrity": "sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==",
+      "dev": true,
+      "dependencies": {
+        "array-equal": "^1.0.0",
+        "broccoli-plugin": "^4.0.7",
+        "debug": "^4.1.1",
+        "fs-tree-diff": "^2.0.1",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "walk-sync": "^2.0.2"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-cli-mirage/node_modules/broccoli-funnel/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ember-cli-mirage/node_modules/broccoli-funnel/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/ember-cli-mirage/node_modules/broccoli-funnel/node_modules/walk-sync": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^2.0.0",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-cli-mirage/node_modules/broccoli-merge-trees": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz",
+      "integrity": "sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-plugin": "^4.0.2",
+        "merge-trees": "^2.0.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
       }
     },
     "node_modules/ember-cli-mirage/node_modules/broccoli-plugin": {
@@ -15732,6 +15864,19 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/ember-cli-mirage/node_modules/matcher-collection": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
+      "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "minimatch": "^3.0.2"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/ember-cli-mirage/node_modules/micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -15808,6 +15953,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/ember-cli-mirage/node_modules/pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ember-cli-mirage/node_modules/promise-map-series": {
@@ -18881,9 +19038,9 @@
       }
     },
     "node_modules/ember-destroyable-polyfill": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.2.tgz",
-      "integrity": "sha512-9t+ya+9c+FkNM5IAyJIv6ETG8jfZQaUnFCO5SeLlV0wkSw7TOexyb61jh5GVee0KmknfRhrRGGAyT4Y0TwkZ+w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.3.tgz",
+      "integrity": "sha512-TovtNqCumzyAiW0/OisSkkVK93xnVF4NRU6+FN0ubpfwEOpRrmM2RqDwXI6YAChCgSHON1cz0DfQStpA1Gjuuw==",
       "dev": true,
       "dependencies": {
         "ember-cli-babel": "^7.22.1",
@@ -26613,13 +26770,10 @@
       ]
     },
     "node_modules/fake-xml-http-request": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fake-xml-http-request/-/fake-xml-http-request-2.1.1.tgz",
-      "integrity": "sha512-Kn2WYYS6cDBS5jq/voOfSGCA0TafOYAUPbEp8mUVpD/DVV5bQIDjlq+MLLvNUokkbTpjBVlLDaM5PnX+PwZMlw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fake-xml-http-request/-/fake-xml-http-request-2.1.2.tgz",
+      "integrity": "sha512-HaFMBi7r+oEC9iJNpc3bvcW7Z7iLmM26hPDmlb0mFwyANSsOQAtJxbdWsXITKOzZUyMYK0zYCv3h5yDj9TsiXg==",
+      "dev": true
     },
     "node_modules/faker": {
       "version": "5.5.2",
@@ -30656,9 +30810,9 @@
       "dev": true
     },
     "node_modules/miragejs": {
-      "version": "0.1.41",
-      "resolved": "https://registry.npmjs.org/miragejs/-/miragejs-0.1.41.tgz",
-      "integrity": "sha512-ur8x7sBskgey64vdzKGVCVC3hgKXWl2Cg5lZbxd6OmKrhr9LCCP/Bv7qh4wsQxIMHZnENxybFATXnrQ+rzSOWQ==",
+      "version": "0.1.47",
+      "resolved": "https://registry.npmjs.org/miragejs/-/miragejs-0.1.47.tgz",
+      "integrity": "sha512-99tuCbIAlMhNhyF3s5d3+5/FdJ7O4jSq/5e3e+sDv7L8dZdwJuwutXe0pobJ7hm6yRChTDjK+Nn8dZZd175wbg==",
       "dev": true,
       "dependencies": {
         "@miragejs/pretender-node-polyfill": "^0.1.0",
@@ -30686,7 +30840,7 @@
         "lodash.uniq": "^4.5.0",
         "lodash.uniqby": "^4.7.0",
         "lodash.values": "^4.3.0",
-        "pretender": "^3.4.3"
+        "pretender": "^3.4.7"
       },
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -33913,12 +34067,12 @@
       }
     },
     "node_modules/pretender": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/pretender/-/pretender-3.4.3.tgz",
-      "integrity": "sha512-AlbkBly9R8KR+R0sTCJ/ToOeEoUMtt52QVCetui5zoSmeLOU3S8oobFsyPLm1O2txR6t58qDNysqPnA1vVi8Hg==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/pretender/-/pretender-3.4.7.tgz",
+      "integrity": "sha512-jkPAvt1BfRi0RKamweJdEcnjkeu7Es8yix3bJ+KgBC5VpG/Ln4JE3hYN6vJym4qprm8Xo5adhWpm3HCoft1dOw==",
       "dev": true,
       "dependencies": {
-        "fake-xml-http-request": "^2.1.1",
+        "fake-xml-http-request": "^2.1.2",
         "route-recognizer": "^0.3.3"
       }
     },
@@ -43783,17 +43937,6 @@
             "silent-error": "^1.1.1"
           }
         },
-        "ember-destroyable-polyfill": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.3.tgz",
-          "integrity": "sha512-TovtNqCumzyAiW0/OisSkkVK93xnVF4NRU6+FN0ubpfwEOpRrmM2RqDwXI6YAChCgSHON1cz0DfQStpA1Gjuuw==",
-          "dev": true,
-          "requires": {
-            "ember-cli-babel": "^7.22.1",
-            "ember-cli-version-checker": "^5.1.1",
-            "ember-compatibility-helpers": "^1.2.1"
-          }
-        },
         "fs-tree-diff": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
@@ -52642,22 +52785,76 @@
       }
     },
     "ember-cli-mirage": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ember-cli-mirage/-/ember-cli-mirage-1.1.8.tgz",
-      "integrity": "sha512-i0/CNwdyza+o+0RW92i/dEhAqTcyoAJ9jGKKiOLK74RwDG0Bgt5w/CdqKfIFBf/lIGPXHPveneWsyckeSiVr4A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-mirage/-/ember-cli-mirage-2.4.0.tgz",
+      "integrity": "sha512-cy8B+IZV07V6xgnFzktKUsntTQvIqPSS3u4+XaLdNW91yOowLsN2BsuQldN3eCnwswgE3a9eGNGS4I0BD4llNA==",
       "dev": true,
       "requires": {
+        "@embroider/macros": "^0.41.0",
         "broccoli-file-creator": "^2.1.1",
-        "broccoli-funnel": "^2.0.2",
-        "broccoli-merge-trees": "^3.0.2",
-        "ember-auto-import": "^1.2.19",
-        "ember-cli-babel": "^7.5.0",
-        "ember-get-config": "^0.2.2",
-        "ember-inflector": "^2.0.0 || ^3.0.0",
+        "broccoli-funnel": "^3.0.3",
+        "broccoli-merge-trees": "^4.2.0",
+        "ember-auto-import": "^1.12.0",
+        "ember-cli-babel": "^7.26.6",
+        "ember-destroyable-polyfill": "^2.0.3",
+        "ember-get-config": "0.2.4 - 0.5.0",
+        "ember-inflector": "^2.0.0 || ^3.0.0 || ^4.0.2",
         "lodash-es": "^4.17.11",
-        "miragejs": "^0.1.31"
+        "miragejs": "^0.1.43"
       },
       "dependencies": {
+        "@embroider/macros": {
+          "version": "0.41.0",
+          "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-0.41.0.tgz",
+          "integrity": "sha512-QISzwEEfLsskZeL0jyZDs1RoQSotwBWj+4upTogNHuxQP5j/9H3IMG/3QB1gh8GEpbudATb/cS4NDYK3UBxufw==",
+          "dev": true,
+          "requires": {
+            "@embroider/shared-internals": "0.41.0",
+            "assert-never": "^1.1.0",
+            "ember-cli-babel": "^7.23.0",
+            "lodash": "^4.17.10",
+            "resolve": "^1.8.1",
+            "semver": "^7.3.2"
+          },
+          "dependencies": {
+            "@embroider/shared-internals": {
+              "version": "0.41.0",
+              "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-0.41.0.tgz",
+              "integrity": "sha512-fiqUVB6cfh2UBEFE4yhT5EzagkZ1Q26+OhBV0nJszFEJZx4DqVIb3pxSSZ8P+HhpxuJsQ2XpMA/j02ZPFZfbdQ==",
+              "dev": true,
+              "requires": {
+                "ember-rfc176-data": "^0.3.17",
+                "fs-extra": "^7.0.1",
+                "lodash": "^4.17.10",
+                "pkg-up": "^3.1.0",
+                "resolve-package-path": "^1.2.2",
+                "semver": "^7.3.2",
+                "typescript-memoize": "^1.0.0-alpha.3"
+              }
+            },
+            "fs-extra": {
+              "version": "7.0.1",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+              "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+              }
+            },
+            "resolve-package-path": {
+              "version": "1.2.7",
+              "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-1.2.7.tgz",
+              "integrity": "sha512-fVEKHGeK85bGbVFuwO9o1aU0n3vqQGrezPc51JGu9UTXpFQfWq5qCeKxyaRUSvephs+06c5j5rPq/dzHGEo8+Q==",
+              "dev": true,
+              "requires": {
+                "path-root": "^0.1.1",
+                "resolve": "^1.10.0"
+              }
+            }
+          }
+        },
         "@embroider/shared-internals": {
           "version": "1.8.3",
           "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-1.8.3.tgz",
@@ -52877,6 +53074,60 @@
                 "is-extendable": "^0.1.0"
               }
             }
+          }
+        },
+        "broccoli-funnel": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz",
+          "integrity": "sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "broccoli-plugin": "^4.0.7",
+            "debug": "^4.1.1",
+            "fs-tree-diff": "^2.0.1",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "walk-sync": "^2.0.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.3.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+              "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+              "dev": true,
+              "requires": {
+                "ms": "2.1.2"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            },
+            "walk-sync": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+              "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+              "dev": true,
+              "requires": {
+                "@types/minimatch": "^3.0.3",
+                "ensure-posix-path": "^1.1.0",
+                "matcher-collection": "^2.0.0",
+                "minimatch": "^3.0.4"
+              }
+            }
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz",
+          "integrity": "sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^4.0.2",
+            "merge-trees": "^2.0.0"
           }
         },
         "broccoli-plugin": {
@@ -53108,6 +53359,16 @@
             }
           }
         },
+        "matcher-collection": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
+          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "minimatch": "^3.0.2"
+          }
+        },
         "micromatch": {
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -53163,6 +53424,15 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
           "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        },
+        "pkg-up": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+          "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
           "dev": true,
           "requires": {
             "find-up": "^3.0.0"
@@ -55092,9 +55362,9 @@
       }
     },
     "ember-destroyable-polyfill": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.2.tgz",
-      "integrity": "sha512-9t+ya+9c+FkNM5IAyJIv6ETG8jfZQaUnFCO5SeLlV0wkSw7TOexyb61jh5GVee0KmknfRhrRGGAyT4Y0TwkZ+w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.3.tgz",
+      "integrity": "sha512-TovtNqCumzyAiW0/OisSkkVK93xnVF4NRU6+FN0ubpfwEOpRrmM2RqDwXI6YAChCgSHON1cz0DfQStpA1Gjuuw==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.22.1",
@@ -61158,9 +61428,9 @@
       "dev": true
     },
     "fake-xml-http-request": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fake-xml-http-request/-/fake-xml-http-request-2.1.1.tgz",
-      "integrity": "sha512-Kn2WYYS6cDBS5jq/voOfSGCA0TafOYAUPbEp8mUVpD/DVV5bQIDjlq+MLLvNUokkbTpjBVlLDaM5PnX+PwZMlw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fake-xml-http-request/-/fake-xml-http-request-2.1.2.tgz",
+      "integrity": "sha512-HaFMBi7r+oEC9iJNpc3bvcW7Z7iLmM26hPDmlb0mFwyANSsOQAtJxbdWsXITKOzZUyMYK0zYCv3h5yDj9TsiXg==",
       "dev": true
     },
     "faker": {
@@ -64447,9 +64717,9 @@
       }
     },
     "miragejs": {
-      "version": "0.1.41",
-      "resolved": "https://registry.npmjs.org/miragejs/-/miragejs-0.1.41.tgz",
-      "integrity": "sha512-ur8x7sBskgey64vdzKGVCVC3hgKXWl2Cg5lZbxd6OmKrhr9LCCP/Bv7qh4wsQxIMHZnENxybFATXnrQ+rzSOWQ==",
+      "version": "0.1.47",
+      "resolved": "https://registry.npmjs.org/miragejs/-/miragejs-0.1.47.tgz",
+      "integrity": "sha512-99tuCbIAlMhNhyF3s5d3+5/FdJ7O4jSq/5e3e+sDv7L8dZdwJuwutXe0pobJ7hm6yRChTDjK+Nn8dZZd175wbg==",
       "dev": true,
       "requires": {
         "@miragejs/pretender-node-polyfill": "^0.1.0",
@@ -64477,7 +64747,7 @@
         "lodash.uniq": "^4.5.0",
         "lodash.uniqby": "^4.7.0",
         "lodash.values": "^4.3.0",
-        "pretender": "^3.4.3"
+        "pretender": "^3.4.7"
       },
       "dependencies": {
         "lodash.assign": {
@@ -66991,12 +67261,12 @@
       "dev": true
     },
     "pretender": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/pretender/-/pretender-3.4.3.tgz",
-      "integrity": "sha512-AlbkBly9R8KR+R0sTCJ/ToOeEoUMtt52QVCetui5zoSmeLOU3S8oobFsyPLm1O2txR6t58qDNysqPnA1vVi8Hg==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/pretender/-/pretender-3.4.7.tgz",
+      "integrity": "sha512-jkPAvt1BfRi0RKamweJdEcnjkeu7Es8yix3bJ+KgBC5VpG/Ln4JE3hYN6vJym4qprm8Xo5adhWpm3HCoft1dOw==",
       "dev": true,
       "requires": {
-        "fake-xml-http-request": "^2.1.1",
+        "fake-xml-http-request": "^2.1.2",
         "route-recognizer": "^0.3.3"
       }
     },

--- a/admin/package.json
+++ b/admin/package.json
@@ -61,7 +61,7 @@
     "ember-cli-htmlbars": "^6.1.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-matomo-tag-manager": "^1.3.1",
-    "ember-cli-mirage": "^1.1.8",
+    "ember-cli-mirage": "^2.4.0",
     "ember-cli-notifications": "^8.0.0",
     "ember-cli-sass": "^11.0.1",
     "ember-cli-showdown": "^6.0.1",


### PR DESCRIPTION
## :egg: Problème
Ember-cli-mirage n'est pas à jour et nous le fait savoir : 
<img width="857" alt="image" src="https://user-images.githubusercontent.com/26384707/217273237-9b560c5f-21c7-4083-8a28-150c049f6815.png">


## :bowl_with_spoon: Proposition
Mettre à jour la librairie

## :milk_glass: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :butter: Pour tester
Vérifier que la CI fonctionne correctement