### PR TITLE
[TECH] Ajouter une config pour Renovate (PIX-7043).

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>1024pix/renovate-config:default"],
+  "enabled": true
+}


### PR DESCRIPTION
## :egg: Problème
[Depuis l'ADR](https://github.com/1024pix/pix/blob/f3699bfccbdbb035acdfa757ee1dbfd3cf04bcc0/docs/adr/0039-mise-%C3%A0-jour-des-d%C3%A9pendances.md), nous n'avons pas mis en place de configuration Renovate sur le monorepo.

## :bowl_with_spoon: Proposition
Ajouter la config pour Renovate, pour le monorepo nous partons sur la configuration par défaut qui nécessite 1 approve pour que la PR se merge

## :milk_glass: Remarque
Renovate commencera les PR dès qu'on ajoutera le repo dans notre config GitHub, ça ne se passe donc pas dès le merge de cette PR

## :butter: Pour tester
RAS