### PR TITLE
[FEATURE] Retirer le réferentiel 'France' de la liste des référentiels mis à disposition aux utilisateurs de PixOrga pour faire une sélection de sujets (PIX-7045)

### DIFF
--- a/api/lib/domain/usecases/get-learning-content-for-target-profile-submission.js
+++ b/api/lib/domain/usecases/get-learning-content-for-target-profile-submission.js
@@ -1,4 +1,4 @@
-const AUTHORIZED_FRAMEWORKS = ['Pix', 'France'];
+const AUTHORIZED_FRAMEWORKS = ['Pix'];
 
 module.exports = async function getLearningContentForTargetProfileSubmission({ learningContentRepository, locale }) {
   return learningContentRepository.findByFrameworkNames({

--- a/api/tests/acceptance/application/frameworks/frameworks-controller_test.js
+++ b/api/tests/acceptance/application/frameworks/frameworks-controller_test.js
@@ -309,23 +309,6 @@ describe('Acceptance | Controller | frameworks-controller', function () {
               },
             },
           },
-          {
-            type: 'frameworks',
-            id: 'frameworkFrance',
-            attributes: {
-              name: 'France',
-            },
-            relationships: {
-              areas: {
-                data: [
-                  {
-                    type: 'areas',
-                    id: 'areaFrance1',
-                  },
-                ],
-              },
-            },
-          },
         ],
         included: [
           {
@@ -389,72 +372,6 @@ describe('Acceptance | Controller | frameworks-controller', function () {
                   {
                     type: 'competences',
                     id: 'competencePix1_1',
-                  },
-                ],
-              },
-            },
-          },
-          {
-            type: 'tubes',
-            id: 'tubeFrance1_1_1_1',
-            attributes: {
-              name: '@tubeFrance1_1_1_1',
-              'is-mobile-compliant': true,
-              'is-tablet-compliant': false,
-              'practical-description': 'tubeFrance1_1_1_1 practicalDescription fr',
-              'practical-title': 'tubeFrance1_1_1_1 practicalTitle fr',
-            },
-          },
-          {
-            type: 'thematics',
-            id: 'thematicFrance1_1_1',
-            attributes: {
-              index: 0,
-              name: 'thematicFrance1_1_1 name fr',
-            },
-            relationships: {
-              tubes: {
-                data: [
-                  {
-                    type: 'tubes',
-                    id: 'tubeFrance1_1_1_1',
-                  },
-                ],
-              },
-            },
-          },
-          {
-            type: 'competences',
-            id: 'competenceFrance1_1',
-            attributes: {
-              index: 0,
-              name: 'competenceFrance1_1 name fr',
-            },
-            relationships: {
-              thematics: {
-                data: [
-                  {
-                    type: 'thematics',
-                    id: 'thematicFrance1_1_1',
-                  },
-                ],
-              },
-            },
-          },
-          {
-            type: 'areas',
-            id: 'areaFrance1',
-            attributes: {
-              code: 1,
-              color: 'areaFrance1 color',
-              title: 'areaFrance1 title fr',
-            },
-            relationships: {
-              competences: {
-                data: [
-                  {
-                    type: 'competences',
-                    id: 'competenceFrance1_1',
                   },
                 ],
               },


### PR DESCRIPTION
## :egg: Problème
En fait, faut pas France

## :bowl_with_spoon: Proposition
On retire France

## :milk_glass: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :butter: Pour tester
aller dans la /selection-sujets sur PixOrga et constater que le référentiel France n'apparaît plus
