### PR TITLE
[FEATURE] Ajout d'une page d'édition de déclencheurs de contenus formatifs dans Pix Admin (PIX-7023)

### DIFF
--- a/admin/app/components/trainings/create-training-triggers.hbs
+++ b/admin/app/components/trainings/create-training-triggers.hbs
@@ -1,0 +1,33 @@
+<section class="page-section trigger-card">
+  <h2 class="trigger-card__title">{{t "pages.trainings.training.triggers.prerequisite.title"}}</h2>
+  <p class="trigger-card__description">Si l’apprenant réussit tous les acquis des sujets sélectionnés alors le contenu
+    formatif ne lui sera pas proposé</p>
+  <PixButtonLink
+    class="trigger-card__toggler"
+    @route="authenticated.trainings.training.triggers.edit"
+    @query={{hash type="prerequisite"}}
+    @backgroundColor="transparent-light"
+    @isBorderVisible={{true}}
+    aria-label={{t "pages.trainings.training.triggers.prerequisite.alternative-title"}}
+  >
+    <FaIcon @icon="plus" />
+    {{t "pages.trainings.training.triggers.prerequisite.title"}}
+  </PixButtonLink>
+</section>
+
+<section class="page-section trigger-card">
+  <h2 class="trigger-card__title">{{t "pages.trainings.training.triggers.goal.title"}}</h2>
+  <p class="trigger-card__description">Si l’apprenant réussit les acquis des sujets sélectionnés alors le contenu
+    formatif lui sera proposé</p>
+  <PixButtonLink
+    class="trigger-card__toggler"
+    @route="authenticated.trainings.training.triggers.edit"
+    @query={{hash type="goal"}}
+    @backgroundColor="transparent-light"
+    @isBorderVisible={{true}}
+    aria-label={{t "pages.trainings.training.triggers.goal.alternative-title"}}
+  >
+    <FaIcon @icon="plus" />
+    {{t "pages.trainings.training.triggers.goal.title"}}
+  </PixButtonLink>
+</section>

--- a/admin/app/controllers/authenticated/trainings/training/triggers.js
+++ b/admin/app/controllers/authenticated/trainings/training/triggers.js
@@ -1,3 +1,10 @@
+import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 
-export default class TrainingDetailsTriggersController extends Controller {}
+export default class TrainingDetailsTriggersController extends Controller {
+  @service router;
+
+  get showTriggersEditForm() {
+    return this.router.currentRoute.localName.includes('edit');
+  }
+}

--- a/admin/app/controllers/authenticated/trainings/training/triggers/edit.js
+++ b/admin/app/controllers/authenticated/trainings/training/triggers/edit.js
@@ -1,0 +1,8 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+
+export default class TrainingEditTriggersController extends Controller {
+  queryParams = ['type'];
+
+  @tracked type = null;
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -110,7 +110,9 @@ Router.map(function () {
       this.route('list');
       this.route('new');
       this.route('training', { path: '/:training_id' }, function () {
-        this.route('triggers');
+        this.route('triggers', function () {
+          this.route('edit');
+        });
         this.route('target-profiles');
       });
     });

--- a/admin/app/routes/authenticated/trainings/training/triggers/edit.js
+++ b/admin/app/routes/authenticated/trainings/training/triggers/edit.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class EditTriggerRoute extends Route {
+  model() {
+    return this.modelFor('authenticated.trainings.training');
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -67,6 +67,7 @@
 @import 'components/target-profiles/create-target-profile-form';
 @import 'components/trainings/create-training-form';
 @import 'components/trainings/training-details-card';
+@import 'components/trainings/training-triggers-tab';
 @import 'components/target-profiles/details';
 @import 'components/target-profiles/insights';
 @import 'components/target-profiles/list-items';

--- a/admin/app/styles/components/trainings/training-triggers-tab.scss
+++ b/admin/app/styles/components/trainings/training-triggers-tab.scss
@@ -9,4 +9,13 @@
   &__description {
     @include text-small;
   }
+
+  &__toggler {
+    display: inline-flex;
+    margin-top: $spacing-s;
+
+    svg {
+      margin-right: $spacing-xs;
+    }
+  }
 }

--- a/admin/app/styles/components/trainings/training-triggers-tab.scss
+++ b/admin/app/styles/components/trainings/training-triggers-tab.scss
@@ -1,0 +1,12 @@
+.trigger-card {
+  &__title {
+    @include subheading;
+
+    font-weight: 500;
+    margin-bottom: $spacing-xs;
+  }
+
+  &__description {
+    @include text-small;
+  }
+}

--- a/admin/app/templates/authenticated/trainings/training/triggers.hbs
+++ b/admin/app/templates/authenticated/trainings/training/triggers.hbs
@@ -1,13 +1,7 @@
 <p>En savoir plus sur les déclencheurs, consulter la documentation ici</p>
 
-<section class="page-section trigger-card">
-  <h2 class="trigger-card__title">{{t "pages.trainings.training.triggers.prerequisite.title"}}</h2>
-  <p class="trigger-card__description">Si l’apprenant réussit tous les acquis des sujets sélectionnés alors le contenu
-    formatif ne lui sera pas proposé</p>
-</section>
-
-<section class="page-section trigger-card">
-  <h2 class="trigger-card__title">{{t "pages.trainings.training.triggers.goal.title"}}</h2>
-  <p class="trigger-card__description">Si l’apprenant réussit les acquis des sujets sélectionnés alors le contenu
-    formatif lui sera proposé</p>
-</section>
+{{#if this.showTriggersEditForm}}
+  {{outlet}}
+{{else}}
+  <Trainings::CreateTrainingTriggers />
+{{/if}}

--- a/admin/app/templates/authenticated/trainings/training/triggers.hbs
+++ b/admin/app/templates/authenticated/trainings/training/triggers.hbs
@@ -1,11 +1,13 @@
 <p>En savoir plus sur les déclencheurs, consulter la documentation ici</p>
 
-<section class="page-section">
-  <h2>{{t "pages.trainings.training.triggers.prerequisite.title"}}</h2>
-  <p>Si l’apprenant réussit tous les acquis des sujets sélectionnés alors le contenu formatif ne lui sera pas proposé</p>
+<section class="page-section trigger-card">
+  <h2 class="trigger-card__title">{{t "pages.trainings.training.triggers.prerequisite.title"}}</h2>
+  <p class="trigger-card__description">Si l’apprenant réussit tous les acquis des sujets sélectionnés alors le contenu
+    formatif ne lui sera pas proposé</p>
 </section>
 
-<section class="page-section">
-  <h2>{{t "pages.trainings.training.triggers.goal.title"}}</h2>
-  <p>Si l’apprenant réussit les acquis des sujets sélectionnés alors le contenu formatif lui sera proposé</p>
+<section class="page-section trigger-card">
+  <h2 class="trigger-card__title">{{t "pages.trainings.training.triggers.goal.title"}}</h2>
+  <p class="trigger-card__description">Si l’apprenant réussit les acquis des sujets sélectionnés alors le contenu
+    formatif lui sera proposé</p>
 </section>

--- a/admin/app/templates/authenticated/trainings/training/triggers/edit.hbs
+++ b/admin/app/templates/authenticated/trainings/training/triggers/edit.hbs
@@ -1,0 +1,1 @@
+<p>1. Objectif à atteindre</p>

--- a/admin/tests/acceptance/authenticated/trainings/edit-triggers_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/edit-triggers_test.js
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { click, currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
+import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import setupIntl from '../../../helpers/setup-intl';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | Trainings | Triggers edit', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  let trainingId;
+
+  hooks.beforeEach(async function () {
+    trainingId = 2;
+
+    server.create('training', {
+      id: 2,
+      title: 'Devenir tailleur de citrouille',
+      link: 'http://www.example2.net',
+      type: 'autoformation',
+      duration: '10:00:00',
+      locale: 'fr-fr',
+      editorName: "Ministère de l'éducation nationale et de la jeunesse",
+      editorLogoUrl: 'https://mon-logo.svg',
+      prerequisiteThreshold: null,
+      goalThreshold: null,
+    });
+  });
+
+  module('When admin member is not logged in', function () {
+    test('it should not be accessible by an unauthenticated user', async function (assert) {
+      // when
+      await visit(`/trainings/1/triggers/edit`);
+
+      // then
+      assert.strictEqual(currentURL(), '/login');
+    });
+  });
+
+  module('When admin member is logged in', function () {
+    test('it should be accessible by an authenticated user : prerequisite edit', async function (assert) {
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+      // when
+      const screen = await visit(`/trainings/${trainingId}/`);
+      await click(
+        screen.getByRole('link', {
+          name: this.intl.t('pages.trainings.training.triggers.prerequisite.alternative-title'),
+        })
+      );
+
+      // then
+      assert.strictEqual(currentURL(), `/trainings/${trainingId}/triggers/edit?type=prerequisite`);
+    });
+
+    test('it should be accessible by an authenticated user : goal edit', async function (assert) {
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+      // when
+      const screen = await visit(`/trainings/${trainingId}/`);
+      await click(
+        screen.getByRole('link', { name: this.intl.t('pages.trainings.training.triggers.goal.alternative-title') })
+      );
+
+      // then
+      assert.strictEqual(currentURL(), `/trainings/${trainingId}/triggers/edit?type=goal`);
+    });
+  });
+});

--- a/admin/translations/en.json
+++ b/admin/translations/en.json
@@ -27,10 +27,12 @@
         "triggers": {
           "tabName": "Triggers",
           "prerequisite": {
-            "title": "Prerequisite"
+            "title": "Prerequisite",
+            "alternative-title": "Add a prerequisite threshold to reach"
           },
           "goal": {
-            "title": "Goal"
+            "title": "Goal",
+            "alternative-title": "Add a goal threshold to not exceed"
           }
         },
         "targetProfiles": {

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -27,10 +27,12 @@
         "triggers": {
           "tabName": "Déclencheurs",
           "prerequisite": {
-            "title": "Objectifs à atteindre"
+            "title": "Objectif à atteindre",
+            "alternative-title": "Ajouter un objectif à atteindre"
           },
           "goal": {
-            "title": "Objectif à ne pas dépasser"
+            "title": "Objectif à ne pas dépasser",
+            "alternative-title": "Ajouter un objectif à ne pas dépasser"
           }
         },
         "targetProfiles": {


### PR DESCRIPTION
## :egg: Problème

À l'heure actuelle, il n'est pas possible de créer des déclencheurs de contenu formatif dans Pix Admin.

## :bowl_with_spoon: Proposition

Ajout d'une URL avec query parameter pour définir le type de déclencheur à éditer :

`/trainings/TRAINING_ID/triggers/edit?type=prerequisite | goal`

## :milk_glass: Remarques

Le contenu de la page `/edit` sera créé dans une prochaine PR.

## :butter: Pour tester

- [Se connecter à la RA](https://admin-pr5624.review.pix.fr/)
- [Accéder à un contenu formatif](https://admin-pr5624.review.pix.fr/trainings/101034/triggers)
- Cliquer sur les liens `Objectif à atteindre` et `Objectif à ne pas dépasser` et vérifier que le routage vers la page `/edit` fonctionne bien, avec le bon type en query parameter
