### PR TITLE
[BUGFIX][MON-PIX] Éviter la redirection vers la page de connexion d'un utilisateur anonyme déjà authentifié désirant relancer le parcours simplifié  (PIX-7010)

### DIFF
--- a/mon-pix/app/instance-initializers/session.js
+++ b/mon-pix/app/instance-initializers/session.js
@@ -1,18 +1,33 @@
 import PixWindow from 'mon-pix/utils/pix-window';
 
+const EMBER_SIMPLE_AUTH_LOCALSTORAGE_KEY = 'ember_simple_auth-session';
+
 export function initialize(/* applicationInstance */) {
   const currentURL = PixWindow.getLocationHref();
 
   const isGarAuthenticationURL = currentURL.includes('/connexion/gar');
   const isAuthenticatedExternalUser = currentURL.includes('externalUser=');
+  const isCampaignURL = currentURL.includes('/campagnes');
+  const isSimplifiedAccess = isCampaignURL && _isAnonymousUserAuthenticated();
+  const shouldRemoveCurrentSessionFromLocalStorage =
+    isGarAuthenticationURL || isAuthenticatedExternalUser || isSimplifiedAccess;
 
-  if (isGarAuthenticationURL || isAuthenticatedExternalUser) {
+  if (shouldRemoveCurrentSessionFromLocalStorage) {
     _removeCurrentSessionFromLocalStorage();
   }
 }
 
+function _isAnonymousUserAuthenticated() {
+  try {
+    const emberSimpleAuthSession = JSON.parse(window.localStorage.getItem(EMBER_SIMPLE_AUTH_LOCALSTORAGE_KEY));
+    return emberSimpleAuthSession.authenticated?.authenticator === 'authenticator:anonymous';
+  } catch (error) {
+    return false;
+  }
+}
+
 function _removeCurrentSessionFromLocalStorage() {
-  window.localStorage.removeItem('ember_simple_auth-session');
+  window.localStorage.removeItem(EMBER_SIMPLE_AUTH_LOCALSTORAGE_KEY);
 }
 
 export default {

--- a/mon-pix/tests/unit/instance-initializers/session-test.js
+++ b/mon-pix/tests/unit/instance-initializers/session-test.js
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 module('Unit | Instance Initializer | session', function () {
   module('when a session exists', function () {
     module('when a user finalizes a GAR authentication process', function () {
-      test('should remove the current session before the application loads', async function (assert) {
+      test('it removes the current session before the application loads', async function (assert) {
         // given
         run(() => {
           // eslint-disable-next-line ember/no-classic-classes
@@ -51,7 +51,7 @@ module('Unit | Instance Initializer | session', function () {
     });
 
     module('when current URL contains externalUser as query parameter', function () {
-      test('should remove the current session before the application loads', async function (assert) {
+      test('it removes the current session before the application loads', async function (assert) {
         // given
         run(() => {
           // eslint-disable-next-line ember/no-classic-classes
@@ -76,6 +76,122 @@ module('Unit | Instance Initializer | session', function () {
               refresh_token: 'refresh_token',
               expires_in: 45,
               expires_at: 1667837187635,
+            },
+          })
+        );
+
+        // when
+        await this.instance.boot();
+
+        // then
+        const session = window.localStorage.getItem(key);
+        assert.notOk(session);
+        run(this.instance, 'destroy');
+        run(this.application, 'destroy');
+        sinon.restore();
+      });
+    });
+  });
+
+  module('when user is anonymously authenticated', function () {
+    module('when current URL is a campaign URL', function () {
+      test('it removes the current session before the application loads', async function (assert) {
+        // given
+        run(() => {
+          // eslint-disable-next-line ember/no-classic-classes
+          this.TestApplication = Application.extend();
+          this.TestApplication.instanceInitializer({
+            name: 'initializer under test',
+            initialize,
+          });
+          this.application = this.TestApplication.create({ autoboot: false, Resolver, modulePrefix: 'mon-pix-test' });
+          this.instance = this.application.buildInstance();
+        });
+        const key = 'ember_simple_auth-session';
+        sinon.stub(PixWindow, 'getLocationHref').returns('/campagnes');
+        window.localStorage.setItem(
+          key,
+          JSON.stringify({
+            authenticated: {
+              authenticator: 'authenticator:anonymous',
+              access_token: 'access_token',
+              user_id: 1,
+            },
+          })
+        );
+
+        // when
+        await this.instance.boot();
+
+        // then
+        const session = window.localStorage.getItem(key);
+        assert.notOk(session);
+        run(this.instance, 'destroy');
+        run(this.application, 'destroy');
+        sinon.restore();
+      });
+    });
+
+    module('when current URL is a campaign URL with a code', function () {
+      test('it removes the current session before the application loads', async function (assert) {
+        // given
+        run(() => {
+          // eslint-disable-next-line ember/no-classic-classes
+          this.TestApplication = Application.extend();
+          this.TestApplication.instanceInitializer({
+            name: 'initializer under test',
+            initialize,
+          });
+          this.application = this.TestApplication.create({ autoboot: false, Resolver, modulePrefix: 'mon-pix-test' });
+          this.instance = this.application.buildInstance();
+        });
+        const key = 'ember_simple_auth-session';
+        sinon.stub(PixWindow, 'getLocationHref').returns('/campagnes/SIMPLIFIE');
+        window.localStorage.setItem(
+          key,
+          JSON.stringify({
+            authenticated: {
+              authenticator: 'authenticator:anonymous',
+              access_token: 'access_token',
+              user_id: 1,
+            },
+          })
+        );
+
+        // when
+        await this.instance.boot();
+
+        // then
+        const session = window.localStorage.getItem(key);
+        assert.notOk(session);
+        run(this.instance, 'destroy');
+        run(this.application, 'destroy');
+        sinon.restore();
+      });
+    });
+
+    module('when current URL is a campaign tutorial URL with a code', function () {
+      test('it removes the current session before the application loads', async function (assert) {
+        // given
+        run(() => {
+          // eslint-disable-next-line ember/no-classic-classes
+          this.TestApplication = Application.extend();
+          this.TestApplication.instanceInitializer({
+            name: 'initializer under test',
+            initialize,
+          });
+          this.application = this.TestApplication.create({ autoboot: false, Resolver, modulePrefix: 'mon-pix-test' });
+          this.instance = this.application.buildInstance();
+        });
+        const key = 'ember_simple_auth-session';
+        sinon.stub(PixWindow, 'getLocationHref').returns('/campagnes/SIMPLIFIE/evaluation/didacticiel');
+        window.localStorage.setItem(
+          key,
+          JSON.stringify({
+            authenticated: {
+              authenticator: 'authenticator:anonymous',
+              access_token: 'access_token',
+              user_id: 1,
             },
           })
         );


### PR DESCRIPTION
## :egg: Problème

Lorsqu'un utilisateur anonyme authentifié sur un parcours simplifié tente de relancer un nouveau parcours simplifié, ce dernier est redirigé vers la page de connexion car le fonctionnement d'invalidation de session, par défaut, redirige l'utilisateur vers la page de connexion.

Cette redirection ne devrait pas se faire.

## :bowl_with_spoon: Proposition

Utiliser un [instance-initializer](https://guides.emberjs.com/release/applications/initializers/) pour supprimer la session anonyme en cours dans le cas où cet utilisateur tente de relancer un nouveau parcours simplifié.

## :milk_glass: Remarques

- Le comportement ne sera pas le même lorsque l'on utilise l'URL `/campagnes/<code>/evaluation/didacticiel`. La session sera supprimée avant le chargement de l'application, mais comme l'utilisateur anonyme tente d'accéder à une route dont il n'a pas le droit sans être authentifié, il sera redirigé vers la page de connexion.
- Un utilisateur anonyme sera créé à chaque lancement d'un parcours simplifié même dans le cas d'un utilisateur anonyme précédemment authentifié.

## :butter: Pour tester

#### /campagnes

- Ouvrir l'URL suivante : https://app-pr5625.review.pix.fr/campagnes/SIMPLIFIE
- Cliquer sur le bouton `Je commence`
- Passer le didactitiel en cliquant sur le bouton `Ignorer`
- Passer ou valider une question du parcours
- Coller l'URL suivante : https://app-pr5625.review.pix.fr/campagnes dans la barre d'adresse pour relancer un nouveau parcours simplifié
- Entrer le code `SIMPLIFIE`
- Cliquer sur le bouton `Accéder au parcours`
- Constater que vous êtes dans une nouvelle session car vous êtes sur la page de présentation du parcours et que la session ESA est vide (localStorage)

#### /campagnes/SIMPLIFIE

- Ouvrir l'URL suivante : https://app-pr5625.review.pix.fr/campagnes/SIMPLIFIE
- Cliquer sur le bouton `Je commence`
- Passer le didactitiel en cliquant sur le bouton `Ignorer`
- Passer ou valider une question du parcours
- Coller l'URL suivante : https://app-pr5625.review.pix.fr/campagnes/SIMPLIFIE dans la barre d'adresse pour relancer un nouveau parcours simplifié
- Constater que vous êtes dans une nouvelle session car vous êtes sur la page de présentation du parcours et que la session ESA est vide (localStorage)