### PR TITLE
[BUGFIX] Utiliser les champs provenant du modèle passé en argument pour le pixScore (PIX-7055).

### DIFF
--- a/mon-pix/app/components/profile-content.hbs
+++ b/mon-pix/app/components/profile-content.hbs
@@ -16,8 +16,8 @@
         <h2 class="sr-only">{{t "pages.profile.accessibility.user-score"}}</h2>
         <HexagonScore
           @pixScore={{@model.profile.pixScore}}
-          @maxReachablePixScore={{this.model.profile.maxReachablePixScore}}
-          @maxReachableLevel={{this.model.profile.maxReachableLevel}}
+          @maxReachablePixScore={{@model.profile.maxReachablePixScore}}
+          @maxReachableLevel={{@model.profile.maxReachableLevel}}
         />
       </div>
     </div>


### PR DESCRIPTION
## :egg: Problème
La PR #5609 introduit une régression sur le composant `hexagon-score` dans la page `/competences` uniquement.

## :bowl_with_spoon: Proposition
Le modèle utilisé n'était pas bon 

## :milk_glass: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :butter: Pour tester
- Se connecter
- Aller sur la page `/competences`
- Constater que le messsage de la tooltip est bon