### PR TITLE
[FEATURE] Ajout des composants Pix UI dans les pages /connexion et /inscription sur Pix App (PIX-7032).

### DIFF
--- a/mon-pix/app/components/authentication/login-or-register-oidc.hbs
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.hbs
@@ -56,9 +56,9 @@
       <PixInput
         @id="email"
         @label={{t "pages.login-or-register-oidc.login-form.email"}}
+        name="email"
         @errorMessage={{this.emailValidationMessage}}
-        @value={{this.email}}
-        type="email"
+        @validationStatus={{this.emailValidationStatus}}
         {{on "change" this.validateEmail}}
         autocomplete="off"
         required

--- a/mon-pix/app/components/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.js
@@ -29,6 +29,7 @@ export default class LoginOrRegisterOidcComponent extends Component {
   @tracked registerErrorMessage = null;
   @tracked email = '';
   @tracked password = '';
+  @tracked emailValidationStatus = 'default';
   @tracked emailValidationMessage = null;
 
   get identityProviderOrganizationName() {
@@ -96,8 +97,10 @@ export default class LoginOrRegisterOidcComponent extends Component {
     const isInvalidInput = !isEmailValid(this.email);
 
     this.emailValidationMessage = null;
+    this.emailValidationStatus = 'default';
 
     if (isInvalidInput) {
+      this.emailValidationStatus = 'error';
       this.emailValidationMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['invalidEmail']);
     }
   }

--- a/mon-pix/app/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/components/password-reset-demand-form.hbs
@@ -1,16 +1,20 @@
-<main class="sign-form__container" role="main">
+<main class="password-reset-demand-form__container" role="main">
 
   <a href={{this.showcase.url}} class="pix-logo__link">
     <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{this.showcase.linkText}}" />
   </a>
 
-  <div class="sign-form__header">
-    {{#unless this.hasSucceeded}}
-      <h1 class="sign-form-title">{{t "pages.password-reset-demand.title"}}</h1>
-      <div class="sign-form-header__instruction sign-form-header__instruction--short sign-form-subtitle">
+  <div class="password-reset-demand-form__header">
+    {{#if this.hasSucceeded}}
+      <h1 class="password-reset-demand-form__title">
+        {{t "pages.password-reset-demand.succeed.subtitle"}}
+      </h1>
+    {{else}}
+      <h1 class="password-reset-demand-form__title--forgotten-password">{{t "pages.password-reset-demand.title"}}</h1>
+      <p class="password-reset-demand-form__subtitle">
         {{t "pages.password-reset-demand.subtitle"}}
-      </div>
-    {{/unless}}
+      </p>
+    {{/if}}
   </div>
 
   {{#if this.hasFailed}}
@@ -30,27 +34,22 @@
   {{/if}}
 
   {{#if this.hasSucceeded}}
-    <div class="sign-form-header__instruction sign-form-subtitle">{{t
-        "pages.password-reset-demand.succeed.subtitle"
-      }}</div>
-
-    <div class="password-reset-demand-form__body" aria-live="polite">
-      <span class="password-reset-demand-body__text sign-form-text">{{t
-          "pages.password-reset-demand.succeed.instructions"
-          email=this.email
-        }}</span>
-      <span class="password-reset-demand-body__text sign-form-text">{{t
-          "pages.password-reset-demand.succeed.help"
-        }}</span>
+    <div class="password-reset-demand-form__body password-reset-demand-form__body--succeeded" aria-live="polite">
+      <p class="password-reset-demand-body__text">
+        {{t "pages.password-reset-demand.succeed.instructions" email=this.email}}
+      </p>
+      <p class="password-reset-demand-body__text">
+        {{t "pages.password-reset-demand.succeed.help"}}
+      </p>
     </div>
 
     <div class="password-reset-demand-form__home-link">
       <a href={{this.showcase.url}} class="link">{{this.showcase.linkText}}</a>
     </div>
   {{else}}
-    <form {{on "submit" this.savePasswordResetDemand}} class="sign-form__body">
+    <form {{on "submit" this.savePasswordResetDemand}} class="password-reset-demand-form__body">
 
-      <div class="sign-form-body__input">
+      <div class="password-reset-demand-form__input">
         <FormTextfield
           @label="{{t 'pages.password-reset-demand.fields.email.label'}}"
           @textfieldName="email"
@@ -61,17 +60,18 @@
         />
       </div>
 
-      <div class="sign-form-body__bottom-button sign-form-body__bottom-button--big">
-        <PixButton @type="submit" @shape="rounded" @isDisabled={{this.isButtonDisabled}}>
-          {{t "pages.password-reset-demand.actions.reset"}}
-        </PixButton>
-        <LinkTo
-          @route="authentication.login"
-          class="link link--grey sign-form-link password-reset-demand-form__cancel-link"
-        >
-          {{t "pages.password-reset-demand.actions.back-sign-in"}}
-        </LinkTo>
-      </div>
+      <ul class="password-reset-demand-form__actions-list">
+        <li>
+          <PixButton @type="submit" @shape="rounded" @isDisabled={{this.isButtonDisabled}}>
+            {{t "pages.password-reset-demand.actions.reset"}}
+          </PixButton>
+        </li>
+        <li>
+          <LinkTo @route="authentication.login" class="link link--grey password-reset-demand-form__cancel-link">
+            {{t "pages.password-reset-demand.actions.back-sign-in"}}
+          </LinkTo>
+        </li>
+      </ul>
 
     </form>
   {{/if}}

--- a/mon-pix/app/components/reset-password-form.hbs
+++ b/mon-pix/app/components/reset-password-form.hbs
@@ -1,21 +1,21 @@
-<div class="sign-form__container">
+<div class="reset-password-form__container">
 
   <a href={{this.showcase.url}} class="pix-logo__link">
     <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{this.showcase.linkText}}" />
   </a>
 
-  <div class="sign-form__header">
-    <h1 class="sign-form-title">{{@user.fullName}}</h1>
+  <div class="reset-password-form__header">
+    <h1 class="reset-password-form-title">{{@user.fullName}}</h1>
 
     {{#unless this.hasSucceeded}}
-      <div class="sign-form-header__instruction sign-form-subtitle">{{t "pages.reset-password.instruction"}}</div>
+      <p class="reset-password-form-subtitle">{{t "pages.reset-password.instruction"}}</p>
     {{/unless}}
   </div>
 
   {{#unless this.hasSucceeded}}
-    <form {{on "submit" this.handleResetPassword}} class="sign-form__body">
+    <form {{on "submit" this.handleResetPassword}} class="reset-password-form__body">
 
-      <div class="sign-form-body__input">
+      <div class="reset-password-form-body__input">
         <FormTextfield
           @label="{{t 'pages.reset-password.fields.password.label'}}"
           @textfieldName="password"
@@ -25,29 +25,21 @@
           @validationMessage={{this.validation.message}}
         />
       </div>
-
-      <div class="sign-form-body__bottom-button sign-form-body__bottom-button--big">
-        <PixButton @type="submit" @shape="rounded" class="button--big">
-          {{t "pages.reset-password.actions.submit"}}
-        </PixButton>
-      </div>
+      <PixButton @type="submit" @shape="rounded" class="button--big">
+        {{t "pages.reset-password.actions.submit"}}
+      </PixButton>
 
     </form>
   {{/unless}}
 
   {{#if this.hasSucceeded}}
-    <div class="sign-form__body">
-      <div
-        class="password-reset-demand-form__body password-reset-demand-form__body--centered sign-form-text"
-        aria-live="polite"
-      >
+    <div class="reset-password-form__body">
+      <p class="reset-password-form-text" aria-live="polite">
         {{t "pages.reset-password.succeed"}}
-      </div>
-      <div class="sign-form-body__bottom-button sign-form-body__bottom-button--big">
-        <LinkTo @route="authentication.login" class="button button--link button--uppercase button--thin button--round">
-          {{t "pages.reset-password.actions.sign-in"}}
-        </LinkTo>
-      </div>
+      </p>
+      <LinkTo @route="authentication.login" class="button button--link button--thin button--round">
+        {{t "pages.reset-password.actions.sign-in"}}
+      </LinkTo>
     </div>
   {{/if}}
 </div>

--- a/mon-pix/app/components/signin-form.hbs
+++ b/mon-pix/app/components/signin-form.hbs
@@ -5,11 +5,11 @@
   </a>
 
   <div class="sign-form__header">
-    <h1 class="sign-form-title">{{t "pages.sign-in.first-title"}}</h1>
+    <h1 class="sign-form-header__title">{{t "pages.sign-in.first-title"}}</h1>
 
     <div class="sign-form-header__subtitle">
-      <span class="sign-form-header-subtitle sign-form-instruction">{{t "pages.sign-in.subtitle.text"}}</span>
-      <LinkTo @route="inscription" class="link sign-form-link"> {{t "pages.sign-in.subtitle.link"}}</LinkTo>
+      <span class="sign-form-header-subtitle">{{t "pages.sign-in.subtitle.text"}}</span>
+      <LinkTo @route="inscription" class="link"> {{t "pages.sign-in.subtitle.link"}}</LinkTo>
     </div>
   </div>
 
@@ -22,31 +22,29 @@
   <form {{on "submit" this.signin}} class="sign-form__body">
     <p class="sign-form-body__instruction">{{t "common.form.mandatory-all-fields"}}</p>
 
-    <fieldset>
+    <fieldset class="sign-form-body__inputs">
       <legend class="sr-only">{{t "pages.sign-in.fields.legend"}}</legend>
       <div class="sign-form-body__input">
-        <FormTextfield
-          @label="{{t 'pages.sign-in.fields.login.label'}}"
-          @textfieldName="login"
+        <PixInput
+          @id="login"
+          name="login"
+          @label={{t "pages.sign-in.fields.login.label"}}
+          {{on "input" this.updateLogin}}
           @validationStatus="default"
-          @inputBindingValue={{this.login}}
-          @autocomplete="username"
-          @hideRequired={{true}}
-          @require={{true}}
-          @aria-describedby="sign-in-error-message"
+          required
+          autocomplete="email"
         />
       </div>
 
       <div class="sign-form-body__input">
-        <FormTextfield
-          @label="{{t 'pages.sign-in.fields.password.label'}}"
-          @textfieldName="password"
+        <PixInputPassword
+          @id="password"
+          name="password"
+          @label={{t "pages.sign-in.fields.password.label"}}
+          {{on "input" this.updatePassword}}
           @validationStatus="default"
-          @inputBindingValue={{this.password}}
-          @autocomplete="current-password"
-          @hideRequired={{true}}
-          @require={{true}}
-          @aria-describedby="sign-in-error-message"
+          required
+          autocomplete="current-password"
         />
       </div>
     </fieldset>

--- a/mon-pix/app/components/signin-form.hbs
+++ b/mon-pix/app/components/signin-form.hbs
@@ -46,13 +46,13 @@
           required
           autocomplete="current-password"
         />
+        <LinkTo
+          @route="password-reset-demand"
+          class="link link--grey sign-form-link sign-form-body__forgotten-password-link"
+        >
+          {{t "pages.sign-in.forgotten-password"}}</LinkTo>
       </div>
     </fieldset>
-    <LinkTo
-      @route="password-reset-demand"
-      class="link link--grey sign-form-link sign-form-body__forgotten-password-link"
-    >
-      {{t "pages.sign-in.forgotten-password"}}</LinkTo>
 
     <div class="sign-form-body__bottom-button">
       <PixButton @type="submit" @shape="rounded">

--- a/mon-pix/app/components/signin-form.js
+++ b/mon-pix/app/components/signin-form.js
@@ -16,9 +16,8 @@ export default class SigninForm extends Component {
 
   @tracked hasFailed = false;
   @tracked errorMessage;
-
-  login = '';
-  password = '';
+  @tracked password = null;
+  @tracked login = null;
 
   get showcase() {
     return this.url.showcase;
@@ -38,6 +37,16 @@ export default class SigninForm extends Component {
       this.hasFailed = true;
       this._handleApiError(responseError);
     }
+  }
+
+  @action
+  updateLogin(event) {
+    this.login = event.target.value?.trim();
+  }
+
+  @action
+  updatePassword(event) {
+    this.password = event.target.value?.trim();
   }
 
   async _handleApiError(responseError) {

--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -1,84 +1,80 @@
 <main class="sign-form__container" role="main">
+
   <a href={{this.showcase.url}} class="pix-logo__link">
     <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{this.showcase.linkText}}" />
   </a>
 
   <div class="sign-form__header">
-    <h1 class="sign-form-title">{{t "pages.sign-up.first-title"}}</h1>
+    <h1 class="sign-form-header__title">{{t "pages.sign-up.first-title"}}</h1>
     <div class="sign-form-header__subtitle">
       <span class="sign-form-header-subtitle">{{t "common.or"}}</span>
       <LinkTo @route="authentication.login" class="link">{{t "pages.sign-up.subtitle.link"}}</LinkTo>
     </div>
   </div>
 
-  <p class="sign-form__notification-message--error" aria-live="polite" role="alert" id="sign-up-error-message">
-    {{this.errorMessage}}
-  </p>
+  {{#if this.errorMessage}}
+    <p class="sign-form__notification-message--error" aria-live="polite" role="alert" id="sign-up-error-message">
+      {{this.errorMessage}}
+    </p>
+  {{/if}}
 
   <form {{on "submit" this.signup}} class="sign-form__body">
     <p class="sign-form-body__instruction">{{t "common.form.mandatory-all-fields" htmlSafe=true}}</p>
 
-    <fieldset>
+    <fieldset class="sign-form-body__inputs">
       <legend class="sr-only">{{t "pages.sign-up.fields.legend"}}</legend>
       <div class="sign-form-body__input">
-        <FormTextfield
-          @label="{{t 'pages.sign-up.fields.firstname.label'}}"
-          @textfieldName="firstName"
-          @inputBindingValue={{@user.firstName}}
-          @onValidate={{this.validateInput}}
+        <PixInput
+          @id="firstName"
+          name="firstName"
+          @label={{t "pages.sign-up.fields.firstname.label"}}
+          {{on "focusout" this.validateFirstName}}
           @validationStatus={{this.validation.firstName.status}}
-          @validationMessage={{this.validation.firstName.message}}
-          @autocomplete="given-name"
-          @hideRequired={{true}}
-          @require={{true}}
-          @aria-describedby="sign-up-error-message"
+          @errorMessage={{this.validation.firstName.message}}
+          required
+          autocomplete="given-name"
         />
       </div>
 
       <div class="sign-form-body__input">
-        <FormTextfield
-          @label="{{t 'pages.sign-up.fields.lastname.label'}}"
-          @textfieldName="lastName"
-          @inputBindingValue={{@user.lastName}}
-          @onValidate={{this.validateInput}}
+        <PixInput
+          @id="lastName"
+          name="lastName"
+          @label={{t "pages.sign-up.fields.lastname.label"}}
+          {{on "focusout" this.validateLastName}}
           @validationStatus={{this.validation.lastName.status}}
-          @validationMessage={{this.validation.lastName.message}}
-          @autocomplete="family-name"
-          @hideRequired={{true}}
-          @require={{true}}
-          @aria-describedby="sign-up-error-message"
+          @errorMessage={{this.validation.lastName.message}}
+          required
+          autocomplete="family-name"
         />
       </div>
 
       <div class="sign-form-body__input">
-        <FormTextfield
+        <PixInput
+          @id="email"
+          name="email"
           @label="{{t 'pages.sign-up.fields.email.label'}}"
-          @help="{{t 'pages.sign-up.fields.email.help'}}"
-          @textfieldName="email"
+          @information="{{t 'pages.sign-up.fields.email.help'}}"
+          {{on "focusout" this.validateEmail}}
           @validationStatus={{this.validation.email.status}}
-          @onValidate={{this.validateInputEmail}}
-          @inputBindingValue={{@user.email}}
-          @validationMessage={{this.validation.email.message}}
-          @autocomplete="email"
-          @hideRequired={{true}}
-          @require={{true}}
-          @aria-describedby="sign-up-error-message"
+          @errorMessage={{this.validation.email.message}}
+          required
+          autocomplete="email"
         />
       </div>
 
       <div class="sign-form-body__input">
-        <FormTextfield
+        <PixInputPassword
+          @id="password"
+          name="password"
           @label="{{t 'pages.sign-up.fields.password.label'}}"
-          @help="{{t 'pages.sign-up.fields.password.help'}}"
-          @textfieldName="password"
+          @information="{{t 'pages.sign-up.fields.password.help'}}"
+          @value={{this.password}}
+          {{on "focusout" this.validatePassword}}
           @validationStatus={{this.validation.password.status}}
-          @onValidate={{this.validateInputPassword}}
-          @inputBindingValue={{@user.password}}
-          @validationMessage={{this.validation.password.message}}
-          @autocomplete="new-password"
-          @hideRequired={{true}}
-          @require={{true}}
-          @aria-describedby="sign-up-error-message"
+          @errorMessage={{this.validation.password.message}}
+          required
+          autocomplete="new-password"
         />
       </div>
 

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -114,18 +114,27 @@ export default class SignupForm extends Component {
   }
 
   @action
-  validateInput(key) {
-    this._executeFieldValidation(key, this._isValuePresent);
+  validateFirstName(event) {
+    this.args.user.firstName = event.target.value?.trim();
+    this._executeFieldValidation(event.target.id, this._isValuePresent);
   }
 
   @action
-  validateInputEmail(key) {
-    this._executeFieldValidation(key, isEmailValid);
+  validateLastName(event) {
+    this.args.user.lastName = event.target.value?.trim();
+    this._executeFieldValidation(event.target.id, this._isValuePresent);
   }
 
   @action
-  validateInputPassword(key) {
-    this._executeFieldValidation(key, isPasswordValid);
+  validateEmail(event) {
+    this.args.user.email = event.target.value?.trim();
+    this._executeFieldValidation(event.target.id, isEmailValid);
+  }
+
+  @action
+  validatePassword(event) {
+    this.args.user.password = event.target.value?.trim();
+    this._executeFieldValidation(event.target.id, isPasswordValid);
   }
 
   @action

--- a/mon-pix/app/components/update-expired-password-form.hbs
+++ b/mon-pix/app/components/update-expired-password-form.hbs
@@ -42,15 +42,9 @@
         />
       </div>
 
-      {{#if this.isLoading}}
-        <button type="button" disabled class="button button--thin button--round button--big">
-          <span class="loader-in-button">&nbsp;</span>
-        </button>
-      {{else}}
-        <PixButton @type="submit">
-          {{t "pages.update-expired-password.button"}}
-        </PixButton>
-      {{/if}}
+      <PixButton @type="submit" @isLoading={{this.isLoading}}>
+        {{t "pages.update-expired-password.button"}}
+      </PixButton>
     </form>
   {{/unless}}
 

--- a/mon-pix/app/components/update-expired-password-form.hbs
+++ b/mon-pix/app/components/update-expired-password-form.hbs
@@ -8,23 +8,21 @@
     <h1 class="update-expired-password-form-title">{{t "pages.update-expired-password.first-title"}}</h1>
 
     {{#unless this.authenticationHasFailed}}
-      <div
-        class="update-expired-password-form-header__instruction update-expired-password-form-subtitle"
-        id="update-expired-password-authentication-failed-message"
-      >
+      <p class="update-expired-password-form-subtitle" id="update-expired-password-authentication-failed-message">
         {{t "pages.update-expired-password.subtitle"}}
-      </div>
+      </p>
     {{/unless}}
   </div>
 
   {{#if this.errorMessage}}
-    <div
-      class="update-expired-password-form__notification-message update-expired-password-form__notification-message--error"
+    <p
+      class="update-expired-password-form__error-notification-message"
       aria-live="polite"
+      role="alert"
       id="update-expired-password-error-message"
     >
       {{this.errorMessage}}
-    </div>
+    </p>
   {{/if}}
 
   {{#unless this.authenticationHasFailed}}
@@ -44,37 +42,26 @@
         />
       </div>
 
-      <div
-        class="update-expired-password-form-body__bottom-button update-expired-password-form-body__bottom-button--big"
-      >
-        {{#if this.isLoading}}
-          <button type="button" disabled class="button button--thin button--round button--big">
-            <span class="loader-in-button">&nbsp;</span>
-          </button>
-        {{else}}
-          <PixButton @type="submit">
-            {{t "pages.update-expired-password.button"}}
-          </PixButton>
-        {{/if}}
-      </div>
+      {{#if this.isLoading}}
+        <button type="button" disabled class="button button--thin button--round button--big">
+          <span class="loader-in-button">&nbsp;</span>
+        </button>
+      {{else}}
+        <PixButton @type="submit">
+          {{t "pages.update-expired-password.button"}}
+        </PixButton>
+      {{/if}}
     </form>
   {{/unless}}
 
   {{#if this.authenticationHasFailed}}
     <div class="update-expired-password-form__body">
-      <div
-        class="password-reset-demand-form__body password-reset-demand-form__body--centered update-expired-password-form-text"
-        aria-live="polite"
-      >
+      <p class="update-expired-password-form-text" aria-live="polite">
         {{t "pages.update-expired-password.validation"}}
-      </div>
-      <div
-        class="update-expired-password-form-body__bottom-button update-expired-password-form-body__bottom-button--big"
-      >
-        <LinkTo @route="authentication.login" class="button button--link button--uppercase button--thin button--round">
-          {{t "pages.update-expired-password.go-to-login"}}
-        </LinkTo>
-      </div>
+      </p>
+      <LinkTo @route="authentication.login" class="button button--link button--thin button--round">
+        {{t "pages.update-expired-password.go-to-login"}}
+      </LinkTo>
     </div>
   {{/if}}
 </div>

--- a/mon-pix/app/components/user-account/email-with-validation-form.hbs
+++ b/mon-pix/app/components/user-account/email-with-validation-form.hbs
@@ -4,12 +4,13 @@
     <PixInput
       @id="newEmail"
       @label={{t "pages.user-account.account-update-email-with-validation.fields.new-email.label"}}
+      @validationStatus={{this.newEmailValidationStatus}}
       @errorMessage={{this.newEmailValidationMessage}}
       @value={{this.newEmail}}
       type="email"
       {{on "change" this.validateNewEmail}}
-      autocomplete="off"
       required
+      autocomplete="off"
     />
   </div>
   <div class="update-email-with-validation__informations">
@@ -20,8 +21,8 @@
       @id="update-email-with-validation__password"
       @label={{t "pages.user-account.account-update-email-with-validation.fields.password.label"}}
       {{on "change" this.passwordChanged}}
-      autocomplete="off"
       required
+      autocomplete="off"
     />
   </div>
   {{#if this.errorMessage}}

--- a/mon-pix/app/components/user-account/email-with-validation-form.js
+++ b/mon-pix/app/components/user-account/email-with-validation-form.js
@@ -22,6 +22,7 @@ export default class EmailWithValidationForm extends Component {
   @tracked newEmailValidationMessage = null;
   @tracked errorMessage = null;
   @tracked hasRequestedUpdate = false;
+  @tracked newEmailValidationStatus = 'default';
 
   get isFormValid() {
     return isEmailValid(this.newEmail) && !isEmpty(this.password);
@@ -34,8 +35,10 @@ export default class EmailWithValidationForm extends Component {
     const isInvalidInput = !isEmailValid(this.newEmail);
 
     this.newEmailValidationMessage = null;
+    this.newEmailValidationStatus = 'default';
 
     if (isInvalidInput) {
+      this.newEmailValidationStatus = 'error';
       this.newEmailValidationMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['invalidEmail']);
     }
   }

--- a/mon-pix/app/routes/update-expired-password.js
+++ b/mon-pix/app/routes/update-expired-password.js
@@ -14,7 +14,7 @@ export default class UpdateExpiredPasswordRoute extends Route {
     const resetExpiredPasswordDemand = resetExpiredPasswordDemands.firstObject;
 
     if (!resetExpiredPasswordDemand) {
-      return this.router.replaceWith('');
+      return this.router.replaceWith('login');
     }
 
     return resetExpiredPasswordDemand;

--- a/mon-pix/app/styles/components/_password-reset-demand-form.scss
+++ b/mon-pix/app/styles/components/_password-reset-demand-form.scss
@@ -1,29 +1,73 @@
 .password-reset-demand-form {
 
-  &__body {
+  &__container {
     display: flex;
     flex-direction: column;
-    justify-content: center;
-    width: 100%;
-    padding: 30px 20px;
+    gap: 20px;
+    align-items: center;
+    width: 95%;
+    max-width: 609px;
+    margin: 0 auto;
+    padding: 20px 10px;
+    font-family: $font-open-sans;
+    background-color: $pix-neutral-0;
+    border-radius: 10px;
 
     @include device-is('tablet') {
-      padding: 30px 50px;
-    }
-
-    &--centered {
-      text-align: center;
+      margin: 20px 0;
+      padding: 40px 80px;
     }
   }
 
+  &__header {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    align-items: center;
+    font-weight: $font-light;
+    text-align: center;
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+
+    &--succeeded {
+      align-items: flex-start;
+      padding: 30px 20px 0;
+
+      @include device-is('tablet') {
+        padding: 30px 0 0;
+      }
+    }
+  }
+
+  &__title {
+    font-size: 1.375rem;
+
+    &--forgotten-password {
+      color: $pix-neutral-80;
+      font-size: 1.563rem;
+  
+      @include device-is('desktop') {
+        font-size: 2rem;
+      }
+    }
+  }
+
+  &__subtitle {
+    font-size: 1rem;
+  }
+
   &__cancel-link {
-    align-self: center;
-    margin-top: 24px;
+    font-size: 0.938rem;
   }
 
   &__home-link {
     align-self: center;
-    margin-bottom: 60px;
+    margin-bottom: 30px;
   }
 
   &__notification-message--error {
@@ -34,8 +78,28 @@
     line-height: 1.625rem;
     text-align: center;
   }
+
+  &__input {
+    width: 100%;
+    max-width: 450px;
+  }
+
+  &__actions-list {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    align-items: center;
+    margin: 10px 0;
+  }
 }
 
 .password-reset-demand-body__text {
   margin-bottom: 15px;
+  color: $pix-neutral-80;
+  font-size: 0.8rem;
+  font-family: $font-open-sans;
+
+  @include device-is('tablet') {
+    font-size: 0.938rem;
+  }
 }

--- a/mon-pix/app/styles/components/_reset-password-form.scss
+++ b/mon-pix/app/styles/components/_reset-password-form.scss
@@ -1,4 +1,74 @@
-.reset-password-form__login {
-  margin-top: 20px;
-  margin-bottom: 60px;
+.reset-password-form {
+  &__container {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    align-items: center;
+    width: 95%;
+    max-width: 609px;
+    padding: 30px 10px;
+    background-color: $pix-neutral-0;
+    border-radius: 10px;
+
+    @include device-is('tablet') {
+      margin: 20px 0;
+      padding: 40px 80px;
+    }
+  }
+
+  &__header {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    align-items: center;
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    align-items: center;
+    width: 100%;
+  }
+}
+
+.reset-password-form-body {
+  &__input {
+    width: 100%;
+    max-width: 450px;
+  }
+}
+
+.reset-password-form-title {
+  color: $pix-neutral-80;
+  font-weight: $font-light;
+  font-size: 1.563rem;
+  font-family: $font-open-sans;
+
+  @include device-is('desktop') {
+    font-size: 2.25rem;
+  }
+}
+
+.reset-password-form-subtitle {
+  width: 100%;
+  margin-top: 10px;
+  color: $pix-neutral-80;
+  font-weight: $font-light;
+  font-size: 0.938rem;
+  font-family: $font-open-sans;
+  line-height: 28px;
+  text-align: center;
+
+  @include device-is('tablet') {
+    margin-top: 24px;
+    font-size: 1.375rem;
+  }
+}
+
+.reset-password-form-text {
+  padding: 20px 0;
+  color: $pix-neutral-80;
+  font-size: 0.938rem;
+  font-family: $font-open-sans;
 }

--- a/mon-pix/app/styles/components/_signup-form.scss
+++ b/mon-pix/app/styles/components/_signup-form.scss
@@ -11,12 +11,13 @@
     padding: 0 15px;
 
     @include device-is('tablet') {
-      margin: 15px 0 5px;
+      margin: 8px 0 5px;
       padding: 0;
     }
   }
 
   &__cgu-label {
-    margin: 3px 0 3px 15px;
+    margin: 3px 0 3px 5px;
+    font-size: 0.875rem;
   }
 }

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -21,7 +21,7 @@
   &__container {
     display: flex;
     flex-direction: column;
-    gap: 20px;
+    gap: $spacing-m;
     align-items: center;
     width: 95%;
     max-width: 609px;
@@ -39,7 +39,7 @@
   &__header {
     display: flex;
     flex-direction: column;
-    gap: 5px;
+    gap: $spacing-s;
     align-items: center;
   }
 
@@ -103,14 +103,14 @@
 
 .sign-form-body {
   &__instruction {
-    margin: 10px 0 30px;
+    margin: 10px 0 24px;
     font-size: 0.875rem;
   }
 
   &__inputs {
     display: flex;
     flex-direction: column;
-    gap: 20px;
+    gap: $spacing-s;
     align-items: center;
   }
 
@@ -190,5 +190,6 @@
   &__forgotten-password-link {
     align-self: flex-end;
     margin: 5px 0 20px;
+    font-size: 0.875rem;
   }
 }

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -115,6 +115,8 @@
   }
 
   &__input {
+    display: flex;
+    flex-direction: column;
     width: 100%;
     max-width: 450px;
     padding: 0 20px;

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -21,8 +21,8 @@
   &__container {
     display: flex;
     flex-direction: column;
+    gap: 20px;
     align-items: center;
-    justify-content: space-around;
     width: 95%;
     max-width: 609px;
     margin: 0 auto;
@@ -31,7 +31,6 @@
     border-radius: 10px;
 
     @include device-is('tablet') {
-      width: 609px;
       margin: 20px 0;
       padding: 40px 80px;
     }
@@ -40,8 +39,8 @@
   &__header {
     display: flex;
     flex-direction: column;
+    gap: 5px;
     align-items: center;
-    margin-top: 20px;
   }
 
   &__body {
@@ -70,10 +69,22 @@
 }
 
 .sign-form-header {
+
+  &__title {
+    margin: 0;
+    color: $pix-neutral-80;
+    font-weight: $font-light;
+    font-size: 1.563rem;
+    font-family: $font-open-sans;
+
+    @include device-is('desktop') {
+      font-size: 2.25rem;
+    }
+  }
+
   &__subtitle {
     display: flex;
     flex-direction: column;
-    padding: 5px 20px 24px;
     font-size: 1rem;
     font-family: $font-open-sans;
     text-align: center;
@@ -82,34 +93,30 @@
       flex-direction: row;
     }
   }
-
-  &__instruction {
-    width: 100%;
-    margin: 10px 0 40px;
-
-    @include device-is('tablet') {
-      margin: 24px 0 40px;
-
-      &--short {
-        width: 400px;
-      }
-    }
-  }
 }
 
 .sign-form-header-subtitle {
   margin-right: 3px;
+  color: $pix-neutral-80;
+  font-weight: $font-light;
 }
 
 .sign-form-body {
   &__instruction {
-    margin: 10px 0;
+    margin: 10px 0 30px;
     font-size: 0.875rem;
+  }
+
+  &__inputs {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    align-items: center;
   }
 
   &__input {
     width: 100%;
-    max-width: 449px;
+    max-width: 450px;
     padding: 0 20px;
 
     @include device-is('tablet') {
@@ -127,18 +134,6 @@
     align-items: center;
     justify-content: center;
     margin: 5px auto 20px;
-
-    &--big {
-      margin: 10px auto;
-
-      @include device-is('desktop') {
-        margin: 30px auto;
-      }
-
-      @include device-is('mobile') {
-        width: 280px;
-      }
-    }
   }
 
   &__bottom-decoration {
@@ -194,51 +189,4 @@
     align-self: flex-end;
     margin: 5px 0 20px;
   }
-}
-
-// Text Styles
-
-.sign-form-title {
-  margin: 0;
-  color: $pix-neutral-80;
-  font-weight: $font-light;
-  font-size: 1.563rem;
-  font-family: $font-open-sans;
-
-  @include device-is('desktop') {
-    font-size: 2.25rem;
-  }
-}
-
-.sign-form-subtitle {
-  color: $pix-neutral-80;
-  font-weight: $font-light;
-  font-size: 0.938rem;
-  font-family: $font-open-sans;
-  line-height: 28px;
-  text-align: center;
-
-  @include device-is('tablet') {
-    font-size: 1.375rem;
-  }
-}
-
-.sign-form-instruction {
-  color: $pix-neutral-80;
-  font-weight: $font-light;
-  font-size: 0.938rem;
-}
-
-.sign-form-text {
-  color: $pix-neutral-80;
-  font-size: 0.625rem;
-  font-family: $font-open-sans;
-
-  @include device-is('tablet') {
-    font-size: 0.938rem;
-  }
-}
-
-.sign-form-link {
-  font-size: 0.938rem;
 }

--- a/mon-pix/app/styles/pages/_update-expired-password-form.scss
+++ b/mon-pix/app/styles/pages/_update-expired-password-form.scss
@@ -18,6 +18,7 @@
   &__container {
     display: flex;
     flex-direction: column;
+    gap: 20px;
     align-items: center;
     justify-content: space-around;
     width: 95%;
@@ -42,77 +43,34 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin-top: 20px;
+    margin: 0 20px;
   }
 
   &__body {
     display: flex;
     flex-direction: column;
+    gap: 20px;
     width: 100%;
-    padding: 20px 0;
+    padding: 0 20px 30px;
 
     @include device-is('tablet') {
-      padding: 0 80px;
+      padding: 0 80px 40px;
     }
   }
 
-  &__notification-message {
-    width: 100%;
-    max-width: 449px;
-    margin: 10px 0;
-    padding: 9px;
-    color: $pix-neutral-0;
+  &__error-notification-message {
+    max-width: 426px;
+    color: $pix-error-70;
     font-size: 0.875rem;
     text-align: center;
-    border-radius: 3px;
-
-    &--success {
-      background: $pix-success-10;
-    }
-
-    &--error {
-      background: $pix-warning-10;
-    }
-  }
-
-  &__validation-error {
-    color: $pix-error-70;
-    font-weight: normal;
-  }
-}
-
-.update-expired-password-form-header {
-
-  &__subtitle {
-    display: flex;
-    flex-direction: column;
-    padding: 5px 20px;
-    font-size: 1rem;
-    font-family: $font-open-sans;
-    text-align: center;
-
-    @include device-is('tablet') {
-      flex-direction: row;
-    }
-  }
-
-  &__instruction {
-    width: 100%;
-    margin: 10px 0;
   }
 }
 
 .update-expired-password-form-body {
 
-  &__instruction {
-    margin: 10px 0;
-    font-size: 0.875rem;
-  }
-
   &__input {
     width: 100%;
     max-width: 449px;
-    padding: 0 20px;
     font-size: 0.875rem;
 
     @include device-is('tablet') {
@@ -125,31 +83,7 @@
     flex-direction: column;
     align-items: stretch;
     justify-content: center;
-    margin: 5px auto 20px;
-
-    &--big {
-      width: 100%;
-      margin: 10px auto;
-      padding: 0 10px;
-
-      @include device-is('desktop') {
-        margin: 30px auto;
-      }
-    }
-
-    &--margin-top {
-      margin-top: 25px;
-    }
-
-    &--round {
-      border-radius: 5px;
-    }
-  }
-
-  &__forgotten-password-link {
-    align-self: flex-end;
-    margin-right: 10px;
-    margin-bottom: 20px;
+    width: 100%;
   }
 }
 
@@ -169,17 +103,20 @@
 }
 
 .update-expired-password-form-subtitle {
+  width: 100%;
+  margin: 10px 0 0;
   color: $pix-neutral-80;
   font-size: 1rem;
   font-family: $font-roboto;
-  line-height: 28px;
+  line-height: 22px;
   text-align: center;
 }
 
 .update-expired-password-form-text {
   color: $pix-neutral-80;
-  font-size: 0.625rem;
+  font-size: 0.838rem;
   font-family: $font-open-sans;
+  text-align: center;
 
   @include device-is('tablet') {
     font-size: 0.938rem;

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.0",
-        "@1024pix/pix-ui": "^25.0.0",
+        "@1024pix/pix-ui": "^26.0.0",
         "@1024pix/stylelint-config": "^2.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
@@ -1152,9 +1152,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "25.0.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-25.0.1.tgz",
-      "integrity": "sha512-twBJIzgI5dBwHiLj+3RUhtEJ9vgsnU9DBoBn7X2nU5TYr26aAI1UH/3ks+5T2r5Iy1eGKIBEP9+dJzN25ykdDA==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-26.0.1.tgz",
+      "integrity": "sha512-gLZ7VDfuWTMij7NRJlPGVkOUQJUH9t2QsbS6O0M/zhnyQ5QNcC49FQf7VAFYqEwXWrN0w6w1U46Fo0L13Hj4Zw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -42850,9 +42850,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "25.0.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-25.0.1.tgz",
-      "integrity": "sha512-twBJIzgI5dBwHiLj+3RUhtEJ9vgsnU9DBoBn7X2nU5TYr26aAI1UH/3ks+5T2r5Iy1eGKIBEP9+dJzN25ykdDA==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-26.0.1.tgz",
+      "integrity": "sha512-gLZ7VDfuWTMij7NRJlPGVkOUQJUH9t2QsbS6O0M/zhnyQ5QNcC49FQf7VAFYqEwXWrN0w6w1U46Fo0L13Hj4Zw==",
       "dev": true,
       "requires": {
         "color": "^4.2.3",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.0",
-        "@1024pix/pix-ui": "^24.2.2",
+        "@1024pix/pix-ui": "^25.0.0",
         "@1024pix/stylelint-config": "^2.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
@@ -1152,9 +1152,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "24.2.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-24.2.2.tgz",
-      "integrity": "sha512-PFwWOOYqip3b84K44MdSEvlm0T1iqm7V39AWAs7riMopgXig+vRs57Hp1fA28b2nCiKLD5Ah9HiBFTKaRxXVtg==",
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-25.0.1.tgz",
+      "integrity": "sha512-twBJIzgI5dBwHiLj+3RUhtEJ9vgsnU9DBoBn7X2nU5TYr26aAI1UH/3ks+5T2r5Iy1eGKIBEP9+dJzN25ykdDA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -42850,9 +42850,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "24.2.2",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-24.2.2.tgz",
-      "integrity": "sha512-PFwWOOYqip3b84K44MdSEvlm0T1iqm7V39AWAs7riMopgXig+vRs57Hp1fA28b2nCiKLD5Ah9HiBFTKaRxXVtg==",
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-25.0.1.tgz",
+      "integrity": "sha512-twBJIzgI5dBwHiLj+3RUhtEJ9vgsnU9DBoBn7X2nU5TYr26aAI1UH/3ks+5T2r5Iy1eGKIBEP9+dJzN25ykdDA==",
       "dev": true,
       "requires": {
         "color": "^4.2.3",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.0",
-    "@1024pix/pix-ui": "^25.0.0",
+    "@1024pix/pix-ui": "^26.0.0",
     "@1024pix/stylelint-config": "^2.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.0",
-    "@1024pix/pix-ui": "^24.2.2",
+    "@1024pix/pix-ui": "^25.0.0",
     "@1024pix/stylelint-config": "^2.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",

--- a/mon-pix/tests/acceptance/password-reset-demand-form_test.js
+++ b/mon-pix/tests/acceptance/password-reset-demand-form_test.js
@@ -6,7 +6,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import { clickByLabel } from '../helpers/click-by-label';
 import setupIntl from '../helpers/setup-intl';
 
-module('Acceptance | Reset Password', function (hooks) {
+module('Acceptance | Password reset demand form', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   setupIntl(hooks);
@@ -19,14 +19,6 @@ module('Acceptance | Reset Password', function (hooks) {
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line qunit/no-assert-equal
     assert.equal(currentURL(), '/mot-de-passe-oublie');
-  });
-
-  test('display a form to reset the email', async function (assert) {
-    // when
-    await visit('/mot-de-passe-oublie');
-
-    // then
-    assert.dom('.sign-form__container').exists();
   });
 
   test('should stay on mot de passe oublié page, and show success message, when email sent correspond to an existing user', async function (assert) {

--- a/mon-pix/tests/acceptance/password-reset-demand-form_test.js
+++ b/mon-pix/tests/acceptance/password-reset-demand-form_test.js
@@ -16,9 +16,7 @@ module('Acceptance | Password reset demand form', function (hooks) {
     await visit('/mot-de-passe-oublie');
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/mot-de-passe-oublie');
+    assert.strictEqual(currentURL(), '/mot-de-passe-oublie');
   });
 
   test('should stay on mot de passe oublié page, and show success message, when email sent correspond to an existing user', async function (assert) {
@@ -36,9 +34,7 @@ module('Acceptance | Password reset demand form', function (hooks) {
     // when
     await clickByLabel(this.intl.t('pages.password-reset-demand.actions.reset'));
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/mot-de-passe-oublie');
+    assert.strictEqual(currentURL(), '/mot-de-passe-oublie');
     assert.dom('.password-reset-demand-form__body').exists();
   });
 

--- a/mon-pix/tests/acceptance/reset-password-form_test.js
+++ b/mon-pix/tests/acceptance/reset-password-form_test.js
@@ -1,4 +1,5 @@
-import { currentURL, fillIn, find, visit } from '@ember/test-helpers';
+import { currentURL, fillIn } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';
@@ -35,7 +36,7 @@ module('Acceptance | Reset Password Form', function (hooks) {
     assert.equal(currentURL(), '/changer-mot-de-passe/temporaryKey');
   });
 
-  test('should stay on changer-mot-de-passe, and show success message, when password is successfully reset', async function (assert) {
+  test('should stay on changer-mot-de-passe when password is successfully reset', async function (assert) {
     // given
     server.create('user', {
       id: 1000,
@@ -50,17 +51,15 @@ module('Acceptance | Reset Password Form', function (hooks) {
       email: 'brandone.martins@pix.com',
     });
 
-    await visit('/changer-mot-de-passe/brandone-reset-key');
-    await fillIn('#password', 'newPass12345!');
+    const screen = await visit('/changer-mot-de-passe/brandone-reset-key');
+    const passwordInput = screen.getByLabelText('Mot de passe');
+    await fillIn(passwordInput, 'newPass12345!');
 
     // when
     await clickByLabel(this.intl.t('pages.reset-password.actions.submit'));
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/changer-mot-de-passe/brandone-reset-key');
-    assert.ok(find('.sign-form__body').textContent.includes('Votre mot de passe a été modifié avec succès'));
+    assert.strictEqual(currentURL(), '/changer-mot-de-passe/brandone-reset-key');
   });
 
   test('should allow connected user to visit reset-password page', async function (assert) {

--- a/mon-pix/tests/acceptance/reset-password-form_test.js
+++ b/mon-pix/tests/acceptance/reset-password-form_test.js
@@ -31,9 +31,7 @@ module('Acceptance | Reset Password Form', function (hooks) {
     await visit('/changer-mot-de-passe/temporaryKey');
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/changer-mot-de-passe/temporaryKey');
+    assert.strictEqual(currentURL(), '/changer-mot-de-passe/temporaryKey');
   });
 
   test('should stay on changer-mot-de-passe when password is successfully reset', async function (assert) {
@@ -83,8 +81,6 @@ module('Acceptance | Reset Password Form', function (hooks) {
     await visit('/changer-mot-de-passe/brandone-reset-key');
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/changer-mot-de-passe/brandone-reset-key');
+    assert.strictEqual(currentURL(), '/changer-mot-de-passe/brandone-reset-key');
   });
 });

--- a/mon-pix/tests/integration/components/password-reset-demand-form_test.js
+++ b/mon-pix/tests/integration/components/password-reset-demand-form_test.js
@@ -8,29 +8,27 @@ import hbs from 'htmlbars-inline-precompile';
 import { resolve, reject } from 'rsvp';
 import Service from '@ember/service';
 import { clickByLabel } from '../../helpers/click-by-label';
-import { contains } from '../../helpers/contains';
 import { render } from '@1024pix/ember-testing-library';
+import sinon from 'sinon';
 
 module('Integration | Component | password reset demand form', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('renders', async function (assert) {
-    await render(hbs`<PasswordResetDemandForm />`);
-    assert.dom('.sign-form__container').exists();
-  });
+  test('renders all the necessary elements of the form', async function (assert) {
+    // given
+    const service = this.owner.lookup('service:url');
+    service.currentDomain = { getExtension: sinon.stub().returns('org') };
 
-  test('renders all the necessary elements of the form ', async function (assert) {
     // when
-    await render(hbs`<PasswordResetDemandForm />`);
-
+    const screen = await render(hbs`<PasswordResetDemandForm />`);
     // then
-    assert.dom('.pix-logo__link').exists();
-    assert.dom('.sign-form-title').exists();
-    assert.dom('.sign-form-header__instruction').exists();
-    assert.dom('.sign-form__body').exists();
-    assert.dom('.form-textfield__label').exists();
-    assert.dom('.form-textfield__input-field-container').exists();
-    assert.ok(contains(this.intl.t('pages.password-reset-demand.actions.reset')));
+    assert.dom(screen.getByRole('img', { name: "Page d'accueil de Pix.org" })).exists();
+    assert.dom(screen.getByRole('link', { name: "Page d'accueil de Pix.org" })).hasProperty('href', 'https://pix.org/');
+    assert.dom(screen.getByRole('heading', { name: 'Mot de passe oublié ?' })).exists();
+    assert.dom(screen.getByText("Entrez votre adresse e-mail ci-dessous, et c'est repartix")).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'obligatoire Adresse e-mail' })).exists();
+    assert.dom(screen.getByRole('button', { name: 'Réinitialiser mon mot de passe' })).exists();
+    assert.dom(screen.getByRole('link', { name: 'Retour à la page de connexion' })).exists();
   });
 
   test('should display error message when there is an error on password reset demand', async function (assert) {

--- a/mon-pix/tests/integration/components/signin-form_test.js
+++ b/mon-pix/tests/integration/components/signin-form_test.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 import { module, test } from 'qunit';
-import { fillIn, click } from '@ember/test-helpers';
+import { fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { render, clickByName } from '@1024pix/ember-testing-library';
 
@@ -271,25 +271,6 @@ module('Integration | Component | signin form', function (hooks) {
       // Then
       sinon.assert.calledOnce(session.authenticateUser);
       assert.ok(true);
-    });
-  });
-
-  module('when the password visibility button is clicked', function () {
-    test('it should focus on input', async function (assert) {
-      // given
-      const screen = await render(hbs`<SigninForm />`);
-
-      // when
-      await click(screen.getByRole('button', { name: this.intl.t('common.form.visible-password') }));
-
-      // then
-      assert
-        .dom(
-          screen.getByRole('textbox', {
-            name: `${this.intl.t('pages.sign-in.fields.password.label')}`,
-          })
-        )
-        .isFocused();
     });
   });
 });

--- a/mon-pix/tests/integration/components/signup-form_test.js
+++ b/mon-pix/tests/integration/components/signup-form_test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 import Service from '@ember/service';
 
-import { fillIn, findAll, triggerEvent, click } from '@ember/test-helpers';
+import { fillIn, triggerEvent } from '@ember/test-helpers';
 import { render, clickByName } from '@1024pix/ember-testing-library';
 
 import ArrayProxy from '@ember/array/proxy';
@@ -14,7 +14,6 @@ import ENV from '../../../config/environment';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 const ApiErrorMessages = ENV.APP.API_ERROR_MESSAGES;
-const INPUT_TEXT_FIELD_CLASS_DEFAULT = 'form-textfield__input-container--default';
 
 const userEmpty = EmberObject.create({});
 
@@ -55,23 +54,31 @@ module('Integration | Component | SignupForm', function (hooks) {
       const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
 
       // then
-      assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.showcase-homepage', { tld: 'localhost' }) }));
-      assert.ok(screen.getByRole('heading', { name: this.intl.t('pages.sign-up.first-title') }));
-      assert.ok(screen.getByRole('link', { name: this.intl.t('pages.sign-up.subtitle.link') }));
-      assert.ok(screen.getByRole('textbox', { name: this.intl.t('pages.sign-up.fields.firstname.label') }));
-      assert.ok(screen.getByRole('textbox', { name: this.intl.t('pages.sign-up.fields.lastname.label') }));
-      assert.ok(
-        screen.getByLabelText(
-          `${this.intl.t('pages.sign-up.fields.password.label')} ${this.intl.t('pages.sign-up.fields.password.help')}`
+      assert
+        .dom(screen.getByRole('link', { name: this.intl.t('navigation.showcase-homepage', { tld: 'localhost' }) }))
+        .exists();
+      assert.dom(screen.getByRole('heading', { name: this.intl.t('pages.sign-up.first-title') })).exists();
+      assert.dom(screen.getByRole('link', { name: this.intl.t('pages.sign-up.subtitle.link') })).exists();
+      assert.dom(screen.getByRole('textbox', { name: this.intl.t('pages.sign-up.fields.firstname.label') })).exists();
+      assert.dom(screen.getByRole('textbox', { name: this.intl.t('pages.sign-up.fields.lastname.label') })).exists();
+      assert
+        .dom(
+          screen.getByLabelText(
+            `${this.intl.t('pages.sign-up.fields.password.label')} ${this.intl.t('pages.sign-up.fields.password.help')}`
+          )
         )
-      );
-      assert.ok(
-        screen.getByRole('textbox', {
-          name: `${this.intl.t('pages.sign-up.fields.email.label')} ${this.intl.t('pages.sign-up.fields.email.help')}`,
-        })
-      );
-      assert.ok(screen.getByRole('button', { name: this.intl.t('common.form.visible-password') }));
-      assert.ok(screen.getByRole('checkbox', { name: this.intl.t('common.cgu.label') }));
+        .exists();
+      assert
+        .dom(
+          screen.getByRole('textbox', {
+            name: `${this.intl.t('pages.sign-up.fields.email.label')} ${this.intl.t(
+              'pages.sign-up.fields.email.help'
+            )}`,
+          })
+        )
+        .exists();
+      assert.dom(screen.getByRole('button', { name: this.intl.t('common.form.visible-password') })).exists();
+      assert.dom(screen.getByRole('checkbox', { name: this.intl.t('common.cgu.label') })).exists();
     });
 
     test("should have links to Pix's CGU and data protection policy ", async function (assert) {
@@ -129,20 +136,12 @@ module('Integration | Component | SignupForm', function (hooks) {
   });
 
   module('When API returns errors', function () {
-    const userInputs = {
-      email: 'toto@pix.fr',
-      firstName: 'Marion',
-      lastName: 'Yade',
-      password: 'gipix2017',
-      cgu: true,
-    };
-
     test('should display an error if api cannot be reached', async function (assert) {
       // given
       const stubCatchedApiErrorInternetDisconnected = undefined;
 
       const user = EmberObject.create({
-        ...userInputs,
+        cgu: true,
         save() {
           return new reject(stubCatchedApiErrorInternetDisconnected);
         },
@@ -150,6 +149,7 @@ module('Integration | Component | SignupForm', function (hooks) {
 
       this.set('user', user);
       const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
+      await _fillFormWithCorrectData(screen);
 
       // when
       await clickByName(this.intl.t('pages.sign-up.actions.submit'));
@@ -170,7 +170,7 @@ module('Integration | Component | SignupForm', function (hooks) {
       };
 
       const user = EmberObject.create({
-        ...userInputs,
+        cgu: true,
         save() {
           return new reject(apiReturn);
         },
@@ -178,6 +178,7 @@ module('Integration | Component | SignupForm', function (hooks) {
 
       this.set('user', user);
       const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
+      await _fillFormWithCorrectData(screen);
 
       // when
       await clickByName(this.intl.t('pages.sign-up.actions.submit'));
@@ -197,7 +198,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         ],
       };
       const user = EmberObject.create({
-        ...userInputs,
+        cgu: true,
         save() {
           return new reject(apiReturn);
         },
@@ -205,6 +206,7 @@ module('Integration | Component | SignupForm', function (hooks) {
 
       this.set('user', user);
       const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
+      await _fillFormWithCorrectData(screen);
 
       // when
       await clickByName(this.intl.t('pages.sign-up.actions.submit'));
@@ -224,7 +226,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         ],
       };
       const user = EmberObject.create({
-        ...userInputs,
+        cgu: true,
         save() {
           return new reject(apiReturn);
         },
@@ -232,6 +234,7 @@ module('Integration | Component | SignupForm', function (hooks) {
 
       this.set('user', user);
       const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
+      await _fillFormWithCorrectData(screen);
 
       // when
       await clickByName(this.intl.t('pages.sign-up.actions.submit'));
@@ -252,7 +255,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         ],
       };
       const user = EmberObject.create({
-        ...userInputs,
+        cgu: true,
         save() {
           return new reject(apiReturn);
         },
@@ -260,6 +263,7 @@ module('Integration | Component | SignupForm', function (hooks) {
 
       this.set('user', user);
       const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
+      await _fillFormWithCorrectData(screen);
 
       // when
       await clickByName(this.intl.t('pages.sign-up.actions.submit'));
@@ -284,10 +288,6 @@ module('Integration | Component | SignupForm', function (hooks) {
         // given
         let isFormSubmitted = false;
         const user = EmberObject.create({
-          email: 'toto@pix.fr',
-          firstName: 'Marion',
-          lastName: 'Yade',
-          password: 'gipix2017',
           cgu: true,
           save() {
             isFormSubmitted = true;
@@ -298,7 +298,8 @@ module('Integration | Component | SignupForm', function (hooks) {
         this.set('authenticateUser', () => {});
 
         this.set('user', user);
-        await render(hbs`<SignupForm @user={{this.user}} />`);
+        const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
+        await _fillFormWithCorrectData(screen);
 
         // when
         await clickByName(this.intl.t('pages.sign-up.actions.submit'));
@@ -314,24 +315,21 @@ module('Integration | Component | SignupForm', function (hooks) {
         this.set('authenticateUser', authenticateUserStub);
 
         const user = EmberObject.create({
-          email: 'toto@pix.fr',
-          firstName: 'Marion',
-          lastName: 'Yade',
-          password: 'gipix2017',
           cgu: true,
           save() {
             return resolve();
           },
         });
         this.set('user', user);
-        await render(hbs`<SignupForm @user={{this.user}} />`);
+        const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
+        await _fillFormWithCorrectData(screen);
 
         // when
         await clickByName(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
         sinon.assert.calledOnce(session.authenticateUser);
-        sinon.assert.calledWith(session.authenticateUser, 'toto@pix.fr', 'gipix2017');
+        sinon.assert.calledWith(session.authenticateUser, 'jean@example.net', 'Password123');
         assert.notOk(user.password);
         assert.ok(true);
       });
@@ -452,10 +450,6 @@ module('Integration | Component | SignupForm', function (hooks) {
         ];
 
         const userBackToSaveWithErrors = EmberObject.create({
-          email: 'elliott'.repeat(37) + '@example.net',
-          firstName: 'Henry',
-          lastName: 'Thomas',
-          password: 'Pix12345',
           cgu: true,
           errors,
           save() {
@@ -465,6 +459,18 @@ module('Integration | Component | SignupForm', function (hooks) {
 
         this.set('user', userBackToSaveWithErrors);
         const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
+
+        const tooLargeEmail = 'jean'.repeat(37);
+        await fillIn(screen.getByRole('textbox', { name: 'Prénom' }), 'Jean');
+        await fillIn(screen.getByRole('textbox', { name: 'Nom' }), 'Cérien');
+        await fillIn(
+          screen.getByRole('textbox', { name: 'Adresse e-mail (ex: nom@exemple.fr)' }),
+          `${tooLargeEmail}@example.net`
+        );
+        await fillIn(
+          screen.getByLabelText('Mot de passe (8 caractères minimum, dont une majuscule, une minuscule et un chiffre)'),
+          'Password123'
+        );
 
         // when
         await clickByName(this.intl.t('pages.sign-up.actions.submit'));
@@ -588,7 +594,7 @@ module('Integration | Component | SignupForm', function (hooks) {
         assert.dom(screen.queryByText(this.intl.t('common.cgu.error'))).doesNotExist();
       });
 
-      test('should reset validation property, when all things are ok and form is submitted', async function (assert) {
+      test('should reset validation property, when all informations are validated and form is submitted', async function (assert) {
         // given
         const validUser = EmberObject.create({
           email: 'toto@pix.fr',
@@ -603,39 +609,28 @@ module('Integration | Component | SignupForm', function (hooks) {
 
         this.set('user', validUser);
         this.set('authenticateUser', () => {});
-        await render(hbs`<SignupForm @user={{this.user}} />`);
+        const screen = await render(hbs`<SignupForm @user={{this.user}} />`);
 
         // when
         await clickByName(this.intl.t('pages.sign-up.actions.submit'));
 
         // then
-        assert.ok(
-          findAll('.form-textfield__input-field-container')[0]
-            .getAttribute('class')
-            .includes(INPUT_TEXT_FIELD_CLASS_DEFAULT)
-        );
-      });
-
-      module('when the password visibility button is clicked', function () {
-        test('it should focus on input', async function (assert) {
-          // given
-          const screen = await render(hbs`<SignupForm />`);
-
-          // when
-          await click(screen.getByRole('button', { name: this.intl.t('common.form.visible-password') }));
-
-          // then
-          assert
-            .dom(
-              screen.getByRole('textbox', {
-                name: `${this.intl.t('pages.sign-up.fields.password.label')} ${this.intl.t(
-                  'pages.sign-up.fields.password.help'
-                )}`,
-              })
-            )
-            .isFocused();
-        });
+        assert.dom(screen.queryByText(this.intl.t('pages.sign-up.fields.firstname.error'))).doesNotExist();
+        assert.dom(screen.queryByText(this.intl.t('pages.sign-up.fields.lastname.error'))).doesNotExist();
+        assert.dom(screen.queryByText(this.intl.t('pages.sign-up.fields.email.error'))).doesNotExist();
+        assert.dom(screen.queryByText(this.intl.t('pages.sign-up.fields.password.error'))).doesNotExist();
+        assert.dom(screen.queryByText(this.intl.t('common.cgu.error'))).doesNotExist();
       });
     });
   });
+
+  async function _fillFormWithCorrectData(screen) {
+    await fillIn(screen.getByRole('textbox', { name: 'Prénom' }), 'Jean');
+    await fillIn(screen.getByRole('textbox', { name: 'Nom' }), 'Cérien');
+    await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail (ex: nom@exemple.fr)' }), 'jean@example.net');
+    await fillIn(
+      screen.getByLabelText('Mot de passe (8 caractères minimum, dont une majuscule, une minuscule et un chiffre)'),
+      'Password123'
+    );
+  }
 });

--- a/mon-pix/tests/integration/components/update-expired-password-form_test.js
+++ b/mon-pix/tests/integration/components/update-expired-password-form_test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
-import { fillIn, render, triggerEvent } from '@ember/test-helpers';
+import { fillIn, triggerEvent } from '@ember/test-helpers';
 import EmberObject from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
+import { render } from '@1024pix/ember-testing-library';
 
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { contains } from '../../helpers/contains';
@@ -36,7 +37,9 @@ module('Integration | Component | update-expired-password-form', function (hooks
       this.set('resetExpiredPasswordDemand', resetExpiredPasswordDemand);
       const newPassword = 'Pix12345!';
 
-      await render(hbs`<UpdateExpiredPasswordForm @resetExpiredPasswordDemand={{this.resetExpiredPasswordDemand}} />`);
+      const screen = await render(
+        hbs`<UpdateExpiredPasswordForm @resetExpiredPasswordDemand={{this.resetExpiredPasswordDemand}} />`
+      );
 
       // when
       await fillIn(PASSWORD_INPUT_CLASS, newPassword);
@@ -46,7 +49,7 @@ module('Integration | Component | update-expired-password-form', function (hooks
 
       // then
       assert.dom(PASSWORD_INPUT_CLASS).doesNotExist();
-      assert.dom('.password-reset-demand-form__body').exists();
+      assert.dom(screen.getByText('Votre mot de passe a été mis à jour.')).exists();
     });
   });
 

--- a/mon-pix/tests/integration/components/user-account/email-with-validation-form-test.js
+++ b/mon-pix/tests/integration/components/user-account/email-with-validation-form-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { render, triggerEvent } from '@ember/test-helpers';
+import { triggerEvent, fillIn } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { fillInByLabel } from '../../../helpers/fill-in-by-label';
 import { clickByLabel } from '../../../helpers/click-by-label';
 import { contains } from '../../../helpers/contains';
@@ -44,20 +45,16 @@ module('Integration | Component | user-account | email-with-validation-form', fu
         test('should display an invalid error message when focus-out', async function (assert) {
           // given
           const invalidEmail = 'invalidEmail';
+          const expectedInvalidEmailError = 'Votre adresse e-mail n’est pas valide.';
 
-          await render(hbs`<UserAccount::EmailWithValidationForm />`);
+          const screen = await render(hbs`<UserAccount::EmailWithValidationForm />`);
 
           // when
-          await fillInByLabel(
-            this.intl.t('pages.user-account.account-update-email-with-validation.fields.new-email.label'),
-            invalidEmail
-          );
+          await fillIn(screen.getByRole('textbox', { name: 'Nouvelle adresse e-mail' }), invalidEmail);
           await triggerEvent('#newEmail', 'focusout');
 
           // then
-          assert.ok(
-            contains(this.intl.t('pages.user-account.account-update-email-with-validation.fields.errors.invalid-email'))
-          );
+          assert.dom(screen.getByText(expectedInvalidEmailError)).exists();
         });
       });
     });

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -68,7 +68,7 @@
       "mandatory-all-fields": "Tous les champs sont obligatoires.",
       "mandatory-fields": "Les champs marqués de '<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' sont obligatoires",
       "success": "correct",
-      "visible-password": "afficher le mot de passe"
+      "visible-password": "Afficher le mot de passe"
     },
     "french-republic": "République française. Liberté, égalité, fraternité.",
     "french-education-ministry": "Ministère de l'éducation nationale et de la jeunesse. Liberté égalité fraternité",


### PR DESCRIPTION
## :egg: Problème
Actuellement sur Pix App, dans les pages de `/connexion` et `/inscription`, nous n’utilisons pas les composants PIX UI.

## :bowl_with_spoon: Proposition
Afin d'être avec en accord avec le Design System de Pix, nous avons ajouté les composants PixInput et PixInputPassword.

## :milk_glass: Remarques
Le css du ficher sign-form était partagé par plusieurs composants. Ça pose plusieurs problèmes : 
- Même si visuellement ils sont à peu près similaire, ils ont des différences qui rend la modification du css compliqué. 
- Partager le css avec plusieurs page, c'est risquer que l'on modifie pour une page sans regarder le comportement des autres et donc potentiellement casser quelque chose.

On fait donc le choix ici de "dupliquer" le css pour chaque page, avec chacun ses spécificités d'affichage

## :butter: Pour tester
Se rendre sur les pages suivantes et vérifier que l'affichage soit conforme et que les messages d'erreur apparaissent bien (à comparer avec l'intégration ou la recette)

- `/connexion`
- `/inscription`
- `/mot-de-passe-oublie`
- `/mise-a-jour-mot-de-passe-expire`
- `/mon-compte/methodes-de-connexion` vérifier la modification de l'adresse e-mail
