### PR TITLE
[TECH] Rendre le test de la génération de PDF côté API moins fragile (PIX-7070)

### DIFF
--- a/api/tests/integration/application/target-profile/presenter/pdf/learning-content-pdf-presenter_test.js
+++ b/api/tests/integration/application/target-profile/presenter/pdf/learning-content-pdf-presenter_test.js
@@ -6,6 +6,8 @@ const { addRandomSuffix } = require('pdf-lib/cjs/utils');
 const REWRITE_REFERENCE_FILE = false;
 
 describe('Integration | Application | Target-Profiles | Presenter | PDF | LearningContentPdfPresenter', function () {
+  this.timeout(3000);
+
   beforeEach(function () {
     _makePdfLibPredictable();
     MockDate.set(new Date('2020-12-01'));


### PR DESCRIPTION
## :egg: Problème
Ce test d'intégration effectue la génération et la comparaison d'un PDF en se basant sur un référentiel un peu riche.
Du coup, il a un potentiel de timeout assez élevé.

## :bowl_with_spoon: Proposition
Le test ne peut pas vraiment être davantage réduit. 
On met un timeout de 3 secondes pour être sûr qu'il passe

## :butter: Pour tester
Merger. 
Au bout de 15 jours, vérifier les tests flaky dans CircleCI et vérifier qu'il n'y figure plus.