### PR TITLE
[BUGFIX] Corriger la clé de traduction de l'erreur interne sur plusieurs pages de Pix App (PIX-7067).

### DIFF
--- a/mon-pix/app/components/reset-password-form.js
+++ b/mon-pix/app/components/reset-password-form.js
@@ -56,10 +56,10 @@ export default class ResetPasswordForm extends Component {
           this.validation.message = this.intl.t('pages.reset-password.error.expired-demand');
           break;
         case '500':
-          this.validation.message = this.intl.t('api-error-messages.internal-server-error');
+          this.validation.message = this.intl.t('common.api-error-messages.internal-server-error');
           break;
         default:
-          this.validation.message = this.intl.t('api-error-messages.internal-server-error');
+          this.validation.message = this.intl.t('common.api-error-messages.internal-server-error');
           break;
       }
     }

--- a/mon-pix/app/controllers/account-recovery/find-sco-record.js
+++ b/mon-pix/app/controllers/account-recovery/find-sco-record.js
@@ -140,7 +140,7 @@ export default class FindScoRecordController extends Controller {
     };
 
     const internalError = {
-      message: this.intl.t('api-error-messages.internal-server-error'),
+      message: this.intl.t('common.api-error-messages.internal-server-error'),
       title: this.intl.t('pages.account-recovery.errors.title'),
       showBackToHomeButton: true,
     };

--- a/mon-pix/app/controllers/account-recovery/update-sco-record.js
+++ b/mon-pix/app/controllers/account-recovery/update-sco-record.js
@@ -44,7 +44,7 @@ export default class UpdateScoRecordController extends Controller {
     const { status, code } = err.errors?.[0] || {};
 
     const internalError = {
-      errorMessage: this.intl.t('api-error-messages.internal-server-error'),
+      errorMessage: this.intl.t('common.api-error-messages.internal-server-error'),
       showRenewLink: false,
       showBackToHomeButton: true,
     };

--- a/mon-pix/app/routes/account-recovery/update-sco-record.js
+++ b/mon-pix/app/routes/account-recovery/update-sco-record.js
@@ -25,7 +25,7 @@ export default class UpdateScoRecordRoute extends Route {
     };
 
     const internalError = {
-      errorMessage: this.intl.t('api-error-messages.internal-server-error'),
+      errorMessage: this.intl.t('common.api-error-messages.internal-server-error'),
       showBackToHomeButton: true,
     };
 

--- a/mon-pix/tests/acceptance/account-recovery/find-sco-record_test.js
+++ b/mon-pix/tests/acceptance/account-recovery/find-sco-record_test.js
@@ -401,7 +401,7 @@ module('Acceptance | account-recovery | FindScoRecordRoute', function (hooks) {
             name: this.intl.t('pages.account-recovery.errors.title'),
           })
         );
-        assert.ok(screen.getByText(this.intl.t('api-error-messages.internal-server-error')));
+        assert.ok(screen.getByText(this.intl.t('common.api-error-messages.internal-server-error')));
         assert.ok(
           screen.getByRole('link', {
             name: this.intl.t('navigation.back-to-homepage'),

--- a/mon-pix/tests/acceptance/account-recovery/update-sco-record_test.js
+++ b/mon-pix/tests/acceptance/account-recovery/update-sco-record_test.js
@@ -352,7 +352,7 @@ module('Acceptance | account-recovery | UpdateScoRecordRoute', function (hooks) 
           name: this.intl.t('pages.account-recovery.errors.title'),
         })
       );
-      assert.ok(screen.getByText(this.intl.t('api-error-messages.internal-server-error')));
+      assert.ok(screen.getByText(this.intl.t('common.api-error-messages.internal-server-error')));
       assert.ok(screen.getByRole('link', { name: this.intl.t('navigation.back-to-homepage') }));
     });
   });

--- a/mon-pix/tests/unit/components/reset-password-form_test.js
+++ b/mon-pix/tests/unit/components/reset-password-form_test.js
@@ -102,7 +102,7 @@ module('Unit | Component | reset password form', function (hooks) {
         },
         {
           status: '500',
-          message: 'api-error-messages.internal-server-error',
+          message: 'common.api-error-messages.internal-server-error',
         },
       ].forEach((testCase) => {
         test(`it should display ${testCase.message} when http status is ${testCase.status}`, async function (assert) {

--- a/mon-pix/tests/unit/routes/account-recovery/update-sco-record-test.js
+++ b/mon-pix/tests/unit/routes/account-recovery/update-sco-record-test.js
@@ -184,9 +184,7 @@ module('Unit | Route | account-recovery | update sco record', function (hooks) {
 
           // then
           return promise.then((result) => {
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(result.errorMessage, this.intl.t('api-error-messages.internal-server-error'));
+            assert.strictEqual(result.errorMessage, this.intl.t('common.api-error-messages.internal-server-error'));
             assert.true(result.showBackToHomeButton);
           });
         });


### PR DESCRIPTION
## :egg: Problème
Une amélioration des erreurs sur Pix App a récemment été réalisé mais un oubli de modification d'une clé de traduction a entraîné un problème d'affichage sur les pages suivantes : 
- Changement de mot de passe
<img width="399" alt="Capture d’écran 2023-02-07 à 14 28 24" src="https://user-images.githubusercontent.com/58915422/217515302-afd35c49-d93a-4dca-aba2-972ce62f35d4.png">

- Sortie sco : entrer les informations de l'élève
- Sortie sco : créer la méthode de connexion avec adresse e-mail
<img width="512" alt="Capture d’écran 2023-02-08 à 11 57 42" src="https://user-images.githubusercontent.com/58915422/217515367-6db4e9b0-e74b-40c1-b54b-2fe283d632d4.png">


## :bowl_with_spoon: Proposition
Corriger les clés de traduction sur ces différentes pages.

## :milk_glass: Remarques
La clé impacté : `common.api-error-messages.internal-server-error`
Le `common` a été oublié

J'ai fait une passe sur les autres erreurs de type `common.api-error-messages` et ça semble être bon.
## :butter: Pour tester

(ces tests vont impliquer de recevoir des mails, si vous voulez continuer de cette façon, vos variables sendinblue doivent être à jour et `MAILING_ENABLED` à true pour recevoir les mails)
(vous pouvez sinon récupérer les clés en BDD pour continuer sans recevoir les mails)

**Scénario 1 :** Mot de passe oublié 

- Aller sur Pix App, /connexion
- Cliquer sur mot de passe oublié ?
- Fournir une adresse e-mail existante en BDD (si vous voulez recevoir le mail, mettez votre mail en BDD dans un utilisateur au hasard)
- Aller sur votre boîte mail et suivre le lien (le lien renvoi en prod, changez bien en localhost ou dev.app)
- Remplir un mot de passe valide et avant de valider, ouvrir votre console et simuler un problème réseau 
<img width="251" alt="Capture d’écran 2023-02-08 à 12 27 02" src="https://user-images.githubusercontent.com/58915422/217517177-857bf1e8-4627-44f8-ad84-5df07c040f65.png">

- Constater que le message s'affiche correctement


**Scénario 2 :** Sortie SCO (on cherche les infos élèves)
- Aller sur /recupérer-mon-compte
- Remplir les infos d'un élève

Ine/Ina : 123456789CC
Prénom : George
Nom : De Cambridge
Date de naissance : 22/07/2013

- Avant de valider, simuler une erreur réseau encore une fois
- Constater que le message s'affiche correctement

**Scénario 3 :** Sortie SCO (on valide son mot de passe)

- Aller sur /recupérer-mon-compte
- Remplir les infos d'un élève et valider
- Confirmer les infos
- Entrer son adresse e-mail pour recevoir le mail
- Cliquer sur le lien du mail et fournir un mot de passe valide 
- Avant de valider, simuler une erreur réseau encore une fois
- Constater que le message s'affiche correctement