### PR TITLE
[FEATURE] Traduire la page de création d'une session (PIX-6667)

### DIFF
--- a/certif/app/controllers/authenticated/sessions/new.js
+++ b/certif/app/controllers/authenticated/sessions/new.js
@@ -7,9 +7,10 @@ import { inject as service } from '@ember/service';
 export default class SessionsNewController extends Controller {
   @alias('model') session;
   @service router;
+  @service intl;
 
   get pageTitle() {
-    return "Planification d'une session | Pix Certif";
+    return this.intl.t('pages.sessions.new.extra-information');
   }
 
   @action

--- a/certif/app/templates/authenticated/sessions/new.hbs
+++ b/certif/app/templates/authenticated/sessions/new.hbs
@@ -1,18 +1,16 @@
 {{page-title this.pageTitle replace=true}}
 <div>
-  <h1 class="page__title page-title">Création d'une session de certification</h1>
+  <h1 class="page__title page-title">{{t "pages.sessions.new.title"}}</h1>
 
   <form {{on "submit" this.createSession}} class="session-form">
     <p class="session-form__mandatory-information">
-      Les champs marqués de
-      <abbr title="obligatoire" class="mandatory-mark">*</abbr>
-      sont obligatoires.
+      {{t "pages.sessions.new.required-fields" htmlSafe=true}}
     </p>
 
     <div class="session-form__field">
       <label for="session-address" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        Nom du site
+        {{t "pages.sessions.new.address"}}
       </label>
       <Input
         id="session-address"
@@ -32,7 +30,7 @@
     <div class="session-form__field">
       <label for="session-room" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        Nom de la salle
+        {{t "pages.sessions.new.room"}}
       </label>
       <Input
         id="session-room"
@@ -52,7 +50,7 @@
     <div class="session-form__field">
       <label for="session-date" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        Date de début
+        {{t "pages.sessions.new.date"}}
       </label>
       <EmberFlatpickr
         id="session-date"
@@ -76,7 +74,7 @@
     <div class="session-form__field">
       <label for="session-time" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        Heure de début (heure locale)
+        {{t "pages.sessions.new.time"}}
       </label>
       <EmberFlatpickr
         id="session-time"
@@ -101,7 +99,7 @@
     <div class="session-form__field">
       <label for="session-examiner" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        Surveillant(s)
+        {{t "pages.sessions.new.examiner"}}
       </label>
       <Input
         id="session-examiner"
@@ -119,7 +117,7 @@
     </div>
 
     <div class="session-form__field">
-      <label for="session-description" class="label">Observations</label>
+      <label for="session-description" class="label">{{t "pages.sessions.new.description"}}</label>
       <Textarea
         id="session-description"
         name="session-description"
@@ -137,14 +135,14 @@
           @backgroundColor="transparent-light"
           @triggerAction={{this.cancel}}
           @isBorderVisible="true"
-          aria-label="Annuler la création de session et retourner vers la page précédente"
+          aria-label={{t "pages.sessions.new.actions.cancel-extra-information"}}
         >
-          Annuler
+          {{t "common.actions.cancel"}}
         </PixButton>
       </li>
       <li>
         <PixButton @type="submit">
-          Créer la session
+          {{t "pages.sessions.new.actions.create-session"}}
         </PixButton>
       </li>
     </ul>

--- a/certif/tests/acceptance/session-new_test.js
+++ b/certif/tests/acceptance/session-new_test.js
@@ -3,6 +3,7 @@ import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from '../helpers/test-init';
+import { setupIntl, t } from 'ember-intl/test-support';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setFlatpickrDate } from 'ember-flatpickr/test-support/helpers';
@@ -10,6 +11,7 @@ import { setFlatpickrDate } from 'ember-flatpickr/test-support/helpers';
 module('Acceptance | Session creation', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   test('it should not be accessible by an unauthenticated user', async function (assert) {
     // when
@@ -58,26 +60,21 @@ module('Acceptance | Session creation', function (hooks) {
       const sessionTime = '13:45';
 
       const screen = await visit('/sessions/creation');
-      assert.dom(screen.getByRole('textbox', { name: 'Nom de la salle' })).exists();
-      assert.dom(screen.getByRole('textbox', { name: 'Surveillant(s)' })).exists();
-      assert.dom(screen.getByRole('textbox', { name: 'Nom du site' })).exists();
-      assert.dom(screen.getByRole('textbox', { name: 'Observations' })).hasAttribute('maxLength', '350');
-      assert.dom(screen.getByText('Heure de début (heure locale)')).exists();
-      assert.dom(screen.getByText('Date de début')).exists();
-      assert.dom(screen.getByRole('button', { name: 'Créer la session' })).exists();
+      assert.dom(screen.getByRole('heading', { name: t('pages.sessions.new.title') })).exists();
       assert
-        .dom(
-          screen.getByRole('button', { name: 'Annuler la création de session et retourner vers la page précédente' })
-        )
+        .dom(screen.getByRole('textbox', { name: t('pages.sessions.new.description') }))
+        .hasAttribute('maxLength', '350');
+      assert
+        .dom(screen.getByRole('button', { name: t('pages.sessions.new.actions.cancel-extra-information') }))
         .exists();
 
-      await fillIn(screen.getByRole('textbox', { name: 'Nom du site' }), 'My address');
-      await fillIn(screen.getByRole('textbox', { name: 'Nom de la salle' }), 'My room');
-      await fillIn(screen.getByRole('textbox', { name: 'Surveillant(s)' }), 'My examiner');
-      await fillIn(screen.getByRole('textbox', { name: 'Observations' }), 'My description');
+      await fillIn(screen.getByRole('textbox', { name: t('pages.sessions.new.address') }), 'My address');
+      await fillIn(screen.getByRole('textbox', { name: t('pages.sessions.new.room') }), 'My room');
+      await fillIn(screen.getByRole('textbox', { name: t('pages.sessions.new.examiner') }), 'My examiner');
+      await fillIn(screen.getByRole('textbox', { name: t('pages.sessions.new.description') }), 'My description');
       await setFlatpickrDate('#session-date', sessionDate);
       await setFlatpickrDate('#session-time', sessionTime);
-      await click(screen.getByRole('button', { name: 'Créer la session' }));
+      await click(screen.getByRole('button', { name: t('pages.sessions.new.actions.create-session') }));
 
       // then
       const session = server.schema.sessions.findBy({ date: sessionDate });
@@ -96,9 +93,7 @@ module('Acceptance | Session creation', function (hooks) {
       const screen = await visit('/sessions/creation');
 
       // when
-      await click(
-        screen.getByRole('button', { name: 'Annuler la création de session et retourner vers la page précédente' })
-      );
+      await click(screen.getByRole('button', { name: t('pages.sessions.new.actions.cancel-extra-information') }));
 
       // then
       const actualSessionsCount = server.schema.sessions.all().length;

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "actions": {
-      "cancel": "Annuler",
+      "cancel": "Cancel",
       "close": "Fermer",
       "continue": "Continuer",
       "delete": "Supprimer",
@@ -192,6 +192,21 @@
           "session-password": "Mot de passe de session",
           "session-update": "Modifier les informations de la session {sessionId}"
         }
+      },
+      "new": {
+        "title": "Creation of a certification session",
+        "actions": {
+          "cancel-extra-information": "Cancel the session creation and return to the previous page",
+          "create-session": "Create the session"
+        },
+        "address": "Location name",
+        "date": "Starting date",
+        "description": "Observations",
+        "examiner": "Invigilator(s)",
+        "extra-information": "Session scheduling | Pix Certif",
+        "required-fields": "The fields marked by <abbr title=\"required\" class=\"mandatory-mark\">*</abbr> are required.",
+        "room": "Room name",
+        "time": "Starting time (local time)"
       }
     },
     "session-supervising": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -188,6 +188,21 @@
           "session-password": "Mot de passe de session",
           "session-update": "Modifier les informations de la session {sessionId}"
         }
+      },
+      "new": {
+        "title": "Création d’une session de certification",
+        "actions": {
+          "cancel-extra-information": "Annuler la création de session et retourner vers la page précédente",
+          "create-session": "Créer la session"
+        },
+        "address": "Nom du site",
+        "date": "Date de début",
+        "description": "Observations",
+        "examiner": "Surveillant(s)",
+        "extra-information": "Planification d’une session | Pix Certif",
+        "required-fields": "Les champs marqués de <abbr title=\"obligatoire\" class=\"mandatory-mark\">*</abbr> sont obligatoires.",
+        "room": "Nom de la salle",
+        "time": "Heure de début (heure locale)"
       }
     },
     "session-supervising": {


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu’il clique sur “Créer une session”, toutes les informations de la page de création d’une session de certification sont en français.

## :robot: Proposition
Traduire l'ensemble des champs de la page de création d'une session de certification.

- Planification d’une session = Session scheduling
- Création d’une session de certification = Creation of a certification session
- Les champs marqués de * sont obligatoires = The fields marked by * are required.
- Nom du site = Location name
- Nom de la salle = Room name
- Date de début = Starting date
- Heure de début (heure locale) = Starting time (local time)
- Surveillant(s) = Invigilator(s)
- Observations = Observations
- Annuler = Cancel
- Créer la session = Create the session

## :rainbow: Remarques
J'en ai profité pour tester les chaines de traduction sur le test d'acceptation concerné. 

## :100: Pour tester
- Lancer Pix Certif avec un compte (ex: certifsup@example.net).
- Cliquer sur le bouton "Créer une session".
- Constater que les champs en français sont conformes aux champs indiqués plus haut dans la description de PR.
- Rajouter ?lang=en en fin d'URL pour basculer le Pix Certif en anglais (Si ça ne marche pas, aller sur Pix.org, faire la manipulation ?lang=en, puis remplacer app par certif dans l'URL).
- Constater que les champs en anglais correspondent à ceux cités plus haut dans la description.