### PR TITLE
[FEATURE] Initie le formulaire de création de déclencheur de Contenu Formatif (PIX-7024)

### DIFF
--- a/admin/app/components/trainings/edit-trigger-threshold.hbs
+++ b/admin/app/components/trainings/edit-trigger-threshold.hbs
@@ -1,0 +1,13 @@
+<Card class="edit-training-trigger__threshold" @title={{@title}}>
+  <p class="edit-training-trigger-threshold__description">{{@description}}</p>
+  <PixInput
+    class="edit-training-trigger-threshold__input"
+    name="threshold"
+    type="number"
+    @id="thresholdInput"
+    @label="Seuil en % :"
+    @placeholder="Exemple : 16"
+    min="0"
+    max="100"
+  />
+</Card>

--- a/admin/app/controllers/authenticated/trainings/training/triggers/edit.js
+++ b/admin/app/controllers/authenticated/trainings/training/triggers/edit.js
@@ -1,8 +1,47 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
 
 export default class TrainingEditTriggersController extends Controller {
+  @service intl;
+  @service router;
+  @service store;
+  @service notifications;
+
   queryParams = ['type'];
 
   @tracked type = null;
+  @tracked submitting = false;
+
+  get thresholdTitle() {
+    return this.intl.t(`pages.trainings.training.triggers.${this.type}.title`);
+  }
+
+  get thresholdDescription() {
+    return this.intl.t(`pages.trainings.training.triggers.${this.type}.edit.description`);
+  }
+
+  @action
+  goBackToTraining() {
+    this.router.transitionTo('authenticated.trainings.training');
+  }
+
+  @action
+  async onSubmit(event) {
+    event.preventDefault();
+    try {
+      const data = Object.fromEntries(new FormData(event.target).entries());
+      await this.store.createRecord('training-trigger', data).save();
+      this.notifications.success('Le déclencheur a été créé avec succès.');
+      this.goBackToTraining();
+    } catch (error) {
+      this.notifications.error('Une erreur est survenue.');
+    }
+  }
+
+  @action
+  onCancel() {
+    this.goBackToTraining();
+  }
 }

--- a/admin/app/models/training-trigger.js
+++ b/admin/app/models/training-trigger.js
@@ -1,0 +1,8 @@
+import Model, { attr, hasMany } from '@ember-data/model';
+
+export default class TrainingTrigger extends Model {
+  @attr('string') type;
+  @attr('number') trainingId;
+  @attr('number') threshold;
+  @hasMany('tube') tubes;
+}

--- a/admin/app/styles/components/trainings/training-triggers-tab.scss
+++ b/admin/app/styles/components/trainings/training-triggers-tab.scss
@@ -1,3 +1,10 @@
+.training-trigger {
+  &__description {
+    margin-bottom: $spacing-m;
+  }
+}
+
+
 .trigger-card {
   &__title {
     @include subheading;
@@ -17,5 +24,23 @@
     svg {
       margin-right: $spacing-xs;
     }
+  }
+}
+
+.edit-training-trigger {
+  &__actions {
+    display: flex;
+    gap: $spacing-m;
+    margin: $spacing-m 0;
+  }
+}
+
+.edit-training-trigger-threshold {
+  &__description {
+    margin-bottom: $spacing-s;
+  }
+
+  &__input {
+    max-width: 8.75rem;
   }
 }

--- a/admin/app/templates/authenticated/trainings/training/triggers.hbs
+++ b/admin/app/templates/authenticated/trainings/training/triggers.hbs
@@ -1,4 +1,4 @@
-<p>En savoir plus sur les déclencheurs, consulter la documentation ici</p>
+<p class="training-trigger__description">En savoir plus sur les déclencheurs, consulter la documentation ici.</p>
 
 {{#if this.showTriggersEditForm}}
   {{outlet}}

--- a/admin/app/templates/authenticated/trainings/training/triggers/edit.hbs
+++ b/admin/app/templates/authenticated/trainings/training/triggers/edit.hbs
@@ -1,1 +1,21 @@
-<p>1. Objectif à atteindre</p>
+<form class="form edit-training-trigger" {{on "submit" this.onSubmit}}>
+  <Trainings::EditTriggerThreshold @title={{this.thresholdTitle}} @description={{this.thresholdDescription}} />
+
+  <ul class="edit-training-trigger__actions">
+    <li>
+      <PixButton
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
+        @size="big"
+        @triggerAction={{this.onCancel}}
+      >
+        Annuler
+      </PixButton>
+    </li>
+    <li>
+      <PixButton @backgroundColor="green" @size="big" @type="submit" @isLoading={{this.submitting}}>
+        Créer le contenu formatif
+      </PixButton>
+    </li>
+  </ul>
+</form>

--- a/admin/tests/acceptance/authenticated/trainings/edit-triggers_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/edit-triggers_test.js
@@ -68,5 +68,16 @@ module('Acceptance | Trainings | Triggers edit', function (hooks) {
       // then
       assert.strictEqual(currentURL(), `/trainings/${trainingId}/triggers/edit?type=goal`);
     });
+
+    test('it should be able to cancel the edit form', async function (assert) {
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+      // when
+      const screen = await visit(`/trainings/${trainingId}/triggers/edit?type=prerequisite`);
+      await click(screen.getByRole('button', { name: 'Annuler' }));
+
+      // then
+      assert.strictEqual(currentURL(), `/trainings/${trainingId}/triggers`);
+    });
   });
 });

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -28,11 +28,17 @@
           "tabName": "Déclencheurs",
           "prerequisite": {
             "title": "Objectif à atteindre",
-            "alternative-title": "Ajouter un objectif à atteindre"
+            "alternative-title": "Ajouter un objectif à atteindre",
+            "edit": {
+              "description": "Si l’apprenant réussit tous les acquis des sujets sélectionnés alors le contenu formatif ne lui sera pas proposé."
+            }
           },
           "goal": {
             "title": "Objectif à ne pas dépasser",
-            "alternative-title": "Ajouter un objectif à ne pas dépasser"
+            "alternative-title": "Ajouter un objectif à ne pas dépasser",
+            "edit": {
+              "description": "Si l’apprenant réussit les acquis des sujets sélectionnés alors le contenu formatif lui sera proposé."
+            }
           }
         },
         "targetProfiles": {


### PR DESCRIPTION
## :unicorn: Problème
On ne peut pour le moment pas créer de déclencheur de Contenu Formatif.

## :robot: Proposition
Commencer en introduisant graphiquement le formulaire de création de déclencheur avec son premier champ : le seuil de déclenchement.

## :rainbow: Remarques
Le bouton "Créer le contenu formatif" est clickable mais génère une 404 pour le moment. Je propose de ne pas s'embêter avec ça, on le branchera dans une PR prochaine.

## :100: Pour tester
- Sur un détail de CF, dans l'onglet "Déclencheurs", cliquer sur un des deux boutons permettant d'en créer un
- Constater qu'on tombe sur un formulaire avec le champ "Seuil en pourcentage"
- Le bouton "Annuler" retourne sur la page initiale
