### PR TITLE
[TECH][API] Améliorer le code transformant un DTO de type User vers le modèle User du domaine pour Pix Admin (PIX-6943)

### DIFF
--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -1,11 +1,10 @@
 const moment = require('moment');
-const { knex } = require('../../../db/knex-database-connection');
 
+const { knex } = require('../../../db/knex-database-connection');
 const DomainTransaction = require('../DomainTransaction');
 const BookshelfUser = require('../orm-models/User');
 const { isUniqConstraintViolated } = require('../utils/knex-utils');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
-
 const {
   AlreadyExistingEntityError,
   AlreadyRegisteredEmailError,
@@ -439,9 +438,18 @@ function _fromKnexDTOToUserDetailsForAdmin({ userDTO, organizationLearnersDTO, a
   });
 
   const authenticationMethods = authenticationMethodsDTO.map((authenticationMethod) => {
-    if (authenticationMethod.identityProvider === AuthenticationMethod.identityProviders.PIX) {
-      delete authenticationMethod.authenticationComplement.password;
+    const isPixAuthenticationMethodWithAuthenticationComplement =
+      authenticationMethod.identityProvider === AuthenticationMethod.identityProviders.PIX &&
+      authenticationMethod.authenticationComplement;
+    if (isPixAuthenticationMethodWithAuthenticationComplement) {
+      // eslint-disable-next-line no-unused-vars
+      const { password, ...authenticationComplement } = authenticationMethod.authenticationComplement;
+      return {
+        ...authenticationMethod,
+        authenticationComplement,
+      };
     }
+
     return authenticationMethod;
   });
 

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -1118,7 +1118,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
         });
       });
 
-      context('when user has authentication methods', function () {
+      context('when user has authentication methods (PIX + GAR)', function () {
         it('returns the user with his authentication methods', async function () {
           // given
           const userInDB = databaseBuilder.factory.buildUser(userToInsert);


### PR DESCRIPTION
## :unicorn: Problème

La PR [5519](https://github.com/1024pix/pix/pull/5519) a introduit une régression car le cas des utilisateurs ayant une connexion PIX et GAR n'était pas couvert par un test.

La PR [5569](https://github.com/1024pix/pix/pull/5569) a corrigé la régression mais a introduit une manière non-sûre de manipuler les mots de passe.

## :robot: Proposition

Utiliser la déstructuration pour retirer le mot de passe de l'objet `authenticationComplement`.

## :rainbow: Remarques

RAS

## :100: Pour tester

- Se connecter à Pix Admin
- Ouvrir la console développeur
- Ouvrir la page de détails d'un utilisateur ayant Pix comme l'une de ses méthodes de connexion (ex: userpix1@example.net) - https://admin-pr5638.review.pix.fr/users/1
- Constater que dans la requête retournant les détails, ainsi que la liste des méthodes de connexion, que le mot de passe n'y apparait pas. (requête : **GET /api/admin/users/1**)