### PR TITLE
[TECH] Ajouter un index sur la date de création dans la table pole-emploi-sendings

### DIFF
--- a/api/db/migrations/20230209132840_add-created-at-index-on-pole-emploi-sendings.js
+++ b/api/db/migrations/20230209132840_add-created-at-index-on-pole-emploi-sendings.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'pole-emploi-sendings';
+const COLUMN_NAME = 'createdAt';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.index(COLUMN_NAME);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.dropIndex(COLUMN_NAME);
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème
PE nous remonte que certaine requete sont en timeout chez eux, après investigation il semble en effet que le tri par date de création puisse prendre enormement de temps

## :robot: Proposition
Ajouter un index sur le champs createdAt

## :rainbow: Remarques
Après ajout d'index sur date warehouse externe, la requete qui passait en timeout sur metabase, s'execute dans des temps plus que raisonable

## :100: Pour tester
RAS