### PR TITLE
[FEATURE] Empêcher la programmation de session dans le passé via import en masse (PIX-7086)

### DIFF
--- a/api/tests/acceptance/application/certification-centers/certification-centers-controller-post-import-sessions_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-centers-controller-post-import-sessions_test.js
@@ -1,4 +1,10 @@
-const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, knex } = require('../../../test-helper');
+const {
+  expect,
+  databaseBuilder,
+  generateValidRequestAuthorizationHeader,
+  knex,
+  sinon,
+} = require('../../../test-helper');
 const createServer = require('../../../../server');
 
 describe('Acceptance | Controller | certification-centers-controller-post-import-sessions', function () {
@@ -16,6 +22,19 @@ describe('Acceptance | Controller | certification-centers-controller-post-import
   });
 
   describe('POST /api/certification-centers/{certificationCenterId}/sessions/import', function () {
+    let clock;
+
+    beforeEach(async function () {
+      clock = sinon.useFakeTimers({
+        now: new Date('2023-01-01'),
+        toFake: ['Date'],
+      });
+    });
+
+    afterEach(async function () {
+      clock.restore();
+    });
+
     context('when user imports sessions', function () {
       it('should return status 200', async function () {
         // given
@@ -25,7 +44,7 @@ describe('Acceptance | Controller | certification-centers-controller-post-import
         await databaseBuilder.commit();
 
         const newBuffer = `N° de session;* Nom du site;* Nom de la salle;* Date de début;* Heure de début (heure locale);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: jj/mm/aaaa);* Sexe (M ou F);Code Insee;Code postal;Nom de la commune;* Pays;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant local;Temps majoré ?;Tarification part Pix;Code de prépaiement
-        ;site1;salle1;19/10/2022;12:00;surveillant;non;;;;;;;;;;;;;;`;
+        ;site1;salle1;19/10/2023;12:00;surveillant;non;;;;;;;;;;;;;;`;
 
         const options = {
           method: 'POST',
@@ -71,7 +90,7 @@ describe('Acceptance | Controller | certification-centers-controller-post-import
 
             const newBuffer = `N° de session;* Nom du site;* Nom de la salle;* Date de début;* Heure de début (heure locale);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: jj/mm/aaaa);* Sexe (M ou F);Code Insee;Code postal;Nom de la commune;* Pays;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant local;Temps majoré ?;Tarification part Pix;Code de prépaiement
           ${sessionId};;;;;;;Tutu;Jean-Paul;01/01/2000;M;75115;;;FRANCE;;;;;Gratuite;;
-          ${sessionId};site1;salle1;19/10/2022;12:00;surveillant;non;Tata;Corinne;01/01/2000;M;75115;;;FRANCE;;;;;Gratuite;;`;
+          ${sessionId};site1;salle1;19/10/2023;12:00;surveillant;non;Tata;Corinne;01/01/2000;M;75115;;;FRANCE;;;;;Gratuite;;`;
 
             const options = {
               method: 'POST',

--- a/api/tests/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/unit/domain/usecases/create-sessions_test.js
@@ -22,6 +22,7 @@ describe('Unit | UseCase | create-sessions', function () {
   let certificationCandidateRepository;
   let complementaryCertificationRepository;
   let sessionRepository;
+  let clock;
 
   beforeEach(function () {
     accessCode = 'accessCode';
@@ -39,6 +40,44 @@ describe('Unit | UseCase | create-sessions', function () {
     sinon.stub(certificationCpfService, 'getBirthInformation');
     sessionCodeService.getNewSessionCode.returns(accessCode);
     certificationCenterRepository.get.withArgs(certificationCenterId).resolves(certificationCenter);
+
+    clock = sinon.useFakeTimers({
+      now: new Date('2023-01-01'),
+      toFake: ['Date'],
+    });
+  });
+
+  afterEach(async function () {
+    clock.restore();
+  });
+
+  context('when session is scheduled in the past', function () {
+    it('should throw', async function () {
+      // given
+      const sessionScheduledInThePastData = {
+        sessionId: undefined,
+        address: 'Site 1',
+        room: 'Salle 1',
+        date: '2020-03-12',
+        time: '01:00',
+        examiner: 'Pierre',
+        description: 'desc',
+        certificationCandidates: [],
+      };
+
+      const sessions = [sessionScheduledInThePastData];
+
+      // when
+      const error = await catchErr(createSessions)({
+        sessions,
+        certificationCenterId,
+        certificationCenterRepository,
+        sessionRepository,
+      });
+
+      // then
+      expect(error.message).to.equal('Une session ne peut pas être programmée dans le passé');
+    });
   });
 
   context('when sessions are valid', function () {
@@ -467,7 +506,7 @@ function createValidSessionData() {
     sessionId: undefined,
     address: 'Site 1',
     room: 'Salle 1',
-    date: '2022-03-12',
+    date: '2023-03-12',
     time: '01:00',
     examiner: 'Pierre',
     description: 'desc',


### PR DESCRIPTION
## :unicorn: Problème
Il est aujourd'hui possible de programmer une session de certification dans le passé via l'import en masse

## :robot: Proposition
Ne pas permettre la création de session dans le passé


## :100: Pour tester
- Tenter d'importer une session ayant lieu dans le passé et constater l'erreur suivante 

![image](https://user-images.githubusercontent.com/37305474/217857520-02606807-d625-43f1-ab1d-c993e1fa240d.png)

