### PR TITLE
[BUGFIX] Résoudre le problème de double scroll dans Pix Admin

### DIFF
--- a/admin/app/styles/authenticated.scss
+++ b/admin/app/styles/authenticated.scss
@@ -3,13 +3,10 @@ $app-sidebar-width-sm: 80px;
 $app-header-height: 60px;
 
 .app-container {
-  display: flex;
-  height: 100%;
+  display: grid;
+  grid-template-columns: $app-sidebar-width-sm 1fr;
 
   .app-sidebar {
-    width: $app-sidebar-width-sm;
-    min-width: $app-sidebar-width-sm;
-    height: 100%;
     background-color: $pix-neutral-70;
 
     .app-logo {
@@ -31,17 +28,12 @@ $app-header-height: 60px;
   }
 
   .app-body {
-    background-color: $pix-neutral-15;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    flex-direction: column;
+    min-height: 100vh;
     overflow: hidden;
 
     .app-page {
       position: relative;
       width: 100%;
-      overflow-y: auto;
     }
   }
 }

--- a/admin/app/styles/globals/global.scss
+++ b/admin/app/styles/globals/global.scss
@@ -1,18 +1,13 @@
-html,
-body {
-  height: 100%;
-  width: 100%;
-  font-size: 16px;
-  line-height: 1.5;
-}
-
 html {
   font-family: Roboto, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
   color: $pix-neutral-90;
 }
 
 body {
   margin: 0;
+  background-color: $pix-neutral-15;
 }
 
 h1,
@@ -56,7 +51,6 @@ a {
 }
 
 a.pix-button {
-
   &:hover {
     color: $pix-neutral-0;
     text-decoration: none;


### PR DESCRIPTION
## :unicorn: Problème

Sur Pix Admin, lorsque la hauteur de l'écran est trop petite, on rencontre un souci de double scroll assez ennuyant.

![admin integration pix fr_organizations_list](https://user-images.githubusercontent.com/7335131/217886216-ce8e1383-7336-4fa7-9816-5ea7f924dcd0.png)

## :robot: Proposition

Modifier le CSS pour éviter ce souci.

![localhost_4202_organizations_list](https://user-images.githubusercontent.com/7335131/217886536-742d6ed4-f217-4e71-bd64-126ae079c6a7.png)

## :100: Pour tester

- Se balader [sur la RA](https://admin-pr5642.review.pix.fr/) avec une résolution verticale normale puis faible
- S'assurer qu'il n'y a aucun problème
