### PR TITLE
[FEATURE] Supprimer les colonnes inutiles du tableau de paliers dans pix admin (PIX-7102)

### DIFF
--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -11,8 +11,6 @@
         <table class="stages-table">
           <thead>
             <tr>
-              <th class="table__column table__column--id">ID</th>
-              <th class="stages-table__image">Image</th>
               <th class="stages-table__type">{{this.columnNameByStageType}}</th>
               <th class="stages-table__title">Titre</th>
               <th>Message</th>

--- a/admin/app/components/target-profiles/stages/new-stage.hbs
+++ b/admin/app/components/target-profiles/stages/new-stage.hbs
@@ -1,8 +1,4 @@
 <tr aria-label="Informations sur le palier {{@title}}">
-  <td class="table__column table__column--id"></td>
-  <td class="stages-table__image">
-    <img src={{@imageUrl}} alt="" role="presentation" />
-  </td>
   <td>
     <div class="form-field">
       {{#if @isTypeLevel}}

--- a/admin/app/components/target-profiles/stages/stage.hbs
+++ b/admin/app/components/target-profiles/stages/stage.hbs
@@ -1,8 +1,4 @@
 <tr aria-label="Informations sur le palier {{@title}}">
-  <td class="table__column table__column--id">{{@id}}</td>
-  <td class="stages-table__image">
-    <img src={{@imageUrl}} alt="" role="presentation" />
-  </td>
   <td>
     {{#if @isTypeLevel}}
       {{@level}}

--- a/admin/tests/integration/components/target-profiles/stages_test.js
+++ b/admin/tests/integration/components/target-profiles/stages_test.js
@@ -118,8 +118,6 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       assert.dom('table').exists();
       assert.dom('thead').exists();
       assert.dom('tbody').exists();
-      assert.dom(screen.getByText('ID')).exists();
-      assert.dom(screen.getByText('Image')).exists();
       assert.dom(screen.getByText('Seuil')).exists();
       assert.dom(screen.getByText('Titre')).exists();
       assert.dom(screen.getByText('Message')).exists();
@@ -127,13 +125,10 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       assert.dom(screen.getByText('Description prescripteur')).exists();
       assert.dom(screen.getByText('Actions')).exists();
       assert.dom('tbody tr').exists({ count: 1 });
-      assert.strictEqual(find('tbody tr td:first-child').textContent.trim(), '1');
-      assert.dom('tbody tr td:nth-child(2) img').exists();
-      assert.strictEqual(find('tbody tr td:nth-child(2) img').getAttribute('src'), 'data:,');
-      assert.strictEqual(find('tbody tr td:nth-child(3)').textContent.trim(), '100');
-      assert.strictEqual(find('tbody tr td:nth-child(4)').textContent.trim(), 'My title');
-      assert.strictEqual(find('tbody tr td:nth-child(5)').textContent.trim(), 'My message');
-      assert.strictEqual(find('tbody tr td:nth-child(8)').textContent.trim(), 'Voir détail');
+      assert.strictEqual(find('tbody tr td:nth-child(1)').textContent.trim(), '100');
+      assert.strictEqual(find('tbody tr td:nth-child(2)').textContent.trim(), 'My title');
+      assert.strictEqual(find('tbody tr td:nth-child(3)').textContent.trim(), 'My message');
+      assert.strictEqual(find('tbody tr td:nth-child(6)').textContent.trim(), 'Voir détail');
       assert.dom(screen.queryByText('Aucun résultat thématique associé')).doesNotExist();
     });
 
@@ -239,8 +234,6 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       assert.dom('table').exists();
       assert.dom('thead').exists();
       assert.dom('tbody').exists();
-      assert.dom(screen.getByText('ID')).exists();
-      assert.dom(screen.getByText('Image')).exists();
       assert.dom(screen.getByText('Niveau')).exists();
       assert.dom(screen.getByText('Titre')).exists();
       assert.dom(screen.getByText('Message')).exists();
@@ -248,13 +241,10 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       assert.dom(screen.getByText('Description prescripteur')).exists();
       assert.dom(screen.getByText('Actions')).exists();
       assert.dom('tbody tr').exists({ count: 1 });
-      assert.strictEqual(find('tbody tr td:first-child').textContent.trim(), '1');
-      assert.dom('tbody tr td:nth-child(2) img').exists();
-      assert.strictEqual(find('tbody tr td:nth-child(2) img').getAttribute('src'), 'data:,');
-      assert.strictEqual(find('tbody tr td:nth-child(3)').textContent.trim(), '6');
-      assert.strictEqual(find('tbody tr td:nth-child(4)').textContent.trim(), 'My title');
-      assert.strictEqual(find('tbody tr td:nth-child(5)').textContent.trim(), 'My message');
-      assert.strictEqual(find('tbody tr td:nth-child(8)').textContent.trim(), 'Voir détail');
+      assert.strictEqual(find('tbody tr td:nth-child(1)').textContent.trim(), '6');
+      assert.strictEqual(find('tbody tr td:nth-child(2)').textContent.trim(), 'My title');
+      assert.strictEqual(find('tbody tr td:nth-child(3)').textContent.trim(), 'My message');
+      assert.strictEqual(find('tbody tr td:nth-child(6)').textContent.trim(), 'Voir détail');
       assert.dom(screen.queryByText('Aucun résultat thématique associé')).doesNotExist();
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Affichage de colonnes inutiles qui prennent de la place
## :robot: Proposition
Les retirer

## :rainbow: Remarques
Voilà
## :100: Pour tester
1. Se connecter à Pix Admin
2.Page Profiles Cibles
3. Onglet Clés de lectures
4. Scroller jusqu'en bas et vérifier le tableau + la modification de tableau