### PR TITLE
[BUGFIX] Écran de fin de campagne flash : crash si épreuves périmées/archivées (PIX-7106)

### DIFF
--- a/api/lib/domain/services/algorithm-methods/data-fetcher.js
+++ b/api/lib/domain/services/algorithm-methods/data-fetcher.js
@@ -89,6 +89,15 @@ async function fetchForFlashCampaigns({
     flashAssessmentResultRepository.getLatestByAssessmentId(assessmentId),
   ]);
 
+  const challengeIds = new Set(challenges.map(({ id }) => id));
+  const missingChallengeIds = allAnswers
+    .map(({ challengeId }) => challengeId)
+    .filter((challengeId) => !challengeIds.has(challengeId));
+  if (missingChallengeIds.length > 0) {
+    const missingChallenges = await challengeRepository.getMany(missingChallengeIds);
+    challenges.push(...missingChallenges);
+  }
+
   return {
     allAnswers,
     challenges,

--- a/api/tests/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/integration/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -159,7 +159,6 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
       assessmentId,
       campaignParticipationId,
       assessment,
-      lastAnswer,
       answerRepository,
       challengeRepository,
       challenges,
@@ -178,9 +177,8 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
       userId = 'dummyUserId';
       assessmentId = 21;
       campaignParticipationId = 456;
-      lastAnswer = null;
 
-      answerRepository = { findByAssessment: sinon.stub().resolves([lastAnswer]) };
+      answerRepository = { findByAssessment: sinon.stub().resolves([]) };
       challenges = [];
       challengeRepository = { findActiveFlashCompatible: sinon.stub().resolves(challenges) };
       const campaign = domainBuilder.buildCampaign({ assessmentMethod: 'FLASH' });
@@ -249,7 +247,7 @@ describe('Integration | Domain | Use Cases | get-next-challenge-for-campaign-ass
 
     it('should have fetched the next challenge with only most recent knowledge elements', function () {
       // then
-      const allAnswers = [lastAnswer];
+      const allAnswers = [];
       expect(flash.getPossibleNextChallenges).to.have.been.calledWithExactly({
         allAnswers,
         challenges,


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on affiche l'écran de fin de campagne flash pour une campagne qui a été réalisée "il y a longtemps", il se peut que certaines épreuves répondues durant la campagne ait depuis été archivées ou même périmées.
Cela fait planter l'écran.

## :robot: Proposition
Charger les épreuves archivées ou périmées si celles-ci ont été répondues durant la campagne.

## :rainbow: Remarques
N/A

## :100: Pour tester
Dérouler la campagne `FLASH1234` et vérifier que l'écran de fin de campagne s'affiche correctement.