### PR TITLE
[FEATURE] Traduire la page de liste de sessions de certification (PIX-6666)

### DIFF
--- a/certif/app/components/no-session-panel.hbs
+++ b/certif/app/components/no-session-panel.hbs
@@ -1,7 +1,7 @@
 <div class="no-session-panel">
   <div class="no-session-panel__explain-create-session">
-    <img src="{{this.rootURL}}/icons/empty-list-session.svg" alt="Vous pouvez créer des sessions de certifications." />
-    <h1 class="page-title">Créer ma première session de certification</h1>
+    <img src="{{this.rootURL}}/icons/empty-list-session.svg" alt={{t "pages.sessions.list.empty.header-alt"}} />
+    <h1 class="page-title">{{t "pages.sessions.list.empty.header"}}</h1>
 
     <div class="no-session-panel__link-to-create">
       <PixButtonLink @route="authenticated.sessions.new">

--- a/certif/app/components/no-session-panel.hbs
+++ b/certif/app/components/no-session-panel.hbs
@@ -1,15 +1,15 @@
 <div class="no-session-panel">
   <div class="no-session-panel__explain-create-session">
-    <img src="{{this.rootURL}}/icons/empty-list-session.svg" alt={{t "pages.sessions.list.empty.header-alt"}} />
-    <h1 class="page-title">{{t "pages.sessions.list.empty.header"}}</h1>
+    <img src="{{this.rootURL}}/icons/empty-list-session.svg" alt="" role="none" />
+    <h1 class="page-title">{{t "pages.sessions.list.empty.title"}}</h1>
 
     <div class="no-session-panel__link-to-create">
       <PixButtonLink @route="authenticated.sessions.new">
-        {{t "pages.sessions.list.empty.session-creation"}}
+        {{t "pages.sessions.list.actions.creation.label"}}
       </PixButtonLink>
       {{#if this.shouldRenderImportTemplateButton}}
         <PixButtonLink @route="authenticated.sessions.import">
-          {{t "pages.sessions.list.empty.session-multiple-creation"}}
+          {{t "pages.sessions.list.actions.multiple-creation.label"}}
         </PixButtonLink>
       {{/if}}
     </div>

--- a/certif/app/components/session-delete-confirm-modal.hbs
+++ b/certif/app/components/session-delete-confirm-modal.hbs
@@ -6,7 +6,7 @@
 >
   <:content>
     <p class="session-delete-confirmation-modal-warning__content">{{t
-        "pages.sessions.list.delete-modal.label"
+        "pages.sessions.list.delete-modal.content"
         sessionId=@sessionId
         htmlSafe=true
       }}</p>
@@ -18,12 +18,12 @@
         }}</p>
     {{/if}}
     <PixMessage @type="warning" @withIcon={{true}}>
-      {{t "pages.sessions.list.delete-modal.disclaimer"}}
+      {{t "pages.sessions.list.delete-modal.warning"}}
     </PixMessage>
   </:content>
   <:footer>
     <PixButton
-      aria-label="Annuler la suppression de la session"
+      aria-label={{t "pages.sessions.list.delete-modal.actions.cancel.extra-information"}}
       @backgroundColor="transparent-light"
       @isBorderVisible={{true}}
       @triggerAction={{@close}}
@@ -32,7 +32,7 @@
     </PixButton>
 
     <PixButton
-      aria-label="Supprimer la session"
+      aria-label={{t "pages.sessions.list.delete-modal.actions.confirm.extra-information"}}
       @triggerAction={{@confirm}}
       @loadingColor="white"
       @backgroundColor="blue"

--- a/certif/app/components/session-summary-list.hbs
+++ b/certif/app/components/session-summary-list.hbs
@@ -5,35 +5,35 @@
         <thead>
           <tr>
             <th class="table__column table__column--small" scope="col">
-              {{t "pages.sessions.list.session-summary.session-number"}}
+              {{t "pages.sessions.list.table.header.session-number"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              {{t "pages.sessions.list.session-summary.center-name"}}
+              {{t "pages.sessions.list.table.header.center-name"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              {{t "pages.sessions.list.session-summary.room"}}
+              {{t "pages.sessions.list.table.header.room"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              {{t "pages.sessions.list.session-summary.date"}}
+              {{t "pages.sessions.list.table.header.date"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              {{t "pages.sessions.list.session-summary.time"}}
+              {{t "pages.sessions.list.table.header.time"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              {{t "pages.sessions.list.session-summary.supervisor"}}
+              {{t "pages.sessions.list.table.header.supervisor"}}
             </th>
             <th class="table__column table__column" scope="col">
-              {{t "pages.sessions.list.session-summary.enrolled-candidates"}}
+              {{t "pages.sessions.list.table.header.enrolled-candidates"}}
             </th>
             <th class="table__column table__column" scope="col">
-              {{t "pages.sessions.list.session-summary.effective-candidates"}}
+              {{t "pages.sessions.list.table.header.effective-candidates"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              {{t "pages.sessions.list.session-summary.status"}}
+              {{t "pages.sessions.list.table.header.status"}}
             </th>
             <th class="table__column table__column--small" scope="col">
               <span class="sr-only">
-                {{t "pages.sessions.list.session-summary.actions"}}
+                {{t "pages.sessions.list.table.header.actions"}}
               </span>
             </th>
           </tr>
@@ -51,7 +51,7 @@
       </table>
       {{#if (eq @sessionSummaries.length 0)}}
         <div class="table__empty content-text">
-          {{t "pages.sessions.list.session-summary.empty-table"}}
+          {{t "pages.sessions.list.table.empty"}}
         </div>
       {{/if}}
     </div>

--- a/certif/app/components/session-summary-list.hbs
+++ b/certif/app/components/session-summary-list.hbs
@@ -58,7 +58,7 @@
   </div>
 </div>
 
-<PixPagination @pagination={{@sessionSummaries.meta}} />
+<PixPagination @pagination={{@sessionSummaries.meta}} @locale={{this.currentLocale}} />
 
 <SessionDeleteConfirmModal
   @showModal={{this.shouldDisplaySessionDeletionModal}}

--- a/certif/app/components/session-summary-list.hbs
+++ b/certif/app/components/session-summary-list.hbs
@@ -41,66 +41,11 @@
 
         <tbody>
           {{#each @sessionSummaries as |sessionSummary|}}
-            <tr
-              aria-label="{{t 'pages.sessions.list.session-summary.certification-session'}}"
-              {{on "click" (fn @goToSessionDetails sessionSummary.id)}}
-              class="tr--clickable"
-            >
-              <td>
-                <LinkTo
-                  @route="authenticated.sessions.details"
-                  @model={{sessionSummary.id}}
-                  class="session-summary-list__link"
-                  aria-label="{{t 'pages.sessions.list.session-summary.session-and-id' sessionId=sessionSummary.id}}"
-                >
-                  {{sessionSummary.id}}
-                </LinkTo>
-              </td>
-              <td>{{sessionSummary.address}}</td>
-              <td>{{sessionSummary.room}}</td>
-              <td>{{dayjs-format sessionSummary.date "DD/MM/YYYY" allow-empty=true}}</td>
-              <td>{{dayjs-format sessionSummary.time "HH:mm" inputFormat="HH:mm:ss" allow-empty=true}}</td>
-              <td>{{sessionSummary.examiner}}</td>
-              <td>{{sessionSummary.enrolledCandidatesCount}}</td>
-              <td>{{sessionSummary.effectiveCandidatesCount}}</td>
-              <td>{{sessionSummary.statusLabel}}</td>
-              <td>
-                <div class="session-summary-list__delete">
-                  {{#if sessionSummary.hasEffectiveCandidates}}
-                    <PixTooltip @position="left" @isInline={{true}} @id="tooltip-delete-session-button">
-                      <:triggerElement>
-                        <PixIconButton
-                          @icon="trash-alt"
-                          aria-label={{t
-                            "pages.sessions.list.session-summary.delete-session"
-                            sessionSummaryId=sessionSummary.id
-                          }}
-                          disabled={{true}}
-                          aria-describedby="tooltip-delete-session-button"
-                          @withBackground={{true}}
-                        />
-                      </:triggerElement>
-                      <:tooltip>{{t "pages.sessions.list.session-summary.tooltip-label"}}</:tooltip>
-                    </PixTooltip>
-                  {{else}}
-                    <PixIconButton
-                      @icon="trash-alt"
-                      aria-label={{t
-                        "pages.sessions.list.session-summary.delete-session"
-                        sessionSummaryId=sessionSummary.id
-                      }}
-                      disabled={{false}}
-                      @withBackground={{true}}
-                      @triggerAction={{fn
-                        this.openSessionDeletionConfirmModal
-                        sessionSummary.id
-                        sessionSummary.enrolledCandidatesCount
-                      }}
-                    />
-                  {{/if}}
-                </div>
-              </td>
-            </tr>
+            <SessionSummaryRow
+              @sessionSummary={{sessionSummary}}
+              @goToSessionDetails={{@goToSessionDetails}}
+              @openSessionDeletionConfirmModal={{this.openSessionDeletionConfirmModal}}
+            />
           {{/each}}
         </tbody>
       </table>

--- a/certif/app/components/session-summary-list.js
+++ b/certif/app/components/session-summary-list.js
@@ -10,6 +10,7 @@ export default class SessionSummaryList extends Component {
   @tracked currentEnrolledCandidatesCount = null;
   @service store;
   @service notifications;
+  @service intl;
 
   @action
   openSessionDeletionConfirmModal(sessionId, enrolledCandidatesCount, event) {
@@ -17,6 +18,11 @@ export default class SessionSummaryList extends Component {
     this.currentSessionToBeDeletedId = sessionId;
     this.currentEnrolledCandidatesCount = enrolledCandidatesCount;
     this.shouldDisplaySessionDeletionModal = true;
+  }
+
+  get currentLocale() {
+    const [currentLocale] = this.intl.get('locale');
+    return currentLocale;
   }
 
   @action

--- a/certif/app/components/session-summary-list.js
+++ b/certif/app/components/session-summary-list.js
@@ -20,11 +20,6 @@ export default class SessionSummaryList extends Component {
     this.shouldDisplaySessionDeletionModal = true;
   }
 
-  get currentLocale() {
-    const [currentLocale] = this.intl.get('locale');
-    return currentLocale;
-  }
-
   @action
   closeSessionDeletionConfirmModal() {
     this.shouldDisplaySessionDeletionModal = false;
@@ -36,7 +31,7 @@ export default class SessionSummaryList extends Component {
     const sessionSummary = this.store.peekRecord('session-summary', this.currentSessionToBeDeletedId);
     try {
       await sessionSummary.destroyRecord();
-      this.notifications.success('La session a été supprimée avec succès.');
+      this.notifications.success(this.intl.t('pages.sessions.list.delete-modal.success'));
     } catch (err) {
       if (this._doesNotExist(err)) {
         this._handleSessionDoesNotExistsError();

--- a/certif/app/components/session-summary-row.hbs
+++ b/certif/app/components/session-summary-row.hbs
@@ -1,0 +1,54 @@
+<tr
+  aria-label="{{t 'pages.sessions.list.session-summary.certification-session'}}"
+  {{on "click" (fn @goToSessionDetails @sessionSummary.id)}}
+  class="tr--clickable"
+>
+  <td>
+    <LinkTo
+      @route="authenticated.sessions.details"
+      @model={{@sessionSummary.id}}
+      class="session-summary-list__link"
+      aria-label="{{t 'pages.sessions.list.session-summary.session-and-id' sessionId=@sessionSummary.id}}"
+    >
+      {{@sessionSummary.id}}
+    </LinkTo>
+  </td>
+  <td>{{@sessionSummary.address}}</td>
+  <td>{{@sessionSummary.room}}</td>
+  <td>{{dayjs-format @sessionSummary.date "DD/MM/YYYY" allow-empty=true}}</td>
+  <td>{{dayjs-format @sessionSummary.time "HH:mm" inputFormat="HH:mm:ss" allow-empty=true}}</td>
+  <td>{{@sessionSummary.examiner}}</td>
+  <td>{{@sessionSummary.enrolledCandidatesCount}}</td>
+  <td>{{@sessionSummary.effectiveCandidatesCount}}</td>
+  <td>{{this.statusLabel}}</td>
+  <td>
+    <div class="session-summary-list__delete">
+      {{#if @sessionSummary.hasEffectiveCandidates}}
+        <PixTooltip @position="left" @isInline={{true}} @id="tooltip-delete-session-button">
+          <:triggerElement>
+            <PixIconButton
+              @icon="trash-alt"
+              aria-label={{t "pages.sessions.list.session-summary.delete-session" sessionSummaryId=@sessionSummary.id}}
+              disabled={{true}}
+              aria-describedby="tooltip-delete-session-button"
+              @withBackground={{true}}
+            />
+          </:triggerElement>
+          <:tooltip>{{t "pages.sessions.list.session-summary.tooltip-label"}}</:tooltip>
+        </PixTooltip>
+      {{else}}
+        <PixIconButton
+          @icon="trash-alt"
+          aria-label={{t "pages.sessions.list.session-summary.delete-session" sessionSummaryId=@sessionSummary.id}}
+          disabled={{false}}
+          @withBackground={{true}}
+          @triggerAction={{fn
+            @openSessionDeletionConfirmModal
+            @sessionSummary.id
+            @sessionSummary.enrolledCandidatesCount
+          }}
+        />
+      {{/if}}
+    </div>
+  </td>
+</tr>

--- a/certif/app/components/session-summary-row.hbs
+++ b/certif/app/components/session-summary-row.hbs
@@ -1,5 +1,5 @@
 <tr
-  aria-label="{{t 'pages.sessions.list.session-summary.certification-session'}}"
+  aria-label="{{t 'pages.sessions.list.table.row.label'}}"
   {{on "click" (fn @goToSessionDetails @sessionSummary.id)}}
   class="tr--clickable"
 >
@@ -8,7 +8,7 @@
       @route="authenticated.sessions.details"
       @model={{@sessionSummary.id}}
       class="session-summary-list__link"
-      aria-label="{{t 'pages.sessions.list.session-summary.session-and-id' sessionId=@sessionSummary.id}}"
+      aria-label="{{t 'pages.sessions.list.table.row.session-and-id' sessionId=@sessionSummary.id}}"
     >
       {{@sessionSummary.id}}
     </LinkTo>
@@ -28,18 +28,18 @@
           <:triggerElement>
             <PixIconButton
               @icon="trash-alt"
-              aria-label={{t "pages.sessions.list.session-summary.delete-session" sessionSummaryId=@sessionSummary.id}}
+              aria-label={{t "pages.sessions.list.actions.delete-session.label" sessionSummaryId=@sessionSummary.id}}
               disabled={{true}}
               aria-describedby="tooltip-delete-session-button"
               @withBackground={{true}}
             />
           </:triggerElement>
-          <:tooltip>{{t "pages.sessions.list.session-summary.tooltip-label"}}</:tooltip>
+          <:tooltip>{{t "pages.sessions.list.actions.delete-session.disabled"}}</:tooltip>
         </PixTooltip>
       {{else}}
         <PixIconButton
           @icon="trash-alt"
-          aria-label={{t "pages.sessions.list.session-summary.delete-session" sessionSummaryId=@sessionSummary.id}}
+          aria-label={{t "pages.sessions.list.actions.delete-session.label" sessionSummaryId=@sessionSummary.id}}
           disabled={{false}}
           @withBackground={{true}}
           @triggerAction={{fn

--- a/certif/app/components/session-summary-row.js
+++ b/certif/app/components/session-summary-row.js
@@ -1,0 +1,13 @@
+import Component from '@glimmer/component';
+import { CREATED, FINALIZED, PROCESSED } from '../models/session';
+import { inject as service } from '@ember/service';
+
+export default class SessionSummaryRow extends Component {
+  @service intl;
+  get statusLabel() {
+    const { status } = this.args.sessionSummary;
+    if (status === FINALIZED) return this.intl.t(`pages.sessions.list.session-summary.status-label.${FINALIZED}`);
+    if (status === PROCESSED) return this.intl.t(`pages.sessions.list.session-summary.status-label.${PROCESSED}`);
+    return this.intl.t(`pages.sessions.list.session-summary.status-label.${CREATED}`);
+  }
+}

--- a/certif/app/components/session-summary-row.js
+++ b/certif/app/components/session-summary-row.js
@@ -6,8 +6,8 @@ export default class SessionSummaryRow extends Component {
   @service intl;
   get statusLabel() {
     const { status } = this.args.sessionSummary;
-    if (status === FINALIZED) return this.intl.t(`pages.sessions.list.session-summary.status-label.${FINALIZED}`);
-    if (status === PROCESSED) return this.intl.t(`pages.sessions.list.session-summary.status-label.${PROCESSED}`);
-    return this.intl.t(`pages.sessions.list.session-summary.status-label.${CREATED}`);
+    if (status === FINALIZED) return this.intl.t(`pages.sessions.list.status.${FINALIZED}`);
+    if (status === PROCESSED) return this.intl.t(`pages.sessions.list.status.${PROCESSED}`);
+    return this.intl.t(`pages.sessions.list.status.${CREATED}`);
   }
 }

--- a/certif/app/components/sessions/panel-header.hbs
+++ b/certif/app/components/sessions/panel-header.hbs
@@ -1,12 +1,12 @@
 <div class="session-list__header">
-  <h1 class="page-title">{{t "pages.sessions.list.header.title"}}</h1>
+  <h1 class="page-title">{{t "pages.sessions.list.title"}}</h1>
   <div class="session-list-header__actions">
     <PixButtonLink @route="authenticated.sessions.new">
-      {{t "pages.sessions.list.header.session-creation"}}
+      {{t "pages.sessions.list.actions.creation.label"}}
     </PixButtonLink>
     {{#if this.shouldRenderImportTemplateButton}}
       <PixButtonLink @route="authenticated.sessions.import">
-        {{t "pages.sessions.list.header.session-multiple-creation-edition"}}
+        {{t "pages.sessions.list.actions.multiple-creation-edition.label"}}
       </PixButtonLink>
     {{/if}}
   </div>

--- a/certif/app/models/session-summary.js
+++ b/certif/app/models/session-summary.js
@@ -1,6 +1,4 @@
 import Model, { attr } from '@ember-data/model';
-// eslint-disable-next-line ember/no-computed-properties-in-native-classes
-import { computed } from '@ember/object';
 
 export default class SessionSummary extends Model {
   @attr() address;
@@ -11,13 +9,6 @@ export default class SessionSummary extends Model {
   @attr() enrolledCandidatesCount;
   @attr() effectiveCandidatesCount;
   @attr() status;
-
-  @computed('status')
-  get statusLabel() {
-    if (this.status === 'finalized') return 'Finalisée';
-    if (this.status === 'processed') return 'Résultats transmis par Pix';
-    return 'Créée';
-  }
 
   get hasEffectiveCandidates() {
     return this.effectiveCandidatesCount > 0;

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -8,12 +8,6 @@ export const CREATED = 'created';
 export const FINALIZED = 'finalized';
 export const IN_PROCESS = 'in_process';
 export const PROCESSED = 'processed';
-export const statusToDisplayName = {
-  [CREATED]: 'Créée',
-  [FINALIZED]: 'Finalisée',
-  [IN_PROCESS]: 'Finalisée', // we don't want to show "En cours de traitement" status in Pix Certif
-  [PROCESSED]: 'Résultats transmis par Pix',
-};
 
 export default class Session extends Model {
   @service session;
@@ -59,11 +53,6 @@ export default class Session extends Model {
   @computed('id')
   get urlToUpload() {
     return `${ENV.APP.API_HOST}/api/sessions/${this.id}/certification-candidates/import`;
-  }
-
-  @computed('status')
-  get displayStatus() {
-    return statusToDisplayName[this.status];
   }
 
   get urlToDownloadSessionIssueReportSheet() {

--- a/certif/app/templates/authenticated/sessions.hbs
+++ b/certif/app/templates/authenticated/sessions.hbs
@@ -1,2 +1,2 @@
-{{page-title (t "pages.sessions.list.header.title")}}
+{{page-title (t "pages.sessions.list.title")}}
 {{outlet}}

--- a/certif/app/templates/authenticated/sessions.hbs
+++ b/certif/app/templates/authenticated/sessions.hbs
@@ -1,2 +1,2 @@
-{{page-title "Sessions de certification"}}
+{{page-title (t "pages.sessions.list.header.title")}}
 {{outlet}}

--- a/certif/tests/integration/components/session-delete-confirm-modal_test.js
+++ b/certif/tests/integration/components/session-delete-confirm-modal_test.js
@@ -23,7 +23,7 @@ module('Integration | Component | session-delete-confirm-modal', function (hooks
     />`);
 
       // then
-      assert.dom(screen.getByRole('heading', { name: this.intl.t('pages.sessions.list.delete-modal.title') })).exists();
+      assert.dom(screen.getByRole('heading', { name: 'Supprimer la session' })).exists();
       assert
         .dom(screen.getByText('Souhaitez-vous supprimer la session', { exact: false }))
         .hasText('Souhaitez-vous supprimer la session 123 ?');
@@ -45,9 +45,7 @@ module('Integration | Component | session-delete-confirm-modal', function (hooks
     />`);
 
       // then
-      assert
-        .dom(screen.queryByRole('heading', { name: this.intl.t('pages.sessions.list.delete-modal.title') }))
-        .doesNotExist();
+      assert.dom(screen.queryByRole('heading', { name: 'Supprimer la session' })).doesNotExist();
     });
   });
 

--- a/certif/tests/integration/components/session-summary-list_test.js
+++ b/certif/tests/integration/components/session-summary-list_test.js
@@ -240,9 +240,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
           await screen.findByRole('dialog');
 
           // then
-          assert
-            .dom(screen.getByRole('heading', { name: this.intl.t('pages.sessions.list.delete-modal.title') }))
-            .exists();
+          assert.dom(screen.getByRole('heading', { name: 'Supprimer la session' })).exists();
           assert
             .dom(screen.getByText('Souhaitez-vous supprimer la session', { exact: false }))
             .hasText('Souhaitez-vous supprimer la session 123 ?');
@@ -276,9 +274,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
             await screen.findByRole('dialog');
 
             // then
-            assert
-              .dom(screen.getByRole('heading', { name: this.intl.t('pages.sessions.list.delete-modal.title') }))
-              .exists();
+            assert.dom(screen.getByRole('heading', { name: 'Supprimer la session' })).exists();
             assert
               .dom(screen.getByText('sont inscrits à cette session', { exact: false }))
               .hasText('5 candidats sont inscrits à cette session');
@@ -311,9 +307,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
             await screen.findByRole('dialog');
 
             // then
-            assert
-              .dom(screen.getByRole('heading', { name: this.intl.t('pages.sessions.list.delete-modal.title') }))
-              .exists();
+            assert.dom(screen.getByRole('heading', { name: 'Supprimer la session' })).exists();
             assert
               .dom(screen.getByText('est inscrit à cette session', { exact: false }))
               .hasText('1 candidat est inscrit à cette session');
@@ -348,9 +342,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
             await screen.findByRole('dialog');
 
             // then
-            assert
-              .dom(screen.getByRole('heading', { name: this.intl.t('pages.sessions.list.delete-modal.title') }))
-              .exists();
+            assert.dom(screen.getByRole('heading', { name: 'Supprimer la session' })).exists();
             assert.dom(screen.queryByText('sont inscrits à cette session', { exact: false })).doesNotExist();
           });
         });
@@ -380,9 +372,7 @@ module('Integration | Component | session-summary-list', function (hooks) {
             await waitForDialogClose();
 
             // then
-            assert
-              .dom(screen.queryByRole('heading', { name: this.intl.t('pages.sessions.list.delete-modal.title') }))
-              .doesNotExist();
+            assert.dom(screen.queryByRole('heading', { name: 'Supprimer la session' })).doesNotExist();
           });
         });
       });

--- a/certif/tests/unit/models/session-summary_test.js
+++ b/certif/tests/unit/models/session-summary_test.js
@@ -4,44 +4,6 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Model | session-summary', function (hooks) {
   setupTest(hooks);
 
-  module('#statusLabel', function () {
-    test('it should return "Finalisée" when status is finalized', function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const sessionSummary = store.createRecord('session-summary', {
-        id: 123,
-        status: 'finalized',
-      });
-
-      // when/then
-      assert.strictEqual(sessionSummary.statusLabel, 'Finalisée');
-    });
-
-    test('it should return "Résultats transmis par Pix" when status is processed', function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const sessionSummary = store.createRecord('session-summary', {
-        id: 123,
-        status: 'processed',
-      });
-
-      // when/then
-      assert.strictEqual(sessionSummary.statusLabel, 'Résultats transmis par Pix');
-    });
-
-    test('it should return Créée else', function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const sessionSummary = store.createRecord('session-summary', {
-        id: 123,
-        status: 'created',
-      });
-
-      // when/then
-      assert.strictEqual(sessionSummary.statusLabel, 'Créée');
-    });
-  });
-
   module('#hasEffectiveCandidates', function () {
     test('it should return true when at least one candidate has joined the session', function (assert) {
       // given

--- a/certif/tests/unit/models/session_test.js
+++ b/certif/tests/unit/models/session_test.js
@@ -2,28 +2,10 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import config from '../../../config/environment';
 import Service from '@ember/service';
-import { CREATED, FINALIZED } from 'pix-certif/models/session';
+import { CREATED } from 'pix-certif/models/session';
 
 module('Unit | Model | session', function (hooks) {
   setupTest(hooks);
-
-  module('#displayStatus', function () {
-    test('it should return the correct displayName', function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const model1 = store.createRecord('session', {
-        id: 123,
-        status: CREATED,
-      });
-      const model2 = store.createRecord('session', {
-        id: 1234,
-        status: FINALIZED,
-      });
-
-      assert.strictEqual(model1.displayStatus, 'Créée');
-      assert.strictEqual(model2.displayStatus, 'Finalisée');
-    });
-  });
 
   module('#urlToDownloadSupervisorKitPdf', function () {
     test('it should return the correct urlToDownloadSupervisorKitPdf', function (assert) {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -175,7 +175,12 @@
           "delete-session": "Delete the session {sessionSummaryId}",
           "tooltip-label": "At least one candidate has joined the session, you can’t delete it.",
           "empty-table": "No session found",
-          "session-and-id": "Session {sessionId}"
+          "session-and-id": "Session {sessionId}",
+          "status-label": {
+            "created": "Created",
+            "finalized": "Finalised",
+            "processed": "Results transmitted by Pix"
+          }
         },
         "empty": {
           "header": "Create my first certification session",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -150,40 +150,38 @@
       },
       "list": {
         "header": {
-          "title": "Sessions de certification",
-          "session-creation": "Créer une session",
-          "session-multiple-creation-edition": "Créer/éditer plusieurs sessions",
-          "session-import-template": "Template d'import de sessions",
-          "session-import-template-dl-error": "Une erreur s'est produite pendant le téléchargement",
-          "session-import-template-label": "Télécharger le template d'import en masse",
-          "session-import-upload": "Importer en masse"
+          "title": "Certification sessions",
+          "session-creation": "Create a session",
+          "session-multiple-creation-edition": "Create/edit several sessions"
         },
         "delete-modal": {
-          "title": "Supprimer la session",
-          "label": "Souhaitez-vous supprimer la session <span>{sessionId}</span> ?",
-          "enrolled-candidates": "<span>{enrolledCandidatesCount} candidats</span> sont inscrits à cette session",
-          "disclaimer": "Attention, cette action est irréversible."
+          "title": "Delete the session",
+          "label": "Do you want to delete the session <span>{sessionId}</span> ?",
+          "enrolled-candidates": "<span>{enrolledCandidatesCount} candidates</span> are enrolled in this session",
+          "disclaimer": "Warning, this action is irreversible."
         },
         "session-summary": {
-          "session-number": "N° de session",
-          "center-name": "Nom du site",
-          "room": "Salle",
+          "session-number": "Session No.",
+          "center-name": "Location name",
+          "room": "Room",
           "date": "Date",
-          "time": "Heure",
-          "supervisor": "Surveillant(s)",
-          "enrolled-candidates": "Candidats inscrits",
-          "effective-candidates": "Certifications passées",
-          "status": "Statut",
+          "time": "Time",
+          "supervisor": "Invigilator(s)",
+          "enrolled-candidates": "Signed up candidates",
+          "effective-candidates": "Certifications taken",
+          "status": "Status",
           "actions": "Actions",
-          "certification-session": "Session de certification",
-          "delete-session": "Supprimer la session {sessionSummaryId}",
-          "tooltip-label": "Au moins un candidat a rejoint la session, vous ne pouvez pas la supprimer.",
-          "empty-table": "Aucune session trouvée",
+          "certification-session": "Certification session",
+          "delete-session": "Delete the session {sessionSummaryId}",
+          "tooltip-label": "At least one candidate has joined the session, you can’t delete it.",
+          "empty-table": "No session found",
           "session-and-id": "Session {sessionId}"
         },
         "empty": {
-          "session-creation": "Créer une session",
-          "session-multiple-creation": "Créer plusieurs sessionsx"
+          "header": "Create my first certification session",
+          "header-alt": "I can create certification sessions",
+          "session-creation": "Create a session",
+          "session-multiple-creation": "Create several sessions"
         }
       },
       "detail": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -149,44 +149,63 @@
         "breadcrumb-summary": "Récapitulatif"
       },
       "list": {
-        "header": {
-          "title": "Certification sessions",
-          "session-creation": "Create a session",
-          "session-multiple-creation-edition": "Create/edit several sessions"
+        "title": "Certification sessions",
+        "actions": {
+          "creation": {
+            "label": "Create a session"
+          },
+          "delete-session": {
+            "disabled": "At least one candidate has joined the session, you can’t delete it.",
+            "label": "Delete the session {sessionSummaryId}"
+          },
+          "multiple-creation": {
+            "label": "Create several sessions"
+          },
+          "multiple-creation-edition": {
+            "label": "Create/edit several sessions"
+          }
         },
         "delete-modal": {
           "title": "Delete the session",
-          "label": "Do you want to delete the session <span>{sessionId}</span> ?",
+          "actions": {
+            "cancel": {
+              "extra-information": "Cancel the session's deletion."
+            },
+            "confirm": {
+              "extra-information": "Delete the session"
+            }
+          },
+          "content": "Do you want to delete the session <span>{sessionId}</span> ?",
           "enrolled-candidates": "<span>{enrolledCandidatesCount} candidates</span> are enrolled in this session",
-          "disclaimer": "Warning, this action is irreversible."
-        },
-        "session-summary": {
-          "session-number": "Session No.",
-          "center-name": "Location name",
-          "room": "Room",
-          "date": "Date",
-          "time": "Time",
-          "supervisor": "Invigilator(s)",
-          "enrolled-candidates": "Signed up candidates",
-          "effective-candidates": "Certifications taken",
-          "status": "Status",
-          "actions": "Actions",
-          "certification-session": "Certification session",
-          "delete-session": "Delete the session {sessionSummaryId}",
-          "tooltip-label": "At least one candidate has joined the session, you can’t delete it.",
-          "empty-table": "No session found",
-          "session-and-id": "Session {sessionId}",
-          "status-label": {
-            "created": "Created",
-            "finalized": "Finalised",
-            "processed": "Results transmitted by Pix"
-          }
+          "success": "The session has been successfully deleted.",
+          "warning": "Warning, this action is irreversible."
         },
         "empty": {
-          "header": "Create my first certification session",
-          "header-alt": "I can create certification sessions",
-          "session-creation": "Create a session",
-          "session-multiple-creation": "Create several sessions"
+          "title": "Create my first certification session"
+        },
+        "status": {
+          "created": "Created",
+          "finalized": "Finalised",
+          "processed": "Results transmitted by Pix"
+        },
+        "table": {
+          "empty": "No session found",
+          "header": {
+            "actions": "Actions",
+            "center-name": "Location name",
+            "date": "Date",
+            "effective-candidates": "Certifications taken",
+            "enrolled-candidates": "Signed up candidates",
+            "room": "Room",
+            "session-number": "Session No.",
+            "status": "Status",
+            "supervisor": "Invigilator(s)",
+            "time": "Time"
+          },
+          "row": {
+            "label": "Certification session",
+            "session-and-id": "Session {sessionId}"
+          }
         }
       },
       "detail": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -178,6 +178,8 @@
           "session-and-id": "Session {sessionId}"
         },
         "empty": {
+          "header": "Créer ma première session de certification",
+          "header-alt": "Je peux créer des sessions de certifications",
           "session-creation": "Créer une session",
           "session-multiple-creation": "Créer plusieurs sessions"
         }

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -175,7 +175,12 @@
           "delete-session": "Supprimer la session {sessionSummaryId}",
           "tooltip-label": "Au moins un candidat a rejoint la session, vous ne pouvez pas la supprimer.",
           "empty-table": "Aucune session trouvée",
-          "session-and-id": "Session {sessionId}"
+          "session-and-id": "Session {sessionId}",
+          "status-label": {
+            "created": "Créée",
+            "finalized": "Finalisée",
+            "processed": "Résultats transmis par Pix"
+          }
         },
         "empty": {
           "header": "Créer ma première session de certification",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -149,44 +149,63 @@
         "breadcrumb-summary": "Récapitulatif"
       },
       "list": {
-        "header": {
-          "title": "Sessions de certification",
-          "session-creation": "Créer une session",
-          "session-multiple-creation-edition": "Créer/éditer plusieurs sessions"
+        "title": "Sessions de certification",
+        "actions": {
+          "creation": {
+            "label": "Créer une session"
+          },
+          "delete-session": {
+            "disabled": "Au moins un candidat a rejoint la session, vous ne pouvez pas la supprimer.",
+            "label": "Supprimer la session {sessionSummaryId}"
+          },
+          "multiple-creation": {
+            "label": "Créer plusieurs sessions"
+          },
+          "multiple-creation-edition": {
+            "label": "Créer/éditer plusieurs sessions"
+          }
         },
         "delete-modal": {
           "title": "Supprimer la session",
-          "label": "Souhaitez-vous supprimer la session <span>{sessionId}</span> ?",
+          "actions": {
+            "cancel": {
+              "extra-information": "Annuler la suppression de la session"
+            },
+            "confirm": {
+              "extra-information": "Supprimer la session"
+            }
+          },
+          "content": "Souhaitez-vous supprimer la session <span>{sessionId}</span> ?",
           "enrolled-candidates": "<span>{enrolledCandidatesCount} {enrolledCandidatesCount, plural,one {candidat} other {candidats}}</span> {enrolledCandidatesCount, plural,one {est inscrit} other {sont inscrits}} à cette session",
-          "disclaimer": "Attention, cette action est irréversible."
-        },
-        "session-summary": {
-          "session-number": "N° de session",
-          "center-name": "Nom du site",
-          "room": "Salle",
-          "date": "Date",
-          "time": "Heure",
-          "supervisor": "Surveillant(s)",
-          "enrolled-candidates": "Candidats inscrits",
-          "effective-candidates": "Certifications passées",
-          "status": "Statut",
-          "actions": "Actions",
-          "certification-session": "Session de certification",
-          "delete-session": "Supprimer la session {sessionSummaryId}",
-          "tooltip-label": "Au moins un candidat a rejoint la session, vous ne pouvez pas la supprimer.",
-          "empty-table": "Aucune session trouvée",
-          "session-and-id": "Session {sessionId}",
-          "status-label": {
-            "created": "Créée",
-            "finalized": "Finalisée",
-            "processed": "Résultats transmis par Pix"
-          }
+          "success": "La session a été supprimée avec succès.",
+          "warning": "Attention, cette action est irréversible."
         },
         "empty": {
-          "header": "Créer ma première session de certification",
-          "header-alt": "Je peux créer des sessions de certifications",
-          "session-creation": "Créer une session",
-          "session-multiple-creation": "Créer plusieurs sessions"
+          "title": "Créer ma première session de certification"
+        },
+        "status": {
+          "created": "Créée",
+          "finalized": "Finalisée",
+          "processed": "Résultats transmis par Pix"
+        },
+        "table": {
+          "empty": "Aucune session trouvée",
+          "header": {
+            "actions": "Actions",
+            "center-name": "Nom du site",
+            "date": "Date",
+            "effective-candidates": "Certifications passées",
+            "enrolled-candidates": "Candidats inscrits",
+            "room": "Salle",
+            "session-number": "N° de session",
+            "status": "Statut",
+            "supervisor": "Surveillant(s)",
+            "time": "Heure"
+          },
+          "row": {
+            "label": "Session de certification",
+            "session-and-id": "Session {sessionId}"
+          }
         }
       },
       "detail": {


### PR DESCRIPTION
## :unicorn: Problème

Une fois connecté sur Pix Certif, un utilisateur anglophone arrive sur la page “Sessions” qui liste les sessions de certification d’un des centres de certification auquel est rattaché l’utilisateur. Toutes les informations sont en français.

## :robot: Proposition

Traduire l'ensemble des champs de la page de liste des sessions de certification .

**Page de liste de sessions**
- Sessions de certification = Certification sessions
- Créer une session = Create a session
- Créer/éditer plusieurs sessions” = Create/edit several sessions
- N° de session = Session No.
- Nom du site = Location name
- Salle = Room
- Date = Date
- Heure = Time
- Surveillant(s) = Invigilator(s)
- Candidats inscrits = Signed up candidates
- Certifications passées = Certifications taken
- Statut = Status
- Créée = Created
- Finalisée = Finalised
- Résultats transmis par Pix = Results transmitted by Pix
- Au moins un candidat a rejoint la session, vous ne pouvez pas la supprimer. = At least one candidate has joined the session, you can’t delete it.

**Page liste de sessions, sans sessions**
- Vous pouvez créer des sessions de certifications = You can create certification sessions
- Créez votre première session de certification = Create your first certification session

**Page liste de sessions, en-tête**
- Créer/éditer plusieurs sessions = Create/edit several sessions
- Template d’import de sessions = Sessions import template
- Une erreur s’est produite pendant le téléchargement = An error occurred while downloading/uploading (attention downloading si l'erreur se passe pendant le téléchargement du template, uploading si l'erreur se passe pendant l'import du template complété)
- Télécharger le template d’import en masse = Download the template for bulk import
- Importer en masse = Bulk import

**Page liste de sessions, affichage de la liste**
- Session de certification = Certification session
- Supprimer la session {id} = Delete the session {id}
- Aucune session trouvée = No session found

**Modale de suppression d’une session**
- Supprimer la session = Delete the session
- Souhaitez-vous supprimer la session {sessionId} ? = Do you want to delete the session {sessionId} ? 
- {enrolledCandidatesCount} candidats sont inscrits à cette session = {enrolledCandidatesCount} candidates are enrolled in this session
- Attention, cette action est irréversible. = Warning, this action is irreversible

**Traduire les toasters**

- La session a été supprimée avec succès. = The session has been been successfully deleted.
- Une erreur s’est produite lors de la suppression de la session. = An error has occurred while deleting the session.
- La session que vous tentez de supprimer n’existe pas. = The session you are trying to delete doesn’t exist.
- La session a déjà commencé. = The session has already started.

## :rainbow: Remarques
- ❗ l'organisation du fichier suit les recommandations de cet ADR : https://github.com/1024pix/pix/blob/dev/docs/adr/0011-organisation-fichier-trad.md
- Pour le statut d'une session, j'ai du créer un composant enfant `sessionSummaryRow` pour traduire les statuts dans le controller

## :100: Pour tester
- Lancer Pix Certif avec un compte (ex: certifsup@example.net).
- Constater que les champs en français sont conformes aux champs indiqués plus haut dans la description de PR.
- Rajouter ?lang=en en fin d'URL pour basculer le Pix Certif en anglais (Si ça ne marche pas, aller sur Pix.org, faire la manipulation ?lang=en, puis remplacer app par certif dans l'URL).
- Constater que les champs en anglais correspondent à ceux cités plus haut dans la description.