### PR TITLE
[FEATURE] Rendre composant de sélection de sujets générique sur Pix-Admin (PIX-7025)

### DIFF
--- a/admin/app/components/common/tubes-selection.hbs
+++ b/admin/app/components/common/tubes-selection.hbs
@@ -21,17 +21,19 @@
       >
         {{option.label}}
       </PixMultiSelect>
-      <div class="vertical-delimiter"></div>
-      <PixButtonUpload
-        @onChange={{this.fillTubesSelectionFromFile}}
-        @backgroundColor="transparent-light"
-        @isBorderVisible={{true}}
-        @size="small"
-        @id="file-upload"
-        accept=".json"
-      >
-        Importer un fichier JSON
-      </PixButtonUpload>
+      {{#if @displayJsonImportButton}}
+        <div class="vertical-delimiter"></div>
+        <PixButtonUpload
+          @onChange={{this.fillTubesSelectionFromFile}}
+          @backgroundColor="transparent-light"
+          @isBorderVisible={{true}}
+          @size="small"
+          @id="file-upload"
+          accept=".json"
+        >
+          Importer un fichier JSON
+        </PixButtonUpload>
+      {{/if}}
       <div class="tubes-selection__inline-layout--count">{{this.selectedTubesCount}}/{{this.totalTubesCount}}</div>
     </div>
   </Card>
@@ -46,6 +48,7 @@
       @checkTube={{this.checkTube}}
       @uncheckTube={{this.uncheckTube}}
       @tubeLevels={{this.tubeLevels}}
+      @displayDeviceCompatibility={{@displayDeviceCompatibility}}
     />
   {{/if}}
 </div>

--- a/admin/app/components/common/tubes-selection/areas.hbs
+++ b/admin/app/components/common/tubes-selection/areas.hbs
@@ -10,6 +10,7 @@
           @checkTube={{@checkTube}}
           @uncheckTube={{@uncheckTube}}
           @tubeLevels={{@tubeLevels}}
+          @displayDeviceCompatibility={{@displayDeviceCompatibility}}
         />
       {{/each}}
     </PixCollapsible>

--- a/admin/app/components/common/tubes-selection/competence.hbs
+++ b/admin/app/components/common/tubes-selection/competence.hbs
@@ -21,9 +21,11 @@
             <Table::Header @size="small" scope="col">
               <p>Niveau</p>
             </Table::Header>
-            <Table::Header @size="medium" @align="center" scope="col">
-              <p>Compatibilité</p>
-            </Table::Header>
+            {{#if @displayDeviceCompatibility}}
+              <Table::Header @size="medium" @align="center" scope="col">
+                <p>Compatibilité</p>
+              </Table::Header>
+            {{/if}}
           </tr>
         </thead>
 
@@ -46,6 +48,7 @@
                   @checkTube={{@checkTube}}
                   @uncheckTube={{@uncheckTube}}
                   @tubeLevels={{@tubeLevels}}
+                  @displayDeviceCompatibility={{@displayDeviceCompatibility}}
                 />
               </tr>
             {{/each}}

--- a/admin/app/components/common/tubes-selection/tube.hbs
+++ b/admin/app/components/common/tubes-selection/tube.hbs
@@ -16,17 +16,19 @@
     @isDisabled={{not this.checked}}
   />
 </td>
-<td class="table__column--center">
-  <div class="icon-container" aria-label="{{if @tube.mobile 'compatible mobile' 'incompatible mobile'}}">
-    <FaIcon @icon="mobile-screen-button" class="fa-2x {{if @tube.mobile 'is-responsive'}}" />
-    {{#unless @tube.mobile}}
-      <FaIcon @icon="slash" class="fa-2x not-responsive" />
-    {{/unless}}
-  </div>
-  <div class="icon-container" aria-label="{{if @tube.tablet 'compatible tablette' 'incompatible tablette'}}">
-    <FaIcon @icon="tablet-screen-button" class="fa-2x {{if @tube.tablet 'is-responsive'}}" />
-    {{#unless @tube.tablet}}
-      <FaIcon @icon="slash" class="fa-2x not-responsive" />
-    {{/unless}}
-  </div>
-</td>
+{{#if @displayDeviceCompatibility}}
+  <td class="table__column--center">
+    <div class="icon-container" aria-label="{{if @tube.mobile 'compatible mobile' 'incompatible mobile'}}">
+      <FaIcon @icon="mobile-screen-button" class="fa-2x {{if @tube.mobile 'is-responsive'}}" />
+      {{#unless @tube.mobile}}
+        <FaIcon @icon="slash" class="fa-2x not-responsive" />
+      {{/unless}}
+    </div>
+    <div class="icon-container" aria-label="{{if @tube.tablet 'compatible tablette' 'incompatible tablette'}}">
+      <FaIcon @icon="tablet-screen-button" class="fa-2x {{if @tube.tablet 'is-responsive'}}" />
+      {{#unless @tube.tablet}}
+        <FaIcon @icon="slash" class="fa-2x not-responsive" />
+      {{/unless}}
+    </div>
+  </td>
+{{/if}}

--- a/admin/app/components/target-profiles/badge-form/capped-tubes-criterion.hbs
+++ b/admin/app/components/target-profiles/badge-form/capped-tubes-criterion.hbs
@@ -29,6 +29,7 @@
       @checkTube={{this.checkTube}}
       @uncheckTube={{this.uncheckTube}}
       @setLevelTube={{this.setLevelTube}}
+      @displayDeviceCompatibility={{true}}
     />
   </main>
 </section>

--- a/admin/app/components/target-profiles/create-target-profile-form.hbs
+++ b/admin/app/components/target-profiles/create-target-profile-form.hbs
@@ -48,7 +48,12 @@
       </div>
     </Card>
 
-    <Common::TubesSelection @frameworks={{@frameworks}} @onChange={{this.updateTubes}} />
+    <Common::TubesSelection
+      @frameworks={{@frameworks}}
+      @onChange={{this.updateTubes}}
+      @displayJsonImportButton={{true}}
+      @displayDeviceCompatibility={{true}}
+    />
 
     <Card class="create-target-profile__card" @title="3. Personnalisation">
       <PixInput
@@ -82,7 +87,8 @@
       @isBorderVisible={{true}}
       @size="big"
       @triggerAction={{@onCancel}}
-    >Annuler</PixButton>
+    >Annuler
+    </PixButton>
     <PixButton
       @backgroundColor="green"
       @size="big"

--- a/admin/tests/integration/components/common/tubes-selection_test.js
+++ b/admin/tests/integration/components/common/tubes-selection_test.js
@@ -68,7 +68,12 @@ module('Integration | Component | Common::TubesSelection', function (hooks) {
     this.set('onChangeFunction', onChangeFunction);
 
     screen = await render(
-      hbs`<Common::TubesSelection @frameworks={{this.frameworks}} @onChange={{this.onChangeFunction}} />`
+      hbs`<Common::TubesSelection
+          @frameworks={{this.frameworks}}
+          @onChange={{this.onChangeFunction}}
+          @displayJsonImportButton={{true}}
+          @displayDeviceCompatibility={{true}}
+          />`
     );
   });
 
@@ -176,5 +181,14 @@ module('Integration | Component | Common::TubesSelection', function (hooks) {
 
     // then
     assert.dom(screen.getByText('1/3')).exists();
+  });
+
+  test('it should show compatibility column ', async function (assert) {
+    // when
+    await clickByName('1 · Titre domaine');
+    await clickByName('1 Titre competence');
+
+    // then
+    assert.dom(screen.getByText('Compatibilité')).exists();
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
La sélection de sujets est présente sur deux pages différentes. Le composant a été déplacé mais n'est pas générique.

## :robot: Proposition
Rendre le composant sélection de sujets génériques. 
Ajout d'un attribut `displayJsonImport` pour conditionner l'affichage de l'importation json 
Ajout d'un attribut `displayDeviceCompatibility` pour conditionner l'affichage de la colonne de compatibilité.

## :100: Pour tester
Vérifier que les composants sont toujours bien fonctionnels :

- Dans la création de Profil Cible
- Dans la création de Résultat Thématique