### PR TITLE
[FEATURE] Traduire les menus et le layout en anglais (PIX-6668)

### DIFF
--- a/certif/app/components/user-logged-menu.hbs
+++ b/certif/app/components/user-logged-menu.hbs
@@ -40,6 +40,6 @@
   {{/each}}
   <Dropdown::ItemLink @linkTo="logout" class="logged-user-menu-item logged-user-menu-item__last">
     <FaIcon @icon="power-off" @class="logged-user-menu-item__icon" />
-    Se déconnecter
+    {{t "navigation.user-logged-menu.logout"}}
   </Dropdown::ItemLink>
 </Dropdown::Content>

--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -15,7 +15,7 @@
               @route="authenticated.sessions.list"
               class="sidebar-menu__item"
               type="button"
-              aria-label="Sessions de certification"
+              aria-label={{t "navigation.main.sessions-label"}}
             >
               <img
                 src="{{this.rootURL}}/icons/chevron-square-right.svg"
@@ -23,31 +23,26 @@
                 role="presentation"
                 class="sidebar-menu__item-icon"
               />
-              Sessions
+              {{t "navigation.main.sessions"}}
             </LinkTo>
           </li>
           <li>
-            <LinkTo
-              @route="login-session-supervisor"
-              class="sidebar-menu__item"
-              type="button"
-              aria-label="Espace surveillant"
-            >
+            <LinkTo @route="login-session-supervisor" class="sidebar-menu__item" type="button">
               <FaIcon @icon="eye" class="sidebar-menu__item-icon" />
-              Espace surveillant
+              {{t "navigation.main.supervisor"}}
             </LinkTo>
           </li>
         {{/if}}
         <li>
-          <LinkTo @route="authenticated.team" class="sidebar-menu__item" type="button" aria-label="Équipe">
+          <LinkTo @route="authenticated.team" class="sidebar-menu__item" type="button">
             <FaIcon @icon="users" class="sidebar-menu__item-icon" />
-            Équipe
+            {{t "navigation.main.team"}}
           </LinkTo>
         </li>
         <li>
           <a class="sidebar-menu__item" href="{{this.documentationLink}}" target="_blank" rel="noopener noreferrer">
             <FaIcon @icon="book" class="sidebar-menu__item-icon" />
-            Documentation
+            {{t "navigation.main.documentation"}}
           </a>
         </li>
       </ul>

--- a/certif/tests/integration/components/user-logged-menu_test.js
+++ b/certif/tests/integration/components/user-logged-menu_test.js
@@ -1,14 +1,14 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
-import { setupRenderingTest } from 'ember-qunit';
 import { click } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { run } from '@ember/runloop';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | user-logged-menu', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
   let store;
   let certificationPointOfContact;
   let currentAllowedCertificationCenterAccess;

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -29,6 +29,9 @@
       "team": "Team",
       "documentation": "Documentation"
     },
+    "user-logged-menu": {
+      "logout": "Log out"
+    },
     "footer": {
       "a11y": "Accessibility",
       "legal-notice": "Legal notice",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -22,9 +22,16 @@
   },
   "current-lang": "en",
   "navigation": {
+    "main": {
+      "sessions": "Sessions",
+      "sessions-label": "Certification sessions",
+      "supervisor": "Invigilator’s Portal",
+      "team": "Team",
+      "documentation": "Documentation"
+    },
     "footer": {
-      "a11y": "Accessibilité : partiellement conforme",
-      "legal-notice": "Mentions légales",
+      "a11y": "Accessibility",
+      "legal-notice": "Legal notice",
       "current-year": "© {currentYear} Pix"
     }
   },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -22,6 +22,13 @@
   },
   "current-lang": "fr",
   "navigation": {
+    "main": {
+      "sessions": "Sessions",
+      "sessions-label": "Sessions de certification",
+      "supervisor": "Espace surveillant",
+      "team": "Équipe",
+      "documentation": "Documentation"
+    },
     "footer": {
       "a11y": "Accessibilité : partiellement conforme",
       "legal-notice": "Mentions légales",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -29,6 +29,9 @@
       "team": "Équipe",
       "documentation": "Documentation"
     },
+    "user-logged-menu": {
+      "logout": "Se déconnecter"
+    },
     "footer": {
       "a11y": "Accessibilité : partiellement conforme",
       "legal-notice": "Mentions légales",


### PR DESCRIPTION
## :unicorn: Problème

Une fois connecté sur Pix Certif, un utilisateur anglophone dispose d’un menu à gauche et d’une liste déroulante en haut à droite pour naviguer entre les centres de certification dont il est membre ou se déconnecter.

## :robot: Proposition

**Traduire le menu de gauche en anglais :**
- Sessions = Sessions
- Espace Surveillant = Invigilator’s Portal
- Equipe = Team
- Documentation = Documentation

**Traduire la liste déroulante en haut à droite en anglais :**
- Se déconnecter = Log out

**Traduire les liens en bas de la page :**
- Mentions légales = Legal notice
- Accessibilité : partiellement conforme = Accessibility

## :rainbow: Remarques
- ❗ l'organisation du fichier suit les recommandations de cet ADR : https://github.com/1024pix/pix/blob/dev/docs/adr/0011-organisation-fichier-trad.md

## :100: Pour tester
- Lancer Pix Certif avec un compte (ex: certifsup@example.net).
- Constater que les champs en français sont conformes aux champs indiqués plus haut dans la description de PR.
- Rajouter ?lang=en en fin d'URL pour basculer le Pix Certif en anglais (Si ça ne marche pas, aller sur Pix.org, faire la manipulation ?lang=en, puis remplacer app par certif dans l'URL).
- Constater que les champs en anglais correspondent à ceux cités plus haut dans la description.