### PR TITLE
[TECH] Corriger les derniers warnings ESLint et éviter qu'ils reviennent

### DIFF
--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -37,7 +37,7 @@ rules:
   mocha/no-pending-tests: error
   mocha/no-skipped-tests: error
   mocha/no-top-level-hooks: error
-  no-empty-function: warn
+  no-empty-function: error
   # Refer to scripts/_template.js for reliable alternatives to process.exit()
   node/no-process-exit: error
   unicorn/no-empty-file: error

--- a/api/db/migrations/20220922141959_modify-messages-in-complementary-certification-badges.js
+++ b/api/db/migrations/20220922141959_modify-messages-in-complementary-certification-badges.js
@@ -66,5 +66,6 @@ exports.up = async function (knex) {
  * @param { import('knex').Knex } knex
  * @returns { Promise<void> }
  */
-// eslint-disable-next-line no-empty-function
-exports.down = function (_) {};
+exports.down = function () {
+  // do nothing.
+};

--- a/api/db/migrations/20221123110348_remove-NULL-postalCodes.js
+++ b/api/db/migrations/20221123110348_remove-NULL-postalCodes.js
@@ -3,4 +3,6 @@ exports.up = async function (knex) {
   await knex('certification-candidates').where({ birthINSEECode: 'NULL' }).update({ birthINSEECode: null });
 };
 
-exports.down = function () {};
+exports.down = function () {
+  // do nothing.
+};

--- a/api/db/migrations/20230112103200_cancel-pending-organization-invitations-with-an-updatedAt-greater-than-a-year.js
+++ b/api/db/migrations/20230112103200_cancel-pending-organization-invitations-with-an-updatedAt-greater-than-a-year.js
@@ -8,4 +8,6 @@ exports.up = function (knex) {
     .andWhere('updatedAt', '<', dayjs().subtract(1, 'year'));
 };
 
-exports.down = function () {};
+exports.down = function () {
+  // do nothing.
+};

--- a/api/db/migrations/20230112224527_drop-column-end-test-screen-removal.js
+++ b/api/db/migrations/20230112224527_drop-column-end-test-screen-removal.js
@@ -7,4 +7,6 @@ exports.up = async function (knex) {
   });
 };
 
-exports.down = async function () {};
+exports.down = async function () {
+  // do nothing.
+};


### PR DESCRIPTION
## :unicorn: Problème

Des warnings `no-empty-function` sont retournés par ESLint. 
Cela peut induire le développeur en erreur.

## :robot: Proposition

La règle [`no-empty-function`](https://eslint.org/docs/latest/rules/no-empty-function) d'ESLint recommande d'utiliser un commentaire `// do nothing.` pour identifier les fonctions laissées intentionnellement vides.

1. Corriger les 3 warnings qui restent en suivant la recommandation d'utiliser un commentaire `// do nothing.`
2. Modifier un commentaire `// eslint-disable-next-line no-empty-function` actuellement présent dans le code en commentaire `// do nothing.` recommandé par ESLint
3. Empêcher que de nouveaux warnings identiques soient à nouveau introduits en configurant la règle `no-empty-function` pour qu'elle renvoie une erreur

## :rainbow: Remarques

RAS

## :100: Pour tester

Vérifier que la CI s'exécute sans erreur.