### PR TITLE
[FEATURE] ETQ Admin Support, télécharger les attestations de certification d'une session (PIX-7132)

### DIFF
--- a/admin/app/controllers/authenticated/sessions/session/informations.js
+++ b/admin/app/controllers/authenticated/sessions/session/informations.js
@@ -74,12 +74,11 @@ export default class IndexController extends Controller {
   async downloadPDFAttestations() {
     const sessionId = this.model.id;
     const url = `/api/admin/sessions/${sessionId}/attestations`;
-    const fileName = `attestations_session_${sessionId}_pix.pdf`;
     const token = this.session.data.authenticated.access_token;
     try {
-      await this.fileSaver.save({ url, fileName, token });
+      await this.fileSaver.save({ url, token });
     } catch (error) {
-      this.attestationDownloadErrorMessage = error.message;
+      this.notifications.error("Une erreur est survenue, les attestations n'ont pas pu être téléchargées.");
     }
   }
 

--- a/admin/app/controllers/authenticated/sessions/session/informations.js
+++ b/admin/app/controllers/authenticated/sessions/session/informations.js
@@ -11,6 +11,7 @@ export default class IndexController extends Controller {
   @service currentUser;
   @service accessControl;
   @service session;
+  @service fileSaver;
 
   @alias('model') sessionModel;
 
@@ -67,6 +68,19 @@ export default class IndexController extends Controller {
       this._displayErrorTooltip();
     }
     window.setTimeout(() => this._hideTooltip(), 2000);
+  }
+
+  @action
+  async downloadPDFAttestations() {
+    const sessionId = this.model.id;
+    const url = `/api/admin/sessions/${sessionId}/attestations`;
+    const fileName = `attestations_session_${sessionId}_pix.pdf`;
+    const token = this.session.data.authenticated.access_token;
+    try {
+      await this.fileSaver.save({ url, fileName, token });
+    } catch (error) {
+      this.attestationDownloadErrorMessage = error.message;
+    }
   }
 
   @action

--- a/admin/app/styles/authenticated/sessions/session/informations.scss
+++ b/admin/app/styles/authenticated/sessions/session/informations.scss
@@ -67,4 +67,17 @@
       }
     }
   }
+
+  &__download-button {
+    margin: 0 10px;
+  }
+
+  &__download-button:first-child {
+    margin-left: 0;
+  }
+
+  &__published-buttons {
+    display: flex;
+    flex-direction: row;
+  }
 }

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -140,11 +140,28 @@
           </PixButton>
         </div>
 
-        {{#if this.sessionModel.areResultsToBeSentToPrescriber}}
-          <PixButton size="small" @triggerAction={{this.tagSessionAsSentToPrescriber}} @backgroundColor="grey">
-            Résultats transmis au prescripteur
+        <div class="session-info__published-buttons">
+          <PixButton
+            @triggerAction={{this.downloadPDFAttestations}}
+            @backgroundColor="grey"
+            class="session-info__download-button"
+            @isDisabled={{not this.sessionModel.isPublished}}
+            @iconBefore="file-arrow-down"
+          >
+            Télécharger les attestations
           </PixButton>
-        {{/if}}
+
+          {{#if this.sessionModel.areResultsToBeSentToPrescriber}}
+            <PixButton
+              size="small"
+              @triggerAction={{this.tagSessionAsSentToPrescriber}}
+              @backgroundColor="grey"
+              class="session-info__download-button"
+            >
+              Résultats transmis au prescripteur
+            </PixButton>
+          {{/if}}
+        </div>
       </div>
     {{/if}}
   </div>

--- a/admin/tests/acceptance/session_test.js
+++ b/admin/tests/acceptance/session_test.js
@@ -127,7 +127,7 @@ module('Acceptance | Session pages', function (hooks) {
             const screen = await visit('/sessions/2');
 
             // then
-            assert.dom(screen.getByText('Télécharger les attestations')).hasAttribute('disabled');
+            assert.dom(screen.getByRole('button', { name: 'Télécharger les attestations' })).hasAttribute('disabled');
           });
         });
 
@@ -143,7 +143,9 @@ module('Acceptance | Session pages', function (hooks) {
             const screen = await visit('/sessions/2');
 
             // then
-            assert.dom(screen.getByText('Télécharger les attestations')).doesNotHaveAttribute('disabled');
+            assert
+              .dom(screen.getByRole('button', { name: 'Télécharger les attestations' }))
+              .doesNotHaveAttribute('disabled');
           });
         });
 

--- a/admin/tests/acceptance/session_test.js
+++ b/admin/tests/acceptance/session_test.js
@@ -118,6 +118,35 @@ module('Acceptance | Session pages', function (hooks) {
       });
 
       module('Buttons section', function () {
+        module('When the session has not been published', function () {
+          test('it show the disabled certificates download button', async function (assert) {
+            // given
+            this.server.create('session');
+
+            // when
+            const screen = await visit('/sessions/2');
+
+            // then
+            assert.dom(screen.getByText('Télécharger les attestations')).hasAttribute('disabled');
+          });
+        });
+
+        module('When the session has been published', function () {
+          test('it shows the certificates download button', async function (assert) {
+            // given
+            const juryCertificationSummary = this.server.create('jury-certification-summary', {
+              isPublished: true,
+            });
+            this.server.create('session', { juryCertificationSummaries: [juryCertificationSummary] });
+
+            // when
+            const screen = await visit('/sessions/2');
+
+            // then
+            assert.dom(screen.getByText('Télécharger les attestations')).doesNotHaveAttribute('disabled');
+          });
+        });
+
         test('it shows all buttons', async function (assert) {
           // when
           const screen = await visit('/sessions/1');

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -386,6 +386,41 @@ const register = async function (server) {
         ],
       },
     },
+
+    {
+      method: 'GET',
+      path: '/api/admin/sessions/{id}/attestations',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.sessionId,
+          }),
+        },
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleCertif,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        handler: sessionController.getCertificationPDFAttestationsForSession,
+        plugins: {
+          'hapi-swagger': {
+            produces: ['application/pdf'],
+          },
+        },
+        notes: [
+          '- **Route accessible par un user Admin**\n' +
+            "- Récupération des attestations de certification d'une session au format PDF" +
+            ' via un id de certification et un user id',
+        ],
+        tags: ['api', 'certifications', 'PDF'],
+      },
+    },
     {
       method: 'GET',
       path: '/api/sessions/download-results/{token}',

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -416,7 +416,7 @@ const register = async function (server) {
         notes: [
           '- **Route accessible par un user Admin**\n' +
             "- Récupération des attestations de certification d'une session au format PDF" +
-            ' via un id de certification et un user id',
+            ' via un id de session et un user id',
         ],
         tags: ['api', 'certifications', 'PDF'],
       },

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -17,6 +17,7 @@ import * as requestResponseUtils from '../../infrastructure/utils/request-respon
 import * as certificationResultUtils from '../../infrastructure/utils/csv/certification-results.js';
 import { fillCandidatesImportSheet } from '../../infrastructure/files/candidates-import/fill-candidates-import-sheet.js';
 import * as supervisorKitPdf from '../../infrastructure/utils/pdf/supervisor-kit-pdf.js';
+import * as certificationAttestationPdf from '../../infrastructure/utils/pdf/certification-attestation-pdf.js';
 import lodash from 'lodash';
 
 const { trim } = lodash;
@@ -203,6 +204,29 @@ const getSessionResultsToDownload = async function (
     .header('Content-Disposition', `attachment; filename=${fileName}`);
 };
 
+const getCertificationPDFAttestationsForSession = async function (
+  request,
+  h,
+  dependencies = { certificationAttestationPdf }
+) {
+  const sessionId = request.params.id;
+  const isFrenchDomainExtension = request.query.isFrenchDomainExtension;
+  const attestations = await usecases.getCertificationAttestationsForSession({
+    sessionId,
+  });
+
+  const { buffer } = await dependencies.certificationAttestationPdf.getCertificationAttestationsPdfBuffer({
+    certificates: attestations,
+    isFrenchDomainExtension,
+  });
+
+  const fileName = `attestation-pix-session-${sessionId}.pdf`;
+  return h
+    .response(buffer)
+    .header('Content-Disposition', `attachment; filename=${fileName}`)
+    .header('Content-Type', 'application/pdf');
+};
+
 const getSessionResultsByRecipientEmail = async function (
   request,
   h,
@@ -380,6 +404,7 @@ const sessionController = {
   getSupervisorKitPdf,
   getCandidatesImportSheet,
   getCertificationCandidates,
+  getCertificationPDFAttestationsForSession,
   addCertificationCandidate,
   deleteCertificationCandidate,
   getJuryCertificationSummaries,

--- a/api/lib/domain/usecases/certificate/get-certification-attestations-for-session.js
+++ b/api/lib/domain/usecases/certificate/get-certification-attestations-for-session.js
@@ -27,7 +27,7 @@ const getCertificationAttestationsForSession = async function ({
   );
 
   if (isEmpty(certificationAttestations)) {
-    throw new NotFoundError("Pas d'attestation trouvée");
+    throw new NotFoundError('No certification attestations found');
   }
 
   return certificationAttestations;

--- a/api/lib/domain/usecases/certificate/get-certification-attestations-for-session.js
+++ b/api/lib/domain/usecases/certificate/get-certification-attestations-for-session.js
@@ -1,0 +1,36 @@
+import { NotFoundError } from '../../errors.js';
+import isEmpty from 'lodash/isEmpty.js';
+import compact from 'lodash/compact.js';
+import bluebird from 'bluebird';
+
+const getCertificationAttestationsForSession = async function ({
+  sessionId,
+  certificateRepository,
+  certificationCourseRepository,
+}) {
+  const certificationCourses = await certificationCourseRepository.findCertificationCoursesBySessionId({ sessionId });
+
+  if (isEmpty(certificationCourses)) {
+    throw new NotFoundError();
+  }
+
+  const certificationAttestations = compact(
+    await bluebird.mapSeries(certificationCourses, async (certificationCourse) => {
+      try {
+        return await certificateRepository.getCertificationAttestation(certificationCourse.getId());
+      } catch (error) {
+        if (!(error instanceof NotFoundError)) {
+          throw error;
+        }
+      }
+    })
+  );
+
+  if (isEmpty(certificationAttestations)) {
+    throw new NotFoundError("Pas d'attestation trouvée");
+  }
+
+  return certificationAttestations;
+};
+
+export { getCertificationAttestationsForSession };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -555,6 +555,7 @@ import { getCampaignParticipationsCountsByStatus } from './get-campaign-particip
 import { getCampaignProfile } from './get-campaign-profile.js';
 import { getCandidateImportSheetData } from './get-candidate-import-sheet-data.js';
 import { getCertificationAttestation } from './certificate/get-certification-attestation.js';
+import { getCertificationAttestationsForSession } from './certificate/get-certification-attestations-for-session.js';
 import { getCertificationCandidate } from './get-certification-candidate.js';
 import { getCertificationCandidateSubscription } from './get-certification-candidate-subscription.js';
 import { getCertificationCenter } from './get-certification-center.js';
@@ -842,6 +843,7 @@ const usecasesWithoutInjectedDependencies = {
   getCampaignProfile,
   getCandidateImportSheetData,
   getCertificationAttestation,
+  getCertificationAttestationsForSession,
   getCertificationCandidate,
   getCertificationCandidateSubscription,
   getCertificationCenter,

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -976,7 +976,7 @@ describe('Unit | Application | Sessions | Routes', function () {
       });
     });
 
-    describe('GET /api/admin/sessions/{id}/generate-attestations-download-link', function () {
+    describe('GET /api/admin/sessions/{id}/attestations', function () {
       it('return forbidden access if user has METIER role', async function () {
         // given
         sinon
@@ -997,10 +997,7 @@ describe('Unit | Application | Sessions | Routes', function () {
         await httpTestServer.register(moduleUnderTest);
 
         // when
-        const response = await httpTestServer.request(
-          'GET',
-          '/api/admin/sessions/1/generate-attestations-download-link'
-        );
+        const response = await httpTestServer.request('GET', '/api/admin/sessions/1/attestations');
 
         // then
         expect(response.statusCode).to.equal(403);

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -975,6 +975,37 @@ describe('Unit | Application | Sessions | Routes', function () {
         expect(response.statusCode).to.equal(403);
       });
     });
+
+    describe('GET /api/admin/sessions/{id}/generate-attestations-download-link', function () {
+      it('return forbidden access if user has METIER role', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .withArgs([
+            securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            securityPreHandlers.checkAdminMemberHasRoleCertif,
+            securityPreHandlers.checkAdminMemberHasRoleSupport,
+          ])
+          .callsFake(
+            () => (request, h) =>
+              h
+                .response({ errors: new Error('forbidden') })
+                .code(403)
+                .takeover()
+          );
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const response = await httpTestServer.request(
+          'GET',
+          '/api/admin/sessions/1/generate-attestations-download-link'
+        );
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
   });
 
   describe('DELETE /api/sessions/{id}', function () {

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -1108,7 +1108,6 @@ describe('Unit | Controller | sessionController', function () {
       const certification2 = domainBuilder.buildPrivateCertificateWithCompetenceTree({ id: 2 });
       const certification3 = domainBuilder.buildPrivateCertificateWithCompetenceTree({ id: 3 });
       const attestationPDF = 'binary string';
-      const fileName = 'attestation-pix-session-12.pdf';
       const userId = 1;
 
       const request = {
@@ -1126,7 +1125,7 @@ describe('Unit | Controller | sessionController', function () {
 
       certificationAttestationPdf.getCertificationAttestationsPdfBuffer
         .withArgs({ certificates: [certification1, certification2, certification3], isFrenchDomainExtension: true })
-        .resolves({ buffer: attestationPDF, fileName });
+        .resolves({ buffer: attestationPDF });
 
       // when
       const response = await sessionController.getCertificationPDFAttestationsForSession(request, hFake, {

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -1078,6 +1078,68 @@ describe('Unit | Controller | sessionController', function () {
       expect(response.headers['Content-Disposition']).to.contains(`attachment; filename=kit-surveillant-1.pdf`);
     });
   });
+
+  describe('#getSessionPDFAttestations', function () {
+    it('should return an attestation in PDF binary format', async function () {
+      // given
+      const certificationAttestationPdf = {
+        getCertificationAttestationsPdfBuffer: sinon.stub(),
+      };
+      const session = domainBuilder.buildSession.finalized({ id: 12 });
+      domainBuilder.buildCertificationCourse({
+        id: 1,
+        sessionId: 12,
+        userId: 1,
+        completedAt: '2020-01-01',
+      });
+      domainBuilder.buildCertificationCourse({
+        id: 2,
+        sessionId: 12,
+        userId: 2,
+        completedAt: '2020-01-01',
+      });
+      domainBuilder.buildCertificationCourse({
+        id: 3,
+        sessionId: 12,
+        userId: 3,
+        completedAt: '2020-01-01',
+      });
+      const certification1 = domainBuilder.buildPrivateCertificateWithCompetenceTree({ id: 1 });
+      const certification2 = domainBuilder.buildPrivateCertificateWithCompetenceTree({ id: 2 });
+      const certification3 = domainBuilder.buildPrivateCertificateWithCompetenceTree({ id: 3 });
+      const attestationPDF = 'binary string';
+      const fileName = 'attestation-pix-session-12.pdf';
+      const userId = 1;
+
+      const request = {
+        auth: { credentials: { userId } },
+        params: { id: session.id },
+        query: { isFrenchDomainExtension: true },
+      };
+
+      sinon
+        .stub(usecases, 'getCertificationAttestationsForSession')
+        .withArgs({
+          sessionId: session.id,
+        })
+        .resolves([certification1, certification2, certification3]);
+
+      certificationAttestationPdf.getCertificationAttestationsPdfBuffer
+        .withArgs({ certificates: [certification1, certification2, certification3], isFrenchDomainExtension: true })
+        .resolves({ buffer: attestationPDF, fileName });
+
+      // when
+      const response = await sessionController.getCertificationPDFAttestationsForSession(request, hFake, {
+        certificationAttestationPdf,
+      });
+
+      // then
+      expect(response.source).to.deep.equal(attestationPDF);
+      expect(response.headers['Content-Disposition']).to.contains(
+        'attachment; filename=attestation-pix-session-12.pdf'
+      );
+    });
+  });
 });
 
 function buildRequest(sessionId, userId, firstName, lastName, birthdate) {

--- a/api/tests/unit/domain/usecases/get-certification-attestation-for-session_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-attestation-for-session_test.js
@@ -1,0 +1,142 @@
+import { expect, sinon, domainBuilder, catchErr } from '../../../test-helper.js';
+import { getCertificationAttestationsForSession } from '../../../../lib/domain/usecases/certificate/get-certification-attestations-for-session.js';
+import { NotFoundError } from '../../../../lib/domain/errors.js';
+
+describe('Unit | UseCase | get-certification-attestation-for-session', function () {
+  const certificateRepository = {
+    getCertificationAttestation: () => undefined,
+  };
+  const certificationCourseRepository = {
+    findCertificationCoursesBySessionId: () => undefined,
+  };
+
+  const dependencies = {
+    certificateRepository,
+    certificationCourseRepository,
+  };
+
+  beforeEach(function () {
+    certificateRepository.getCertificationAttestation = sinon.stub();
+    certificationCourseRepository.findCertificationCoursesBySessionId = sinon.stub();
+  });
+
+  it('should return multiple certification attestations enhanced with result competence tree for a sessions', async function () {
+    // given
+    domainBuilder.buildSession({
+      id: 11,
+      finalizedAt: new Date('2020-01-02T14:00:00Z'),
+      certificationCenter: 'Centre des deux attestations',
+    });
+
+    const certificationCourse1 = domainBuilder.buildCertificationCourse({
+      id: 1,
+      sessionId: 11,
+      userId: 101,
+      completedAt: '2020-01-01',
+    });
+    domainBuilder.buildResultCompetenceTree({ id: 'firstResultTreeId' });
+    const certificationAttestation1 = domainBuilder.buildCertificationAttestation({
+      id: 1,
+      userId: 101,
+      resultCompetenceTree: 'firstResultTreeId',
+      certificationCenter: 'Centre des deux attestations',
+    });
+
+    const certificationCourse2 = domainBuilder.buildCertificationCourse({
+      id: 2,
+      sessionId: 11,
+      userId: 102,
+      completedAt: '2020-01-01',
+    });
+    domainBuilder.buildResultCompetenceTree({ id: 'secondResultTreeId' });
+    const certificationAttestation2 = domainBuilder.buildCertificationAttestation({
+      id: 2,
+      userId: 102,
+      resultCompetenceTree: 'secondResultTreeId',
+      certificationCenter: 'Centre des deux attestations',
+    });
+
+    certificationCourseRepository.findCertificationCoursesBySessionId
+      .withArgs({ sessionId: 11 })
+      .resolves([certificationCourse1, certificationCourse2]);
+    certificateRepository.getCertificationAttestation.withArgs(1).resolves(certificationAttestation1);
+    certificateRepository.getCertificationAttestation.withArgs(2).resolves(certificationAttestation2);
+
+    // when
+    const actualCertificationAttestations = await getCertificationAttestationsForSession({
+      sessionId: 11,
+      ...dependencies,
+    });
+
+    // then
+    const expectedCertificationAttestations = [
+      domainBuilder.buildCertificationAttestation({
+        id: 1,
+        userId: 101,
+        resultCompetenceTree: 'firstResultTreeId',
+        certificationCenter: 'Centre des deux attestations',
+      }),
+      domainBuilder.buildCertificationAttestation({
+        id: 2,
+        userId: 102,
+        resultCompetenceTree: 'secondResultTreeId',
+        certificationCenter: 'Centre des deux attestations',
+      }),
+    ];
+
+    expect(actualCertificationAttestations).to.deep.equal(expectedCertificationAttestations);
+  });
+
+  describe('when there is no certification courses for the session', function () {
+    it('should throw a NotFoundError', async function () {
+      // given
+      domainBuilder.buildSession({
+        id: 12,
+        finalizedAt: new Date('2020-01-02T14:00:00Z'),
+        certificationCenter: 'Centre sans attestation',
+      });
+
+      certificationCourseRepository.findCertificationCoursesBySessionId.withArgs({ sessionId: 12 }).resolves([]);
+
+      // when
+      const error = await catchErr(getCertificationAttestationsForSession)({
+        sessionId: 12,
+        ...dependencies,
+      });
+
+      // then
+      expect(error).to.be.an.instanceOf(NotFoundError);
+    });
+  });
+
+  describe('when there is no certification attestations for the session', function () {
+    it('should throw a NotFoundError', async function () {
+      // given
+      domainBuilder.buildSession({
+        id: 13,
+        finalizedAt: new Date('2020-01-02T14:00:00Z'),
+        certificationCenter: 'Centre sans attestation',
+      });
+      const certificationCourse = domainBuilder.buildCertificationCourse({
+        id: 3,
+        sessionId: 11,
+        userId: 101,
+        completedAt: '2020-01-01',
+      });
+
+      certificationCourseRepository.findCertificationCoursesBySessionId
+        .withArgs({ sessionId: 13 })
+        .resolves([certificationCourse]);
+      certificateRepository.getCertificationAttestation.withArgs(3).resolves();
+
+      // when
+      const error = await catchErr(getCertificationAttestationsForSession)({
+        sessionId: 13,
+        ...dependencies,
+      });
+
+      // then
+      expect(error).to.be.an.instanceOf(NotFoundError);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un centre de certification ou un precripteur a perdu les attestations de certification de ses candidats, il contacte notre pôle support pour leur demander de rééditer les attestations en question. Nos chers collègues du support nous contactent alors pour qu'on leur édite ces attestations. Un script existe déjà pour générer les attestations de certification par session mais ce processus impacte l'équipe Certif et crée de la latence pour l'équipe Support.

## :robot: Proposition
Nos amis du support ayant déjà accès à Pix Admin et aux sessions de certification qui s'y trouvent, pourquoi ne pas leur mettre à disposition un bouton de téléchargement de ces attestations ? Nous avons donc unilatéralement décidé de créer un tel bouton. 

## :100: Pour tester
- Se rendre sur Pix Admin
- Aller sur une session concernant les certifications et ayant déjà été publiée
- Cliquer sur le bouton "télécharger les attestations"