### PR TITLE
[FEATURE] Rediriger vers la page de détails après la création d'un contenu formatif (PIX-6956)

### DIFF
--- a/admin/app/controllers/authenticated/trainings/new.js
+++ b/admin/app/controllers/authenticated/trainings/new.js
@@ -8,16 +8,16 @@ export default class NewController extends Controller {
   @service router;
 
   @action
-  goBackToTrainingList() {
-    this.router.transitionTo('authenticated.trainings.list');
+  goToTrainingDetails(trainingId) {
+    this.router.transitionTo('authenticated.trainings.training', trainingId);
   }
 
   @action
   async createOrUpdateTraining(trainingFormData) {
     try {
-      await this.store.createRecord('training', trainingFormData).save();
+      const { id } = await this.store.createRecord('training', trainingFormData).save();
       this.notifications.success('Le contenu formatif a été créé avec succès.');
-      this.goBackToTrainingList();
+      this.goToTrainingDetails(id);
     } catch (error) {
       this.notifications.error('Une erreur est survenue.');
     }

--- a/admin/tests/acceptance/authenticated/trainings/training_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/training_test.js
@@ -2,8 +2,8 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import setupIntl from '../../../helpers/setup-intl';
-import { visit, screen } from '@1024pix/ember-testing-library';
-import { currentURL } from '@ember/test-helpers';
+import { visit, screen, fillByLabel, clickByName } from '@1024pix/ember-testing-library';
+import { currentURL, click } from '@ember/test-helpers';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 
 module('Acceptance | Trainings | Training', function (hooks) {
@@ -63,6 +63,26 @@ module('Acceptance | Trainings | Training', function (hooks) {
       });
     });
 
+    test('should be redirected to training detail page after training creation', async function (assert) {
+      // when
+      await visit(`/trainings/list`);
+      await clickByName('Nouveau contenu formatif');
+
+      await fillByLabel('Titre', 'Nouveau contenu formatif');
+      await fillByLabel('Lien', 'http://www.example.net');
+      await click(screen.getByText('Webinaire'));
+
+      await fillByLabel('Jours (JJ)', 1);
+      await fillByLabel('Heures (HH)', 0);
+      await fillByLabel('Minutes (MM)', 0);
+      await click(screen.getByText('Francophone (fr)'));
+      await fillByLabel('Nom du fichier du logo éditeur', 'Logo.svg', { exact: false });
+      await fillByLabel("Nom de l'éditeur", 'Editeur', { exact: false });
+      await click(screen.getByRole('button', { name: 'Créer le contenu formatif' }));
+
+      // then
+      assert.strictEqual(currentURL(), `/trainings/3/triggers`);
+    });
     test('triggers should be accessible for an authenticated user', async function (assert) {
       // when
       await visit(`/trainings/${trainingId}/`);

--- a/admin/tests/unit/controllers/authenticated/trainings/new_test.js
+++ b/admin/tests/unit/controllers/authenticated/trainings/new_test.js
@@ -11,13 +11,13 @@ module('Unit | Controller | authenticated/trainings/new', function (hooks) {
     controller = this.owner.lookup('controller:authenticated/trainings/new');
   });
 
-  module('#goBackToTrainingList', function () {
-    test('should go back to training list page', async function (assert) {
+  module('#goToTrainingDetails', function () {
+    test('should go to training details page', async function (assert) {
       controller.router.transitionTo = sinon.stub();
 
-      controller.goBackToTrainingList();
+      controller.goToTrainingDetails();
 
-      assert.ok(controller.router.transitionTo.calledWith('authenticated.trainings.list'));
+      assert.ok(controller.router.transitionTo.calledWith('authenticated.trainings.training'));
     });
   });
 
@@ -34,7 +34,7 @@ module('Unit | Controller | authenticated/trainings/new', function (hooks) {
         duration: '6h',
       };
 
-      const saveStub = sinon.stub();
+      const saveStub = sinon.stub().resolves({ id: trainingData.id });
 
       controller.store.createRecord = sinon.stub().withArgs('training', trainingData).returns({ save: saveStub });
 
@@ -50,7 +50,7 @@ module('Unit | Controller | authenticated/trainings/new', function (hooks) {
       // then
       assert.ok(saveStub.called);
       assert.ok(controller.notifications.success.calledWith('Le contenu formatif a été créé avec succès.'));
-      assert.ok(controller.router.transitionTo.calledWith('authenticated.trainings.list'));
+      assert.ok(controller.router.transitionTo.calledWith('authenticated.trainings.training', trainingData.id));
     });
 
     test('it should display error notification when training cannot be saved', async function (assert) {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, quand on créer un contenu formatif, on est redirigé vers la page de listing des contenus formatifs. Nous souhaitons maintenant être redirigés vers la page de détails du contenu formatif fraichement créé.

## :robot: Proposition
Faire la redirection. vers la page de détails du contenu formatif après sa création

## :rainbow: Remarques

## :100: Pour tester
- Aller sur pix admin
- Créer un contenu formatif
- vérifier qu'on est bien redirigé vers la page de détail du CF