### PR TITLE
[TECH] Renvoyer une erreur 422 au lieu d'une erreur 503 quand Pôle Emploi ne renvoie pas correctement les infos d'un utilisateur (PIX-6982)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -409,6 +409,14 @@ function _mapToHttpError(error) {
     return new HttpErrors.BadRequestError(error.message);
   }
 
+  if (error instanceof DomainErrors.OidcMissingFieldsError) {
+    return new HttpErrors.UnprocessableEntityError(error.message, error.code, error.meta);
+  }
+
+  if (error instanceof DomainErrors.OidcUserInfoFormatError) {
+    return new HttpErrors.ServiceUnavailableError(error.message, error.code, error.meta);
+  }
+
   if (error instanceof DomainErrors.InvalidIdentityProviderError) {
     return new HttpErrors.BadRequestError(error.message);
   }

--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -91,6 +91,13 @@ module.exports = {
     },
   },
 
+  OIDC_ERRORS: {
+    USER_INFO: {
+      missingFields: { shortCode: 'OIDC01', code: 'USER_INFO_MISSING_FIELDS' },
+      badResponseFormat: { shortCode: 'OIDC02', code: 'USER_INFO_BAD_RESPONSE_FORMAT' },
+    },
+  },
+
   CERTIFICATION_CENTER_TYPES: {
     SUP: 'SUP',
     SCO: 'SCO',

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -1105,6 +1105,30 @@ class UnexpectedOidcStateError extends DomainError {
   }
 }
 
+class OidcMissingFieldsError extends DomainError {
+  constructor(
+    message = 'Mandatory information returned by the identify provider about the user is missing.',
+    code,
+    meta
+  ) {
+    super(message);
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
+class OidcUserInfoFormatError extends DomainError {
+  constructor(
+    message = 'The user information returned by your identity provider is not in the expected format.',
+    code,
+    meta
+  ) {
+    super(message);
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
 class InvalidIdentityProviderError extends DomainError {
   constructor(identityProvider) {
     const message = `Identity provider ${identityProvider} is not supported.`;
@@ -1396,6 +1420,8 @@ module.exports = {
   TargetProfileCannotBeCreated,
   TooManyRows,
   UnexpectedOidcStateError,
+  OidcMissingFieldsError,
+  OidcUserInfoFormatError,
   UnexpectedUserAccountError,
   UnknownCountryForStudentEnrollmentError,
   UserAlreadyExistsWithAuthenticationMethodError,

--- a/api/lib/domain/services/authentication/oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/oidc-authentication-service.js
@@ -2,7 +2,7 @@ const jsonwebtoken = require('jsonwebtoken');
 const querystring = require('querystring');
 const { v4: uuidv4 } = require('uuid');
 
-const { InvalidExternalAPIResponseError } = require('../../errors');
+const { InvalidExternalAPIResponseError, OidcMissingFieldsError, OidcUserInfoFormatError } = require('../../errors');
 const AuthenticationMethod = require('../../models/AuthenticationMethod');
 const AuthenticationSessionContent = require('../../models/AuthenticationSessionContent');
 const settings = require('../../../config');
@@ -10,6 +10,7 @@ const httpAgent = require('../../../infrastructure/http/http-agent');
 const httpErrorsHelper = require('../../../infrastructure/http/errors-helper');
 const DomainTransaction = require('../../../infrastructure/DomainTransaction');
 const monitoringTools = require('../../../infrastructure/monitoring-tools');
+const { OIDC_ERRORS } = require('../../constants');
 
 class OidcAuthenticationService {
   constructor({
@@ -116,35 +117,41 @@ class OidcAuthenticationService {
     if (!response.isSuccessful) {
       const message = 'Une erreur est survenue en récupérant les informations des utilisateurs.';
       const dataToLog = httpErrorsHelper.serializeHttpErrorResponse(response, message);
-
       monitoringTools.logErrorWithCorrelationIds({ message: dataToLog });
-
-      throw new InvalidExternalAPIResponseError(
-        'Une erreur est survenue en récupérant les informations des utilisateurs.'
-      );
+      throw new InvalidExternalAPIResponseError(message);
     }
 
     const userInfoContent = response.data;
 
     if (!userInfoContent || typeof userInfoContent !== 'object') {
-      const message = 'Les informations utilisateur récupérées ne sont pas au format attendu.';
+      const message = `Les informations utilisateur renvoyées par votre fournisseur d'identité ${this.organizationName} ne sont pas au format attendu.`;
       const dataToLog = {
         message,
         typeOfUserInfoContent: typeof userInfoContent,
         userInfoContent,
       };
       monitoringTools.logErrorWithCorrelationIds({ message: dataToLog });
-      throw new InvalidExternalAPIResponseError(message);
+      const error = OIDC_ERRORS.USER_INFO.badResponseFormat;
+      const meta = {
+        shortCode: error.shortCode,
+      };
+      throw new OidcUserInfoFormatError(message, error.code, meta);
     }
 
-    const userInfoMissingFields = this.userInfoMissingFields({ userInfoContent });
+    const userInfoMissingFields = this.getUserInfoMissingFields({ userInfoContent });
+    const message = `Un ou des champs obligatoires (${userInfoMissingFields}) n'ont pas été renvoyés par votre fournisseur d'identité ${this.organizationName}.`;
 
     if (userInfoMissingFields) {
       monitoringTools.logErrorWithCorrelationIds({
-        message: "Un des champs obligatoires n'a pas été renvoyé",
+        message,
         missingFields: userInfoMissingFields,
+        userInfoContent,
       });
-      throw new InvalidExternalAPIResponseError('Les informations utilisateurs récupérées sont incorrectes.');
+      const error = OIDC_ERRORS.USER_INFO.missingFields;
+      const meta = {
+        shortCode: error.shortCode,
+      };
+      throw new OidcMissingFieldsError(message, error.code, meta);
     }
 
     return {
@@ -155,7 +162,7 @@ class OidcAuthenticationService {
     };
   }
 
-  userInfoMissingFields({ userInfoContent }) {
+  getUserInfoMissingFields({ userInfoContent }) {
     const missingFields = [];
     if (!userInfoContent.family_name) {
       missingFields.push('family_name');

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -33,6 +33,8 @@ const {
   UnexpectedOidcStateError,
   InvalidIdentityProviderError,
   SendingEmailToInvalidDomainError,
+  OidcMissingFieldsError,
+  OidcUserInfoFormatError,
 } = require('../../../lib/domain/errors');
 const HttpErrors = require('../../../lib/application/http-errors.js');
 
@@ -579,6 +581,40 @@ describe('Unit | Application | ErrorManager', function () {
 
         // then
         expect(HttpErrors.ServiceUnavailableError).to.have.been.calledWithExactly(error.message);
+      });
+
+      it('instantiates UnprocessableEntityError when OidcMissingFieldsError', async function () {
+        // given
+        const error = new OidcMissingFieldsError('Some message', 'someCode', 'someMetaData');
+        sinon.stub(HttpErrors, 'UnprocessableEntityError');
+        const params = { request: {}, h: hFake, error };
+
+        // when
+        await handle(params.request, params.h, params.error);
+
+        // then
+        expect(HttpErrors.UnprocessableEntityError).to.have.been.calledWithExactly(
+          error.message,
+          error.code,
+          error.meta
+        );
+      });
+
+      it('instantiates ServiceUnavailableError when OidcUserInfoFormatError', async function () {
+        // given
+        const error = new OidcUserInfoFormatError('Some message', 'someCode', 'someMetaData');
+        sinon.stub(HttpErrors, 'ServiceUnavailableError');
+        const params = { request: {}, h: hFake, error };
+
+        // when
+        await handle(params.request, params.h, params.error);
+
+        // then
+        expect(HttpErrors.ServiceUnavailableError).to.have.been.calledWithExactly(
+          error.message,
+          error.code,
+          error.meta
+        );
       });
     });
   });

--- a/mon-pix/app/errors/json-api-error.js
+++ b/mon-pix/app/errors/json-api-error.js
@@ -1,0 +1,30 @@
+export default class JSONApiError extends Error {
+  constructor(message, extras) {
+    super(message);
+    this._extras = extras;
+  }
+
+  get code() {
+    return this._extras?.code;
+  }
+
+  get meta() {
+    return this._extras?.meta;
+  }
+
+  get shortCode() {
+    return this._extras?.meta?.shortCode;
+  }
+
+  get detail() {
+    return this._extras?.detail;
+  }
+
+  get title() {
+    return this._extras?.title;
+  }
+
+  get status() {
+    return this._extras?.status;
+  }
+}

--- a/mon-pix/app/routes/error.js
+++ b/mon-pix/app/routes/error.js
@@ -1,6 +1,7 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import get from 'lodash/get';
+import JSONApiError from 'mon-pix/errors/json-api-error';
 
 export default class ErrorRoute extends Route {
   @service session;
@@ -13,18 +14,26 @@ export default class ErrorRoute extends Route {
 
   setupController(controller, error) {
     super.setupController(...arguments);
+
     controller.errorMessage = error;
+    controller.errorDetail = null;
+    controller.errorStatus = null;
+    controller.errorTitle = null;
 
     const apiError = get(error, 'errors[0]');
 
-    if (apiError) {
+    if (error instanceof JSONApiError) {
+      controller.errorMessage = error.message;
+      controller.errorStatus = error.status;
+      controller.errorTitle = error.title;
+
+      if (error.shortCode) {
+        controller.errorStatus += ` (${error.shortCode})`;
+      }
+    } else if (apiError) {
       controller.errorDetail = apiError.detail;
       controller.errorStatus = apiError.status;
       controller.errorTitle = apiError.title;
-    } else {
-      controller.errorDetail = null;
-      controller.errorStatus = null;
-      controller.errorTitle = null;
     }
 
     if (this.hasUnauthorizedError(error)) {

--- a/mon-pix/app/styles/pages/_error.scss
+++ b/mon-pix/app/styles/pages/_error.scss
@@ -38,18 +38,19 @@
   }
 
   p {
-    font-size: 0.625rem;
-    text-align: left;
+    padding-bottom: 0.8rem;
+    font-size: 1rem;
+    text-align: center;
 
-    @include device-is('desktop') {
-      text-align: center;
+    a {
+      text-decoration: underline;
     }
   }
 }
 
 .error-page-main-content__title {
   padding-bottom: 20px;
-  font-size: 1.25rem;
+  font-size: 1.5rem;
 }
 
 .error-page__index-link {

--- a/mon-pix/tests/unit/routes/error_test.js
+++ b/mon-pix/tests/unit/routes/error_test.js
@@ -1,21 +1,72 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import JSONApiError from 'mon-pix/errors/json-api-error';
 
 module('Unit | Route | error', function (hooks) {
   setupTest(hooks);
 
+  let route;
+
+  hooks.beforeEach(function () {
+    route = this.owner.lookup('route:error');
+  });
+
   test('exists', function (assert) {
-    const route = this.owner.lookup('route:error');
     assert.ok(route);
   });
 
-  module('#hasUnauthorizedError', function (hooks) {
-    let route;
+  module('#setupController', function () {
+    test('handles api errors', function (assert) {
+      // Given
+      const controller = {};
+      const error = { errors: [{ status: '503', title: 'Service Unavailable', detail: 'The service is unavailable' }] };
 
-    hooks.beforeEach(function () {
-      route = this.owner.lookup('route:error');
+      // When
+      route.setupController(controller, error);
+
+      // Then
+      assert.strictEqual(controller.errorMessage, error);
+      assert.strictEqual(controller.errorDetail, error.errors[0].detail);
+      assert.strictEqual(controller.errorStatus, error.errors[0].status);
+      assert.strictEqual(controller.errorTitle, error.errors[0].title);
     });
 
+    test('handles json api errors', function (assert) {
+      // Given
+      const controller = {};
+      const error = new JSONApiError('This is an error message', {
+        status: '503',
+        title: 'Service Unavailable',
+        detail: 'The service is unavailable',
+      });
+
+      // When
+      route.setupController(controller, error);
+
+      // Then
+      assert.strictEqual(controller.errorMessage, error.message);
+      assert.strictEqual(controller.errorDetail, null);
+      assert.strictEqual(controller.errorStatus, error.status);
+      assert.strictEqual(controller.errorTitle, error.title);
+    });
+
+    test('handles unhandled errors', function (assert) {
+      // Given
+      const controller = {};
+      const error = 'This is an error message';
+
+      // When
+      route.setupController(controller, error);
+
+      // Then
+      assert.strictEqual(controller.errorMessage, error);
+      assert.strictEqual(controller.errorDetail, null);
+      assert.strictEqual(controller.errorStatus, null);
+      assert.strictEqual(controller.errorTitle, null);
+    });
+  });
+
+  module('#hasUnauthorizedError', function () {
     test('finds an unauthorized code in the first error object', function (assert) {
       // Given
       const errorEvent = { errors: [{ status: '401' }] };

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -761,7 +761,7 @@
       }
     },
     "error": {
-      "content-text": "'<p>'Please refresh the page or '<LinkTo @route=\"login\">'return to homepage'</LinkTo>'.'</p><p>'You can also contact us via '<a href=\"https://pix.org/en-gb/contact-form\">'the help centre form'</a>'specifying the error code below in the description.'</p><p>'Please excuse any inconvenience caused.'</p><p>'The Pix team.'</p>'",
+      "content-text": "'<p>'Please refresh the page or return to homepage.'</p><p>'You can also contact us via '<a href=\"https://pix.org/en-gb/contact-form\">'the help centre form'</a>'specifying the error code below in the description.'</p><p>'Please excuse any inconvenience caused.'</p><p>'The Pix team.'</p>'",
       "first-title": "Oops, an error occurred!"
     },
     "fill-in-campaign-code": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -761,7 +761,7 @@
       }
     },
     "error": {
-      "content-text": "'<p>'Nous vous invitons à recharger cette page ou '<LinkTo @route=\"login\">'revenir à la page d’accueil'</LinkTo>'.'</p><p>'Vous pouvez aussi nous contacter via '<a href=\"https://support.pix.fr/support/tickets/new\">'le formulaire du centre d'aide'</a>' en nous précisant le code d’erreur ci-dessous dans la description.'</p><p>'Nous vous prions de nous excuser pour la gêne occasionnée.'</p><p>'L’équipe Pix.'</p>'",
+      "content-text": "'<p>'Nous vous invitons à recharger cette page ou revenir à la page d’accueil.'</p><p>'Vous pouvez aussi nous contacter via '<a href=\"https://support.pix.fr/support/tickets/new\">'le formulaire du centre d'aide'</a>' en nous précisant le code d’erreur ci-dessous dans la description.'</p><p>'Nous vous prions de nous excuser pour la gêne occasionnée.'</p><p>'L’équipe Pix.'</p>'",
       "first-title": "Oups, une erreur est survenue !"
     },
     "fill-in-campaign-code": {


### PR DESCRIPTION
## :unicorn: Problème

La route `/api/oidc/token` est en erreur assez souvent lors d'une connexion à Pole Emploi.

Lors de la connexion à Pole Emploi, nous devons recevoir certaines informations requises. Si ces dernières ne sont pas présentes, nous utilisons l'URL de récupération des informations de l'utilisateur `/userInfo`. Si des informations sont encore manquantes après cette appel à `/userInfo`, une erreur 5xx est retournée.

Ceci rend le monitoring fastidieux.

## :robot: Proposition

- Ne plus renvoyer de 503 mais plutôt une 422
- Afficher un message d'erreur clair à l'utilisateur
- Retirer les logs qui ne sont plus nécessaires

## :rainbow: Remarques

Des logs datadog ont été retiré de la méthode `getUserInfoFromEndpoint`. Nous n'avons plus l'utilité car nous avons trouvé la cause étant le manque de données au niveau du fournisseur d'identité.

## :100: Pour tester

Les tests devront se faire en local.

#### Simuler une indisponibilité de l'endpoint /userInfo
- Récupérer la branche
- Modifier le fichier suivant, en transformant cette ligne en `if (true) {`
https://github.com/1024pix/pix/blob/5fe244021e784763aca43dd7960779954ed2d1bc/api/lib/domain/services/authentication/oidc-authentication-service.js#L180
- Modifier le fichier suivant, en transformant cette ligne en `if (true) {`
https://github.com/1024pix/pix/blob/5fe244021e784763aca43dd7960779954ed2d1bc/api/lib/domain/services/authentication/oidc-authentication-service.js#L117
- Se connecter avec pole emploi : http://localhost.fr:4200/connexion/pole-emploi ou http://app.dev.pix.fr/connexion/pole-emploi

#### Simuler une erreur de format de données de l'endpoint /userInfo
- Récupérer la branche
- Modifier le fichier suivant, en transformant cette ligne en `if (true) {`
https://github.com/1024pix/pix/blob/5fe244021e784763aca43dd7960779954ed2d1bc/api/lib/domain/services/authentication/oidc-authentication-service.js#L180
- Modifier le fichier suivant, en transformant cette ligne en `if (true) {`
https://github.com/1024pix/pix/blob/5fe244021e784763aca43dd7960779954ed2d1bc/api/lib/domain/services/authentication/oidc-authentication-service.js#L129
- Se connecter avec pole emploi : http://localhost.fr:4200/connexion/pole-emploi ou http://app.dev.pix.fr/connexion/pole-emploi

#### Simuler un manque de données de l'endpoint /userInfo
- Récupérer la branche
- Modifier le fichier suivant, en transformant cette ligne en `if (true) {`
https://github.com/1024pix/pix/blob/5fe244021e784763aca43dd7960779954ed2d1bc/api/lib/domain/services/authentication/oidc-authentication-service.js#L180
- Modifier le fichier suivant, en transformant cette ligne en `const userInfoMissingFields = 'Champs manquants : given_name'`
https://github.com/1024pix/pix/blob/5fe244021e784763aca43dd7960779954ed2d1bc/api/lib/domain/services/authentication/oidc-authentication-service.js#L139
- Se connecter avec pole emploi : http://localhost.fr:4200/connexion/pole-emploi ou http://app.dev.pix.fr/connexion/pole-emploi