### PR TITLE
[FEATURE] Mettre un message plus explicite sur les champs de titre et description prescripteur lors de la création d'un palier (PIX-6171)

### DIFF
--- a/admin/app/components/target-profiles/stages/new-stage.hbs
+++ b/admin/app/components/target-profiles/stages/new-stage.hbs
@@ -47,10 +47,10 @@
     </div>
   </td>
   <td>
-    FIXME
+    À renseigner ultérieurement
   </td>
   <td>
-    FIXME
+    À renseigner ultérieurement
   </td>
   <td>
     <PixButton


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on créé un palier, on ne peut pas encore renseigner les titres et descriptions prescripteur. Aujourd'hui, à l'emplacement, il y a écrit FIXME.

## :robot: Proposition
Remplacer par le message "A renseigner ultérieurement"

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se rendre sur la page d'ajout de palier, ajouter un palier, et vérifier que sur le palier en instance d'ajout on a bien le nouveau message dans les deux colonnes
