### PR TITLE
[FEATURE] Permettre la sélection de sujets pour les contenus formatifs sur Pix-Admin (PIX-7166)

### DIFF
--- a/admin/app/components/trainings/edit-trigger-threshold.hbs
+++ b/admin/app/components/trainings/edit-trigger-threshold.hbs
@@ -11,3 +11,5 @@
     max="100"
   />
 </Card>
+
+<Common::TubesSelection @frameworks={{@frameworks}} @onChange={{@onChange}} />

--- a/admin/app/controllers/authenticated/trainings/training/triggers/edit.js
+++ b/admin/app/controllers/authenticated/trainings/training/triggers/edit.js
@@ -23,6 +23,14 @@ export default class TrainingEditTriggersController extends Controller {
   }
 
   @action
+  updateTubes(tubesWithLevel) {
+    this.selectedTubes = tubesWithLevel.map(({ id, level }) => ({
+      id,
+      level,
+    }));
+  }
+
+  @action
   goBackToTraining() {
     this.router.transitionTo('authenticated.trainings.training');
   }

--- a/admin/app/routes/authenticated/trainings/training/triggers/edit.js
+++ b/admin/app/routes/authenticated/trainings/training/triggers/edit.js
@@ -1,7 +1,13 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class EditTriggerRoute extends Route {
-  model() {
-    return this.modelFor('authenticated.trainings.training');
+  @service store;
+
+  async model() {
+    const training = this.modelFor('authenticated.trainings.training');
+    const frameworks = await this.store.findAll('framework');
+
+    return { training, frameworks };
   }
 }

--- a/admin/app/styles/components/trainings/training-triggers-tab.scss
+++ b/admin/app/styles/components/trainings/training-triggers-tab.scss
@@ -33,6 +33,10 @@
     gap: $spacing-m;
     margin: $spacing-m 0;
   }
+
+  &__threshold {
+    margin-bottom: $spacing-m;
+  }
 }
 
 .edit-training-trigger-threshold {

--- a/admin/app/templates/authenticated/trainings/training/triggers/edit.hbs
+++ b/admin/app/templates/authenticated/trainings/training/triggers/edit.hbs
@@ -1,5 +1,10 @@
 <form class="form edit-training-trigger" {{on "submit" this.onSubmit}}>
-  <Trainings::EditTriggerThreshold @title={{this.thresholdTitle}} @description={{this.thresholdDescription}} />
+  <Trainings::EditTriggerThreshold
+    @title={{this.thresholdTitle}}
+    @description={{this.thresholdDescription}}
+    @frameworks={{this.model.frameworks}}
+    @onChange={{this.updateTubes}}
+  />
 
   <ul class="edit-training-trigger__actions">
     <li>
@@ -14,7 +19,7 @@
     </li>
     <li>
       <PixButton @backgroundColor="green" @size="big" @type="submit" @isLoading={{this.submitting}}>
-        Créer le contenu formatif
+        Enregistrer le déclencheur
       </PixButton>
     </li>
   </ul>

--- a/admin/mirage/factories/target-profile.js
+++ b/admin/mirage/factories/target-profile.js
@@ -1,4 +1,5 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory, trait } from 'ember-cli-mirage';
+import { createLearningContent } from '../helpers/create-learning-content';
 
 export default Factory.extend({
   name() {
@@ -108,4 +109,10 @@ export default Factory.extend({
       if (targetProfile.oldAreas.length !== 0) targetProfile.update({ isNewFormat: false });
     }
   },
+
+  withFramework: trait({
+    afterCreate(training, server) {
+      createLearningContent(server);
+    },
+  }),
 });

--- a/admin/mirage/factories/training.js
+++ b/admin/mirage/factories/training.js
@@ -1,8 +1,15 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory, trait } from 'ember-cli-mirage';
 import faker from 'faker';
+import { createLearningContent } from '../helpers/create-learning-content';
 
 export default Factory.extend({
   title() {
     return faker.random.word();
   },
+
+  withFramework: trait({
+    afterCreate(training, server) {
+      createLearningContent(server);
+    },
+  }),
 });

--- a/admin/mirage/helpers/create-learning-content.js
+++ b/admin/mirage/helpers/create-learning-content.js
@@ -1,0 +1,74 @@
+export function createLearningContent(server) {
+  const framework_f1 = _createFramework(server, 'Pix');
+  const area_f1_a1 = _createArea('area_f1_a1', framework_f1, server);
+  const area_f1_a2 = _createArea('area_f1_a2', framework_f1, server);
+  const competence_f1_a1_c1 = _createCompetence('competence_f1_a1_c1', area_f1_a1, server);
+  const competence_f1_a1_c2 = _createCompetence('competence_f1_a1_c2', area_f1_a1, server);
+  const competence_f1_a2_c1 = _createCompetence('competence_f1_a2_c1', area_f1_a2, server);
+  const thematic_f1_a1_c1_th1 = _createThematic('thematic_f1_a1_c1_th1', competence_f1_a1_c1, server);
+  const thematic_f1_a1_c1_th2 = _createThematic('thematic_f1_a1_c1_th2', competence_f1_a1_c1, server);
+  const thematic_f1_a1_c2_th1 = _createThematic('thematic_f1_a1_c2_th1', competence_f1_a1_c2, server);
+  const thematic_f1_a2_c1_th1 = _createThematic('thematic_f1_a2_c1_th1', competence_f1_a2_c1, server);
+  _createTube('tube_f1_a1_c1_th1_tu1', true, false, thematic_f1_a1_c1_th1, server);
+  _createTube('tube_f1_a1_c1_th1_tu2', false, true, thematic_f1_a1_c1_th1, server);
+  _createTube('tube_f1_a1_c1_th2_tu1', true, true, thematic_f1_a1_c1_th2, server);
+  _createTube('tube_f1_a1_c2_th1_tu1', true, true, thematic_f1_a1_c2_th1, server);
+  _createTube('tube_f1_a2_c1_th1_tu1', true, true, thematic_f1_a2_c1_th1, server);
+  const framework_f2 = _createFramework(server, 'Pix + Cuisine');
+  const area_f2_a1 = _createArea('area_f2_a1', framework_f2, server);
+  const competence_f2_a1_c1 = _createCompetence('competence_f2_a1_c1', area_f2_a1, server);
+  const thematic_f2_a1_c1_th1 = _createThematic('thematic_f2_a1_c1_th1', competence_f2_a1_c1, server);
+  _createTube('tube_f2_a1_c1_th1_tu1', false, false, thematic_f2_a1_c1_th1, server);
+}
+
+function _createFramework(server, name) {
+  return server.create('framework', { name, areas: [] });
+}
+
+function _createArea(variableName, framework, server) {
+  const area = server.create('area', {
+    code: `${variableName} code`,
+    title: `${variableName} title`,
+    color: `${variableName} color`,
+    frameworkId: framework.id,
+    competences: [],
+  });
+  framework.update({ areas: [...framework.areas.models, area] });
+  return area;
+}
+
+function _createCompetence(variableName, area, server) {
+  const competence = server.create('competence', {
+    name: `${variableName} name`,
+    index: `${variableName} index`,
+    areaId: area.id,
+    thematics: [],
+  });
+  area.update({ competences: [...area.competences.models, competence] });
+  return competence;
+}
+
+function _createThematic(variableName, competence, server) {
+  const thematic = server.create('thematic', {
+    name: `${variableName} name`,
+    index: `${variableName} index`,
+    tubes: [],
+  });
+  competence.update({ thematics: [...competence.thematics.models, thematic] });
+  return thematic;
+}
+
+function _createTube(variableName, mobile, tablet, thematic, server) {
+  const tube = server.create('tube', {
+    id: variableName,
+    name: `${variableName} name`,
+    practicalTitle: `${variableName} practicalTitle`,
+    practicalDescription: `${variableName} practicalDescription`,
+    mobile,
+    tablet,
+    skills: [],
+    competenceId: null,
+  });
+  thematic.update({ tubes: [...thematic.tubes.models, tube] });
+  return tube;
+}

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation_test.js
@@ -4,6 +4,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { clickByName, fillByLabel, visit } from '@1024pix/ember-testing-library';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+import { createLearningContent } from '../../../../../mirage/helpers/create-learning-content';
 
 module('Acceptance | Target profile creation', function (hooks) {
   setupApplicationTest(hooks);
@@ -53,7 +54,7 @@ module('Acceptance | Target profile creation', function (hooks) {
   module('target profile creation', function (hooks) {
     hooks.beforeEach(async function () {
       await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-      _createLearningContent(server);
+      createLearningContent(server);
     });
 
     test('it should create the target profile', async function (assert) {
@@ -144,79 +145,4 @@ async function _selectLearningContent(screen) {
   await clickByName('area_f2_a1 code · area_f2_a1 title');
   await clickByName('competence_f2_a1_c1 index competence_f2_a1_c1 name');
   await clickByName('thematic_f2_a1_c1_th1 name');
-}
-
-function _createLearningContent(server) {
-  const framework_f1 = _createFramework(server, 'Pix');
-  const area_f1_a1 = _createArea('area_f1_a1', framework_f1, server);
-  const area_f1_a2 = _createArea('area_f1_a2', framework_f1, server);
-  const competence_f1_a1_c1 = _createCompetence('competence_f1_a1_c1', area_f1_a1, server);
-  const competence_f1_a1_c2 = _createCompetence('competence_f1_a1_c2', area_f1_a1, server);
-  const competence_f1_a2_c1 = _createCompetence('competence_f1_a2_c1', area_f1_a2, server);
-  const thematic_f1_a1_c1_th1 = _createThematic('thematic_f1_a1_c1_th1', competence_f1_a1_c1, server);
-  const thematic_f1_a1_c1_th2 = _createThematic('thematic_f1_a1_c1_th2', competence_f1_a1_c1, server);
-  const thematic_f1_a1_c2_th1 = _createThematic('thematic_f1_a1_c2_th1', competence_f1_a1_c2, server);
-  const thematic_f1_a2_c1_th1 = _createThematic('thematic_f1_a2_c1_th1', competence_f1_a2_c1, server);
-  _createTube('tube_f1_a1_c1_th1_tu1', true, false, thematic_f1_a1_c1_th1, server);
-  _createTube('tube_f1_a1_c1_th1_tu2', false, true, thematic_f1_a1_c1_th1, server);
-  _createTube('tube_f1_a1_c1_th2_tu1', true, true, thematic_f1_a1_c1_th2, server);
-  _createTube('tube_f1_a1_c2_th1_tu1', true, true, thematic_f1_a1_c2_th1, server);
-  _createTube('tube_f1_a2_c1_th1_tu1', true, true, thematic_f1_a2_c1_th1, server);
-  const framework_f2 = _createFramework(server, 'Pix + Cuisine');
-  const area_f2_a1 = _createArea('area_f2_a1', framework_f2, server);
-  const competence_f2_a1_c1 = _createCompetence('competence_f2_a1_c1', area_f2_a1, server);
-  const thematic_f2_a1_c1_th1 = _createThematic('thematic_f2_a1_c1_th1', competence_f2_a1_c1, server);
-  _createTube('tube_f2_a1_c1_th1_tu1', false, false, thematic_f2_a1_c1_th1, server);
-}
-
-function _createFramework(server, name) {
-  return server.create('framework', { name, areas: [] });
-}
-
-function _createArea(variableName, framework, server) {
-  const area = server.create('area', {
-    code: `${variableName} code`,
-    title: `${variableName} title`,
-    color: `${variableName} color`,
-    frameworkId: framework.id,
-    competences: [],
-  });
-  framework.update({ areas: [...framework.areas.models, area] });
-  return area;
-}
-
-function _createCompetence(variableName, area, server) {
-  const competence = server.create('competence', {
-    name: `${variableName} name`,
-    index: `${variableName} index`,
-    areaId: area.id,
-    thematics: [],
-  });
-  area.update({ competences: [...area.competences.models, competence] });
-  return competence;
-}
-
-function _createThematic(variableName, competence, server) {
-  const thematic = server.create('thematic', {
-    name: `${variableName} name`,
-    index: `${variableName} index`,
-    tubes: [],
-  });
-  competence.update({ thematics: [...competence.thematics.models, thematic] });
-  return thematic;
-}
-
-function _createTube(variableName, mobile, tablet, thematic, server) {
-  const tube = server.create('tube', {
-    id: variableName,
-    name: `${variableName} name`,
-    practicalTitle: `${variableName} practicalTitle`,
-    practicalDescription: `${variableName} practicalDescription`,
-    mobile,
-    tablet,
-    skills: [],
-    competenceId: null,
-  });
-  thematic.update({ tubes: [...thematic.tubes.models, tube] });
-  return tube;
 }

--- a/admin/tests/acceptance/authenticated/trainings/edit-triggers_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/edit-triggers_test.js
@@ -14,21 +14,24 @@ module('Acceptance | Trainings | Triggers edit', function (hooks) {
   let trainingId;
 
   hooks.beforeEach(async function () {
-    _createLearningContent(server);
     trainingId = 2;
 
-    server.create('training', {
-      id: 2,
-      title: 'Devenir tailleur de citrouille',
-      link: 'http://www.example2.net',
-      type: 'autoformation',
-      duration: '10:00:00',
-      locale: 'fr-fr',
-      editorName: "Ministère de l'éducation nationale et de la jeunesse",
-      editorLogoUrl: 'https://mon-logo.svg',
-      prerequisiteThreshold: null,
-      goalThreshold: null,
-    });
+    server.create(
+      'training',
+      {
+        id: 2,
+        title: 'Devenir tailleur de citrouille',
+        link: 'http://www.example2.net',
+        type: 'autoformation',
+        duration: '10:00:00',
+        locale: 'fr-fr',
+        editorName: "Ministère de l'éducation nationale et de la jeunesse",
+        editorLogoUrl: 'https://mon-logo.svg',
+        prerequisiteThreshold: null,
+        goalThreshold: null,
+      },
+      'withFramework'
+    );
   });
 
   module('When admin member is not logged in', function () {
@@ -55,6 +58,11 @@ module('Acceptance | Trainings | Triggers edit', function (hooks) {
 
       // then
       assert.strictEqual(currentURL(), `/trainings/${trainingId}/triggers/edit?type=prerequisite`);
+      assert.dom(screen.getByText('Sélection des sujets', { exact: false })).exists();
+      await click(screen.getByText('area_f1_a1 code', { exact: false }));
+      await click(screen.getByText('competence_f1_a1_c1 index', { exact: false }));
+      await click(screen.getByText('thematic_f1_a1_c1_th1 name', { exact: false }));
+      assert.dom(screen.getByText('2/5')).exists();
     });
 
     test('it should be accessible by an authenticated user : goal edit', async function (assert) {
@@ -82,78 +90,3 @@ module('Acceptance | Trainings | Triggers edit', function (hooks) {
     });
   });
 });
-
-function _createLearningContent(server) {
-  const framework_f1 = _createFramework(server, 'Pix');
-  const area_f1_a1 = _createArea('area_f1_a1', framework_f1, server);
-  const area_f1_a2 = _createArea('area_f1_a2', framework_f1, server);
-  const competence_f1_a1_c1 = _createCompetence('competence_f1_a1_c1', area_f1_a1, server);
-  const competence_f1_a1_c2 = _createCompetence('competence_f1_a1_c2', area_f1_a1, server);
-  const competence_f1_a2_c1 = _createCompetence('competence_f1_a2_c1', area_f1_a2, server);
-  const thematic_f1_a1_c1_th1 = _createThematic('thematic_f1_a1_c1_th1', competence_f1_a1_c1, server);
-  const thematic_f1_a1_c1_th2 = _createThematic('thematic_f1_a1_c1_th2', competence_f1_a1_c1, server);
-  const thematic_f1_a1_c2_th1 = _createThematic('thematic_f1_a1_c2_th1', competence_f1_a1_c2, server);
-  const thematic_f1_a2_c1_th1 = _createThematic('thematic_f1_a2_c1_th1', competence_f1_a2_c1, server);
-  _createTube('tube_f1_a1_c1_th1_tu1', true, false, thematic_f1_a1_c1_th1, server);
-  _createTube('tube_f1_a1_c1_th1_tu2', false, true, thematic_f1_a1_c1_th1, server);
-  _createTube('tube_f1_a1_c1_th2_tu1', true, true, thematic_f1_a1_c1_th2, server);
-  _createTube('tube_f1_a1_c2_th1_tu1', true, true, thematic_f1_a1_c2_th1, server);
-  _createTube('tube_f1_a2_c1_th1_tu1', true, true, thematic_f1_a2_c1_th1, server);
-  const framework_f2 = _createFramework(server, 'Pix + Cuisine');
-  const area_f2_a1 = _createArea('area_f2_a1', framework_f2, server);
-  const competence_f2_a1_c1 = _createCompetence('competence_f2_a1_c1', area_f2_a1, server);
-  const thematic_f2_a1_c1_th1 = _createThematic('thematic_f2_a1_c1_th1', competence_f2_a1_c1, server);
-  _createTube('tube_f2_a1_c1_th1_tu1', false, false, thematic_f2_a1_c1_th1, server);
-}
-
-function _createFramework(server, name) {
-  return server.create('framework', { name, areas: [] });
-}
-
-function _createArea(variableName, framework, server) {
-  const area = server.create('area', {
-    code: `${variableName} code`,
-    title: `${variableName} title`,
-    color: `${variableName} color`,
-    frameworkId: framework.id,
-    competences: [],
-  });
-  framework.update({ areas: [...framework.areas.models, area] });
-  return area;
-}
-
-function _createCompetence(variableName, area, server) {
-  const competence = server.create('competence', {
-    name: `${variableName} name`,
-    index: `${variableName} index`,
-    areaId: area.id,
-    thematics: [],
-  });
-  area.update({ competences: [...area.competences.models, competence] });
-  return competence;
-}
-
-function _createThematic(variableName, competence, server) {
-  const thematic = server.create('thematic', {
-    name: `${variableName} name`,
-    index: `${variableName} index`,
-    tubes: [],
-  });
-  competence.update({ thematics: [...competence.thematics.models, thematic] });
-  return thematic;
-}
-
-function _createTube(variableName, mobile, tablet, thematic, server) {
-  const tube = server.create('tube', {
-    id: variableName,
-    name: `${variableName} name`,
-    practicalTitle: `${variableName} practicalTitle`,
-    practicalDescription: `${variableName} practicalDescription`,
-    mobile,
-    tablet,
-    skills: [],
-    competenceId: null,
-  });
-  thematic.update({ tubes: [...thematic.tubes.models, tube] });
-  return tube;
-}

--- a/admin/tests/acceptance/authenticated/trainings/edit-triggers_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/edit-triggers_test.js
@@ -14,6 +14,7 @@ module('Acceptance | Trainings | Triggers edit', function (hooks) {
   let trainingId;
 
   hooks.beforeEach(async function () {
+    _createLearningContent(server);
     trainingId = 2;
 
     server.create('training', {
@@ -81,3 +82,78 @@ module('Acceptance | Trainings | Triggers edit', function (hooks) {
     });
   });
 });
+
+function _createLearningContent(server) {
+  const framework_f1 = _createFramework(server, 'Pix');
+  const area_f1_a1 = _createArea('area_f1_a1', framework_f1, server);
+  const area_f1_a2 = _createArea('area_f1_a2', framework_f1, server);
+  const competence_f1_a1_c1 = _createCompetence('competence_f1_a1_c1', area_f1_a1, server);
+  const competence_f1_a1_c2 = _createCompetence('competence_f1_a1_c2', area_f1_a1, server);
+  const competence_f1_a2_c1 = _createCompetence('competence_f1_a2_c1', area_f1_a2, server);
+  const thematic_f1_a1_c1_th1 = _createThematic('thematic_f1_a1_c1_th1', competence_f1_a1_c1, server);
+  const thematic_f1_a1_c1_th2 = _createThematic('thematic_f1_a1_c1_th2', competence_f1_a1_c1, server);
+  const thematic_f1_a1_c2_th1 = _createThematic('thematic_f1_a1_c2_th1', competence_f1_a1_c2, server);
+  const thematic_f1_a2_c1_th1 = _createThematic('thematic_f1_a2_c1_th1', competence_f1_a2_c1, server);
+  _createTube('tube_f1_a1_c1_th1_tu1', true, false, thematic_f1_a1_c1_th1, server);
+  _createTube('tube_f1_a1_c1_th1_tu2', false, true, thematic_f1_a1_c1_th1, server);
+  _createTube('tube_f1_a1_c1_th2_tu1', true, true, thematic_f1_a1_c1_th2, server);
+  _createTube('tube_f1_a1_c2_th1_tu1', true, true, thematic_f1_a1_c2_th1, server);
+  _createTube('tube_f1_a2_c1_th1_tu1', true, true, thematic_f1_a2_c1_th1, server);
+  const framework_f2 = _createFramework(server, 'Pix + Cuisine');
+  const area_f2_a1 = _createArea('area_f2_a1', framework_f2, server);
+  const competence_f2_a1_c1 = _createCompetence('competence_f2_a1_c1', area_f2_a1, server);
+  const thematic_f2_a1_c1_th1 = _createThematic('thematic_f2_a1_c1_th1', competence_f2_a1_c1, server);
+  _createTube('tube_f2_a1_c1_th1_tu1', false, false, thematic_f2_a1_c1_th1, server);
+}
+
+function _createFramework(server, name) {
+  return server.create('framework', { name, areas: [] });
+}
+
+function _createArea(variableName, framework, server) {
+  const area = server.create('area', {
+    code: `${variableName} code`,
+    title: `${variableName} title`,
+    color: `${variableName} color`,
+    frameworkId: framework.id,
+    competences: [],
+  });
+  framework.update({ areas: [...framework.areas.models, area] });
+  return area;
+}
+
+function _createCompetence(variableName, area, server) {
+  const competence = server.create('competence', {
+    name: `${variableName} name`,
+    index: `${variableName} index`,
+    areaId: area.id,
+    thematics: [],
+  });
+  area.update({ competences: [...area.competences.models, competence] });
+  return competence;
+}
+
+function _createThematic(variableName, competence, server) {
+  const thematic = server.create('thematic', {
+    name: `${variableName} name`,
+    index: `${variableName} index`,
+    tubes: [],
+  });
+  competence.update({ thematics: [...competence.thematics.models, thematic] });
+  return thematic;
+}
+
+function _createTube(variableName, mobile, tablet, thematic, server) {
+  const tube = server.create('tube', {
+    id: variableName,
+    name: `${variableName} name`,
+    practicalTitle: `${variableName} practicalTitle`,
+    practicalDescription: `${variableName} practicalDescription`,
+    mobile,
+    tablet,
+    skills: [],
+    competenceId: null,
+  });
+  thematic.update({ tubes: [...thematic.tubes.models, tube] });
+  return tube;
+}


### PR DESCRIPTION
## :unicorn: Problème
La sélection des sujets n'est pas disponible pour les contenus formatifs lors de l'ajout d'un déclencheur.

## :robot: Proposition
Ajouter la sélection de sujets ainsi que leur niveaux.

## :100: Pour tester
- Se connecter sur Pix-Admin
- Aller sur un contenu formatif
- Ajouter un déclencheur et vérifier la présence de la sélection de sujets
