### PR TITLE
[BUGFIX] Ajout de l'icône "check" de Font Awesome (PIX-7182)

### DIFF
--- a/mon-pix/config/icons.js
+++ b/mon-pix/config/icons.js
@@ -7,6 +7,7 @@ module.exports = function () {
       'arrow-up',
       'bars',
       'bookmark',
+      'check',
       'chevron-up',
       'chevron-down',
       'circle-check',


### PR DESCRIPTION
## :unicorn: Problème

Le composant PixSelect de Pix-UI affiche une icône "check" sur l'élément sélectionné.
Or, on importait pas cette icône dans mon-pix.

## :robot: Proposition

Ajouter son import.

## :rainbow: Remarques

Ajouter les icônes nécessaires dans les composants du DS dans Pix UI ?

## :100: Pour tester

- Sélectionner une option dans un des PixSelect de https://app-pr5671.review.pix.fr/challenges/rechUXZhn1FiLU28x/preview
- Voir le check dans la liste
