### PR TITLE
[FEATURE] Refacto validation de session pour import en masse partie 1 (PIX-7185)

### DIFF
--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -14,6 +14,7 @@ const map = require('lodash/map');
 const csvHelpers = require('../../../scripts/helpers/csvHelpers');
 const csvSerializer = require('../../infrastructure/serializers/csv/csv-serializer');
 const { getHeaders } = require('../../infrastructure/files/sessions-import');
+const { UnprocessableEntityError } = require('../../application/http-errors');
 
 module.exports = {
   async saveSession(request) {
@@ -192,6 +193,9 @@ module.exports = {
   async importSessions(request, h) {
     const certificationCenterId = request.params.certificationCenterId;
     const parsedCsvData = await csvHelpers.parseCsvWithHeader(request.payload.path);
+    if (parsedCsvData.length === 0) {
+      throw new UnprocessableEntityError('No session data in csv');
+    }
     const sessions = csvSerializer.deserializeForSessionsImport(parsedCsvData);
     await usecases.createSessions({ sessions, certificationCenterId });
     return h.response().code(200);

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -88,7 +88,11 @@ class Session {
   }
 
   generateSupervisorPassword() {
-    this.supervisorPassword = _.times(NB_CHAR, _randomCharacter).join('');
+    this.supervisorPassword = Session.generateSupervisorPassword();
+  }
+
+  static generateSupervisorPassword() {
+    return _.times(NB_CHAR, _randomCharacter).join('');
   }
 
   isSupervisable(supervisorPassword) {

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -98,6 +98,11 @@ class Session {
   canEnrollCandidate() {
     return _.isNull(this.finalizedAt);
   }
+
+  isSessionScheduledInThePast() {
+    const sessionDate = new Date(`${this.date}T${this.time}`);
+    return sessionDate < new Date();
+  }
 }
 
 module.exports = Session;

--- a/api/lib/domain/services/session-code-service.js
+++ b/api/lib/domain/services/session-code-service.js
@@ -24,7 +24,7 @@ function _generateSessionCode() {
 }
 
 module.exports = {
-  async getNewSessionCode() {
+  getNewSessionCode() {
     return _generateSessionCode();
   },
 };

--- a/api/lib/domain/services/sessions-import-validation-service.js
+++ b/api/lib/domain/services/sessions-import-validation-service.js
@@ -1,0 +1,13 @@
+const { UnprocessableEntityError } = require('../../application/http-errors');
+const Session = require('../models/Session');
+
+module.exports = {
+  async validate({ sessions }) {
+    sessions.forEach((session) => {
+      const domainSession = new Session(session);
+      if (domainSession.isSessionScheduledInThePast()) {
+        throw new UnprocessableEntityError(`Une session ne peut pas être programmée dans le passé`);
+      }
+    });
+  },
+};

--- a/api/lib/domain/services/sessions-import-validation-service.js
+++ b/api/lib/domain/services/sessions-import-validation-service.js
@@ -1,13 +1,23 @@
 const { UnprocessableEntityError } = require('../../application/http-errors');
 const Session = require('../models/Session');
 const { SessionWithIdAndInformationOnMassImportError } = require('../errors');
+const { mapSeries } = require('bluebird');
+const sessionCodeService = require('./session-code-service');
 
 module.exports = {
-  async validate({ sessions }) {
-    sessions.forEach((session) => {
+  async validate({ sessions, certificationCenterId, certificationCenter, sessionRepository }) {
+    return mapSeries(sessions, async (session) => {
       const { sessionId } = session;
 
-      const domainSession = new Session(session);
+      const accessCode = sessionCodeService.getNewSessionCode();
+      const supervisorPassword = Session.generateSupervisorPassword();
+      const domainSession = new Session({
+        ...session,
+        certificationCenterId,
+        certificationCenter,
+        accessCode,
+        supervisorPassword,
+      });
       if (domainSession.isSessionScheduledInThePast()) {
         throw new UnprocessableEntityError(`Une session ne peut pas être programmée dans le passé`);
       }
@@ -17,6 +27,11 @@ module.exports = {
           throw new SessionWithIdAndInformationOnMassImportError(
             `Merci de ne pas renseigner les informations de session pour la session: ${sessionId}`
           );
+        }
+
+        const isSessionExisting = await sessionRepository.isSessionExisting({ ...session });
+        if (isSessionExisting) {
+          throw new UnprocessableEntityError(`Session happening on ${session.date} at ${session.time} already exists`);
         }
       }
     });

--- a/api/lib/domain/services/sessions-import-validation-service.js
+++ b/api/lib/domain/services/sessions-import-validation-service.js
@@ -1,13 +1,28 @@
 const { UnprocessableEntityError } = require('../../application/http-errors');
 const Session = require('../models/Session');
+const { SessionWithIdAndInformationOnMassImportError } = require('../errors');
 
 module.exports = {
   async validate({ sessions }) {
     sessions.forEach((session) => {
+      const { sessionId } = session;
+
       const domainSession = new Session(session);
       if (domainSession.isSessionScheduledInThePast()) {
         throw new UnprocessableEntityError(`Une session ne peut pas être programmée dans le passé`);
       }
+
+      if (sessionId) {
+        if (_hasSessionInfo(domainSession)) {
+          throw new SessionWithIdAndInformationOnMassImportError(
+            `Merci de ne pas renseigner les informations de session pour la session: ${sessionId}`
+          );
+        }
+      }
     });
   },
 };
+
+function _hasSessionInfo(session) {
+  return session.address || session.room || session.date || session.time || session.examiner;
+}

--- a/api/lib/domain/services/sessions-import-validation-service.js
+++ b/api/lib/domain/services/sessions-import-validation-service.js
@@ -10,24 +10,34 @@ module.exports = {
       throw new UnprocessableEntityError(`Une session ne peut pas être programmée dans le passé`);
     }
 
+    if (sessionId) {
+      if (_hasSessionInfo(session)) {
+        throw new SessionWithIdAndInformationOnMassImportError(
+          `Merci de ne pas renseigner les informations de session pour la session: ${sessionId}`
+        );
+      }
+
+      if (await _isSessionStarted({ certificationCourseRepository, sessionId })) {
+        throw new UnprocessableEntityError("Impossible d'ajouter un candidat à une session qui a déjà commencé.");
+      }
+    }
+
     if (!sessionId) {
-      return sessionValidator.validate(session);
+      sessionValidator.validate(session);
+
+      const isSessionExisting = await sessionRepository.isSessionExisting({ ...session });
+      if (isSessionExisting) {
+        throw new UnprocessableEntityError(`Session happening on ${session.date} at ${session.time} already exists`);
+      }
     }
 
-    if (_hasSessionInfo(session)) {
-      throw new SessionWithIdAndInformationOnMassImportError(
-        `Merci de ne pas renseigner les informations de session pour la session: ${sessionId}`
-      );
+    if (session.certificationCandidates?.length) {
+      if (_hasDuplicateCertificationCandidates(session.certificationCandidates)) {
+        throw new UnprocessableEntityError(`Une session contient au moins un élève en double.`);
+      }
     }
 
-    const isSessionExisting = await sessionRepository.isSessionExisting({ ...session });
-    if (isSessionExisting) {
-      throw new UnprocessableEntityError(`Session happening on ${session.date} at ${session.time} already exists`);
-    }
-
-    if (await _isSessionStarted({ certificationCourseRepository, sessionId })) {
-      throw new UnprocessableEntityError("Impossible d'ajouter un candidat à une session qui a déjà commencé.");
-    }
+    return;
   },
 };
 
@@ -40,4 +50,12 @@ async function _isSessionStarted({ certificationCourseRepository, sessionId }) {
     sessionId,
   });
   return foundCertificationCourses.length > 0;
+}
+
+function _hasDuplicateCertificationCandidates(certificationCandidates) {
+  const uniqCertificationCandidates = new Set(
+    certificationCandidates.map(({ lastName, firstName, birthdate }) => `${lastName}${firstName}${birthdate}`)
+  );
+
+  return uniqCertificationCandidates.size < certificationCandidates.length;
 }

--- a/api/lib/domain/usecases/create-session.js
+++ b/api/lib/domain/usecases/create-session.js
@@ -20,7 +20,7 @@ module.exports = async function createSession({
     );
   }
 
-  const accessCode = await sessionCodeService.getNewSessionCode();
+  const accessCode = sessionCodeService.getNewSessionCode();
   const { name: certificationCenter } = await certificationCenterRepository.get(certificationCenterId);
   const domainSession = new Session({
     ...session,

--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -29,17 +29,16 @@ module.exports = async function createSessions({
     await bluebird.mapSeries(sessions, async (session) => {
       let { sessionId } = session;
       const { date, time } = session;
-      const sessionDate = new Date(`${date}T${time}`);
-
-      if (_isSessionScheduledInThePast(sessionDate)) {
-        throw new UnprocessableEntityError('Une session ne peut pas être programmée dans le passé');
-      }
 
       const domainSession = new Session({
         ...session,
         certificationCenterId,
         certificationCenter,
       });
+
+      if (domainSession.isSessionScheduledInThePast()) {
+        throw new UnprocessableEntityError(`Une session ne peut pas être programmée dans le passé`);
+      }
 
       if (sessionId) {
         if (await _isSessionStarted({ certificationCourseRepository, sessionId })) {
@@ -89,10 +88,6 @@ module.exports = async function createSessions({
     });
   });
 };
-
-function _isSessionScheduledInThePast(sessionDate) {
-  return sessionDate < new Date();
-}
 
 function _hasSessionInfo(session) {
   return session.address || session.room || session.date || session.time || session.examiner;

--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -18,7 +18,6 @@ module.exports = async function createSessions({
   certificationCpfCityRepository,
   certificationCandidateRepository,
   complementaryCertificationRepository,
-  certificationCourseRepository,
 }) {
   const { name: certificationCenter, isSco } = await certificationCenterRepository.get(certificationCenterId);
 
@@ -35,9 +34,6 @@ module.exports = async function createSessions({
       });
 
       if (sessionId) {
-        if (await _isSessionStarted({ certificationCourseRepository, sessionId })) {
-          throw new UnprocessableEntityError("Impossible d'ajouter un candidat à une session qui a déjà commencé.");
-        }
         await _deleteExistingCandidatesInSession({ certificationCandidateRepository, sessionId, domainTransaction });
       }
 
@@ -94,13 +90,6 @@ function _hasDuplicateCertificationCandidates(certificationCandidates) {
   );
 
   return uniqCertificationCandidates.size < certificationCandidates.length;
-}
-
-async function _isSessionStarted({ certificationCourseRepository, sessionId }) {
-  const foundCertificationCourses = await certificationCourseRepository.findCertificationCoursesBySessionId({
-    sessionId,
-  });
-  return foundCertificationCourses.length > 0;
 }
 
 async function _deleteExistingCandidatesInSession({ certificationCandidateRepository, sessionId, domainTransaction }) {

--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -60,8 +60,8 @@ module.exports = async function createSessions({
           throw new UnprocessableEntityError(`Session happening on ${date} at ${time} already exists`);
         }
 
-        _validateNewSessionToSave(domainSession, certificationCenterId, certificationCenter);
-        const { id } = await _saveNewSessionReturningId(sessionRepository, domainSession, domainTransaction);
+        _validateNewSessionToSave({ domainSession, certificationCenterId, certificationCenter });
+        const { id } = await _saveNewSessionReturningId({ sessionRepository, domainSession, domainTransaction });
         sessionId = id;
       }
 
@@ -93,11 +93,11 @@ function _hasSessionInfo(session) {
   return session.address || session.room || session.date || session.time || session.examiner;
 }
 
-async function _saveNewSessionReturningId(sessionRepository, domainSession, domainTransaction) {
+async function _saveNewSessionReturningId({ sessionRepository, domainSession, domainTransaction }) {
   return await sessionRepository.save(domainSession, domainTransaction);
 }
 
-function _validateNewSessionToSave(domainSession, certificationCenterId, certificationCenter) {
+function _validateNewSessionToSave({ domainSession, certificationCenterId, certificationCenter }) {
   domainSession.accessCode = sessionCodeService.getNewSessionCode();
   domainSession.certificationCenterId = certificationCenterId;
   domainSession.certificationCenter = certificationCenter;

--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -19,10 +19,6 @@ module.exports = async function createSessions({
   complementaryCertificationRepository,
   certificationCourseRepository,
 }) {
-  if (sessions.length === 0) {
-    throw new UnprocessableEntityError('No session data in csv');
-  }
-
   const { name: certificationCenter, isSco } = await certificationCenterRepository.get(certificationCenterId);
 
   await DomainTransaction.execute(async (domainTransaction) => {

--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -17,6 +17,7 @@ module.exports = async function createSessions({
   certificationCpfCityRepository,
   certificationCandidateRepository,
   complementaryCertificationRepository,
+  certificationCourseRepository,
 }) {
   const { name: certificationCenter, isSco } = await certificationCenterRepository.get(certificationCenterId);
 
@@ -35,7 +36,7 @@ module.exports = async function createSessions({
         supervisorPassword,
       });
 
-      await sessionsImportValidationService.validate({ session, certificationCenterId, certificationCenter });
+      await sessionsImportValidationService.validate({ session, sessionRepository, certificationCourseRepository });
 
       if (sessionId) {
         await _deleteExistingCandidatesInSession({ certificationCandidateRepository, sessionId, domainTransaction });

--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -1,4 +1,3 @@
-const { UnprocessableEntityError } = require('../../application/http-errors');
 const Session = require('../models/Session');
 const sessionCodeService = require('../services/session-code-service');
 const certificationCpfService = require('../services/certification-cpf-service');
@@ -54,10 +53,6 @@ module.exports = async function createSessions({
       if (session.certificationCandidates.length) {
         const { certificationCandidates } = session;
 
-        if (_hasDuplicateCertificationCandidates(certificationCandidates)) {
-          throw new UnprocessableEntityError(`Une session contient au moins un élève en double.`);
-        }
-
         await _createCertificationCandidates({
           certificationCandidates,
           sessionId,
@@ -81,14 +76,6 @@ function _hasSessionInfo(session) {
 
 async function _saveNewSessionReturningId({ sessionRepository, domainSession, domainTransaction }) {
   return await sessionRepository.save(domainSession, domainTransaction);
-}
-
-function _hasDuplicateCertificationCandidates(certificationCandidates) {
-  const uniqCertificationCandidates = new Set(
-    certificationCandidates.map(({ lastName, firstName, birthdate }) => `${lastName}${firstName}${birthdate}`)
-  );
-
-  return uniqCertificationCandidates.size < certificationCandidates.length;
 }
 
 async function _deleteExistingCandidatesInSession({ certificationCandidateRepository, sessionId, domainTransaction }) {

--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -6,7 +6,7 @@ const certificationCpfService = require('../services/certification-cpf-service')
 const sessionsImportValidationService = require('../services/sessions-import-validation-service');
 const CertificationCandidate = require('../models/CertificationCandidate');
 const bluebird = require('bluebird');
-const { InvalidCertificationCandidate, SessionWithIdAndInformationOnMassImportError } = require('../errors');
+const { InvalidCertificationCandidate } = require('../errors');
 const DomainTransaction = require('../../infrastructure/DomainTransaction');
 
 module.exports = async function createSessions({
@@ -39,13 +39,6 @@ module.exports = async function createSessions({
         if (await _isSessionStarted({ certificationCourseRepository, sessionId })) {
           throw new UnprocessableEntityError("Impossible d'ajouter un candidat à une session qui a déjà commencé.");
         }
-
-        if (_hasSessionInfo(session)) {
-          throw new SessionWithIdAndInformationOnMassImportError(
-            `Merci de ne pas renseigner les informations de session pour la session: ${sessionId}`
-          );
-        }
-
         await _deleteExistingCandidatesInSession({ certificationCandidateRepository, sessionId, domainTransaction });
       }
 

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -131,6 +131,7 @@ const dependencies = {
   scoringCertificationService: require('../../domain/services/scoring/scoring-certification-service'),
   supOrganizationParticipantRepository: require('../../infrastructure/repositories/sup-organization-participant-repository'),
   sessionForAttendanceSheetRepository: require('../../infrastructure/repositories/sessions/session-for-attendance-sheet-repository'),
+  sessionsImportValidationService: require('../../domain/services/sessions-import-validation-service'),
   sessionPublicationService: require('../../domain/services/session-publication-service'),
   sessionRepository: require('../../infrastructure/repositories/sessions/session-repository'),
   sessionForSupervisingRepository: require('../../infrastructure/repositories/sessions/session-for-supervising-repository'),

--- a/api/scripts/data-generation/generate-certif-cli.js
+++ b/api/scripts/data-generation/generate-certif-cli.js
@@ -184,7 +184,7 @@ async function _createComplementaryCertificationHabilitations(
 }
 
 async function _createSessionAndReturnId(certificationCenterId, databaseBuilder) {
-  const sessionCode = await getNewSessionCode();
+  const sessionCode = getNewSessionCode();
   const { id } = databaseBuilder.factory.buildSession({
     certificationCenterId,
     accessCode: sessionCode,

--- a/api/tests/unit/domain/models/Session_test.js
+++ b/api/tests/unit/domain/models/Session_test.js
@@ -261,7 +261,7 @@ describe('Unit | Domain | Models | Session', function () {
   });
 
   context('#generateSupervisorPassword', function () {
-    it('should return a supervisor password containing 5 digits/letters except 0, 1 and vowels', async function () {
+    it('should assign a supervisor password to supervisorPassword property containing 5 digits/letters except 0, 1 and vowels', async function () {
       // given
       const session = domainBuilder.buildSession();
 
@@ -270,6 +270,17 @@ describe('Unit | Domain | Models | Session', function () {
 
       // then
       expect(session.supervisorPassword).to.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/);
+    });
+  });
+
+  context('static #generateSupervisorPassword', function () {
+    it('should return a supervisor password containing 5 digits/letters except 0, 1 and vowels', async function () {
+      // given
+      // when
+      const supervisorPassword = Session.generateSupervisorPassword();
+
+      // then
+      expect(supervisorPassword).to.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/);
     });
   });
 

--- a/api/tests/unit/domain/models/Session_test.js
+++ b/api/tests/unit/domain/models/Session_test.js
@@ -1,5 +1,5 @@
 const Session = require('../../../../lib/domain/models/Session');
-const { expect } = require('../../../test-helper');
+const { expect, sinon } = require('../../../test-helper');
 const _ = require('lodash');
 const { domainBuilder } = require('../../../test-helper');
 
@@ -259,15 +259,57 @@ describe('Unit | Domain | Models | Session', function () {
       expect(result).to.be.false;
     });
   });
-});
 
-context('#generateSupervisorPassword', function () {
-  it('should return a supervisor password containing 5 digits/letters except 0, 1 and vowels', async function () {
-    // when
-    const session = domainBuilder.buildSession();
-    session.generateSupervisorPassword();
+  context('#generateSupervisorPassword', function () {
+    it('should return a supervisor password containing 5 digits/letters except 0, 1 and vowels', async function () {
+      // given
+      const session = domainBuilder.buildSession();
 
-    // then
-    expect(session.supervisorPassword).to.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/);
+      // when
+      session.generateSupervisorPassword();
+
+      // then
+      expect(session.supervisorPassword).to.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/);
+    });
+  });
+
+  context('#isSessionScheduledInThePast', function () {
+    let clock;
+    beforeEach(function () {
+      clock = sinon.useFakeTimers({
+        now: new Date('2023-01-01'),
+        toFake: ['Date'],
+      });
+    });
+
+    afterEach(async function () {
+      clock.restore();
+    });
+
+    context('when session is scheduled in the past', function () {
+      it('should return true', async function () {
+        // given
+        const session = domainBuilder.buildSession({ date: '2022-01-01' });
+
+        // when
+        const isSessionScheduledInThePast = session.isSessionScheduledInThePast();
+
+        // then
+        expect(isSessionScheduledInThePast).to.be.true;
+      });
+    });
+
+    context('when session is not scheduled in the past', function () {
+      it('should return false', async function () {
+        // given
+        const session = domainBuilder.buildSession({ date: '2024-01-01' });
+
+        // when
+        const isSessionScheduledInThePast = session.isSessionScheduledInThePast();
+
+        // then
+        expect(isSessionScheduledInThePast).to.be.false;
+      });
+    });
   });
 });

--- a/api/tests/unit/domain/services/session-code-service_test.js
+++ b/api/tests/unit/domain/services/session-code-service_test.js
@@ -3,9 +3,9 @@ const sessionCodeService = require('../../../../lib/domain/services/session-code
 
 describe('Unit | Service | CodeSession', function () {
   describe('#getNewSessionCode', function () {
-    it('should return a non ambiguous session code with 4 random capital letters and 2 random numbers', async function () {
+    it('should return a non ambiguous session code with 4 random capital letters and 2 random numbers', function () {
       // when
-      const result = await sessionCodeService.getNewSessionCode();
+      const result = sessionCodeService.getNewSessionCode();
 
       // then
       expect(result).to.match(/[B,C,D,F,G,H,J,K,M,P,Q,R,T,V,W,X,Y]{4}[2,3,4,6,7,8,9]{2}/);

--- a/api/tests/unit/domain/services/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-import-validation-service_test.js
@@ -1,5 +1,6 @@
 const { catchErr, expect, sinon } = require('../../../test-helper');
 const sessionsImportValidationService = require('../../../../lib/domain/services/sessions-import-validation-service');
+const { SessionWithIdAndInformationOnMassImportError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Service | sessions import validation Service', function () {
   describe('#validate', function () {
@@ -65,5 +66,73 @@ describe('Unit | Service | sessions import validation Service', function () {
         });
       });
     });
+
+    context('unnecessary session information validation', function () {
+      context('when there is a sessionId and session information', function () {
+        it('should throw', async function () {
+          const sessions = [
+            {
+              ..._createValidSessionData(),
+              sessionId: 1234,
+              certificationCandidates: [],
+            },
+          ];
+
+          // when
+          const error = await catchErr(sessionsImportValidationService.validate)({
+            sessions,
+          });
+
+          // then
+          expect(error).to.be.an.instanceOf(SessionWithIdAndInformationOnMassImportError);
+          expect(error.message).to.equal(
+            'Merci de ne pas renseigner les informations de session pour la session: 1234'
+          );
+        });
+      });
+
+      context('when there is session information but no sessionId', function () {
+        it('should not throw', async function () {
+          const sessions = [
+            {
+              ..._createValidSessionData(),
+              certificationCandidates: [],
+            },
+          ];
+
+          // when
+          // then
+          expect(sessionsImportValidationService.validate({ sessions })).not.to.throw;
+        });
+      });
+
+      context('when there is a sessionId but no session information', function () {
+        it('should not throw', async function () {
+          const sessions = [
+            {
+              certificationCandidates: [],
+              sessionId: 123,
+            },
+          ];
+
+          // when
+          // then
+          expect(sessionsImportValidationService.validate({ sessions })).not.to.throw;
+        });
+      });
+    });
   });
 });
+
+function _createValidSessionData() {
+  return {
+    sessionId: undefined,
+    address: 'Site 1',
+    room: 'Salle 1',
+    date: '2023-03-12',
+    time: '01:00',
+    examiner: 'Pierre',
+    description: 'desc',
+    certificationCandidates: [],
+  };
+}

--- a/api/tests/unit/domain/services/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-import-validation-service_test.js
@@ -1,20 +1,64 @@
 const { catchErr, expect, sinon } = require('../../../test-helper');
 const sessionsImportValidationService = require('../../../../lib/domain/services/sessions-import-validation-service');
 const { SessionWithIdAndInformationOnMassImportError } = require('../../../../lib/domain/errors');
+const { UnprocessableEntityError } = require('../../../../lib/application/http-errors');
 
 describe('Unit | Service | sessions import validation Service', function () {
   describe('#validate', function () {
     let clock;
+    let sessionRepository;
 
     beforeEach(function () {
       clock = sinon.useFakeTimers({
         now: new Date('2023-01-01'),
         toFake: ['Date'],
       });
+      sessionRepository = { isSessionExisting: sinon.stub() };
     });
 
     afterEach(async function () {
       clock.restore();
+    });
+
+    context('when the parsed data is valid', function () {
+      context('when there is no sessionId', function () {
+        it('should not throw', async function () {
+          // given
+          const sessionScheduledInThePastData = {
+            sessionId: undefined,
+            address: 'Site 1',
+            room: 'Salle 1',
+            date: '2024-03-12',
+            time: '01:00',
+            examiner: 'Pierre',
+            description: 'desc',
+            certificationCandidates: [],
+          };
+
+          const sessions = [sessionScheduledInThePastData];
+
+          // when
+          // then
+          expect(await sessionsImportValidationService.validate({ sessions })).to.not.throw;
+        });
+      });
+
+      context('when there is a sessionId', function () {
+        it('should not throw', async function () {
+          // given
+          const sessionScheduledInThePastData = {
+            sessionId: 1,
+            certificationCandidates: [],
+          };
+
+          const sessions = [sessionScheduledInThePastData];
+          sessionRepository.isSessionExisting.withArgs({ ...sessions[0] }).resolves(false);
+
+          // when
+          // then
+          expect(await sessionsImportValidationService.validate({ sessions, sessionRepository })).to.not.throw;
+        });
+      });
     });
 
     context('date validation', function () {
@@ -41,28 +85,6 @@ describe('Unit | Service | sessions import validation Service', function () {
 
           // then
           expect(error.message).to.equal('Une session ne peut pas être programmée dans le passé');
-        });
-      });
-
-      context('when no session is scheduled in the past', function () {
-        it('should not throw', function () {
-          // given
-          const sessionScheduledInThePastData = {
-            sessionId: undefined,
-            address: 'Site 1',
-            room: 'Salle 1',
-            date: '2024-03-12',
-            time: '01:00',
-            examiner: 'Pierre',
-            description: 'desc',
-            certificationCandidates: [],
-          };
-
-          const sessions = [sessionScheduledInThePastData];
-
-          // when
-          // then
-          expect(sessionsImportValidationService.validate({ sessions })).to.not.throw;
         });
       });
     });
@@ -119,6 +141,23 @@ describe('Unit | Service | sessions import validation Service', function () {
           // then
           expect(sessionsImportValidationService.validate({ sessions })).not.to.throw;
         });
+      });
+    });
+
+    context('when there already is an existing session with the same data as a newly imported one', function () {
+      it('should throw an error', async function () {
+        // given
+        const sessions = [{ sessionId: 1234 }];
+        sessionRepository.isSessionExisting.withArgs({ ...sessions[0] }).resolves(true);
+
+        // when
+        const err = await catchErr(sessionsImportValidationService.validate)({
+          sessions,
+          sessionRepository,
+        });
+
+        // then
+        expect(err).to.be.instanceOf(UnprocessableEntityError);
       });
     });
   });

--- a/api/tests/unit/domain/services/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-import-validation-service_test.js
@@ -1,0 +1,69 @@
+const { catchErr, expect, sinon } = require('../../../test-helper');
+const sessionsImportValidationService = require('../../../../lib/domain/services/sessions-import-validation-service');
+
+describe('Unit | Service | sessions import validation Service', function () {
+  describe('#validate', function () {
+    let clock;
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers({
+        now: new Date('2023-01-01'),
+        toFake: ['Date'],
+      });
+    });
+
+    afterEach(async function () {
+      clock.restore();
+    });
+
+    context('date validation', function () {
+      context('when at least one session is scheduled in the past', function () {
+        it('should throw', async function () {
+          // given
+          const sessionScheduledInThePastData = {
+            sessionId: undefined,
+            address: 'Site 1',
+            room: 'Salle 1',
+            date: '2020-03-12',
+            time: '01:00',
+            examiner: 'Pierre',
+            description: 'desc',
+            certificationCandidates: [],
+          };
+
+          const sessions = [sessionScheduledInThePastData];
+
+          // when
+          const error = await catchErr(sessionsImportValidationService.validate)({
+            sessions,
+          });
+
+          // then
+          expect(error.message).to.equal('Une session ne peut pas être programmée dans le passé');
+        });
+      });
+
+      context('when no session is scheduled in the past', function () {
+        it('should not throw', function () {
+          // given
+          const sessionScheduledInThePastData = {
+            sessionId: undefined,
+            address: 'Site 1',
+            room: 'Salle 1',
+            date: '2024-03-12',
+            time: '01:00',
+            examiner: 'Pierre',
+            description: 'desc',
+            certificationCandidates: [],
+          };
+
+          const sessions = [sessionScheduledInThePastData];
+
+          // when
+          // then
+          expect(sessionsImportValidationService.validate({ sessions })).to.not.throw;
+        });
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/services/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-import-validation-service_test.js
@@ -87,16 +87,8 @@ describe('Unit | Service | sessions import validation Service', function () {
       context('when at least one session is scheduled in the past', function () {
         it('should throw', async function () {
           // given
-          const session = domainBuilder.buildSession({
-            sessionId: undefined,
-            address: 'Site 1',
-            room: 'Salle 1',
-            date: '2020-03-12',
-            time: '01:00',
-            examiner: 'Pierre',
-            description: 'desc',
-            certificationCandidates: [],
-          });
+          const session = _buildValidSessionWithoutId();
+          session.date = '2020-03-12';
 
           // when
           const error = await catchErr(sessionsImportValidationService.validate)({
@@ -153,7 +145,7 @@ describe('Unit | Service | sessions import validation Service', function () {
     context('when there already is an existing session with the same data as a newly imported one', function () {
       it('should throw an error', async function () {
         // given
-        const session = domainBuilder.buildSession({ sessionId: 1234 });
+        const session = _buildValidSessionWithoutId();
         sessionRepository.isSessionExisting.withArgs({ ...session }).resolves(true);
 
         // when
@@ -174,13 +166,9 @@ describe('Unit | Service | sessions import validation Service', function () {
           // given
           const validCandidateData = _createValidCandidateData(1);
           const validCandidateDataDuplicate = _createValidCandidateData(1);
-          const session = domainBuilder.buildSession({
-            ..._createValidSessionData(),
-            id: null,
-            certificationCandidates: [validCandidateData, validCandidateDataDuplicate],
-          });
+          const session = _buildValidSessionWithoutId();
+          session.certificationCandidates = [validCandidateData, validCandidateDataDuplicate];
 
-          // when
           // when
           const error = await catchErr(sessionsImportValidationService.validate)({
             session,

--- a/api/tests/unit/domain/usecases/create-session_test.js
+++ b/api/tests/unit/domain/usecases/create-session_test.js
@@ -73,7 +73,7 @@ describe('Unit | UseCase | create-session', function () {
           sessionRepository.save = sinon.stub();
           userWithMemberships.hasAccessToCertificationCenter.withArgs(certificationCenterId).returns(true);
           userRepository.getWithCertificationCenterMemberships.withArgs(userId).returns(userWithMemberships);
-          sessionCodeService.getNewSessionCode.resolves(accessCode);
+          sessionCodeService.getNewSessionCode.returns(accessCode);
           certificationCenterRepository.get.withArgs(certificationCenterId).resolves(certificationCenter);
           sessionRepository.save.resolves();
           sessionValidator.validate.returns();

--- a/api/tests/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/unit/domain/usecases/create-sessions_test.js
@@ -500,19 +500,6 @@ describe('Unit | UseCase | create-sessions', function () {
     });
   });
 
-  context('when there is no session data', function () {
-    it('should throw an error', async function () {
-      // given
-      const sessions = [];
-
-      // when
-      const err = await catchErr(createSessions)({ sessions, certificationCenterId });
-
-      // then
-      expect(err).to.be.instanceOf(UnprocessableEntityError);
-    });
-  });
-
   context('when there already is an existing session with the same data as a newly imported one', function () {
     it('should throw an error', async function () {
       // given

--- a/api/tests/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/unit/domain/usecases/create-sessions_test.js
@@ -23,7 +23,6 @@ describe('Unit | UseCase | create-sessions', function () {
   let certificationCandidateRepository;
   let complementaryCertificationRepository;
   let sessionRepository;
-  let clock;
 
   beforeEach(function () {
     accessCode = 'accessCode';
@@ -42,44 +41,6 @@ describe('Unit | UseCase | create-sessions', function () {
     sinon.stub(certificationCpfService, 'getBirthInformation');
     sessionCodeService.getNewSessionCode.returns(accessCode);
     certificationCenterRepository.get.withArgs(certificationCenterId).resolves(certificationCenter);
-
-    clock = sinon.useFakeTimers({
-      now: new Date('2023-01-01'),
-      toFake: ['Date'],
-    });
-  });
-
-  afterEach(async function () {
-    clock.restore();
-  });
-
-  context('when session is scheduled in the past', function () {
-    it('should throw', async function () {
-      // given
-      const sessionScheduledInThePastData = {
-        sessionId: undefined,
-        address: 'Site 1',
-        room: 'Salle 1',
-        date: '2020-03-12',
-        time: '01:00',
-        examiner: 'Pierre',
-        description: 'desc',
-        certificationCandidates: [],
-      };
-
-      const sessions = [sessionScheduledInThePastData];
-
-      // when
-      const error = await catchErr(createSessions)({
-        sessions,
-        certificationCenterId,
-        certificationCenterRepository,
-        sessionRepository,
-      });
-
-      // then
-      expect(error.message).to.equal('Une session ne peut pas être programmée dans le passé');
-    });
   });
 
   context('when sessions are valid', function () {

--- a/api/tests/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/unit/domain/usecases/create-sessions_test.js
@@ -419,29 +419,6 @@ describe('Unit | UseCase | create-sessions', function () {
       expect(err).to.be.instanceOf(EntityValidationError);
     });
   });
-
-  context('when there already is an existing session with the same data as a newly imported one', function () {
-    it('should throw an error', async function () {
-      // given
-      const sessions = [{ ...createValidSessionData(), examiner: 'Paul' }];
-      sessionRepository.isSessionExisting.withArgs({ ...sessions[0] }).resolves(true);
-
-      const domainTransaction = Symbol('trx');
-      sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));
-
-      // when
-      const err = await catchErr(createSessions)({
-        sessions,
-        certificationCenterId,
-        certificationCenterRepository,
-        sessionRepository,
-      });
-
-      // then
-      expect(err).to.be.instanceOf(UnprocessableEntityError);
-      expect(sessionRepository.save).not.to.have.been.called;
-    });
-  });
 });
 
 function createValidSessionData() {

--- a/api/tests/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/unit/domain/usecases/create-sessions_test.js
@@ -134,42 +134,6 @@ describe('Unit | UseCase | create-sessions', function () {
 
     context('when the session has candidates', function () {
       context('when certification center is not managing students', function () {
-        context('when a candidate is registered more than once in the same session', function () {
-          it('should throw', async function () {
-            // given
-            const validSessionData = createValidSessionData();
-            const validCandidateData = createValidCandidateData(1);
-            const validCandidateDataDuplicate = createValidCandidateData(1);
-            const scoCertificationCenter = domainBuilder.buildCertificationCenter({
-              id: certificationCenterId,
-              type: 'SUP',
-            });
-            certificationCenterRepository.get.withArgs(certificationCenterId).resolves(scoCertificationCenter);
-
-            const sessions = [
-              {
-                ...validSessionData,
-                certificationCandidates: [{ ...validCandidateData }, { ...validCandidateDataDuplicate }],
-              },
-            ];
-            sessionRepository.save.resolves({ id: 99 });
-            const domainTransaction = Symbol('trx');
-            sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));
-
-            // when
-            const error = await catchErr(createSessions)({
-              sessions,
-              certificationCenterId,
-              certificationCandidateRepository,
-              certificationCenterRepository,
-              sessionRepository,
-            });
-
-            // then
-            expect(error.message).to.equal('Une session contient au moins un élève en double.');
-          });
-        });
-
         context('when certification candidate has complementary certification', function () {
           it('should save certificationCandidate with complementary certification', async function () {
             // given

--- a/api/tests/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/unit/domain/usecases/create-sessions_test.js
@@ -1,7 +1,6 @@
 const { domainBuilder, expect, catchErr, sinon } = require('../../../test-helper');
 const createSessions = require('../../../../lib/domain/usecases/create-sessions');
 const { EntityValidationError, InvalidCertificationCandidate } = require('../../../../lib/domain/errors');
-const { UnprocessableEntityError } = require('../../../../lib/application/http-errors');
 const sessionCodeService = require('../../../../lib/domain/services/session-code-service');
 const Session = require('../../../../lib/domain/models/Session');
 const certificationCpfService = require('../../../../lib/domain/services/certification-cpf-service');
@@ -15,7 +14,6 @@ describe('Unit | UseCase | create-sessions', function () {
   let certificationCenterName;
   let certificationCenter;
   let certificationCenterRepository;
-  let certificationCourseRepository;
   let certificationCandidateRepository;
   let complementaryCertificationRepository;
   let sessionRepository;
@@ -29,7 +27,6 @@ describe('Unit | UseCase | create-sessions', function () {
       name: certificationCenterName,
     });
     certificationCenterRepository = { get: sinon.stub() };
-    certificationCourseRepository = { findCertificationCoursesBySessionId: sinon.stub() };
     certificationCandidateRepository = { saveInSession: sinon.stub(), deleteBySessionId: sinon.stub() };
     complementaryCertificationRepository = { getByLabel: sinon.stub() };
     sessionRepository = { save: sinon.stub(), isSessionExisting: sinon.stub() };
@@ -93,35 +90,6 @@ describe('Unit | UseCase | create-sessions', function () {
       });
 
       context('when there is only sessionId and candidate information', function () {
-        context('when a session has already started', function () {
-          it('should throw', async function () {
-            const candidate = createValidCandidateData(1);
-            const sessions = [
-              {
-                sessionId: 1234,
-                certificationCandidates: [candidate],
-              },
-            ];
-
-            certificationCourseRepository.findCertificationCoursesBySessionId
-              .withArgs({ sessionId: sessions[0].sessionId })
-              .resolves([domainBuilder.buildCertificationCourse({ sessionId: 1234 })]);
-
-            // when
-            const error = await catchErr(createSessions)({
-              sessions,
-              certificationCenterId,
-              certificationCenterRepository,
-              certificationCourseRepository,
-              sessionRepository,
-            });
-
-            // then
-            expect(error).to.be.instanceOf(UnprocessableEntityError);
-            expect(error.message).to.equal("Impossible d'ajouter un candidat à une session qui a déjà commencé.");
-          });
-        });
-
         it('should only save candidate in session', async function () {
           // given
           const candidate1 = createValidCandidateData(1);
@@ -137,7 +105,6 @@ describe('Unit | UseCase | create-sessions', function () {
           const cpfBirthInformationValidation2 = CpfBirthInformationValidation.success({ ...candidate2 });
           certificationCpfService.getBirthInformation.onCall(0).resolves(cpfBirthInformationValidation1);
           certificationCpfService.getBirthInformation.onCall(1).resolves(cpfBirthInformationValidation2);
-          certificationCourseRepository.findCertificationCoursesBySessionId.resolves([]);
 
           const domainTransaction = Symbol('trx');
           sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));
@@ -148,7 +115,6 @@ describe('Unit | UseCase | create-sessions', function () {
             certificationCenterId,
             certificationCenterRepository,
             certificationCandidateRepository,
-            certificationCourseRepository,
             sessionRepository,
           });
 

--- a/api/tests/unit/domain/usecases/create-sessions_test.js
+++ b/api/tests/unit/domain/usecases/create-sessions_test.js
@@ -1,10 +1,6 @@
 const { domainBuilder, expect, catchErr, sinon } = require('../../../test-helper');
 const createSessions = require('../../../../lib/domain/usecases/create-sessions');
-const {
-  EntityValidationError,
-  InvalidCertificationCandidate,
-  SessionWithIdAndInformationOnMassImportError,
-} = require('../../../../lib/domain/errors');
+const { EntityValidationError, InvalidCertificationCandidate } = require('../../../../lib/domain/errors');
 const { UnprocessableEntityError } = require('../../../../lib/application/http-errors');
 const sessionCodeService = require('../../../../lib/domain/services/session-code-service');
 const Session = require('../../../../lib/domain/models/Session');
@@ -94,43 +90,6 @@ describe('Unit | UseCase | create-sessions', function () {
         // then
 
         expect(sessionRepository.save).to.have.been.calledTwice;
-      });
-
-      context('when there is a sessionId and session information', function () {
-        it('should throw', async function () {
-          // given
-          const candidate1 = createValidCandidateData(1);
-          const candidate2 = createValidCandidateData(2);
-          const sessions = [
-            {
-              ...createValidSessionData(),
-              sessionId: 1234,
-
-              certificationCandidates: [candidate1, candidate2],
-            },
-          ];
-
-          const domainTransaction = Symbol('trx');
-          sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));
-          certificationCourseRepository.findCertificationCoursesBySessionId.onCall(0).resolves([]);
-          certificationCourseRepository.findCertificationCoursesBySessionId.onCall(1).resolves([]);
-
-          // when
-          const error = await catchErr(createSessions)({
-            sessions,
-            certificationCenterId,
-            certificationCenterRepository,
-            certificationCandidateRepository,
-            certificationCourseRepository,
-            sessionRepository,
-          });
-
-          // then
-          expect(error).to.be.an.instanceOf(SessionWithIdAndInformationOnMassImportError);
-          expect(error.message).to.equal(
-            'Merci de ne pas renseigner les informations de session pour la session: 1234'
-          );
-        });
       });
 
       context('when there is only sessionId and candidate information', function () {


### PR DESCRIPTION
## :unicorn: Problème
Le usecase `create-sessions` permettant l'import de session en masse manque de clarté car il gère beaucoup de choses : la validation des données fournies par le csv avec la BDD et la création des sessions et des candidats.

## :robot: Proposition
Transférer la validation des données de session (uniquement) du usecase dans un nouveau service : `sessions-import-validation-service`

## :rainbow: Remarques
Cette PR gère la validation de session uniquement. La validation des candidats via le service sera fait dans une PR ultérieure.

## :100: Pour tester
Non regression sur l'import de session via csv