### PR TITLE
[TECH] Generer le mot de passe surveillant au plus tôt (PIX-7195)

### DIFF
--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -39,7 +39,7 @@ class Session {
     certificationCandidates,
     certificationCenterId,
     assignedCertificationOfficerId,
-    supervisorPassword,
+    supervisorPassword = Session.generateSupervisorPassword(),
   } = {}) {
     this.id = id;
     this.accessCode = accessCode;
@@ -85,10 +85,6 @@ class Session {
 
   isAccessible() {
     return this.status === statuses.CREATED;
-  }
-
-  generateSupervisorPassword() {
-    this.supervisorPassword = Session.generateSupervisorPassword();
   }
 
   static generateSupervisorPassword() {

--- a/api/lib/domain/usecases/create-session.js
+++ b/api/lib/domain/usecases/create-session.js
@@ -28,7 +28,5 @@ module.exports = async function createSession({
     certificationCenter,
   });
 
-  domainSession.generateSupervisorPassword();
-
   return sessionRepository.save(domainSession);
 };

--- a/api/lib/domain/usecases/create-sessions.js
+++ b/api/lib/domain/usecases/create-sessions.js
@@ -25,14 +25,12 @@ module.exports = async function createSessions({
       let { sessionId } = sessionDTO;
 
       const accessCode = sessionCodeService.getNewSessionCode();
-      const supervisorPassword = Session.generateSupervisorPassword();
       const session = new Session({
         ...sessionDTO,
         id: sessionId,
         certificationCenterId,
         certificationCenter,
         accessCode,
-        supervisorPassword,
       });
 
       await sessionsImportValidationService.validate({ session, sessionRepository, certificationCourseRepository });

--- a/api/tests/acceptance/application/session/session-for-supervising-controller-supervise_test.js
+++ b/api/tests/acceptance/application/session/session-for-supervising-controller-supervise_test.js
@@ -23,8 +23,6 @@ describe('Acceptance | Controller | session-for-supervising-controller-supervise
 
     const certificationCenter = databaseBuilder.factory.buildCertificationCenter({});
     const session = domainBuilder.buildSession({ id: 121, certificationCenterId: certificationCenter.id });
-    session.generateSupervisorPassword();
-    const supervisorPassword = session.supervisorPassword;
     databaseBuilder.factory.buildUser({ id: 3456 });
     databaseBuilder.factory.buildSession(session);
     await databaseBuilder.commit();
@@ -41,7 +39,7 @@ describe('Acceptance | Controller | session-for-supervising-controller-supervise
           type: 'supervisor-authentications',
           attributes: {
             'session-id': '121',
-            'supervisor-password': supervisorPassword,
+            'supervisor-password': session.supervisorPassword,
           },
         },
       },

--- a/api/tests/unit/domain/models/Session_test.js
+++ b/api/tests/unit/domain/models/Session_test.js
@@ -61,6 +61,15 @@ describe('Unit | Domain | Models | Session', function () {
     expect(_.keys(session)).to.have.deep.members(SESSION_PROPS);
   });
 
+  it('should default a supervisor password property containing 5 digits/letters except 0, 1 and vowels', async function () {
+    // given
+    // when
+    const session = new Session();
+
+    // then
+    expect(session.supervisorPassword).to.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/);
+  });
+
   context('#areResultsFlaggedAsSent', function () {
     context('when session resultsSentToPrescriberAt timestamp is defined', function () {
       it('should return true', function () {
@@ -74,6 +83,7 @@ describe('Unit | Domain | Models | Session', function () {
         expect(areResultsFlaggedAsSent).to.be.true;
       });
     });
+
     context('when session resultsSentToPrescriberAt timestamp is falsy', function () {
       it('should return false', function () {
         // given
@@ -215,7 +225,6 @@ describe('Unit | Domain | Models | Session', function () {
     it('should return true when the supervisor password match', function () {
       // given
       const session = domainBuilder.buildSession.created();
-      session.generateSupervisorPassword();
 
       // when
       const isSupervisable = session.isSupervisable(session.supervisorPassword);
@@ -257,19 +266,6 @@ describe('Unit | Domain | Models | Session', function () {
 
       // then
       expect(result).to.be.false;
-    });
-  });
-
-  context('#generateSupervisorPassword', function () {
-    it('should assign a supervisor password to supervisorPassword property containing 5 digits/letters except 0, 1 and vowels', async function () {
-      // given
-      const session = domainBuilder.buildSession();
-
-      // when
-      session.generateSupervisorPassword();
-
-      // then
-      expect(session.supervisorPassword).to.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/);
     });
   });
 

--- a/api/tests/unit/domain/usecases/supervise-session_test.js
+++ b/api/tests/unit/domain/usecases/supervise-session_test.js
@@ -42,7 +42,6 @@ describe('Unit | UseCase | supervise-session', function () {
     const sessionId = 123;
     const userId = 434;
     const session = domainBuilder.buildSession.processed({ id: sessionId });
-    session.generateSupervisorPassword();
     sessionRepository.get.resolves(session);
 
     // when
@@ -63,7 +62,6 @@ describe('Unit | UseCase | supervise-session', function () {
     const sessionId = 123;
     const userId = 434;
     const session = domainBuilder.buildSession.created({ id: sessionId });
-    session.generateSupervisorPassword();
     sessionRepository.get.resolves(session);
 
     // when


### PR DESCRIPTION
## :unicorn: Problème
L'attribution du mot de passe surveillant à une session nécessite de modifier celle-çi

## :robot: Proposition
Le faire directement dans le constructeur par défaut

## :rainbow: Remarques

## :100: Pour tester
 - [ ] Créer une session (https://certif-pr5676.review.pix.fr/sessions/106294)
 - [ ] S'assurer qu'il y a bien un mot de passe surveillant
