### PR TITLE
[FEATURE] Afficher de meilleurs messages d'erreurs lorsque l'utilisateur saisit un nombre décimal en seuil de palier sur PixAdmin (PIX-7077)

### DIFF
--- a/api/lib/domain/models/target-profile-management/StageCollection.js
+++ b/api/lib/domain/models/target-profile-management/StageCollection.js
@@ -90,11 +90,11 @@ class StageCollection {
     }
 
     if (stage.level != null) {
-      if (stage.level > this._maxLevel || stage.level < 0) {
+      if (!_.isInteger(stage.level) || stage.level > this._maxLevel || stage.level < 0) {
         throw new InvalidStageError(`Niveau doit être compris entre 0 et ${this._maxLevel}.`);
       }
     } else {
-      if (stage.threshold > 100 || stage.threshold < 0) {
+      if (!_.isInteger(stage.threshold) || stage.threshold > 100 || stage.threshold < 0) {
         throw new InvalidStageError('Seuil doit être compris entre 0 et 100.');
       }
     }

--- a/api/tests/unit/domain/usecases/create-stage_test.js
+++ b/api/tests/unit/domain/usecases/create-stage_test.js
@@ -38,6 +38,40 @@ describe('Unit | UseCases | create-stage', function () {
       expect(error.message).to.equal('Palier non valide : Seuil ou niveau obligatoire.');
     });
 
+    it('should throw InvalidStageError for a level that is not a number', function () {
+      // given
+      const stageWithLevel = {
+        level: 5,
+        threshold: null,
+        title: 'title',
+        message: 'message',
+      };
+
+      // when
+      const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithLevel });
+
+      // then
+      expect(error).to.be.an.instanceof(InvalidStageError);
+      expect(error.message).to.equal('Palier non valide : Niveau doit être compris entre 0 et 2.');
+    });
+
+    it('should throw InvalidStageError for a level that is not an integer', function () {
+      // given
+      const stageWithLevel = {
+        level: 3.5,
+        threshold: null,
+        title: 'title',
+        message: 'message',
+      };
+
+      // when
+      const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithLevel });
+
+      // then
+      expect(error).to.be.an.instanceof(InvalidStageError);
+      expect(error.message).to.equal('Palier non valide : Niveau doit être compris entre 0 et 2.');
+    });
+
     it('should throw InvalidStageError for a level that exceeds max level', function () {
       // given
       const stageWithLevel = {
@@ -70,6 +104,40 @@ describe('Unit | UseCases | create-stage', function () {
       // then
       expect(error).to.be.an.instanceof(InvalidStageError);
       expect(error.message).to.equal('Palier non valide : Niveau doit être compris entre 0 et 2.');
+    });
+
+    it('should throw InvalidStageError for a threshold that is not  number', function () {
+      // given
+      const stageWithThreshold = {
+        level: null,
+        threshold: 'toto',
+        title: 'title',
+        message: 'message',
+      };
+
+      // when
+      const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithThreshold });
+
+      // then
+      expect(error).to.be.an.instanceof(InvalidStageError);
+      expect(error.message).to.equal('Palier non valide : Seuil doit être compris entre 0 et 100.');
+    });
+
+    it('should throw InvalidStageError for a threshold that is not an integer', function () {
+      // given
+      const stageWithThreshold = {
+        level: null,
+        threshold: 101.5,
+        title: 'title',
+        message: 'message',
+      };
+
+      // when
+      const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithThreshold });
+
+      // then
+      expect(error).to.be.an.instanceof(InvalidStageError);
+      expect(error.message).to.equal('Palier non valide : Seuil doit être compris entre 0 et 100.');
     });
 
     it('should throw InvalidStageError for a threshold that exceeds 100', function () {
@@ -274,6 +342,40 @@ describe('Unit | UseCases | create-stage', function () {
       expect(error.message).to.equal('Palier non valide : Niveau obligatoire.');
     });
 
+    it('should throw InvalidStageError for a level that is not a number', function () {
+      // given
+      const stageWithLevel = {
+        level: 'toto',
+        threshold: null,
+        title: 'title',
+        message: 'message',
+      };
+
+      // when
+      const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithLevel });
+
+      // then
+      expect(error).to.be.an.instanceof(InvalidStageError);
+      expect(error.message).to.equal('Palier non valide : Niveau doit être compris entre 0 et 5.');
+    });
+
+    it('should throw InvalidStageError for a level that is not an integer', function () {
+      // given
+      const stageWithLevel = {
+        level: 4.5,
+        threshold: null,
+        title: 'title',
+        message: 'message',
+      };
+
+      // when
+      const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithLevel });
+
+      // then
+      expect(error).to.be.an.instanceof(InvalidStageError);
+      expect(error.message).to.equal('Palier non valide : Niveau doit être compris entre 0 et 5.');
+    });
+
     it('should throw InvalidStageError for a level that exceeds max level', function () {
       // given
       const stageWithLevel = {
@@ -433,6 +535,40 @@ describe('Unit | UseCases | create-stage', function () {
       // then
       expect(error).to.be.an.instanceof(InvalidStageError);
       expect(error.message).to.equal('Palier non valide : Seuil obligatoire.');
+    });
+
+    it('should throw InvalidStageError for a threshold that is not a number', function () {
+      // given
+      const stageWithThreshold = {
+        level: null,
+        threshold: 'toto',
+        title: 'title',
+        message: 'message',
+      };
+
+      // when
+      const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithThreshold });
+
+      // then
+      expect(error).to.be.an.instanceof(InvalidStageError);
+      expect(error.message).to.equal('Palier non valide : Seuil doit être compris entre 0 et 100.');
+    });
+
+    it('should throw InvalidStageError for a threshold that is not an integer', function () {
+      // given
+      const stageWithThreshold = {
+        level: null,
+        threshold: 40.5,
+        title: 'title',
+        message: 'message',
+      };
+
+      // when
+      const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithThreshold });
+
+      // then
+      expect(error).to.be.an.instanceof(InvalidStageError);
+      expect(error.message).to.equal('Palier non valide : Seuil doit être compris entre 0 et 100.');
     });
 
     it('should throw InvalidStageError for a threshold that exceeds 100', function () {

--- a/api/tests/unit/domain/usecases/update-stage_test.js
+++ b/api/tests/unit/domain/usecases/update-stage_test.js
@@ -24,6 +24,76 @@ describe('Unit | UseCases | update-stage', function () {
       });
     });
 
+    it('should throw InvalidStageError for a level that is not a number', function () {
+      // given
+      stageCollection = domainBuilder.buildStageCollection({
+        id: 100,
+        stages: [
+          {
+            id: 51,
+            level: 3,
+            threshold: null,
+            message: 'ancien message palier',
+            title: 'ancien titre palier',
+            prescriberDescription: 'ancienne description prescripteur palier',
+            prescriberTitle: 'ancien titre prescripteur palier',
+          },
+        ],
+        maxLevel: 5,
+      });
+      const stageToUpdate = {
+        id: 51,
+        level: 'toto',
+        threshold: null,
+        message: 'nouveau message palier',
+        title: 'nouveau titre palier',
+        prescriberDescription: 'nouvelle description prescripteur palier',
+        prescriberTitle: 'nouveau titre prescripteur palier',
+      };
+
+      // when
+      const error = catchErrSync(usecases.updateStage)({ stageCollection, stage: stageToUpdate });
+
+      // then
+      expect(error).to.be.an.instanceof(InvalidStageError);
+      expect(error.message).to.equal('Palier non valide : Niveau doit être compris entre 0 et 5.');
+    });
+
+    it('should throw InvalidStageError for a level that is not an integer', function () {
+      // given
+      stageCollection = domainBuilder.buildStageCollection({
+        id: 100,
+        stages: [
+          {
+            id: 51,
+            level: 3,
+            threshold: null,
+            message: 'ancien message palier',
+            title: 'ancien titre palier',
+            prescriberDescription: 'ancienne description prescripteur palier',
+            prescriberTitle: 'ancien titre prescripteur palier',
+          },
+        ],
+        maxLevel: 5,
+      });
+      const stageToUpdate = {
+        id: 51,
+        level: 4.5,
+        threshold: null,
+        message: 'nouveau message palier',
+        title: 'nouveau titre palier',
+        prescriberDescription: 'nouvelle description prescripteur palier',
+        prescriberTitle: 'nouveau titre prescripteur palier',
+      };
+
+      // when
+      const error = catchErrSync(usecases.updateStage)({ stageCollection, stage: stageToUpdate });
+
+      // then
+      expect(error).to.be.an.instanceof(InvalidStageError);
+      expect(error.message).to.equal('Palier non valide : Niveau doit être compris entre 0 et 5.');
+    });
+
     it('should throw InvalidStageError for a level that exceed max level ', function () {
       // given
       stageCollection = domainBuilder.buildStageCollection({
@@ -386,6 +456,46 @@ describe('Unit | UseCases | update-stage', function () {
       // then
       expect(error).to.be.an.instanceof(InvalidStageError);
       expect(error.message).to.equal('Palier non valide : Seuil ou niveau obligatoire.');
+    });
+
+    it('should throw InvalidStageError for a threshold that is not a number', function () {
+      // given
+      const stageToUpdate = {
+        id: 51,
+        level: null,
+        threshold: 'toto',
+        message: 'nouveau message palier',
+        title: 'nouveau titre palier',
+        prescriberDescription: 'nouvelle description prescripteur palier',
+        prescriberTitle: 'nouveau titre prescripteur palier',
+      };
+
+      // when
+      const error = catchErrSync(usecases.updateStage)({ stageCollection, stage: stageToUpdate });
+
+      // then
+      expect(error).to.be.an.instanceof(InvalidStageError);
+      expect(error.message).to.equal('Palier non valide : Seuil doit être compris entre 0 et 100.');
+    });
+
+    it('should throw InvalidStageError for a threshold that is not an integer', function () {
+      // given
+      const stageToUpdate = {
+        id: 51,
+        level: null,
+        threshold: 40.5,
+        message: 'nouveau message palier',
+        title: 'nouveau titre palier',
+        prescriberDescription: 'nouvelle description prescripteur palier',
+        prescriberTitle: 'nouveau titre prescripteur palier',
+      };
+
+      // when
+      const error = catchErrSync(usecases.updateStage)({ stageCollection, stage: stageToUpdate });
+
+      // then
+      expect(error).to.be.an.instanceof(InvalidStageError);
+      expect(error.message).to.equal('Palier non valide : Seuil doit être compris entre 0 et 100.');
     });
 
     it('should throw InvalidStageError for a threshold that exceeds 100', function () {


### PR DESCRIPTION
## :unicorn: Problème
Les messages n'étaient pas assez explicites

## :robot: Proposition
Mettre de meilleures messages

## :rainbow: Remarques
Ici nous avons juste ajouté la vérification de si le palier est bien un nombre entier. Le reste des messages ont étés modifiés dans la branche parente.

## :100: Pour tester
Déclencher des erreurs en pagaille