### PR TITLE
[BUGFIX] La dropdown de changement d'orga dans PixOrga ne s'affichait pas correctement sur la page de sélection de sujets (PIX-7198)

### DIFF
--- a/orga/app/styles/components/layout/user-logged-menu.scss
+++ b/orga/app/styles/components/layout/user-logged-menu.scss
@@ -57,6 +57,7 @@
   top: 60px;
   width: 400px;
   max-width: 100%;
+  z-index: 2;
 
   &__icon {
     margin-right: 8px;


### PR DESCRIPTION
## :unicorn: Problème
![avant-ticket](https://user-images.githubusercontent.com/48727874/219664357-b53f1a2a-5d7e-4e0e-a711-aaa089819987.png)

## :robot: Proposition
Problème de z-index
![apres-ticket](https://user-images.githubusercontent.com/48727874/219664501-3a5033da-e235-4793-bfdd-fb06bc0fef79.png)


## :rainbow: Remarques

## :100: Pour tester
Se rendre sur la page de sélection de sujets, afficher la dropdown et bouger dans la page et constater qu'elle reste au-dessus en toutes circonstances