### PR TITLE
[BUGFIX] Correction de l'emplacement du total des campagnes (PIX-7145)

### DIFF
--- a/orga/app/styles/components/campaign/filters.scss
+++ b/orga/app/styles/components/campaign/filters.scss
@@ -71,6 +71,8 @@
   }
 
   &__results {
+    display: flex;
+    align-items: center;
     color: $pix-neutral-60;
     font-size: 0.875em;
     font-weight: 500;


### PR DESCRIPTION
## :unicorn: Problème
La dernière montée de version a eu comme impact de rehausser le total du nombre de campagne dans la page “campagnes” de Pix Orga.

## :robot: Proposition
Ajouter du style pour recentrer ce texte.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Aller sur Pix Orga, 
- Dans l'onglet Campagne, vérifier que le nombre total de campagne est bien aligné verticalement.
