### PR TITLE
[FEATURE] Ajout de validation par champ lors de l'ajout de palier (PIX-7100)

### DIFF
--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -23,10 +23,12 @@
             {{#each @targetProfile.stages as |stage|}}
               {{#if stage.isNew}}
                 <TargetProfiles::Stages::NewStage
+                  @stage={{stage}}
                   @imageUrl={{@targetProfile.imageUrl}}
                   @title={{stage.title}}
                   @isTypeLevel={{stage.isTypeLevel}}
                   @availableLevels={{this.availableLevels}}
+                  @unavailableThresholds={{this.unavailableThresholds}}
                   @threshold={{stage.threshold}}
                   @level={{stage.level}}
                   @setLevel={{fn this.onStageLevelChange stage}}

--- a/admin/app/components/target-profiles/stages.js
+++ b/admin/app/components/target-profiles/stages.js
@@ -20,6 +20,10 @@ export default class Stages extends Component {
     return difference(allLevels, unavailableLevels);
   }
 
+  get unavailableThresholds() {
+    return this.args.targetProfile.stages.map((stage) => (stage.isNew ? null : stage.threshold));
+  }
+
   get isTypeLevel() {
     return this.args.targetProfile.stages?.firstObject?.isTypeLevel ?? this.firstStageType == 'level';
   }

--- a/admin/app/components/target-profiles/stages/new-stage.hbs
+++ b/admin/app/components/target-profiles/stages/new-stage.hbs
@@ -1,48 +1,48 @@
 <tr aria-label="Informations sur le palier {{@title}}">
   <td>
-      {{#if @isTypeLevel}}
-        <Stages::StageLevelSelect
-          @availableLevels={{@availableLevels}}
-          @value={{@level}}
-          @onChange={{@setLevel}}
-          class="stages-table__level-select"
-          required="true"
-          @label="Niveau du palier"
-        />
-      {{else}}
-        <PixInput
-          @id="threshold"
-          @errorMessage="Le seuil est invalide"
-          @validationStatus={{this.thresholdStatus}}
-          @requiredLabel="Champ obligatoire"
-          type="number"
-          @value={{@threshold}}
-          @ariaLabel="Seuil du palier"
-          {{on "focusout" this.checkThresholdValidity}}
-        />
-      {{/if}}
+    {{#if @isTypeLevel}}
+      <Stages::StageLevelSelect
+        @availableLevels={{@availableLevels}}
+        @value={{@level}}
+        @onChange={{@setLevel}}
+        class="stages-table__level-select"
+        required="true"
+        @label="Niveau du palier"
+      />
+    {{else}}
+      <PixInput
+        @id="threshold"
+        @errorMessage="Le seuil est invalide"
+        @validationStatus={{this.thresholdStatus}}
+        @requiredLabel="Champ obligatoire"
+        type="number"
+        @value={{@threshold}}
+        @ariaLabel="Seuil du palier"
+        {{on "focusout" this.checkThresholdValidity}}
+      />
+    {{/if}}
   </td>
   <td>
-      <PixInput
-        @id="title"
-        @errorMessage="Le titre est vide"
-        @validationStatus={{this.titleStatus}}
-        @requiredLabel="Champ obligatoire"
-        @value={{@title}}
-        @ariaLabel="Titre du palier"
-        {{on "focusout" this.checkTitleValidity}}
-      />
+    <PixInput
+      @id="title"
+      @errorMessage="Le titre est vide"
+      @validationStatus={{this.titleStatus}}
+      @requiredLabel="Champ obligatoire"
+      @value={{@title}}
+      @ariaLabel="Titre du palier"
+      {{on "focusout" this.checkTitleValidity}}
+    />
   </td>
   <td>
-      <PixInput
-        @id="message"
-        @errorMessage="Le message est vide"
-        @validationStatus={{this.messageStatus}}
-        @requiredLabel="Champ obligatoire"
-        @value={{@message}}
-        @ariaLabel="Message du palier"
-        {{on "focusout" this.checkMessageValidity}}
-      />
+    <PixInput
+      @id="message"
+      @errorMessage="Le message est vide"
+      @validationStatus={{this.messageStatus}}
+      @requiredLabel="Champ obligatoire"
+      @value={{@message}}
+      @ariaLabel="Message du palier"
+      {{on "focusout" this.checkMessageValidity}}
+    />
   </td>
   <td>
     À renseigner ultérieurement

--- a/admin/app/components/target-profiles/stages/new-stage.hbs
+++ b/admin/app/components/target-profiles/stages/new-stage.hbs
@@ -1,6 +1,5 @@
 <tr aria-label="Informations sur le palier {{@title}}">
   <td>
-    <div class="form-field">
       {{#if @isTypeLevel}}
         <Stages::StageLevelSelect
           @availableLevels={{@availableLevels}}
@@ -11,40 +10,39 @@
           @label="Niveau du palier"
         />
       {{else}}
-        <Input
-          class={{if @errors.threshold "form-control is-invalid" "form-control"}}
-          @type="number"
-          required="true"
+        <PixInput
+          @id="threshold"
+          @errorMessage="Le seuil est invalide"
+          @validationStatus={{this.thresholdStatus}}
+          @requiredLabel="Champ obligatoire"
+          type="number"
           @value={{@threshold}}
-          aria-label="Seuil du palier"
+          @ariaLabel="Seuil du palier"
+          {{on "focusout" this.checkThresholdValidity}}
         />
-        {{#if @errors.threshold}}
-          <div class="form-field__error">
-            {{get @errors.threshold "0.message"}}
-          </div>
-        {{/if}}
       {{/if}}
-    </div>
   </td>
   <td>
-    <div class="form-field">
-      <Input
-        class={{if @errors.title "form-field__text form-control is-invalid" "form-field__text form-control"}}
-        required="true"
+      <PixInput
+        @id="title"
+        @errorMessage="Le titre est vide"
+        @validationStatus={{this.titleStatus}}
+        @requiredLabel="Champ obligatoire"
         @value={{@title}}
-        aria-label="Titre du palier"
+        @ariaLabel="Titre du palier"
+        {{on "focusout" this.checkTitleValidity}}
       />
-      {{#if @errors.title}}
-        <div class="form-field__error">
-          {{get @errors.title "0.message"}}
-        </div>
-      {{/if}}
-    </div>
   </td>
   <td>
-    <div class="form-field">
-      <Input class="form-control" required="true" @value={{@message}} aria-label="Message du palier" />
-    </div>
+      <PixInput
+        @id="message"
+        @errorMessage="Le message est vide"
+        @validationStatus={{this.messageStatus}}
+        @requiredLabel="Champ obligatoire"
+        @value={{@message}}
+        @ariaLabel="Message du palier"
+        {{on "focusout" this.checkMessageValidity}}
+      />
   </td>
   <td>
     À renseigner ultérieurement

--- a/admin/app/components/target-profiles/stages/new-stage.js
+++ b/admin/app/components/target-profiles/stages/new-stage.js
@@ -1,0 +1,54 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import isInteger from 'lodash/isInteger';
+
+export default class NewStage extends Component {
+  @tracked thresholdStatus = 'default';
+  @tracked titleStatus = 'default';
+  @tracked messageStatus = 'default';
+
+  @action
+  checkThresholdValidity(event) {
+    const threshold = Number(event.target.value);
+    if (!isInteger(threshold)) {
+      this.thresholdStatus = 'error';
+      return;
+    }
+    if (this.args.unavailableThresholds.includes(threshold)) {
+      this.thresholdStatus = 'error';
+      return;
+    }
+    if (threshold < 0 || threshold > 100) {
+      this.thresholdStatus = 'error';
+      return;
+    }
+
+    this.thresholdStatus = 'success';
+    this.args.stage.set('threshold', threshold);
+  }
+
+  @action
+  checkTitleValidity(event) {
+    const title = event.target.value.trim();
+
+    if (!title) {
+      this.titleStatus = 'error';
+      return;
+    }
+    this.titleStatus = 'success';
+    this.args.stage.set('title', title);
+  }
+
+  @action
+  checkMessageValidity(event) {
+    const message = event.target.value.trim();
+
+    if (!message) {
+      this.messageStatus = 'error';
+      return;
+    }
+    this.messageStatus = 'success';
+    this.args.stage.set('message', message);
+  }
+}

--- a/admin/app/components/users/user-detail-personal-information/add-authentication-method-modal.hbs
+++ b/admin/app/components/users/user-detail-personal-information/add-authentication-method-modal.hbs
@@ -9,9 +9,10 @@
         @id="new-email-for-adding-authentication-method"
         @label="Nouvelle adresse e-mail"
         {{on "change" @onChangeNewEmail}}
-        @errorMessage={{if @showAlreadyExistingEmailError "Cette adresse e-mail est déjà utilisée" ""}}
+        @validationStatus={{if @showAlreadyExistingEmailError "error" "default"}}
+        @errorMessage="Cette adresse e-mail est déjà utilisée"
         type="email"
-        required
+        @requiredLabel="Champ obligatoire"
       />
     </form>
   </:content>

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -93,7 +93,7 @@ Router.map(function () {
       this.route('list');
       this.route('new');
       this.route('target-profile', { path: '/:target_profile_id' }, function () {
-        this.route('details', { path: '/' });
+        this.route('details');
         this.route('organizations');
         this.route('insights');
         this.route('badges', function () {

--- a/admin/app/routes/authenticated/target-profiles/index.js
+++ b/admin/app/routes/authenticated/target-profiles/index.js
@@ -4,6 +4,6 @@ export default class IndexRoute extends Route {
   @service router;
 
   beforeModel() {
-    this.router.replaceWith('authenticated.target-profiles.target-profile.details');
+    this.router.transitionTo('authenticated.target-profiles.list');
   }
 }

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.0",
-        "@1024pix/pix-ui": "^24.1.0",
+        "@1024pix/pix-ui": "^26.0.3",
         "@1024pix/stylelint-config": "^1.0.1",
         "@babel/eslint-parser": "^7.19.1",
         "@ember/optional-features": "^2.0.0",
@@ -1204,9 +1204,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-24.1.0.tgz",
-      "integrity": "sha512-NNRnU3Y6gDlLc7sbCY/+VlJG2kHbzpJpglFrCV3aWP/7fHQDs9xYl1xdRLFotrITDMC+sw9OyqZPzzBtcaVt+Q==",
+      "version": "26.0.3",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-26.0.3.tgz",
+      "integrity": "sha512-eArhgo0n7liad64m85cunP6Yb0UvzIQdtF1ux+oX/sz4VitJGPqbC/jHftltG1OA6S5YdXdy7W4i5Rk79e1I0Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -41024,9 +41024,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-24.1.0.tgz",
-      "integrity": "sha512-NNRnU3Y6gDlLc7sbCY/+VlJG2kHbzpJpglFrCV3aWP/7fHQDs9xYl1xdRLFotrITDMC+sw9OyqZPzzBtcaVt+Q==",
+      "version": "26.0.3",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-26.0.3.tgz",
+      "integrity": "sha512-eArhgo0n7liad64m85cunP6Yb0UvzIQdtF1ux+oX/sz4VitJGPqbC/jHftltG1OA6S5YdXdy7W4i5Rk79e1I0Q==",
       "dev": true,
       "requires": {
         "color": "^4.2.3",

--- a/admin/package.json
+++ b/admin/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.0",
-    "@1024pix/pix-ui": "^24.1.0",
+    "@1024pix/pix-ui": "^26.0.3",
     "@1024pix/stylelint-config": "^1.0.1",
     "@babel/eslint-parser": "^7.19.1",
     "@ember/optional-features": "^2.0.0",

--- a/admin/tests/acceptance/authenticated/target-profiles/list_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/list_test.js
@@ -63,7 +63,7 @@ module('Acceptance | Target Profiles | List', function (hooks) {
         await clickByName('Profil Cible');
 
         // then
-        assert.strictEqual(currentURL(), '/target-profiles/1');
+        assert.strictEqual(currentURL(), '/target-profiles/1/details');
         assert.dom(screen.getByText('1 · Area 1')).exists();
       });
 

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation_test.js
@@ -73,7 +73,7 @@ module('Acceptance | Target profile creation', function (hooks) {
       await clickByName('Créer le profil cible');
 
       // then
-      assert.strictEqual(currentURL(), '/target-profiles/1');
+      assert.strictEqual(currentURL(), '/target-profiles/1/details');
       await _unfoldLearningContent();
       assert.dom(screen.getByRole('heading', { name: 'Un profil cible, et vite !' })).exists();
       let isMobileCompliant = screen.getByTestId('mobile-compliant-tube_f1_a1_c1_th1_tu1').getAttribute('aria-label');

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
@@ -32,7 +32,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
           await visit('/target-profiles/1');
 
           // then
-          assert.strictEqual(currentURL(), '/target-profiles/1');
+          assert.strictEqual(currentURL(), '/target-profiles/1/details');
         });
       });
 
@@ -109,7 +109,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
       await clickByName('Enregistrer');
 
       // then
-      assert.strictEqual(currentURL(), '/target-profiles/1');
+      assert.strictEqual(currentURL(), '/target-profiles/1/details');
       assert.dom(screen.getByRole('heading', { name: 'nom modifié' })).exists();
       assert.dom(screen.queryByText('Enregistrer')).doesNotExist();
       await clickByName('Éditer');
@@ -133,7 +133,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
       await clickByName('Annuler');
 
       // then
-      assert.strictEqual(currentURL(), '/target-profiles/1');
+      assert.strictEqual(currentURL(), '/target-profiles/1/details');
       assert.dom(screen.getByRole('heading', { name: 'Nom à éditer' })).exists();
       assert.dom(screen.queryByText('Enregistrer')).doesNotExist();
     });

--- a/admin/tests/acceptance/authenticated/users/authentication-method_test.js
+++ b/admin/tests/acceptance/authenticated/users/authentication-method_test.js
@@ -29,7 +29,7 @@ module('Acceptance | authenticated/users | authentication-method', function (hoo
 
       await screen.findByRole('dialog');
 
-      await fillByLabel('Nouvelle adresse e-mail', 'nouvel-email@example.net');
+      await fillByLabel(/Nouvelle adresse e-mail/, 'nouvel-email@example.net');
       await clickByName("Enregistrer l'adresse e-mail");
 
       // then
@@ -60,7 +60,7 @@ module('Acceptance | authenticated/users | authentication-method', function (hoo
 
       await screen.findByRole('dialog');
 
-      await fillByLabel('Nouvelle adresse e-mail', 'nouvel-email@example.net');
+      await fillByLabel(/Nouvelle adresse e-mail/, 'nouvel-email@example.net');
       await clickByName("Enregistrer l'adresse e-mail");
 
       // then

--- a/api/lib/domain/models/target-profile-management/StageCollection.js
+++ b/api/lib/domain/models/target-profile-management/StageCollection.js
@@ -98,8 +98,8 @@ class StageCollection {
         throw new InvalidStageError('Seuil doit être compris entre 0 et 100.');
       }
     }
-    if (_.isEmpty(stage.title)) throw new InvalidStageError('Titre obligatoire.');
-    if (_.isEmpty(stage.message)) throw new InvalidStageError('Message obligatoire.');
+    if (_.isEmpty(stage.title?.trim())) throw new InvalidStageError('Titre obligatoire.');
+    if (_.isEmpty(stage.message?.trim())) throw new InvalidStageError('Message obligatoire.');
   }
 
   _hasLevel(level) {

--- a/api/tests/unit/domain/usecases/create-stage_test.js
+++ b/api/tests/unit/domain/usecases/create-stage_test.js
@@ -174,38 +174,76 @@ describe('Unit | UseCases | create-stage', function () {
       expect(error.message).to.equal('Palier non valide : Seuil doit être compris entre 0 et 100.');
     });
 
-    it('should throw InvalidStageError when title not provided', function () {
-      // given
-      const stageWithThreshold = {
-        level: null,
-        threshold: 50,
-        title: null,
-        message: 'message',
-      };
+    context('title', function () {
+      it('should throw InvalidStageError when title not provided', function () {
+        // given
+        const stageWithThreshold = {
+          level: null,
+          threshold: 50,
+          title: null,
+          message: 'message',
+        };
 
-      // when
-      const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithThreshold });
+        // when
+        const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithThreshold });
 
-      // then
-      expect(error).to.be.an.instanceof(InvalidStageError);
-      expect(error.message).to.equal('Palier non valide : Titre obligatoire.');
+        // then
+        expect(error).to.be.an.instanceof(InvalidStageError);
+        expect(error.message).to.equal('Palier non valide : Titre obligatoire.');
+      });
+
+      it('should throw InvalidStageError when empty title', function () {
+        // given
+        const stageWithThreshold = {
+          level: null,
+          threshold: 50,
+          title: ' ',
+          message: 'message',
+        };
+
+        // when
+        const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithThreshold });
+
+        // then
+        expect(error).to.be.an.instanceof(InvalidStageError);
+        expect(error.message).to.equal('Palier non valide : Titre obligatoire.');
+      });
     });
 
-    it('should throw InvalidStageError when message not provided', function () {
-      // given
-      const stageWithThreshold = {
-        level: null,
-        threshold: 50,
-        title: 'title',
-        message: '',
-      };
+    context('message', function () {
+      it('should throw InvalidStageError when not provided', function () {
+        // given
+        const stageWithThreshold = {
+          level: null,
+          threshold: 50,
+          title: 'title',
+          message: null,
+        };
 
-      // when
-      const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithThreshold });
+        // when
+        const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithThreshold });
 
-      // then
-      expect(error).to.be.an.instanceof(InvalidStageError);
-      expect(error.message).to.equal('Palier non valide : Message obligatoire.');
+        // then
+        expect(error).to.be.an.instanceof(InvalidStageError);
+        expect(error.message).to.equal('Palier non valide : Message obligatoire.');
+      });
+
+      it('should throw InvalidStageError when empty', function () {
+        // given
+        const stageWithThreshold = {
+          level: null,
+          threshold: 50,
+          title: 'title',
+          message: ' ',
+        };
+
+        // when
+        const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithThreshold });
+
+        // then
+        expect(error).to.be.an.instanceof(InvalidStageError);
+        expect(error.message).to.equal('Palier non valide : Message obligatoire.');
+      });
     });
 
     it('should create a stage by level', function () {
@@ -427,38 +465,76 @@ describe('Unit | UseCases | create-stage', function () {
       expect(error.message).to.equal('Palier non valide : Niveau déjà utilisé.');
     });
 
-    it('should throw InvalidStageError when title not provided', function () {
-      // given
-      const stageWithLevel = {
-        level: 4,
-        threshold: null,
-        title: null,
-        message: 'message',
-      };
+    context('title', function () {
+      it('should throw InvalidStageError when not provided', function () {
+        // given
+        const stageWithLevel = {
+          level: 4,
+          threshold: null,
+          title: null,
+          message: 'message',
+        };
 
-      // when
-      const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithLevel });
+        // when
+        const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithLevel });
 
-      // then
-      expect(error).to.be.an.instanceof(InvalidStageError);
-      expect(error.message).to.equal('Palier non valide : Titre obligatoire.');
+        // then
+        expect(error).to.be.an.instanceof(InvalidStageError);
+        expect(error.message).to.equal('Palier non valide : Titre obligatoire.');
+      });
+
+      it('should throw InvalidStageError when empty', function () {
+        // given
+        const stageWithLevel = {
+          level: 4,
+          threshold: null,
+          title: ' ',
+          message: 'message',
+        };
+
+        // when
+        const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithLevel });
+
+        // then
+        expect(error).to.be.an.instanceof(InvalidStageError);
+        expect(error.message).to.equal('Palier non valide : Titre obligatoire.');
+      });
     });
 
-    it('should throw InvalidStageError when message not provided', function () {
-      // given
-      const stageWithLevel = {
-        level: 4,
-        threshold: null,
-        title: 'title',
-        message: '',
-      };
+    context('message', function () {
+      it('should throw InvalidStageError when not provided', function () {
+        // given
+        const stageWithLevel = {
+          level: 4,
+          threshold: null,
+          title: 'title',
+          message: null,
+        };
 
-      // when
-      const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithLevel });
+        // when
+        const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithLevel });
 
-      // then
-      expect(error).to.be.an.instanceof(InvalidStageError);
-      expect(error.message).to.equal('Palier non valide : Message obligatoire.');
+        // then
+        expect(error).to.be.an.instanceof(InvalidStageError);
+        expect(error.message).to.equal('Palier non valide : Message obligatoire.');
+      });
+
+      it('should throw InvalidStageError when empty', function () {
+        // given
+        const stageWithLevel = {
+          level: 4,
+          threshold: null,
+          title: 'title',
+          message: ' ',
+        };
+
+        // when
+        const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithLevel });
+
+        // then
+        expect(error).to.be.an.instanceof(InvalidStageError);
+        expect(error.message).to.equal('Palier non valide : Message obligatoire.');
+      });
     });
   });
 
@@ -622,38 +698,76 @@ describe('Unit | UseCases | create-stage', function () {
       expect(error.message).to.equal('Palier non valide : Seuil déjà utilisé.');
     });
 
-    it('should throw InvalidStageError when title not provided', function () {
-      // given
-      const stageWithThreshold = {
-        level: null,
-        threshold: 65,
-        title: null,
-        message: 'message',
-      };
+    context('title', function () {
+      it('should throw InvalidStageError when title not provided', function () {
+        // given
+        const stageWithThreshold = {
+          level: null,
+          threshold: 65,
+          title: null,
+          message: 'message',
+        };
 
-      // when
-      const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithThreshold });
+        // when
+        const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithThreshold });
 
-      // then
-      expect(error).to.be.an.instanceof(InvalidStageError);
-      expect(error.message).to.equal('Palier non valide : Titre obligatoire.');
+        // then
+        expect(error).to.be.an.instanceof(InvalidStageError);
+        expect(error.message).to.equal('Palier non valide : Titre obligatoire.');
+      });
+
+      it('should throw InvalidStageError when empty title', function () {
+        // given
+        const stageWithThreshold = {
+          level: null,
+          threshold: 65,
+          title: ' ',
+          message: 'message',
+        };
+
+        // when
+        const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithThreshold });
+
+        // then
+        expect(error).to.be.an.instanceof(InvalidStageError);
+        expect(error.message).to.equal('Palier non valide : Titre obligatoire.');
+      });
     });
 
-    it('should throw InvalidStageError when message not provided', function () {
-      // given
-      const stageWithThreshold = {
-        level: null,
-        threshold: 65,
-        title: 'title',
-        message: '',
-      };
+    context('message', function () {
+      it('should throw InvalidStageError when not provided', function () {
+        // given
+        const stageWithThreshold = {
+          level: null,
+          threshold: 65,
+          title: 'title',
+          message: null,
+        };
 
-      // when
-      const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithThreshold });
+        // when
+        const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithThreshold });
 
-      // then
-      expect(error).to.be.an.instanceof(InvalidStageError);
-      expect(error.message).to.equal('Palier non valide : Message obligatoire.');
+        // then
+        expect(error).to.be.an.instanceof(InvalidStageError);
+        expect(error.message).to.equal('Palier non valide : Message obligatoire.');
+      });
+
+      it('should throw InvalidStageError when empty', function () {
+        // given
+        const stageWithThreshold = {
+          level: null,
+          threshold: 65,
+          title: 'title',
+          message: ' ',
+        };
+
+        // when
+        const error = catchErrSync(usecases.createStage)({ stageCollection, stage: stageWithThreshold });
+
+        // then
+        expect(error).to.be.an.instanceof(InvalidStageError);
+        expect(error.message).to.equal('Palier non valide : Message obligatoire.');
+      });
     });
   });
 });

--- a/api/tests/unit/domain/usecases/update-stage_test.js
+++ b/api/tests/unit/domain/usecases/update-stage_test.js
@@ -249,44 +249,88 @@ describe('Unit | UseCases | update-stage', function () {
       expect(error.message).to.equal('Palier non valide : Niveau doit être compris entre 0 et 5.');
     });
 
-    it('should throw InvalidStageError when title not provided', function () {
-      // given
-      const stageToUpdate = {
-        id: 51,
-        level: 4,
-        threshold: null,
-        message: 'nouveau message palier',
-        title: null,
-        prescriberDescription: 'nouvelle description prescripteur palier',
-        prescriberTitle: 'nouveau titre prescripteur palier',
-      };
+    context('title', function () {
+      it('should throw InvalidStageError when not provided', function () {
+        // given
+        const stageToUpdate = {
+          id: 51,
+          level: 4,
+          threshold: null,
+          message: 'nouveau message palier',
+          title: null,
+          prescriberDescription: 'nouvelle description prescripteur palier',
+          prescriberTitle: 'nouveau titre prescripteur palier',
+        };
 
-      // when
-      const error = catchErrSync(usecases.updateStage)({ stageCollection, stage: stageToUpdate });
+        // when
+        const error = catchErrSync(usecases.updateStage)({ stageCollection, stage: stageToUpdate });
 
-      // then
-      expect(error).to.be.an.instanceof(InvalidStageError);
-      expect(error.message).to.equal('Palier non valide : Titre obligatoire.');
+        // then
+        expect(error).to.be.an.instanceof(InvalidStageError);
+        expect(error.message).to.equal('Palier non valide : Titre obligatoire.');
+      });
+
+      it('should throw InvalidStageError when empty', function () {
+        // given
+        const stageToUpdate = {
+          id: 51,
+          level: 4,
+          threshold: null,
+          message: 'nouveau message palier',
+          title: ' ',
+          prescriberDescription: 'nouvelle description prescripteur palier',
+          prescriberTitle: 'nouveau titre prescripteur palier',
+        };
+
+        // when
+        const error = catchErrSync(usecases.updateStage)({ stageCollection, stage: stageToUpdate });
+
+        // then
+        expect(error).to.be.an.instanceof(InvalidStageError);
+        expect(error.message).to.equal('Palier non valide : Titre obligatoire.');
+      });
     });
 
-    it('should throw InvalidStageError when message not provided', function () {
-      // given
-      const stageToUpdate = {
-        id: 51,
-        level: 4,
-        threshold: null,
-        message: '',
-        title: 'nouveau titre palier',
-        prescriberDescription: 'nouvelle description prescripteur palier',
-        prescriberTitle: 'nouveau titre prescripteur palier',
-      };
+    context('message', function () {
+      it('should throw InvalidStageError when not provided', function () {
+        // given
+        const stageToUpdate = {
+          id: 51,
+          level: 4,
+          threshold: null,
+          message: null,
+          title: 'nouveau titre palier',
+          prescriberDescription: 'nouvelle description prescripteur palier',
+          prescriberTitle: 'nouveau titre prescripteur palier',
+        };
 
-      // when
-      const error = catchErrSync(usecases.updateStage)({ stageCollection, stage: stageToUpdate });
+        // when
+        const error = catchErrSync(usecases.updateStage)({ stageCollection, stage: stageToUpdate });
 
-      // then
-      expect(error).to.be.an.instanceof(InvalidStageError);
-      expect(error.message).to.equal('Palier non valide : Message obligatoire.');
+        // then
+        expect(error).to.be.an.instanceof(InvalidStageError);
+        expect(error.message).to.equal('Palier non valide : Message obligatoire.');
+      });
+
+      it('should throw InvalidStageError when empty', function () {
+        // given
+        const stageToUpdate = {
+          id: 51,
+          level: 4,
+          threshold: null,
+          message: ' ',
+          title: 'nouveau titre palier',
+          prescriberDescription: 'nouvelle description prescripteur palier',
+          prescriberTitle: 'nouveau titre prescripteur palier',
+        };
+
+        // when
+        const error = catchErrSync(usecases.updateStage)({ stageCollection, stage: stageToUpdate });
+
+        // then
+        expect(error).to.be.an.instanceof(InvalidStageError);
+        expect(error.message).to.equal('Palier non valide : Message obligatoire.');
+      });
     });
 
     context('Multiple stage collection', function () {
@@ -545,7 +589,27 @@ describe('Unit | UseCases | update-stage', function () {
         level: null,
         threshold: 33,
         message: 'nouveau message palier',
-        title: '',
+        title: null,
+        prescriberDescription: 'nouvelle description prescripteur palier',
+        prescriberTitle: 'nouveau titre prescripteur palier',
+      };
+
+      // when
+      const error = catchErrSync(usecases.updateStage)({ stageCollection, stage: stageToUpdate });
+
+      // then
+      expect(error).to.be.an.instanceof(InvalidStageError);
+      expect(error.message).to.equal('Palier non valide : Titre obligatoire.');
+    });
+
+    it('should throw InvalidStageError when empty title', function () {
+      // given
+      const stageToUpdate = {
+        id: 51,
+        level: null,
+        threshold: 33,
+        message: 'nouveau message palier',
+        title: ' ',
         prescriberDescription: 'nouvelle description prescripteur palier',
         prescriberTitle: 'nouveau titre prescripteur palier',
       };
@@ -565,6 +629,26 @@ describe('Unit | UseCases | update-stage', function () {
         level: null,
         threshold: 33,
         message: null,
+        title: 'nouveau titre palier',
+        prescriberDescription: 'nouvelle description prescripteur palier',
+        prescriberTitle: 'nouveau titre prescripteur palier',
+      };
+
+      // when
+      const error = catchErrSync(usecases.updateStage)({ stageCollection, stage: stageToUpdate });
+
+      // then
+      expect(error).to.be.an.instanceof(InvalidStageError);
+      expect(error.message).to.equal('Palier non valide : Message obligatoire.');
+    });
+
+    it('should throw InvalidStageError when empty message', function () {
+      // given
+      const stageToUpdate = {
+        id: 51,
+        level: null,
+        threshold: 33,
+        message: ' ',
         title: 'nouveau titre palier',
         prescriberDescription: 'nouvelle description prescripteur palier',
         prescriberTitle: 'nouveau titre prescripteur palier',


### PR DESCRIPTION
## :unicorn: Problème
L'utilisateur ne prenez conscience d'erreurs dans l'ajout de palier que lors de la validation de l'ajout du palier.

## :robot: Proposition
Ajouter une validation front sur les inputs  afin que l'utilisateur soit directement au courant des modifications à apporter

## :rainbow: Remarques
Nous en avons profité pour mettre à jour pix-UI (dernière version disponible) ainsi que pour améliorer le routing de la page insights.

## :100: Pour tester
- Aller sur PixAdmin
- Se rendre sur la page Profiles-Cibles
-  Sélectionner un profile-cible de type seuil avant de réitérer toutes les étapes suivantes sur un profile cible de type niveaux
- Cliquer sur l'onglet "Clés de lecture"
- Se rendre en bas de la page
- Tester l'ajout d'un nouveau palier en oubliant (ou pas) les différents champs à compléter