### PR TITLE
[TECH] Active la règle de lint SCSS d'ajout d'espace après les `:` sur Pix Orga

### DIFF
--- a/orga/.stylelintrc.json
+++ b/orga/.stylelintrc.json
@@ -5,7 +5,6 @@
     "declaration-block-no-duplicate-properties": null,
     "declaration-block-no-redundant-longhand-properties": null,
     "declaration-block-single-line-max-declarations": null,
-    "declaration-colon-space-after": null,
     "declaration-empty-line-before": null,
     "length-zero-no-unit": null,
     "no-descending-specificity": null,

--- a/orga/app/styles/components/campaign/list-header.scss
+++ b/orga/app/styles/components/campaign/list-header.scss
@@ -23,7 +23,7 @@
     ul {
       width: 100%;
       list-style: none;
-      margin:0;
+      margin: 0;
       padding: 0;
       display: flex;
     }

--- a/orga/app/styles/components/campaign/list.scss
+++ b/orga/app/styles/components/campaign/list.scss
@@ -14,6 +14,6 @@
 
   &__table-header-background {
     background: $pix-neutral-10;
-    box-shadow:0px 0px 0px 4px $pix-neutral-0 inset;
+    box-shadow: 0px 0px 0px 4px $pix-neutral-0 inset;
   }
 }

--- a/orga/app/styles/components/campaign/settings/campaign-settings.scss
+++ b/orga/app/styles/components/campaign/settings/campaign-settings.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
 
   > dl {
-    margin:0
+    margin: 0
   }
 }
 

--- a/orga/app/styles/components/ui/information.scss
+++ b/orga/app/styles/components/ui/information.scss
@@ -4,7 +4,7 @@
 }
 
 .information {
-  padding:0 $spacing-xs;
+  padding: 0 $spacing-xs;
   border-left: 1px solid $pix-neutral-22;
   font-size: 0.875rem;
 
@@ -20,6 +20,6 @@
 
   &:first-of-type {
     padding-left: 0;
-    border:none;
+    border: none;
   }
 }

--- a/orga/app/styles/pages/authenticated/campaigns/details/activity.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/activity.scss
@@ -8,7 +8,7 @@
   padding: 0;
 
   .warning-text {
-    font-size:0.825rem;
+    font-size: 0.825rem;
   }
 }
 


### PR DESCRIPTION
## :christmas_tree: Problème
On désactive une règle de lint utile.

## :gift: Solution
Réactiver cette règle et corriger les soucis.

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que la CI passe.
