### PR TITLE
[FEATURE] Créer la page "Récapitulatif" pour l'import en masse des sessions sur Pix Certif (PIX-6953).

### DIFF
--- a/certif/app/components/import/step-one-section.hbs
+++ b/certif/app/components/import/step-one-section.hbs
@@ -69,8 +69,8 @@
     <PixButtonLink @route="authenticated.sessions.list" @backgroundColor="transparent-light" @isBorderVisible={{true}}>
       {{t "common.actions.cancel"}}
     </PixButtonLink>
-    <PixButtonLink onclick={{@importSessions}} @isDisabled={{@isImportDisabled}}>
+    <PixButton @triggerAction={{@importSessions}} @isDisabled={{@isImportDisabled}}>
       {{t "common.actions.continue"}}
-    </PixButtonLink>
+    </PixButton>
   </div>
 </section>

--- a/certif/app/components/import/step-one-section.hbs
+++ b/certif/app/components/import/step-one-section.hbs
@@ -1,55 +1,55 @@
 <p>Comment ça marche ?</p>
 <PixCollapsible
-  @title={{t "pages.sessions.import.instructions-creation-title"}}
+  @title={{t "pages.sessions.import.step-one.instructions.creation.title"}}
   @iconTitle="plus"
   class="import-page_section--instructions"
 >
-  {{t "pages.sessions.import.instructions-creation-list"}}
+  {{t "pages.sessions.import.step-one.instructions.creation.list"}}
   <ul>
-    <li>{{t "pages.sessions.import.instructions-creation-list-with-candidates" htmlSafe=true}}</li>
-    <li>{{t "pages.sessions.import.instructions-creation-list-without-candidates" htmlSafe=true}}</li>
+    <li>{{t "pages.sessions.import.step-one.instructions.creation.list-with-candidates" htmlSafe=true}}</li>
+    <li>{{t "pages.sessions.import.step-one.instructions.creation.list-without-candidates" htmlSafe=true}}</li>
   </ul>
 </PixCollapsible>
 <PixCollapsible
-  @title={{t "pages.sessions.import.instructions-edition-title"}}
+  @title={{t "pages.sessions.import.step-one.instructions.edition.title"}}
   @iconTitle="plus"
   class="import-page__section--instructions"
 >
   <ul>
-    <li>{{t "pages.sessions.import.instructions-edition-replace" htmlSafe=true}}</li>
-    <li>{{t "pages.sessions.import.instructions-edition-subscription" htmlSafe=true}}</li>
+    <li>{{t "pages.sessions.import.step-one.instructions.edition.replace" htmlSafe=true}}</li>
+    <li>{{t "pages.sessions.import.step-one.instructions.edition.subscription" htmlSafe=true}}</li>
   </ul>
   <PixMessage @type="warning" @withIcon={{true}}>
-    {{t "pages.sessions.import.instructions-edition-warning"}}
+    {{t "pages.sessions.import.step-one.instructions.edition.warning"}}
   </PixMessage>
 </PixCollapsible>
 
 <section class="import-page__section--download panel">
   <div class="import-page__section--download__button">
     <FaIcon @icon="file-arrow-down" class="fa-2x download-icon" />
-    {{t "pages.sessions.import.session-import-template-label"}}
+    {{t "pages.sessions.import.step-one.session-import-template-label"}}
     <PixButton
       @backgroundColor="transparent-light"
       @isBorderVisible="{{true}}"
-      aria-label={{t "pages.sessions.import.session-import-template-label"}}
+      aria-label={{t "pages.sessions.import.step-one.session-import-template-label"}}
       @triggerAction={{@downloadSessionImportTemplate}}
     >
-      {{t "pages.sessions.import.session-import-template"}}
+      {{t "pages.sessions.import.step-one.session-import-template"}}
     </PixButton>
   </div>
 
   <div tabindex="0" class="import-page__section--download__button">
     <FaIcon @icon="cloud-arrow-up" class="fa-2x download-icon" />
-    {{t "pages.sessions.import.session-import-upload-label"}}
+    {{t "pages.sessions.import.step-one.session-import-upload-label"}}
     <PixButtonUpload
       @backgroundColor="transparent-light"
       @isBorderVisible="{{true}}"
       @id="file-upload"
       @onChange={{@preImportSessions}}
-      aria-label={{t "pages.sessions.import.session-import-upload-label"}}
+      aria-label={{t "pages.sessions.import.step-one.session-import-upload-label"}}
       accept=".csv"
     >
-      {{t "pages.sessions.import.session-import-upload"}}
+      {{t "pages.sessions.import.step-one.session-import-upload"}}
     </PixButtonUpload>
   </div>
 
@@ -57,7 +57,7 @@
     <div class="import-page__file-name" aria-label={{@fileName}}>
       {{@fileName}}
       <PixIconButton
-        @ariaLabel={{t "pages.sessions.import.cancel"}}
+        @ariaLabel={{t "pages.sessions.import.step-one.cancel"}}
         @icon="circle-xmark"
         @triggerAction={{@removeImport}}
         class="import-page-file-name__cancel"

--- a/certif/app/components/import/step-one-section.hbs
+++ b/certif/app/components/import/step-one-section.hbs
@@ -27,29 +27,29 @@
 <section class="import-page__section--download panel">
   <div class="import-page__section--download__button">
     <FaIcon @icon="file-arrow-down" class="fa-2x download-icon" />
-    {{t "pages.sessions.import.step-one.session-import-template-label"}}
+    <span>{{t "pages.sessions.import.step-one.actions.session-import-template.extra-information"}}</span>
     <PixButton
       @backgroundColor="transparent-light"
       @isBorderVisible="{{true}}"
-      aria-label={{t "pages.sessions.import.step-one.session-import-template-label"}}
+      aria-label={{t "pages.sessions.import.step-one.actions.session-import-template.extra-information"}}
       @triggerAction={{@downloadSessionImportTemplate}}
     >
-      {{t "pages.sessions.import.step-one.session-import-template"}}
+      {{t "pages.sessions.import.step-one.actions.session-import-template.label"}}
     </PixButton>
   </div>
 
   <div tabindex="0" class="import-page__section--download__button">
     <FaIcon @icon="cloud-arrow-up" class="fa-2x download-icon" />
-    {{t "pages.sessions.import.step-one.session-import-upload-label"}}
+    <span>{{t "pages.sessions.import.step-one.actions.session-import-upload.extra-information"}}</span>
     <PixButtonUpload
       @backgroundColor="transparent-light"
       @isBorderVisible="{{true}}"
       @id="file-upload"
       @onChange={{@preImportSessions}}
-      aria-label={{t "pages.sessions.import.step-one.session-import-upload-label"}}
+      aria-label={{t "pages.sessions.import.step-one.actions.session-import-upload.extra-information"}}
       accept=".csv"
     >
-      {{t "pages.sessions.import.step-one.session-import-upload"}}
+      {{t "pages.sessions.import.step-one.actions.session-import-upload.label"}}
     </PixButtonUpload>
   </div>
 
@@ -57,7 +57,7 @@
     <div class="import-page__file-name" aria-label={{@fileName}}>
       {{@fileName}}
       <PixIconButton
-        @ariaLabel={{t "pages.sessions.import.step-one.cancel"}}
+        @ariaLabel={{t "pages.sessions.import.step-one.actions.cancel.label"}}
         @icon="circle-xmark"
         @triggerAction={{@removeImport}}
         class="import-page-file-name__cancel"

--- a/certif/app/components/import/step-one-section.hbs
+++ b/certif/app/components/import/step-one-section.hbs
@@ -1,4 +1,4 @@
-<p>Comment ça marche ?</p>
+<p>{{t "pages.sessions.import.step-one.instructions.title"}}</p>
 <PixCollapsible
   @title={{t "pages.sessions.import.step-one.instructions.creation.title"}}
   @iconTitle="plus"

--- a/certif/app/components/import/step-one-section.hbs
+++ b/certif/app/components/import/step-one-section.hbs
@@ -1,0 +1,76 @@
+<p>Comment ça marche ?</p>
+<PixCollapsible
+  @title={{t "pages.sessions.import.instructions-creation-title"}}
+  @iconTitle="plus"
+  class="import-page_section--instructions"
+>
+  {{t "pages.sessions.import.instructions-creation-list"}}
+  <ul>
+    <li>{{t "pages.sessions.import.instructions-creation-list-with-candidates" htmlSafe=true}}</li>
+    <li>{{t "pages.sessions.import.instructions-creation-list-without-candidates" htmlSafe=true}}</li>
+  </ul>
+</PixCollapsible>
+<PixCollapsible
+  @title={{t "pages.sessions.import.instructions-edition-title"}}
+  @iconTitle="plus"
+  class="import-page__section--instructions"
+>
+  <ul>
+    <li>{{t "pages.sessions.import.instructions-edition-replace" htmlSafe=true}}</li>
+    <li>{{t "pages.sessions.import.instructions-edition-subscription" htmlSafe=true}}</li>
+  </ul>
+  <PixMessage @type="warning" @withIcon={{true}}>
+    {{t "pages.sessions.import.instructions-edition-warning"}}
+  </PixMessage>
+</PixCollapsible>
+
+<section class="import-page__section--download panel">
+  <div class="import-page__section--download__button">
+    <FaIcon @icon="file-arrow-down" class="fa-2x download-icon" />
+    {{t "pages.sessions.import.session-import-template-label"}}
+    <PixButton
+      @backgroundColor="transparent-light"
+      @isBorderVisible="{{true}}"
+      aria-label={{t "pages.sessions.import.session-import-template-label"}}
+      @triggerAction={{@downloadSessionImportTemplate}}
+    >
+      {{t "pages.sessions.import.session-import-template"}}
+    </PixButton>
+  </div>
+
+  <div tabindex="0" class="import-page__section--download__button">
+    <FaIcon @icon="cloud-arrow-up" class="fa-2x download-icon" />
+    {{t "pages.sessions.import.session-import-upload-label"}}
+    <PixButtonUpload
+      @backgroundColor="transparent-light"
+      @isBorderVisible="{{true}}"
+      @id="file-upload"
+      @onChange={{@preImportSessions}}
+      aria-label={{t "pages.sessions.import.session-import-upload-label"}}
+      accept=".csv"
+    >
+      {{t "pages.sessions.import.session-import-upload"}}
+    </PixButtonUpload>
+  </div>
+
+  {{#if @file}}
+    <div class="import-page__file-name" aria-label={{@fileName}}>
+      {{@fileName}}
+      <PixIconButton
+        @ariaLabel={{t "pages.sessions.import.cancel"}}
+        @icon="circle-xmark"
+        @triggerAction={{@removeImport}}
+        class="import-page-file-name__cancel"
+      />
+    </div>
+  {{/if}}
+
+  <div class="import-page__section--link-buttons">
+    <PixButtonLink @route="authenticated.sessions.list" @backgroundColor="transparent-light" @isBorderVisible={{true}}>
+      {{t "common.actions.cancel"}}
+    </PixButtonLink>
+    <PixButtonLink onclick={{@importSessions}} @isDisabled={{@isImportDisabled}}>
+      {{t "common.actions.continue"}}
+    </PixButtonLink>
+  </div>
+</section>

--- a/certif/app/components/import/step-one-section.hbs
+++ b/certif/app/components/import/step-one-section.hbs
@@ -65,12 +65,21 @@
     </div>
   {{/if}}
 
-  <div class="import-page__section--link-buttons">
-    <PixButtonLink @route="authenticated.sessions.list" @backgroundColor="transparent-light" @isBorderVisible={{true}}>
-      {{t "common.actions.cancel"}}
-    </PixButtonLink>
-    <PixButton @triggerAction={{@importSessions}} @isDisabled={{@isImportDisabled}}>
-      {{t "common.actions.continue"}}
-    </PixButton>
-  </div>
+  <ul class="import-page__section--link-buttons">
+    <li>
+      <PixButtonLink
+        @route="authenticated.sessions.list"
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
+      >
+        {{t "common.actions.cancel"}}
+      </PixButtonLink>
+    </li>
+    <li>
+      <PixButton @triggerAction={{@importSessions}} @isDisabled={{@isImportDisabled}}>
+        {{t "common.actions.continue"}}
+      </PixButton>
+    </li>
+  </ul>
+
 </section>

--- a/certif/app/components/import/step-two-section.hbs
+++ b/certif/app/components/import/step-two-section.hbs
@@ -1,0 +1,3 @@
+<section class="import-page__section--download panel">
+  <p>La liste des sessions a été importée avec succès.</p>
+</section>

--- a/certif/app/components/import/step-two-section.hbs
+++ b/certif/app/components/import/step-two-section.hbs
@@ -1,3 +1,5 @@
 <section class="import-page__section--download panel">
-  <p>La liste des sessions a été importée avec succès.</p>
+  <PixMessage @type={{if @isImportInError "error" "info"}}>
+    <p>{{@report}}</p>
+  </PixMessage>
 </section>

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -30,7 +30,7 @@ export default class ImportController extends Controller {
     try {
       await this.fileSaver.save({ url, token });
     } catch (e) {
-      this.notifications.error(this.intl.t('pages.sessions.sessions.session-import-template-dl-error'));
+      this.notifications.error(this.intl.t('pages.sessions.import.step-one.errors.download'));
     }
   }
 

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -62,4 +62,8 @@ export default class ImportController extends Controller {
     this.file = null;
     this.isImportDisabled = true;
   }
+
+  reset() {
+    this.isImportStepOne = true;
+  }
 }

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -15,6 +15,8 @@ export default class ImportController extends Controller {
   @tracked file = null;
   @tracked isImportDisabled = true;
   @tracked isImportStepOne = true;
+  @tracked report;
+  @tracked isImportInError = false;
 
   get fileName() {
     return this.file.name;
@@ -49,10 +51,12 @@ export default class ImportController extends Controller {
         return;
       }
       await adapter.importSessions(this.file, certificationCenterId);
-      this.isImportStepOne = false;
+      this.report = 'La liste des sessions a été importée avec succès.';
     } catch (err) {
-      this.notifications.error("Aucune session n'a été importée");
+      this.isImportInError = true;
+      this.report = err.errors[0].detail;
     } finally {
+      this.isImportStepOne = false;
       this.removeImport();
     }
   }

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -14,6 +14,7 @@ export default class ImportController extends Controller {
 
   @tracked file = null;
   @tracked isImportDisabled = true;
+  @tracked isImportStepOne = true;
 
   get fileName() {
     return this.file.name;
@@ -48,7 +49,7 @@ export default class ImportController extends Controller {
         return;
       }
       await adapter.importSessions(this.file, certificationCenterId);
-      this.notifications.success('La liste des sessions a été importée avec succès.');
+      this.isImportStepOne = false;
     } catch (err) {
       this.notifications.error("Aucune session n'a été importée");
     } finally {

--- a/certif/app/routes/authenticated/sessions/import.js
+++ b/certif/app/routes/authenticated/sessions/import.js
@@ -12,4 +12,8 @@ export default class ImportRoute extends Route {
       return this.router.replaceWith('authenticated.sessions.list');
     }
   }
+
+  resetController(controller) {
+    controller.reset();
+  }
 }

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -148,6 +148,12 @@
   }
 }
 
+.import-page-section-breadcrumb {
+  &__summary-link {
+    cursor: default;
+  }
+}
+
 .import-page-file-name {
   &__cancel {
     margin-left: 8px;

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -77,7 +77,7 @@
       background-color: $pix-neutral-25;
       border-radius: 50%;
       color: $pix-neutral-0;
-      content: "" counter(import-breadcrumb);
+      content: '' counter(import-breadcrumb);
       font-size: 1.1rem;
       font-weight: $font-medium;
       display: flex;
@@ -94,7 +94,6 @@
     ol li.active::before {
       background-color: $pix-success-60;
     }
-
   }
 
   &__section--download {

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -124,11 +124,8 @@
 
   &__section--link-buttons {
     display: flex;
+    gap: $spacing-s;
     margin-top: 24px;
-  }
-
-  &__section--link-buttons a:first-of-type {
-    margin-right: 16px;
   }
 
   &__file-name {

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -2,7 +2,10 @@
 <main class="import-page">
   <h1 class="page-title">{{t "pages.sessions.import.title"}}</h1>
 
-  <nav aria-label="Fil d'Ariane" class="import-page__section--breadcrumb panel">
+  <nav
+    aria-label={{t "pages.sessions.import.breadcrumb.extra-information"}}
+    class="import-page__section--breadcrumb panel"
+  >
     <ol>
       <li class={{if this.isImportStepOne "active" ""}}>
         <a href="">

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -1,98 +1,34 @@
 {{page-title (t "pages.sessions.import.title")}}
 <main class="import-page">
   <h1 class="page-title">{{t "pages.sessions.import.title"}}</h1>
-  <p>Comment ça marche ?</p>
-  <PixCollapsible
-    @title={{t "pages.sessions.import.instructions-creation-title"}}
-    @iconTitle="plus"
-    class="import-page_section--instructions"
-  >
-    {{t "pages.sessions.import.instructions-creation-list"}}
-    <ul>
-      <li>{{t "pages.sessions.import.instructions-creation-list-with-candidates" htmlSafe=true}}</li>
-      <li>{{t "pages.sessions.import.instructions-creation-list-without-candidates" htmlSafe=true}}</li>
-    </ul>
-  </PixCollapsible>
-  <PixCollapsible
-    @title={{t "pages.sessions.import.instructions-edition-title"}}
-    @iconTitle="plus"
-    class="import-page__section--instructions"
-  >
-    <ul>
-      <li>{{t "pages.sessions.import.instructions-edition-replace" htmlSafe=true}}</li>
-      <li>{{t "pages.sessions.import.instructions-edition-subscription" htmlSafe=true}}</li>
-    </ul>
-    <PixMessage @type="warning" @withIcon={{true}}>
-      {{t "pages.sessions.import.instructions-edition-warning"}}
-    </PixMessage>
-  </PixCollapsible>
+
   <nav aria-label="Fil d'Ariane" class="import-page__section--breadcrumb panel">
     <ol>
-      <li class="active">
+      <li class={{if this.isImportStepOne "active" ""}}>
         <a href="">
           {{t "pages.sessions.import.breadcrumb-import"}}
         </a>
       </li>
       <FaIcon @icon="chevron-right" class="breadcrumb-icon" />
-      <li>
+      <li class={{if this.isImportStepOne "" "active"}}>
         <a href="">
           {{t "pages.sessions.import.breadcrumb-summary"}}
         </a>
       </li>
     </ol>
   </nav>
-  <section class="import-page__section--download panel">
-    <div class="import-page__section--download__button">
-      <FaIcon @icon="file-arrow-down" class="fa-2x download-icon" />
-      {{t "pages.sessions.import.session-import-template-label"}}
-      <PixButton
-        @backgroundColor="transparent-light"
-        @isBorderVisible="{{true}}"
-        aria-label={{t "pages.sessions.import.session-import-template-label"}}
-        @triggerAction={{this.downloadSessionImportTemplate}}
-      >
-        {{t "pages.sessions.import.session-import-template"}}
-      </PixButton>
-    </div>
 
-    <div class="import-page__section--download__button">
-      <FaIcon @icon="cloud-arrow-up" class="fa-2x download-icon" />
-      {{t "pages.sessions.import.session-import-upload-label"}}
-      <PixButtonUpload
-        @backgroundColor="transparent-light"
-        @isBorderVisible="{{true}}"
-        @id="file-upload"
-        @onChange={{this.preImportSessions}}
-        aria-label={{t "pages.sessions.import.session-import-upload-label"}}
-        accept=".csv"
-      >
-        {{t "pages.sessions.import.session-import-upload"}}
-      </PixButtonUpload>
-    </div>
-
-    {{#if this.file}}
-      <div class="import-page__file-name" aria-label={{this.fileName}}>
-        {{this.fileName}}
-        <PixIconButton
-          @ariaLabel={{t "pages.sessions.import.cancel"}}
-          @icon="circle-xmark"
-          @triggerAction={{this.removeImport}}
-          class="import-page-file-name__cancel"
-        />
-      </div>
-    {{/if}}
-
-    <div class="import-page__section--link-buttons">
-      <PixButtonLink
-        @route="authenticated.sessions.list"
-        @backgroundColor="transparent-light"
-        @isBorderVisible={{true}}
-      >
-        {{t "common.actions.cancel"}}
-      </PixButtonLink>
-      <PixButtonLink onclick={{this.importSessions}} @isDisabled={{this.isImportDisabled}}>
-        {{t "common.actions.continue"}}
-      </PixButtonLink>
-    </div>
-  </section>
+  {{#if this.isImportStepOne}}
+    <Import::StepOneSection
+      @downloadSessionImportTemplate={{this.downloadSessionImportTemplate}}
+      @preImportSessions={{this.preImportSessions}}
+      @file={{this.file}}
+      @fileName={{this.fileName}}
+      @removeImport={{this.removeImport}}
+      @importSessions={{this.importSessions}}
+      @isImportDisabled={{this.isImportDisabled}}
+    />
+  {{else}}
+    <Import::StepTwoSection />
+  {{/if}}
 </main>

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -1,5 +1,8 @@
 {{page-title (t "pages.sessions.import.title")}}
 <main class="import-page">
+  <PixReturnTo @route="authenticated.sessions.list" class="import-page__previous-page-button">
+    {{t "pages.sessions.import.previous-page-button"}}
+  </PixReturnTo>
   <h1 class="page-title">{{t "pages.sessions.import.title"}}</h1>
 
   <nav

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -6,13 +6,13 @@
     <ol>
       <li class={{if this.isImportStepOne "active" ""}}>
         <a href="">
-          {{t "pages.sessions.import.breadcrumb-import"}}
+          {{t "pages.sessions.import.breadcrumb.import"}}
         </a>
       </li>
       <FaIcon @icon="chevron-right" class="breadcrumb-icon" />
       <li class={{if this.isImportStepOne "" "active"}}>
         <a href="">
-          {{t "pages.sessions.import.breadcrumb-summary"}}
+          {{t "pages.sessions.import.breadcrumb.summary"}}
         </a>
       </li>
     </ol>

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -1,3 +1,4 @@
+{{! template-lint-disable link-href-attributes }}
 {{page-title (t "pages.sessions.import.title")}}
 <main class="import-page">
   <PixReturnTo @route="authenticated.sessions.list" class="import-page__previous-page-button">
@@ -17,7 +18,7 @@
       </li>
       <FaIcon @icon="chevron-right" class="breadcrumb-icon" />
       <li class={{if this.isImportStepOne "" "active"}}>
-        <a href="">
+        <a role="link" aria-disabled="true" class="import-page-section-breadcrumb__summary-link">
           {{t "pages.sessions.import.breadcrumb.summary"}}
         </a>
       </li>

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -36,6 +36,6 @@
       @isImportDisabled={{this.isImportDisabled}}
     />
   {{else}}
-    <Import::StepTwoSection />
+    <Import::StepTwoSection @report={{this.report}} @isImportInError={{this.isImportInError}} />
   {{/if}}
 </main>

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -306,7 +306,7 @@ export default function () {
               code: 'INVALID_DOCUMENT',
               status: '422',
               title: 'Unprocessable Entity',
-              detail: 'Une erreur personnalisée.',
+              detail: 'Fichier non valide',
             },
           ],
         }

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -96,6 +96,28 @@ module('Acceptance | Session Import', function (hooks) {
         assert.dom(await screen.getByLabelText('fichier.csv')).hasText('fichier.csv');
       });
 
+      module('when leaving page and coming back', function () {
+        test('it should get back to step 1', async function (assert) {
+          // given
+          const blob = new Blob(['foo']);
+          const file = new File([blob], 'fichier.csv');
+          screen = await visit('/sessions/import');
+          const importButton = screen.getByLabelText('Importer le modèle complété');
+          await triggerEvent(importButton, 'change', { files: [file] });
+          const importConfirmationButton = screen.getByText('Continuer');
+          await click(importConfirmationButton);
+
+          // when
+          const outLink = screen.getByRole('link', { name: 'Revenir à la liste des sessions' });
+          await click(outLink);
+          await click(screen.getByRole('link', { name: 'Créer/éditer plusieurs sessions' }));
+
+          // then
+          assert.dom(importButton).exists();
+          assert.dom(screen.queryByLabelText('fichier.csv')).doesNotExist();
+        });
+      });
+
       module('when cancelling the import', function () {
         test("it should remove the file's name", async function (assert) {
           // given

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -71,12 +71,12 @@ module('Acceptance | Session Import', function (hooks) {
 
         // when
         screen = await visit('/sessions/import');
-        const importButton = await screen.findByText('Continuer');
+        const importButton = screen.getByRole('button', { name: 'Continuer' });
         assert.dom(importButton).hasClass('pix-button--disabled');
         const input = await screen.findByLabelText('Importer le modèle complété');
         await triggerEvent(input, 'change', { files: [file] });
         assert.dom(importButton).doesNotHaveClass('pix-button--disabled');
-        await click(await screen.findByText('Continuer'));
+        await click(importButton);
 
         // then
         assert.dom(importButton).hasClass('pix-button--disabled');
@@ -104,7 +104,7 @@ module('Acceptance | Session Import', function (hooks) {
           screen = await visit('/sessions/import');
           const importButton = screen.getByLabelText('Importer le modèle complété');
           await triggerEvent(importButton, 'change', { files: [file] });
-          const importConfirmationButton = screen.getByText('Continuer');
+          const importConfirmationButton = screen.getByRole('button', { name: 'Continuer' });
           await click(importConfirmationButton);
 
           // when
@@ -146,7 +146,7 @@ module('Acceptance | Session Import', function (hooks) {
           screen = await visit('/sessions/import');
           const input = screen.getByLabelText('Importer le modèle complété');
           await triggerEvent(input, 'change', { files: [file] });
-          const importButton = await screen.findByText('Continuer');
+          const importButton = screen.getByRole('button', { name: 'Continuer' });
           await click(importButton);
 
           // then
@@ -164,7 +164,7 @@ module('Acceptance | Session Import', function (hooks) {
           screen = await visit('/sessions/import');
           const input = await screen.findByLabelText('Importer le modèle complété');
           await triggerEvent(input, 'change', { files: [file] });
-          const importButton = await screen.findByText('Continuer');
+          const importButton = screen.getByRole('button', { name: 'Continuer' });
           await click(importButton);
 
           // then

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -122,16 +122,14 @@ module('Acceptance | Session Import', function (hooks) {
 
           // when
           screen = await visit('/sessions/import');
-          const input = await screen.findByLabelText('Importer le modèle complété');
+          const input = screen.getByLabelText('Importer le modèle complété');
           await triggerEvent(input, 'change', { files: [file] });
           const importButton = await screen.findByText('Continuer');
           await click(importButton);
 
           // then
-          assert
-            .dom('[data-test-notification-message="success"]')
-            .hasText('La liste des sessions a été importée avec succès.');
-          assert.dom(await screen.queryByLabelText('fichier.csv')).doesNotExist();
+          assert.dom(screen.getByText('La liste des sessions a été importée avec succès.')).exists();
+          assert.dom(screen.queryByLabelText('fichier.csv')).doesNotExist();
         });
       });
 

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -168,7 +168,7 @@ module('Acceptance | Session Import', function (hooks) {
           await click(importButton);
 
           // then
-          assert.dom('[data-test-notification-message="error"]').hasText("Aucune session n'a été importée");
+          assert.dom(screen.getByText('Fichier non valide')).exists();
         });
       });
     });

--- a/certif/tests/unit/controllers/authenticated/sessions/import_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/import_test.js
@@ -114,43 +114,5 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
       sinon.assert.calledWith(adapter.importSessions, file, '123');
       assert.ok(controller);
     });
-
-    test('should call the notifications service in case of an error', async function (assert) {
-      // given
-      const store = this.owner.lookup('service:store');
-      const adapter = store.adapterFor('sessions-import');
-      const sessionsImportStub = sinon.stub(adapter, 'importSessions');
-      sessionsImportStub.rejects();
-      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-        id: 123,
-      });
-
-      class CurrentUserStub extends Service {
-        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-      }
-
-      this.owner.register('service:current-user', CurrentUserStub);
-      const token = 'a token';
-
-      controller.file = Symbol('file 1');
-
-      controller.session = {
-        isAuthenticated: true,
-        data: {
-          authenticated: {
-            access_token: token,
-          },
-        },
-      };
-
-      controller.notifications = { error: sinon.stub(), clearAll: sinon.stub() };
-
-      // when
-      await controller.importSessions();
-
-      // then
-      sinon.assert.calledOnce(controller.notifications.error);
-      assert.ok(controller);
-    });
   });
 });

--- a/certif/tests/unit/controllers/authenticated/sessions/import_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/import_test.js
@@ -93,7 +93,8 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
       this.owner.register('service:current-user', CurrentUserStub);
       const token = 'a token';
 
-      controller.file = Symbol('file 1');
+      const file = Symbol('file 1');
+      controller.file = file;
 
       controller.session = {
         isAuthenticated: true,
@@ -104,13 +105,13 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
         },
       };
 
-      controller.notifications = { success: sinon.stub(), clearAll: sinon.stub() };
+      controller.notifications = { clearAll: sinon.stub() };
 
       // when
       await controller.importSessions();
 
       // then
-      sinon.assert.calledOnce(controller.notifications.success);
+      sinon.assert.calledWith(adapter.importSessions, file, '123');
       assert.ok(controller);
     });
 

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "actions": {
+      "back": "Retour",
       "cancel": "Cancel",
       "close": "Close",
       "continue": "Continue",
@@ -132,6 +133,7 @@
       },
       "import": {
         "title": "Créer/éditer plusieurs sessions",
+        "previous-page-button": "Revenir à la liste des sessions",
         "step-one": {
           "cancel": "Annuler l'import",
           "session-import-template": "Télécharger (.csv)",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -132,22 +132,32 @@
       },
       "import": {
         "title": "Créer/éditer plusieurs sessions",
-        "cancel": "Annuler l'import",
-        "session-import-template": "Télécharger (.csv)",
-        "session-import-template-dl-error": "Une erreur s'est produite pendant le téléchargement",
-        "session-import-template-label": "Télécharger le modèle vierge",
-        "session-import-upload": "Importer (.csv)",
-        "session-import-upload-label": "Importer le modèle complété",
-        "instructions-creation-title": "Pour créer des sessions ?",
-        "instructions-creation-list": "Vous pouvez créer des sessions :",
-        "instructions-creation-list-with-candidates": "<strong>Avec candidats</strong>, complétez le modèle dans son intégralité,",
-        "instructions-creation-list-without-candidates": "<strong>Sans candidat</strong>, complétez uniquement les informations des sessions.",
-        "instructions-edition-title": "Pour éditer la liste des candidats de sessions déjà créées ?",
-        "instructions-edition-replace": "<strong>Pour remplacer</strong> une liste pré-existante dans le fichier modèle,",
-        "instructions-edition-subscription": "<strong>Pour inscrire</strong> des candidats dans une session vide.",
-        "instructions-edition-warning": "Attention à renseigner le numéro de session sans les autres informations de sessions (ex: date, heure, etc.) pour éviter les doublons lors de la création.",
-        "breadcrumb-import": "Import du modèle",
-        "breadcrumb-summary": "Récapitulatif"
+        "step-one": {
+          "cancel": "Annuler l'import",
+          "session-import-template": "Télécharger (.csv)",
+          "session-import-template-dl-error": "Une erreur s'est produite pendant le téléchargement",
+          "session-import-template-label": "Télécharger le modèle vierge",
+          "session-import-upload": "Importer (.csv)",
+          "session-import-upload-label": "Importer le modèle complété",
+          "instructions": {
+            "creation": {
+              "title": "Pour créer des sessions ?",
+              "list": "Vous pouvez créer des sessions :",
+              "list-with-candidates": "<strong>Avec candidats</strong>, complétez le modèle dans son intégralité,",
+              "list-without-candidates": "<strong>Sans candidat</strong>, complétez uniquement les informations des sessions."
+            },
+            "edition": {
+              "title": "Pour éditer la liste des candidats de sessions déjà créées ?",
+              "replace": "<strong>Pour remplacer</strong> une liste pré-existante dans le fichier modèle,",
+              "subscription": "<strong>Pour inscrire</strong> des candidats dans une session vide.",
+              "warning": "Attention à renseigner le numéro de session sans les autres informations de sessions (ex: date, heure, etc.) pour éviter les doublons lors de la création."
+            }
+          }
+        },
+        "breadcrumb": {
+          "import": "Import du modèle",
+          "summary": "Récapitulatif"
+        }
       },
       "list": {
         "title": "Certification sessions",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -151,10 +151,12 @@
               "replace": "<strong>Pour remplacer</strong> une liste pré-existante dans le fichier modèle,",
               "subscription": "<strong>Pour inscrire</strong> des candidats dans une session vide.",
               "warning": "Attention à renseigner le numéro de session sans les autres informations de sessions (ex: date, heure, etc.) pour éviter les doublons lors de la création."
-            }
+            },
+            "title": "Comment ça marche ?"
           }
         },
         "breadcrumb": {
+          "extra-information": "Fil d'Arianne",
           "import": "Import du modèle",
           "summary": "Récapitulatif"
         }

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -132,15 +132,30 @@
         "unfinished-test-list-description": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon."
       },
       "import": {
+        "breadcrumb": {
+          "extra-information": "Fil d'Arianne",
+          "import": "Import du modèle",
+          "summary": "Récapitulatif"
+        },
         "title": "Créer/éditer plusieurs sessions",
         "previous-page-button": "Revenir à la liste des sessions",
         "step-one": {
-          "cancel": "Annuler l'import",
-          "session-import-template": "Télécharger (.csv)",
-          "session-import-template-dl-error": "Une erreur s'est produite pendant le téléchargement",
-          "session-import-template-label": "Télécharger le modèle vierge",
-          "session-import-upload": "Importer (.csv)",
-          "session-import-upload-label": "Importer le modèle complété",
+          "actions": {
+            "cancel": {
+              "label": "Annuler l'import"
+            },
+            "session-import-upload": {
+              "extra-information": "Importer le modèle complété",
+              "label": "Importer (.csv)"
+            },
+            "session-import-template": {
+              "extra-information": "Télécharger le modèle vierge",
+              "label": "Télécharger (.csv)"
+            }
+          },
+          "errors": {
+            "download": "Une erreur s'est produite pendant le téléchargement"
+          },
           "instructions": {
             "creation": {
               "title": "Pour créer des sessions ?",
@@ -156,11 +171,6 @@
             },
             "title": "Comment ça marche ?"
           }
-        },
-        "breadcrumb": {
-          "extra-information": "Fil d'Arianne",
-          "import": "Import du modèle",
-          "summary": "Récapitulatif"
         }
       },
       "list": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -132,22 +132,32 @@
       },
       "import": {
         "title": "Créer/éditer plusieurs sessions",
-        "cancel": "Annuler l'import",
-        "session-import-template": "Télécharger (.csv)",
-        "session-import-template-dl-error": "Une erreur s'est produite pendant le téléchargement",
-        "session-import-template-label": "Télécharger le modèle vierge",
-        "session-import-upload": "Importer (.csv)",
-        "session-import-upload-label": "Importer le modèle complété",
-        "instructions-creation-title": "Pour créer des sessions ?",
-        "instructions-creation-list": "Vous pouvez créer des sessions :",
-        "instructions-creation-list-with-candidates": "<strong>Avec candidats</strong>, complétez le modèle dans son intégralité,",
-        "instructions-creation-list-without-candidates": "<strong>Sans candidat</strong>, complétez uniquement les informations des sessions.",
-        "instructions-edition-title": "Pour éditer la liste des candidats de sessions déjà créées ?",
-        "instructions-edition-replace": "<strong>Pour remplacer</strong> une liste pré-existante dans le fichier modèle,",
-        "instructions-edition-subscription": "<strong>Pour inscrire</strong> des candidats dans une session vide.",
-        "instructions-edition-warning": "Attention à renseigner le numéro de session sans les autres informations de sessions (ex: date, heure, etc.) pour éviter les doublons lors de la création.",
-        "breadcrumb-import": "Import du modèle",
-        "breadcrumb-summary": "Récapitulatif"
+        "step-one": {
+          "cancel": "Annuler l'import",
+          "session-import-template": "Télécharger (.csv)",
+          "session-import-template-dl-error": "Une erreur s'est produite pendant le téléchargement",
+          "session-import-template-label": "Télécharger le modèle vierge",
+          "session-import-upload": "Importer (.csv)",
+          "session-import-upload-label": "Importer le modèle complété",
+          "instructions": {
+            "creation": {
+              "title": "Pour créer des sessions ?",
+              "list": "Vous pouvez créer des sessions :",
+              "list-with-candidates": "<strong>Avec candidats</strong>, complétez le modèle dans son intégralité,",
+              "list-without-candidates": "<strong>Sans candidat</strong>, complétez uniquement les informations des sessions."
+            },
+            "edition": {
+              "title": "Pour éditer la liste des candidats de sessions déjà créées ?",
+              "replace": "<strong>Pour remplacer</strong> une liste pré-existante dans le fichier modèle,",
+              "subscription": "<strong>Pour inscrire</strong> des candidats dans une session vide.",
+              "warning": "Attention à renseigner le numéro de session sans les autres informations de sessions (ex: date, heure, etc.) pour éviter les doublons lors de la création."
+            }
+          }
+        },
+        "breadcrumb": {
+          "import": "Import du modèle",
+          "summary": "Récapitulatif"
+        }
       },
       "list": {
         "title": "Sessions de certification",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "actions": {
+      "back": "Retour",
       "cancel": "Annuler",
       "close": "Fermer",
       "continue": "Continuer",
@@ -132,6 +133,7 @@
       },
       "import": {
         "title": "Créer/éditer plusieurs sessions",
+        "previous-page-button": "Revenir à la liste des sessions",
         "step-one": {
           "cancel": "Annuler l'import",
           "session-import-template": "Télécharger (.csv)",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -151,10 +151,12 @@
               "replace": "<strong>Pour remplacer</strong> une liste pré-existante dans le fichier modèle,",
               "subscription": "<strong>Pour inscrire</strong> des candidats dans une session vide.",
               "warning": "Attention à renseigner le numéro de session sans les autres informations de sessions (ex: date, heure, etc.) pour éviter les doublons lors de la création."
-            }
+            },
+            "title": "Comment ça marche ?"
           }
         },
         "breadcrumb": {
+          "extra-information": "Fil d'Arianne",
           "import": "Import du modèle",
           "summary": "Récapitulatif"
         }

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -132,15 +132,30 @@
         "unfinished-test-list-description": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon."
       },
       "import": {
+        "breadcrumb": {
+          "extra-information": "Fil d'Arianne",
+          "import": "Import du modèle",
+          "summary": "Récapitulatif"
+        },
         "title": "Créer/éditer plusieurs sessions",
         "previous-page-button": "Revenir à la liste des sessions",
         "step-one": {
-          "cancel": "Annuler l'import",
-          "session-import-template": "Télécharger (.csv)",
-          "session-import-template-dl-error": "Une erreur s'est produite pendant le téléchargement",
-          "session-import-template-label": "Télécharger le modèle vierge",
-          "session-import-upload": "Importer (.csv)",
-          "session-import-upload-label": "Importer le modèle complété",
+          "actions": {
+            "cancel": {
+              "label": "Annuler l'import"
+            },
+            "session-import-upload": {
+              "extra-information": "Importer le modèle complété",
+              "label": "Importer (.csv)"
+            },
+            "session-import-template": {
+              "extra-information": "Télécharger le modèle vierge",
+              "label": "Télécharger (.csv)"
+            }
+          },
+          "errors": {
+            "download": "Une erreur s'est produite pendant le téléchargement"
+          },
           "instructions": {
             "creation": {
               "title": "Pour créer des sessions ?",
@@ -156,11 +171,6 @@
             },
             "title": "Comment ça marche ?"
           }
-        },
-        "breadcrumb": {
-          "extra-information": "Fil d'Arianne",
-          "import": "Import du modèle",
-          "summary": "Récapitulatif"
         }
       },
       "list": {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix Certif, lorsque l'on fait un import de sessions en masse, une notification nous est retourné. Or on doit être normalement être redirigé vers une nouvelle page récapitulatif.

## :robot: Proposition
Créer la page "Récapitulatif"

## :rainbow: Remarques
Le lien "Récapitulatif" du fil d'Arianne est désactivée (il reste "actif" visuellement lorsqu'on arrive sur la page)
https://a11y-guidelines.orange.com/en/articles/disable-elements/#disable-a-link

## :100: Pour tester

- Se connecter sur pix Certif avec certifpro@example.net
- Cliquer sur Editer/créer plusieurs sessions
- Remplir le fichier csv avec des données viables
- Valider et constater que l'on est redirigé vers la nouvelle page avec un message de confirmation.

- Remplir le fichier csv avec des données erronées 
- Valider et constater que l'on est redirigé vers la nouvelle page avec message d'erreur.

- Toujours sur la page de récapitulatif, cliquer sur le lien pour revenir à la liste des sessions
- Cliquer sur le bouton pour créer/éditer plusieurs sessions
- Constater que l'on revient bien dans la première étape pour importer le modèle