### PR TITLE
[BUGFIX] Ne pas avoir d'erreur 500 lorsque le nom de salle n'est pas fourni sur la première ligne du CSV (PIX-7212).

### DIFF
--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -51,7 +51,12 @@ function deserializeForSessionsImport(parsedCsvData) {
         sessions.push(currentParsedSession);
       }
     } else {
-      currentParsedSession = sessions.at(-1) ?? emptySession;
+      if (sessions.at(-1)) {
+        currentParsedSession = sessions.at(-1);
+      } else {
+        currentParsedSession = emptySession;
+        sessions.push(currentParsedSession);
+      }
     }
 
     const examiner = data.examiner.trim();
@@ -66,7 +71,7 @@ function deserializeForSessionsImport(parsedCsvData) {
 
   return sessions.map((session) => ({
     ...session,
-    examiner: session.examiner?.join(', '),
+    examiner: session.examiner ? session.examiner.join(', ') : '',
   }));
 }
 

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -1,7 +1,7 @@
 const logger = require('../../logger');
 const { FileValidationError } = require('../../../../lib/domain/errors');
 const { convertDateValue } = require('../../utils/date-utils');
-const { headers, COMPLEMENTARY_CERTIFICATION_SUFFIX } = require('../../utils/csv/sessions-import');
+const { headers, emptySession, COMPLEMENTARY_CERTIFICATION_SUFFIX } = require('../../utils/csv/sessions-import');
 const { isEmpty } = require('lodash');
 const { checkCsvHeader, parseCsvWithHeader } = require('../../helpers/csv');
 
@@ -51,8 +51,9 @@ function deserializeForSessionsImport(parsedCsvData) {
         sessions.push(currentParsedSession);
       }
     } else {
-      currentParsedSession = sessions.at(-1);
+      currentParsedSession = sessions.at(-1) ?? emptySession;
     }
+
     const examiner = data.examiner.trim();
     if (examiner.length && !currentParsedSession.examiner.includes(examiner)) {
       currentParsedSession.examiner.push(examiner);
@@ -208,8 +209,8 @@ function _verifyHeaders({ csvLineKeys, parsedCsvLine, headers }) {
   });
 }
 
-function _hasSessionInformation({ room }) {
-  return Boolean(room);
+function _hasSessionInformation({ address, room, date, time, examiner }) {
+  return Boolean(address) || Boolean(room) || Boolean(date) || Boolean(time) || Boolean(examiner);
 }
 
 function _hasCandidateInformation({ lastName }) {

--- a/api/lib/infrastructure/utils/csv/sessions-import.js
+++ b/api/lib/infrastructure/utils/csv/sessions-import.js
@@ -44,6 +44,7 @@ const emptySession = {
   extraTimePercentage: '',
   billingMode: '',
   prepaymentCode: '',
+  certificationCandidates: [],
 };
 
 const COMPLEMENTARY_CERTIFICATION_SUFFIX = "('oui' ou laisser vide)";

--- a/api/lib/infrastructure/utils/csv/sessions-import.js
+++ b/api/lib/infrastructure/utils/csv/sessions-import.js
@@ -22,9 +22,34 @@ const headers = {
   prepaymentCode: 'Code de prépaiement',
 };
 
+const emptySession = {
+  sessionId: '',
+  address: '',
+  room: '',
+  date: '',
+  time: '',
+  examiner: '',
+  description: '',
+  lastName: '',
+  firstName: '',
+  birthdate: '',
+  sex: '',
+  birthINSEECode: '',
+  birthPostalCode: '',
+  birthCity: '',
+  birthCountry: '',
+  resultRecipientEmail: '',
+  email: '',
+  externalId: '',
+  extraTimePercentage: '',
+  billingMode: '',
+  prepaymentCode: '',
+};
+
 const COMPLEMENTARY_CERTIFICATION_SUFFIX = "('oui' ou laisser vide)";
 
 module.exports = {
   headers,
+  emptySession,
   COMPLEMENTARY_CERTIFICATION_SUFFIX,
 };

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -3,6 +3,7 @@ const csvSerializer = require('../../../../../lib/infrastructure/serializers/csv
 const logger = require('../../../../../lib/infrastructure/logger');
 const _ = require('lodash');
 const { FileValidationError } = require('../../../../../lib/domain/errors');
+const { emptySession } = require('../../../../../lib/infrastructure/utils/csv/sessions-import');
 
 describe('Unit | Serializer | CSV | csv-serializer', function () {
   describe('#serializeLine', function () {
@@ -88,6 +89,44 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
         // then
         expect(error).to.be.instanceOf(FileValidationError);
+      });
+    });
+
+    describe('when importing sessions', function () {
+      describe('when every mandatory information is missing', function () {
+        it('should not throw an error', async function () {
+          const parsedCsvData = [
+            {
+              'N° de session': '',
+              '* Nom du site': '',
+              '* Nom de la salle': '',
+              '* Date de début': '',
+              '* Heure de début (heure locale)': '',
+              '* Surveillant(s)': '',
+              'Observations (optionnel)': '',
+              '* Nom de naissance': 'Paul',
+              '* Prénom': 'Pierre',
+              '* Date de naissance (format: jj/mm/aaaa)': '12/09/1987',
+              '* Sexe (M ou F)': 'M',
+              'Code Insee': '',
+              'Code postal': '',
+              'Nom de la commune': '',
+              '* Pays': 'France',
+              'E-mail du destinataire des résultats (formateur, enseignant…)': '',
+              'E-mail de convocation': '',
+              'Identifiant local': '',
+              'Temps majoré ?': '',
+              'Tarification part Pix': '',
+              'Code de prépaiement': '',
+            },
+          ];
+
+          // when
+          const result = await csvSerializer.deserializeForSessionsImport(parsedCsvData);
+
+          // then
+          expect(result).to.deep.equal([emptySession]);
+        });
       });
     });
 
@@ -302,7 +341,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           const expectedResult = [
             {
               sessionId: 1,
-              examiner: undefined,
+              examiner: '',
               certificationCandidates: [
                 {
                   lastName: 'Candidat 1',


### PR DESCRIPTION
## :unicorn: Problème

Lors de l'import d'un fichier CSV, si la première ligne du fichier ne contient pas de nom de salle, une erreur 500 est levée.

## :robot: Proposition

Passer un objet vide à la place du undefined retourné en tant que session courante.

## :rainbow: Remarques

On ne renvoie pas d'erreur à ce niveau car les erreurs sont traitées à l'étape suivante du traitement du fichier.

## :100: Pour tester

Importer le fichier csv suivant : 
```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
,11 rue des églantines,,28/01/2024,15:00,José,observations,,,,,,,,,,,,,,,,
```

Constater qu'une erreur 422 est levée, et non une erreur 500.