### PR TITLE
[BUGFIX] Ne pas envoyer l'ancienne valeur lorsque le nouveau palier est en Erreur (Pix-7211)

### DIFF
--- a/admin/app/components/target-profiles/stages/new-stage.hbs
+++ b/admin/app/components/target-profiles/stages/new-stage.hbs
@@ -3,7 +3,6 @@
     {{#if @isTypeLevel}}
       <Stages::StageLevelSelect
         @availableLevels={{@availableLevels}}
-        @value={{@level}}
         @onChange={{@setLevel}}
         class="stages-table__level-select"
         required="true"
@@ -16,7 +15,6 @@
         @validationStatus={{this.thresholdStatus}}
         @requiredLabel="Champ obligatoire"
         type="number"
-        @value={{@threshold}}
         @ariaLabel="Seuil du palier"
         {{on "focusout" this.checkThresholdValidity}}
       />
@@ -28,7 +26,6 @@
       @errorMessage="Le titre est vide"
       @validationStatus={{this.titleStatus}}
       @requiredLabel="Champ obligatoire"
-      @value={{@title}}
       @ariaLabel="Titre du palier"
       {{on "focusout" this.checkTitleValidity}}
     />
@@ -39,7 +36,6 @@
       @errorMessage="Le message est vide"
       @validationStatus={{this.messageStatus}}
       @requiredLabel="Champ obligatoire"
-      @value={{@message}}
       @ariaLabel="Message du palier"
       {{on "focusout" this.checkMessageValidity}}
     />

--- a/admin/app/components/target-profiles/stages/new-stage.js
+++ b/admin/app/components/target-profiles/stages/new-stage.js
@@ -11,15 +11,13 @@ export default class NewStage extends Component {
   @action
   checkThresholdValidity(event) {
     const threshold = Number(event.target.value);
-    if (!isInteger(threshold)) {
-      this.thresholdStatus = 'error';
-      return;
-    }
-    if (this.args.unavailableThresholds.includes(threshold)) {
-      this.thresholdStatus = 'error';
-      return;
-    }
-    if (threshold < 0 || threshold > 100) {
+    if (
+      !isInteger(threshold) ||
+      this.args.unavailableThresholds.includes(threshold) ||
+      threshold < 0 ||
+      threshold > 100
+    ) {
+      this.args.stage.set('threshold', null);
       this.thresholdStatus = 'error';
       return;
     }
@@ -34,6 +32,7 @@ export default class NewStage extends Component {
 
     if (!title) {
       this.titleStatus = 'error';
+      this.args.stage.set('title', null);
       return;
     }
     this.titleStatus = 'success';
@@ -46,6 +45,7 @@ export default class NewStage extends Component {
 
     if (!message) {
       this.messageStatus = 'error';
+      this.args.stage.set('message', null);
       return;
     }
     this.messageStatus = 'success';


### PR DESCRIPTION
## :unicorn: Problème
A la création du palier, nous envoyons l'ancienne valeur lorsque la nouvelle valeur saisie est en erreur

## :robot: Proposition
Si une erreur est levé, mettre la valeur du model a null avant d'être jeter par le Back

## :rainbow: Remarques
RAS

## :100: Pour tester
Ajouter un nouveau palier sur le profil cible 501 - Saisir seuil titre message valide . essayer de mettre chacun des champs invalide. et cliquer sur enregistrer. Une erreur Back est levé.