### PR TITLE
[FEATURE] Passer "Certification complémentaires" au singulier sur Pix Certif (PIX-7033).

### DIFF
--- a/certif/app/components/certification-candidate-details-modal.hbs
+++ b/certif/app/components/certification-candidate-details-modal.hbs
@@ -101,7 +101,7 @@
       {{/if}}
       {{#if @displayComplementaryCertification}}
         <li class="certification-candidate-details-modal__row">
-          <span class="certification-candidate-details-modal__row__label">Certifications complémentaires</span>
+          <span class="certification-candidate-details-modal__row__label">Certification complémentaire</span>
           <span class="certification-candidate-details-modal__row__value">
             {{if @candidate.complementaryCertifications @candidate.complementaryCertificationsList "-"}}
           </span>

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -63,7 +63,7 @@
               <th class="certification-candidates-table__payment-options">Tarification part Pix</th>
             {{/if}}
             {{#if @displayComplementaryCertification}}
-              <th>Certifications complémentaires</th>
+              <th>Certification complémentaire</th>
             {{/if}}
           </tr>
         </thead>

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -298,7 +298,7 @@
 
       {{#if this.complementaryCertifications.length}}
         <div class="new-certification-candidate-modal__form__field">
-          <span class="label">Certifications complémentaires</span>
+          <span class="label">Certification complémentaire</span>
           <div class="complementary-certifications-checkbox-list">
             <fieldset id="complementary-certifications">
               <label for="no-complementaryCertification">


### PR DESCRIPTION
## :unicorn: Problème
Un candidat ne peut être inscrit qu'à une seule certification complémentaire à la fois, pourtant on retrouve “Certifications complémentaires” au pluriel sur plusieurs pages de l'application.

## :robot: Proposition
Passer "Certification complémentaires" au singulier.

## :100: Pour tester

- Se connecter sur Pix Certif avec certifsup@example.net
- Cliquer sur la session qui possède 5 candidats
- Cliquer sur le bouton Inscrire candidat
- Constater que le Certification complémentaire de la modale a été corrigé (`certification-candidate-details-modal.hbs`)
- Annuler l'inscription et dans les détails de la session, cliquer sur l'onglet candidat
- Cliquer sur "Voir détails" d'un candidat au hasard
- Constater que le "Certification complémentaire" de la modale a été corrigé (`new-certification-candidate-modal.hbs`)
- (`enrolled-candidates.hbs` ?)