### PR TITLE
[FEATURE] Ajouter des messages d'erreur visuels lors de champs invalides dans l'édition de palier

### DIFF
--- a/admin/app/components/stages/stage.hbs
+++ b/admin/app/components/stages/stage.hbs
@@ -17,6 +17,7 @@
       @stageTypeName={{this.stageTypeName}}
       @toggleEditMode={{@toggleEditMode}}
       @availableLevels={{@availableLevels}}
+      @unavailableThresholds={{@unavailableThresholds}}
     />
   {{else}}
     <Stages::ViewStage

--- a/admin/app/components/stages/update-stage.hbs
+++ b/admin/app/components/stages/update-stage.hbs
@@ -12,13 +12,17 @@
           @value={{this.level}}
         />
       {{else}}
-        <Input
-          id="threshold-or-level"
-          @type="number"
-          class="form-control"
+        <PixInput
+          @id="threshold-or-level"
+          @errorMessage="Le seuil est invalide"
+          @validationStatus={{this.thresholdStatus}}
+          @requiredLabel="Champ obligatoire"
+          type="number"
           @value={{this.threshold}}
+          @ariaLabel="Seuil du palier"
           min="0"
           max="100"
+          {{on "focusout" this.checkThresholdValidity}}
         />
       {{/if}}
       <br />
@@ -26,13 +30,27 @@
       <label for="title" class="form-field__label">
         Titre
       </label>
-      <Input id="title" @type="text" class="form-control" @value={{this.title}} />
+      <PixInput
+        @id="title"
+        @errorMessage="Le titre est vide"
+        @validationStatus={{this.titleStatus}}
+        @requiredLabel="Champ obligatoire"
+        @value={{this.title}}
+        type="text"
+        @ariaLabel="Titre du palier"
+        {{on "focusout" this.checkTitleValidity}}
+      />
       <br />
 
       <label for="message" class="form-field__label">
         Message
       </label>
-      <Textarea id="message" class="form-control" @value={{this.message}} rows="4" />
+      <PixTextarea
+        id="message"
+        @value={{this.message}}
+        @errorMessage={{this.messageError}}
+        {{on "focusout" this.checkMessageValidity}}
+      />
       <br />
 
       <label for="prescriberTitle" class="form-field__label">

--- a/admin/app/components/stages/update-stage.js
+++ b/admin/app/components/stages/update-stage.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
+import isInteger from 'lodash/isInteger';
 
 export default class UpdateStage extends Component {
   @service notifications;
@@ -12,6 +13,9 @@ export default class UpdateStage extends Component {
   @tracked message;
   @tracked prescriberTitle;
   @tracked prescriberDescription;
+  @tracked thresholdStatus = 'default';
+  @tracked titleStatus = 'default';
+  @tracked messageError = null;
 
   constructor() {
     super(...arguments);
@@ -44,11 +48,57 @@ export default class UpdateStage extends Component {
   @action
   async updateStage(event) {
     event.preventDefault();
+    if ([this.thresholdStatus, this.titleStatus].includes('error')) return;
     await this._updateStage();
   }
 
   @action
   setLevel(level) {
     this.level = level;
+  }
+
+  @action
+  checkThresholdValidity(event) {
+    const newThreshold = Number(event.target.value);
+    if (
+      !isInteger(newThreshold) ||
+      newThreshold < 0 ||
+      newThreshold > 100 ||
+      this.args.unavailableThresholds.includes(newThreshold)
+    ) {
+      this.thresholdStatus = 'error';
+      this.threshold = null;
+      return;
+    }
+
+    this.thresholdStatus = 'success';
+    this.threshold = newThreshold;
+  }
+
+  @action
+  checkTitleValidity(event) {
+    const title = event.target.value.trim();
+
+    if (!title) {
+      this.titleStatus = 'error';
+      this.title = null;
+      return;
+    }
+    this.titleStatus = 'success';
+    this.title = title;
+  }
+
+  @action
+  checkMessageValidity(event) {
+    const message = event.target.value.trim();
+
+    if (!message) {
+      this.message = null;
+
+      this.messageError = 'Message vide.';
+      return;
+    }
+    this.messageError = null;
+    this.message = message;
   }
 }

--- a/admin/app/controllers/authenticated/target-profiles/target-profile/stages/stage.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile/stages/stage.js
@@ -14,6 +14,10 @@ export default class StageController extends Controller {
     return difference(allLevels, unavailableLevels);
   }
 
+  get unavailableThresholds() {
+    return this.model.targetProfile.stages.map((stage) => (this.model.stage.id === stage.id ? null : stage.threshold));
+  }
+
   @action
   toggleEditMode() {
     this.isEditMode = !this.isEditMode;

--- a/admin/app/templates/authenticated/target-profiles/target-profile/stages/stage.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile/stages/stage.hbs
@@ -2,6 +2,7 @@
   @stage={{@model.stage}}
   @targetProfile={{@model.targetProfile}}
   @availableLevels={{this.availableLevels}}
+  @unavailableThresholds={{this.unavailableThresholds}}
   @toggleEditMode={{this.toggleEditMode}}
   @isEditMode={{this.isEditMode}}
 />


### PR DESCRIPTION
## :unicorn: Problème
L'utilisateur n'a pas de retours visuels d'erreurs possibles avant de valider l'édition de son palier.

## :robot: Proposition
Ajouter des messages d'erreur à chaque focus-out

## :rainbow: Remarques
Bonsoir

## :100: Pour tester
Aller éditer des paliers dans Pix Admin et faire exprès de mettre des valeurs invalides