### PR TITLE
[FEATURE] Utiliser un counter CSS pour les formulaires de création de Profile cible et de déclencheur de contenu formatif (PIX-7203)

### DIFF
--- a/admin/app/components/common/tubes-selection.hbs
+++ b/admin/app/components/common/tubes-selection.hbs
@@ -3,7 +3,7 @@
   {{did-update this.refreshAreas this.selectedFrameworkIds}}
   class="tubes-selection"
 >
-  <Card class="tubes-selection__card" @title="2. Sélection des sujets">
+  <Card class="tubes-selection__card" @title="Sélection des sujets">
     <div class="tubes-selection__inline-layout">
       <PixMultiSelect
         class="tubes-selection__multi-select"

--- a/admin/app/components/target-profiles/create-target-profile-form.hbs
+++ b/admin/app/components/target-profiles/create-target-profile-form.hbs
@@ -1,7 +1,7 @@
 <form class="form create-target-profile" {{on "submit" this.onSubmit}}>
 
   <section class="form-section">
-    <Card class="create-target-profile__card" @title="1. Information sur le profil cible">
+    <Card class="create-target-profile__card" @title="Information sur le profil cible">
       <PixInput
         class="form-field"
         @id="targetProfileName"
@@ -55,7 +55,7 @@
       @displayDeviceCompatibility={{true}}
     />
 
-    <Card class="create-target-profile__card" @title="3. Personnalisation">
+    <Card class="create-target-profile__card" @title="Personnalisation">
       <PixInput
         @id="imageUrl"
         class="input-url"

--- a/admin/app/styles/components/target-profiles/create-target-profile-form.scss
+++ b/admin/app/styles/components/target-profiles/create-target-profile-form.scss
@@ -1,8 +1,17 @@
 .create-target-profile {
   color: $pix-neutral-70;
+  counter-reset: title;
 
   &__card {
     margin-bottom: $spacing-m;
+  }
+
+  .card__title {
+    counter-increment: title;
+
+    &::before {
+      content: counter(title) '.\00a0';
+    }
   }
 
   &__checkbox-container {

--- a/admin/app/styles/components/trainings/training-triggers-tab.scss
+++ b/admin/app/styles/components/trainings/training-triggers-tab.scss
@@ -4,7 +4,6 @@
   }
 }
 
-
 .trigger-card {
   &__title {
     @include subheading;
@@ -28,6 +27,8 @@
 }
 
 .edit-training-trigger {
+  counter-reset: title;
+
   &__actions {
     display: flex;
     gap: $spacing-m;
@@ -36,6 +37,14 @@
 
   &__threshold {
     margin-bottom: $spacing-m;
+  }
+
+  .card__title {
+    counter-increment: title;
+
+    &::before {
+      content: counter(title) '.\00a0';
+    }
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème

Les titres des cards de ces formulaires étaient numérotés de façon brute dans le code. Ce qui n'est pas très pérenne.

## :robot: Proposition

Utiliser [les `counters` CSS](https://developer.mozilla.org/fr/docs/Web/CSS/CSS_Counter_Styles/Using_CSS_counters).

## :100: Pour tester

- Se connecter à [la RA](https://admin-pr5706.review.pix.fr/)
- Visiter les pages de [création de profil cible](https://admin-pr5706.review.pix.fr/target-profiles/new) et de [déclencheur de contenu formatif](https://admin-pr5706.review.pix.fr/trainings/101034/triggers/edit?type=prerequisite)
- Vérifier que les numéros avant les intitulés de titre sont bons 
