### PR TITLE
[FEATURE] Gérer le fonctionnement du Palier 0 (PIX-6514)

### DIFF
--- a/admin/app/components/stages/stage-level-select.hbs
+++ b/admin/app/components/stages/stage-level-select.hbs
@@ -5,6 +5,7 @@
   @value={{@value}}
   @id={{@id}}
   @label={{@label}}
+  @isDisabled={{@isDisabled}}
   @screenReaderOnly={{true}}
   @hideDefaultOption={{true}}
 />

--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -20,17 +20,16 @@
             </tr>
           </thead>
           <tbody>
-            {{#each @targetProfile.stages as |stage|}}
+            {{#each @targetProfile.stages as |stage index|}}
               {{#if stage.isNew}}
                 <TargetProfiles::Stages::NewStage
+                  @setFirstStage={{(and this.setFirstStage (eq index 0))}}
                   @stage={{stage}}
                   @imageUrl={{@targetProfile.imageUrl}}
                   @title={{stage.title}}
                   @isTypeLevel={{stage.isTypeLevel}}
                   @availableLevels={{this.availableLevels}}
                   @unavailableThresholds={{this.unavailableThresholds}}
-                  @threshold={{stage.threshold}}
-                  @level={{stage.level}}
                   @setLevel={{fn this.onStageLevelChange stage}}
                   @message={{stage.message}}
                   @errors={{stage.errors}}

--- a/admin/app/components/target-profiles/stages.js
+++ b/admin/app/components/target-profiles/stages.js
@@ -14,6 +14,13 @@ export default class Stages extends Component {
   @tracked
   firstStageType = undefined;
 
+  get setFirstStage() {
+    return (
+      (this.isTypeLevel && this.availableLevels.includes(0)) ||
+      (!this.isTypeLevel && !this.unavailableThresholds.includes(0))
+    );
+  }
+
   get availableLevels() {
     const unavailableLevels = this.args.targetProfile.stages.map((stage) => (stage.isNew ? null : stage.level));
     const allLevels = Array.from({ length: this.args.targetProfile.maxLevel + 1 }, (_, i) => i);
@@ -65,10 +72,16 @@ export default class Stages extends Component {
 
   @action
   addStage() {
+    const isFirstStage = this.args.targetProfile.stages.length === 0;
     const nextLowestLevelAvailable = this.isTypeLevel ? this.availableLevels?.[0] : undefined;
     this.store.createRecord('stage', {
       targetProfile: this.args.targetProfile,
       level: this.isTypeLevel ? nextLowestLevelAvailable.toString() : undefined,
+      threshold: !this.isTypeLevel && this.setFirstStage ? '0' : undefined,
+      title: isFirstStage ? 'Parcours terminé !' : null,
+      message: isFirstStage
+        ? 'Vous n’êtes visiblement pas tombé sur vos sujets préférés...Ou peut-être avez-vous besoin d’aide ? Dans tous les cas, rien n’est perdu d’avance ! Avec de l’accompagnement et un peu d’entraînement vous développerez à coup sûr vos compétences !'
+        : null,
     });
   }
 

--- a/admin/app/components/target-profiles/stages/new-stage.hbs
+++ b/admin/app/components/target-profiles/stages/new-stage.hbs
@@ -4,8 +4,10 @@
       <Stages::StageLevelSelect
         @availableLevels={{@availableLevels}}
         @onChange={{@setLevel}}
+        @value={{@stage.level}}
         class="stages-table__level-select"
         required="true"
+        @isDisabled={{@setFirstStage}}
         @label="Niveau du palier"
       />
     {{else}}
@@ -15,6 +17,8 @@
         @validationStatus={{this.thresholdStatus}}
         @requiredLabel="Champ obligatoire"
         type="number"
+        @value={{this.threshold}}
+        readonly={{@setFirstStage}}
         @ariaLabel="Seuil du palier"
         {{on "focusout" this.checkThresholdValidity}}
       />
@@ -25,6 +29,7 @@
       @id="title"
       @errorMessage="Le titre est vide"
       @validationStatus={{this.titleStatus}}
+      @value={{this.title}}
       @requiredLabel="Champ obligatoire"
       @ariaLabel="Titre du palier"
       {{on "focusout" this.checkTitleValidity}}
@@ -37,6 +42,7 @@
       @validationStatus={{this.messageStatus}}
       @requiredLabel="Champ obligatoire"
       @ariaLabel="Message du palier"
+      @value={{this.message}}
       {{on "focusout" this.checkMessageValidity}}
     />
   </td>
@@ -47,14 +53,16 @@
     À renseigner ultérieurement
   </td>
   <td>
-    <PixButton
-      @backgroundColor="transparent-light"
-      @size="small"
-      @isBorderVisible={{true}}
-      aria-label="Supprimer palier"
-      @triggerAction={{@remove}}
-    >
-      <FaIcon @icon="minus" />
-    </PixButton>
+    {{#unless @setFirstStage}}
+      <PixButton
+        @backgroundColor="transparent-light"
+        @size="small"
+        @isBorderVisible={{true}}
+        aria-label="Supprimer palier"
+        @triggerAction={{@remove}}
+      >
+        <FaIcon @icon="minus" />
+      </PixButton>
+    {{/unless}}
   </td>
 </tr>

--- a/admin/app/components/target-profiles/stages/new-stage.js
+++ b/admin/app/components/target-profiles/stages/new-stage.js
@@ -8,6 +8,15 @@ export default class NewStage extends Component {
   @tracked titleStatus = 'default';
   @tracked messageStatus = 'default';
 
+  constructor(...args) {
+    super(...args);
+    const { stage } = this.args;
+
+    this.threshold = stage.threshold;
+    this.title = stage.title;
+    this.message = stage.message;
+  }
+
   @action
   checkThresholdValidity(event) {
     const threshold = Number(event.target.value);

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -156,18 +156,23 @@ module('Acceptance | Target Profile Insights', function (hooks) {
           await clickByName('Nouveau palier');
 
           const [firstStageTitleInput, secondStageTitleInput] = screen.getAllByLabelText('Titre du palier');
-          const [firstStageLevelButton] = screen.getAllByLabelText('Niveau du palier');
+          const [firstStageLevelButton, secondStageLevelButton] = screen.getAllByLabelText('Niveau du palier');
           const [firstStageLevelMessage, secondStageLevelMessage] = screen.getAllByLabelText('Message du palier');
           await fillIn(firstStageTitleInput, 'mon premier palier');
           await fillIn(secondStageTitleInput, 'mon deuxième palier');
-          await click(firstStageLevelButton);
+
+          await click(secondStageLevelButton);
           await screen.findByRole('listbox');
           await click(screen.getByRole('option', { name: '3' }));
+          await waitForElementToBeRemoved(() => screen.queryByRole('listbox'));
+
           await fillIn(firstStageLevelMessage, 'mon message un');
           await fillIn(secondStageLevelMessage, 'mon message deux');
+
           await clickByName('Enregistrer');
 
           // then
+          assert.true(firstStageLevelButton.hasAttributes('aria-disabled', 'true'));
           assert.dom(screen.getByText('mon premier palier')).exists();
           assert.dom(screen.getByText('mon deuxième palier')).exists();
           assert.dom(screen.getByText('3')).exists();
@@ -229,16 +234,16 @@ module('Acceptance | Target Profile Insights', function (hooks) {
           const [firstStageLevelMessage, secondStageLevelMessage] = screen.getAllByLabelText('Message du palier');
           await fillIn(firstStageTitleInput, 'mon premier palier');
           await fillIn(secondStageTitleInput, 'mon deuxième palier');
-          await fillIn(firstStageThresholdInput, 20);
           await fillIn(secondStageThresholdInput, 50);
           await fillIn(firstStageLevelMessage, 'mon message 1');
           await fillIn(secondStageLevelMessage, 'mon message 2');
           await clickByName('Enregistrer');
 
           // then
+          assert.true(firstStageThresholdInput.hasAttributes('value', '0'));
           assert.dom(screen.getByText('mon premier palier')).exists();
           assert.dom(screen.getByText('mon deuxième palier')).exists();
-          assert.dom(screen.getByText(20)).exists();
+          assert.dom(screen.getByText(0)).exists();
           assert.dom(screen.getByText(50)).exists();
           assert.dom(screen.getByText('mon message 1')).exists();
           assert.dom(screen.getByText('mon message 2')).exists();


### PR DESCRIPTION
## :unicorn: Problème
Le palier 0 est requis. Or il était possible de le modifier et de ce fait ne pas avoir de palier à 0

## :robot: Proposition
Ne pas permettre de modifier le 1er palier
Ne pas permettre de supprimer la 1ere ligne contenant le palier 0
Ajouter les messages par défaut du 1er palier

## :rainbow: Remarques
Inclus le 6515 / 6119

## :100: Pour tester
Aller sur Pix Admin.
Créer un profil cible vierge.
Ajouter deux palier palier de type seuil et vérifier que le 1er contient un titre et un message par défaut. Que sa valeur ne soit pas éditable lors de la création, ni supprimable

Réitérer la même opération pour le palier de type niveau
