### PR TITLE
[CHORE] Améliorer les instructions pour l'archivage en masse des campages (PIX-7219)

### DIFF
--- a/admin/app/templates/authenticated/tools.hbs
+++ b/admin/app/templates/authenticated/tools.hbs
@@ -12,8 +12,10 @@
         <h2 class="page-section__title">Archiver des campagnes en masse</h2>
       </header>
       <PixMessage class="tools__warning" @type="warning" @withIcon={{true}}>
-        L'envoi du fichier (format .csv) va archiver toutes les campagnes. Le fichier ne doit comporter qu'une seule
-        colonne à renseigner correspondant aux id des campagnes.
+        L'envoi du fichier .csv via le bouton ci-dessous va archiver toutes campagnes renseignées.<br />
+        Le fichier ne doit comporter qu'une seule colonne, correspondant aux id des campagnes, et avoir comme en-tête
+        <strong>“campaignId”</strong>
+        dans la première cellule de la colonne.
       </PixMessage>
       <PixButtonUpload @id="file-upload" @onChange={{this.archiveCampaigns}} accept=".csv">
         Envoyer le fichier des campagnes à archiver


### PR DESCRIPTION
## :unicorn: Problème
L'archivage en masse est maintenant possible, mais les instructions pour le fichier csv n'étaient pas complètes

## :robot: Proposition
Préciser que le fichier contient qu'une colonne qui doit avoir comme en-tête `campaignId`

## :rainbow: Remarques


## :100: Pour tester
- Se connecter à pix Admin
- Aller dans l'onglet Outils et lire la consigne