### PR TITLE
[FEATURE] Empêcher la modification du palier 0 (PIX-6598)

### DIFF
--- a/admin/app/components/stages/stage-level-select.hbs
+++ b/admin/app/components/stages/stage-level-select.hbs
@@ -4,8 +4,8 @@
   @onChange={{@onChange}}
   @value={{@value}}
   @id={{@id}}
-  @label={{@label}}
   @isDisabled={{@isDisabled}}
+  @label={{@label}}
   @screenReaderOnly={{true}}
   @hideDefaultOption={{true}}
 />

--- a/admin/app/components/stages/update-stage.hbs
+++ b/admin/app/components/stages/update-stage.hbs
@@ -8,6 +8,7 @@
         <Stages::StageLevelSelect
           @id="threshold-or-level"
           @availableLevels={{@availableLevels}}
+          @isDisabled={{this.isDisabled}}
           @onChange={{this.setLevel}}
           @value={{this.level}}
         />
@@ -18,6 +19,7 @@
           @validationStatus={{this.thresholdStatus}}
           @requiredLabel="Champ obligatoire"
           type="number"
+          readonly={{this.isDisabled}}
           @value={{this.threshold}}
           @ariaLabel="Seuil du palier"
           min="0"

--- a/admin/app/components/stages/update-stage.js
+++ b/admin/app/components/stages/update-stage.js
@@ -25,6 +25,8 @@ export default class UpdateStage extends Component {
     this.message = this.args.stage.message;
     this.prescriberTitle = this.args.stage.prescriberTitle;
     this.prescriberDescription = this.args.stage.prescriberDescription;
+
+    this.isDisabled = this.threshold === 0 || this.level === '0';
   }
 
   async _updateStage() {


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'édition nous pouvons modifier un palier 0 pour ne plus en avoir. Ce qui est problématique.

## :robot: Proposition
Ne pas permettre de modifier la palier 0

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter sur Pix Admin, aller sur le profil cible 500 / 501 et vérifier que pour le palier a niveau la liste d"roulant n'est pas selectionnable. Et pour le palier à seuil que l'on ne puisse pas modifier sa valeur.