### PR TITLE
[BUGFIX] Gerer l'asynchronisme de PGBoss.send (PIX-7230)

### DIFF
--- a/api/lib/infrastructure/jobs/cpf-export/handlers/planner.js
+++ b/api/lib/infrastructure/jobs/cpf-export/handlers/planner.js
@@ -17,6 +17,7 @@ module.exports = async function planner({ job, pgBoss, cpfCertificationResultRep
       certificationCourseIdChunks.length
     } job(s) for ${certificationCourseIds.length} certifications`
   );
+
   for (const [index, certificationCourseIds] of certificationCourseIdChunks.entries()) {
     const batchId = `${job.id}#${index}`;
     await cpfCertificationResultRepository.markCertificationToExport({
@@ -24,7 +25,7 @@ module.exports = async function planner({ job, pgBoss, cpfCertificationResultRep
       batchId,
     });
 
-    pgBoss.send('CpfExportBuilderJob', {
+    await pgBoss.send('CpfExportBuilderJob', {
       batchId,
     });
   }


### PR DESCRIPTION
## :unicorn: Problème
On ne gere pas l'asynchronisme de pgBoss.send lors de la creation de tach du job CPF. De nombreux appels peuvent être perdus

## :robot: Proposition
Ajouter un await

## :rainbow: Remarques
Le probleme apparait lorsqu'il y a de nombreux appels

## :100: Pour tester
Lancer le job CPF pour une 30 aine de job
```
CPF_PLANNER_JOB_CRON=0 * * * *
CPF_PLANNER_JOB_CHUNK_SIZE=1
CPF_PLANNER_JOB_MONTHS_TO_PROCESS=999
CPF_PLANNER_JOB_MINIMUM_RELIABILITY_PERIOD=0
```
verifier que le nombre de CPFBuilderJob creee correspond au nombre attendu specifié par le log:

> CpfExportPlannerJob start from 7/1/2021 to 11/30/2022, plan 26 job(s) for 1260600 certifications

