### PR TITLE
[FEATURE] Empêcher la création de palier tant qu'une erreur subsiste (PIX-7222)

### DIFF
--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -2,11 +2,6 @@
 <div class="content-text content-text--small">
   <form class="form" {{on "submit" this.createStages}}>
     {{#if this.hasStages}}
-      {{#if this.displayNoZeroStage}}
-        <PixMessage type="warning">
-          Attention ! Il n'y a pas de palier à 0
-        </PixMessage>
-      {{/if}}
       <div class="table-admin">
         <table class="stages-table">
           <thead>

--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -26,13 +26,10 @@
                   @setFirstStage={{(and this.setFirstStage (eq index 0))}}
                   @stage={{stage}}
                   @imageUrl={{@targetProfile.imageUrl}}
-                  @title={{stage.title}}
                   @isTypeLevel={{stage.isTypeLevel}}
                   @availableLevels={{this.availableLevels}}
                   @unavailableThresholds={{this.unavailableThresholds}}
                   @setLevel={{fn this.onStageLevelChange stage}}
-                  @message={{stage.message}}
-                  @errors={{stage.errors}}
                   @remove={{fn this.removeStage stage}}
                 />
               {{else}}

--- a/admin/app/components/target-profiles/stages.js
+++ b/admin/app/components/target-profiles/stages.js
@@ -11,8 +11,7 @@ export default class Stages extends Component {
   @service store;
   @service notifications;
 
-  @tracked
-  firstStageType = undefined;
+  @tracked firstStageType = undefined;
 
   get setFirstStage() {
     return (
@@ -78,10 +77,11 @@ export default class Stages extends Component {
       targetProfile: this.args.targetProfile,
       level: this.isTypeLevel ? nextLowestLevelAvailable.toString() : undefined,
       threshold: !this.isTypeLevel && this.setFirstStage ? '0' : undefined,
-      title: isFirstStage ? 'Parcours terminé !' : null,
-      message: isFirstStage
-        ? 'Vous n’êtes visiblement pas tombé sur vos sujets préférés...Ou peut-être avez-vous besoin d’aide ? Dans tous les cas, rien n’est perdu d’avance ! Avec de l’accompagnement et un peu d’entraînement vous développerez à coup sûr vos compétences !'
-        : null,
+      title: this.isTypeLevel && isFirstStage ? 'Parcours terminé !' : null,
+      message:
+        this.isTypeLevel && isFirstStage
+          ? 'Vous n’êtes visiblement pas tombé sur vos sujets préférés...Ou peut-être avez-vous besoin d’aide ? Dans tous les cas, rien n’est perdu d’avance ! Avec de l’accompagnement et un peu d’entraînement vous développerez à coup sûr vos compétences !'
+          : null,
     });
   }
 
@@ -105,6 +105,19 @@ export default class Stages extends Component {
   @action
   async createStages(event) {
     event.preventDefault();
+
+    const isStagesValid = this.newStages.map((stage) => {
+      return (
+        ((stage.isTypeLevel && stage.level !== null) || (!stage.isTypeLevel && stage.threshold !== null)) &&
+        stage.message !== null &&
+        stage.title !== null
+      );
+    });
+
+    if (isStagesValid.includes(false)) {
+      this.notifications.error('Veuillez corriger les champs en erreurs.');
+      return;
+    }
 
     try {
       for (const stage of this.newStages) {

--- a/admin/app/components/target-profiles/stages.js
+++ b/admin/app/components/target-profiles/stages.js
@@ -47,14 +47,6 @@ export default class Stages extends Component {
     return this.args.targetProfile.stages.filter((stage) => stage.isNew);
   }
 
-  get displayNoZeroStage() {
-    if (!this.hasStages) return false;
-    if (this.isTypeLevel) {
-      return !this.args.targetProfile.stages.any((stage) => stage.level === 0);
-    }
-    return !this.args.targetProfile.stages.any((stage) => stage.threshold === 0);
-  }
-
   get columnNameByStageType() {
     return this.isTypeLevel ? LEVEL_COLUMN_NAME : THRESHOLD_COLUMN_NAME;
   }

--- a/admin/tests/integration/components/target-profiles/stages_test.js
+++ b/admin/tests/integration/components/target-profiles/stages_test.js
@@ -125,61 +125,6 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       assert.dom('table').doesNotExist();
       assert.dom(screen.getByText('Aucun palier associé')).exists();
     });
-
-    test('it should display a warning when there is no threshold at 0', async function (assert) {
-      // given
-      const stage = EmberObject.create({
-        id: 1,
-        threshold: 100,
-        title: 'My title',
-        message: 'My message',
-      });
-      this.set('model', { stages: [stage] });
-
-      // when
-      const screen = await render(hbs`<TargetProfiles::Stages @targetProfile={{this.model}} />`);
-
-      // then
-      assert.dom(screen.getByText("Attention ! Il n'y a pas de palier à 0")).exists();
-    });
-
-    module('when no stage with threshold 0', function () {
-      test('it should display warning message', async function (assert) {
-        // given
-        const stage = EmberObject.create({
-          id: 1,
-          threshold: 100,
-          title: 'My title',
-          message: 'My message',
-        });
-        this.set('model', { stages: [stage], imageUrl: 'data:,' });
-
-        // when
-        const screen = await render(hbs`<TargetProfiles::Stages @targetProfile={{this.model}} />`);
-
-        // then
-        assert.dom(screen.queryByText("Attention ! Il n'y a pas de palier à 0")).exists();
-      });
-    });
-
-    module('when one stage with threshold 0', function () {
-      test('it should not display warning message', async function (assert) {
-        // given
-        const stage = EmberObject.create({
-          id: 1,
-          threshold: 0,
-          title: 'My title',
-          message: 'My message',
-        });
-        this.set('model', { stages: [stage], imageUrl: 'data:,' });
-
-        // when
-        const screen = await render(hbs`<TargetProfiles::Stages @targetProfile={{this.model}} />`);
-
-        // then
-        assert.dom(screen.queryByText("Attention ! Il n'y a pas de palier à 0")).doesNotExist();
-      });
-    });
   });
 
   module('when stage type is level', function () {
@@ -213,46 +158,6 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       assert.strictEqual(find('tbody tr td:nth-child(3)').textContent.trim(), 'My message');
       assert.strictEqual(find('tbody tr td:nth-child(6)').textContent.trim(), 'Voir détail');
       assert.dom(screen.queryByText('Aucun résultat thématique associé')).doesNotExist();
-    });
-
-    module('when no stage with level 0', function () {
-      test('it should display warning message', async function (assert) {
-        // given
-        const stage = EmberObject.create({
-          id: 1,
-          level: 6,
-          isTypeLevel: true,
-          title: 'My title',
-          message: 'My message',
-        });
-        this.set('model', { stages: [stage], imageUrl: 'data:,' });
-
-        // when
-        const screen = await render(hbs`<TargetProfiles::Stages @targetProfile={{this.model}} />`);
-
-        // then
-        assert.dom(screen.queryByText("Attention ! Il n'y a pas de palier à 0")).exists();
-      });
-    });
-
-    module('when one stage with level 0', function () {
-      test('it should not display warning message', async function (assert) {
-        // given
-        const stage = EmberObject.create({
-          id: 1,
-          level: 0,
-          isTypeLevel: true,
-          title: 'My title',
-          message: 'My message',
-        });
-        this.set('model', { stages: [stage], imageUrl: 'data:,' });
-
-        // when
-        const screen = await render(hbs`<TargetProfiles::Stages @targetProfile={{this.model}} />`);
-
-        // then
-        assert.dom(screen.queryByText("Attention ! Il n'y a pas de palier à 0")).doesNotExist();
-      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Si sur une liste de 2 palier à créer , un contient une erreur. le second est crée mais pas le 1er

## :robot: Proposition
Empêcher la création tant qu'une erreur existe

## :rainbow: Remarques
RAS

## :100: Pour tester
Pix Admin => Profil Cible => 500 / 501 => Ajouter des paliers => laisser des erreurs sur un palier => Sauvegarder => Message d'erreur apparaît sans création. => Faire les corrections => Enregistrer => Tout est OK