### PR TITLE
[FEATURE] Internationaliser les urls des mentions légales et d'accessibilité sur Pix Certif (PIX-7209).

### DIFF
--- a/certif/app/components/layout/footer.hbs
+++ b/certif/app/components/layout/footer.hbs
@@ -2,12 +2,7 @@
   <nav class="footer__navigation">
     <ul class="footer__navigation-list">
       <li>
-        <a
-          href="https://pix.fr/mentions-legales/"
-          target="_blank"
-          class="footer-navigation__item"
-          rel="noopener noreferrer"
-        >
+        <a href={{this.legalNoticeUrl}} target="_blank" class="footer-navigation__item" rel="noopener noreferrer">
           {{t "navigation.footer.legal-notice"}}
         </a>
       </li>

--- a/certif/app/components/layout/footer.hbs
+++ b/certif/app/components/layout/footer.hbs
@@ -8,12 +8,7 @@
       </li>
 
       <li>
-        <a
-          href="https://pix.fr/accessibilite-pix-certif/"
-          target="_blank"
-          class="footer-navigation__item"
-          rel="noopener noreferrer"
-        >
+        <a href={{this.accessibilityUrl}} target="_blank" class="footer-navigation__item" rel="noopener noreferrer">
           {{t "navigation.footer.a11y"}}
         </a>
       </li>

--- a/certif/app/components/layout/footer.js
+++ b/certif/app/components/layout/footer.js
@@ -3,9 +3,14 @@ import { inject as service } from '@ember/service';
 
 export default class Footer extends Component {
   @service intl;
+  @service url;
 
   get currentYear() {
     const currentYear = new Date().getFullYear();
     return this.intl.t('navigation.footer.current-year', { currentYear });
+  }
+
+  get legalNoticeUrl() {
+    return this.url.legalNoticeUrl;
   }
 }

--- a/certif/app/components/layout/footer.js
+++ b/certif/app/components/layout/footer.js
@@ -13,4 +13,8 @@ export default class Footer extends Component {
   get legalNoticeUrl() {
     return this.url.legalNoticeUrl;
   }
+
+  get accessibilityUrl() {
+    return this.url.accessibilityUrl;
+  }
 }

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -42,4 +42,15 @@ export default class Url extends Service {
 
     return currentLanguage === 'fr' ? 'https://pix.org/fr/mentions-legales' : 'https://pix.org/en-gb/legal-notice';
   }
+
+  get accessibilityUrl() {
+    const topLevelDomain = this.currentDomain.getExtension();
+    const currentLanguage = this.intl.t('current-lang');
+
+    if (topLevelDomain === 'fr') return 'https://pix.fr/accessibilite-pix-certif';
+
+    return currentLanguage === 'fr'
+      ? 'https://pix.org/fr/accessibilite-pix-certif'
+      : 'https://pix.org/en-gb/accessibility-pix-certif';
+  }
 }

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -33,4 +33,13 @@ export default class Url extends Service {
     }
     return url;
   }
+
+  get legalNoticeUrl() {
+    const topLevelDomain = this.currentDomain.getExtension();
+    const currentLanguage = this.intl.t('current-lang');
+
+    if (topLevelDomain === 'fr') return 'https://pix.fr/mentions-legales';
+
+    return currentLanguage === 'fr' ? 'https://pix.org/fr/mentions-legales' : 'https://pix.org/en-gb/legal-notice';
+  }
 }

--- a/certif/tests/integration/components/layout/footer_test.js
+++ b/certif/tests/integration/components/layout/footer_test.js
@@ -34,11 +34,16 @@ module('Integration | Component | Layout::Footer', function (hooks) {
   });
 
   test('should display accessibility link', async function (assert) {
+    // given
+    const service = this.owner.lookup('service:url');
+    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+
     // when
     const screen = await renderScreen(hbs`<Layout::Footer />}`);
 
     // then
-    assert.dom(screen.getByText(this.intl.t('navigation.footer.a11y'))).exists();
-    assert.dom('a[href="https://pix.fr/accessibilite-pix-certif/"]').exists();
+    assert
+      .dom(screen.getByRole('link', { name: this.intl.t('navigation.footer.a11y') }))
+      .hasAttribute('href', 'https://pix.fr/accessibilite-pix-certif');
   });
 });

--- a/certif/tests/integration/components/layout/footer_test.js
+++ b/certif/tests/integration/components/layout/footer_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import setupRenderingIntlTest from '../../../helpers/setup-intl-rendering';
+import sinon from 'sinon';
 
 module('Integration | Component | Layout::Footer', function (hooks) {
   setupRenderingIntlTest(hooks);
@@ -19,12 +20,17 @@ module('Integration | Component | Layout::Footer', function (hooks) {
   });
 
   test('should display legal notice link', async function (assert) {
+    // given
+    const service = this.owner.lookup('service:url');
+    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+
     // when
     const screen = await renderScreen(hbs`<Layout::Footer />}`);
 
     // then
-    assert.dom(screen.getByText(this.intl.t('navigation.footer.legal-notice'))).exists();
-    assert.dom('a[href="https://pix.fr/mentions-legales/"]').exists();
+    assert
+      .dom(screen.getByRole('link', { name: this.intl.t('navigation.footer.legal-notice') }))
+      .hasAttribute('href', 'https://pix.fr/mentions-legales');
   });
 
   test('should display accessibility link', async function (assert) {

--- a/certif/tests/unit/services/url_test.js
+++ b/certif/tests/unit/services/url_test.js
@@ -183,4 +183,52 @@ module('Unit | Service | url', function (hooks) {
       });
     });
   });
+
+  module('#accessibilityUrl', function () {
+    module('when current domain is fr', function () {
+      test('should return "pix.fr" url', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url');
+        service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+
+        // when
+        const accessibilityUrl = service.accessibilityUrl;
+
+        // then
+        assert.strictEqual(accessibilityUrl, 'https://pix.fr/accessibilite-pix-certif');
+      });
+    });
+
+    module('when current domain is org', function () {
+      module('when current language is en', function () {
+        test('should return "pix.org/en-gb" url', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { getExtension: sinon.stub().returns('org') };
+          service.intl = { t: sinon.stub().returns('en') };
+
+          // when
+          const accessibilityUrl = service.accessibilityUrl;
+
+          // then
+          assert.strictEqual(accessibilityUrl, 'https://pix.org/en-gb/accessibility-pix-certif');
+        });
+      });
+
+      module('when current language is fr', function () {
+        test('should return "pix.org/fr" url', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { getExtension: sinon.stub().returns('org') };
+          service.intl = { t: sinon.stub().returns('fr') };
+
+          // when
+          const accessibilityUrl = service.accessibilityUrl;
+
+          // then
+          assert.strictEqual(accessibilityUrl, 'https://pix.org/fr/accessibilite-pix-certif');
+        });
+      });
+    });
+  });
 });

--- a/certif/tests/unit/services/url_test.js
+++ b/certif/tests/unit/services/url_test.js
@@ -135,4 +135,52 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(forgottenPasswordUrl, expectedForgottenPasswordUrl);
     });
   });
+
+  module('#legalNoticeUrl', function () {
+    module('when current domain is fr', function () {
+      test('should return "pix.fr" url', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url');
+        service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+
+        // when
+        const legalNoticeUrl = service.legalNoticeUrl;
+
+        // then
+        assert.strictEqual(legalNoticeUrl, 'https://pix.fr/mentions-legales');
+      });
+    });
+
+    module('when current domain is org', function () {
+      module('when current language is en', function () {
+        test('should return "pix.org/en-gb" url', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { getExtension: sinon.stub().returns('org') };
+          service.intl = { t: sinon.stub().returns('en') };
+
+          // when
+          const legalNoticeUrl = service.legalNoticeUrl;
+
+          // then
+          assert.strictEqual(legalNoticeUrl, 'https://pix.org/en-gb/legal-notice');
+        });
+      });
+
+      module('when current language is fr', function () {
+        test('should return "pix.org/fr" url', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { getExtension: sinon.stub().returns('org') };
+          service.intl = { t: sinon.stub().returns('fr') };
+
+          // when
+          const legalNoticeUrl = service.legalNoticeUrl;
+
+          // then
+          assert.strictEqual(legalNoticeUrl, 'https://pix.org/fr/mentions-legales');
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Suite à l'internationalisation de Pix Certif, on souhaite retourner différents urls en fonction du domaine et du language choisit par l'utilisation. Or actuellement les urls sont définit en dur en français.

## :robot: Proposition
Retourner différents urls pour accéder aux pages mentions légales et accessibilité à partir du service url.

## :rainbow: Remarques
L'url des cgu dans la double mire de Pix Certif (scénario invitation) ne retourne pas les bons urls (voir avec accès ?)

## :100: Pour tester

- Se connecter sur Pix Certif avec certifpro@example.net en .FR
- Constater que les urls (mentions légale et accessibilité) retournent bien sur le site pix.fr
- Se connecter sur Pix Certif avec certifpro@example.net en .ORG (en restant en français)
- Constater que les urls (mentions légale et accessibilité) retournent bien sur le site pix.org/fr
- Passer en anglais (?lang=en)
- Constater que les urls (mentions légale et accessibilité) retournent bien sur le site pix.org/en-gb


