### PR TITLE
[FEATURE] Rendre le champ "IdPixLabel" obligatoire (PIX-4328).

### DIFF
--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -195,6 +195,7 @@
         @information={{t "pages.campaign-creation.external-id-label.suggestion"}}
         @label={{t "pages.campaign-creation.external-id-label.label"}}
         maxlength="255"
+        @requiredLabel={{t "pages.campaign-creation.external-id-label.required"}}
         {{on "change" this.onChangeExternalIdLabel}}
       />
       {{#if @errors.idPixLabel}}

--- a/orga/tests/integration/components/campaign/create-form_test.js
+++ b/orga/tests/integration/components/campaign/create-form_test.js
@@ -477,6 +477,24 @@ module('Integration | Component | Campaign::CreateForm', function (hooks) {
       // then
       assert.contains(t('pages.campaign-creation.legal-warning'));
     });
+
+    test('it set the external id as required', async function (assert) {
+      // when
+      const screen = await render(
+        hbs`<Campaign::CreateForm
+  @onSubmit={{this.createCampaignSpy}}
+  @onCancel={{this.cancelSpy}}
+  @errors={{this.errors}}
+  @targetProfiles={{this.targetProfiles}}
+  @membersSortedByFullName={{this.defaultMembers}}
+/>`
+      );
+      await clickByName(t('pages.campaign-creation.yes'));
+
+      // then
+      const label = screen.getByLabelText(new RegExp(t('pages.campaign-creation.external-id-label.label')));
+      assert.true(label.hasAttribute('aria-required', false));
+    });
   });
 
   test('it should send campaign creation action when submitted', async function (assert) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -333,7 +333,8 @@
       "external-id-label": {
         "label": "external user ID label",
         "question-label": "Do you need an external user ID?",
-        "suggestion": "Example : \"Student Number\" or \"Email address\" *"
+        "suggestion": "Example : \"Student Number\" or \"Email address\" *",
+        "required": "The external user ID label is mandatory."
       },
       "landing-page-text": {
         "label": "Text to display on the starting page"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -333,7 +333,8 @@
       "external-id-label": {
         "label": "Libellé de l’identifiant",
         "question-label": "Souhaitez-vous demander un identifiant externe ?",
-        "suggestion": "Exemple: \"Numéro de l'étudiant\" ou \"Adresse e-mail professionnelle\" *"
+        "suggestion": "Exemple: \"Numéro de l'étudiant\" ou \"Adresse e-mail professionnelle\" *",
+        "required": "L'id externe est obligatoire"
       },
       "landing-page-text": {
         "label": "Texte de la page d'accueil"


### PR DESCRIPTION
## :unicorn: Problème
Le champ IdPixLabel n'est pas obligatoire.

## :robot: Proposition
Rendre le champ IdPixLabel obligatoire.


## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que le champ IdPixLabel est obligatoire