### PR TITLE
[BUGFIX] Permettre la modification de contenu formatif (PIX-7245).

### DIFF
--- a/api/lib/infrastructure/repositories/training-repository.js
+++ b/api/lib/infrastructure/repositories/training-repository.js
@@ -5,6 +5,7 @@ const { NotFoundError } = require('../../domain/errors');
 const DomainTransaction = require('../DomainTransaction');
 const UserRecommendedTraining = require('../../domain/read-models/UserRecommendedTraining');
 const { fetchPage } = require('../utils/knex-utils');
+const pick = require('lodash/pick');
 const TABLE_NAME = 'trainings';
 
 module.exports = {
@@ -58,10 +59,19 @@ module.exports = {
   },
 
   async update({ id, attributesToUpdate, domainTransaction = DomainTransaction.emptyTransaction() }) {
+    const pickedAttributesToUpdate = pick(attributesToUpdate, [
+      'title',
+      'link',
+      'type',
+      'duration',
+      'locale',
+      'editorName',
+      'editorLogoUrl',
+    ]);
     const knexConn = domainTransaction?.knexTransaction || knex;
     const [updatedTraining] = await knexConn(TABLE_NAME)
       .where({ id })
-      .update({ ...attributesToUpdate, updatedAt: new Date() })
+      .update({ ...pickedAttributesToUpdate, updatedAt: new Date() })
       .returning('*');
 
     const targetProfileTrainings = await knexConn('target-profile-trainings').where({ trainingId: id });

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -241,8 +241,7 @@ describe('Integration | Repository | training-repository', function () {
         link: 'https://example.net/mon-nouveau-lien',
         editorName: 'Mon nouvel editeur',
         editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/nouveau-logo.svg',
-        prerequisiteThreshold: 10,
-        goalThreshold: 20,
+        notExistingAttribute: 'notExistingValue',
       };
 
       // when
@@ -256,7 +255,6 @@ describe('Integration | Repository | training-repository', function () {
       expect(updatedTraining.type).to.equal(training.type);
       expect(updatedTraining.editorName).to.be.equal(attributesToUpdate.editorName);
       expect(updatedTraining.editorLogoUrl).to.be.equal(attributesToUpdate.editorLogoUrl);
-      expect(updatedTraining.prerequisiteThreshold).to.be.equal(attributesToUpdate.prerequisiteThreshold);
       expect(updatedTraining.updatedAt).to.be.above(currentTraining.updatedAt);
     });
 
@@ -275,8 +273,6 @@ describe('Integration | Repository | training-repository', function () {
         link: 'https://example.net/mon-nouveau-lien',
         editorName: 'Mon nouvel editeur',
         editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/nouveau-logo.svg',
-        prerequisiteThreshold: 10,
-        goalThreshold: 20,
       };
 
       // when
@@ -288,8 +284,6 @@ describe('Integration | Repository | training-repository', function () {
       expect(updatedTraining.link).to.equal(attributesToUpdate.link);
       expect(updatedTraining.editorName).to.be.equal(attributesToUpdate.editorName);
       expect(updatedTraining.editorLogoUrl).to.be.equal(attributesToUpdate.editorLogoUrl);
-      expect(updatedTraining.prerequisiteThreshold).to.be.equal(attributesToUpdate.prerequisiteThreshold);
-      expect(updatedTraining.goalThreshold).to.be.equal(attributesToUpdate.goalThreshold);
       expect(updatedTraining.targetProfileIds).to.deep.equal([targetProfile.id]);
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous ne pouvons pas mettre à jour un contenu formatif s'il inclut des champs en plus, car on fait un passe plat.

## :robot: Proposition
- Deserializer uniquement les attributs du Training
- Mettre à jour uniquement les attributs du Training

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter sur Pix Admin
- Aller sur les contenu formatif
- Editer un contenu formatif en étant dans l'onglet "profil cibles" 
- Constater la bonne MAJ