### PR TITLE
[BUGFIX] Ajout de la dépendance manquante participantResultsSharedRepository

### DIFF
--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -112,6 +112,7 @@ const dependencies = {
   organizationLearnersCsvService: require('../../domain/services/organization-learners-csv-service'),
   organizationLearnersXmlService: require('../../domain/services/organization-learners-xml-service'),
   participantResultRepository: require('../../infrastructure/repositories/participant-result-repository'),
+  participantResultsSharedRepository: require('../../infrastructure/repositories/participant-results-shared-repository'),
   participationsForCampaignManagementRepository: require('../../infrastructure/repositories/participations-for-campaign-management-repository'),
   participationsForUserManagementRepository: require('../../infrastructure/repositories/participations-for-user-management-repository'),
   userOrganizationsForAdminRepository: require('../../infrastructure/repositories/user-organizations-for-admin-repository'),


### PR DESCRIPTION
## :unicorn: Problème
La dépendance `participantResultsSharedRepository` utilisé dans le usecase `saveComputedCampaignParticipationResult`
 introduite dans #5444 était manquante.

## :robot: Proposition
Rajouter la dépendance.

## :100: Pour tester
Rejoindre une campagne, suivre tout le parcours et regarder les logs du worker pour vérifier que le job est ok.
