### PR TITLE
[FEATURE] Ajouter un déclencheur à un contenu formatif (PIX-7176).

### DIFF
--- a/admin/app/adapters/training-trigger.js
+++ b/admin/app/adapters/training-trigger.js
@@ -1,0 +1,21 @@
+import ApplicationAdapter from './application';
+
+export default class TrainingTriggerAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+
+  urlForCreateRecord(modelName, { adapterOptions }) {
+    const { trainingId } = adapterOptions;
+
+    return `${this.host}/${this.namespace}/trainings/${trainingId}/triggers`;
+  }
+
+  createRecord(store, type, snapshot) {
+    const { adapterOptions } = snapshot;
+    const payload = this.serialize(snapshot);
+    payload.data.attributes.tubes = adapterOptions.tubes;
+
+    const url = this.buildURL(type.modelName, null, snapshot, 'createRecord');
+
+    return this.ajax(url, 'PUT', { data: payload });
+  }
+}

--- a/admin/app/controllers/authenticated/trainings/training/triggers/edit.js
+++ b/admin/app/controllers/authenticated/trainings/training/triggers/edit.js
@@ -40,7 +40,9 @@ export default class TrainingEditTriggersController extends Controller {
     event.preventDefault();
     try {
       const data = Object.fromEntries(new FormData(event.target).entries());
-      await this.store.createRecord('training-trigger', data).save();
+      await this.store
+        .createRecord('training-trigger', { ...data, type: this.type })
+        .save({ adapterOptions: { tubes: this.selectedTubes, trainingId: this.model.training.id } });
       this.notifications.success('Le déclencheur a été créé avec succès.');
       this.goBackToTraining();
     } catch (error) {

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -30,10 +30,11 @@ import { getPaginatedJuryCertificationSummariesBySessionId } from './handlers/ge
 import { createAdminMember } from './handlers/admin-members';
 import {
   attachTargetProfilesToTraining,
+  createOrUpdateTrainingTrigger,
   createTraining,
   findPaginatedTrainingSummaries,
-  getTargetProfileSummariesForTraining,
   getTraining,
+  getTargetProfileSummariesForTraining,
   updateTraining,
 } from './handlers/trainings';
 
@@ -312,6 +313,7 @@ export default function () {
   this.patch('/admin/trainings/:id', updateTraining);
   this.get('/admin/trainings/:id/target-profile-summaries', getTargetProfileSummariesForTraining);
   this.post('/admin/trainings/:id/attach-target-profiles', attachTargetProfilesToTraining);
+  this.put('/admin/trainings/:id/triggers', createOrUpdateTrainingTrigger);
 
   this.get('/admin/certifications/:id');
   this.get('/admin/certifications/:id/certified-profile', (schema, request) => {

--- a/admin/mirage/handlers/trainings.js
+++ b/admin/mirage/handlers/trainings.js
@@ -78,8 +78,27 @@ function updateTraining(schema, request) {
   return training;
 }
 
+function createOrUpdateTrainingTrigger(schema, request) {
+  const body = JSON.parse(request.requestBody);
+  const attributes = body.data.attributes;
+
+  const trainingTrigger = schema.trainingTriggers.findOrCreateBy({
+    trainingId: attributes.trainingId,
+    type: attributes.type,
+  });
+
+  const tubes = schema.tubes.where(({ id }) => attributes.tubes.map(({ id }) => id).includes(id)).models;
+  tubes.forEach((tube) => {
+    tube.update({ level: attributes.tubes.find(({ id }) => id === tube.id).level });
+  });
+
+  trainingTrigger.update({ ...attributes, tubes });
+  return trainingTrigger;
+}
+
 export {
   attachTargetProfilesToTraining,
+  createOrUpdateTrainingTrigger,
   createTraining,
   findPaginatedTrainingSummaries,
   getTargetProfileSummariesForTraining,

--- a/admin/mirage/serializers/training-trigger.js
+++ b/admin/mirage/serializers/training-trigger.js
@@ -1,0 +1,7 @@
+import ApplicationSerializer from './application';
+
+const include = ['tubes'];
+
+export default ApplicationSerializer.extend({
+  include,
+});

--- a/admin/tests/acceptance/authenticated/trainings/edit-triggers_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/edit-triggers_test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { click, currentURL } from '@ember/test-helpers';
-import { visit } from '@1024pix/ember-testing-library';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
+import { visit, clickByName } from '@1024pix/ember-testing-library';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 import setupIntl from '../../../helpers/setup-intl';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -58,11 +58,6 @@ module('Acceptance | Trainings | Triggers edit', function (hooks) {
 
       // then
       assert.strictEqual(currentURL(), `/trainings/${trainingId}/triggers/edit?type=prerequisite`);
-      assert.dom(screen.getByText('Sélection des sujets', { exact: false })).exists();
-      await click(screen.getByText('area_f1_a1 code', { exact: false }));
-      await click(screen.getByText('competence_f1_a1_c1 index', { exact: false }));
-      await click(screen.getByText('thematic_f1_a1_c1_th1 name', { exact: false }));
-      assert.dom(screen.getByText('2/5')).exists();
     });
 
     test('it should be accessible by an authenticated user : goal edit', async function (assert) {
@@ -84,6 +79,31 @@ module('Acceptance | Trainings | Triggers edit', function (hooks) {
       // when
       const screen = await visit(`/trainings/${trainingId}/triggers/edit?type=prerequisite`);
       await click(screen.getByRole('button', { name: 'Annuler' }));
+
+      // then
+      assert.strictEqual(currentURL(), `/trainings/${trainingId}/triggers`);
+    });
+
+    test('it should be able to save a new trigger', async function (assert) {
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+      // when
+      const screen = await visit(`/trainings/${trainingId}/`);
+      await click(
+        screen.getByRole('link', {
+          name: this.intl.t('pages.trainings.training.triggers.prerequisite.alternative-title'),
+        })
+      );
+
+      const thresholdInputs = screen.getByLabelText('Seuil en % :');
+      await fillIn(thresholdInputs, 20);
+
+      await click(screen.getByText('area_f1_a1 code', { exact: false }));
+      await click(screen.getByText('competence_f1_a1_c1 index', { exact: false }));
+      await click(screen.getByText('thematic_f1_a1_c1_th1 name', { exact: false }));
+      assert.dom(screen.getByText('2/5')).exists();
+
+      await clickByName('Enregistrer le déclencheur');
 
       // then
       assert.strictEqual(currentURL(), `/trainings/${trainingId}/triggers`);

--- a/admin/tests/unit/adapters/training-trigger_test.js
+++ b/admin/tests/unit/adapters/training-trigger_test.js
@@ -1,0 +1,61 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Adapter | TrainingTrigger', function (hooks) {
+  setupTest(hooks);
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:training-trigger');
+    adapter.ajax = sinon.stub();
+  });
+
+  module('#urlForCreateRecord', function () {
+    test('should build create url from targetProfileId', async function (assert) {
+      // when
+      const options = { adapterOptions: { trainingId: 788 } };
+      const url = await adapter.urlForCreateRecord('training-trigger', options);
+
+      // then
+      assert.true(url.endsWith('/api/admin/trainings/788/triggers'));
+    });
+  });
+
+  module('#createRecord', function (createRecordHooks) {
+    let trainingId;
+    let tubes;
+    createRecordHooks.beforeEach(function () {
+      trainingId = 1;
+      tubes = [
+        { id: 1, level: 2 },
+        { id: 2, level: 4 },
+      ];
+    });
+
+    test('should trigger PUT request with correct payload', async function (assert) {
+      // given
+      sinon.stub(adapter, 'urlForCreateRecord').returns('https://example.net');
+      const attributesWithoutTubes = { type: 'prerequisite', threshold: 10 };
+      const expectedPayload = {
+        data: {
+          data: {
+            attributes: {
+              ...attributesWithoutTubes,
+              tubes,
+            },
+          },
+        },
+      };
+
+      // when
+      await adapter.createRecord(Symbol(), Symbol(), {
+        adapterOptions: { tubes, trainingId },
+        serialize: sinon.stub().returns({ data: { attributes: attributesWithoutTubes } }),
+      });
+
+      // then
+      assert.ok(adapter.ajax.calledWith(`https://example.net`, 'PUT', expectedPayload));
+    });
+  });
+});

--- a/api/lib/application/trainings/index.js
+++ b/api/lib/application/trainings/index.js
@@ -205,29 +205,15 @@ exports.register = async (server) => {
               attributes: Joi.object({
                 type: Joi.string().valid('prerequisite', 'goal').required(),
                 threshold: Joi.number().min(0).max(100).required(),
-              }),
-              relationships: Joi.object({
-                tubes: Joi.object({
-                  data: Joi.array().items(
-                    Joi.object({
-                      id: identifiersType.tubeId.required(),
-                      type: Joi.string().valid('tubes').required(),
-                    })
-                  ),
-                }),
+                tubes: Joi.array().items(
+                  Joi.object({
+                    id: identifiersType.tubeId.required(),
+                    level: Joi.number().min(0).max(8).required(),
+                  })
+                ),
               }),
               type: Joi.string().valid('training-triggers'),
             }).required(),
-            included: Joi.array()
-              .items(
-                Joi.object({
-                  attributes: Joi.object({
-                    id: identifiersType.tubeId.required(),
-                    level: Joi.number().min(0).max(8).required(),
-                  }),
-                }).required()
-              )
-              .required(),
           }).required(),
           options: {
             allowUnknown: true,

--- a/api/tests/unit/application/trainings/index_test.js
+++ b/api/tests/unit/application/trainings/index_test.js
@@ -969,28 +969,9 @@ describe('Unit | Router | training-router', function () {
             trainingId: 123,
             type: 'prerequisite',
             threshold: 30,
-          },
-          relationships: {
-            tubes: {
-              data: [
-                {
-                  id: 'recTube123',
-                  type: 'tubes',
-                },
-              ],
-            },
+            tubes: [{ id: 'recTube123', level: 2 }],
           },
         },
-        included: [
-          {
-            attributes: {
-              id: 'recTube123',
-              level: 2,
-            },
-            id: 'recTube123',
-            type: 'tubes',
-          },
-        ],
       };
     });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-trigger-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-trigger-serializer_test.js
@@ -57,28 +57,9 @@ describe('Unit | Serializer | JSONAPI | training-trigger-serializer', function (
             trainingId: 123,
             type: 'prerequisite',
             threshold: 30,
-          },
-          relationships: {
-            tubes: {
-              data: [
-                {
-                  id: 'recTube123',
-                  type: 'tubes',
-                },
-              ],
-            },
+            tubes: [{ id: 'recTube123', level: 2 }],
           },
         },
-        included: [
-          {
-            attributes: {
-              id: 'recTube123',
-              level: 2,
-            },
-            id: 'recTube123',
-            type: 'tubes',
-          },
-        ],
       };
 
       // when


### PR DESCRIPTION
## :unicorn: Problème

Le formulaire de création de déclencheur de contenu formatif est utilisable, mais l'action de sauvegarde n'était pas encore branchée à l'API.

## :robot: Proposition

Gérer le submit du formulaire en se branchant à l'endpoint PUT `/api/admin/trainings/:trainingId/triggers`.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Se connecter à [la RA](https://admin-pr5722.review.pix.fr/)
- Créer un nouveau déclencheur de contenu formatif
- L'enregistrer
- Avoir une notification de validation et être redirigé
