### PR TITLE
[BUGFIX] Rétablissement de l'espacement des titres sur la double mire (PIX-7134).

### DIFF
--- a/orga/app/styles/components/login-or-register.scss
+++ b/orga/app/styles/components/login-or-register.scss
@@ -59,6 +59,10 @@
     @include device-is('tablet') {
       min-width: 360px;
     }
+
+    .form-title {
+      margin: $spacing-m 0;
+    }
   }
 
   &__divider {


### PR DESCRIPTION
## :unicorn: Problème
[La dernière montée de version de Pix UI dans Pix Orga](https://1024pix.atlassian.net/browse/PIX-6844) a cassé la page d’invitation à rejoindre un espace Pix Orga : les CTA sont trop proche des titres.

## :robot: Proposition
Rajouter le spacing pour ces titres la.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Vérifier sur la page de double mire suite à une invitation sur Pix Orga, l'espacement des titres.
