### PR TITLE
[CHORE] Aligner les en-tête et le contenu sur le tableau de la page des prescrits (PIX-7247)

### DIFF
--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -38,9 +38,10 @@
         >
           {{t "pages.organization-participants.table.column.last-name.label"}}
         </Table::HeaderSort>
-        <Table::Header>{{t "pages.organization-participants.table.column.first-name"}}</Table::Header>
+        <Table::Header @size="wide">{{t "pages.organization-participants.table.column.first-name"}}</Table::Header>
         <Table::HeaderSort
           @size="medium"
+          @align="center"
           @onSort={{@sortByParticipationCount}}
           @order={{@participationCountOrder}}
           @ariaLabelDefaultSort={{t
@@ -51,7 +52,7 @@
         >
           {{t "pages.organization-participants.table.column.participation-count.label"}}
         </Table::HeaderSort>
-        <Table::Header @size="medium" @align="right">
+        <Table::Header @size="medium" @align="center">
           {{t "pages.organization-participants.table.column.latest-participation"}}
         </Table::Header>
         <Table::Header @size="medium" @align="center">
@@ -83,7 +84,7 @@
               </LinkTo>
             </td>
             <td class="ellipsis" title={{participant.firstName}}>{{participant.firstName}}</td>
-            <td class="table__column--right">{{participant.participationCount}}</td>
+            <td class="table__column--center">{{participant.participationCount}}</td>
             <td>
               <div class="organization-participant-list-page__last-participation">
                 <span>{{dayjs-format participant.lastParticipationDate "DD/MM/YYYY"}}</span>

--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -74,7 +74,7 @@
           {{t "pages.organization-participants.table.column.last-name.label"}}
         </Table::HeaderSort>
         <Table::Header @size="wide">{{t "pages.sco-organization-participants.table.column.first-name"}}</Table::Header>
-        <Table::Header @size="medium" @align="center">
+        <Table::Header @size="medium">
           {{t "pages.sco-organization-participants.table.column.date-of-birth"}}
         </Table::Header>
         <Table::Header @size="medium">{{t "pages.sco-organization-participants.table.column.division"}}</Table::Header>
@@ -83,6 +83,7 @@
         </Table::Header>
         <Table::HeaderSort
           @size="medium"
+          @align="center"
           @onSort={{@sortByParticipationCount}}
           @order={{@participationCountOrder}}
           @ariaLabelDefaultSort={{t
@@ -92,7 +93,6 @@
           @ariaLabelSortDown={{t
             "pages.sco-organization-participants.table.column.participation-count.ariaLabelSortDown"
           }}
-          class="organization-participant-list-page__participant-count"
         >
           {{t "pages.sco-organization-participants.table.column.participation-count.label"}}
         </Table::HeaderSort>
@@ -131,17 +131,15 @@
               </LinkTo>
             </td>
             <td class="ellipsis" title={{student.firstName}}>{{student.firstName}}</td>
-            <td class="table__column--center">{{dayjs-format student.birthdate "DD/MM/YYYY" allow-empty=true}}</td>
+            <td>{{dayjs-format student.birthdate "DD/MM/YYYY" allow-empty=true}}</td>
             <td class="ellipsis">{{student.division}}</td>
             <td class="sco-organization-participant-list-page__authentication-methods">
               {{#each student.authenticationMethods as |authenticationMethod|}}
                 <p>{{t authenticationMethod}}</p>
               {{/each}}
             </td>
-            <td
-              class="table__column--right organization-participant-list-page__participant-count"
-            >{{student.participationCount}}</td>
-            <td class="table__column--center">
+            <td class="table__column--center">{{student.participationCount}}</td>
+            <td>
               {{#if student.lastParticipationDate}}
                 <div class="organization-participant-list-page__last-participation">
                   <span>{{dayjs-format student.lastParticipationDate "DD/MM/YYYY" allow-empty=true}}</span>

--- a/orga/app/components/sup-organization-participant/list.hbs
+++ b/orga/app/components/sup-organization-participant/list.hbs
@@ -62,12 +62,13 @@
           {{t "pages.organization-participants.table.column.last-name.label"}}
         </Table::HeaderSort>
         <Table::Header @size="wide">{{t "pages.sup-organization-participants.table.column.first-name"}}</Table::Header>
-        <Table::Header @size="medium" @align="center">
+        <Table::Header @size="medium">
           {{t "pages.sup-organization-participants.table.column.date-of-birth"}}
         </Table::Header>
         <Table::Header @size="wide">{{t "pages.sup-organization-participants.table.column.group"}}</Table::Header>
         <Table::HeaderSort
           @size="medium"
+          @align="center"
           @onSort={{@sortByParticipationCount}}
           @order={{@participationCountOrder}}
           @ariaLabelDefaultSort={{t
@@ -77,7 +78,6 @@
           @ariaLabelSortDown={{t
             "pages.sup-organization-participants.table.column.participation-count.ariaLabelSortDown"
           }}
-          class="organization-participant-list-page__participant-count"
         >
           {{t "pages.sup-organization-participants.table.column.participation-count.label"}}
         </Table::HeaderSort>
@@ -117,12 +117,10 @@
               </LinkTo>
             </td>
             <td class="ellipsis">{{student.firstName}}</td>
-            <td class="table__column--center">{{dayjs-format student.birthdate "DD/MM/YYYY"}}</td>
+            <td>{{dayjs-format student.birthdate "DD/MM/YYYY"}}</td>
             <td class="ellipsis">{{student.group}}</td>
-            <td
-              class="table__column--right organization-participant-list-page__participant-count"
-            >{{student.participationCount}}</td>
-            <td class="table__column--center">
+            <td class="table__column--center">{{student.participationCount}}</td>
+            <td>
               {{#if student.lastParticipationDate}}
                 <div class="organization-participant-list-page__last-participation">
                   <span>{{dayjs-format student.lastParticipationDate "DD/MM/YYYY" allow-empty=true}}</span>

--- a/orga/app/styles/pages/authenticated/organization-participants.scss
+++ b/orga/app/styles/pages/authenticated/organization-participants.scss
@@ -27,10 +27,6 @@ $margin-right: 32px;
     }
   }
 
-  &__participant-count {
-    padding-left: 0;
-  }
-
   &__certifiable-at {
     display: block;
     margin-top: $spacing-xxs;

--- a/orga/app/styles/pages/authenticated/sco-organization-participants/list.scss
+++ b/orga/app/styles/pages/authenticated/sco-organization-participants/list.scss
@@ -7,7 +7,7 @@
   }
 
   &__certificability-header {
-    display: flex;
+    display: inline-flex;
     flex-wrap: wrap;
   }
 }

--- a/orga/app/styles/pages/authenticated/sup-organization-participants/list.scss
+++ b/orga/app/styles/pages/authenticated/sup-organization-participants/list.scss
@@ -1,6 +1,6 @@
 .sup-organization-participant-list-page {
   &__certificability-header {
-    display: flex;
+    display: inline-flex;
     flex-wrap: wrap;
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Sur la page participants/étudiants/élèves, il y a actuellement plusieurs types de comportement dans les colonnes du tableau : justifié à gauche, à droite, ou centré.

## :robot: Proposition
Dans le tableau de la liste des prescrits (étudiants/élèves/participants) d’une orga, modifier les alignements pour rendre le plus harmonieux possible.

## :rainbow: Remarques
Suite à différents essais, il a été choisi de justifier à gauche toutes les colonnes avant la colonne "nombre de participations", puis à partir de celle-ci, les centrer.

## :100: Pour tester

- Aller sur Pix Orga : (Pour les 3 types d'orga).
- Aller sur la page élèves/étudiants/participants.
- Vérifier les alignements (cf Remarques)
