### PR TITLE
[FEATURE][MON-PIX] Améliorer l'utilisabilité de la page d'erreur en cas de non-consentement du partage des informations de l'utilisateur entre l'identity provider et Pix (PIX-7248)

### DIFF
--- a/mon-pix/app/errors/application-error.js
+++ b/mon-pix/app/errors/application-error.js
@@ -1,0 +1,10 @@
+export class ApplicationError extends Error {
+  constructor({ cause, extras, message }) {
+    super(message, { cause });
+    this._extras = extras;
+  }
+
+  get extras() {
+    return this._extras;
+  }
+}

--- a/mon-pix/app/errors/factories/create-application-error.js
+++ b/mon-pix/app/errors/factories/create-application-error.js
@@ -1,0 +1,20 @@
+import { ApplicationError } from 'mon-pix/errors/application-error';
+
+const ERROR_CODES_MAP_TO_I18N_KEY = {
+  access_denied: 'pages.login-or-register-oidc.error.data-sharing-refused',
+};
+
+function withCodeAndDescription({ code, description, intl: intlService }) {
+  let message = description;
+  const translationKey = ERROR_CODES_MAP_TO_I18N_KEY[code];
+
+  if (translationKey) {
+    message = intlService.t(translationKey);
+  }
+
+  return new ApplicationError({ message, extras: { code, description } });
+}
+
+export const createTranslatedApplicationError = {
+  withCodeAndDescription,
+};

--- a/mon-pix/app/routes/authentication/login-oidc.js
+++ b/mon-pix/app/routes/authentication/login-oidc.js
@@ -5,12 +5,14 @@ import get from 'lodash/get';
 import ENV from 'mon-pix/config/environment';
 import fetch from 'fetch';
 import JSONApiError from 'mon-pix/errors/json-api-error';
+import { createTranslatedApplicationError } from 'mon-pix/errors/factories/create-application-error';
 
 export default class LoginOidcRoute extends Route {
   @service session;
   @service router;
   @service location;
   @service oidcIdentityProviders;
+  @service intl;
 
   _unsetOidcProperties() {
     this.session.set('data.nextURL', undefined);
@@ -21,7 +23,12 @@ export default class LoginOidcRoute extends Route {
   beforeModel(transition) {
     const queryParams = transition.to.queryParams;
     if (queryParams.error) {
-      throw new Error(`${queryParams.error}: ${queryParams.error_description}`);
+      const error = createTranslatedApplicationError.withCodeAndDescription({
+        code: queryParams.error,
+        description: queryParams.error_description,
+        intl: this.intl,
+      });
+      throw error;
     }
 
     if (!queryParams.code) {

--- a/mon-pix/app/routes/error.js
+++ b/mon-pix/app/routes/error.js
@@ -2,6 +2,7 @@ import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import get from 'lodash/get';
 import JSONApiError from 'mon-pix/errors/json-api-error';
+import { ApplicationError } from 'mon-pix/errors/application-error';
 
 export default class ErrorRoute extends Route {
   @service session;
@@ -30,6 +31,8 @@ export default class ErrorRoute extends Route {
       if (error.shortCode) {
         controller.errorStatus += ` (${error.shortCode})`;
       }
+    } else if (error instanceof ApplicationError) {
+      controller.errorMessage = error.message;
     } else if (apiError) {
       controller.errorDetail = apiError.detail;
       controller.errorStatus = apiError.status;

--- a/mon-pix/tests/unit/errors/factories/create-application-error_test.js
+++ b/mon-pix/tests/unit/errors/factories/create-application-error_test.js
@@ -1,0 +1,71 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import { createTranslatedApplicationError } from 'mon-pix/errors/factories/create-application-error';
+
+module('Unit | Errors | Factories | create-application-error', function (hooks) {
+  setupTest(hooks);
+
+  hooks.afterEach(function () {
+    sinon.restore();
+  });
+
+  module('when the error code is provided', function () {
+    test('returns an application error with a translated message', function (assert) {
+      // Given
+      const intlService = this.owner.lookup('service:intl');
+
+      intlService.t = sinon.stub().returns('My translated error message');
+
+      // When
+      const error = createTranslatedApplicationError.withCodeAndDescription({
+        code: 'access_denied',
+        description: 'Error description',
+        intl: intlService,
+      });
+
+      // Then
+      sinon.assert.calledWith(intlService.t, 'pages.login-or-register-oidc.error.data-sharing-refused');
+      assert.strictEqual(error.message, 'My translated error message');
+    });
+  });
+
+  module('when the error code is not in the list of handled error codes', function () {
+    test('returns an application error with provided error description as message', function (assert) {
+      // Given
+      const intlService = this.owner.lookup('service:intl');
+
+      intlService.t = sinon.stub().returns('My translated error message');
+
+      // When
+      const error = createTranslatedApplicationError.withCodeAndDescription({
+        code: 'ERROR_CODE',
+        description: 'Error description',
+        intl: intlService,
+      });
+
+      // Then
+      sinon.assert.notCalled(intlService.t);
+      assert.strictEqual(error.message, 'Error description');
+    });
+  });
+
+  module('when the error code is not provided', function () {
+    test('returns an application error with provided error description as message', function (assert) {
+      // Given
+      const intlService = this.owner.lookup('service:intl');
+
+      intlService.t = sinon.stub().returns('My translated error message');
+
+      // When
+      const error = createTranslatedApplicationError.withCodeAndDescription({
+        description: 'Error description',
+        intl: intlService,
+      });
+
+      // Then
+      sinon.assert.notCalled(intlService.t);
+      assert.strictEqual(error.message, 'Error description');
+    });
+  });
+});

--- a/mon-pix/tests/unit/routes/authentication/login-oidc_test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-oidc_test.js
@@ -3,13 +3,14 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import * as fetch from 'fetch';
+import { ApplicationError } from 'mon-pix/errors/application-error';
 
 module('Unit | Route | login-oidc', function (hooks) {
   setupTest(hooks);
 
   module('#beforeModel', function () {
     module('when receives error from identity provider', function () {
-      test('should throw an error', function (assert) {
+      test('throws an error', function (assert) {
         // given
         const route = this.owner.lookup('route:authentication/login-oidc');
 
@@ -25,7 +26,7 @@ module('Unit | Route | login-oidc', function (hooks) {
               },
             });
           },
-          Error,
+          ApplicationError,
           'access_denied: Access was denied.'
         );
       });

--- a/mon-pix/tests/unit/routes/error_test.js
+++ b/mon-pix/tests/unit/routes/error_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import JSONApiError from 'mon-pix/errors/json-api-error';
+import { ApplicationError } from 'mon-pix/errors/application-error';
 
 module('Unit | Route | error', function (hooks) {
   setupTest(hooks);
@@ -48,6 +49,21 @@ module('Unit | Route | error', function (hooks) {
       assert.strictEqual(controller.errorDetail, null);
       assert.strictEqual(controller.errorStatus, error.status);
       assert.strictEqual(controller.errorTitle, error.title);
+    });
+
+    test('handles application errors', function (assert) {
+      // Given
+      const controller = {};
+      const error = new ApplicationError({ message: 'This is an error message' });
+
+      // When
+      route.setupController(controller, error);
+
+      // Then
+      assert.strictEqual(controller.errorMessage, error.message);
+      assert.strictEqual(controller.errorDetail, null);
+      assert.strictEqual(controller.errorStatus, null);
+      assert.strictEqual(controller.errorTitle, null);
     });
 
     test('handles unhandled errors', function (assert) {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -984,7 +984,8 @@
         "expired-authentication-key": "Your authentication demand has expired.",
         "invalid-email": "Your email address is invalid.",
         "login-unauthorized-error": "There was an error in the email address or password entered.",
-        "account-conflict": "Ce compte est déjà associé à cet organisme. Veuillez vous connecter avec un autre compte ou contacter le support."
+        "account-conflict": "Ce compte est déjà associé à cet organisme. Veuillez vous connecter avec un autre compte ou contacter le support.",
+        "data-sharing-refused": "You have declined to share your information with us."
       }
     },
     "oidc-reconciliation": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -984,7 +984,8 @@
         "expired-authentication-key": "Votre demande d'authentification a expiré.",
         "invalid-email": "Votre adresse e-mail n’est pas valide.",
         "login-unauthorized-error": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects.",
-        "account-conflict": "Ce compte est déjà associé à cet organisme. Veuillez vous connecter avec un autre compte ou contacter le support."
+        "account-conflict": "Ce compte est déjà associé à cet organisme. Veuillez vous connecter avec un autre compte ou contacter le support.",
+        "data-sharing-refused": "Vous avez refusé de partager vos informations avec nous."
       }
     },
     "oidc-reconciliation": {


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu'un utilisateur se connecte avec un SSO et refuse de fournir les informations nécessaire au bon fonctionnement de la plateforme Pix, il arrive sur une page d'erreur générique avec le message que nous fourni l'identity provider.

![Screenshot 2023-02-24 at 09 48 30](https://user-images.githubusercontent.com/6919604/221134718-9c6122c2-b157-4b79-8471-e2a175ed7d9d.png)

## :robot: Proposition

- Faire un mapping entre le code d'erreur retourné par l'identity provider et une clé de traduction
- Afficher le message d'erreur traduit sur la page d'erreur générique 

## :rainbow: Remarques

Actuellement certains comptes fourni par Pôle Emploi ont l'option `Se souvenir de ma décision` active et donc impossible d'afficher la page de décision de partage d'information.

## :100: Pour tester

⚠️ A tester uniquement en local

- Se connecter à Pix App
- Cliquer sur le bouton `Se connecter avec pôle emploi`
- Se connecter avec l'un des utilisateurs (**andreia** ou **Emilie)** fourni dans le jeu de données de pôle emploi (voir confluence)
- ⚠️ **Ne pas cliquer sur `Se souvenir de ma décision`**
- Cliquer sur le bouton `Refuser`
- Constater que vous arrivez sur la page d'erreur générique avec le message d'erreur que nous avons défini
