### PR TITLE
[BUGFIX] Afficher 1024 comme nombre max de Pix au lieu du max actuel (PIX-7254).

### DIFF
--- a/mon-pix/app/components/hexagon-score.hbs
+++ b/mon-pix/app/components/hexagon-score.hbs
@@ -3,7 +3,7 @@
     <div class="hexagon-score-content__title">{{t "common.pix"}}</div>
     <div class="hexagon-score-content__pix-score">{{this.score}}</div>
     <div class="hexagon-score-content__pix-total">
-      {{@maxReachablePixScore}}
+      1024
       <PixTooltip @isLight={{true}} @isWide={{true}} @position="bottom" @id="hexagon-score-tooltip">
         <:triggerElement>
           <button
@@ -18,7 +18,7 @@
         <:tooltip>
           <div class="hexagon-score__information hexagon-score-information__text">
             <p class="hexagon-score-information__text--strong">
-              {{t "pages.profile.total-score-helper.title" maxReachablePixScore=@maxReachablePixScore}}
+              {{t "pages.profile.total-score-helper.title"}}
             </p>
             {{t
               "pages.profile.total-score-helper.explanation"

--- a/mon-pix/tests/integration/components/hexagon-score_test.js
+++ b/mon-pix/tests/integration/components/hexagon-score_test.js
@@ -52,21 +52,5 @@ module('Integration | Component | hexagon-score', function (hooks) {
       // then
       assert.ok(screen.getByRole('button', { name: this.intl.t('pages.profile.total-score-helper.label') }));
     });
-
-    test('should display maxReachablePixScore', async function (assert) {
-      // given
-      const maxReachablePixScore = 100;
-      const maxReachableLevel = 5;
-      this.set('maxReachablePixScore', maxReachablePixScore);
-      this.set('maxReachableLevel', maxReachableLevel);
-
-      // when
-      const screen = await render(
-        hbs`<HexagonScore @maxReachableLevel={{this.maxReachableLevel}} @maxReachablePixScore={{this.maxReachablePixScore}}/>`
-      );
-
-      // then
-      assert.ok(screen.getByText(maxReachablePixScore));
-    });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1062,7 +1062,7 @@
       "total-score-helper": {
         "label": "Open tooltip",
         "icon": "Pix information",
-        "title": "Why {maxReachablePixScore} pix?",
+        "title": "Why 1024 pix?",
         "explanation": "<p>That’s the maximum number of pix you can get when the 8 levels of the Pix framework will be available.'</p><p>'Today, '<span class=\"hexagon-score-information__text--strong\">'the maximum number available is {maxReachablePixScore} pix'</span>', corresponding to level {maxReachableLevel}.'</p>'"
       }
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1062,7 +1062,7 @@
       "total-score-helper": {
         "label": "Ouvrir l'infobulle",
         "icon": "Information sur les pix",
-        "title": "Pourquoi {maxReachablePixScore} pix ?",
+        "title": "Pourquoi 1024 pix ?",
         "explanation": "<p>C’est le nombre maximum de pix qu’on pourra atteindre lorsque les 8 niveaux du référentiel Pix seront disponibles.'</p><p>'Aujourd’hui, '<span class=\"hexagon-score-information__text--strong\">'le maximum est de {maxReachablePixScore} pix'</span>', correspondant au niveau {maxReachableLevel}.'</p>'"
       }
     },


### PR DESCRIPTION
## :unicorn: Problème
Lors de la PR https://github.com/1024pix/pix/pull/5609 une erreur a été commise d'utiliser la `maxReachablePixScore` retourné par l'API, cependant il s'agit du `maxReachablePixScore` actuel et non final lorsque l'application aura le niveau 8. 

## :robot: Proposition
Remettre les valeurs en dur comme avant pour le 1024 :'( 

## :rainbow: Remarques
Le score max final devrait être aussi retourné par l'API, car ceci ne facilite pas l'open source et l'utilisation d'un référentiel plus petit/ sur un nombre maximum différent

## :100: Pour tester
- Se connecter 
- Voir le score sur la page d'accueil et voir qu'il est sur 1024 
- Ouvrir la tooltip et constater qu'il y a la phrase "Pourquoi 1024 pix ?"