### PR TITLE
[TECH] Utiliser uniquement des exports nommés dans lib (PIX-7202)

### DIFF
--- a/api/codemods/migrate-cjs-to-esm/todo.md
+++ b/api/codemods/migrate-cjs-to-esm/todo.md
@@ -1,0 +1,18 @@
+
+> pix-api@3.332.0 esm-migration:prepare:detect
+> jscodeshift --transform ./codemods/migrate-cjs-to-esm/transforms/src/detect-incompatible-cjs-named-exports.js --extensions js --ignore-config=.codemodsignore . | grep papapa -A 1 | grep path
+
+  path: 'db/knexfile.js',
+  path: 'lib/infrastructure/mailers/mailer.js',
+  path: 'lib/infrastructure/utils/redis-monitor.js',
+  path: 'db/database-builder/database-buffer.js',
+  path: 'tests/test-helper.js',
+  path: 'lib/infrastructure/caches/learning-content-cache.js',
+  path: 'tests/tooling/domain-builder/domain-builder.js',
+  path: 'tests/tooling/learning-content-builder/index.js',
+  path: 'tests/tooling/chai-custom-helpers/deep-equal-array.js',
+  path: 'tests/tooling/chai-custom-helpers/deep-equal-instance-omitting.js',
+  path: 'tests/tooling/chai-custom-helpers/deep-equal-instance.js',
+  path: 'tests/tooling/chai-custom-helpers/index.js',
+  path: 'tests/tooling/domain-builder/factory/build-validation.js',
+  path: 'tests/tooling/domain-builder/factory/build-skill-learning-content-data-object.js',

--- a/api/codemods/migrate-cjs-to-esm/transforms/prepare.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/prepare.js
@@ -6,6 +6,7 @@ const codemods = [
   require('./src/cjs-named-export-containing-functions-to-cjs-named-export'),
   require('./src/cjs-anonymous-export-to-cjs-named-export'),
   require('./src/bookshelf-anonymous-call-expression-export-to-cjs-named-export'),
+  require('./src/joi-anonymous-call-expression-export-to-cjs-named-export'),
 ];
 
 const transformScripts = (fileInfo, api, options) => {

--- a/api/codemods/migrate-cjs-to-esm/transforms/prepare.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/prepare.js
@@ -3,6 +3,8 @@
 const codemods = [
   require('./src/add-file-extension-to-import'),
   require('./src/cjs-anonymous-function-export-to-cjs-named-export'),
+  require('./src/cjs-named-export-containing-functions-to-cjs-named-export'),
+  require('./src/cjs-anonymous-export-to-cjs-named-export'),
 ];
 
 const transformScripts = (fileInfo, api, options) => {

--- a/api/codemods/migrate-cjs-to-esm/transforms/prepare.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/prepare.js
@@ -7,6 +7,7 @@ const codemods = [
   require('./src/cjs-anonymous-export-to-cjs-named-export'),
   require('./src/bookshelf-anonymous-call-expression-export-to-cjs-named-export'),
   require('./src/joi-anonymous-call-expression-export-to-cjs-named-export'),
+  require('./src/cjs-anonymous-class-export-to-cjs-named-export'),
 ];
 
 const transformScripts = (fileInfo, api, options) => {

--- a/api/codemods/migrate-cjs-to-esm/transforms/prepare.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/prepare.js
@@ -5,6 +5,7 @@ const codemods = [
   require('./src/cjs-anonymous-function-export-to-cjs-named-export'),
   require('./src/cjs-named-export-containing-functions-to-cjs-named-export'),
   require('./src/cjs-anonymous-export-to-cjs-named-export'),
+  require('./src/bookshelf-anonymous-call-expression-export-to-cjs-named-export'),
 ];
 
 const transformScripts = (fileInfo, api, options) => {

--- a/api/codemods/migrate-cjs-to-esm/transforms/prepare.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/prepare.js
@@ -2,6 +2,7 @@
 /* eslint-disable no-undef */
 const codemods = [
   require('./src/add-file-extension-to-import'),
+  require('./src/cjs-anonymous-function-export-to-cjs-named-export'),
 ];
 
 const transformScripts = (fileInfo, api, options) => {

--- a/api/codemods/migrate-cjs-to-esm/transforms/src/add-file-extension-to-import.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/src/add-file-extension-to-import.js
@@ -1,7 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair
-/* eslint-disable no-undef */
-const util = require('util');
-
 function transformer(file, api, _options) {
   const j = api.jscodeshift;
 

--- a/api/codemods/migrate-cjs-to-esm/transforms/src/bookshelf-anonymous-call-expression-export-to-cjs-named-export.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/src/bookshelf-anonymous-call-expression-export-to-cjs-named-export.js
@@ -1,0 +1,60 @@
+const serializationOptions = { quote: 'single', trailingComma: true };
+
+function transformer(file, api, _options) {
+  const j = api.jscodeshift;
+  // ------------------------------------------------------------------ SEARCH
+  const nodes = j(file.source)
+    .find(j.AssignmentExpression, {
+      left: {
+        type: 'MemberExpression',
+        object: {
+          type: 'Identifier',
+          name: 'module',
+        },
+        property: {
+          type: 'Identifier',
+          name: 'exports',
+        },
+      },
+    })
+    .filter((path) => {
+      return path.node.right.type === 'CallExpression' && path.node.right.callee.object?.name === 'Bookshelf';
+    });
+
+  if (nodes.length === 0) {
+    return file.source;
+  }
+
+  // ----------------------------------------------------------------- REPLACE
+  let callExpressionToInsert;
+
+  nodes.map((path) => {
+    callExpressionToInsert = path.node.right;
+  });
+
+  const variableDeclarationName = callExpressionToInsert.arguments[1].properties[0].value.value;
+  const variableDeclarationNameInPascalCase = variableDeclarationName
+    .split('-')
+    .reduce((acc, curr) => acc + curr.charAt(0).toUpperCase() + curr.slice(1), '');
+
+  const variableDeclarationNameFormated = 'Bookshelf' + variableDeclarationNameInPascalCase.slice(0, -1);
+
+  const variableDeclarationToInsert = j.variableDeclaration('const', [
+    j.variableDeclarator(j.identifier(variableDeclarationNameFormated), j.callExpression.from(callExpressionToInsert)),
+  ]);
+
+  j(nodes.paths()[0].parentPath).insertBefore(variableDeclarationToInsert);
+
+  return nodes
+    .replaceWith((path) => {
+      const propertyToInsert = j.property(
+        'init',
+        j.identifier(variableDeclarationNameFormated),
+        j.identifier(variableDeclarationNameFormated)
+      );
+      return j.assignmentExpression('=', j.identifier('module.exports'), j.objectExpression([propertyToInsert]));
+    })
+    .toSource(serializationOptions);
+}
+
+module.exports = transformer;

--- a/api/codemods/migrate-cjs-to-esm/transforms/src/cjs-anonymous-class-export-to-cjs-named-export.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/src/cjs-anonymous-class-export-to-cjs-named-export.js
@@ -1,0 +1,48 @@
+const serializationOptions = { quote: 'single', trailingComma: true };
+
+function transformer(file, api, _options) {
+  const j = api.jscodeshift;
+  // ------------------------------------------------------------------ SEARCH
+  const nodes = j(file.source)
+    .find(j.AssignmentExpression, {
+      left: {
+        type: 'MemberExpression',
+        object: {
+          type: 'Identifier',
+          name: 'module',
+        },
+        property: {
+          type: 'Identifier',
+          name: 'exports',
+        },
+      },
+    })
+    .filter((path) => {
+      return path.node.right.type === 'ClassExpression';
+    });
+
+  if (nodes.length === 0) {
+    return file.source;
+  }
+
+  let classExpressionToInsert;
+
+  nodes.map((path) => {
+    classExpressionToInsert = path.node.right;
+  });
+
+  const className = classExpressionToInsert.id.name;
+
+  j(nodes.paths()[0].parentPath).insertBefore(
+    j.classDeclaration(classExpressionToInsert.id, classExpressionToInsert.body, classExpressionToInsert.superClass)
+  );
+
+  return nodes
+    .replaceWith((path) => {
+      const propertyToInsert = j.property('init', j.identifier(className), j.identifier(className));
+      return j.assignmentExpression('=', j.identifier('module.exports'), j.objectExpression([propertyToInsert]));
+    })
+    .toSource(serializationOptions);
+}
+
+module.exports = transformer;

--- a/api/codemods/migrate-cjs-to-esm/transforms/src/cjs-anonymous-export-to-cjs-named-export.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/src/cjs-anonymous-export-to-cjs-named-export.js
@@ -1,0 +1,38 @@
+function transformer(file, api, _options) {
+  const j = api.jscodeshift;
+  // ------------------------------------------------------------------ SEARCH
+  const nodes = j(file.source)
+    .find(j.AssignmentExpression, {
+      left: {
+        type: 'MemberExpression',
+        object: {
+          type: 'Identifier',
+          name: 'module',
+        },
+        property: {
+          type: 'Identifier',
+          name: 'exports',
+        },
+      },
+    })
+    .filter((path) => {
+      return path.node.right.type === 'Identifier';
+    });
+
+  if (nodes.length === 0) {
+    return file.source;
+  }
+  // ----------------------------------------------------------------- REPLACE
+  return nodes
+    .replaceWith((path) => {
+      const identifierName = path.node.right.name;
+      return j.assignmentExpression(
+        '=',
+        j.memberExpression(j.identifier('module'), j.identifier('exports'), false),
+        j.objectExpression([j.property('init', j.identifier(identifierName), j.identifier(identifierName))])
+      );
+    })
+    .toSource({ quote: 'single' });
+}
+
+module.exports = transformer;

--- a/api/codemods/migrate-cjs-to-esm/transforms/src/cjs-anonymous-function-export-to-cjs-named-export.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/src/cjs-anonymous-function-export-to-cjs-named-export.js
@@ -1,0 +1,68 @@
+const serializationOptions = { quote: 'single', trailingComma: true };
+
+function transformer(file, api, _options) {
+  const j = api.jscodeshift;
+  let functionNode;
+  // ------------------------------------------------------------------ SEARCH
+  const nodes = j(file.source)
+    .find(j.AssignmentExpression, {
+      left: {
+        type: 'MemberExpression',
+        object: {
+          type: 'Identifier',
+          name: 'module',
+        },
+        property: {
+          type: 'Identifier',
+          name: 'exports',
+        },
+      },
+    })
+    .filter((path) => {
+      return path.node.right.type === 'FunctionExpression';
+    });
+
+  if (nodes.length === 0) {
+    return file.source;
+  }
+  // ----------------------------------------------------------------- REPLACE
+
+  nodes.map((path) => {
+    functionNode = path.node.right;
+  });
+
+  const params = functionNode.params.map((param) => {
+    if (!param) return null;
+    if(param.type === 'AssignmentPattern') {
+      return j.assignmentPattern.from(param);
+    }
+    return param.type === 'ObjectPattern' ? j.objectPattern(param.properties) : j.identifier(param.name);
+  });
+
+  const nodeToInsert = j.variableDeclaration('const', [
+    j.variableDeclarator(
+      j.identifier(functionNode.id.name),
+      j.functionExpression.from({
+        id: null,
+        params,
+        body: j.blockStatement(functionNode.body.body),
+        async: functionNode.async,
+      })
+    ),
+  ]);
+
+  j(nodes.paths()[0].parentPath).insertBefore(nodeToInsert);
+
+  return nodes
+    .replaceWith((path) => {
+      const functionIdentifier = j.identifier(path.node.right.id.name);
+      return j.assignmentExpression(
+        '=',
+        j.identifier('module.exports'),
+        j.objectExpression([j.property('init', functionIdentifier, functionIdentifier)])
+      );
+    })
+    .toSource(serializationOptions);
+}
+
+module.exports = transformer;

--- a/api/codemods/migrate-cjs-to-esm/transforms/src/cjs-named-export-containing-functions-to-cjs-named-export.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/src/cjs-named-export-containing-functions-to-cjs-named-export.js
@@ -38,7 +38,7 @@ function transformer(file, api, _options) {
   const variableDeclarationsToInsert = functionNodesToInsert.map((functionNode) => {
     const params = functionNode.value.params.map((param) => {
       if (!param) return null;
-      if(param.type === 'AssignmentPattern') {
+      if (param.type === 'AssignmentPattern') {
         return j.assignmentPattern.from(param);
       }
       return param.type === 'ObjectPattern' ? j.objectPattern(param.properties) : j.identifier(param.name);
@@ -46,8 +46,8 @@ function transformer(file, api, _options) {
 
     return j.variableDeclaration('const', [
       j.variableDeclarator(
-        j.identifier(functionNode.key.name),
-        j.functionExpression.from ({
+        j.identifier(functionNode.key.name === 'delete' ? 'remove' : functionNode.key.name),
+        j.functionExpression.from({
           id: null,
           params,
           body: j.blockStatement(functionNode.value.body.body),
@@ -63,7 +63,8 @@ function transformer(file, api, _options) {
     .replaceWith((path) => {
       const functionExpressions = path.node.right.properties;
       const functionExpressionsPropertiesToInsert = functionExpressions.map((functionExpression) => {
-        return j.property('init', j.identifier(functionExpression.key.name), j.identifier(functionExpression.key.name));
+        const functionName = functionExpression.key.name === 'delete' ? 'remove' : functionExpression.key.name;
+        return j.property('init', j.identifier(functionName), j.identifier(functionName));
       });
       return j.assignmentExpression(
         '=',

--- a/api/codemods/migrate-cjs-to-esm/transforms/src/cjs-named-export-containing-functions-to-cjs-named-export.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/src/cjs-named-export-containing-functions-to-cjs-named-export.js
@@ -1,0 +1,77 @@
+const serializationOptions = { quote: 'single', trailingComma: true };
+
+function transformer(file, api, _options) {
+  const j = api.jscodeshift;
+  // ------------------------------------------------------------------ SEARCH
+  const nodes = j(file.source)
+    .find(j.AssignmentExpression, {
+      left: {
+        type: 'MemberExpression',
+        object: {
+          type: 'Identifier',
+          name: 'module',
+        },
+        property: {
+          type: 'Identifier',
+          name: 'exports',
+        },
+      },
+    })
+    .filter((path) => {
+      return (
+        path.node.right.type === 'ObjectExpression' &&
+        path.node.right.properties.every((property) => property.value.type === 'FunctionExpression')
+      );
+    });
+
+  if (nodes.length === 0) {
+    return file.source;
+  }
+
+  // ----------------------------------------------------------------- REPLACE
+  let functionNodesToInsert = [];
+
+  nodes.map((path) => {
+    functionNodesToInsert = path.node.right.properties;
+  });
+
+  const variableDeclarationsToInsert = functionNodesToInsert.map((functionNode) => {
+    const params = functionNode.value.params.map((param) => {
+      if (!param) return null;
+      if(param.type === 'AssignmentPattern') {
+        return j.assignmentPattern.from(param);
+      }
+      return param.type === 'ObjectPattern' ? j.objectPattern(param.properties) : j.identifier(param.name);
+    });
+
+    return j.variableDeclaration('const', [
+      j.variableDeclarator(
+        j.identifier(functionNode.key.name),
+        j.functionExpression.from ({
+          id: null,
+          params,
+          body: j.blockStatement(functionNode.value.body.body),
+          async: functionNode.value.async,
+        })
+      ),
+    ]);
+  });
+
+  j(nodes.paths()[0].parentPath).insertBefore(variableDeclarationsToInsert);
+
+  return nodes
+    .replaceWith((path) => {
+      const functionExpressions = path.node.right.properties;
+      const functionExpressionsPropertiesToInsert = functionExpressions.map((functionExpression) => {
+        return j.property('init', j.identifier(functionExpression.key.name), j.identifier(functionExpression.key.name));
+      });
+      return j.assignmentExpression(
+        '=',
+        j.identifier('module.exports'),
+        j.objectExpression(functionExpressionsPropertiesToInsert)
+      );
+    })
+    .toSource(serializationOptions);
+}
+
+module.exports = transformer;

--- a/api/codemods/migrate-cjs-to-esm/transforms/src/detect-incompatible-cjs-named-exports.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/src/detect-incompatible-cjs-named-exports.js
@@ -1,0 +1,40 @@
+const serializationOptions = { quote: 'single', trailingComma: true };
+
+function transformer(file, api, _options) {
+  const j = api.jscodeshift;
+  // ------------------------------------------------------------------ SEARCH
+  const nodes = j(file.source)
+    .find(j.AssignmentExpression, {
+      left: {
+        type: 'MemberExpression',
+        object: {
+          type: 'Identifier',
+          name: 'module',
+        },
+        property: {
+          type: 'Identifier',
+          name: 'exports',
+        },
+      },
+    })
+    .filter((path) => {
+      return (
+        path.node.right.type === 'ClassExpression' ||
+        path.node.right.type === 'CallExpression' ||
+        path.node.right.type === 'NewExpression' ||
+        path.node.right.type === 'FunctionExpression' ||
+        (path.node.right.type === 'ObjectExpression' &&
+          path.node.right.properties.length > 0 &&
+          path.node.right.properties.some((prop) => {
+            return prop.value.type !== 'Identifier';
+          }))
+      );
+    });
+
+  if (nodes.length === 0) return file.source;
+
+  console.log('papapa', file);
+  return file.source;
+}
+
+module.exports = transformer;

--- a/api/codemods/migrate-cjs-to-esm/transforms/src/joi-anonymous-call-expression-export-to-cjs-named-export.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/src/joi-anonymous-call-expression-export-to-cjs-named-export.js
@@ -1,0 +1,58 @@
+const serializationOptions = { quote: 'single', trailingComma: true };
+
+function transformer(file, api, _options) {
+  const j = api.jscodeshift;
+  // ------------------------------------------------------------------ SEARCH
+  const nodes = j(file.source)
+    .find(j.AssignmentExpression, {
+      left: {
+        type: 'MemberExpression',
+        object: {
+          type: 'Identifier',
+          name: 'module',
+        },
+        property: {
+          type: 'Identifier',
+          name: 'exports',
+        },
+      },
+    })
+    .filter((path) => {
+      return (
+        path.node.right.type === 'CallExpression' &&
+        (path.node.right.callee?.object?.callee?.object?.name === 'Joi' ||
+          path.node.right.callee?.object?.name === 'Joi')
+      );
+    });
+
+  if (nodes.length === 0) {
+    return file.source;
+  }
+  // ----------------------------------------------------------------- REPLACE
+  let callExpressionToInsert;
+
+  nodes.map((path) => {
+    callExpressionToInsert = path.node.right;
+  });
+
+  const variableDeclarationName = 'joiObject';
+
+  const variableDeclarationToInsert = j.variableDeclaration('const', [
+    j.variableDeclarator(j.identifier(variableDeclarationName), j.callExpression.from(callExpressionToInsert)),
+  ]);
+
+  j(nodes.paths()[0].parentPath).insertBefore(variableDeclarationToInsert);
+
+  return nodes
+    .replaceWith((path) => {
+      const propertyToInsert = j.property(
+        'init',
+        j.identifier(variableDeclarationName),
+        j.identifier(variableDeclarationName)
+      );
+      return j.assignmentExpression('=', j.identifier('module.exports'), j.objectExpression([propertyToInsert]));
+    })
+    .toSource(serializationOptions);
+}
+
+module.exports = transformer;

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/bookshelf-anonymous-call-expression-export-to-cjs-named-export/bookshelf-model-case.input.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/bookshelf-anonymous-call-expression-export-to-cjs-named-export/bookshelf-model-case.input.js
@@ -1,0 +1,13 @@
+module.exports = Bookshelf.model(
+  modelName,
+  {
+    tableName: 'organization-invitations',
+    hasTimestamps: ['createdAt', 'updatedAt'],
+    organization() {
+      return this.belongsTo('Organization', 'organizationId');
+    },
+  },
+  {
+    modelName,
+  }
+);

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/bookshelf-anonymous-call-expression-export-to-cjs-named-export/bookshelf-model-case.output.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/bookshelf-anonymous-call-expression-export-to-cjs-named-export/bookshelf-model-case.output.js
@@ -1,0 +1,13 @@
+const BookshelfOrganizationInvitation = Bookshelf.model(modelName, {
+  tableName: 'organization-invitations',
+  hasTimestamps: ['createdAt', 'updatedAt'],
+  organization() {
+    return this.belongsTo('Organization', 'organizationId');
+  },
+}, {
+  modelName,
+});
+
+module.exports = {
+  BookshelfOrganizationInvitation: BookshelfOrganizationInvitation,
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-class-export-to-cjs-named-export/simple.input.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-class-export-to-cjs-named-export/simple.input.js
@@ -1,0 +1,14 @@
+module.exports = class CoverPageLegaLMentionText extends Text {
+  constructor({ language }) {
+    const text = textByLang[language];
+    super({
+      text,
+      positionX: PositionManager.coverPageLegalMentionHorizontalStart,
+      positionY: PositionManager.coverPageLegalMentionVerticalStart,
+      fontSize: FontManager.coverPageLegalMentionHeight,
+      font: FontManager.coverPageLegalMentionFont,
+      fontColor: ColorManager.coverPageLegalMentionColor,
+      maxWidth: PositionManager.coverPageLegalMentionWidth,
+    });
+  }
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-class-export-to-cjs-named-export/simple.output.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-class-export-to-cjs-named-export/simple.output.js
@@ -1,0 +1,19 @@
+
+class CoverPageLegaLMentionText extends Text {
+  constructor({ language }) {
+    const text = textByLang[language];
+    super({
+      text,
+      positionX: PositionManager.coverPageLegalMentionHorizontalStart,
+      positionY: PositionManager.coverPageLegalMentionVerticalStart,
+      fontSize: FontManager.coverPageLegalMentionHeight,
+      font: FontManager.coverPageLegalMentionFont,
+      fontColor: ColorManager.coverPageLegalMentionColor,
+      maxWidth: PositionManager.coverPageLegalMentionWidth,
+    });
+  }
+}
+
+module.exports = {
+  CoverPageLegaLMentionText: CoverPageLegaLMentionText,
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-export-to-cjs-named-export/class-export.input.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-export-to-cjs-named-export/class-export.input.js
@@ -1,0 +1,7 @@
+class Foo {
+  constructor({ id }) {
+    this.id = id;
+  }
+}
+
+module.exports = Foo;

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-export-to-cjs-named-export/class-export.output.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-export-to-cjs-named-export/class-export.output.js
@@ -1,0 +1,9 @@
+class Foo {
+  constructor({ id }) {
+    this.id = id;
+  }
+}
+
+module.exports = {
+  Foo: Foo
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/asynchronous-function.input.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/asynchronous-function.input.js
@@ -1,0 +1,3 @@
+module.exports = async function foo({ userId, userRepository }) {
+  return userRepository.updatePixOrgaTermsOfServiceAcceptedToTrue(userId);
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/asynchronous-function.output.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/asynchronous-function.output.js
@@ -1,0 +1,13 @@
+const foo = async function(
+  {
+    userId,
+    userRepository,
+  },
+) {
+  return userRepository.updatePixOrgaTermsOfServiceAcceptedToTrue(userId);
+};
+
+module.exports = {
+  foo: foo,
+};
+

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/correctly-transform-with-private-function.input.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/correctly-transform-with-private-function.input.js
@@ -1,0 +1,7 @@
+module.exports = function foo({ userId, userRepository }) {
+  return _bar();
+};
+
+function _bar() {
+  return 'bar';
+}

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/correctly-transform-with-private-function.output.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/correctly-transform-with-private-function.output.js
@@ -1,0 +1,16 @@
+const foo = function(
+  {
+    userId,
+    userRepository,
+  },
+) {
+  return _bar();
+};
+
+module.exports = {
+  foo: foo,
+};
+
+function _bar() {
+  return 'bar';
+}

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/correctly-transforms-with-imports.input.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/correctly-transforms-with-imports.input.js
@@ -1,0 +1,63 @@
+const { UserNotAuthorizedToAccessEntityError } = require('../errors.js');
+const Scorecard = require('../models/Scorecard.js');
+const KnowledgeElement = require('../models/KnowledgeElement.js');
+const _ = require('lodash');
+module.exports = async function findTutorials({
+  authenticatedUserId,
+  scorecardId,
+  knowledgeElementRepository,
+  skillRepository,
+  tubeRepository,
+  tutorialRepository,
+  locale,
+}) {
+  const { userId, competenceId } = Scorecard.parseId(scorecardId);
+
+  if (parseInt(authenticatedUserId) !== parseInt(userId)) {
+    throw new UserNotAuthorizedToAccessEntityError();
+  }
+
+  const knowledgeElements = await knowledgeElementRepository.findUniqByUserIdAndCompetenceId({ userId, competenceId });
+  const invalidatedDirectKnowledgeElements = _getInvalidatedDirectKnowledgeElements(knowledgeElements);
+
+  if (invalidatedDirectKnowledgeElements.length === 0) {
+    return [];
+  }
+  const skills = await skillRepository.findActiveByCompetenceId(competenceId);
+  const failedSkills = _getFailedSkills(skills, invalidatedDirectKnowledgeElements);
+
+  const skillsGroupedByTube = _getSkillsGroupedByTube(failedSkills);
+  const easiestSkills = _getEasiestSkills(skillsGroupedByTube);
+
+  const tubeNamesForTutorials = _.keys(skillsGroupedByTube);
+  const tubes = await tubeRepository.findByNames({ tubeNames: tubeNamesForTutorials, locale });
+
+  const tutorialsWithTubesList = await _getTutorialsWithTubesList(
+    easiestSkills,
+    tubes,
+    tutorialRepository,
+    userId,
+    locale
+  );
+  return _.orderBy(_.flatten(tutorialsWithTubesList), 'tubeName');
+};
+
+async function _getTutorialsWithTubesList(easiestSkills, tubes, tutorialRepository, userId, locale) {
+  return await Promise.all(
+    _.map(easiestSkills, async (skill) => {
+      const tube = _.find(tubes, { name: skill.tubeName });
+      const tutorials = await tutorialRepository.findByRecordIdsForCurrentUser({
+        ids: skill.tutorialIds,
+        userId,
+        locale,
+      });
+      return _.map(tutorials, (tutorial) => {
+        tutorial.tubeName = tube.name;
+        tutorial.tubePracticalTitle = tube.practicalTitle;
+        tutorial.tubePracticalDescription = tube.practicalDescription;
+        tutorial.skillId = skill.id;
+        return tutorial;
+      });
+    })
+  );
+}

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/correctly-transforms-with-imports.output.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/correctly-transforms-with-imports.output.js
@@ -1,0 +1,70 @@
+const { UserNotAuthorizedToAccessEntityError } = require('../errors.js');
+const Scorecard = require('../models/Scorecard.js');
+const KnowledgeElement = require('../models/KnowledgeElement.js');
+const _ = require('lodash');
+
+const findTutorials = async function(
+  {
+    authenticatedUserId,
+    scorecardId,
+    knowledgeElementRepository,
+    skillRepository,
+    tubeRepository,
+    tutorialRepository,
+    locale,
+  },
+) {
+  const { userId, competenceId } = Scorecard.parseId(scorecardId);
+
+  if (parseInt(authenticatedUserId) !== parseInt(userId)) {
+    throw new UserNotAuthorizedToAccessEntityError();
+  }
+
+  const knowledgeElements = await knowledgeElementRepository.findUniqByUserIdAndCompetenceId({ userId, competenceId });
+  const invalidatedDirectKnowledgeElements = _getInvalidatedDirectKnowledgeElements(knowledgeElements);
+
+  if (invalidatedDirectKnowledgeElements.length === 0) {
+    return [];
+  }
+  const skills = await skillRepository.findActiveByCompetenceId(competenceId);
+  const failedSkills = _getFailedSkills(skills, invalidatedDirectKnowledgeElements);
+
+  const skillsGroupedByTube = _getSkillsGroupedByTube(failedSkills);
+  const easiestSkills = _getEasiestSkills(skillsGroupedByTube);
+
+  const tubeNamesForTutorials = _.keys(skillsGroupedByTube);
+  const tubes = await tubeRepository.findByNames({ tubeNames: tubeNamesForTutorials, locale });
+
+  const tutorialsWithTubesList = await _getTutorialsWithTubesList(
+    easiestSkills,
+    tubes,
+    tutorialRepository,
+    userId,
+    locale
+  );
+  return _.orderBy(_.flatten(tutorialsWithTubesList), 'tubeName');
+};
+
+module.exports = {
+  findTutorials: findTutorials,
+};
+
+async function _getTutorialsWithTubesList(easiestSkills, tubes, tutorialRepository, userId, locale) {
+  return await Promise.all(
+    _.map(easiestSkills, async (skill) => {
+      const tube = _.find(tubes, { name: skill.tubeName });
+      const tutorials = await tutorialRepository.findByRecordIdsForCurrentUser({
+        ids: skill.tutorialIds,
+        userId,
+        locale,
+      });
+      return _.map(tutorials, (tutorial) => {
+        tutorial.tubeName = tube.name;
+        tutorial.tubePracticalTitle = tube.practicalTitle;
+        tutorial.tubePracticalDescription = tube.practicalDescription;
+        tutorial.skillId = skill.id;
+        return tutorial;
+      });
+    })
+  );
+}

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/do-not-transform-named-export.input.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/do-not-transform-named-export.input.js
@@ -1,0 +1,5 @@
+const foo = 'bar';
+
+module.exports = {
+  foo,
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/do-not-transform-named-export.output.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/do-not-transform-named-export.output.js
@@ -1,0 +1,5 @@
+const foo = 'bar';
+
+module.exports = {
+  foo,
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/synchronous-function.input.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/synchronous-function.input.js
@@ -1,0 +1,3 @@
+module.exports = function foo({ userId, userRepository }) {
+  return userRepository.updatePixOrgaTermsOfServiceAcceptedToTrue(userId);
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/synchronous-function.output.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-anonymous-function-export-to-cjs-named-export/synchronous-function.output.js
@@ -1,0 +1,13 @@
+const foo = function(
+  {
+    userId,
+    userRepository,
+  },
+) {
+  return userRepository.updatePixOrgaTermsOfServiceAcceptedToTrue(userId);
+};
+
+module.exports = {
+  foo: foo,
+};
+

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/asynchronous-function.input.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/asynchronous-function.input.js
@@ -1,0 +1,5 @@
+module.exports = {
+  async foo(arg){
+    return 'Hello world!';
+  },
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/asynchronous-function.output.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/asynchronous-function.output.js
@@ -1,0 +1,7 @@
+const foo = async function(arg) {
+  return 'Hello world!';
+};
+
+module.exports = {
+  foo: foo,
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/complex-example.input.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/complex-example.input.js
@@ -1,0 +1,17 @@
+module.exports = {
+  foo() {
+    return 'Hello world!';
+  },
+  foo1(arg1, arg2) {
+    return 'Hello world!';
+  },
+  async foo2({ arg1, arg2 }) {
+    return 'Hello world!';
+  },
+  async foo3({ arg1, arg2 } = {}) {
+    return 'Hello world!';
+  },
+  async foo4(arg1, { arg2, arg3 }) {
+    return 'Hello world!';
+  },
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/complex-example.output.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/complex-example.output.js
@@ -1,0 +1,38 @@
+const foo = function() {
+  return 'Hello world!';
+};
+
+const foo1 = function(arg1, arg2) {
+  return 'Hello world!';
+};
+
+const foo2 = async function(
+  {
+    arg1,
+    arg2,
+  },
+) {
+  return 'Hello world!';
+};
+
+const foo3 = async function({ arg1, arg2 } = {}) {
+  return 'Hello world!';
+};
+
+const foo4 = async function(
+  arg1,
+  {
+    arg2,
+    arg3,
+  },
+) {
+  return 'Hello world!';
+};
+
+module.exports = {
+  foo: foo,
+  foo1: foo1,
+  foo2: foo2,
+  foo3: foo3,
+  foo4: foo4,
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/function-with-object-params.input.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/function-with-object-params.input.js
@@ -1,0 +1,5 @@
+module.exports = {
+  foo({ arg1, arg2 }) {
+    return `${arg1} ${arg2}`;
+  },
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/function-with-object-params.output.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/function-with-object-params.output.js
@@ -1,0 +1,12 @@
+const foo = function(
+  {
+    arg1,
+    arg2,
+  },
+) {
+  return `${arg1} ${arg2}`;
+};
+
+module.exports = {
+  foo: foo,
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/replace-reserved-keyword.input.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/replace-reserved-keyword.input.js
@@ -1,0 +1,5 @@
+module.exports = {
+  delete(arg) {
+    return 'Hello world!';
+  },
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/replace-reserved-keyword.output.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/replace-reserved-keyword.output.js
@@ -1,0 +1,7 @@
+const remove = function(arg) {
+  return 'Hello world!';
+};
+
+module.exports = {
+  remove: remove,
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/synchronous-function.input.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/synchronous-function.input.js
@@ -1,0 +1,5 @@
+module.exports = {
+  foo(arg){
+    return 'Hello world!';
+  },
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/synchronous-function.output.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/synchronous-function.output.js
@@ -1,0 +1,7 @@
+const foo = function(arg) {
+  return 'Hello world!';
+};
+
+module.exports = {
+  foo: foo,
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/synchronous-functions.input.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/synchronous-functions.input.js
@@ -1,0 +1,8 @@
+module.exports = {
+  foo(arg){
+    return 'Hello world!';
+  },
+  bar(arg){
+    return 'Hello world!';
+  },
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/synchronous-functions.output.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/cjs-named-export-containing-functions-to-cjs-named-export/synchronous-functions.output.js
@@ -1,0 +1,12 @@
+const foo = function(arg) {
+  return 'Hello world!';
+};
+
+const bar = function(arg) {
+  return 'Hello world!';
+};
+
+module.exports = {
+  foo: foo,
+  bar: bar,
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/joi-anonymous-call-expression-export-to-cjs-named-export/joi-object-case.input.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/joi-anonymous-call-expression-export-to-cjs-named-export/joi-object-case.input.js
@@ -1,0 +1,8 @@
+const Joi = require('joi');
+
+module.exports = Joi.object({
+  code: Joi.string().required().description('An application-specific error code.'),
+  title: Joi.string().required().description('A short, human-readable summary of the problem'),
+  status: Joi.string().required().description('the HTTP status code applicable of the problem'),
+  detail: Joi.string().required().description('a human-readable explanation specific of the problem'),
+}).label('Response-Error-Object');

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/joi-anonymous-call-expression-export-to-cjs-named-export/joi-object-case.output.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__testfixtures__/joi-anonymous-call-expression-export-to-cjs-named-export/joi-object-case.output.js
@@ -1,0 +1,12 @@
+const Joi = require('joi');
+
+const joiObject = Joi.object({
+  code: Joi.string().required().description('An application-specific error code.'),
+  title: Joi.string().required().description('A short, human-readable summary of the problem'),
+  status: Joi.string().required().description('the HTTP status code applicable of the problem'),
+  detail: Joi.string().required().description('a human-readable explanation specific of the problem'),
+}).label('Response-Error-Object');
+
+module.exports = {
+  joiObject: joiObject,
+};

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__tests__/bookshelf-anonymous-call-expression-export-to-cjs-named-export.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__tests__/bookshelf-anonymous-call-expression-export-to-cjs-named-export.js
@@ -1,0 +1,5 @@
+const { defineTests } = require('../__testutils__/defineTests');
+
+describe('bookshelf-anonymous-call-expression-export-to-cjs-named-export', () => {
+  defineTests(__dirname, 'bookshelf-anonymous-call-expression-export-to-cjs-named-export');
+});

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__tests__/cjs-anonymous-class-export-to-cjs-named-export-test.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__tests__/cjs-anonymous-class-export-to-cjs-named-export-test.js
@@ -1,0 +1,5 @@
+const { defineTests } = require('../__testutils__/defineTests');
+
+describe('cjs-anonymous-class-export-to-cjs-named-export', () => {
+  defineTests(__dirname, 'cjs-anonymous-class-export-to-cjs-named-export');
+});

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__tests__/cjs-anonymous-export-to-cjs-named-export-test.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__tests__/cjs-anonymous-export-to-cjs-named-export-test.js
@@ -1,0 +1,5 @@
+const { defineTests } = require('../__testutils__/defineTests');
+
+describe('cjs-anonymous-export-to-cjs-named-export', () => {
+  defineTests(__dirname, 'cjs-anonymous-export-to-cjs-named-export');
+});

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__tests__/cjs-anonymous-function-export-to-cjs-named-export-test.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__tests__/cjs-anonymous-function-export-to-cjs-named-export-test.js
@@ -1,0 +1,5 @@
+const { defineTests } = require('../__testutils__/defineTests');
+
+describe('cjs-anonymous-function-export-to-cjs-named-export', () => {
+  defineTests(__dirname, 'cjs-anonymous-function-export-to-cjs-named-export');
+});

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__tests__/cjs-named-export-containing-functions-to-cjs-named-export.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__tests__/cjs-named-export-containing-functions-to-cjs-named-export.js
@@ -1,0 +1,6 @@
+
+const { defineTests } = require('../__testutils__/defineTests');
+
+describe('cjs-named-export-containing-functions-to-cjs-named-export', () => {
+  defineTests(__dirname, 'cjs-named-export-containing-functions-to-cjs-named-export');
+});

--- a/api/codemods/migrate-cjs-to-esm/transforms/tests/__tests__/joi-anonymous-call-expression-export-to-cjs-named-export-test.js
+++ b/api/codemods/migrate-cjs-to-esm/transforms/tests/__tests__/joi-anonymous-call-expression-export-to-cjs-named-export-test.js
@@ -1,0 +1,6 @@
+
+const { defineTests } = require('../__testutils__/defineTests');
+
+describe('joi-anonymous-call-expression-export-to-cjs-named-export', () => {
+  defineTests(__dirname, 'joi-anonymous-call-expression-export-to-cjs-named-export');
+});

--- a/api/package.json
+++ b/api/package.json
@@ -170,7 +170,8 @@
     "test:codemods": "cd codemods/migrate-cjs-to-esm; npm install; npm run test",
     "test:lint": "npm test && npm run lint",
     "esm-migration:prepare": "jscodeshift --transform ./codemods/migrate-cjs-to-esm/transforms/prepare.js --extensions js --ignore-config=.codemodsignore ./lib",
-    "esm-migration:execute": "jscodeshift --transform ./codemods/migrate-cjs-to-esm/transforms/execute.js --extensions js --ignore-config=.codemodsignore ./lib"
+    "esm-migration:execute": "jscodeshift --transform ./codemods/migrate-cjs-to-esm/transforms/execute.js --extensions js --ignore-config=.codemodsignore ./lib",
+    "esm-migration:prepare:detect": "jscodeshift --transform ./codemods/migrate-cjs-to-esm/transforms/src/detect-incompatible-cjs-named-exports.js --extensions js --ignore-config=.codemodsignore ./lib | grep papapa -A 1 | grep path"
   },
   "optionalDependencies": {
     "nyc": "^15.1.0"


### PR DESCRIPTION
## :unicorn: Problème
Les exports anonymes rendent la migration vers ESM complexe.

## :robot: Proposition
Ajouter: 
- un codemod qui transforme tous les exports CJS anonymes en exports CJS nommés;
- un codemod qui transforme tous les imports CJS anonymes en imports CJS nommés.

## :rainbow: Remarques
Cette PR commence par lib, mais sera suivie d'une autre sur:
- tests;
- db;
- scripts.

Il faudra prendre en compte ce cas : https://github.com/1024pix/pix/pull/5738

## :100: Pour tester
Vérifier en local et sur la CI que:
- le lint passe;
- le build passe; 
- le test passe.