### PR TITLE
[FEATURE] Ajout d'un feature toggle pour l'envoi des données à PoleEmploi (PIX-7016).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -248,6 +248,7 @@ module.exports = (function () {
       },
       poleEmploiSendingsLimit: _getNumber(process.env.POLE_EMPLOI_SENDING_LIMIT, 100),
       accessTokenLifespanMs: ms(process.env.POLE_EMPLOI_ACCESS_TOKEN_LIFESPAN || '7d'),
+      pushEnabled: isFeatureEnabled(process.env.PUSH_DATA_TO_POLE_EMPLOI_ENABLED),
     },
 
     cnav: {
@@ -381,6 +382,7 @@ module.exports = (function () {
     config.poleEmploi.logoutUrl = 'http://logout-url.fr';
     config.poleEmploi.afterLogoutUrl = 'http://after-logout.url';
     config.poleEmploi.temporaryStorage.redisUrl = null;
+    config.poleEmploi.pushEnabled = true;
 
     config.temporaryStorage.redisUrl = null;
 

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -31,11 +31,20 @@ const supervisorAccessRepository = require('../../infrastructure/repositories/su
 const targetProfileRepository = require('../../infrastructure/repositories/target-profile-repository.js');
 const userRepository = require('../../infrastructure/repositories/user-repository.js');
 const participantResultsSharedRepository = require('../../infrastructure/repositories/participant-results-shared-repository.js');
-const poleEmploiNotifier = require('../../infrastructure/externals/pole-emploi/pole-emploi-notifier.js');
 const juryCertificationSummaryRepository = require('../../infrastructure/repositories/jury-certification-summary-repository.js');
 const finalizedSessionRepository = require('../../infrastructure/repositories/sessions/finalized-session-repository.js');
 const challengeRepository = require('../../infrastructure/repositories/challenge-repository.js');
 const logger = require('../../infrastructure/logger.js');
+const poleEmploiNotifier = require('../../infrastructure/externals/pole-emploi/pole-emploi-notifier.js');
+const disabledPoleEmploiNotifier = require('../../infrastructure/externals/pole-emploi/disabled-pole-emploi-notifier.js');
+
+function requirePoleEmploiNotifier() {
+  if (settings.poleEmploi.pushEnabled) {
+    return poleEmploiNotifier;
+  } else {
+    return disabledPoleEmploiNotifier;
+  }
+}
 
 const dependencies = {
   assessmentRepository,
@@ -62,7 +71,7 @@ const dependencies = {
   targetProfileRepository,
   userRepository,
   participantResultsSharedRepository,
-  poleEmploiNotifier,
+  poleEmploiNotifier: requirePoleEmploiNotifier(),
   juryCertificationSummaryRepository,
   finalizedSessionRepository,
   challengeRepository,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -1,3 +1,4 @@
+const settings = require('../../config.js');
 const accountRecoveryDemandRepository = require('../../infrastructure/repositories/account-recovery-demand-repository.js');
 const adminMemberRepository = require('../../infrastructure/repositories/admin-member-repository.js');
 const algorithmDataFetcherService = require('../../domain/services/algorithm-methods/data-fetcher.js');
@@ -120,7 +121,6 @@ const pickChallengeService = require('../services/pick-challenge-service.js');
 const pixAuthenticationService = require('../../domain/services/authentication/pix-authentication-service.js');
 const placementProfileService = require('../../domain/services/placement-profile-service.js');
 const poleEmploiSendingRepository = require('../../infrastructure/repositories/pole-emploi-sending-repository.js');
-const poleEmploiNotifier = require('../../infrastructure/externals/pole-emploi/pole-emploi-notifier.js');
 const prescriberRepository = require('../../infrastructure/repositories/prescriber-repository.js');
 const resetPasswordService = require('../../domain/services/reset-password-service.js');
 const resetPasswordDemandRepository = require('../../infrastructure/repositories/reset-password-demands-repository.js');
@@ -137,7 +137,6 @@ const sessionRepository = require('../../infrastructure/repositories/sessions/se
 const sessionForSupervisingRepository = require('../../infrastructure/repositories/sessions/session-for-supervising-repository.js');
 const sessionJuryCommentRepository = require('../../infrastructure/repositories/sessions/session-jury-comment-repository.js');
 const sessionSummaryRepository = require('../../infrastructure/repositories/sessions/session-summary-repository.js');
-const settings = require('../../config.js');
 const skillRepository = require('../../infrastructure/repositories/skill-repository.js');
 const skillSetRepository = require('../../infrastructure/repositories/skill-set-repository.js');
 const studentRepository = require('../../infrastructure/repositories/student-repository.js');
@@ -168,8 +167,18 @@ const userRepository = require('../../infrastructure/repositories/user-repositor
 const userService = require('../../domain/services/user-service.js');
 const userSavedTutorialRepository = require('../../infrastructure/repositories/user-saved-tutorial-repository.js');
 const verifyCertificateCodeService = require('../../domain/services/verify-certificate-code-service.js');
-
 const participantResultsSharedRepository = require('../../infrastructure/repositories/participant-results-shared-repository.js');
+const poleEmploiNotifier = require('../../infrastructure/externals/pole-emploi/pole-emploi-notifier.js');
+const disabledPoleEmploiNotifier = require('../../infrastructure/externals/pole-emploi/disabled-pole-emploi-notifier.js');
+
+function requirePoleEmploiNotifier() {
+  if (settings.poleEmploi.pushEnabled) {
+    return poleEmploiNotifier;
+  } else {
+    return disabledPoleEmploiNotifier;
+  }
+}
+
 const dependencies = {
   accountRecoveryDemandRepository,
   adminMemberRepository,
@@ -294,7 +303,7 @@ const dependencies = {
   pixAuthenticationService,
   placementProfileService,
   poleEmploiSendingRepository,
-  poleEmploiNotifier,
+  poleEmploiNotifier: requirePoleEmploiNotifier(),
   prescriberRepository,
   resetPasswordService,
   resetPasswordDemandRepository,

--- a/api/lib/infrastructure/externals/pole-emploi/disabled-pole-emploi-notifier.js
+++ b/api/lib/infrastructure/externals/pole-emploi/disabled-pole-emploi-notifier.js
@@ -1,0 +1,8 @@
+module.exports = {
+  async notify() {
+    return {
+      isSuccessful: false,
+      code: 'SENDING-DISABLED',
+    };
+  },
+};

--- a/api/sample.env
+++ b/api/sample.env
@@ -532,6 +532,7 @@ AUTH_SECRET=Change me!
 # default: 7d
 # sample: POLE_EMPLOI_ID_TOKEN_LIFESPAN=
 
+
 # Test result URL
 # Refer to https://pole-emploi.io/data/api/pole-emploi-connect
 #
@@ -539,6 +540,11 @@ AUTH_SECRET=Change me!
 # type: URL
 # sample: POLE_EMPLOI_SENDING_URL=
 
+# Enable to push campaign results to pole emploi
+# presence: required to activate or disable the push
+# type: boolean
+# default: true
+# sample: PUSH_DATA_TO_POLE_EMPLOI_ENABLED=true
 
 # ===================
 # CNAV CONFIGURATION

--- a/api/tests/integration/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
+++ b/api/tests/integration/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
@@ -7,7 +7,7 @@ const {
   sinon,
 } = require('../../../test-helper');
 const useCases = require('../../../../lib/domain/usecases/index.js');
-const poleEmploiNotifier = require('../../../../lib/infrastructure/externals/pole-emploi/pole-emploi-notifier');
+const poleEmploiNotifier = require('../../../../lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js');
 
 describe('Integration | Domain | UseCases | send-shared-participation-results-to-pole-emploi', function () {
   let campaignParticipationId, userId, responseCode;
@@ -27,7 +27,6 @@ describe('Integration | Domain | UseCases | send-shared-participation-results-to
     databaseBuilder.factory.buildCampaignSkill({ campaignId });
     campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ campaignId, userId }).id;
     databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId });
-
     const learningContentObjects = learningContentBuilder.buildLearningContent.fromAreas([]);
     mockLearningContent(learningContentObjects);
     return databaseBuilder.commit();

--- a/api/tests/unit/infrastructure/externals/pole-emploi/diabled-pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/diabled-pole-emploi-notifier_test.js
@@ -1,0 +1,15 @@
+const { expect } = require('../../../../test-helper');
+const { notify } = require('../../../../../lib/infrastructure/externals/pole-emploi/disabled-pole-emploi-notifier');
+
+describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier', function () {
+  describe('#notify', function () {
+    it("returns failed results with the code 'SENDING-DISABLED'", async function () {
+      const results = await notify();
+
+      expect(results).to.deep.equal({
+        isSuccessful: false,
+        code: 'SENDING-DISABLED',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
L'envoi des données à Pole emploi à la volée est source de beaucoup d'erreur à cause de la gestion du token.

## :robot: Proposition
Ne plus faire les envois des résultats de campagne à Pole emploi à la volée mais faire en sorte que Pole emploi puisse les récupérer via des requêtes API.
La fonctionnalité est en phase de développement et on veut pouvoir activer/désactiver la fonctionnalité pendant l'exécution.
Pour pouvoir faire ça, on part sur un feature toggle.


## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Mettre la variable d'env PUSH_DATA_TO_POLE_EMPLOI_ENABLED à true ou false pour activer ou désactiver l"envoi.
Vérifier que les données ont été envoyées à PE en cas d'activation de la feature et qu'elles sont juste enregistrées en BDD en cas de désactivation.
