### PR TITLE
[BUGFIX] N'afficher le lien vers l'import de session en masse que pour les centres qui ne sont pas isScoManagingStudent (PIX-7276).

### DIFF
--- a/certif/app/components/no-session-panel.js
+++ b/certif/app/components/no-session-panel.js
@@ -3,8 +3,13 @@ import { inject as service } from '@ember/service';
 
 export default class PanelHeader extends Component {
   @service featureToggles;
+  @service currentUser;
+
+  get isScoManagingStudents() {
+    return this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents;
+  }
 
   get shouldRenderImportTemplateButton() {
-    return this.featureToggles.featureToggles.isMassiveSessionManagementEnabled;
+    return this.featureToggles.featureToggles.isMassiveSessionManagementEnabled && !this.isScoManagingStudents;
   }
 }

--- a/certif/app/components/sessions/panel-header.js
+++ b/certif/app/components/sessions/panel-header.js
@@ -3,8 +3,12 @@ import { inject as service } from '@ember/service';
 
 export default class PanelHeader extends Component {
   @service featureToggles;
+  @service currentUser;
 
   get shouldRenderImportTemplateButton() {
-    return this.featureToggles.featureToggles.isMassiveSessionManagementEnabled;
+    return (
+      this.featureToggles.featureToggles.isMassiveSessionManagementEnabled &&
+      !this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents
+    );
   }
 }

--- a/certif/app/routes/authenticated/sessions/import.js
+++ b/certif/app/routes/authenticated/sessions/import.js
@@ -4,11 +4,15 @@ import Route from '@ember/routing/route';
 export default class ImportRoute extends Route {
   @service featureToggles;
   @service router;
+  @service currentUser;
 
   beforeModel() {
     const { isMassiveSessionManagementEnabled } = this.featureToggles.featureToggles;
 
-    if (!isMassiveSessionManagementEnabled) {
+    if (
+      !isMassiveSessionManagementEnabled ||
+      this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents
+    ) {
       return this.router.replaceWith('authenticated.sessions.list');
     }
   }

--- a/certif/tests/acceptance/routes/authenticated/sessions/import_test.js
+++ b/certif/tests/acceptance/routes/authenticated/sessions/import_test.js
@@ -13,58 +13,84 @@ module('Acceptance | Routes | Authenticated | Sessions | import', function (hook
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  let certificationPointOfContact;
+  module('When a user tries to go on the multiple sessions import page', function () {
+    module('when the user belongs to a SCO isManagingStudent center', function () {
+      module('with feature toggle authorization', function () {
+        test('it should redirect the user to the sessions list page', async function (assert) {
+          // given
+          const certificationCenter = createAllowedCertificationCenterAccess({
+            certificationCenterName: 'Centre SCO isManagingStudent',
+            certificationCenterType: 'SCO',
+            isRelatedOrganizationManagingStudents: true,
+          });
+          const certificationPointOfContact = createCertificationPointOfContactWithCustomCenters({
+            pixCertifTermsOfServiceAccepted: true,
+            allowedCertificationCenterAccesses: [certificationCenter],
+          });
+          await authenticateSession(certificationPointOfContact.id);
 
-  module('When a user tries to go on the multiple sessions import page', function (hooks) {
-    hooks.beforeEach(async function () {
-      certificationPointOfContact = server.create('certification-point-of-contact', {
-        firstName: 'Buffy',
-        lastName: 'Summers',
-      });
+          server.create('session-summary', { certificationCenterId: certificationCenter.id });
+          server.create('feature-toggle', { id: 0, isMassiveSessionManagementEnabled: true });
 
-      const certificationCenter = createAllowedCertificationCenterAccess({
-        certificationCenterName: 'Centre SUP',
-        certificationCenterType: 'SUP',
-      });
-      certificationPointOfContact = createCertificationPointOfContactWithCustomCenters({
-        pixCertifTermsOfServiceAccepted: true,
-        allowedCertificationCenterAccesses: [certificationCenter],
-      });
-      await authenticateSession(certificationPointOfContact.id);
-      server.create('session-summary', { certificationCenterId: certificationCenter.id });
-    });
+          // when
+          const screen = await visit(`/sessions/import`);
 
-    module('without feature toggle authorization', function (hooks) {
-      let screen;
-
-      hooks.beforeEach(async function () {
-        server.create('feature-toggle', { id: 0, isMassiveSessionManagementEnabled: false });
-      });
-
-      test('it should redirect the user to the sessions list page', async function (assert) {
-        // when
-        screen = await visit(`/sessions/import`);
-
-        // then
-        assert.strictEqual(currentURL(), '/sessions/liste');
-        assert.dom(screen.getByText('Sessions de certification')).exists();
+          // then
+          assert.strictEqual(currentURL(), '/sessions/liste');
+          assert.dom(screen.getByText('Sessions de certification')).exists();
+        });
       });
     });
 
-    module('with feature toggle authorization', function (hooks) {
-      let screen;
+    module('when the user belongs to a center that is not SCO isManagingStudent', function () {
+      module('without feature toggle authorization', function () {
+        test('it should redirect the user to the sessions list page', async function (assert) {
+          // given
+          const certificationCenter = createAllowedCertificationCenterAccess({
+            certificationCenterName: 'Centre SUP',
+            certificationCenterType: 'SUP',
+            isRelatedOrganizationManagingStudents: false,
+          });
+          const certificationPointOfContact = createCertificationPointOfContactWithCustomCenters({
+            pixCertifTermsOfServiceAccepted: true,
+            allowedCertificationCenterAccesses: [certificationCenter],
+          });
+          await authenticateSession(certificationPointOfContact.id);
+          server.create('session-summary', { certificationCenterId: certificationCenter.id });
+          server.create('feature-toggle', { id: 0, isMassiveSessionManagementEnabled: false });
 
-      hooks.beforeEach(async function () {
-        server.create('feature-toggle', { id: 0, isMassiveSessionManagementEnabled: true });
+          // when
+          const screen = await visit(`/sessions/import`);
+
+          // then
+          assert.strictEqual(currentURL(), '/sessions/liste');
+          assert.dom(screen.getByText('Sessions de certification')).exists();
+        });
       });
 
-      test('it should redirect the user to the sessions list page', async function (assert) {
-        // when
-        screen = await visit(`/sessions/import`);
+      module('with feature toggle authorization', function () {
+        test('it should transition to sessions import page', async function (assert) {
+          // given
+          const certificationCenter = createAllowedCertificationCenterAccess({
+            certificationCenterName: 'Centre SUP',
+            certificationCenterType: 'SUP',
+            isRelatedOrganizationManagingStudents: false,
+          });
+          const certificationPointOfContact = createCertificationPointOfContactWithCustomCenters({
+            pixCertifTermsOfServiceAccepted: true,
+            allowedCertificationCenterAccesses: [certificationCenter],
+          });
+          await authenticateSession(certificationPointOfContact.id);
+          server.create('session-summary', { certificationCenterId: certificationCenter.id });
+          server.create('feature-toggle', { id: 0, isMassiveSessionManagementEnabled: true });
 
-        // then
-        assert.strictEqual(currentURL(), '/sessions/import');
-        assert.dom(screen.getByText('Créer/éditer plusieurs sessions')).exists();
+          // when
+          const screen = await visit(`/sessions/import`);
+
+          // then
+          assert.strictEqual(currentURL(), '/sessions/import');
+          assert.dom(screen.getByText('Créer/éditer plusieurs sessions')).exists();
+        });
       });
     });
   });

--- a/certif/tests/integration/components/no-session-panel_test.js
+++ b/certif/tests/integration/components/no-session-panel_test.js
@@ -23,28 +23,78 @@ module('Integration | Component | no-session-panel', function (hooks) {
 
   module('isMassiveSessionManagementEnabled feature toggle', function () {
     module('isMassiveSessionManagementEnabled feature toggle is true', function () {
-      test('it renders a button link to the session import page', async function (assert) {
-        // given
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isMassiveSessionManagementEnabled: true };
-        }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
+      module('when certification center is not a type SCO which manages students', function () {
+        test('it renders a button link to the sessions import page', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+            type: 'SUP',
+            isRelatedToManagingStudentsOrganization: false,
+          });
 
-        // when
-        const { getByRole } = await render(hbs`<NoSessionPanel />`);
+          class CurrentUserStub extends Service {
+            currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+          }
+          class FeatureTogglesStub extends Service {
+            featureToggles = { isMassiveSessionManagementEnabled: true };
+          }
 
-        // then
-        assert.dom(getByRole('link', { name: 'Créer plusieurs sessions' })).exists();
+          this.owner.register('service:featureToggles', FeatureTogglesStub);
+          this.owner.register('service:current-user', CurrentUserStub);
+
+          // when
+          const { getByRole } = await render(hbs`<NoSessionPanel />`);
+
+          // then
+          assert.dom(getByRole('link', { name: 'Créer plusieurs sessions' })).exists();
+        });
+      });
+
+      module('when certification center is a type SCO which manages students', function () {
+        test('it does not render a button link to the sessions import page', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+            type: 'SCO',
+            isRelatedToManagingStudentsOrganization: true,
+          });
+
+          class CurrentUserStub extends Service {
+            currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+          }
+          class FeatureTogglesStub extends Service {
+            featureToggles = { isMassiveSessionManagementEnabled: true };
+          }
+
+          this.owner.register('service:featureToggles', FeatureTogglesStub);
+          this.owner.register('service:current-user', CurrentUserStub);
+
+          // when
+          const { queryByRole } = await render(hbs`<NoSessionPanel />`);
+
+          // then
+          assert.dom(queryByRole('link', { name: 'Créer plusieurs sessions' })).doesNotExist();
+        });
       });
     });
 
     module('isMassiveSessionManagementEnabled feature toggle is false', function () {
       test('it does not render a link to the session import page', async function (assert) {
         // given
+        const store = this.owner.lookup('service:store');
+        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+          isRelatedToManagingStudentsOrganization: false,
+        });
+
+        class CurrentUserStub extends Service {
+          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+        }
         class FeatureTogglesStub extends Service {
           featureToggles = { isMassiveSessionManagementEnabled: false };
         }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
+
+        this.owner.register('service:feature-toggles', FeatureTogglesStub);
+        this.owner.register('service:current-user', CurrentUserStub);
 
         // when
         const { queryByRole } = await render(hbs`<NoSessionPanel />`);

--- a/certif/tests/integration/components/sessions/panel-header_test.js
+++ b/certif/tests/integration/components/sessions/panel-header_test.js
@@ -12,7 +12,7 @@ module('Integration | Component | panel-header', function (hooks) {
     class FeatureTogglesStub extends Service {
       featureToggles = { isMassiveSessionManagementEnabled: false };
     }
-    this.owner.register('service:featureToggles', FeatureTogglesStub);
+    this.owner.register('service:feature-toggles', FeatureTogglesStub);
 
     // when
     const { getByRole } = await render(hbs`<Sessions::PanelHeader />`);
@@ -23,28 +23,77 @@ module('Integration | Component | panel-header', function (hooks) {
 
   module('isMassiveSessionManagementEnabled feature toggle', function () {
     module('isMassiveSessionManagementEnabled feature toggle is true', function () {
-      test('it renders a link to the session import page', async function (assert) {
-        // given
-        class FeatureTogglesStub extends Service {
-          featureToggles = { isMassiveSessionManagementEnabled: true };
-        }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
+      module('when certification center is a type SCO which manages students', function () {
+        test('it does not render a link to the session import page', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+            type: 'SCO',
+            isRelatedToManagingStudentsOrganization: true,
+          });
 
-        // when
-        const { getByRole } = await render(hbs`<Sessions::PanelHeader />`);
+          class CurrentUserStub extends Service {
+            currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+          }
+          class FeatureTogglesStub extends Service {
+            featureToggles = { isMassiveSessionManagementEnabled: true };
+          }
 
-        // then
-        assert.dom(getByRole('link', { name: 'Créer/éditer plusieurs sessions' })).exists();
+          this.owner.register('service:feature-toggles', FeatureTogglesStub);
+          this.owner.register('service:current-user', CurrentUserStub);
+
+          // when
+          const { queryByRole } = await render(hbs`<Sessions::PanelHeader />`);
+
+          // then
+          assert.dom(queryByRole('link', { name: 'Créer/éditer plusieurs sessions' })).doesNotExist();
+        });
+      });
+
+      module('when certification center is not a type SCO which manages students', function () {
+        test('it renders a link to the session import page', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+            type: 'SUP',
+            isRelatedToManagingStudentsOrganization: false,
+          });
+
+          class CurrentUserStub extends Service {
+            currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+          }
+          class FeatureTogglesStub extends Service {
+            featureToggles = { isMassiveSessionManagementEnabled: true };
+          }
+
+          this.owner.register('service:feature-toggles', FeatureTogglesStub);
+          this.owner.register('service:current-user', CurrentUserStub);
+
+          // when
+          const { getByRole } = await render(hbs`<Sessions::PanelHeader />`);
+
+          // then
+          assert.dom(getByRole('link', { name: 'Créer/éditer plusieurs sessions' })).exists();
+        });
       });
     });
 
     module('isMassiveSessionManagementEnabled feature toggle is false', function () {
       test('it does not render a link to the session import page', async function (assert) {
         // given
+        const store = this.owner.lookup('service:store');
+        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+          type: 'PRO',
+        });
+
+        class CurrentUserStub extends Service {
+          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+        }
         class FeatureTogglesStub extends Service {
           featureToggles = { isMassiveSessionManagementEnabled: false };
         }
-        this.owner.register('service:featureToggles', FeatureTogglesStub);
+        this.owner.register('service:feature-toggles', FeatureTogglesStub);
+        this.owner.register('service:current-user', CurrentUserStub);
 
         // when
         const { queryByRole } = await render(hbs`<Sessions::PanelHeader />`);


### PR DESCRIPTION
## :unicorn: Problème
Le bouton qui mène à l’import de session en masse ne doit pas apparaitre pour les centres scolaires qui gèrent des élèves. Ils ne doivent pas non plus pouvoir accéder à la l'url sessions/import.

## :robot: Proposition
- Rajouter une condition à l’affichage de ce bouton qui devra vérifier que le centre n’est PAS scoIsManagingStudent.
- Rajouter une condition d'accès à la route sessions/import qui devra vérifier que le centre n’est PAS scoIsManagingStudent.

## :100: Pour tester
- Se connecter avec le compte CertifSco@example.net : 
 - Si aucune session n'existe pour le centre, vérifier que l'affichage des boutons dans le cas d'une liste de sessions vide ne laisse pas apparaitre le bouton "Créer/éditer des sessions"
 - Si une ou des sessions existent, vérifier que le bouton 'Créer/éditer des sessions" n'apparait pas.
 - Depuis la page sessions/liste, modifier l'URL pour accéder à la page import `/sessions/import`. On doit être redirigé vers la page sessions/liste.
- Se déconnecter puis se reconnecter avec le compte certifpro@example.net : 
 - Si aucune session n'existe pour le centre, vérifier que le bouton "Créer/éditer des sessions" apparait.
 - Si une ou des sessions existent, vérifier que le bouton 'Créer/éditer des sessions" apparait.
 - Depuis la page sessions/liste, modifier l'URL pour accéder à la page import `/sessions/import`. On doit être redirigé vers la page sessions/liste.