### PR TITLE
[BUGFIX] Gérer les adresses e-mail invalides lors de l'envoi d'invitations depuis Pix Orga (PIX-7188)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -489,6 +489,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.BadRequestError(error.message, 'SENDING_EMAIL_TO_INVALID_DOMAIN');
   }
 
+  if (error instanceof DomainErrors.SendingEmailToInvalidEmailAddressError) {
+    return new HttpErrors.BadRequestError(error.message, 'SENDING_EMAIL_TO_INVALID_EMAIL_ADDRESS', error.meta);
+  }
+
   return new HttpErrors.BaseHttpError(error.message);
 }
 

--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -102,10 +102,11 @@ class ImproveCompetenceEvaluationForbiddenError extends BaseHttpError {
 }
 
 class BadRequestError extends BaseHttpError {
-  constructor(message, code) {
+  constructor(message, code, meta) {
     super(message);
     this.title = 'Bad Request';
     this.status = 400;
+    this.meta = meta;
     this.code = code;
   }
 }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -398,6 +398,16 @@ class SendingEmailToInvalidDomainError extends DomainError {
   }
 }
 
+class SendingEmailToInvalidEmailAddressError extends DomainError {
+  constructor(emailAddress, errorMessage) {
+    super(`Failed to send email to ${emailAddress} because email address seems to be invalid.`);
+    this.meta = {
+      emailAddress,
+      errorMessage,
+    };
+  }
+}
+
 class SendingEmailToRefererError extends DomainError {
   constructor(failedEmailReferers) {
     super(
@@ -1404,6 +1414,7 @@ module.exports = {
   OrganizationLearnersCouldNotBeSavedError,
   SendingEmailError,
   SendingEmailToInvalidDomainError,
+  SendingEmailToInvalidEmailAddressError,
   SendingEmailToRefererError,
   SendingEmailToResultRecipientError,
   SessionAlreadyFinalizedError,

--- a/api/lib/domain/models/EmailingAttempt.js
+++ b/api/lib/domain/models/EmailingAttempt.js
@@ -2,6 +2,7 @@ module.exports = class EmailingAttempt {
   static errorCode = {
     PROVIDER_ERROR: 'PROVIDER_ERROR',
     INVALID_DOMAIN: 'INVALID_DOMAIN',
+    INVALID_EMAIL: 'INVALID_EMAIL',
   };
 
   constructor(email, status, errorCode) {
@@ -16,6 +17,10 @@ module.exports = class EmailingAttempt {
 
   hasFailedBecauseDomainWasInvalid() {
     return this.status === AttemptStatus.FAILURE && this.errorCode === EmailingAttempt.errorCode.INVALID_DOMAIN;
+  }
+
+  hasFailedBecauseEmailWasInvalid() {
+    return this.status === AttemptStatus.FAILURE && this.errorCode === EmailingAttempt.errorCode.INVALID_EMAIL;
   }
 
   hasSucceeded() {

--- a/api/lib/domain/models/EmailingAttempt.js
+++ b/api/lib/domain/models/EmailingAttempt.js
@@ -5,10 +5,11 @@ module.exports = class EmailingAttempt {
     INVALID_EMAIL: 'INVALID_EMAIL',
   };
 
-  constructor(email, status, errorCode) {
+  constructor(email, status, errorCode, errorMessage) {
     this.email = email;
     this.status = status;
     this.errorCode = errorCode;
+    this.errorMessage = errorMessage;
   }
 
   hasFailed() {
@@ -31,8 +32,8 @@ module.exports = class EmailingAttempt {
     return new EmailingAttempt(email, AttemptStatus.SUCCESS);
   }
 
-  static failure(email, errorCode = EmailingAttempt.errorCode.PROVIDER_ERROR) {
-    return new EmailingAttempt(email, AttemptStatus.FAILURE, errorCode);
+  static failure(email, errorCode = EmailingAttempt.errorCode.PROVIDER_ERROR, errorMessage) {
+    return new EmailingAttempt(email, AttemptStatus.FAILURE, errorCode, errorMessage);
   }
 };
 

--- a/api/lib/domain/services/organization-invitation-service.js
+++ b/api/lib/domain/services/organization-invitation-service.js
@@ -1,7 +1,11 @@
 const randomString = require('randomstring');
 const Membership = require('../models/Membership.js');
 const mailService = require('../../domain/services/mail-service.js');
-const { SendingEmailError, SendingEmailToInvalidDomainError } = require('../errors.js');
+const {
+  SendingEmailError,
+  SendingEmailToInvalidDomainError,
+  SendingEmailToInvalidEmailAddressError,
+} = require('../errors.js');
 
 const _generateCode = () => {
   return randomString.generate({ length: 10, capitalization: 'uppercase' });
@@ -44,6 +48,10 @@ const createOrUpdateOrganizationInvitation = async ({
   if (mailerResponse?.status === 'FAILURE') {
     if (mailerResponse.hasFailedBecauseDomainWasInvalid()) {
       throw new SendingEmailToInvalidDomainError(email);
+    }
+
+    if (mailerResponse.hasFailedBecauseEmailWasInvalid()) {
+      throw new SendingEmailToInvalidEmailAddressError(email, mailerResponse.errorMessage);
     }
 
     throw new SendingEmailError();

--- a/api/lib/infrastructure/mailers/MailingProviderInvalidEmailError.js
+++ b/api/lib/infrastructure/mailers/MailingProviderInvalidEmailError.js
@@ -1,0 +1,3 @@
+class MailingProviderInvalidEmailError extends Error {}
+
+module.exports = { MailingProviderInvalidEmailError };

--- a/api/lib/infrastructure/mailers/mailer.js
+++ b/api/lib/infrastructure/mailers/mailer.js
@@ -4,6 +4,7 @@ const { mailing } = require('../../config.js');
 const logger = require('../logger.js');
 const mailCheck = require('../mail-check.js');
 const EmailingAttempt = require('../../domain/models/EmailingAttempt.js');
+const { MailingProviderInvalidEmailError } = require('./MailingProviderInvalidEmailError');
 
 const debugEmail = Debug('pix:mailer:email');
 
@@ -37,6 +38,11 @@ class Mailer {
       await this._provider.sendEmail(options);
     } catch (err) {
       logger.warn({ err }, `Could not send email to '${options.to}'`);
+
+      if (err instanceof MailingProviderInvalidEmailError) {
+        return EmailingAttempt.failure(options.to, EmailingAttempt.errorCode.INVALID_EMAIL, err.message);
+      }
+
       return EmailingAttempt.failure(options.to);
     }
 

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -35,6 +35,7 @@ const {
   SendingEmailToInvalidDomainError,
   OidcMissingFieldsError,
   OidcUserInfoFormatError,
+  SendingEmailToInvalidEmailAddressError,
 } = require('../../../lib/domain/errors');
 const HttpErrors = require('../../../lib/application/http-errors.js');
 
@@ -615,6 +616,30 @@ describe('Unit | Application | ErrorManager', function () {
           error.code,
           error.meta
         );
+      });
+    });
+
+    context('Mailing provider errors', function () {
+      context('When receiving SendingEmailToInvalidEmailAddressError', function () {
+        it('instantiates a BadRequest error', function () {
+          // Given
+          const error = new SendingEmailToInvalidEmailAddressError(
+            'invalid@email.net',
+            'Mailing provider error message'
+          );
+          sinon.stub(HttpErrors, 'BadRequestError');
+          const params = { request: {}, h: hFake, error };
+
+          // When
+          handle(params.request, params.h, params.error);
+
+          // then
+          expect(HttpErrors.BadRequestError).to.have.been.calledWithExactly(
+            error.message,
+            'SENDING_EMAIL_TO_INVALID_EMAIL_ADDRESS',
+            error.meta
+          );
+        });
       });
     });
   });

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -597,4 +597,8 @@ describe('Unit | Domain | Errors', function () {
   it('should export an DifferentExternalIdentifierError', function () {
     expect(errors.DifferentExternalIdentifierError).to.exist;
   });
+
+  it('exports SendingEmailToInvalidEmailAddressError', function () {
+    expect(errors.SendingEmailToInvalidEmailAddressError).to.exist;
+  });
 });

--- a/api/tests/unit/domain/models/EmailingAttempt_test.js
+++ b/api/tests/unit/domain/models/EmailingAttempt_test.js
@@ -150,5 +150,25 @@ describe('Unit | Domain | Models | EmailingAttempt', function () {
       const expectedEmailAttempt = new EmailingAttempt('example@example.net', 'FAILURE', 'INVALID_DOMAIN');
       expect(result).to.deepEqualInstance(expectedEmailAttempt);
     });
+
+    context('with given error code and message', function () {
+      it('creates an EmailingAttempt error', function () {
+        // When
+        const result = EmailingAttempt.failure(
+          'example@example.net',
+          EmailingAttempt.errorCode.INVALID_EMAIL,
+          'Failure error message'
+        );
+
+        // Then
+        const expectedEmailAttempt = new EmailingAttempt(
+          'example@example.net',
+          'FAILURE',
+          'INVALID_EMAIL',
+          'Failure error message'
+        );
+        expect(result).to.deepEqualInstance(expectedEmailAttempt);
+      });
+    });
   });
 });

--- a/api/tests/unit/domain/models/EmailingAttempt_test.js
+++ b/api/tests/unit/domain/models/EmailingAttempt_test.js
@@ -62,6 +62,41 @@ describe('Unit | Domain | Models | EmailingAttempt', function () {
     });
   });
 
+  describe('#hasFailedBecauseEmailWasInvalid', function () {
+    it('returns true if status is failure because email was invalid', function () {
+      // given
+      const attempt = new EmailingAttempt('example@example.net', 'FAILURE', 'INVALID_EMAIL');
+
+      // when
+      const result = attempt.hasFailedBecauseEmailWasInvalid();
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('returns false if status is failure with another reason', function () {
+      // given
+      const attempt = new EmailingAttempt('example@example.net', 'FAILURE');
+
+      // when
+      const result = attempt.hasFailedBecauseEmailWasInvalid();
+
+      // then
+      expect(result).to.be.false;
+    });
+
+    it('returns false if status is success', function () {
+      // given
+      const attempt = new EmailingAttempt('example@example.net', 'SUCCESS');
+
+      // when
+      const result = attempt.hasFailedBecauseEmailWasInvalid();
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+
   describe('#hasSucceeded', function () {
     it('should return true if status is success', function () {
       // given

--- a/orga/app/controllers/authenticated/team/new.js
+++ b/orga/app/controllers/authenticated/team/new.js
@@ -51,6 +51,13 @@ export default class NewController extends Controller {
       errorMessages = errors.map((error) => {
         switch (error.status) {
           case '400':
+            if (error.code === ERROR_CODES.SENDING_EMAIL_TO_INVALID_EMAIL_ADDRESS) {
+              return this.intl.t(ERROR_MESSAGES.SENDING_EMAIL_TO_INVALID_EMAIL_ADDRESS, {
+                email: error.meta?.emailAddress,
+                errorMessage: error.meta?.errorMessage,
+              });
+            }
+
             return this.intl.t(ERROR_MESSAGES.STATUS_400);
           case '404':
             return this.intl.t(ERROR_MESSAGES.STATUS_404);
@@ -77,4 +84,8 @@ const ERROR_MESSAGES = {
   STATUS_404: 'pages.team-new.errors.status.404',
   STATUS_412: 'pages.team-new.errors.status.412',
   STATUS_500: 'pages.team-new.errors.status.500',
+  SENDING_EMAIL_TO_INVALID_EMAIL_ADDRESS: 'pages.team-new.errors.sending-email-to-invalid-email-address',
+};
+const ERROR_CODES = {
+  SENDING_EMAIL_TO_INVALID_EMAIL_ADDRESS: 'SENDING_EMAIL_TO_INVALID_EMAIL_ADDRESS',
 };

--- a/orga/tests/acceptance/team-creation_test.js
+++ b/orga/tests/acceptance/team-creation_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
-import { currentURL, visit } from '@ember/test-helpers';
-import { fillByLabel, clickByName } from '@1024pix/ember-testing-library';
+import { currentURL } from '@ember/test-helpers';
+import { fillByLabel, clickByName, visit } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import authenticateSession from '../helpers/authenticate-session';
 
@@ -275,6 +275,44 @@ module('Acceptance | Team Creation', function (hooks) {
         assert.strictEqual(currentURL(), '/equipe/creation');
         assert.contains(expectedErrorMessage);
       });
+
+      module(
+        'when error 400 is returned from backend because the mailing provider returns an invalid email error',
+        function () {
+          test('displays an error notification', async function (assert) {
+            // Given
+            const errorMessage = 'Mailing provider error message';
+            const screen = await visit('/equipe/creation');
+            server.post(
+              `/organizations/${organizationId}/invitations`,
+              {
+                errors: [
+                  {
+                    detail: 'error message',
+                    status: '400',
+                    title: 'Bad Request',
+                    code: 'SENDING_EMAIL_TO_INVALID_EMAIL_ADDRESS',
+                    meta: { emailAddress: email, errorMessage },
+                  },
+                ],
+              },
+              400
+            );
+            await fillByLabel(inputLabel, email);
+
+            // When
+            await clickByName(inviteButton);
+
+            // Then
+            const expectedErrorMessage = this.intl.t('pages.team-new.errors.sending-email-to-invalid-email-address', {
+              email,
+              errorMessage,
+            });
+            assert.strictEqual(currentURL(), '/equipe/creation');
+            assert.dom(screen.getByText(expectedErrorMessage)).exists();
+          });
+        }
+      );
     });
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1144,7 +1144,8 @@
           "404": "This email address doesn't match any Pix user.",
           "412": "This member has already been added.",
           "500": "Something went wrong. Please try again."
-        }
+        },
+        "sending-email-to-invalid-email-address": "Sending email to the address {email} failed. The sending server replied: \"{errorMessage}\"."
       },
       "invited-members": "By clicking on the link provided in the invitation, the invited members will be able to create an account or log in with an existing Pix account.",
       "several-email-requirement": "Invite several members by separating the email addresses with commas."

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1144,7 +1144,8 @@
           "404": "Cet email n'appartient à aucun utilisateur.",
           "412": "Ce membre a déjà été ajouté.",
           "500": "Quelque chose s'est mal passé. Veuillez réessayer."
-        }
+        },
+        "sending-email-to-invalid-email-address": "L'envoi d'e-mail pour l'adresse {email} a échoué. Le serveur d'envoi a répondu : \"{errorMessage}\""
       },
       "invited-members": "À la réception de l'e-mail, les invités pourront choisir de se créer un compte Pix ou de se connecter avec un compte Pix existant.",
       "several-email-requirement": "Vous pouvez inviter plusieurs membres en séparant les adresses e-mails par des virgules."


### PR DESCRIPTION
## :unicorn: Problème

L’envoi d’invitations depuis Pix Orga déclenche parfois une erreur 503, dû au renvoi par sendinblue d’une erreur 400 avec le message :

```json
{"code":"invalid_parameter","message":"email is not valid in to"}
```

Le problème est dû au fait que, côté Pix, nous ne vérifions que la validité du domaine de l’adresse e-mail (à l’aide de la méthode native resolveMx de node) et ne gérons que l’erreur dans ce cas là. Or, sendinblue vérifie aussi le "local-part" de l'adresse e-mail (partie avant le @) et peut donc considérer comme invalide une adresse dont nous pensons qu'elle est valide.

## :robot: Solution

Attraper l’erreur 400 renvoyée par Sendinblue et renvoyer l'erreur `SendingEmailToInvalidEmailAddressError` au front avec un statut 400.

Au niveau du front, afficher une notification d'erreur avec un message traduit.
> L'envoi d'e-mail pour l'adresse clement@example.net a échoué. Le serveur d'envoi a répondu : "email is not valid in to".

## :rainbow: Remarques

RAS

## :100: Pour tester

⚠️ Test à effectuer en local

A faire avant de faire tourner l'API

- Modifier le fichier `.env` avec `MAILING_ENABLED=true` (⚠️ remettre à `false` à la fin du test)
- Modifier le fichier `api/lib/infrastructure/mailers/mailer.js` à la ligne 39 avec `throw new MailingProviderInvalidEmailError('email is not valid in to');`

Une fois que l'API et Pix Orga sont lancés

- Se connecter sur Pix Orga avec le compte `sco.admin@example.net`
- Ouvrir la page `Équipe`
- Cliquer sur le bouton `Inviter un membre`
- Fournir une adresse e-mail, de préférence la votre pour le test
- Constater qu'une notification d'erreur s'affiche avec le message `L'envoi d'e-mail pour l'adresse {votre_adresse} a échoué. Le serveur d'envoi a répondu : "email is not valid in to"`