### PR TITLE
[FEATURE] Renommer le nom des déclencheurs des contenus formatifs (PIX-7277).

### DIFF
--- a/admin/app/components/trainings/create-training-triggers.hbs
+++ b/admin/app/components/trainings/create-training-triggers.hbs
@@ -1,7 +1,6 @@
 <section class="page-section trigger-card">
   <h2 class="trigger-card__title">{{t "pages.trainings.training.triggers.prerequisite.title"}}</h2>
-  <p class="trigger-card__description">Si l’apprenant réussit tous les acquis des sujets sélectionnés alors le contenu
-    formatif ne lui sera pas proposé</p>
+  <p class="trigger-card__description">{{t "pages.trainings.training.triggers.prerequisite.edit.description"}}</p>
   <PixButtonLink
     class="trigger-card__toggler"
     @route="authenticated.trainings.training.triggers.edit"
@@ -17,8 +16,7 @@
 
 <section class="page-section trigger-card">
   <h2 class="trigger-card__title">{{t "pages.trainings.training.triggers.goal.title"}}</h2>
-  <p class="trigger-card__description">Si l’apprenant réussit les acquis des sujets sélectionnés alors le contenu
-    formatif lui sera proposé</p>
+  <p class="trigger-card__description">S{{t "pages.trainings.training.triggers.goal.edit.description"}}</p>
   <PixButtonLink
     class="trigger-card__toggler"
     @route="authenticated.trainings.training.triggers.edit"

--- a/admin/translations/fr.json
+++ b/admin/translations/fr.json
@@ -27,17 +27,17 @@
         "triggers": {
           "tabName": "Déclencheurs",
           "prerequisite": {
-            "title": "Objectif à atteindre",
-            "alternative-title": "Ajouter un objectif à atteindre",
+            "title": "Prérequis",
+            "alternative-title": "Ajouter un prérequis",
             "edit": {
-              "description": "Si l’apprenant réussit tous les acquis des sujets sélectionnés alors le contenu formatif ne lui sera pas proposé."
+              "description": "Si l’apprenant réussit tous les acquis des sujets sélectionnés alors le contenu formatif lui sera proposé."
             }
           },
           "goal": {
             "title": "Objectif à ne pas dépasser",
             "alternative-title": "Ajouter un objectif à ne pas dépasser",
             "edit": {
-              "description": "Si l’apprenant réussit les acquis des sujets sélectionnés alors le contenu formatif lui sera proposé."
+              "description": "Si l’apprenant réussit les acquis des sujets sélectionnés alors le contenu formatif ne lui sera pas proposé."
             }
           }
         },


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Admin, le nom des déclencheurs des contenus formatifs est ambiguë et provoque de la confusion.
 
## :robot: Proposition
Renommer les déclencheurs : `Objectifs à atteindre` devient `Prérequis`.
De plus, les phrases de description étaient inversées.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter sur Pix Admin
- Se rendre sur les contenus formatifs
- Cliquer sur un CF
- Constater le changement de wording