### PR TITLE
[BUGFIX] fix(api): réparer le worker.

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -9,7 +9,6 @@ const { disconnect } = require('./db/knex-database-connection');
 const cache = require('./lib/infrastructure/caches/learning-content-cache');
 const temporaryStorage = require('./lib/infrastructure/temporary-storage/index');
 const redisMonitor = require('./lib/infrastructure/utils/redis-monitor');
-const { main } = require('./worker');
 
 let server;
 
@@ -48,7 +47,7 @@ process.on('SIGINT', () => {
   try {
     await start();
     if (process.env.START_JOB_IN_WEB_PROCESS) {
-      await main();
+      require('./worker.js');
     }
   } catch (error) {
     logger.error(error);

--- a/api/worker.js
+++ b/api/worker.js
@@ -46,21 +46,14 @@ async function runJobs() {
 
   await scheduleCpfJobs(pgBoss);
 }
-
-const main = async () => {
-  const startInWebProcess = process.env.START_JOB_IN_WEB_PROCESS;
-  const isEntryPointFromOtherFile = require.main.filename !== __filename;
-  if (!startInWebProcess || (startInWebProcess && isEntryPointFromOtherFile)) {
-    runJobs();
-  } else {
-    logger.error(
-      'Worker process is started in the web process. Please unset the START_JOB_IN_WEB_PROCESS environment variable to start a dedicated worker process.'
-    );
-    // eslint-disable-next-line node/no-process-exit
-    process.exit(1);
-  }
-};
-
-module.exports = {
-  main,
-};
+const startInWebProcess = process.env.START_JOB_IN_WEB_PROCESS;
+const isEntryPointFromOtherFile = require.main.filename !== __filename;
+if (!startInWebProcess || (startInWebProcess && isEntryPointFromOtherFile)) {
+  runJobs();
+} else {
+  logger.error(
+    'Worker process is started in the web process. Please unset the START_JOB_IN_WEB_PROCESS environment variable to start a dedicated worker process.'
+  );
+  // eslint-disable-next-line node/no-process-exit
+  process.exit(1);
+}


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le worker ne fonctionne plus en production, et la mémoire s'emballe sur les containers.

## :robot: Proposition
Après une analyse, il apparait que les modifications sur le fichier worker.js aient causé ces deux problèmes. Cette PR restaure le fichier à son état avant l'apparition de ces problèmes.

## :rainbow: Remarques
Afin de permettre la migration en ESM, il faudra : 

- Exporter une fonction main depuis le fichier `worker.js` qui permet d'instancier et d'executer un worker (la modif qui avait été faite, mais qui cassait tout)
- Créer un fichier `index.js` (dans le même repertoire que le worker) qui invoke la methode main() du fichier `worker.js`.
- Mettre à jour le script dans le package.json: 
```json
     "start:job": "node ./worker/index.js",
    "start:job:watch": "nodemon ./worker/index.js",
```
- Importer cette méthode main dans le fichier `index.js` pour enlever ce maudit `require` dynamique


## :100: Pour tester
- vérifier que le worker est opérationnel en RA