### PR TITLE
[TECH] Retourner des tubes complets lors de la création de déclencheurs de contenu formatif (PIX-7291).

### DIFF
--- a/api/lib/domain/models/TrainingTrigger.js
+++ b/api/lib/domain/models/TrainingTrigger.js
@@ -4,10 +4,10 @@ const types = {
 };
 
 class TrainingTrigger {
-  constructor({ id, trainingId, tubes, type, threshold } = {}) {
+  constructor({ id, trainingId, triggerTubes, type, threshold } = {}) {
     this.id = id;
     this.trainingId = trainingId;
-    this.tubes = tubes;
+    this.triggerTubes = triggerTubes;
     if (!Object.values(types).includes(type)) {
       throw new Error('Invalid trigger type');
     }

--- a/api/lib/domain/models/TrainingTriggerTube.js
+++ b/api/lib/domain/models/TrainingTriggerTube.js
@@ -1,7 +1,7 @@
 class TrainingTriggerTube {
-  constructor({ id, tubeId, level } = {}) {
+  constructor({ id, tube, level } = {}) {
     this.id = id;
-    this.tubeId = tubeId;
+    this.tube = tube;
     this.level = level;
   }
 }

--- a/api/lib/domain/usecases/create-or-update-training-trigger.js
+++ b/api/lib/domain/usecases/create-or-update-training-trigger.js
@@ -7,5 +7,5 @@ module.exports = async function createOrUpdateTrainingTrigger({
   trainingTriggerRepository,
 }) {
   await trainingRepository.get(trainingId);
-  return trainingTriggerRepository.createOrUpdate({ trainingId, tubes, type, threshold });
+  return trainingTriggerRepository.createOrUpdate({ trainingId, triggerTubesForCreation: tubes, type, threshold });
 };

--- a/api/lib/infrastructure/repositories/training-trigger-repository.js
+++ b/api/lib/infrastructure/repositories/training-trigger-repository.js
@@ -42,6 +42,6 @@ function _toDomain({ trainingTrigger, tubes = [] }) {
     trainingId: trainingTrigger.trainingId,
     type: trainingTrigger.type,
     threshold: trainingTrigger.threshold,
-    tubes: tubes.map(({ tubeId, level }) => new TrainingTriggerTube({ id: tubeId, level })),
+    triggerTubes: tubes.map(({ id, tubeId, level }) => new TrainingTriggerTube({ id, tube: { id: tubeId }, level })),
   });
 }

--- a/api/lib/infrastructure/serializers/jsonapi/training-trigger-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/training-trigger-serializer.js
@@ -3,13 +3,38 @@ const { Serializer, Deserializer } = require('jsonapi-serializer');
 module.exports = {
   serialize(training = {}, meta) {
     return new Serializer('training-triggers', {
-      attributes: ['trainingId', 'type', 'threshold', 'tubes'],
-      tubes: {
+      transform(training) {
+        return {
+          ...training,
+          triggerTubes: training.triggerTubes.map((triggerTube) => {
+            return {
+              ...triggerTube,
+              tube: { ...triggerTube.tube },
+            };
+          }),
+        };
+      },
+      attributes: ['trainingId', 'type', 'threshold', 'triggerTubes'],
+      triggerTubes: {
         ref: 'id',
         includes: true,
-        attributes: ['id', 'level'],
+        attributes: ['id', 'level', 'tube'],
+        tube: {
+          ref: 'id',
+          attributes: ['id', 'name', 'practicalTitle', 'practicalDescription', 'competences'],
+        },
       },
       meta,
+      typeForAttribute(attribute) {
+        switch (attribute) {
+          case 'triggerTubes':
+            return 'trigger-tubes';
+          case 'tube':
+            return 'tubes';
+          default:
+            return attribute;
+        }
+      },
     }).serialize(training);
   },
 

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -264,28 +264,9 @@ describe('Acceptance | Controller | training-controller', function () {
               trainingId: `${trainingId}`,
               type: 'prerequisite',
               threshold: 30,
-            },
-            relationships: {
-              tubes: {
-                data: [
-                  {
-                    id: `${tube.id}`,
-                    type: 'tubes',
-                  },
-                ],
-              },
+              tubes: [{ id: `${tube.id}`, level: `${tube.level}` }],
             },
           },
-          included: [
-            {
-              attributes: {
-                id: `${tube.id}`,
-                level: `${tube.level}`,
-              },
-              id: `${tube.id}`,
-              type: 'tubes',
-            },
-          ],
         },
       };
 
@@ -296,9 +277,6 @@ describe('Acceptance | Controller | training-controller', function () {
           attributes: {
             type: 'prerequisite',
             threshold: 30,
-          },
-          relationships: {
-            tubes: { data: [{ id: 'recTube123', level: 2 }] },
           },
         },
       };
@@ -312,10 +290,10 @@ describe('Acceptance | Controller | training-controller', function () {
       expect(response.result.data.id).to.exist;
       expect(response.result.data.attributes.type).to.deep.equal(expectedResponse.data.attributes.type);
       expect(response.result.data.attributes.threshold).to.deep.equal(expectedResponse.data.attributes.threshold);
-      expect(response.result.data.relationships.tubes.data[0].id).to.deep.equal(
-        expectedResponse.data.relationships.tubes.data[0].id
+      expect(response.result.included.find(({ type }) => type === 'trigger-tubes').attributes.level).to.equal(
+        tube.level
       );
-      expect(response.result.data.attributes.level).to.deep.equal(expectedResponse.data.attributes.level);
+      expect(response.result.included.find(({ type }) => type === 'tubes').attributes.id).to.equal(tube.id);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
@@ -1,10 +1,83 @@
-const { expect, databaseBuilder, knex, sinon } = require('../../../test-helper');
+const { expect, databaseBuilder, domainBuilder, knex, mockLearningContent, sinon } = require('../../../test-helper');
 const trainingTriggerRepository = require('../../../../lib/infrastructure/repositories/training-trigger-repository');
 const TrainingTrigger = require('../../../../lib/domain/models/TrainingTrigger');
 const TrainingTriggerTube = require('../../../../lib/domain/models/TrainingTriggerTube');
 const _ = require('lodash');
 
 describe('Integration | Repository | training-trigger-repository', function () {
+  let tube;
+  let tube1;
+
+  beforeEach(async function () {
+    tube = domainBuilder.buildTube({
+      id: 'recTube0',
+      name: 'tubeName',
+      title: 'tubeTitle',
+      description: 'tubeDescription',
+      practicalTitle: 'translatedPracticalTitle',
+      practicalDescription: 'translatedPracticalDescription',
+      isMobileCompliant: true,
+      isTabletCompliant: true,
+      competenceId: 'recCompetence0',
+      thematicId: 'thematicCoucou',
+      skillIds: ['skillSuper', 'skillGenial'],
+      skills: [],
+    });
+    tube1 = domainBuilder.buildTube({
+      id: 'recTube1',
+      name: 'tubeName1',
+      title: 'tubeTitle1',
+      description: 'tubeDescription1',
+      practicalTitle: 'translatedPracticalTitle',
+      practicalDescription: 'translatedPracticalDescription',
+      isMobileCompliant: true,
+      isTabletCompliant: true,
+      competenceId: 'recCompetence0',
+      thematicId: 'thematicCoucou',
+      skillIds: ['skillSuper', 'skillGenial'],
+      skills: [],
+    });
+    const learningContent = {
+      tubes: [
+        {
+          id: 'recTube0',
+          name: 'tubeName',
+          title: 'tubeTitle',
+          description: 'tubeDescription',
+          practicalTitle_i18n: {
+            fr: 'translatedPracticalTitle',
+          },
+          practicalDescription_i18n: {
+            fr: 'translatedPracticalDescription',
+          },
+          isMobileCompliant: true,
+          isTabletCompliant: true,
+          competenceId: 'recCompetence0',
+          thematicId: 'thematicCoucou',
+          skillIds: ['skillSuper', 'skillGenial'],
+        },
+        {
+          id: 'recTube1',
+          name: 'tubeName1',
+          title: 'tubeTitle1',
+          description: 'tubeDescription1',
+          practicalTitle_i18n: {
+            fr: 'translatedPracticalTitle',
+          },
+          practicalDescription_i18n: {
+            fr: 'translatedPracticalDescription',
+          },
+          isMobileCompliant: true,
+          isTabletCompliant: true,
+          competenceId: 'recCompetence0',
+          thematicId: 'thematicCoucou',
+          skillIds: ['skillSuper', 'skillGenial'],
+        },
+      ],
+    };
+    mockLearningContent(learningContent);
+  });
+
   describe('#createOrUpdate', function () {
     afterEach(async function () {
       await databaseBuilder.knex('training-trigger-tubes').delete();
@@ -15,8 +88,8 @@ describe('Integration | Repository | training-trigger-repository', function () {
       it('should create training trigger', async function () {
         // when
         const tubes = [
-          { id: 'tubeId1', level: 2 },
-          { id: 'tubeId2', level: 4 },
+          { id: tube.id, level: 2 },
+          { id: tube1.id, level: 4 },
         ];
         const type = TrainingTrigger.types.PREREQUISITE;
         const threshold = 20;
@@ -25,7 +98,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
 
         const createdTrainingTrigger = await trainingTriggerRepository.createOrUpdate({
           trainingId,
-          tubes,
+          triggerTubesForCreation: tubes,
           type,
           threshold,
         });
@@ -53,9 +126,14 @@ describe('Integration | Repository | training-trigger-repository', function () {
         expect(createdTrainingTriggerTubes[0]).to.be.instanceOf(TrainingTriggerTube);
         expect(createdTrainingTriggerTubes[0].id).to.deep.equal(trainingTriggerTubes[0].id);
         expect(createdTrainingTriggerTubes[0].tube.id).to.deep.equal(trainingTriggerTubes[0].tubeId);
+        expect(createdTrainingTriggerTubes[0].tube.name).to.deep.equal(tube.name);
+        expect(createdTrainingTriggerTubes[0].tube.title).to.deep.equal(tube.title);
         expect(createdTrainingTriggerTubes[0].level).to.deep.equal(trainingTriggerTubes[0].level);
+
         expect(createdTrainingTriggerTubes[1].id).to.deep.equal(trainingTriggerTubes[1].id);
         expect(createdTrainingTriggerTubes[1].tube.id).to.deep.equal(trainingTriggerTubes[1].tubeId);
+        expect(createdTrainingTriggerTubes[1].tube.name).to.deep.equal(tube1.name);
+        expect(createdTrainingTriggerTubes[1].tube.title).to.deep.equal(tube1.title);
         expect(createdTrainingTriggerTubes[1].level).to.deep.equal(trainingTriggerTubes[1].level);
       });
     });
@@ -101,7 +179,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
           threshold: 42,
           trainingId: trainingTrigger.trainingId,
           type: trainingTrigger.type,
-          tubes,
+          triggerTubesForCreation: tubes,
         });
 
         // then
@@ -155,7 +233,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
         tubes.pop();
         const updatedTrainingTrigger = await trainingTriggerRepository.createOrUpdate({
           trainingId: trainingTrigger.trainingId,
-          tubes,
+          triggerTubesForCreation: tubes,
           type: trainingTrigger.type,
           threshold: trainingTrigger.threshold,
         });

--- a/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
@@ -49,11 +49,13 @@ describe('Integration | Repository | training-trigger-repository', function () {
           })
           .orderBy('tubeId', 'asc');
 
-        const createdTrainingTriggerTubes = _.sortBy(createdTrainingTrigger.tubes, 'id');
+        const createdTrainingTriggerTubes = _.sortBy(createdTrainingTrigger.triggerTubes, 'id');
         expect(createdTrainingTriggerTubes[0]).to.be.instanceOf(TrainingTriggerTube);
-        expect(createdTrainingTriggerTubes[0].id).to.deep.equal(trainingTriggerTubes[0].tubeId);
+        expect(createdTrainingTriggerTubes[0].id).to.deep.equal(trainingTriggerTubes[0].id);
+        expect(createdTrainingTriggerTubes[0].tube.id).to.deep.equal(trainingTriggerTubes[0].tubeId);
         expect(createdTrainingTriggerTubes[0].level).to.deep.equal(trainingTriggerTubes[0].level);
-        expect(createdTrainingTriggerTubes[1].id).to.deep.equal(trainingTriggerTubes[1].tubeId);
+        expect(createdTrainingTriggerTubes[1].id).to.deep.equal(trainingTriggerTubes[1].id);
+        expect(createdTrainingTriggerTubes[1].tube.id).to.deep.equal(trainingTriggerTubes[1].tubeId);
         expect(createdTrainingTriggerTubes[1].level).to.deep.equal(trainingTriggerTubes[1].level);
       });
     });
@@ -112,7 +114,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
         expect(updatedTrainingTrigger).to.be.instanceOf(TrainingTrigger);
         expect(updatedTrainingTrigger.threshold).to.equal(42);
 
-        const updatedTrainingTriggerTubes = _.sortBy(updatedTrainingTrigger.tubes, 'id');
+        const updatedTrainingTriggerTubes = _.sortBy(updatedTrainingTrigger.triggerTubes, 'id');
         expect(updatedTrainingTriggerTubes[0].level).to.deep.equal(trainingTriggerTubes[0].level);
         expect(updatedTrainingTriggerTubes).to.be.lengthOf(trainingTriggerTubes.length);
 
@@ -164,7 +166,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
         });
 
         expect(trainingTriggerTubes).to.have.lengthOf(1);
-        expect(updatedTrainingTrigger.tubes).to.have.lengthOf(1);
+        expect(updatedTrainingTrigger.triggerTubes).to.have.lengthOf(1);
 
         const othersTrainingTubes = await knex('training-trigger-tubes').where({ id: anotherTrainingTriggerTube.id });
         expect(othersTrainingTubes).to.have.lengthOf(1);

--- a/api/tests/tooling/domain-builder/factory/build-training-trigger.js
+++ b/api/tests/tooling/domain-builder/factory/build-training-trigger.js
@@ -1,17 +1,24 @@
 const buildTube = require('./build-tube');
 const TrainingTrigger = require('../../../../lib/domain/models/TrainingTrigger');
+const TrainingTriggerTube = require('../../../../lib/domain/models/TrainingTriggerTube');
 
 module.exports = function buildTrainingTrigger({
   id = 1000,
   trainingId = 156,
-  tubesWithLevel = [{ ...buildTube(), level: 2 }],
+  triggerTubes = [
+    new TrainingTriggerTube({
+      id: 10002,
+      tube: buildTube(),
+      level: 2,
+    }),
+  ],
   type = TrainingTrigger.types.PREREQUISITE,
   threshold = 60,
 } = {}) {
   return new TrainingTrigger({
     id,
     trainingId,
-    tubes: tubesWithLevel,
+    triggerTubes,
     type,
     threshold,
   });

--- a/api/tests/unit/domain/usecases/create-or-update-training-trigger_test.js
+++ b/api/tests/unit/domain/usecases/create-or-update-training-trigger_test.js
@@ -53,7 +53,7 @@ describe('Unit | UseCase | create-or-update-training-trigger', function () {
       // then
       expect(trainingTriggerRepository.createOrUpdate).to.have.been.calledWith({
         trainingId,
-        tubes,
+        triggerTubesForCreation: tubes,
         type,
         threshold,
       });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-trigger-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-trigger-serializer_test.js
@@ -10,31 +10,49 @@ describe('Unit | Serializer | JSONAPI | training-trigger-serializer', function (
       const expectedSerializedTraining = {
         data: {
           attributes: {
-            'training-id': trainingTrigger.trainingId,
-            threshold: trainingTrigger.threshold,
-            type: trainingTrigger.type,
+            threshold: 60,
+            'training-id': 156,
+            type: 'prerequisite',
           },
+          id: '1000',
           relationships: {
-            tubes: {
+            'trigger-tubes': {
               data: [
                 {
-                  id: 'recTube123',
-                  type: 'tubes',
+                  id: '10002',
+                  type: 'trigger-tubes',
                 },
               ],
             },
           },
-          id: trainingTrigger.id.toString(),
           type: 'training-triggers',
         },
         included: [
           {
             attributes: {
               id: 'recTube123',
-              level: 2,
+              name: '@tubeName',
+              'practical-description': 'description pratique',
+              'practical-title': 'titre pratique',
             },
             id: 'recTube123',
             type: 'tubes',
+          },
+          {
+            attributes: {
+              id: 10002,
+              level: 2,
+            },
+            id: '10002',
+            relationships: {
+              tube: {
+                data: {
+                  id: 'recTube123',
+                  type: 'tubes',
+                },
+              },
+            },
+            type: 'trigger-tubes',
           },
         ],
       };


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous retournons un object `TrainingTriggerTube` qui comprend uniquement un `tubeId`, ce qui n'est pas suffisant pour l'affichage des déclencheurs dans Pix Admin, car il manque tous les autres champs du tubes. 

De plus, lors de la recommandation de contenu formatif, il faudra pouvoir avoir les tubes complets.

## :robot: Proposition
- Remplacer dans le modèle `TrainingTrigger` l'attribut `tubes` et `triggerTubes`, qui est plus correcte car il porte le level.
- Remplacer dans le modèle `TrainingTriggerTube` l'attribut `tubeId` en `tube`, qui lui contient l'objet tube complet

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Vérifier la non-régression sur Pix Admin de la création de contenu formatif

- Se connecter sur Pix Admin 
- Se rendre sur l'onglet Contenu Formatif
- Selectionner un CF
- Ajouter un déclencheur