### PR TITLE
[BUGFIX] Fix traductions manquantes sur la page de liste des sessions (PIX-7255)

### DIFF
--- a/certif/app/components/session-summary-list.js
+++ b/certif/app/components/session-summary-list.js
@@ -12,6 +12,10 @@ export default class SessionSummaryList extends Component {
   @service notifications;
   @service intl;
 
+  get currentLocale() {
+    return this.intl.locale[0];
+  }
+
   @action
   openSessionDeletionConfirmModal(sessionId, enrolledCandidatesCount, event) {
     event.stopPropagation();

--- a/certif/tests/unit/components/session-summary-list_test.js
+++ b/certif/tests/unit/components/session-summary-list_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import Service from '@ember/service';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
 module('Unit | Component | session-summary', function (hooks) {
@@ -70,6 +71,22 @@ module('Unit | Component | session-summary', function (hooks) {
 
       // then
       assert.false(component.shouldDisplaySessionDeletionModal);
+    });
+  });
+
+  module('#currentLocale', function () {
+    test('should set shouldDisplaySessionDeletionModal to false', async function (assert) {
+      // given
+      class IntlStub extends Service {
+        locale = ['fr'];
+      }
+      this.owner.register('service:intl', IntlStub);
+
+      // when
+      const locale = await component.currentLocale;
+
+      // then
+      assert.strictEqual(locale, 'fr');
     });
   });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -205,7 +205,8 @@
             }
           },
           "content": "Do you want to delete the session <span>{sessionId}</span> ?",
-          "enrolled-candidates": "<span>{enrolledCandidatesCount} candidates</span> are enrolled in this session",
+          "enrolled-candidates": "<span>{enrolledCandidatesCount} {enrolledCandidatesCount, plural,one {candidate} other {candidates}}</span> {enrolledCandidatesCount, plural,one {is} other {are}} enrolled in this session",
+
           "success": "The session has been successfully deleted.",
           "warning": "Warning, this action is irreversible."
         },


### PR DESCRIPTION
## :unicorn: Problème
Suite au ticket #5652 , certaines traductions manquent : 

- Footer pas traduit en anglais
- Modale suppression de session pas pluralisée "1 candidates are enrolled" (géré en français)

## :robot: Proposition
Footer en anglais :

- Voir = View 
  - … sur … éléments = … of … items
  - Page = page

- Modale de suppression de session pluralisée :
  - Singulier : 1 candidate is enrolled
  - Pluriel : x candidates are enrolled

## :rainbow: Remarques

Rendu final : 

![Screenshot 2023-02-27 at 17-22-53 Certification sessions Pix Certif](https://user-images.githubusercontent.com/11388201/221620957-a2678c06-95f0-4d21-9e3c-5c3bfe18daa1.png)
![Screenshot 2023-02-27 at 17-23-00 Certification sessions Pix Certif](https://user-images.githubusercontent.com/11388201/221620963-ddd31108-5b48-424b-871b-b5edeb1bd708.png)


## :100: Pour tester
Lancer Pix Certif avec un compte (ex: [certifsup@example.net](mailto:certifsup@example.net)).
    Constater que les champs en français sont conformes aux champs indiqués plus haut dans la description de PR.
    Rajouter ?lang=en en fin d'URL pour basculer le Pix Certif en anglais (Si ça ne marche pas, aller sur Pix.org, faire la manipulation ?lang=en, puis remplacer app par certif dans l'URL).
    Constater que les champs en anglais correspondent à ceux cités plus haut dans la description.
