### PR TITLE
[FEATURE] Retourner les déclencheurs liés au contenu formatif demandé (PIX-7256).

### DIFF
--- a/api/lib/application/trainings/training-controller.js
+++ b/api/lib/application/trainings/training-controller.js
@@ -19,7 +19,7 @@ module.exports = {
   async getById(request) {
     const { trainingId } = request.params;
     const training = await usecases.getTraining({ trainingId });
-    return trainingSerializer.serialize(training);
+    return trainingSerializer.serializeForAdmin(training);
   },
   async create(request, h) {
     const deserializedTraining = await trainingSerializer.deserialize(request.payload);

--- a/api/lib/domain/models/Training.js
+++ b/api/lib/domain/models/Training.js
@@ -1,17 +1,5 @@
 class Training {
-  constructor({
-    id,
-    title,
-    link,
-    type,
-    duration,
-    locale,
-    targetProfileIds,
-    editorName,
-    editorLogoUrl,
-    prerequisiteThreshold,
-    goalThreshold,
-  } = {}) {
+  constructor({ id, title, link, type, duration, locale, targetProfileIds, editorName, editorLogoUrl } = {}) {
     this.id = id;
     this.title = title;
     this.link = link;
@@ -21,8 +9,6 @@ class Training {
     this.targetProfileIds = targetProfileIds;
     this.editorName = editorName;
     this.editorLogoUrl = editorLogoUrl;
-    this.prerequisiteThreshold = prerequisiteThreshold;
-    this.goalThreshold = goalThreshold;
   }
 }
 

--- a/api/lib/domain/models/Training.js
+++ b/api/lib/domain/models/Training.js
@@ -1,5 +1,5 @@
 class Training {
-  constructor({ id, title, link, type, duration, locale, targetProfileIds, editorName, editorLogoUrl } = {}) {
+  constructor({ id, title, link, type, duration, locale, targetProfileIds, editorName, editorLogoUrl, triggers } = {}) {
     this.id = id;
     this.title = title;
     this.link = link;
@@ -9,6 +9,7 @@ class Training {
     this.targetProfileIds = targetProfileIds;
     this.editorName = editorName;
     this.editorLogoUrl = editorLogoUrl;
+    this.triggers = triggers;
   }
 }
 

--- a/api/lib/domain/usecases/create-or-update-training-trigger.js
+++ b/api/lib/domain/usecases/create-or-update-training-trigger.js
@@ -6,6 +6,6 @@ module.exports = async function createOrUpdateTrainingTrigger({
   trainingRepository,
   trainingTriggerRepository,
 }) {
-  await trainingRepository.get(trainingId);
+  await trainingRepository.get({ trainingId });
   return trainingTriggerRepository.createOrUpdate({ trainingId, triggerTubesForCreation: tubes, type, threshold });
 };

--- a/api/lib/domain/usecases/get-training.js
+++ b/api/lib/domain/usecases/get-training.js
@@ -1,3 +1,3 @@
 module.exports = function getTraining({ trainingId, trainingRepository }) {
-  return trainingRepository.get(trainingId);
+  return trainingRepository.get({ trainingId });
 };

--- a/api/lib/domain/usecases/get-training.js
+++ b/api/lib/domain/usecases/get-training.js
@@ -1,3 +1,3 @@
 module.exports = function getTraining({ trainingId, trainingRepository }) {
-  return trainingRepository.get({ trainingId });
+  return trainingRepository.getWithTriggers({ trainingId });
 };

--- a/api/lib/domain/usecases/update-training.js
+++ b/api/lib/domain/usecases/update-training.js
@@ -1,6 +1,6 @@
 module.exports = async function updateTraining({ training, trainingRepository }) {
   const trainingId = training.id;
-  await trainingRepository.get(trainingId);
+  await trainingRepository.get({ trainingId });
 
   return trainingRepository.update({
     id: trainingId,

--- a/api/lib/infrastructure/repositories/training-repository.js
+++ b/api/lib/infrastructure/repositories/training-repository.js
@@ -6,6 +6,7 @@ const DomainTransaction = require('../DomainTransaction.js');
 const UserRecommendedTraining = require('../../domain/read-models/UserRecommendedTraining.js');
 const { fetchPage } = require('../utils/knex-utils.js');
 const pick = require('lodash/pick');
+const trainingTriggerRepository = require('./training-trigger-repository.js');
 const TABLE_NAME = 'trainings';
 
 async function get({ trainingId, domainTransaction = DomainTransaction.emptyTransaction() }) {
@@ -22,6 +23,13 @@ async function get({ trainingId, domainTransaction = DomainTransaction.emptyTran
 
 module.exports = {
   get,
+
+  async getWithTriggers({ trainingId, domainTransaction = DomainTransaction.emptyTransaction() }) {
+    const training = await get({ trainingId, domainTransaction });
+    const trainingTriggers = await trainingTriggerRepository.findByTrainingId({ trainingId, domainTransaction });
+    training.triggers = trainingTriggers;
+    return training;
+  },
 
   async findPaginatedSummaries({ page, domainTransaction = DomainTransaction.emptyTransaction() }) {
     const knexConn = domainTransaction?.knexTransaction || knex;

--- a/api/lib/infrastructure/repositories/training-repository.js
+++ b/api/lib/infrastructure/repositories/training-repository.js
@@ -9,13 +9,14 @@ const pick = require('lodash/pick');
 const TABLE_NAME = 'trainings';
 
 module.exports = {
-  async get(id) {
-    const training = await knex(TABLE_NAME).where({ id }).first();
+  async get({ trainingId, domainTransaction = DomainTransaction.emptyTransaction() }) {
+    const knexConn = domainTransaction?.knexTransaction || knex;
+    const training = await knexConn(TABLE_NAME).where({ id: trainingId }).first();
     if (!training) {
-      throw new NotFoundError(`Not found training for ID ${id}`);
+      throw new NotFoundError(`Not found training for ID ${trainingId}`);
     }
 
-    const targetProfileTrainings = await knex('target-profile-trainings').where('trainingId', training.id);
+    const targetProfileTrainings = await knexConn('target-profile-trainings').where('trainingId', training.id);
 
     return _toDomain(training, targetProfileTrainings);
   },

--- a/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
@@ -1,6 +1,72 @@
 const { Serializer, Deserializer } = require('jsonapi-serializer');
 
 module.exports = {
+  serializeForAdmin(training = {}, meta) {
+    return new Serializer('trainings', {
+      transform(training) {
+        const duration = training.duration;
+        duration.days = duration.days || 0;
+        duration.hours = duration.hours || 0;
+        duration.minutes = duration.minutes || 0;
+
+        return {
+          ...training,
+          triggers: training.triggers.map((trigger) => ({
+            ...trigger,
+            triggerTubes: trigger.triggerTubes.map((triggerTube) => ({
+              ...triggerTube,
+              tube: { ...triggerTube.tube },
+            })),
+          })),
+        };
+      },
+      attributes: [
+        'duration',
+        'link',
+        'locale',
+        'title',
+        'type',
+        'editorName',
+        'editorLogoUrl',
+        'triggers',
+        'targetProfileSummaries',
+      ],
+      triggers: {
+        ref: 'id',
+        attributes: ['threshold', 'triggerTubes', 'type'],
+        triggerTubes: {
+          ref: 'id',
+          attributes: ['level', 'tube'],
+          tube: {
+            ref: 'id',
+            attributes: ['name', 'practicalTitle', 'skills'],
+          },
+        },
+      },
+      targetProfileSummaries: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        nullIfMissing: true,
+        relationshipLinks: {
+          related: function (record, current, parent) {
+            return `/api/admin/trainings/${parent.id}/target-profile-summaries`;
+          },
+        },
+      },
+      typeForAttribute(attribute) {
+        switch (attribute) {
+          case 'triggerTubes':
+            return 'trigger-tubes';
+          case 'tube':
+            return 'tubes';
+          default:
+            return attribute;
+        }
+      },
+      meta,
+    }).serialize(training);
+  },
+
   serialize(training = {}, meta) {
     return new Serializer('trainings', {
       attributes: [

--- a/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
@@ -11,8 +11,6 @@ module.exports = {
         'type',
         'editorName',
         'editorLogoUrl',
-        'prerequisiteThreshold',
-        'goalThreshold',
         'targetProfileSummaries',
       ],
       targetProfileSummaries: {

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -39,8 +39,6 @@ describe('Acceptance | Controller | training-controller', function () {
           },
           'editor-logo-url': trainingAttributes.editorLogoUrl,
           'editor-name': trainingAttributes.editorName,
-          'goal-threshold': trainingAttributes.goalThreshold,
-          'prerequisite-threshold': trainingAttributes.prerequisiteThreshold,
         },
       };
 
@@ -85,8 +83,6 @@ describe('Acceptance | Controller | training-controller', function () {
           locale: 'fr',
           'editor-name': 'Un ministère',
           'editor-logo-url': 'https://mon-logo.svg',
-          'prerequisite-threshold': null,
-          'goal-threshold': null,
         },
       };
 

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -17,11 +17,56 @@ describe('Acceptance | Controller | training-controller', function () {
   });
 
   describe('GET /api/admin/trainings/{trainingId}', function () {
+    let learningContent;
+    let tubeName;
+
+    beforeEach(async function () {
+      tubeName = 'tube0_0';
+      learningContent = [
+        {
+          areas: [
+            {
+              id: 'recArea1',
+              titleFrFr: 'area1_Title',
+              color: 'someColor',
+              competences: [
+                {
+                  id: 'competenceId',
+                  nameFrFr: 'Mener une recherche et une veille d’information',
+                  index: '1.1',
+                  tubes: [
+                    {
+                      id: 'recTube0_0',
+                      name: tubeName,
+                      skills: [
+                        {
+                          id: 'skillWeb2Id',
+                          nom: '@web2',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
+      mockLearningContent(learningContentObjects);
+    });
+
     it('should get a training with the specific id', async function () {
       // given
       const superAdmin = await insertUserWithRoleSuperAdmin();
       databaseBuilder.factory.buildTraining();
       const { id: trainingId, ...trainingAttributes } = databaseBuilder.factory.buildTraining();
+      const trainingTrigger = databaseBuilder.factory.buildTrainingTrigger({ trainingId });
+      const trainingTriggerTube = databaseBuilder.factory.buildTrainingTriggerTube({
+        trainingTriggerId: trainingTrigger.id,
+        tubeId: 'recTube0_0',
+      });
       await databaseBuilder.commit();
 
       const expectedResponse = {
@@ -56,6 +101,16 @@ describe('Acceptance | Controller | training-controller', function () {
       expect(response.result.data.type).to.equal(expectedResponse.type);
       expect(response.result.data.id).to.equal(expectedResponse.id);
       expect(response.result.data.attributes).to.deep.equal(expectedResponse.attributes);
+
+      const returnedTube = response.result.included.find((included) => included.type === 'tubes').attributes;
+      expect(returnedTube.name).to.deep.equal(tubeName);
+      const returnedTriggerTube = response.result.included.find(
+        (included) => included.type === 'trigger-tubes'
+      ).attributes;
+      expect(returnedTriggerTube.level).to.deep.equal(trainingTriggerTube.level);
+      const returnedTrigger = response.result.included.find((included) => included.type === 'triggers').attributes;
+      expect(returnedTrigger.type).to.deep.equal(trainingTrigger.type);
+      expect(returnedTrigger.threshold).to.deep.equal(trainingTrigger.threshold);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -30,7 +30,7 @@ describe('Integration | Repository | training-repository', function () {
         await databaseBuilder.commit();
 
         // when
-        const training = await trainingRepository.get(expectedTraining.id);
+        const training = await trainingRepository.get({ trainingId: expectedTraining.id });
 
         // then
         expect(training).to.deep.equal(expectedTraining);
@@ -40,7 +40,7 @@ describe('Integration | Repository | training-repository', function () {
     context('when training does not exist', function () {
       it('should throw a NotFoundError', async function () {
         // when
-        const error = await catchErr(trainingRepository.get)(134);
+        const error = await catchErr(trainingRepository.get)({ trainingId: 134 });
 
         // then
         expect(error).to.be.instanceOf(NotFoundError);

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -1,9 +1,10 @@
-const { expect, databaseBuilder, domainBuilder, catchErr, knex } = require('../../../test-helper');
+const { expect, databaseBuilder, domainBuilder, catchErr, knex, mockLearningContent } = require('../../../test-helper');
 const trainingRepository = require('../../../../lib/infrastructure/repositories/training-repository');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const TrainingSummary = require('../../../../lib/domain/read-models/TrainingSummary');
 const Training = require('../../../../lib/domain/models/Training');
 const UserRecommendedTraining = require('../../../../lib/domain/read-models/UserRecommendedTraining');
+const TrainingTrigger = require('../../../../lib/domain/models/TrainingTrigger');
 
 describe('Integration | Repository | training-repository', function () {
   describe('#get', function () {
@@ -46,6 +47,84 @@ describe('Integration | Repository | training-repository', function () {
         expect(error).to.be.instanceOf(NotFoundError);
         expect(error.message).to.be.equal('Not found training for ID 134');
       });
+    });
+  });
+
+  describe('#getWithTriggers', function () {
+    let tube;
+
+    beforeEach(async function () {
+      tube = domainBuilder.buildTube({
+        id: 'recTube0',
+        name: 'tubeName',
+        title: 'tubeTitle',
+        description: 'tubeDescription',
+        practicalTitle: 'translatedPracticalTitle',
+        practicalDescription: 'translatedPracticalDescription',
+        isMobileCompliant: true,
+        isTabletCompliant: true,
+        competenceId: 'recCompetence0',
+        thematicId: 'thematicCoucou',
+        skillIds: ['skillSuper', 'skillGenial'],
+        skills: [],
+      });
+      const learningContent = {
+        tubes: [
+          {
+            id: 'recTube0',
+            name: 'tubeName',
+            title: 'tubeTitle',
+            description: 'tubeDescription',
+            practicalTitle_i18n: {
+              fr: 'translatedPracticalTitle',
+            },
+            practicalDescription_i18n: {
+              fr: 'translatedPracticalDescription',
+            },
+            isMobileCompliant: true,
+            isTabletCompliant: true,
+            competenceId: 'recCompetence0',
+            thematicId: 'thematicCoucou',
+            skillIds: ['skillSuper', 'skillGenial'],
+          },
+        ],
+      };
+      mockLearningContent(learningContent);
+    });
+
+    it('should throw an error when training does not exist', async function () {
+      // when
+      const error = await catchErr(trainingRepository.getWithTriggers)({ trainingId: 134 });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+      expect(error.message).to.be.equal('Not found training for ID 134');
+    });
+
+    it('should return training with triggers', async function () {
+      // given
+      const training = databaseBuilder.factory.buildTraining();
+      const trainingTrigger = databaseBuilder.factory.buildTrainingTrigger({ trainingId: training.id });
+      const trainingTriggerTube = databaseBuilder.factory.buildTrainingTriggerTube({
+        trainingTriggerId: trainingTrigger.id,
+        tubeId: tube.id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await trainingRepository.getWithTriggers({ trainingId: training.id });
+
+      // then
+      expect(result).to.be.instanceOf(Training);
+      expect(result.triggers).to.have.lengthOf(1);
+      expect(result.triggers[0]).to.be.instanceOf(TrainingTrigger);
+      expect(result.triggers[0].id).to.deep.equal(trainingTrigger.id);
+      expect(result.triggers[0].threshold).to.deep.equal(trainingTrigger.threshold);
+      expect(result.triggers[0].type).to.deep.equal(trainingTrigger.type);
+      expect(result.triggers[0].triggerTubes).to.have.lengthOf(1);
+      expect(result.triggers[0].triggerTubes[0].id).to.deep.equal(trainingTriggerTube.id);
+      expect(result.triggers[0].triggerTubes[0].tube.name).to.deep.equal(tube.name);
+      expect(result.triggers[0].triggerTubes[0].level).to.deep.equal(trainingTriggerTube.level);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
@@ -251,4 +251,62 @@ describe('Integration | Repository | training-trigger-repository', function () {
       });
     });
   });
+
+  describe('#findByTrainingId', function () {
+    it('should return the training trigger', async function () {
+      // given
+      const trainingId = databaseBuilder.factory.buildTraining().id;
+      const trainingTrigger = databaseBuilder.factory.buildTrainingTrigger({ trainingId });
+      const trainingTrigger2 = databaseBuilder.factory.buildTrainingTrigger({
+        trainingId,
+        type: TrainingTrigger.types.GOAL,
+      });
+      const trainingTriggerTube = databaseBuilder.factory.buildTrainingTriggerTube({
+        trainingTriggerId: trainingTrigger.id,
+        tubeId: tube.id,
+      });
+      const trainingTriggerTube2 = databaseBuilder.factory.buildTrainingTriggerTube({
+        trainingTriggerId: trainingTrigger2.id,
+        tubeId: tube1.id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await trainingTriggerRepository.findByTrainingId({ trainingId });
+
+      // then
+      expect(result).to.have.lengthOf(2);
+
+      expect(result[0]).to.be.instanceOf(TrainingTrigger);
+      expect(result[0].id).to.equal(trainingTrigger.id);
+      expect(result[0].trainingId).to.equal(trainingTrigger.trainingId);
+      expect(result[0].type).to.equal(trainingTrigger.type);
+      expect(result[0].threshold).to.equal(trainingTrigger.threshold);
+      expect(result[0].triggerTubes).to.have.lengthOf(1);
+      expect(result[0].triggerTubes[0]).to.be.instanceOf(TrainingTriggerTube);
+      expect(result[0].triggerTubes[0].tube.id).to.equal(trainingTriggerTube.tubeId);
+      expect(result[0].triggerTubes[0].level).to.equal(trainingTriggerTube.level);
+
+      expect(result[1]).to.be.instanceOf(TrainingTrigger);
+      expect(result[1].id).to.equal(trainingTrigger2.id);
+      expect(result[1].trainingId).to.equal(trainingTrigger2.trainingId);
+      expect(result[1].type).to.equal(trainingTrigger2.type);
+      expect(result[1].threshold).to.equal(trainingTrigger2.threshold);
+      expect(result[1].triggerTubes).to.have.lengthOf(1);
+      expect(result[1].triggerTubes[0]).to.be.instanceOf(TrainingTriggerTube);
+      expect(result[1].triggerTubes[0].tube.id).to.equal(trainingTriggerTube2.tubeId);
+      expect(result[1].triggerTubes[0].level).to.equal(trainingTriggerTube2.level);
+    });
+
+    it('should return empty array when no training trigger found', async function () {
+      // given
+      const trainingId = 123;
+
+      // when
+      const result = await trainingTriggerRepository.findByTrainingId({ trainingId });
+
+      // then
+      expect(result).to.be.empty;
+    });
+  });
 });

--- a/api/tests/tooling/domain-builder/factory/build-training-trigger-tube.js
+++ b/api/tests/tooling/domain-builder/factory/build-training-trigger-tube.js
@@ -1,0 +1,10 @@
+const buildTube = require('./build-tube');
+const TrainingTriggerTube = require('../../../../lib/domain/models/TrainingTriggerTube');
+
+module.exports = function buildTrainingTriggerTube({ id = 1000, tube = buildTube(), level = 8 } = {}) {
+  return new TrainingTriggerTube({
+    id,
+    tube,
+    level,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/build-training.js
+++ b/api/tests/tooling/domain-builder/factory/build-training.js
@@ -12,6 +12,7 @@ module.exports = function buildTraining({
   targetProfileIds = [1],
   editorName = 'Ministère education nationale',
   editorLogoUrl = 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
+  triggers,
 } = {}) {
   return new Training({
     id,
@@ -23,5 +24,6 @@ module.exports = function buildTraining({
     targetProfileIds,
     editorName,
     editorLogoUrl,
+    triggers,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-training.js
+++ b/api/tests/tooling/domain-builder/factory/build-training.js
@@ -12,8 +12,6 @@ module.exports = function buildTraining({
   targetProfileIds = [1],
   editorName = 'Ministère education nationale',
   editorLogoUrl = 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
-  goalThreshold = 70,
-  prerequisiteThreshold = 30,
 } = {}) {
   return new Training({
     id,
@@ -25,7 +23,5 @@ module.exports = function buildTraining({
     targetProfileIds,
     editorName,
     editorLogoUrl,
-    goalThreshold,
-    prerequisiteThreshold,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -128,6 +128,7 @@ const buildThematic = require('./build-thematic');
 const buildTraining = require('./build-training');
 const buildTrainingSummary = require('./build-training-summary');
 const buildTrainingTrigger = require('./build-training-trigger');
+const buildTrainingTriggerTube = require('./build-training-trigger-tube');
 const buildTube = require('./build-tube');
 const buildTutorial = require('./build-tutorial');
 const buildTutorialForUser = require('./build-tutorial-for-user');
@@ -272,6 +273,7 @@ module.exports = {
   buildTraining,
   buildTrainingSummary,
   buildTrainingTrigger,
+  buildTrainingTriggerTube,
   buildTube,
   buildTutorial,
   buildTutorialForUser,

--- a/api/tests/unit/application/trainings/training-controller_test.js
+++ b/api/tests/unit/application/trainings/training-controller_test.js
@@ -48,7 +48,7 @@ describe('Unit | Controller | training-controller', function () {
       const trainingId = 1;
 
       sinon.stub(usecases, 'getTraining').resolves(training);
-      sinon.stub(trainingSerializer, 'serialize').returns(expectedResult);
+      sinon.stub(trainingSerializer, 'serializeForAdmin').returns(expectedResult);
 
       // when
       const response = await trainingController.getById({
@@ -59,7 +59,7 @@ describe('Unit | Controller | training-controller', function () {
 
       // then
       expect(usecases.getTraining).to.have.been.calledWith({ trainingId });
-      expect(trainingSerializer.serialize).to.have.been.calledOnce;
+      expect(trainingSerializer.serializeForAdmin).to.have.been.calledOnce;
       expect(response).to.deep.equal(expectedResult);
     });
   });

--- a/api/tests/unit/domain/usecases/create-or-update-training-trigger_test.js
+++ b/api/tests/unit/domain/usecases/create-or-update-training-trigger_test.js
@@ -18,7 +18,7 @@ describe('Unit | UseCase | create-or-update-training-trigger', function () {
     it('should throw an error when training does not exist', async function () {
       // given
       const trainingId = Symbol('trainingId');
-      trainingRepository.get.withArgs(trainingId).throws(new Error('Not Found'));
+      trainingRepository.get.withArgs({ trainingId }).throws(new Error('Not Found'));
 
       // when
       const error = await catchErr(createOrUpdateTrainingTrigger)({ trainingId, trainingRepository });
@@ -37,7 +37,7 @@ describe('Unit | UseCase | create-or-update-training-trigger', function () {
       const type = Symbol('type');
       const threshold = Symbol('threshold');
       const expectedTrainingTrigger = Symbol('trainingTrigger');
-      trainingRepository.get.withArgs(trainingId).resolves();
+      trainingRepository.get.withArgs({ trainingId }).resolves();
       trainingTriggerRepository.createOrUpdate.resolves(expectedTrainingTrigger);
 
       // when

--- a/api/tests/unit/domain/usecases/get-training_test.js
+++ b/api/tests/unit/domain/usecases/get-training_test.js
@@ -7,7 +7,7 @@ describe('Unit | UseCase | get-training', function () {
 
   beforeEach(function () {
     trainingRepository = {
-      get: sinon.stub(),
+      getWithTriggers: sinon.stub(),
     };
   });
 
@@ -16,7 +16,7 @@ describe('Unit | UseCase | get-training', function () {
       // given
       const trainingId = 1;
       const trainingToFind = Symbol('existing-training');
-      trainingRepository.get.withArgs({ trainingId }).resolves(trainingToFind);
+      trainingRepository.getWithTriggers.withArgs({ trainingId }).resolves(trainingToFind);
 
       // when
       const training = await getTraining({ trainingId, trainingRepository });
@@ -30,7 +30,7 @@ describe('Unit | UseCase | get-training', function () {
     it('should throw an error', async function () {
       // given
       const trainingId = 123;
-      trainingRepository.get.withArgs({ trainingId }).rejects(new NotFoundError());
+      trainingRepository.getWithTriggers.withArgs({ trainingId }).rejects(new NotFoundError());
 
       // when
       const err = await catchErr(getTraining)({ trainingId, trainingRepository });

--- a/api/tests/unit/domain/usecases/get-training_test.js
+++ b/api/tests/unit/domain/usecases/get-training_test.js
@@ -16,7 +16,7 @@ describe('Unit | UseCase | get-training', function () {
       // given
       const trainingId = 1;
       const trainingToFind = Symbol('existing-training');
-      trainingRepository.get.withArgs(trainingId).resolves(trainingToFind);
+      trainingRepository.get.withArgs({ trainingId }).resolves(trainingToFind);
 
       // when
       const training = await getTraining({ trainingId, trainingRepository });
@@ -30,7 +30,7 @@ describe('Unit | UseCase | get-training', function () {
     it('should throw an error', async function () {
       // given
       const trainingId = 123;
-      trainingRepository.get.withArgs(trainingId).rejects(new NotFoundError());
+      trainingRepository.get.withArgs({ trainingId }).rejects(new NotFoundError());
 
       // when
       const err = await catchErr(getTraining)({ trainingId, trainingRepository });

--- a/api/tests/unit/domain/usecases/update-training_test.js
+++ b/api/tests/unit/domain/usecases/update-training_test.js
@@ -22,7 +22,7 @@ describe('Unit | UseCase | update-training', function () {
     });
 
     // then
-    expect(trainingRepository.get).to.have.been.calledWithExactly(training.id);
+    expect(trainingRepository.get).to.have.been.calledWithExactly({ trainingId: training.id });
   });
 
   it('should throw a NotFoundError when the training does not exist', async function () {
@@ -43,7 +43,7 @@ describe('Unit | UseCase | update-training', function () {
   it('should update training and return it', async function () {
     // given
     const newTrainingAttributes = { id: 1011, title: 'new title' };
-    trainingRepository.get.resolves(Symbol('current-training'));
+    trainingRepository.get.withArgs({ trainingId: newTrainingAttributes.id }).resolves(Symbol('current-training'));
     const expectedUpdatedTraining = Symbol('updated-training');
     trainingRepository.update.resolves(expectedUpdatedTraining);
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -21,8 +21,6 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
             locale: 'fr-fr',
             'editor-name': 'Ministère education nationale',
             'editor-logo-url': 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
-            'prerequisite-threshold': 30,
-            'goal-threshold': 70,
           },
           relationships: {
             'target-profile-summaries': {
@@ -68,8 +66,6 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
             locale: 'fr-fr',
             'editor-name': 'Ministère education nationale',
             'editor-logo-url': 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
-            'prerequisite-threshold': 30,
-            'goal-threshold': 70,
           },
           relationships: {
             'target-profile-summaries': {
@@ -106,8 +102,6 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
             locale: 'fr-fr',
             'editor-name': 'Ministère education nationale',
             'editor-logo-url': 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
-            'prerequisite-threshold': 30,
-            'goal-threshold': 70,
           },
         },
       };
@@ -124,8 +118,6 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
         type: 'webinaire',
         editorLogoUrl: 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
         editorName: 'Ministère education nationale',
-        prerequisiteThreshold: 30,
-        goalThreshold: 70,
       });
     });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -2,6 +2,115 @@ const { expect, domainBuilder } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/training-serializer');
 
 describe('Unit | Serializer | JSONAPI | training-serializer', function () {
+  describe('#serializeForAdmin', function () {
+    it('should convert a training model to JSON', function () {
+      // given
+      const trainingId = 123;
+      const skills = [domainBuilder.buildSkill({ id: 'skill_1', name: '@web1' })];
+      const tube = domainBuilder.buildTube({ id: 'tube_1', name: 'Tube 1', skills });
+      const triggerTubes = [domainBuilder.buildTrainingTriggerTube({ trainingId: 123, tube })];
+      const triggers = [domainBuilder.buildTrainingTrigger({ trainingId: 123, triggerTubes })];
+      const training = domainBuilder.buildTraining({ id: trainingId, triggers });
+
+      const expectedSerializedTraining = {
+        data: {
+          attributes: {
+            duration: {
+              days: 0,
+              hours: 5,
+              minutes: 0,
+            },
+            'editor-logo-url': 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
+            'editor-name': 'Ministère education nationale',
+            link: 'https://example.net',
+            locale: 'fr-fr',
+            title: 'Training 1',
+            type: 'webinar',
+          },
+          id: '123',
+          relationships: {
+            'target-profile-summaries': {
+              links: {
+                related: '/api/admin/trainings/123/target-profile-summaries',
+              },
+            },
+            triggers: {
+              data: [
+                {
+                  id: '1000',
+                  type: 'triggers',
+                },
+              ],
+            },
+          },
+          type: 'trainings',
+        },
+        included: [
+          {
+            attributes: {
+              name: tube.name,
+              'practical-title': tube.practicalTitle,
+              skills: [
+                {
+                  competenceId: skills[0].competenceId,
+                  difficulty: skills[0].difficulty,
+                  id: skills[0].id,
+                  learningMoreTutorialIds: [],
+                  name: skills[0].name,
+                  pixValue: skills[0].pixValue,
+                  tubeId: skills[0].tubeId,
+                  tutorialIds: skills[0].tutorialIds,
+                  version: skills[0].version,
+                },
+              ],
+            },
+            id: tube.id,
+            type: 'tubes',
+          },
+          {
+            attributes: {
+              level: triggerTubes[0].level,
+            },
+            id: `${triggerTubes[0].id}`,
+            relationships: {
+              tube: {
+                data: {
+                  id: tube.id,
+                  type: 'tubes',
+                },
+              },
+            },
+            type: 'trigger-tubes',
+          },
+          {
+            attributes: {
+              threshold: triggers[0].threshold,
+              type: triggers[0].type,
+            },
+            id: '1000',
+            relationships: {
+              'trigger-tubes': {
+                data: [
+                  {
+                    id: '1000',
+                    type: 'trigger-tubes',
+                  },
+                ],
+              },
+            },
+            type: 'triggers',
+          },
+        ],
+      };
+
+      // when
+      const json = serializer.serializeForAdmin(training);
+
+      // then
+      expect(json).to.deep.equal(expectedSerializedTraining);
+    });
+  });
+
   describe('#serialize', function () {
     it('should convert a training model to JSON', function () {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix Admin, nous pouvons créer des déclencheurs mais nous ne pouvons pas les consulter, ce qui peut engendrer de la confusion, et inciter à recréer quelque chose qui est déjà présent en base.

## :robot: Proposition
Permettre de visionner les déclencheurs déjà liés au contenu formatif
Cette PR s'intéresse uniquement à l'API. L'appel `GET /api/admin/trainings/:id` retourne désormais les déclencheurs associés au CF.

## :rainbow: Remarques
Un serializer a été ajouté (`serializeForAdmin`) car uniquement dans ce contexte on souhaite retourner toutes la grappe des déclencheurs 

J'ai pour l'instant serializé uniquement certains champs des tubes car je ne sais pas ce dont on a besoin, il faudra donc le faire évoluer en fonction des besoins.

## :100: Pour tester
- Se connecter sur Pix Admin
- Aller dans l'onglet contenu formatif
- Puis dans le détail d'un CF, vérifier l'appel réseau pour récupérer le CF et voir dans la réponse les déclencheurs associés