### PR TITLE
[FEATURE] Permettre de confirmer la création massive des sessions sur Pix Certif (PIX-7234).

### DIFF
--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -206,4 +206,18 @@ module.exports = {
     });
     return h.response(sessionMassImportReport).code(200);
   },
+
+  async createSessionsForMassImport(request, h) {
+    const { certificationCenterId } = request.params;
+    const authenticatedUserId = request.auth.credentials.userId;
+
+    const { cachedValidatedSessionsKey } = request.payload.data.attributes;
+
+    await usecases.createSessions({
+      cachedValidatedSessionsKey,
+      certificationCenterId,
+      userId: authenticatedUserId,
+    });
+    return h.response().code(201);
+  },
 };

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -414,6 +414,35 @@ exports.register = async function (server) {
         tags: ['api', 'certification-center-membership'],
       },
     },
+
+    {
+      method: 'POST',
+      path: '/api/certification-centers/{certificationCenterId}/sessions/confirm-for-mass-import',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkUserIsMemberOfCertificationCenter,
+            assign: 'isMemberOfCertificationCenter',
+          },
+        ],
+        validate: {
+          params: Joi.object({ certificationCenterId: identifiersType.certificationCenterId }),
+          payload: Joi.object({
+            data: {
+              attributes: {
+                cachedValidatedSessionsKey: Joi.string().required(),
+              },
+            },
+          }),
+        },
+        handler: certificationCenterController.createSessionsForMassImport,
+        tags: ['api', 'certification-center', 'sessions', 'mass-import'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+            "- Elle permet de créer les sessions et candidats lors de l'import en masse",
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/lib/domain/services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service.js
+++ b/api/lib/domain/services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service.js
@@ -22,4 +22,9 @@ module.exports = {
 
     return sessions;
   },
+
+  async delete({ cachedValidatedSessionsKey, userId }) {
+    const key = `${userId}:${cachedValidatedSessionsKey}`;
+    await temporaryStorage.delete(key);
+  },
 };

--- a/api/lib/domain/services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service.js
+++ b/api/lib/domain/services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service.js
@@ -15,4 +15,11 @@ module.exports = {
 
     return uuid;
   },
+
+  async getByKeyAndUserId({ cachedValidatedSessionsKey, userId }) {
+    const key = `${userId}:${cachedValidatedSessionsKey}`;
+    const sessions = await temporaryStorage.get(key);
+
+    return sessions;
+  },
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -415,6 +415,7 @@ const createOrganizationPlacesLot = require('./create-organization-places-lot.js
 const createOrganizationsWithTagsAndTargetProfiles = require('./create-organizations-with-tags-and-target-profiles.js');
 const createPasswordResetDemand = require('./create-password-reset-demand.js');
 const createSession = require('./create-session.js');
+const createSessions = require('./sessions-mass-import/create-sessions.js');
 const createStage = require('./target-profile-management/create-stage.js');
 const createTag = require('./create-tag.js');
 const createTargetProfile = require('./create-target-profile.js');
@@ -703,6 +704,7 @@ const usecases = {
   createOrganizationsWithTagsAndTargetProfiles,
   createPasswordResetDemand,
   createSession,
+  createSessions,
   createStage,
   createTag,
   createTargetProfile,

--- a/api/lib/domain/usecases/sessions-mass-import/create-sessions.js
+++ b/api/lib/domain/usecases/sessions-mass-import/create-sessions.js
@@ -1,0 +1,83 @@
+const { NotFoundError } = require('../../errors');
+const bluebird = require('bluebird');
+const DomainTransaction = require('../../../infrastructure/DomainTransaction.js');
+const temporarySessionsStorageForMassImportService = require('../../services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service');
+const Session = require('../../models/Session');
+const CertificationCandidate = require('../../models/CertificationCandidate');
+
+module.exports = async function createSessions({
+  userId,
+  cachedValidatedSessionsKey,
+  certificationCandidateRepository,
+  sessionRepository,
+}) {
+  const temporaryCachedSessions = await temporarySessionsStorageForMassImportService.getByKeyAndUserId({
+    cachedValidatedSessionsKey,
+    userId,
+  });
+
+  if (!temporaryCachedSessions) {
+    throw new NotFoundError();
+  }
+
+  await DomainTransaction.execute(async (domainTransaction) => {
+    return await bluebird.mapSeries(temporaryCachedSessions, async (sessionDTO) => {
+      let { id: sessionId } = sessionDTO;
+      const { certificationCandidates } = sessionDTO;
+
+      if (sessionId) {
+        await _deleteExistingCandidatesInSession({ certificationCandidateRepository, sessionId, domainTransaction });
+      } else {
+        const { id } = await _saveNewSessionReturningId({
+          sessionRepository,
+          sessionDTO,
+          domainTransaction,
+        });
+        sessionId = id;
+      }
+
+      if (_hasCandidates(certificationCandidates)) {
+        await _saveCertificationCandidates({
+          certificationCandidates,
+          sessionId,
+          certificationCandidateRepository,
+          domainTransaction,
+        });
+      }
+    });
+  });
+
+  await temporarySessionsStorageForMassImportService.delete({
+    cachedValidatedSessionsKey,
+    userId,
+  });
+};
+
+function _hasCandidates(certificationCandidates) {
+  return certificationCandidates.length > 0;
+}
+
+async function _saveNewSessionReturningId({ sessionRepository, sessionDTO, domainTransaction }) {
+  const sessionToSave = new Session({ ...sessionDTO });
+  return await sessionRepository.save(sessionToSave, domainTransaction);
+}
+
+async function _deleteExistingCandidatesInSession({ certificationCandidateRepository, sessionId, domainTransaction }) {
+  await certificationCandidateRepository.deleteBySessionId({ sessionId, domainTransaction });
+}
+
+async function _saveCertificationCandidates({
+  certificationCandidates,
+  sessionId,
+  certificationCandidateRepository,
+  domainTransaction,
+}) {
+  await bluebird.mapSeries(certificationCandidates, async (certificationCandidateDTO) => {
+    const certificationCandidate = new CertificationCandidate({ ...certificationCandidateDTO });
+    await certificationCandidateRepository.saveInSession({
+      sessionId,
+      certificationCandidate,
+      domainTransaction,
+    });
+  });
+}

--- a/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-create-sessions_test.js
+++ b/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-create-sessions_test.js
@@ -1,0 +1,65 @@
+const { expect, databaseBuilder, knex, generateValidRequestAuthorizationHeader } = require('../../../../test-helper');
+const createServer = require('../../../../../server');
+const temporarySessionsStorageForMassImportService = require('../../../../../lib/domain/services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service');
+
+describe('Acceptance | Controller | certification-centers-controller-post-create-sessions', function () {
+  describe('POST /api/certification-centers/{certificationCenterId}/sessions/confirm-for-mass-import', function () {
+    afterEach(async function () {
+      await knex('sessions').delete();
+      await knex('certification-center-memberships').delete();
+      await knex('certification-centers').delete();
+      await knex('users').delete();
+    });
+
+    context('when user confirm sessions for import', function () {
+      it('should return status 201', async function () {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const { name: certificationCenter, id: certificationCenterId } =
+          databaseBuilder.factory.buildCertificationCenter();
+        databaseBuilder.factory.buildCertificationCenterMembership({
+          userId,
+          certificationCenterId,
+        });
+        const sessionToSave = {
+          id: undefined,
+          certificationCenterId,
+          certificationCenter,
+          address: '3 rue du Chateau',
+          examiner: 'John Smith',
+          room: 'room',
+          date: '2023-01-01',
+          time: '11:00',
+          accessCode: 'accessCode',
+          supervisorPassword: 'KV2CP',
+          certificationCandidates: [],
+        };
+        const newCachedSessionUUID = await temporarySessionsStorageForMassImportService.save({
+          sessions: [sessionToSave],
+          userId,
+        });
+        await databaseBuilder.commit();
+        const server = await createServer();
+
+        const options = {
+          method: 'POST',
+          url: `/api/certification-centers/${certificationCenterId}/sessions/confirm-for-mass-import`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+          },
+          payload: { data: { attributes: { cachedValidatedSessionsKey: newCachedSessionUUID } } },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        const sessions = await knex('sessions');
+        expect(sessions.length).to.equal(1);
+        expect(sessions[0].certificationCenter).to.equal(certificationCenter);
+        expect(sessions[0].supervisorPassword).to.equal(sessionToSave.supervisorPassword);
+        expect(response.statusCode).to.equal(201);
+      });
+    });
+  });
+});

--- a/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-validate-sessions_test.js
+++ b/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-validate-sessions_test.js
@@ -4,10 +4,10 @@ const {
   generateValidRequestAuthorizationHeader,
   knex,
   sinon,
-} = require('../../../test-helper');
-const createServer = require('../../../../server');
+} = require('../../../../test-helper');
+const createServer = require('../../../../../server');
 
-describe('Acceptance | Controller | certification-centers-controller-post-validate-sessions-for-mass-import', function () {
+describe('Acceptance | Controller | certification-centers-controller-post-validate-sessions', function () {
   let server;
 
   beforeEach(async function () {

--- a/api/tests/unit/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/unit/application/certification-centers/certification-center-controller_test.js
@@ -565,4 +565,29 @@ describe('Unit | Controller | certifications-center-controller', function () {
       });
     });
   });
+
+  describe('#createSessionsForMassImport', function () {
+    it('should call the usecase to create sessions', async function () {
+      // given
+      const request = {
+        payload: { data: { attributes: { cachedValidatedSessionsKey: 'uuid' } } },
+        params: { certificationCenterId: 123 },
+        auth: { credentials: { userId: 2 } },
+      };
+
+      sinon.stub(usecases, 'createSessions');
+
+      usecases.createSessions.resolves();
+
+      // when
+      await certificationCenterController.createSessionsForMassImport(request, hFake);
+
+      // then
+      expect(usecases.createSessions).to.have.been.calledWith({
+        cachedValidatedSessionsKey: 'uuid',
+        certificationCenterId: 123,
+        userId: 2,
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service_test.js
@@ -19,4 +19,41 @@ describe('Unit | Domain | Services | sessions mass import', function () {
       expect(result).to.deep.equal([{ id: 1, name: 'session 1' }]);
     });
   });
+
+  describe('#getByKeyAndUserId', function () {
+    context('when key not exists', function () {
+      it('should return undefined', async function () {
+        // given
+        const key = 'key';
+        const userId = 123;
+
+        // when
+        const result = await temporarySessionsStorageForMassImport.getByKeyAndUserId({
+          cachedValidatedSessionsKey: key,
+          userId,
+        });
+
+        // then
+        expect(result).to.be.undefined;
+      });
+    });
+
+    context('when key exists', function () {
+      it('should get sessions accessible with cached validated sessions key and user id', async function () {
+        // given
+        const sessions = [{ id: 1, name: 'session 1' }];
+        const userId = '123';
+        const key = await temporarySessionsStorageForMassImport.save({ sessions, userId });
+
+        // when
+        const result = await temporarySessionsStorageForMassImport.getByKeyAndUserId({
+          cachedValidatedSessionsKey: key,
+          userId,
+        });
+
+        // then
+        expect(result).to.deep.equal([{ id: 1, name: 'session 1' }]);
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service_test.js
@@ -56,4 +56,26 @@ describe('Unit | Domain | Services | sessions mass import', function () {
       });
     });
   });
+
+  describe('#delete', function () {
+    it('should delete cached validated sessions', async function () {
+      // given
+      const sessions = [{ id: 1, name: 'session 1' }];
+      const userId = '123';
+      const key = await temporarySessionsStorageForMassImport.save({ sessions, userId });
+
+      // when
+      await temporarySessionsStorageForMassImport.delete({
+        cachedValidatedSessionsKey: key,
+        userId,
+      });
+
+      // then
+      const result = await temporarySessionsStorageForMassImport.getByKeyAndUserId({
+        cachedValidatedSessionsKey: key,
+        userId,
+      });
+      expect(result).to.be.undefined;
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/sessions-mass-import/create-sessions_test.js
+++ b/api/tests/unit/domain/usecases/sessions-mass-import/create-sessions_test.js
@@ -1,0 +1,200 @@
+const { expect, sinon, catchErr, domainBuilder } = require('../../../../test-helper');
+const { NotFoundError } = require('../../../../../lib/domain/errors');
+const createSessions = require('../../../../../lib/domain/usecases/sessions-mass-import/create-sessions');
+const temporarySessionsStorageForMassImportService = require('../../../../../lib/domain/services/sessions-mass-import/temporary-sessions-storage-for-mass-import-service');
+const DomainTransaction = require('../../../../../lib/infrastructure/DomainTransaction');
+const Session = require('../../../../../lib/domain/models/Session');
+
+describe('Unit | UseCase | sessions-mass-import | create-sessions', function () {
+  let certificationCandidateRepository;
+  let sessionRepository;
+  let dependencies;
+
+  beforeEach(function () {
+    certificationCandidateRepository = { saveInSession: sinon.stub(), deleteBySessionId: sinon.stub() };
+    sessionRepository = { save: sinon.stub() };
+    dependencies = {
+      certificationCandidateRepository,
+      sessionRepository,
+    };
+  });
+
+  context('when there are no cached sessions matching the key', function () {
+    it('should throw a NotFound error', async function () {
+      // given
+      temporarySessionsStorageForMassImportService.getByKeyAndUserId = sinon.stub();
+      temporarySessionsStorageForMassImportService.getByKeyAndUserId.resolves(undefined);
+      const userId = 1234;
+      const cachedValidatedSessionsKey = 'uuid';
+
+      // when
+      const error = await catchErr(createSessions)({
+        cachedValidatedSessionsKey,
+        userId,
+        ...dependencies,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+
+  context('when there are cached sessions matching the key', function () {
+    context('when at least one of the sessions does NOT exist', function () {
+      context('when session has no candidate', function () {
+        it('should should only save the session', async function () {
+          // given
+          const temporaryCachedSessions = [
+            {
+              id: undefined,
+              certificationCenter: 'Centre de Certifix',
+              certificationCenterId: 567,
+              address: 'Site 1',
+              room: 'Salle 1',
+              date: '2023-03-12',
+              time: '01:00',
+              examiner: 'Pierre',
+              description: 'desc',
+              supervisorPassword: 'Y722G',
+              accessCode: 'accessCode',
+              certificationCandidates: [],
+            },
+          ];
+          temporarySessionsStorageForMassImportService.getByKeyAndUserId = sinon
+            .stub()
+            .resolves(temporaryCachedSessions);
+          const userId = 1234;
+          const cachedValidatedSessionsKey = 'uuid';
+          const domainTransaction = Symbol('trx');
+          sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));
+          sessionRepository.save.resolves({ id: 1234 });
+
+          // when
+          await createSessions({
+            cachedValidatedSessionsKey,
+            userId,
+            ...dependencies,
+          });
+
+          // then
+          const expectedSession = new Session({ ...temporaryCachedSessions[0] });
+          expect(sessionRepository.save).to.have.been.calledOnceWith(expectedSession, domainTransaction);
+          expect(certificationCandidateRepository.saveInSession).to.not.have.been.called;
+        });
+      });
+
+      context('when session has at least one candidate', function () {
+        it('should save the session and the candidates', async function () {
+          // given
+          const certificationCandidate = domainBuilder.buildCertificationCandidate({ sessionId: undefined });
+          const temporaryCachedSessions = [
+            {
+              id: undefined,
+              certificationCenter: 'Centre de Certifix',
+              certificationCenterId: 567,
+              address: 'Site 1',
+              room: 'Salle 1',
+              date: '2023-03-12',
+              time: '01:00',
+              examiner: 'Pierre',
+              description: 'desc',
+              supervisorPassword: 'Y722G',
+              accessCode: 'accessCode',
+              certificationCandidates: [certificationCandidate],
+            },
+          ];
+          temporarySessionsStorageForMassImportService.getByKeyAndUserId = sinon
+            .stub()
+            .resolves(temporaryCachedSessions);
+          const userId = 1234;
+          const cachedValidatedSessionsKey = 'uuid';
+          const domainTransaction = Symbol('trx');
+          sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));
+          sessionRepository.save.resolves({ id: 1234 });
+
+          // when
+          await createSessions({
+            cachedValidatedSessionsKey,
+            userId,
+            ...dependencies,
+          });
+
+          // then
+          const expectedSession = new Session({ ...temporaryCachedSessions[0] });
+          expect(sessionRepository.save).to.have.been.calledOnceWith(expectedSession, domainTransaction);
+          expect(certificationCandidateRepository.saveInSession).to.have.been.calledOnceWith({
+            sessionId: 1234,
+            certificationCandidate,
+            domainTransaction,
+          });
+        });
+      });
+    });
+
+    context('when at least one of the sessions already exists', function () {
+      it('should delete previous candidates and save the new candidates', async function () {
+        // given
+        const certificationCandidate = domainBuilder.buildCertificationCandidate({ sessionId: undefined });
+        const temporaryCachedSessions = [
+          {
+            id: 1234,
+            certificationCandidates: [{ ...certificationCandidate }],
+          },
+        ];
+        temporarySessionsStorageForMassImportService.getByKeyAndUserId = sinon.stub().resolves(temporaryCachedSessions);
+        const userId = 1234;
+        const cachedValidatedSessionsKey = 'uuid';
+        const domainTransaction = Symbol('trx');
+        sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));
+
+        // when
+        await createSessions({
+          cachedValidatedSessionsKey,
+          userId,
+          ...dependencies,
+        });
+
+        // then
+        expect(certificationCandidateRepository.deleteBySessionId).to.have.been.calledOnceWith({
+          sessionId: 1234,
+          domainTransaction,
+        });
+        expect(certificationCandidateRepository.saveInSession).to.have.been.calledOnceWith({
+          sessionId: 1234,
+          certificationCandidate,
+          domainTransaction,
+        });
+      });
+    });
+
+    it('should delete cached sessions', async function () {
+      // given
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ sessionId: undefined });
+      const temporaryCachedSessions = [
+        {
+          id: 1234,
+          certificationCandidates: [{ ...certificationCandidate }],
+        },
+      ];
+      temporarySessionsStorageForMassImportService.getByKeyAndUserId = sinon.stub().resolves(temporaryCachedSessions);
+      temporarySessionsStorageForMassImportService.delete = sinon.stub();
+      const userId = 1234;
+      const cachedValidatedSessionsKey = 'uuid';
+      const domainTransaction = Symbol('trx');
+      sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => lambda(domainTransaction));
+
+      // when
+      await createSessions({
+        cachedValidatedSessionsKey,
+        userId,
+        ...dependencies,
+      });
+
+      // then
+      expect(temporarySessionsStorageForMassImportService.delete).to.have.been.calledOnceWith({
+        cachedValidatedSessionsKey,
+        userId,
+      });
+    });
+  });
+});

--- a/certif/app/adapters/sessions-mass-import-report.js
+++ b/certif/app/adapters/sessions-mass-import-report.js
@@ -1,0 +1,15 @@
+import ApplicationAdapter from './application';
+import { inject as service } from '@ember/service';
+
+export default class SessionsMassImportReportAdapter extends ApplicationAdapter {
+  @service currentUser;
+
+  buildURL(modelName, id, snapshot, requestType, query) {
+    if (requestType === 'confirm-mass-import') {
+      const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;
+      return `${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/sessions/confirm-for-mass-import`;
+    } else {
+      return super.buildURL(modelName, id, snapshot, requestType, query);
+    }
+  }
+}

--- a/certif/app/components/import/step-two-section.hbs
+++ b/certif/app/components/import/step-two-section.hbs
@@ -18,5 +18,9 @@
           {{t "pages.sessions.import.step-two.candidates-count" candidatesCount=@candidatesCount}}</li>
       </ul>
     </PixMessage>
+
+    <PixButton class="import-page__section--confirm-button">
+      {{t "pages.sessions.import.step-two.actions.confirm.label"}}
+    </PixButton>
   {{/if}}
 </section>

--- a/certif/app/components/import/step-two-section.hbs
+++ b/certif/app/components/import/step-two-section.hbs
@@ -19,7 +19,7 @@
       </ul>
     </PixMessage>
 
-    <PixButton class="import-page__section--confirm-button">
+    <PixButton class="import-page__section--confirm-button" @triggerAction={{@createSessions}}>
       {{t "pages.sessions.import.step-two.actions.confirm.label"}}
     </PixButton>
   {{/if}}

--- a/certif/app/models/sessions-mass-import-report.js
+++ b/certif/app/models/sessions-mass-import-report.js
@@ -1,0 +1,18 @@
+import Model, { attr } from '@ember-data/model';
+import { memberAction } from 'ember-api-actions';
+
+export default class SessionsMassImportReportModel extends Model {
+  @attr('string') cachedValidatedSessionsKey;
+
+  confirm = memberAction({
+    type: 'post',
+    urlType: 'confirm-mass-import',
+    before(attributes) {
+      return {
+        data: {
+          attributes,
+        },
+      };
+    },
+  });
+}

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -168,3 +168,8 @@
     margin-left: 8px;
   }
 }
+
+.import-page__section--confirm-button {
+  margin-top: $spacing-m;
+  width: fit-content;
+}

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -42,6 +42,7 @@
       @candidatesCount={{this.candidatesCount}}
       @isImportInError={{this.isImportInError}}
       @errorsReport={{this.errorsReport}}
+      @createSessions={{this.createSessions}}
     />
   {{/if}}
 </main>

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -195,6 +195,22 @@ module('Acceptance | Session Import', function (hooks) {
             assert.dom(screen.getByText('3 candidats')).exists();
             assert.dom(screen.queryByLabelText('fichier.csv')).doesNotExist();
           });
+
+          test('it should display a confirm button', async function (assert) {
+            // given
+            const blob = new Blob(['foo']);
+            const file = new File([blob], 'fichier.csv');
+
+            // when
+            screen = await visit('/sessions/import');
+            const input = screen.getByLabelText('Importer le modèle complété');
+            await triggerEvent(input, 'change', { files: [file] });
+            const importButton = screen.getByRole('button', { name: 'Continuer' });
+            await click(importButton);
+
+            // then
+            assert.dom(screen.getByRole('button', { name: 'Finaliser la création/édition' })).exists();
+          });
         });
 
         module('when the file is not valid', function () {
@@ -211,6 +227,21 @@ module('Acceptance | Session Import', function (hooks) {
 
             // then
             assert.dom(screen.getByText('Fichier non valide')).exists();
+          });
+
+          test('it should not display the confirm button', async function (assert) {
+            //given
+            const file = new Blob(['foo'], { type: 'invalid-file' });
+
+            // when
+            screen = await visit('/sessions/import');
+            const input = await screen.findByLabelText('Importer le modèle complété');
+            await triggerEvent(input, 'change', { files: [file] });
+            const importButton = screen.getByRole('button', { name: 'Continuer' });
+            await click(importButton);
+
+            // then
+            assert.dom(screen.queryByRole('button', { name: 'Finaliser la création/édition' })).doesNotExist();
           });
         });
       });

--- a/certif/tests/unit/adapters/sessions-mass-import-report_test.js
+++ b/certif/tests/unit/adapters/sessions-mass-import-report_test.js
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
+import sinon from 'sinon';
+
+module('Unit | Adapters | Sessions mass import report', function (hooks) {
+  setupTest(hooks);
+
+  module('#buildURL', function () {
+    module('when request type is confirm-mass-import', function () {
+      test('should build url', async function (assert) {
+        // when
+        const adapter = this.owner.lookup('adapter:sessions-mass-import-report');
+        adapter.ajax = sinon.stub();
+        const store = this.owner.lookup('service:store');
+        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+          id: 123,
+        });
+
+        class CurrentUserStub extends Service {
+          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+        const url = await adapter.buildURL(undefined, undefined, undefined, 'confirm-mass-import', undefined);
+
+        // then
+        assert.true(url.endsWith('certification-centers/123/sessions/confirm-for-mass-import'));
+      });
+    });
+  });
+});

--- a/certif/tests/unit/models/sessions-mass-import-report_test.js
+++ b/certif/tests/unit/models/sessions-mass-import-report_test.js
@@ -1,0 +1,48 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import Service from '@ember/service';
+import ENV from 'pix-certif/config/environment';
+
+-module('Unit | Model | sessions mass import report', function (hooks) {
+  setupTest(hooks);
+
+  module('#confirm', function () {
+    test('confirm sessions mass import', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const adapter = store.adapterFor('sessions-mass-import-report');
+      sinon.stub(adapter, 'ajax');
+      adapter.ajax.resolves();
+
+      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+        id: 123,
+      });
+      class CurrentUserStub extends Service {
+        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      const sessionsMassImportReport = await store.createRecord('sessions-mass-import-report', {
+        cachedValidatedSessionsKey: 'UUID',
+      });
+
+      // when
+      await sessionsMassImportReport.confirm({ cachedValidatedSessionsKey: 'UUID' });
+
+      // then
+      const url = `${ENV.APP.API_HOST}/api/certification-centers/123/sessions/confirm-for-mass-import`;
+      const payload = {
+        data: {
+          data: {
+            attributes: {
+              cachedValidatedSessionsKey: 'UUID',
+            },
+          },
+        },
+      };
+      sinon.assert.calledWith(adapter.ajax, url, 'POST', payload);
+      assert.ok(true);
+    });
+  });
+});

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -175,6 +175,11 @@
           }
         },
         "step-two": {
+          "actions": {
+            "confirm": {
+              "label": "Finaliser la création/édition"
+            }
+          },
           "sessions-and-empty-sessions-count": "{sessionsCount} {sessionsCount, plural,one {session} other {sessions}} including {sessionsWithoutCandidatesCount} {sessionsWithoutCandidatesCount, plural,one {session} other {sessions}} without candidates",
           "candidates-count": "{candidatesCount} {candidatesCount, plural,one {candidate} other {candidates}}"
         }

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -175,6 +175,11 @@
           }
         },
         "step-two": {
+          "actions": {
+            "confirm": {
+              "label": "Finaliser la création/édition"
+            }
+          },
           "sessions-and-empty-sessions-count": "{sessionsCount} {sessionsCount, plural,one {session} other {sessions}} dont {sessionsWithoutCandidatesCount} {sessionsWithoutCandidatesCount, plural,one {session} other {sessions}} sans candidat",
           "candidates-count": "{candidatesCount} {candidatesCount, plural,one {candidat} other {candidats}}"
         }


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui sur Pix Certif, l'import de sessions en masse ne fait que valider les sessions et candidats fournis dans le fichier csv. 

## :robot: Proposition
Finaliser l'import de sessions en permettant la confirmation de l'import et la création des sessions et candidats

## :rainbow: Remarques
Nous supprimons l'entrée redis à la fin de la création des sessions et candidats.

## :100: Pour tester

- Se connecter sur Certif avec certifpro@example.net
- Cliquer sur le bouton pour créer plusieurs sessions
- Importer un fichier valide
- Constater dans la deuxième étape, la présence d'un bouton pour finaliser l'import
- Cliquer sur le bouton et vérifier que les sessions et candidats fournis dans le fichier ont bien été crées.
- Vérifier que la clé à bien été supprimé dans redis

Tester des cas d'erreurs pour s'assurer de la non-régression


Exemple fichier passant: 

```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
,Site 1,Salle 1,01/04/2023,14:00,surveillant 1,,toto,tata,01/01/2000,M,75115,,,FRANCE,,,,,Gratuite,,,
```
