### PR TITLE
[TECH] Transformer manuellement les exports CJS hétérogènes dans le cadre de la migration ESM (PIX-7202)

### DIFF
--- a/api/lib/application/target-profiles/presenter/pdf/manager/font-manager.js
+++ b/api/lib/application/target-profiles/presenter/pdf/manager/font-manager.js
@@ -18,7 +18,7 @@ const fonts = {
   robotoRegular: 'Roboto-Regular.ttf',
 };
 
-module.exports = {
+const FontManager = {
   key: {
     robotoCondensedBold: 'robotoCondensedBold',
     robotoCondensedLight: 'robotoCondensedLight',
@@ -186,3 +186,5 @@ module.exports = {
     }
   },
 };
+
+module.exports = FontManager;

--- a/api/lib/application/target-profiles/presenter/pdf/manager/position-manager.js
+++ b/api/lib/application/target-profiles/presenter/pdf/manager/position-manager.js
@@ -13,7 +13,7 @@ const THEMATIC_HORIZONTAL_START = 10;
 const THEMATIC_WIDTH = 70;
 const TUBES_FIRST_PART_WIDTH = 140;
 
-module.exports = {
+const PositionManager = {
   maxWidth: null,
   /**
    * @param page{PDFPage}
@@ -78,3 +78,5 @@ module.exports = {
     return this.maxWidth - this.tubeSecondPartStart - this.margin;
   },
 };
+
+module.exports = PositionManager;

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -47,7 +47,7 @@ function _getLogForHumans() {
   return processOutputingToTerminal && !forceJSONLogs;
 }
 
-module.exports = (function () {
+const configuration = (function () {
   const config = {
     rootPath: path.normalize(__dirname + '/..'),
 
@@ -443,4 +443,6 @@ module.exports = (function () {
 
   return config;
 })();
+
+module.exports = configuration;
 /* eslint-enable node/no-process-env*/

--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -4,103 +4,131 @@ const PIX_COUNT_BY_LEVEL = 8;
 const COMPETENCES_COUNT = 16;
 const MAX_REACHABLE_PIX_BY_COMPETENCE = settings.features.maxReachableLevel * PIX_COUNT_BY_LEVEL;
 
+const MAX_REACHABLE_LEVEL = settings.features.maxReachableLevel;
+const MAX_REACHABLE_PIX_SCORE = MAX_REACHABLE_PIX_BY_COMPETENCE * COMPETENCES_COUNT;
+const MAX_CHALLENGES_PER_COMPETENCE_FOR_CERTIFICATION = 3;
+const MAX_CHALLENGES_PER_AREA_FOR_CERTIFICATION_PLUS = 4;
+const MAX_MASTERY_RATE = 1;
+const MINIMUM_DELAY_IN_DAYS_FOR_RESET = settings.features.dayBeforeCompetenceResetV2;
+const MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING = settings.features.dayBeforeImproving;
+const MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING = settings.features.dayBeforeRetrying;
+
+const MINIMUM_CERTIFIABLE_COMPETENCES_FOR_CERTIFIABILITY = 5;
+const MINIMUM_COMPETENCE_LEVEL_FOR_CERTIFIABILITY = 1;
+const MINIMUM_REPRODUCIBILITY_RATE_TO_BE_CERTIFIED = 50;
+const MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED = 80;
+const UNCERTIFIED_LEVEL = -1;
+
+const MAX_LEVEL_TO_BE_AN_EASY_TUBE = 3;
+const DEFAULT_LEVEL_FOR_FIRST_CHALLENGE = 2;
+const MAX_DIFF_BETWEEN_USER_LEVEL_AND_SKILL_LEVEL = 2;
+
+const ALL_TREATMENTS = ['t1', 't2', 't3'];
+const LEVENSHTEIN_DISTANCE_MAX_RATE = 0.25;
+const PIX_ORIGIN = 'Pix';
+
+const PIX_ORGA = {
+  SCOPE: 'pix-orga',
+  NOT_LINKED_ORGANIZATION_MSG:
+    "L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite.",
+};
+
+const PIX_ADMIN = {
+  SCOPE: 'pix-admin',
+  NOT_ALLOWED_MSG: "Vous n'avez pas les droits pour vous connecter.",
+  ROLES: {
+    SUPER_ADMIN: 'SUPER_ADMIN',
+    SUPPORT: 'SUPPORT',
+    METIER: 'METIER',
+    CERTIF: 'CERTIF',
+  },
+};
+
+const PIX_CERTIF = {
+  SCOPE: 'pix-certif',
+  NOT_LINKED_CERTIFICATION_MSG:
+    "L'accès à Pix Certif est limité aux centres de certification Pix. Contactez le référent de votre centre de certification si vous pensez avoir besoin d'y accéder.",
+};
+
+const LOCALE = {
+  ENGLISH_SPOKEN: 'en',
+  FRENCH_FRANCE: 'fr-fr',
+  FRENCH_SPOKEN: 'fr',
+};
+
+const STUDENT_RECONCILIATION_ERRORS = {
+  RECONCILIATION: {
+    IN_OTHER_ORGANIZATION: {
+      email: { shortCode: 'R11', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+      username: { shortCode: 'R12', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+      samlId: { shortCode: 'R13', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+    },
+    IN_SAME_ORGANIZATION: {
+      email: { shortCode: 'R31', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+      username: { shortCode: 'R32', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+      samlId: { shortCode: 'R33', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+      anotherStudentIsAlreadyReconciled: { shortCode: 'R70', code: 'USER_ALREADY_RECONCILED_IN_THIS_ORGANIZATION' },
+    },
+    ACCOUNT_BELONGING_TO_ANOTHER_USER: { shortCode: 'R90', code: 'ACCOUNT_SEEMS_TO_BELONGS_TO_ANOTHER_USER' },
+  },
+  LOGIN_OR_REGISTER: {
+    IN_DB: {
+      username: { shortCode: 'S50', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_IN_DB' },
+    },
+    IN_SAME_ORGANIZATION: {
+      email: { shortCode: 'S51', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+      username: { shortCode: 'S52', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+      samlId: { shortCode: 'S53', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+    },
+    IN_OTHER_ORGANIZATION: {
+      email: { shortCode: 'S61', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+      username: { shortCode: 'S62', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+      samlId: { shortCode: 'S63', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+    },
+  },
+};
+
+const OIDC_ERRORS = {
+  USER_INFO: {
+    missingFields: { shortCode: 'OIDC01', code: 'USER_INFO_MISSING_FIELDS' },
+    badResponseFormat: { shortCode: 'OIDC02', code: 'USER_INFO_BAD_RESPONSE_FORMAT' },
+  },
+};
+
+const CERTIFICATION_CENTER_TYPES = {
+  SUP: 'SUP',
+  SCO: 'SCO',
+  PRO: 'PRO',
+};
+
 module.exports = {
   PIX_COUNT_BY_LEVEL,
   COMPETENCES_COUNT,
-  MAX_REACHABLE_LEVEL: settings.features.maxReachableLevel,
-  MAX_REACHABLE_PIX_SCORE: MAX_REACHABLE_PIX_BY_COMPETENCE * COMPETENCES_COUNT,
+  MAX_REACHABLE_LEVEL,
+  MAX_REACHABLE_PIX_SCORE,
   MAX_REACHABLE_PIX_BY_COMPETENCE,
-  MAX_CHALLENGES_PER_COMPETENCE_FOR_CERTIFICATION: 3,
-  MAX_CHALLENGES_PER_AREA_FOR_CERTIFICATION_PLUS: 4,
-  MAX_MASTERY_RATE: 1,
-  MINIMUM_DELAY_IN_DAYS_FOR_RESET: settings.features.dayBeforeCompetenceResetV2,
-  MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING: settings.features.dayBeforeImproving,
-  MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING: settings.features.dayBeforeRetrying,
-
-  MINIMUM_CERTIFIABLE_COMPETENCES_FOR_CERTIFIABILITY: 5,
-  MINIMUM_COMPETENCE_LEVEL_FOR_CERTIFIABILITY: 1,
-  MINIMUM_REPRODUCIBILITY_RATE_TO_BE_CERTIFIED: 50,
-  MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED: 80,
-  UNCERTIFIED_LEVEL: -1,
-
-  MAX_LEVEL_TO_BE_AN_EASY_TUBE: 3,
-  DEFAULT_LEVEL_FOR_FIRST_CHALLENGE: 2,
-  MAX_DIFF_BETWEEN_USER_LEVEL_AND_SKILL_LEVEL: 2,
-
-  ALL_TREATMENTS: ['t1', 't2', 't3'],
-  LEVENSHTEIN_DISTANCE_MAX_RATE: 0.25,
-
-  PIX_ORIGIN: 'Pix',
-
-  PIX_ORGA: {
-    SCOPE: 'pix-orga',
-    NOT_LINKED_ORGANIZATION_MSG:
-      "L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite.",
-  },
-
-  PIX_ADMIN: {
-    SCOPE: 'pix-admin',
-    NOT_ALLOWED_MSG: "Vous n'avez pas les droits pour vous connecter.",
-    ROLES: {
-      SUPER_ADMIN: 'SUPER_ADMIN',
-      SUPPORT: 'SUPPORT',
-      METIER: 'METIER',
-      CERTIF: 'CERTIF',
-    },
-  },
-  PIX_CERTIF: {
-    SCOPE: 'pix-certif',
-    NOT_LINKED_CERTIFICATION_MSG:
-      "L'accès à Pix Certif est limité aux centres de certification Pix. Contactez le référent de votre centre de certification si vous pensez avoir besoin d'y accéder.",
-  },
-  LOCALE: {
-    ENGLISH_SPOKEN: 'en',
-    FRENCH_FRANCE: 'fr-fr',
-    FRENCH_SPOKEN: 'fr',
-  },
-
-  STUDENT_RECONCILIATION_ERRORS: {
-    RECONCILIATION: {
-      IN_OTHER_ORGANIZATION: {
-        email: { shortCode: 'R11', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
-        username: { shortCode: 'R12', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
-        samlId: { shortCode: 'R13', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
-      },
-      IN_SAME_ORGANIZATION: {
-        email: { shortCode: 'R31', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
-        username: { shortCode: 'R32', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
-        samlId: { shortCode: 'R33', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
-        anotherStudentIsAlreadyReconciled: { shortCode: 'R70', code: 'USER_ALREADY_RECONCILED_IN_THIS_ORGANIZATION' },
-      },
-      ACCOUNT_BELONGING_TO_ANOTHER_USER: { shortCode: 'R90', code: 'ACCOUNT_SEEMS_TO_BELONGS_TO_ANOTHER_USER' },
-    },
-    LOGIN_OR_REGISTER: {
-      IN_DB: {
-        username: { shortCode: 'S50', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_IN_DB' },
-      },
-      IN_SAME_ORGANIZATION: {
-        email: { shortCode: 'S51', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
-        username: { shortCode: 'S52', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
-        samlId: { shortCode: 'S53', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
-      },
-      IN_OTHER_ORGANIZATION: {
-        email: { shortCode: 'S61', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
-        username: { shortCode: 'S62', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
-        samlId: { shortCode: 'S63', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
-      },
-    },
-  },
-
-  OIDC_ERRORS: {
-    USER_INFO: {
-      missingFields: { shortCode: 'OIDC01', code: 'USER_INFO_MISSING_FIELDS' },
-      badResponseFormat: { shortCode: 'OIDC02', code: 'USER_INFO_BAD_RESPONSE_FORMAT' },
-    },
-  },
-
-  CERTIFICATION_CENTER_TYPES: {
-    SUP: 'SUP',
-    SCO: 'SCO',
-    PRO: 'PRO',
-  },
+  MAX_CHALLENGES_PER_COMPETENCE_FOR_CERTIFICATION,
+  MAX_CHALLENGES_PER_AREA_FOR_CERTIFICATION_PLUS,
+  MAX_MASTERY_RATE,
+  MINIMUM_DELAY_IN_DAYS_FOR_RESET,
+  MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING,
+  MINIMUM_DELAY_IN_DAYS_BEFORE_RETRYING,
+  MINIMUM_CERTIFIABLE_COMPETENCES_FOR_CERTIFIABILITY,
+  MINIMUM_COMPETENCE_LEVEL_FOR_CERTIFIABILITY,
+  MINIMUM_REPRODUCIBILITY_RATE_TO_BE_CERTIFIED,
+  MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED,
+  UNCERTIFIED_LEVEL,
+  MAX_LEVEL_TO_BE_AN_EASY_TUBE,
+  DEFAULT_LEVEL_FOR_FIRST_CHALLENGE,
+  MAX_DIFF_BETWEEN_USER_LEVEL_AND_SKILL_LEVEL,
+  ALL_TREATMENTS,
+  LEVENSHTEIN_DISTANCE_MAX_RATE,
+  PIX_ORIGIN,
+  PIX_ORGA,
+  PIX_ADMIN,
+  PIX_CERTIF,
+  LOCALE,
+  STUDENT_RECONCILIATION_ERRORS,
+  OIDC_ERRORS,
+  CERTIFICATION_CENTER_TYPES,
 };

--- a/api/lib/domain/constants/oidc-identity-providers.js
+++ b/api/lib/domain/constants/oidc-identity-providers.js
@@ -4,20 +4,24 @@ const FwbOidcAuthenticationService = require('../services/authentication/fwb-oid
 
 const DEFAULT_PROPERTY_PATHS_TO_PICK = ['clientId', 'authenticationUrl', 'userInfoUrl', 'tokenUrl', 'clientSecret'];
 
+const POLE_EMPLOI = {
+  configKey: 'poleEmploi',
+  propertyPathsToPick: [...DEFAULT_PROPERTY_PATHS_TO_PICK, 'sendingUrl', 'logoutUrl', 'afterLogoutUrl'],
+  service: new PoleEmploiOidcAuthenticationService(),
+};
+const CNAV = {
+  configKey: 'cnav',
+  propertyPathsToPick: DEFAULT_PROPERTY_PATHS_TO_PICK,
+  service: new CnavOidcAuthenticationService(),
+};
+const FWB = {
+  configKey: 'fwb',
+  propertyPathsToPick: DEFAULT_PROPERTY_PATHS_TO_PICK,
+  service: new FwbOidcAuthenticationService(),
+};
+
 module.exports = {
-  POLE_EMPLOI: {
-    configKey: 'poleEmploi',
-    propertyPathsToPick: [...DEFAULT_PROPERTY_PATHS_TO_PICK, 'sendingUrl', 'logoutUrl', 'afterLogoutUrl'],
-    service: new PoleEmploiOidcAuthenticationService(),
-  },
-  CNAV: {
-    configKey: 'cnav',
-    propertyPathsToPick: DEFAULT_PROPERTY_PATHS_TO_PICK,
-    service: new CnavOidcAuthenticationService(),
-  },
-  FWB: {
-    configKey: 'fwb',
-    propertyPathsToPick: DEFAULT_PROPERTY_PATHS_TO_PICK,
-    service: new FwbOidcAuthenticationService(),
-  },
+  POLE_EMPLOI,
+  CNAV,
+  FWB,
 };

--- a/api/lib/domain/constants/organization-places-categories.js
+++ b/api/lib/domain/constants/organization-places-categories.js
@@ -1,4 +1,4 @@
-module.exports = {
+const organisationPlacesCategories = {
   T0: 'T0',
   T1: 'T1',
   T2: 'T2',
@@ -10,3 +10,5 @@ module.exports = {
   SPECIAL_REDUCE_RATE: 'SPECIAL_REDUCE_RATE',
   FULL_RATE: 'FULL_RATE',
 };
+
+module.exports = organisationPlacesCategories;

--- a/api/lib/domain/constants/saml-identity-providers.js
+++ b/api/lib/domain/constants/saml-identity-providers.js
@@ -1,7 +1,9 @@
-module.exports = {
-  SamlIdentityProviders: {
-    GAR: {
-      code: 'GAR',
-    },
+const SamlIdentityProviders = {
+  GAR: {
+    code: 'GAR',
   },
+};
+
+module.exports = {
+  SamlIdentityProviders,
 };

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -125,13 +125,17 @@ function buildEventDispatcher(handlersStubs) {
   return eventDispatcher;
 }
 
-module.exports = {
-  eventDispatcher: buildEventDispatcher({}),
-  eventBus: eventBusBuilder.build(),
-  _forTestOnly: {
-    handlers: handlersToBeInjected,
-    buildEventDispatcher: function (stubbedHandlers) {
-      return buildEventDispatcher(stubbedHandlers);
-    },
+const eventDispatcher = buildEventDispatcher({});
+const eventBus = eventBusBuilder.build();
+const _forTestOnly = {
+  handlers: handlersToBeInjected,
+  buildEventDispatcher: function (stubbedHandlers) {
+    return buildEventDispatcher(stubbedHandlers);
   },
+};
+
+module.exports = {
+  eventDispatcher,
+  eventBus,
+  _forTestOnly,
 };

--- a/api/lib/domain/usecases/get-available-target-profiles-for-organization.js
+++ b/api/lib/domain/usecases/get-available-target-profiles-for-organization.js
@@ -1,3 +1,6 @@
-module.exports = function ({ organizationId, TargetProfileForSpecifierRepository }) {
+module.exports = function getAvailableTargetProfilesForOrganization({
+  organizationId,
+  TargetProfileForSpecifierRepository,
+}) {
   return TargetProfileForSpecifierRepository.availableForOrganization(organizationId);
 };

--- a/api/lib/infrastructure/authentication.js
+++ b/api/lib/infrastructure/authentication.js
@@ -49,7 +49,7 @@ function validateClientApplication(decoded) {
   return { isValid: true, credentials: { client_id: decoded.clientId, scope: decoded.scope, source: decoded.source } };
 }
 
-module.exports = {
+const autentication = {
   schemeName: 'jwt-scheme',
 
   scheme(_, { key, validate }) {
@@ -82,3 +82,5 @@ module.exports = {
 
   defaultStrategy: 'jwt-user',
 };
+
+module.exports = autentication;

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -12,7 +12,7 @@ class HttpResponse {
   }
 }
 
-module.exports = {
+const HttpAgent = {
   async post({ url, payload, headers, timeout }) {
     const startTime = performance.now();
     let responseTime = null;
@@ -113,3 +113,5 @@ module.exports = {
     }
   },
 };
+
+module.exports = HttpAgent;

--- a/api/lib/infrastructure/plugins/i18n.js
+++ b/api/lib/infrastructure/plugins/i18n.js
@@ -1,14 +1,16 @@
 const hapiI18n = require('hapi-i18n');
+const plugin = hapiI18n;
+const options = {
+  locales: ['en', 'fr'],
+  directory: __dirname + '/../../../translations',
+  defaultLocale: 'fr',
+  queryParameter: 'lang',
+  languageHeaderField: 'Accept-Language',
+  objectNotation: true,
+  updateFiles: false,
+};
 
 module.exports = {
-  plugin: hapiI18n,
-  options: {
-    locales: ['en', 'fr'],
-    directory: __dirname + '/../../../translations',
-    defaultLocale: 'fr',
-    queryParameter: 'lang',
-    languageHeaderField: 'Accept-Language',
-    objectNotation: true,
-    updateFiles: false,
-  },
+  plugin,
+  options,
 };

--- a/api/lib/infrastructure/plugins/pino.js
+++ b/api/lib/infrastructure/plugins/pino.js
@@ -20,15 +20,18 @@ function logObjectSerializer(req) {
   };
 }
 
-module.exports = {
-  plugin: hapiPino,
-  options: {
-    serializers: {
-      req: logObjectSerializer,
-    },
-    instance: logger,
-    // Remove duplicated req property: https://github.com/pinojs/hapi-pino#optionsgetchildbindings-request---key-any-
-    getChildBindings: () => ({}),
-    logQueryParams: true,
+const plugin = hapiPino;
+const options = {
+  serializers: {
+    req: logObjectSerializer,
   },
+  instance: logger,
+  // Remove duplicated req property: https://github.com/pinojs/hapi-pino#optionsgetchildbindings-request---key-any-
+  getChildBindings: () => ({}),
+  logQueryParams: true,
+};
+
+module.exports = {
+  plugin,
+  options,
 };

--- a/api/lib/infrastructure/plugins/sentry.js
+++ b/api/lib/infrastructure/plugins/sentry.js
@@ -2,19 +2,22 @@ const hapiSentry = require('hapi-sentry');
 const packageJSON = require('../../../package.json');
 const config = require('../../config.js');
 
-module.exports = {
-  plugin: hapiSentry,
-  options: {
-    client: {
-      dsn: config.sentry.dsn,
-      environment: config.sentry.environment,
-      release: `v${packageJSON.version}`,
-      maxBreadcrumbs: config.sentry.maxBreadcrumbs,
-      debug: config.sentry.debug,
-      maxValueLength: config.sentry.maxValueLength,
-    },
-    scope: {
-      tags: [{ name: 'source', value: 'api' }],
-    },
+const plugin = hapiSentry;
+const options = {
+  client: {
+    dsn: config.sentry.dsn,
+    environment: config.sentry.environment,
+    release: `v${packageJSON.version}`,
+    maxBreadcrumbs: config.sentry.maxBreadcrumbs,
+    debug: config.sentry.debug,
+    maxValueLength: config.sentry.maxValueLength,
   },
+  scope: {
+    tags: [{ name: 'source', value: 'api' }],
+  },
+};
+
+module.exports = {
+  plugin,
+  options,
 };

--- a/api/lib/infrastructure/serializers/jsonapi/tutorial-attributes.js
+++ b/api/lib/infrastructure/serializers/jsonapi/tutorial-attributes.js
@@ -1,7 +1,6 @@
 const tutorialEvaluationAttributes = require('./tutorial-evaluation-attributes.js');
 const userSavedTutorialAttributes = require('./user-saved-tutorial-attributes.js');
-
-module.exports = {
+const tutorialAttributes = {
   ref: 'id',
   includes: true,
   attributes: [
@@ -18,3 +17,5 @@ module.exports = {
   tutorialEvaluation: tutorialEvaluationAttributes,
   userSavedTutorial: userSavedTutorialAttributes,
 };
+
+module.exports = tutorialAttributes;

--- a/api/lib/infrastructure/serializers/jsonapi/tutorial-evaluation-attributes.js
+++ b/api/lib/infrastructure/serializers/jsonapi/tutorial-evaluation-attributes.js
@@ -1,5 +1,7 @@
-module.exports = {
+const tutorialEvaluationAttributes = {
   ref: 'id',
   includes: true,
   attributes: ['id', 'userId', 'tutorialId', 'status'],
 };
+
+module.exports = tutorialEvaluationAttributes;

--- a/api/lib/infrastructure/serializers/jsonapi/user-saved-tutorial-attributes.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-saved-tutorial-attributes.js
@@ -1,5 +1,7 @@
-module.exports = {
+const userSavedTutorialAttributes = {
   ref: 'id',
   includes: true,
   attributes: ['id', 'userId', 'tutorialId'],
 };
+
+module.exports = userSavedTutorialAttributes;


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la migration des modules cjs vers les modules esm, certains exports sont très hétérogène. Cependant ils sont peux nombreux. On peut donc les traiter à la main. 
On souhaite remplacer par exemple : 
```javascript
module.exports = {
  maxWidth: null,
  /**
   * @param page{PDFPage}
   * @returns {void}
   */
  initialize(page) {
    if (this.maxWidth) return;
    this.maxWidth = page.getWidth();
  },
  get margin() {
    return BORDER;
  },
}
```

par un export d'identifiant de l'objet

```javascript
const PositionManager = {
  maxWidth: null,
  /**
   * @param page{PDFPage}
   * @returns {void}
   */
  initialize(page) {
    if (this.maxWidth) return;
    this.maxWidth = page.getWidth();
  },
  get margin() {
    return BORDER;
  },
}

module.exports = PositionManager;
```

Cela facilitera grandement la migration par codemod. En effet, on souhaite faire des exports nommés en ESM qui s'écrivent sous la forme : 

```javascript
export { identifiant1, identifiant2, ... }
```


## :robot: Proposition
Ces changements étant peu nombreux, on les traite à la main


## :100: Pour tester
- Vérifier que les tests passent