### PR TITLE
[FEATURE] Ajuster les largeurs de colonnes du tableau de paliers (PIX-7103)

### DIFF
--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -14,8 +14,8 @@
               <th class="stages-table__type">{{this.columnNameByStageType}}</th>
               <th class="stages-table__title">Titre</th>
               <th>Message</th>
-              <th>Titre prescripteur</th>
-              <th>Description prescripteur</th>
+              <th class="stages-table__prescriber-title">Titre prescripteur</th>
+              <th class="stages-table__prescriber-description">Description prescripteur</th>
               <th class="stages-table__actions">Actions</th>
             </tr>
           </thead>

--- a/admin/app/styles/components/target-profiles/stages.scss
+++ b/admin/app/styles/components/target-profiles/stages.scss
@@ -1,23 +1,19 @@
 .stages-table {
 
-  &__id {
-    width: 110px;
-  }
-
   &__type {
-    width: 150px;
+    width: 130px;
   }
 
   &__title {
     width: 250px;
   }
 
-  &__image {
-    width: 130px;
+  &__prescriber-title {
+    width: 140px;
+  }
 
-    img {
-      width: 90px;
-    }
+  &__prescriber-description {
+    width: 140px;
   }
 
   &__actions {
@@ -26,10 +22,6 @@
 
   &__level-select {
     width: calc(100% - 8px);
-  }
-
-  .btn {
-    font-size: 0.9rem;
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème
La colonne de message faisait la taille ou était plus petite que celle du titre ce qui causait une mauvaise lisibilité des lignes du tableaux et qui n'était pas ergonomique lors de l'écriture du message vu que celui-ci peut être long.

## :robot: Proposition
Ajuster les largeurs de colonnes selon.

## :rainbow: Remarques
Bonsoir

## :100: Pour tester
- Se connecter à Pix Admin
- Se rendre sur la page "Profiles cibles"
- Cliquer sur l'onglet "Clés de lecture"
- Scroller en bas de la page
- Vérifier les largeurs de colonnes du tableau que ce soit lors de la lecture ou de l'édition de ce dernier.