### PR TITLE
[BUGFIX] Ajouter un margin au bloc des trainings dans la page de fin de parcours (PIX-7306)

### DIFF
--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -36,6 +36,7 @@
   }
 
   &__trainings {
+    margin-top: $spacing-xl;
     padding: 2.5rem 2rem 3rem;
     background-color: $pix-neutral-10;
     border-radius: 10px;


### PR DESCRIPTION
## :unicorn: Problème
Un petit décalage a été introduit suite à l'ajout du block trainings
![image (2)](https://user-images.githubusercontent.com/35958509/221911377-54504cab-53bd-4862-95a0-46c10ee87dc6.png)

## :robot: Proposition
Ajouter un margin pour remettre l'espace manquant

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- aller sur pix app et aller sur la page de fin de parcours d'une campagne avec trainings
