### PR TITLE
[FEATURE] Améliorer les tests sur Pix App avec Testing Library (PIX-7131).

### DIFF
--- a/mon-pix/app/components/account-recovery/confirmation-step.hbs
+++ b/mon-pix/app/components/account-recovery/confirmation-step.hbs
@@ -11,7 +11,11 @@
 
   <p class="account-recovery__content--information-text--details">
     {{t "pages.account-recovery.find-sco-record.confirmation-step.contact-support"}}
-    <a href="{{t 'pages.account-recovery.contact-support.link-url'}}" target="_blank" rel="noopener noreferrer">
+    <a
+      href="{{t 'pages.account-recovery.find-sco-record.contact-support.link-url'}}"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
       {{t "pages.account-recovery.find-sco-record.contact-support.link-text"}}
     </a>
   </p>

--- a/mon-pix/app/components/inaccessible-campaign.hbs
+++ b/mon-pix/app/components/inaccessible-campaign.hbs
@@ -16,7 +16,7 @@
       {{/if}}
     </div>
     <div class="campaign-landing-page__error-text">
-      <p class="campaign-landing-page__error-text title">{{yield}}</p>
+      <h1 class="campaign-landing-page__error-text title">{{yield}}</h1>
       <LinkTo @route="authenticated" class="button button--extra-big button--link campaign-landing-page__error-button">
         {{t "navigation.back-to-profile"}}
       </LinkTo>

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-assessment_test.js
@@ -1,8 +1,8 @@
-import { click, fillIn, currentURL, visit } from '@ember/test-helpers';
+import { click, fillIn, currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { authenticate } from '../helpers/authentication';
 import { resumeCampaignOfTypeAssessmentByCode } from '../helpers/campaign';
-import { clickByLabel } from '../helpers/click-by-label';
 import { invalidateSession } from '../helpers/invalidate-session';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -22,25 +22,30 @@ module('Acceptance | Campaigns | Resume Campaigns with type Assessment', functio
     await resumeCampaignOfTypeAssessmentByCode(campaign.code, true);
   });
 
-  module('When the user is not logged', function (hooks) {
-    hooks.beforeEach(async function () {
+  module('When the user is not logged', function () {
+    test('should propose to signup', async function (assert) {
+      // given
       await invalidateSession();
-      await visit(`/campagnes/${campaign.code}`);
-      await clickByLabel('Je commence');
-    });
+      const screen = await visit(`/campagnes/${campaign.code}`);
 
-    test('should propose to signup', function (assert) {
+      // when
+      await click(screen.getByRole('button', { name: 'Je commence' }));
+
+      // then
       assert.ok(currentURL().includes('/inscription'));
     });
 
     test('should redirect to campaign participation when user logs in', async function (assert) {
       // given
-      await click('[href="/connexion"]');
-      await fillIn('#login', studentInfo.email);
-      await fillIn('#password', studentInfo.password);
+      await invalidateSession();
+      const screen = await visit(`/campagnes/${campaign.code}`);
+      await click(screen.getByRole('button', { name: 'Je commence' }));
+      await click(screen.getByRole('link', { name: 'connectez-vous à votre compte' }));
+      await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail ou identifiant' }), studentInfo.email);
+      await fillIn(screen.getByLabelText('Mot de passe'), studentInfo.password);
 
       // when
-      await click('.sign-form-body__bottom-button button');
+      await click(screen.getByRole('button', { name: 'Je me connecte' }));
 
       // then
       assert.ok(currentURL().includes('/assessments/'));
@@ -50,7 +55,7 @@ module('Acceptance | Campaigns | Resume Campaigns with type Assessment', functio
   module('When user is logged', function () {
     module('When there is no more questions', function () {
       test('should redirect to last checkpoint page', async function (assert) {
-        // when
+        // given & when
         await visit(`/campagnes/${campaign.code}`);
 
         // then
@@ -61,8 +66,8 @@ module('Acceptance | Campaigns | Resume Campaigns with type Assessment', functio
     module('When user has completed his campaign participation', function () {
       test('should redirect directly to results', async function (assert) {
         // given
-        await visit(`/campagnes/${campaign.code}`);
-        await clickByLabel('Voir mes résultats');
+        const screen = await visit(`/campagnes/${campaign.code}`);
+        await click(screen.getByRole('link', { name: 'Voir mes résultats' }));
 
         // when
         await visit(`/campagnes/${campaign.code}`);
@@ -75,9 +80,9 @@ module('Acceptance | Campaigns | Resume Campaigns with type Assessment', functio
     module('When user has already send his results', function () {
       test('should redirect directly to shared results', async function (assert) {
         // given
-        await visit(`/campagnes/${campaign.code}`);
-        await clickByLabel('Voir mes résultats');
-        await clickByLabel("J'envoie mes résultats");
+        const screen = await visit(`/campagnes/${campaign.code}`);
+        await click(screen.getByRole('link', { name: 'Voir mes résultats' }));
+        await click(screen.getByRole('button', { name: "J'envoie mes résultats" }));
 
         // when
         await visit(`/campagnes/${campaign.code}`);
@@ -103,8 +108,8 @@ module('Acceptance | Campaigns | Resume Campaigns with type Assessment', functio
 
       test('should display results page', async function (assert) {
         // when
-        await visit(`/campagnes/${campaign.code}`);
-        await clickByLabel('Voir mes résultats');
+        const screen = await visit(`/campagnes/${campaign.code}`);
+        await click(screen.getByRole('link', { name: 'Voir mes résultats' }));
 
         // then
         assert.ok(currentURL().includes(`/campagnes/${campaign.code}/evaluation/resultats`));

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
@@ -1,4 +1,4 @@
-import { click, fillIn, currentURL, find } from '@ember/test-helpers';
+import { click, fillIn, currentURL } from '@ember/test-helpers';
 import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { authenticate } from '../helpers/authentication';
@@ -6,10 +6,16 @@ import { startCampaignByCode, startCampaignByCodeAndExternalId } from '../helper
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { Response } from 'miragejs';
-import { clickByLabel } from '../helpers/click-by-label';
 import setupIntl from '../helpers/setup-intl';
 
 const PROFILES_COLLECTION = 'PROFILES_COLLECTION';
+const PASSWORD_INPUT_LABEL = 'Mot de passe (8 caractères minimum, dont une majuscule, une minuscule et un chiffre)';
+const EMAIL_INPUT_LABEL = 'Adresse e-mail (ex: nom@exemple.fr)';
+const FIRST_NAME_INPUT_LABEL = 'Prénom';
+const LAST_NAME_INPUT_LABEL = 'Nom';
+const DAY_BIRTH_INPUT_LABEL = 'jour de naissance';
+const MONTH_BIRTH_INPUT_LABEL = 'mois de naissance';
+const YEAR_BIRTH_INPUT_LABEL = 'année de naissance';
 
 module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection', function (hooks) {
   setupApplicationTest(hooks);
@@ -26,22 +32,21 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
 
     module('When user is not logged in', function () {
       module('When campaign has external id', function () {
-        module('When participant external id is not set in the url', function (hooks) {
-          hooks.beforeEach(async function () {
-            campaign = server.create('campaign', { type: PROFILES_COLLECTION, idPixLabel: 'email' });
-            const screen = await startCampaignByCode(campaign.code);
-            await fillIn('#firstName', campaignParticipant.firstName);
-            await fillIn('#lastName', campaignParticipant.lastName);
-            await fillIn('#email', campaignParticipant.email);
-            await fillIn('#password', campaignParticipant.password);
-            await click(screen.getByRole('checkbox', { name: this.intl.t('common.cgu.label') }));
-            await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
-          });
-
+        module('When participant external id is not set in the url', function () {
           test('should redirect to send profile page after completion of external id', async function (assert) {
+            // then
+            campaign = server.create('campaign', { type: PROFILES_COLLECTION, idPixLabel: 'Adresse e-mail' });
+            const screen = await startCampaignByCode(campaign.code);
+            await fillIn(screen.getByRole('textbox', { name: FIRST_NAME_INPUT_LABEL }), campaignParticipant.firstName);
+            await fillIn(screen.getByRole('textbox', { name: LAST_NAME_INPUT_LABEL }), campaignParticipant.lastName);
+            await fillIn(screen.getByRole('textbox', { name: EMAIL_INPUT_LABEL }), campaignParticipant.email);
+            await fillIn(screen.getByLabelText(PASSWORD_INPUT_LABEL), campaignParticipant.password);
+            await click(screen.getByRole('checkbox', { name: this.intl.t('common.cgu.label') }));
+            await click(screen.getByRole('button', { name: "Je m'inscris" }));
+
             // when
-            await fillIn('#id-pix-label', 'monmail@truc.fr');
-            await clickByLabel(this.intl.t('pages.fill-in-participant-external-id.buttons.continue'));
+            await fillIn(screen.getByRole('textbox', { name: 'Adresse e-mail' }), 'monmail@truc.fr');
+            await click(screen.getByRole('button', { name: 'Continuer' }));
 
             // then
             assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
@@ -58,12 +63,15 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
                 idPixLabel: 'toto',
               });
               const screen = await startCampaignByCodeAndExternalId(campaign.code);
-              await fillIn('#firstName', campaignParticipant.firstName);
-              await fillIn('#lastName', campaignParticipant.lastName);
-              await fillIn('#email', campaignParticipant.email);
-              await fillIn('#password', campaignParticipant.password);
+              await fillIn(
+                screen.getByRole('textbox', { name: FIRST_NAME_INPUT_LABEL }),
+                campaignParticipant.firstName
+              );
+              await fillIn(screen.getByRole('textbox', { name: LAST_NAME_INPUT_LABEL }), campaignParticipant.lastName);
+              await fillIn(screen.getByRole('textbox', { name: EMAIL_INPUT_LABEL }), campaignParticipant.email);
+              await fillIn(screen.getByLabelText(PASSWORD_INPUT_LABEL), campaignParticipant.password);
               await click(screen.getByRole('checkbox', { name: this.intl.t('common.cgu.label') }));
-              await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
+              await click(screen.getByRole('button', { name: "Je m'inscris" }));
 
               // then
               assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
@@ -79,24 +87,28 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
                 idPixLabel: 'toto',
                 organizationType: 'SCO',
               });
-              await visit(`/campagnes/${campaign.code}?participantExternalId=a73at01r3`);
+              const screen = await visit(`/campagnes/${campaign.code}?participantExternalId=a73at01r3`);
               assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
-              await clickByLabel("C'est parti !");
+              await click(screen.getByRole('button', { name: "C'est parti !" }));
 
               // when
-              await click('#login-button');
-
-              await fillIn('#login', campaignParticipant.email);
-              await fillIn('#password', campaignParticipant.password);
-              await click('#submit-connexion');
-
-              await fillIn('#firstName', campaignParticipant.firstName);
-              await fillIn('#lastName', campaignParticipant.lastName);
-              await fillIn('#dayOfBirth', '10');
-              await fillIn('#monthOfBirth', '12');
-              await fillIn('#yearOfBirth', '2000');
-              await clickByLabel(this.intl.t('pages.join.button'));
-              await clickByLabel(this.intl.t('pages.join.sco.associate'));
+              await click(screen.getByRole('button', { name: 'Se connecter' }));
+              await fillIn(
+                screen.getByRole('textbox', { name: 'Adresse e-mail ou identifiant' }),
+                campaignParticipant.email
+              );
+              await fillIn(screen.getByLabelText('Mot de passe'), campaignParticipant.password);
+              await click(screen.getByRole('button', { name: 'Se connecter' }));
+              await fillIn(
+                screen.getByRole('textbox', { name: FIRST_NAME_INPUT_LABEL }),
+                campaignParticipant.firstName
+              );
+              await fillIn(screen.getByRole('textbox', { name: LAST_NAME_INPUT_LABEL }), campaignParticipant.lastName);
+              await fillIn(screen.getByRole('textbox', { name: DAY_BIRTH_INPUT_LABEL }), '10');
+              await fillIn(screen.getByRole('textbox', { name: MONTH_BIRTH_INPUT_LABEL }), '12');
+              await fillIn(screen.getByRole('textbox', { name: YEAR_BIRTH_INPUT_LABEL }), '2000');
+              await click(screen.getByRole('button', { name: "C'est parti !" }));
+              await click(screen.getByRole('button', { name: 'Associer' }));
 
               // then
               assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
@@ -110,12 +122,12 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
           // given & when
           campaign = server.create('campaign', { type: PROFILES_COLLECTION, idPixLabel: null });
           const screen = await startCampaignByCode(campaign.code);
-          await fillIn('#firstName', campaignParticipant.firstName);
-          await fillIn('#lastName', campaignParticipant.lastName);
-          await fillIn('#email', campaignParticipant.email);
-          await fillIn('#password', campaignParticipant.password);
+          await fillIn(screen.getByRole('textbox', { name: FIRST_NAME_INPUT_LABEL }), campaignParticipant.firstName);
+          await fillIn(screen.getByRole('textbox', { name: LAST_NAME_INPUT_LABEL }), campaignParticipant.lastName);
+          await fillIn(screen.getByRole('textbox', { name: EMAIL_INPUT_LABEL }), campaignParticipant.email);
+          await fillIn(screen.getByLabelText(PASSWORD_INPUT_LABEL), campaignParticipant.password);
           await click(screen.getByRole('checkbox', { name: this.intl.t('common.cgu.label') }));
-          await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
+          await click(screen.getByRole('button', { name: "Je m'inscris" }));
 
           // then
           assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
@@ -127,14 +139,14 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
           // given
           campaign = server.create('campaign', { type: PROFILES_COLLECTION });
           const screen = await startCampaignByCodeAndExternalId(campaign.code);
-          await fillIn('#firstName', campaignParticipant.firstName);
-          await fillIn('#lastName', campaignParticipant.lastName);
-          await fillIn('#email', campaignParticipant.email);
-          await fillIn('#password', campaignParticipant.password);
+          await fillIn(screen.getByRole('textbox', { name: FIRST_NAME_INPUT_LABEL }), campaignParticipant.firstName);
+          await fillIn(screen.getByRole('textbox', { name: LAST_NAME_INPUT_LABEL }), campaignParticipant.lastName);
+          await fillIn(screen.getByRole('textbox', { name: EMAIL_INPUT_LABEL }), campaignParticipant.email);
+          await fillIn(screen.getByLabelText(PASSWORD_INPUT_LABEL), campaignParticipant.password);
           await click(screen.getByRole('checkbox', { name: this.intl.t('common.cgu.label') }));
 
           // when
-          await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
+          await click(screen.getByRole('button', { name: "Je m'inscris" }));
 
           // then
           assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
@@ -151,9 +163,11 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
         test('should redirect to landing page', async function (assert) {
           // when
           campaign = server.create('campaign', { type: PROFILES_COLLECTION });
-          await visit(`/campagnes/${campaign.code}`);
+          const screen = await visit(`/campagnes/${campaign.code}`);
+
+          // then
           assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
-          assert.strictEqual(find('.campaign-landing-page__start-button').textContent.trim(), "C'est parti !");
+          assert.dom(screen.getByRole('button', { name: "C'est parti !" })).exists();
         });
       });
 
@@ -170,19 +184,20 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
         module('When association is not already done', function () {
           test('should redirect to send profile page', async function (assert) {
             // given
-            await visit(`/campagnes/${campaign.code}`);
-            await clickByLabel("C'est parti !");
-            await fillIn('#firstName', 'Robert');
-            await fillIn('#lastName', 'Smith');
-            await fillIn('#dayOfBirth', '10');
-            await fillIn('#monthOfBirth', '12');
-            await fillIn('#yearOfBirth', '2000');
-            await clickByLabel(this.intl.t('pages.join.button'));
-            await clickByLabel(this.intl.t('pages.join.sco.associate'));
-            await fillIn('#id-pix-label', 'truc');
+            const screen = await visit(`/campagnes/${campaign.code}`);
+            await click(screen.getByRole('button', { name: "C'est parti !" }));
+            await fillIn(screen.getByRole('textbox', { name: FIRST_NAME_INPUT_LABEL }), 'Robert');
+            await fillIn(screen.getByRole('textbox', { name: LAST_NAME_INPUT_LABEL }), 'Smith');
+            await fillIn(screen.getByRole('textbox', { name: DAY_BIRTH_INPUT_LABEL }), '10');
+            await fillIn(screen.getByRole('textbox', { name: MONTH_BIRTH_INPUT_LABEL }), '12');
+            await fillIn(screen.getByRole('textbox', { name: YEAR_BIRTH_INPUT_LABEL }), '2000');
+            await click(screen.getByRole('button', { name: "C'est parti !" }));
+            await click(screen.getByRole('button', { name: 'Associer' }));
+
+            await fillIn(screen.getByRole('textbox', { name: 'nom de naissance de maman' }), 'truc');
 
             // when
-            await clickByLabel(this.intl.t('pages.fill-in-participant-external-id.buttons.continue'));
+            await click(screen.getByRole('button', { name: 'Continuer' }));
 
             //then
             assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
@@ -198,15 +213,15 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
             test('should display error modal when fields are filled in', async function (assert) {
               // given
               const screen = await visit(`/campagnes/${campaign.code}`);
-              await clickByLabel("C'est parti !");
+              await click(screen.getByRole('button', { name: "C'est parti !" }));
 
               // when
-              await fillIn('#firstName', 'Robert');
-              await fillIn('#lastName', 'Smith');
-              await fillIn('#dayOfBirth', '10');
-              await fillIn('#monthOfBirth', '12');
-              await fillIn('#yearOfBirth', '2000');
-              await clickByLabel(this.intl.t('pages.join.button'));
+              await fillIn(screen.getByRole('textbox', { name: FIRST_NAME_INPUT_LABEL }), 'Robert');
+              await fillIn(screen.getByRole('textbox', { name: LAST_NAME_INPUT_LABEL }), 'Smith');
+              await fillIn(screen.getByRole('textbox', { name: DAY_BIRTH_INPUT_LABEL }), '10');
+              await fillIn(screen.getByRole('textbox', { name: MONTH_BIRTH_INPUT_LABEL }), '12');
+              await fillIn(screen.getByRole('textbox', { name: YEAR_BIRTH_INPUT_LABEL }), '2000');
+              await click(screen.getByRole('button', { name: "C'est parti !" }));
 
               //then
               assert.ok(screen.getByRole('dialog', { name: this.intl.t('pages.join.sco.login-information-title') }));
@@ -215,16 +230,16 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
             test('should redirect to connection form when continue button is clicked', async function (assert) {
               // given
               const screen = await visit(`/campagnes/${campaign.code}`);
-              await clickByLabel("C'est parti !");
+              await click(screen.getByRole('button', { name: "C'est parti !" }));
 
               // when
-              await fillIn('#firstName', 'Robert');
-              await fillIn('#lastName', 'Smith');
-              await fillIn('#dayOfBirth', '10');
-              await fillIn('#monthOfBirth', '12');
-              await fillIn('#yearOfBirth', '2000');
-              await clickByLabel(this.intl.t('pages.join.button'));
-              await clickByLabel(this.intl.t('pages.join.sco.continue-with-pix'));
+              await fillIn(screen.getByRole('textbox', { name: FIRST_NAME_INPUT_LABEL }), 'Robert');
+              await fillIn(screen.getByRole('textbox', { name: LAST_NAME_INPUT_LABEL }), 'Smith');
+              await fillIn(screen.getByRole('textbox', { name: DAY_BIRTH_INPUT_LABEL }), '10');
+              await fillIn(screen.getByRole('textbox', { name: MONTH_BIRTH_INPUT_LABEL }), '12');
+              await fillIn(screen.getByRole('textbox', { name: YEAR_BIRTH_INPUT_LABEL }), '2000');
+              await click(screen.getByRole('button', { name: "C'est parti !" }));
+              await click(screen.getByRole('button', { name: 'Continuer avec mon compte Pix' }));
 
               //then
               assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/rejoindre/identification`);
@@ -242,11 +257,11 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
               type: PROFILES_COLLECTION,
               idPixLabel: 'nom de naissance de maman',
             });
-            await startCampaignByCode(campaign.code);
+            const screen = await startCampaignByCode(campaign.code);
 
             // when
-            await fillIn('#id-pix-label', 'monmail@truc.fr');
-            await clickByLabel(this.intl.t('pages.fill-in-participant-external-id.buttons.continue'));
+            await fillIn(screen.getByRole('textbox', { name: 'nom de naissance de maman' }), 'truc');
+            await click(screen.getByRole('button', { name: 'Continuer' }));
 
             // then
             assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
@@ -268,38 +283,33 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
         });
       });
 
-      module('When campaign does not have external id', function (hooks) {
-        hooks.beforeEach(async function () {
-          campaign = server.create('campaign', { type: PROFILES_COLLECTION, idPixLabel: null });
-          await visit(`campagnes/${campaign.code}`);
-        });
-
+      module('When campaign does not have external id', function () {
         test('should redirect to send profile page after clicking on start button in landing page', async function (assert) {
+          // given
+          campaign = server.create('campaign', { type: PROFILES_COLLECTION, idPixLabel: null });
+          const screen = await visit(`campagnes/${campaign.code}`);
+
           // when
-          await click('.campaign-landing-page__start-button');
+          await click(screen.getByRole('button', { name: "C'est parti !" }));
 
           // then
           assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
         });
       });
 
-      module(
-        'When campaign does not have external id but a participant external id is set in the url',
-        function (hooks) {
-          hooks.beforeEach(async function () {
-            campaign = server.create('campaign', { type: PROFILES_COLLECTION, idPixLabel: null });
-            await visit(`/campagnes/${campaign.code}?participantExternalId=a73at01r3`);
-          });
+      module('When campaign does not have external id but a participant external id is set in the url', function () {
+        test('should redirect to send profile page after clicking on start button in landing page', async function (assert) {
+          // given
+          campaign = server.create('campaign', { type: PROFILES_COLLECTION, idPixLabel: null });
+          const screen = await visit(`/campagnes/${campaign.code}?participantExternalId=a73at01r3`);
 
-          test('should redirect to send profile page after clicking on start button in landing page', async function (assert) {
-            // when
-            await click('.campaign-landing-page__start-button');
+          // when
+          await click(screen.getByRole('button', { name: "C'est parti !" }));
 
-            // then
-            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
-          });
-        }
-      );
+          // then
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
+        });
+      });
     });
   });
 });

--- a/mon-pix/tests/integration/components/account-recovery/confirmation-email-sent-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/confirmation-email-sent-test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
-import { contains } from '../../../helpers/contains';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | account-recovery/confirmation-email-sent', function (hooks) {
@@ -9,12 +8,28 @@ module('Integration | Component | account-recovery/confirmation-email-sent', fun
 
   test('should display a sent email confirmation message', async function (assert) {
     //given / when
-    await render(hbs`<AccountRecovery::ConfirmationEmailSent />`);
+    const screen = await render(hbs`<AccountRecovery::ConfirmationEmailSent />`);
 
     //then
-    assert.ok(contains(this.intl.t('pages.account-recovery.find-sco-record.send-email-confirmation.title')));
-    assert.ok(contains(this.intl.t('pages.account-recovery.find-sco-record.send-email-confirmation.send-email')));
-    assert.ok(contains(this.intl.t('pages.account-recovery.find-sco-record.send-email-confirmation.check-spam')));
-    assert.ok(contains(this.intl.t('pages.account-recovery.find-sco-record.send-email-confirmation.return')));
+    assert
+      .dom(
+        screen.getByRole('heading', {
+          name: this.intl.t('pages.account-recovery.find-sco-record.send-email-confirmation.title'),
+        })
+      )
+      .exists();
+    assert
+      .dom(screen.getByText(this.intl.t('pages.account-recovery.find-sco-record.send-email-confirmation.send-email')))
+      .exists();
+    assert
+      .dom(screen.getByText(this.intl.t('pages.account-recovery.find-sco-record.send-email-confirmation.check-spam')))
+      .exists();
+    assert
+      .dom(
+        screen.getByRole('link', {
+          name: this.intl.t('pages.account-recovery.find-sco-record.send-email-confirmation.return'),
+        })
+      )
+      .exists();
   });
 });

--- a/mon-pix/tests/integration/components/account-recovery/confirmation-step-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/confirmation-step-test.js
@@ -1,11 +1,10 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
-import { contains } from '../../../helpers/contains';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { clickByLabel } from '../../../helpers/click-by-label';
 import sinon from 'sinon';
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 
 module('Integration | Component | confirmation-step', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -22,23 +21,42 @@ module('Integration | Component | confirmation-step', function (hooks) {
     this.set('studentInformationForAccountRecovery', studentInformationForAccountRecovery);
 
     // when
-    await render(hbs`<AccountRecovery::ConfirmationStep
+    const screen = await render(hbs`<AccountRecovery::ConfirmationStep
       @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
     />`);
 
     // then
-    assert.ok(
-      contains(
-        this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.good-news', { firstName: 'Philippe' })
+    assert
+      .dom(
+        screen.getByRole('heading', {
+          name: this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.good-news', {
+            firstName: 'Philippe',
+          }),
+        })
       )
-    );
-    assert.ok(contains(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.found-account')));
-    assert.ok(contains(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.contact-support')));
-    assert.ok(contains('Auguste'));
-    assert.ok(contains('Philippe'));
-    assert.ok(contains('Philippe.auguste2312'));
-    assert.ok(contains('Collège George-Besse, Loches'));
-    assert.ok(contains(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account')));
+      .exists();
+    assert
+      .dom(screen.getByText(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.found-account')))
+      .exists();
+    assert
+      .dom(
+        screen.getByRole('link', {
+          name: this.intl.t('pages.account-recovery.find-sco-record.contact-support.link-text'),
+        })
+      )
+      .hasAttribute('href', this.intl.t('pages.account-recovery.find-sco-record.contact-support.link-url'));
+
+    assert.dom(screen.getByText('Auguste')).exists();
+    assert.dom(screen.getByText('Philippe')).exists();
+    assert.dom(screen.getByText('Philippe.auguste2312')).exists();
+    assert.dom(screen.getByText('Collège George-Besse, Loches')).exists();
+    assert
+      .dom(
+        screen.getByRole('checkbox', {
+          name: this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'),
+        })
+      )
+      .exists();
   });
 
   module('when user does not have a username', function () {
@@ -53,12 +71,16 @@ module('Integration | Component | confirmation-step', function (hooks) {
       this.set('studentInformationForAccountRecovery', studentInformationForAccountRecovery);
 
       // when
-      await render(hbs`<AccountRecovery::ConfirmationStep
+      const screen = await render(hbs`<AccountRecovery::ConfirmationStep
         @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
       />`);
 
       // then
-      assert.notOk(contains(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.fields.username')));
+      assert
+        .dom(
+          screen.queryByText(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.fields.username'))
+        )
+        .doesNotExist();
     });
   });
 
@@ -76,11 +98,15 @@ module('Integration | Component | confirmation-step', function (hooks) {
     this.set('cancelAccountRecovery', cancelAccountRecovery);
 
     // when
-    await render(hbs`<AccountRecovery::ConfirmationStep
+    const screen = await render(hbs`<AccountRecovery::ConfirmationStep
       @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
       @cancelAccountRecovery={{this.cancelAccountRecovery}}
     />`);
-    await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.cancel'));
+    await click(
+      screen.getByRole('button', {
+        name: this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.cancel'),
+      })
+    );
 
     // then
     sinon.assert.calledOnce(cancelAccountRecovery);
@@ -132,8 +158,16 @@ module('Integration | Component | confirmation-step', function (hooks) {
       @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
       @continueAccountRecoveryBackupEmailConfirmation={{this.continueAccountRecoveryBackupEmailConfirmation}}
     />`);
-    await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'));
-    await clickByLabel(this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'));
+    await click(
+      screen.getByRole('checkbox', {
+        name: this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.certify-account'),
+      })
+    );
+    await click(
+      screen.getByRole('button', {
+        name: this.intl.t('pages.account-recovery.find-sco-record.confirmation-step.buttons.confirm'),
+      })
+    );
 
     // then
     sinon.assert.calledOnce(continueAccountRecoveryBackupEmailConfirmation);

--- a/mon-pix/tests/integration/components/account-recovery/confirmation-step-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/confirmation-step-test.js
@@ -128,7 +128,7 @@ module('Integration | Component | confirmation-step', function (hooks) {
     this.set('continueAccountRecoveryBackupEmailConfirmation', continueAccountRecoveryBackupEmailConfirmation);
 
     // when
-    await render(hbs`<AccountRecovery::ConfirmationStep
+    const screen = await render(hbs`<AccountRecovery::ConfirmationStep
       @studentInformationForAccountRecovery={{this.studentInformationForAccountRecovery}}
       @continueAccountRecoveryBackupEmailConfirmation={{this.continueAccountRecoveryBackupEmailConfirmation}}
     />`);

--- a/mon-pix/tests/integration/components/challenge-illustration_test.js
+++ b/mon-pix/tests/integration/components/challenge-illustration_test.js
@@ -1,49 +1,32 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import hbs from 'htmlbars-inline-precompile';
-import { find, render, triggerEvent } from '@ember/test-helpers';
+import { triggerEvent } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | challenge-illustration', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  const IMG_SRC = 'http://www.example.com/this-is-an-example.png';
-  const IMG_ALT = "texte alternatif à l'image";
-  const HIDDEN_CLASS_NAME = 'challenge-illustration__loaded-image--hidden';
-
-  function findImageElement() {
-    return find('.challenge-illustration__loaded-image');
-  }
-
-  function findImagePlaceholderElement() {
-    return find('.challenge-illustration__placeholder');
-  }
-
-  test('renders', async function (assert) {
-    // when
-    await render(hbs`<ChallengeIllustration/>`);
-
-    // then
-    assert.dom('div[data-test-id="challenge-illustration"]').exists();
-  });
-
   test('should display placeholder and hidden image, then only image when it has loaded', async function (assert) {
     // given
-    this.set('src', IMG_SRC);
-    this.set('alt', IMG_ALT);
+    const imageSource = 'http://www.example.com/this-is-an-example.png';
+    const imageAlternativeText = "texte alternatif à l'image";
+
+    this.set('src', imageSource);
+    this.set('alt', imageAlternativeText);
 
     // when
-    await render(hbs`<ChallengeIllustration @src={{this.src}} @alt={{this.alt}}/>`);
+    const screen = await render(hbs`<ChallengeIllustration @src={{this.src}} @alt={{this.alt}}/>`);
 
     // then
-    assert.ok(findImageElement());
-    assert.ok(findImageElement().className.includes(HIDDEN_CLASS_NAME));
-    assert.strictEqual(findImageElement().getAttribute('alt'), IMG_ALT);
-    assert.strictEqual(findImageElement().getAttribute('src'), IMG_SRC);
-    assert.ok(findImagePlaceholderElement());
+    const hiddenImage = await screen.getByAltText(imageAlternativeText);
+    assert.dom(hiddenImage).exists();
+    assert.dom(screen.getByLabelText("Chargement de l'image en cours")).exists();
 
-    await triggerEvent(findImageElement(), 'load');
-    assert.ok(findImageElement());
-    assert.notOk(findImageElement().className.includes(HIDDEN_CLASS_NAME));
-    assert.notOk(findImagePlaceholderElement());
+    await triggerEvent(hiddenImage, 'load');
+
+    const visibleImage = screen.getByRole('img', { name: imageAlternativeText });
+    assert.dom(visibleImage).hasAttribute('src', imageSource);
+    assert.dom(screen.queryByLabelText("Chargement de l'image en cours")).doesNotExist();
   });
 });

--- a/mon-pix/tests/integration/components/checkpoint-continue_test.js
+++ b/mon-pix/tests/integration/components/checkpoint-continue_test.js
@@ -1,13 +1,38 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | checkpoint-continue', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('renders', async function (assert) {
-    await render(hbs`<CheckpointContinue />`);
-    assert.dom('.checkpoint__continue').exists();
+  module('when is the final checkpoint', function () {
+    test('should display "See my results" link', async function (assert) {
+      // given
+      this.nextPageButtonText = this.intl.t('pages.checkpoint.actions.next-page.results');
+
+      // when
+      const screen = await render(
+        hbs`<CheckpointContinue @finalCheckpoint={{true}} @nextPageButtonText={{this.nextPageButtonText}} />`
+      );
+
+      // then
+      assert.dom(screen.getByText(this.nextPageButtonText)).exists();
+    });
+  });
+
+  module('when is not the final checkpoint', function () {
+    test('should display "Continue" link', async function (assert) {
+      // given
+      this.nextPageButtonText = this.intl.t('pages.checkpoint.actions.next-page.continue');
+
+      // when
+      const screen = await render(
+        hbs`<CheckpointContinue @finalCheckpoint={{false}} @nextPageButtonText={{this.nextPageButtonText}} />`
+      );
+
+      // then
+      assert.dom(screen.getByText(this.nextPageButtonText)).exists();
+    });
   });
 });

--- a/mon-pix/tests/integration/components/update-expired-password-form_test.js
+++ b/mon-pix/tests/integration/components/update-expired-password-form_test.js
@@ -1,28 +1,28 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
-import { fillIn, triggerEvent } from '@ember/test-helpers';
+import { fillIn, triggerEvent, click } from '@ember/test-helpers';
 import EmberObject from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 import { render } from '@1024pix/ember-testing-library';
 
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { contains } from '../../helpers/contains';
-import { clickByLabel } from '../../helpers/click-by-label';
 
 import ENV from '../../../config/environment';
 const ApiErrorMessages = ENV.APP.API_ERROR_MESSAGES;
 
-const PASSWORD_INPUT_CLASS = '.form-textfield__input';
+const PASSWORD_INPUT_LABEL = '* Mot de passe (8 caractères minimum, dont une majuscule, une minuscule et un chiffre)';
 
 module('Integration | Component | update-expired-password-form', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('renders', async function (assert) {
-    // when
-    await render(hbs`{{update-expired-password-form}}`);
+  test('renders elements', async function (assert) {
+    // given / when
+    const screen = await render(hbs`{{update-expired-password-form}}`);
 
     //then
-    assert.dom('.update-expired-password-form__container').exists();
+    assert.dom(screen.getByRole('heading', { name: 'Réinitialiser le mot de passe' })).exists();
+    assert.dom(screen.getByRole('button', { name: 'Réinitialiser' })).exists();
+    assert.dom(screen.getByLabelText(PASSWORD_INPUT_LABEL)).exists();
   });
 
   module('successful cases', function () {
@@ -42,13 +42,13 @@ module('Integration | Component | update-expired-password-form', function (hooks
       );
 
       // when
-      await fillIn(PASSWORD_INPUT_CLASS, newPassword);
-      await triggerEvent(PASSWORD_INPUT_CLASS, 'change');
+      await fillIn(screen.getByLabelText(PASSWORD_INPUT_LABEL), newPassword);
+      await triggerEvent(screen.getByLabelText(PASSWORD_INPUT_LABEL), 'change');
 
-      await clickByLabel(this.intl.t('pages.update-expired-password.button'));
+      await click(screen.getByRole('button', { name: 'Réinitialiser' }));
 
       // then
-      assert.dom(PASSWORD_INPUT_CLASS).doesNotExist();
+      assert.dom(screen.queryByLabelText(PASSWORD_INPUT_LABEL)).doesNotExist();
       assert.dom(screen.getByText('Votre mot de passe a été mis à jour.')).exists();
     });
   });
@@ -65,16 +65,18 @@ module('Integration | Component | update-expired-password-form', function (hooks
       this.set('resetExpiredPasswordDemand', resetExpiredPasswordDemand);
       const newPassword = 'Pix12345!';
 
-      await render(hbs`<UpdateExpiredPasswordForm @resetExpiredPasswordDemand={{this.resetExpiredPasswordDemand}} />`);
+      const screen = await render(
+        hbs`<UpdateExpiredPasswordForm @resetExpiredPasswordDemand={{this.resetExpiredPasswordDemand}} />`
+      );
 
       // when
-      await fillIn(PASSWORD_INPUT_CLASS, newPassword);
-      await triggerEvent(PASSWORD_INPUT_CLASS, 'change');
+      await fillIn(screen.getByLabelText(PASSWORD_INPUT_LABEL), newPassword);
+      await triggerEvent(screen.getByLabelText(PASSWORD_INPUT_LABEL), 'change');
 
-      await clickByLabel(this.intl.t('pages.update-expired-password.button'));
+      await click(screen.getByRole('button', { name: 'Réinitialiser' }));
 
       // then
-      assert.ok(contains(this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY)));
+      assert.ok(this.intl.t(ApiErrorMessages.INTERNAL_SERVER_ERROR.I18N_KEY));
     });
   });
 });

--- a/mon-pix/tests/integration/components/user-certifications-panel_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-panel_test.js
@@ -1,24 +1,19 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
 module('Integration | Component | user certifications panel', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('renders', async function (assert) {
-    await render(hbs`<UserCertificationsPanel />`);
-    assert.dom('.user-certifications-panel').exists();
-  });
-
   module('when there is no certifications', function () {
     test('should render a panel which indicate there is no certifications', async function (assert) {
-      // when
-      await render(hbs`<UserCertificationsPanel />`);
+      // given / when
+      const screen = await render(hbs`<UserCertificationsPanel />`);
 
       // then
-      assert.dom('.user-certifications-panel__no-certification-panel').exists();
+      assert.dom(screen.getByText("Vous n'avez pas encore de certification.")).exists();
     });
   });
 
@@ -41,10 +36,15 @@ module('Integration | Component | user certifications panel', function (hooks) {
       this.set('certifications', certifications);
 
       // when
-      await render(hbs`<UserCertificationsPanel @certifications={{this.certifications}}/>`);
+      const screen = await render(hbs`<UserCertificationsPanel @certifications={{this.certifications}}/>`);
 
       // then
-      assert.dom('.user-certifications-panel__certifications-list').exists();
+      assert.dom(screen.getByText('date')).exists();
+      assert.dom(screen.getByText('statut')).exists();
+      assert.dom(screen.getByText('score pix')).exists();
+      assert.dom(screen.getByText('centre de certification')).exists();
+      assert.dom(screen.getByText('Université de Paris')).exists();
+      assert.dom(screen.getByText('Université de Lyon')).exists();
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Nous avons désormais [un package Pix](https://www.npmjs.com/package/@1024pix/ember-testing-library) qui contient des [méthodes utilisant testing library](https://github.com/1024pix/ember-testing-library/blob/dev/addon/index.js). 

Il est de plus en plus présents dans nos tests front mais nombre d'entre eux se basent toujours sur du html, du css.
Or une bonne pratique pour les tests consiste à séparer les préoccupations entre le style et les tests. Les noms de classe et la structure DOM changent avec le temps.

## :robot: Proposition
Unifier nos tests sur Pix App en utilisants les méthodes du package et de testing library.

## :rainbow: Remarques
D'autres PR seront nécessaires pour couvrir tous les tests de l'appli

## :100: Pour tester
Rien a tester
