### PR TITLE
[TECH] Rétablir le linter sur les dossier de tests et de scripts

### DIFF
--- a/api/.eslintignore
+++ b/api/.eslintignore
@@ -1,6 +1,4 @@
 # https://eslint.org/docs/user-guide/configuring#eslintignore
 # .file are implicitly ignored, unless explicitly specified here
 node_modules/
-scripts/
-tests/
 codemods/


### PR DESCRIPTION
## :unicorn: Problème
Le linter ne tourne plus sur les dossiers de test et de script

## :robot: Proposition
modifier le eslintignore pour les prendre en compte

## :rainbow: Remarques

## :100: Pour tester
- la CI passe