### PR TITLE
[BUGFIX] Restreindre les droits d'accès de modification des contenus formatifs (PIX-7305).

### DIFF
--- a/admin/app/components/menu-bar.hbs
+++ b/admin/app/components/menu-bar.hbs
@@ -76,7 +76,7 @@
         </PixTooltip>
       </li>
     {{/if}}
-    {{#if this.accessControl.hasAccessToTrainingsActionsScope}}
+    {{#if this.accessControl.hasAccessToTrainings}}
       <li class="menu-bar__entry">
         <PixTooltip @position="right">
           <:triggerElement>

--- a/admin/app/controllers/authenticated/trainings/list.js
+++ b/admin/app/controllers/authenticated/trainings/list.js
@@ -3,4 +3,8 @@ import { inject as service } from '@ember/service';
 
 export default class ListController extends Controller {
   @service accessControl;
+
+  get canCreateTrainings() {
+    return this.accessControl.hasAccessToTrainingsActionsScope;
+  }
 }

--- a/admin/app/controllers/authenticated/trainings/training.js
+++ b/admin/app/controllers/authenticated/trainings/training.js
@@ -5,8 +5,13 @@ import Controller from '@ember/controller';
 
 export default class Training extends Controller {
   @service notifications;
+  @service accessControl;
 
   @tracked isEditMode = false;
+
+  get canEdit() {
+    return this.accessControl.hasAccessToTrainingsActionsScope;
+  }
 
   @action
   toggleEditMode() {

--- a/admin/app/controllers/authenticated/trainings/training/target-profiles.js
+++ b/admin/app/controllers/authenticated/trainings/training/target-profiles.js
@@ -7,7 +7,12 @@ import uniq from 'lodash/uniq';
 export default class TrainingDetailsTargetProfilesController extends Controller {
   @tracked targetProfilesToAttach = '';
 
+  @service accessControl;
   @service notifications;
+
+  get canAttachTargetProfiles() {
+    return this.accessControl.hasAccessToTrainingsActionsScope;
+  }
 
   get noTargetProfilesToAttach() {
     return this.targetProfilesToAttach === '';

--- a/admin/app/controllers/authenticated/trainings/training/triggers.js
+++ b/admin/app/controllers/authenticated/trainings/training/triggers.js
@@ -3,8 +3,13 @@ import Controller from '@ember/controller';
 
 export default class TrainingDetailsTriggersController extends Controller {
   @service router;
+  @service accessControl;
 
   get showTriggersEditForm() {
     return this.router.currentRoute.localName.includes('edit');
+  }
+
+  get canCreateTriggers() {
+    return this.accessControl.hasAccessToTrainingsActionsScope;
   }
 }

--- a/admin/app/services/access-control.js
+++ b/admin/app/services/access-control.js
@@ -18,11 +18,7 @@ export default class AccessControlService extends Service {
   }
 
   get hasAccessToTrainingsActionsScope() {
-    return (
-      this.currentUser.adminMember.isSuperAdmin ||
-      this.currentUser.adminMember.isSupport ||
-      this.currentUser.adminMember.isMetier
-    );
+    return this.currentUser.adminMember.isSuperAdmin || this.currentUser.adminMember.isMetier;
   }
 
   get hasAccessToTrainingsCreationActionsScope() {

--- a/admin/app/services/access-control.js
+++ b/admin/app/services/access-control.js
@@ -29,6 +29,14 @@ export default class AccessControlService extends Service {
     return !!(this.currentUser.adminMember.isSuperAdmin || this.currentUser.adminMember.isMetier);
   }
 
+  get hasAccessToTrainings() {
+    return (
+      this.currentUser.adminMember.isSuperAdmin ||
+      this.currentUser.adminMember.isMetier ||
+      this.currentUser.adminMember.isSupport
+    );
+  }
+
   restrictAccessTo(roles, redirectionUrl) {
     const currentUserIsAllowed = roles.some((role) => this.currentUser.adminMember[role]);
     if (!currentUserIsAllowed) {

--- a/admin/app/services/access-control.js
+++ b/admin/app/services/access-control.js
@@ -21,10 +21,6 @@ export default class AccessControlService extends Service {
     return this.currentUser.adminMember.isSuperAdmin || this.currentUser.adminMember.isMetier;
   }
 
-  get hasAccessToTrainingsCreationActionsScope() {
-    return !!(this.currentUser.adminMember.isSuperAdmin || this.currentUser.adminMember.isMetier);
-  }
-
   get hasAccessToTrainings() {
     return (
       this.currentUser.adminMember.isSuperAdmin ||

--- a/admin/app/templates/authenticated/trainings/list.hbs
+++ b/admin/app/templates/authenticated/trainings/list.hbs
@@ -1,6 +1,6 @@
 <header class="page-header">
   <h1 class="page-title">Tous les contenus formatifs</h1>
-  {{#if this.accessControl.hasAccessToTrainingsCreationActionsScope}}
+  {{#if this.canCreateTrainings}}
     <div class="page-actions">
       <PixButton
         @route="authenticated.trainings.new"

--- a/admin/app/templates/authenticated/trainings/training.hbs
+++ b/admin/app/templates/authenticated/trainings/training.hbs
@@ -21,13 +21,15 @@
       />
     {{else}}
       <Trainings::TrainingDetailsCard @training={{@model}} />
-      <PixButton
-        @size="small"
-        @backgroundColor="transparent-light"
-        @isBorderVisible={{true}}
-        @triggerAction={{this.toggleEditMode}}
-      >Editer
-      </PixButton>
+      {{#if this.canEdit}}
+        <PixButton
+          @size="small"
+          @backgroundColor="transparent-light"
+          @isBorderVisible={{true}}
+          @triggerAction={{this.toggleEditMode}}
+        >Editer
+        </PixButton>
+      {{/if}}
     {{/if}}
   </section>
 

--- a/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
+++ b/admin/app/templates/authenticated/trainings/training/target-profiles.hbs
@@ -1,20 +1,23 @@
 <div class="training-target-profiles">
-  <section class="page-section">
-    <header class="page-section__header">
-      <h2 class="page-section__title">Rattacher un ou plusieurs profil(s) cible(s)</h2>
-    </header>
-    <div class="training__forms-section">
-      <form class="training__sub-form form" {{on "submit" this.attachTargetProfiles}}>
-        <Input
-          aria-label="ID du ou des profil(s) cible(s)"
-          @value={{this.targetProfilesToAttach}}
-          class="training-sub-form__input form-field__text form-control"
-          placeholder="1, 2"
-        />
-        <PixButton @type="submit" @size="small" @isDisabled={{this.noTargetProfilesToAttach}}>Valider</PixButton>
-      </form>
-    </div>
-  </section>
+
+  {{#if this.canAttachTargetProfiles}}
+    <section class="page-section">
+      <header class="page-section__header">
+        <h2 class="page-section__title">Rattacher un ou plusieurs profil(s) cible(s)</h2>
+      </header>
+      <div class="training__forms-section">
+        <form class="training__sub-form form" {{on "submit" this.attachTargetProfiles}}>
+          <Input
+            aria-label="ID du ou des profil(s) cible(s)"
+            @value={{this.targetProfilesToAttach}}
+            class="training-sub-form__input form-field__text form-control"
+            placeholder="1, 2"
+          />
+          <PixButton @type="submit" @size="small" @isDisabled={{this.noTargetProfilesToAttach}}>Valider</PixButton>
+        </form>
+      </div>
+    </section>
+  {{/if}}
 
   <section class="page-section">
     <header class="page-section__header">

--- a/admin/app/templates/authenticated/trainings/training/triggers.hbs
+++ b/admin/app/templates/authenticated/trainings/training/triggers.hbs
@@ -2,6 +2,6 @@
 
 {{#if this.showTriggersEditForm}}
   {{outlet}}
-{{else}}
+{{else if this.canCreateTriggers}}
   <Trainings::CreateTrainingTriggers />
 {{/if}}

--- a/admin/tests/acceptance/authenticated/trainings/edit-triggers_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/edit-triggers_test.js
@@ -108,5 +108,24 @@ module('Acceptance | Trainings | Triggers edit', function (hooks) {
       // then
       assert.strictEqual(currentURL(), `/trainings/${trainingId}/triggers`);
     });
+
+    module('when admin member is "SUPPORT"', function () {
+      test('it should not edit a trigger', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole({ isSupport: true })(server);
+
+        // when
+        const screen = await visit(`/trainings/${trainingId}/`);
+
+        // then
+        assert
+          .dom(
+            screen.queryByRole('link', {
+              name: this.intl.t('pages.trainings.training.triggers.prerequisite.alternative-title'),
+            })
+          )
+          .doesNotExist();
+      });
+    });
   });
 });

--- a/admin/tests/acceptance/authenticated/trainings/list_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/list_test.js
@@ -4,6 +4,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { clickByName, visit } from '@1024pix/ember-testing-library';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
+
 module('Acceptance | Trainings | List', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -70,6 +71,20 @@ module('Acceptance | Trainings | List', function (hooks) {
         // then
         assert.strictEqual(currentURL(), '/trainings/1/triggers');
         assert.dom(screen.getByText('Formation 1')).exists();
+      });
+    });
+
+    module('when admin member has role "SUPPORT"', function (hooks) {
+      hooks.beforeEach(async () => {
+        await authenticateAdminMemberWithRole({ isSupport: true })(server);
+      });
+
+      test('should not create a new training', async function (assert) {
+        // given
+        const screen = await visit('/trainings/list');
+
+        // then
+        assert.dom(screen.queryByRole('link', { name: 'Nouveau contenu formatif' })).doesNotExist();
       });
     });
   });

--- a/admin/tests/acceptance/authenticated/trainings/target-profiles_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/target-profiles_test.js
@@ -52,17 +52,33 @@ module('Acceptance | Trainings | Target profiles', function (hooks) {
       assert.strictEqual(currentURL(), `/trainings/${trainingId}/target-profiles`);
     });
 
-    test('is should attach a target profile to a training', async function (assert) {
-      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
-      server.create('target-profile-summary', { id: 1, name: 'Super profil cible' });
+    module('when admin role is "SUPER_ADMIN" or "METIER"', function () {
+      test('is should attach a target profile to a training', async function (assert) {
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+        server.create('target-profile-summary', { id: 1, name: 'Super profil cible' });
 
-      // when
-      const screen = await visit(`/trainings/${trainingId}/target-profiles`);
-      await fillByLabel('ID du ou des profil(s) cible(s)', '1');
-      await clickByName('Valider');
+        // when
+        const screen = await visit(`/trainings/${trainingId}/target-profiles`);
+        await fillByLabel('ID du ou des profil(s) cible(s)', '1');
+        await clickByName('Valider');
 
-      // then
-      assert.dom(screen.getByRole('link', { name: 'Super profil cible' })).exists();
+        // then
+        assert.dom(screen.queryByRole('link', { name: 'Super profil cible' })).exists();
+      });
+    });
+
+    module('when admin role is "SUPPORT"', function () {
+      test('is should not be able to attach a target profile to a training', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole({ isSupport: true })(server);
+        server.create('target-profile-summary', { id: 1, name: 'Super profil cible' });
+
+        // when
+        const screen = await visit(`/trainings/${trainingId}/target-profiles`);
+
+        // then
+        assert.dom(screen.queryByText('ID du ou des profil(s) cible(s)')).doesNotExist();
+      });
     });
   });
 });

--- a/admin/tests/acceptance/authenticated/trainings/training_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/training_test.js
@@ -112,17 +112,33 @@ module('Acceptance | Trainings | Training', function (hooks) {
       assert.ok(screen.getByText('Obsolète'));
     });
 
-    test('should be possible to edit training details', async function (assert) {
-      // given
-      await visit(`/trainings/${trainingId}`);
+    module('when admin role is "SUPER_ADMIN" or "METIER"', function () {
+      test('should be possible to edit training details', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+        await visit(`/trainings/${trainingId}`);
 
-      // when
-      await click(screen.getByRole('button', { name: 'Editer' }));
-      await fillByLabel('Titre', 'Nouveau contenu formatif modifié');
-      await click(screen.getByRole('button', { name: 'Modifier le contenu formatif' }));
+        // when
+        await click(screen.getByRole('button', { name: 'Editer' }));
+        await fillByLabel('Titre', 'Nouveau contenu formatif modifié');
+        await click(screen.getByRole('button', { name: 'Modifier le contenu formatif' }));
 
-      // then
-      assert.dom(screen.getByRole('heading', { name: 'Nouveau contenu formatif modifié' })).exists();
+        // then
+        assert.dom(screen.getByRole('heading', { name: 'Nouveau contenu formatif modifié' })).exists();
+      });
+    });
+
+    module('when admin role is "SUPPORT', function () {
+      test('should not be possible to edit training details', async function (assert) {
+        // given
+        await authenticateAdminMemberWithRole({ isSupport: true })(server);
+
+        // when
+        await visit(`/trainings/${trainingId}`);
+
+        // then
+        assert.notOk(screen.queryByRole('button', { name: 'Editer' }));
+      });
     });
   });
 });

--- a/admin/tests/unit/services/access-control-test.js
+++ b/admin/tests/unit/services/access-control-test.js
@@ -137,7 +137,7 @@ module('Unit | Service | access-control', function (hooks) {
       const service = this.owner.lookup('service:access-control');
 
       // when & then
-      assert.true(service.hasAccessToTrainingsActionsScope);
+      assert.false(service.hasAccessToTrainingsActionsScope);
     });
 
     test('should be true if admin member has role "METIER"', function (assert) {
@@ -200,6 +200,48 @@ module('Unit | Service | access-control', function (hooks) {
 
       // when & then
       assert.false(service.hasAccessToTrainingsCreationActionsScope);
+    });
+  });
+
+  module('#hasAccessToTrainings', function () {
+    test('should be true if admin member has role "SUPER_ADMIN"', function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:current-user');
+      currentUser.adminMember = { isSuperAdmin: true };
+      const service = this.owner.lookup('service:access-control');
+
+      // when & then
+      assert.true(service.hasAccessToTrainings);
+    });
+
+    test('should be true if admin member has role "SUPPORT"', function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:current-user');
+      currentUser.adminMember = { isSupport: true };
+      const service = this.owner.lookup('service:access-control');
+
+      // when & then
+      assert.true(service.hasAccessToTrainings);
+    });
+
+    test('should be true if admin member has role "METIER"', function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:current-user');
+      currentUser.adminMember = { isMetier: true };
+      const service = this.owner.lookup('service:access-control');
+
+      // when & then
+      assert.true(service.hasAccessToTrainings);
+    });
+
+    test('should be false if admin member has role "CERTIF"', function (assert) {
+      // given
+      const currentUser = this.owner.lookup('service:current-user');
+      currentUser.adminMember = { isCertif: true, isMetier: false, isSuperAdmin: false, isSupport: false };
+      const service = this.owner.lookup('service:access-control');
+
+      // when & then
+      assert.false(service.hasAccessToTrainings);
     });
   });
 

--- a/admin/tests/unit/services/access-control-test.js
+++ b/admin/tests/unit/services/access-control-test.js
@@ -130,10 +130,10 @@ module('Unit | Service | access-control', function (hooks) {
       assert.true(service.hasAccessToTrainingsActionsScope);
     });
 
-    test('should be true if admin member has role "SUPPORT"', function (assert) {
+    test('should be false if admin member has role "SUPPORT"', function (assert) {
       // given
       const currentUser = this.owner.lookup('service:current-user');
-      currentUser.adminMember = { isSupport: true };
+      currentUser.adminMember = { isCertif: false, isMetier: false, isSuperAdmin: false, isSupport: true };
       const service = this.owner.lookup('service:access-control');
 
       // when & then

--- a/admin/tests/unit/services/access-control-test.js
+++ b/admin/tests/unit/services/access-control-test.js
@@ -161,48 +161,6 @@ module('Unit | Service | access-control', function (hooks) {
     });
   });
 
-  module('#hasAccessToTrainingsCreationActionsScope', function () {
-    test('should be true if admin member has role "SUPER_ADMIN"', function (assert) {
-      // given
-      const currentUser = this.owner.lookup('service:current-user');
-      currentUser.adminMember = { isSuperAdmin: true };
-      const service = this.owner.lookup('service:access-control');
-
-      // when & then
-      assert.true(service.hasAccessToTrainingsCreationActionsScope);
-    });
-
-    test('should be true if admin member has role "METIER"', function (assert) {
-      // given
-      const currentUser = this.owner.lookup('service:current-user');
-      currentUser.adminMember = { isMetier: true };
-      const service = this.owner.lookup('service:access-control');
-
-      // when & then
-      assert.true(service.hasAccessToTrainingsCreationActionsScope);
-    });
-
-    test('should be false if admin member has role "SUPPORT"', function (assert) {
-      // given
-      const currentUser = this.owner.lookup('service:current-user');
-      currentUser.adminMember = { isSupport: true };
-      const service = this.owner.lookup('service:access-control');
-
-      // when & then
-      assert.false(service.hasAccessToTrainingsCreationActionsScope);
-    });
-
-    test('should be false if admin member has role "CERTIF"', function (assert) {
-      // given
-      const currentUser = this.owner.lookup('service:current-user');
-      currentUser.adminMember = { isCertif: true };
-      const service = this.owner.lookup('service:access-control');
-
-      // when & then
-      assert.false(service.hasAccessToTrainingsCreationActionsScope);
-    });
-  });
-
   module('#hasAccessToTrainings', function () {
     test('should be true if admin member has role "SUPER_ADMIN"', function (assert) {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il est possible sur Pix Admin avec le rôle SUPPORT d'accéder aux boutons d'éditions/créations des CF.

## :robot: Proposition
Revoir les droits d'accès des différents boutons d'édition/création et des pages des CF.

Les pages des CF sont consultables par tous les rôles sauf CERTIF.
Les formulations de créations et d'éditions sont accessibles aux rôles SUPER_ADMIN et METIER

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

### ETQ SUPER_ADMIN et METIER

- Se connecter sur Pix Admin 
- Je peux accéder à la liste des CF
- Je peux créer un CF (j'ai le bouton en haut à droite)
- Je peux accéder à un CF
- Je peux éditer le CF (j'ai le bouton d'édition) 
- Je peux ajouter des déclencheurs
- Je peux ajouter des profils cibles


### ETQ CERTIF

- Se connecter sur Pix Admin 
- Je ne peux pas accéder à la liste des CF


### ETQ SUPPORT

- Se connecter sur Pix Admin 
- Je peux accéder à la liste des CF
- Je **ne peux pas** créer un CF (j'ai le bouton en haut à droite)
- Je peux accéder à un CF
- Je **ne peux pas** éditer le CF (j'ai le bouton d'édition) 
- Je **ne peux pas** ajouter des déclencheurs
- Je **ne peux pas** ajouter des profils cibles
 