### PR TITLE
[BUGFIX] Améliorer le message d'erreur lorsqu'un utilisateur tente de rejoindre une organisation via une invitation en se connectant avec une adresse email inconnue sur Pix Orga (PIX-7269)

### DIFF
--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -74,6 +74,10 @@ module.exports = function (environment) {
           CODE: '403',
           I18N_KEY: 'pages.login-form.errors.status.403',
         },
+        USER_NOT_FOUND: {
+          CODE: '404',
+          I18N_KEY: 'pages.login-form.errors.status.404',
+        },
         INTERNAL_SERVER_ERROR: {
           CODE: '500',
           I18N_KEY: 'common.api-error-messages.internal-server-error',

--- a/orga/tests/integration/components/auth/login-form_test.js
+++ b/orga/tests/integration/components/auth/login-form_test.js
@@ -208,6 +208,34 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
     assert.dom('login-form__information').doesNotExist();
   });
 
+  module('When the user fills the login form with an invalid email or password', function (hooks) {
+    hooks.beforeEach(function () {
+      StoreStub.prototype.createRecord = () => {
+        return EmberObject.create({
+          save() {
+            return reject({ errors: [{ status: '404' }] });
+          },
+          deleteRecord() {},
+        });
+      };
+    });
+
+    test('displays the correct error message', async function (assert) {
+      // given
+      const screen = await renderScreen(
+        hbs`<Auth::LoginForm @isWithInvitation='true' @organizationInvitationId='1' @organizationInvitationCode='C0D3' />`
+      );
+      await fillByLabel(emailInputLabel, 'pix@example.net');
+      await fillByLabel(passwordInputLabel, 'JeMeLoggue1024');
+
+      //  when
+      await clickByName(loginLabel);
+
+      // then
+      assert.dom(screen.getByText("L'adresse e-mail et/ou le mot de passe saisis sont incorrects.")).exists();
+    });
+  });
+
   module('when domain is pix.org', function () {
     test('should not display recovery link', async function (assert) {
       //given

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -600,6 +600,7 @@
         "should-change-password": "You currently have a temporary password. <a href=\"{url}\">Reset your password here</a>.",
         "status": {
           "403": "Access to this Pix Orga space is limited to invited members. Each Pix Orga space is managed by an administrator specific to the organisation using it. Please contact your administrator to get invited.",
+          "404":"There was an error in the email address or password entered.",
           "409": "This invitation has been already accepted or cancelled."
         }
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -600,6 +600,7 @@
         "should-change-password": "Vous avez actuellement un mot de passe temporaire. Cliquez sur <a href=\"{url}\">mot de passe oublié</a> pour le réinitialiser.",
         "status": {
           "403": "L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite.",
+          "404": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects.",
           "409": "Cette invitation a déjà été acceptée ou annulée."
         }
       },


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Orga, lorsqu'un utilisateur tente de rejoindre une organisation via une invitation et qu'il se connecte avec une mauvaise adresse e-mail, il reçoit le message d'erreur suivant (statut 404) : `Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.`. 

Puis lorsqu'il clique une deuxième fois sur le bouton "Je me connecte", il reçoit le message suivant (statut 401) : `L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects.`

## :robot: Proposition
Il faut que le même message d'erreur soit retourné, peut importe le nombre de fois où l'utilisateur clique sur le bouton "Je me connecte".

Retourner le message d'erreur suivant : `L'adresse e-mail et/ou le mot de passe saisis sont incorrects.` avec un statut 404.

## :rainbow: Remarques
Le message retourné côté back ne concerne que l'adresse e-mail de l'utilisateur : `Not found user for email ${email}.`

Mais on souhaite retourner à l'utilisateur un message générique.

## :100: Pour tester

1. Se rendre sur la double mire Pix Orga `/rejoindre?invitationId=100048&code=INVIABC123`
2. Cliquer sur le bouton `Se connecter`
3. Remplir les champs avec une adresse e-mail relié à aucun utilisateur de Pix Orga
4. Cliquer sur le bouton `Je me connecte`
5. Constater le message d'erreur suivant : `L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects.`  avec un statut 404 dans la console du navigateur.
6. Cliquer à nouveau plusieurs fois sur le bouton `Je me connecte` et constater que le message d'erreur retourné est toujours le même.
