### PR TITLE
[FEATURE] Traduction de la page de détails d'une session sur Pix Certif (PIX-6669).

### DIFF
--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -7,12 +7,13 @@ import { alias } from '@ember/object/computed';
 
 export default class SessionsDetailsController extends Controller {
   @service currentUser;
+  @service intl;
 
   @alias('model.session') session;
   @alias('model.certificationCandidates') certificationCandidates;
 
   get pageTitle() {
-    return `Détails | Session ${this.session.id} | Pix Certif`;
+    return `${this.intl.t('pages.sessions.detail.page-title')} | Session ${this.session.id} | Pix Certif`;
   }
 
   @computed('certificationCandidates.length')

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -1,23 +1,23 @@
 {{page-title this.pageTitle replace=true}}
 <div class="session-details-page">
   <PixReturnTo @route="authenticated.sessions.list" class="session-details-page__return-to">
-    Retour à la liste des sessions
+    {{t "pages.sessions.actions.return"}}
   </PixReturnTo>
   <div class="page__title session-details__header">
     <div class="session-details-header__title">
-      <h1 class="page-title">Session {{this.session.id}}</h1>
+      <h1 class="page-title">{{t "pages.sessions.detail.title" sessionId=this.session.id}}</h1>
     </div>
 
     <div class="session-details-header__datetime">
       <div class="session-details-header-datetime__date">
-        <h2 class="label-text session-details-content__label">Date</h2>
+        <h2 class="label-text session-details-content__label">{{t "pages.sessions.detail.date"}}</h2>
         <span class="content-text content-text--big session-details-header-datetime__text">
-          {{dayjs-format this.session.date "dddd DD MMM YYYY" allow-empty=true locale="fr"}}
+          {{dayjs-format this.session.date "dddd DD MMM YYYY" allow-empty=true}}
         </span>
       </div>
 
       <div>
-        <h2 class="label-text session-details-content__label">Heure de début (heure locale)</h2>
+        <h2 class="label-text session-details-content__label">{{t "pages.sessions.detail.datetime"}}</h2>
         <span class="content-text content-text--big session-details-header-datetime__text">
           {{dayjs-format this.session.time "HH:mm" inputFormat="HH:mm:ss" allow-empty=true}}
         </span>
@@ -32,27 +32,27 @@
   <div class="panel session-details__controls">
     <nav class="navbar session-details__controls-navbar-tabs">
       <LinkTo @route="authenticated.sessions.details.parameters" class="navbar-item">
-        Détails
+        {{t "pages.sessions.detail.tabs.details"}}
       </LinkTo>
       <LinkTo @route="authenticated.sessions.details.certification-candidates" class="navbar-item">
-        Candidats
+        {{t "pages.sessions.detail.tabs.candidates"}}
         {{this.certificationCandidatesCount}}
       </LinkTo>
     </nav>
     <div class="session-details__controls-links">
-      <span class="session-details__controls-title">Téléchargements :</span>
+      <span class="session-details__controls-title">{{t "pages.sessions.detail.downloads.label"}}</span>
       <PixButtonLink
         class="session-details__controls-download-button"
         @href="{{this.session.urlToDownloadSessionIssueReportSheet}}"
         @backgroundColor="transparent"
         @size="small"
         target="_blank"
-        aria-label="Télécharger le pv d'incident"
+        aria-label={{t "pages.sessions.detail.downloads.incident-report.extra-information"}}
         rel="noopener noreferrer"
         download
       >
         <FaIcon @icon="file-download" class="session-details__controls-icon" />
-        PV d'incident
+        {{t "pages.sessions.detail.downloads.incident-report.label"}}
       </PixButtonLink>
       <PixButtonLink
         class="session-details__controls-download-button"
@@ -60,12 +60,12 @@
         @backgroundColor="transparent"
         @size="small"
         target="_blank"
-        aria-label="Télécharger le kit surveillant"
+        aria-label={{t "pages.sessions.detail.downloads.invigilator-kit.extra-information"}}
         rel="noopener noreferrer"
         download
       >
         <FaIcon @icon="file-download" class="session-details__controls-icon" />
-        Kit surveillant
+        {{t "pages.sessions.detail.downloads.invigilator-kit.label"}}
       </PixButtonLink>
       {{#if this.shouldDisplayDownloadButton}}
         <PixButtonLink
@@ -74,12 +74,12 @@
           @backgroundColor="transparent"
           @size="small"
           target="_blank"
-          aria-label="Télécharger la feuille d'émargement"
+          aria-label={{t "pages.sessions.detail.downloads.attendance-sheet.extra-information"}}
           rel="noopener noreferrer"
           download
         >
           <FaIcon @icon="file-download" class="session-details__controls-icon" />
-          Feuille d'émargement
+          {{t "pages.sessions.detail.downloads.attendance-sheet.label"}}
         </PixButtonLink>
       {{/if}}
     </div>

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -1,7 +1,7 @@
 <div class="panel session-details-container">
   <div class="session-details-row">
     <div class="session-details-content session-details-content--multiple session-details-content--copyable">
-      <h3 class="label-text session-details-content__label">Numéro de session</h3>
+      <h3 class="label-text session-details-content__label">{{t "pages.sessions.detail.parameters.session.label"}}</h3>
       <div class="session-details-content__clipboard" {{on "mouseout" this.removeSessionNumberTooltip}}>
         <span class="content-text content-text--bold session-details-content__text">{{this.session.id}}</span>
         {{#if (is-clipboard-supported)}}
@@ -11,7 +11,7 @@
                 @clipboardText={{this.session.id}}
                 @success={{this.showSessionIdTooltip}}
                 @classNames="icon-button session-details-content__clipboard-button"
-                aria-label={{t "copy-session-number"}}
+                aria-label={{t "pages.sessions.detail.parameters.session.copy-number"}}
               >
                 <FaIcon @icon="copy" prefix="fas" />
               </CopyButton>
@@ -23,8 +23,11 @@
     </div>
 
     <div class="session-details-content session-details-content--multiple session-details-content--copyable">
-      <h3 class="label-text session-details-content__label">{{t "pages.sessions.detail.parameters.session-access-code"}}
-        <div class="session-details-content__sub-label">{{t "pages.sessions.detail.parameters.session-candidate"}}</div>
+      <h3 class="label-text session-details-content__label">
+        {{t "pages.sessions.detail.parameters.access-code.label"}}
+        <div class="session-details-content__sub-label">
+          {{t "pages.sessions.detail.parameters.access-code.candidate"}}
+        </div>
       </h3>
       <div class="session-details-content__clipboard" {{on "mouseout" this.removeAccessCodeTooltip}}>
         <span class="content-text content-text--bold session-details-content__text">{{this.session.accessCode}}</span>
@@ -36,7 +39,7 @@
                 @clipboardText={{this.session.accessCode}}
                 @success={{this.showAccessCodeTooltip}}
                 @classNames="icon-button session-details-content__clipboard-button"
-                aria-label={{t "pages.sessions.detail.parameters.copy-access-code-number"}}
+                aria-label={{t "pages.sessions.detail.parameters.access-code.copy-code"}}
               >
                 <FaIcon @icon="copy" prefix="fas" />
               </CopyButton>
@@ -49,8 +52,10 @@
 
     <div class="session-details-content session-details-content--multiple session-details-content--copyable">
       <h3 class="label-text session-details-content__label">
-        {{t "pages.sessions.detail.parameters.session-password"}}
-        <div class="session-details-content__sub-label">{{t "pages.session-supervising.header.supervisor"}}</div>
+        {{t "pages.sessions.detail.parameters.password.label"}}
+        <div class="session-details-content__sub-label">
+          {{t "pages.sessions.detail.parameters.password.invigilator"}}
+        </div>
       </h3>
       <div class="session-details-content__clipboard" {{on "mouseout" this.removeSupervisorPasswordTooltip}}>
         <span class="content-text content-text--bold session-details-content__text">
@@ -68,7 +73,7 @@
                 @clipboardText={{this.session.supervisorPassword}}
                 @success={{this.showSupervisorPasswordTooltip}}
                 @classNames="icon-button session-details-content__clipboard-button"
-                aria-label={{t "pages.sessions.detail.parameters.copy-session-password-supervisor"}}
+                aria-label={{t "pages.sessions.detail.parameters.password.copy-password"}}
               >
                 <FaIcon @icon="copy" prefix="fas" />
               </CopyButton>
@@ -81,19 +86,19 @@
 
     <div class="session-details-content session-details-content--multiple">
       <h3 class="label-text session-details-content__label">
-        {{t "pages.session-supervising.header.center-name-full"}}
+        {{t "pages.sessions.detail.parameters.location-name"}}
       </h3>
       <span class="content-text session-details-content__text">{{this.session.address}}</span>
     </div>
 
     <div class="session-details-content session-details-content--multiple">
-      <h3 class="label-text session-details-content__label">{{t "pages.session-supervising.header.room"}}</h3>
+      <h3 class="label-text session-details-content__label">{{t "pages.sessions.detail.parameters.room"}}</h3>
       <span class="content-text session-details-content__text">{{this.session.room}}</span>
     </div>
 
     <div class="session-details-content session-details-content--multiple">
       <h3 class="label-text session-details-content__label">
-        {{t "pages.session-supervising.header.multiple-supervisor"}}
+        {{t "pages.sessions.detail.parameters.invigilators"}}
       </h3>
       <span class="content-text session-details-content__text">{{this.session.examiner}}</span>
     </div>
@@ -120,14 +125,14 @@
         </p>
       {{else}}
         <PixButtonLink @route="authenticated.sessions.finalize" @model={{this.session.id}} class="push-right">
-          {{t "pages.sessions.detail.parameters.finalizing"}}
+          {{t "pages.sessions.detail.parameters.actions.finalizing"}}
         </PixButtonLink>
       {{/if}}
     {{else}}
       <PixButtonLink
         @route="authenticated.sessions.update"
         @model={{this.session.id}}
-        aria-label={{t "pages.sessions.detail.parameters.session-update" sessionId=this.session.id}}
+        aria-label={{t "pages.sessions.detail.parameters.actions.update" sessionId=this.session.id}}
       >
         {{t "common.actions.update"}}
       </PixButtonLink>

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -2,7 +2,7 @@
 {{page-title (t "pages.sessions.import.title")}}
 <main class="import-page">
   <PixReturnTo @route="authenticated.sessions.list" class="import-page__previous-page-button">
-    {{t "pages.sessions.import.previous-page-button"}}
+    {{t "pages.sessions.actions.return"}}
   </PixReturnTo>
   <h1 class="page-title">{{t "pages.sessions.import.title"}}</h1>
 

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -52,7 +52,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
     test('it should redirect from candidates to session list on click on return button', async function (assert) {
       // when
       const screen = await visit(`/sessions/${session.id}/candidats`);
-      await click(screen.getByRole('link', { name: 'Retour à la liste des sessions' }));
+      await click(screen.getByRole('link', { name: 'Revenir à la liste des sessions' }));
 
       // then
       assert.deepEqual(currentURL(), '/sessions/liste');

--- a/certif/tests/acceptance/session-details-parameters_test.js
+++ b/certif/tests/acceptance/session-details-parameters_test.js
@@ -3,7 +3,7 @@ import { click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from '../helpers/test-init';
 import { visit } from '@1024pix/ember-testing-library';
-import { setupIntl, t } from 'ember-intl/test-support';
+import { setupIntl } from 'ember-intl/test-support';
 
 import { CREATED, FINALIZED } from 'pix-certif/models/session';
 
@@ -54,6 +54,28 @@ module('Acceptance | Session Details Parameters', function (hooks) {
     });
 
     module('when looking at the session details', function () {
+      test('should display details parameters information', async function (assert) {
+        // given
+        const sessionCreated = server.create('session', { certificationCenterId: allowedCertificationCenterAccess.id });
+
+        // when
+        const screen = await visit(`/sessions/${sessionCreated.id}`);
+
+        // then
+        assert.dom(screen.getByRole('heading', { name: 'Numéro de session', level: 3 })).exists();
+        assert.dom(screen.getByRole('heading', { name: "Code d'accès Candidat", level: 3 })).exists();
+        assert.dom(screen.getByRole('heading', { name: 'Mot de passe de session Surveillant', level: 3 })).exists();
+        assert.dom(screen.getByRole('heading', { name: 'Nom du site', level: 3 })).exists();
+        assert.dom(screen.getByRole('heading', { name: 'Salle', level: 3 })).exists();
+        assert.dom(screen.getByRole('heading', { name: 'Surveillant(s)', level: 3 })).exists();
+
+        assert.dom(screen.getByRole('button', { name: 'Copier le numéro de session' })).exists();
+        assert.dom(screen.getByRole('button', { name: 'Copier le code d’accès à la session' })).exists();
+        assert
+          .dom(screen.getByRole('button', { name: 'Copier le mot de passe de session pour le surveillant' }))
+          .exists();
+      });
+
       module('when the session is not finalized', function () {
         module('when the session is CREATED', function () {
           test('it should not display the finalize button if no candidate has joined the session', async function (assert) {
@@ -63,14 +85,10 @@ module('Acceptance | Session Details Parameters', function (hooks) {
 
             // when
             const screen = await visit(`/sessions/${sessionCreated.id}`);
-            const updateButton = screen.getByRole('link', {
-              name: t('pages.sessions.detail.parameters.session-update', { sessionId: 123 }),
-            });
-            const finalizeButton = screen.queryByRole('button', {
-              name: t('pages.sessions.detail.parameters.finalize'),
-            });
 
             // then
+            const updateButton = screen.getByRole('link', { name: 'Modifier les informations de la session 123' });
+            const finalizeButton = screen.queryByRole('button', { name: 'Finaliser la session' });
             assert.dom(updateButton).exists();
             assert.dom(finalizeButton).doesNotExist();
           });
@@ -82,7 +100,7 @@ module('Acceptance | Session Details Parameters', function (hooks) {
 
             // when
             const screen = await visit(`/sessions/${sessionCreatedAndStarted.id}`);
-            const finalizeButton = screen.getByRole('link', { name: t('pages.sessions.detail.parameters.finalizing') });
+            const finalizeButton = screen.getByRole('link', { name: 'Finaliser la session' });
 
             await click(finalizeButton);
 
@@ -120,8 +138,10 @@ module('Acceptance | Session Details Parameters', function (hooks) {
           const screen = await visit(`/sessions/${sessionFinalized.id}`);
 
           // then
-          const finalizeText = screen.getByText(t('pages.sessions.detail.parameters.finalization-info'));
-          const finalizeButton = screen.queryByRole('button', { name: t('finalizing') });
+          const finalizeText = screen.getByText(
+            'Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix.'
+          );
+          const finalizeButton = screen.queryByRole('button', { name: 'Finaliser la session' });
 
           assert.dom(finalizeText).exists();
           assert.dom(finalizeButton).doesNotExist();

--- a/certif/tests/acceptance/session-details_test.js
+++ b/certif/tests/acceptance/session-details_test.js
@@ -72,7 +72,7 @@ module('Acceptance | Session Details', function (hooks) {
     test('it should redirect to session list on click on return button', async function (assert) {
       // when
       const screen = await visitScreen(`/sessions/${session.id}`);
-      await click(screen.getByRole('link', { name: 'Retour à la liste des sessions' }));
+      await click(screen.getByRole('link', { name: 'Revenir à la liste des sessions' }));
 
       // then
       assert.deepEqual(currentURL(), '/sessions/liste');
@@ -106,13 +106,20 @@ module('Acceptance | Session Details', function (hooks) {
         const screen = await visit('/sessions/123');
 
         // then
-        assert.dom(screen.getByRole('heading', { name: 'Session 123' })).exists();
+        assert.dom(screen.getByRole('heading', { name: 'Session 123', level: 1 })).exists();
         assert.dom(screen.getByText('123 rue des peupliers')).exists();
         assert.dom(screen.getByText('Salle 101')).exists();
         assert.dom(screen.getByText('Winston')).exists();
         assert.dom(screen.getByText('ABC123')).exists();
+
+        assert.dom(screen.getByRole('heading', { name: 'Heure de début (heure locale)', level: 2 })).exists();
         assert.dom(screen.getByText('lundi 18 févr. 2019')).exists();
+
+        assert.dom(screen.getByRole('heading', { name: 'Date', level: 2 })).exists();
         assert.dom(screen.getByText('14:00')).exists();
+
+        assert.dom(screen.getByRole('link', { name: "Télécharger le PV d'incident" })).exists();
+        assert.dom(screen.getByRole('link', { name: 'Télécharger le kit surveillant' })).exists();
       });
 
       test('it should show issue report sheet download button', async function (assert) {
@@ -124,7 +131,7 @@ module('Acceptance | Session Details', function (hooks) {
         const screen = await visit(`/sessions/${sessionWithCandidates.id}`);
 
         // then
-        assert.dom(screen.getByRole('link', { name: "Télécharger le pv d'incident" })).exists();
+        assert.dom(screen.getByRole('link', { name: "Télécharger le PV d'incident" })).exists();
       });
 
       test('it should show attendance sheet download button when there is one or more candidate', async function (assert) {

--- a/certif/tests/acceptance/session-list_test.js
+++ b/certif/tests/acceptance/session-list_test.js
@@ -319,7 +319,7 @@ module('Acceptance | Session List', function (hooks) {
         await click(screen.getByRole('link', { name: 'Session 26' }));
 
         // when
-        await click(screen.getByRole('link', { name: 'Retour à la liste des sessions' }));
+        await click(screen.getByRole('link', { name: 'Revenir à la liste des sessions' }));
 
         // then
         assert.contains('Page 2 / 2');

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -141,7 +141,6 @@
           "summary": "Récapitulatif"
         },
         "title": "Créer/éditer plusieurs sessions",
-        "previous-page-button": "Revenir à la liste des sessions",
         "step-one": {
           "actions": {
             "cancel": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -8,7 +8,7 @@
       "add": "Add",
       "delete": "Delete",
       "quit": "Quit",
-      "update": "Modify"
+      "update": "Edit"
     },
     "api-error-messages": {
       "bad-request-error": "The data entered was not in the correct format.",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -123,6 +123,9 @@
       }
     },
     "sessions": {
+      "actions": {
+        "return": "Return to the sessions list"
+      },
       "enrolled-candidates": {
         "without-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec la possibilité de supprimer un candidat dans la dernière colonne.",
         "with-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec un lien pour voir les détails du candidat et la possibilité de supprimer un candidat dans la dernière colonne."
@@ -239,6 +242,29 @@
         }
       },
       "detail": {
+        "date": "Date",
+        "datetime": "Starting time (local time)",
+        "downloads": {
+          "label": "Downloads:",
+          "attendance-sheet": {
+            "extra-information": "Download attendance sheet",
+            "label": "Attendance sheet"
+          },
+          "incident-report": {
+            "extra-information": "Download incident report",
+            "label": "Incident report"
+          },
+          "invigilator-kit": {
+            "extra-information": "Download invigilator’s kit",
+            "label": "Invigilator’s kit"
+          }
+        },
+        "page-title": "Details",
+        "tabs": {
+          "details": "Details",
+          "candidates": "Candidates"
+        },
+        "title": "Session {sessionId}",
         "panel-clea": {
           "title": "Des candidats ont obtenu le certificat CléA numérique",
           "description": "Pour générer les certificats CléA numérique, téléchargez la liste des candidats, complétez-la, enregistrez-la au format .xlsx puis importez-la sur la ",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -273,16 +273,29 @@
           "error-message": "Une erreur est survenue lors du téléchargement du fichier. Veuillez réessayer ou contacter certif@pix.fr en indiquant le numéro de la session concernée."
         },
         "parameters": {
-          "copy-access-code-number": "Copier le code du numéro de session",
-          "copy-session-number": "Copier le code du numéro de session",
-          "copy-session-password-supervisor": "Copier le mot de passe de session pour le surveillant",
-          "finalization-info": "Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix",
-          "finalizing": "Finaliser la session",
+          "actions": {
+            "finalizing": "Finalise the session",
+            "update": "Edit the details for session {sessionId}"
+          },
+          "finalization-info": "The finalisation information for the session has already been transmitted to Pix.",
+          "invigilators": "Invigilator(s)",
+          "location-name": "Location name",
+          "session": {
+            "copy-number": "Copy the session number",
+            "label": "Session number"
+          },
+          "access-code": {
+            "label": "Access code",
+            "candidate": "Candidate",
+            "copy-code": "Copy the session’s access code"
+          },
+          "room": "Room",
           "observations": "Observations",
-          "session-access-code": "Code d'accès",
-          "session-candidate": "Candidat",
-          "session-password": "Mot de passe de session",
-          "session-update": "Modifier les informations de la session {sessionId}"
+          "password": {
+            "copy-password": "Copy the invigilator’s session password",
+            "label": "Session password",
+            "invigilator": "Invigilator"
+          }
         }
       },
       "candidates": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -141,7 +141,6 @@
           "summary": "Récapitulatif"
         },
         "title": "Créer/éditer plusieurs sessions",
-        "previous-page-button": "Revenir à la liste des sessions",
         "step-one": {
           "actions": {
             "cancel": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -272,16 +272,29 @@
           "error-message": "Une erreur est survenue lors du téléchargement du fichier. Veuillez réessayer ou contacter certif@pix.fr en indiquant le numéro de la session concernée."
         },
         "parameters": {
-          "copy-access-code-number": "Copier le code du numéro de session",
-          "copy-session-number": "Copier le code du numéro de session",
-          "copy-session-password-supervisor": "Copier le mot de passe de session pour le surveillant",
-          "finalization-info": "Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix",
-          "finalizing": "Finaliser la session",
+          "actions": {
+            "finalizing": "Finaliser la session",
+            "update": "Modifier les informations de la session {sessionId}"
+          },
+          "finalization-info": "Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix.",
+          "invigilators": "Surveillant(s)",
+          "location-name": "Nom du site",
+          "session": {
+            "copy-number": "Copier le numéro de session",
+            "label": "Numéro de session"
+          },
+          "access-code": {
+            "label": "Code d'accès",
+            "candidate": "Candidat",
+            "copy-code": "Copier le code d’accès à la session"
+          },
+          "room": "Salle",
           "observations": "Observations",
-          "session-access-code": "Code d'accès",
-          "session-candidate": "Candidat",
-          "session-password": "Mot de passe de session",
-          "session-update": "Modifier les informations de la session {sessionId}"
+          "password": {
+            "copy-password": "Copier le mot de passe de session pour le surveillant",
+            "label": "Mot de passe de session",
+            "invigilator": "Surveillant"
+          }
         }
       },
       "candidates": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -123,6 +123,9 @@
       }
     },
     "sessions": {
+      "actions": {
+        "return": "Revenir à la liste des sessions"
+      },
       "enrolled-candidates": {
         "without-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec la possibilité de supprimer un candidat dans la dernière colonne.",
         "with-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec un lien pour voir les détails du candidat et la possibilité de supprimer un candidat dans la dernière colonne."
@@ -238,6 +241,29 @@
         }
       },
       "detail": {
+        "date": "Date",
+        "datetime": "Heure de début (heure locale)",
+        "downloads": {
+          "label": "Téléchargements :",
+          "attendance-sheet": {
+            "extra-information": "Télécharger la feuille d'émargement",
+            "label": "Feuille d'émargement"
+          },
+          "incident-report": {
+            "extra-information": "Télécharger le PV d'incident",
+            "label": "PV d'incident"
+          },
+          "invigilator-kit": {
+            "extra-information": "Télécharger le kit surveillant",
+            "label": "Kit surveillant"
+          }
+        },
+        "page-title": "Détails",
+        "tabs": {
+          "details": "Détails",
+          "candidates": "Candidats"
+        },
+        "title": "Session {sessionId}",
         "panel-clea": {
           "title": "Des candidats ont obtenu le certificat CléA numérique",
           "description": "Pour générer les certificats CléA numérique, téléchargez la liste des candidats, complétez-la, enregistrez-la au format .xlsx puis importez-la sur la ",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement les pages de Pix Certif ne sont pas encore toutes traduite en anglais, comme la page de détails d'une session.

## :robot: Proposition
Traduire la page

## :rainbow: Remarques
Traduction des aria-label des boutons également et du titre présent dans l'onglet du navigateur

## :100: Pour tester

- Se connecter sur Pix Certif avec certifpro@example.net (en .org, et passer `?lang=en` dans l'url)
- Cliquer sur une session
- Constater que tous les éléments sont traduits, notamment les aria-label (à vérifier via la console ou par lecteur d'écran)

<img width="1770" alt="Capture d’écran 2023-03-01 à 18 16 10" src="https://user-images.githubusercontent.com/58915422/222218494-2249413f-d4d2-45b9-8d6e-0761b95b18c3.png">

- Chercher une session qui est finalisé pour voir le message suivant traduit : `Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix.`
- Chercher une session qui peut être finalisé pour voir le bouton `Finaliser la session`
