### PR TITLE
[BUGFIX] Corriger le lien d'Accessibilité dans le footer de app.pix.org (PIX-7177)

### DIFF
--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -60,12 +60,13 @@ export default class Url extends Service {
   }
 
   get accessibilityUrl() {
+    const tld = this.currentDomain.getExtension();
     const currentLanguage = this.intl.t('current-lang');
 
-    if (currentLanguage === 'en') {
-      return `https://pix.${this.currentDomain.getExtension()}/en-gb/accessibility`;
+    if (tld === 'fr') {
+      return `https://pix.fr/accessibilite`;
     }
-    return `https://pix.${this.currentDomain.getExtension()}/accessibilite`;
+    return currentLanguage === 'fr' ? `https://pix.org/fr/accessibilite` : `https://pix.org/en-gb/accessibility`;
   }
 
   get accessibilityHelpUrl() {

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -234,4 +234,71 @@ module('Unit | Service | locale', function (hooks) {
       });
     });
   });
+
+  module('#accessibilityUrl', function () {
+    module('when website is pix.fr', function () {
+      test('returns the French page URL', function (assert) {
+        // given
+        const service = this.owner.lookup('service:url');
+        const expectedAccessibilityUrl = 'https://pix.fr/accessibilite';
+        service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+
+        // when
+        const accessibilityUrl = service.accessibilityUrl;
+
+        // then
+        assert.strictEqual(accessibilityUrl, expectedAccessibilityUrl);
+      });
+
+      module('when current language is "en"', function () {
+        test('returns the French page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          const expectedAccessibilityUrl = 'https://pix.fr/accessibilite';
+          service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+          service.intl = { t: sinon.stub().returns('en') };
+
+          // when
+          const accessibilityUrl = service.accessibilityUrl;
+
+          // then
+          assert.strictEqual(accessibilityUrl, expectedAccessibilityUrl);
+        });
+      });
+    });
+
+    module('when website is pix.org', function () {
+      module('when current language is "fr"', function () {
+        test('returns the French page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          const expectedAccessibilityUrl = 'https://pix.org/fr/accessibilite';
+          service.currentDomain = { getExtension: sinon.stub().returns('org') };
+          service.intl = { t: sinon.stub().returns('fr') };
+
+          // when
+          const accessibilityUrl = service.accessibilityUrl;
+
+          // then
+          assert.strictEqual(accessibilityUrl, expectedAccessibilityUrl);
+        });
+      });
+
+      module('when current language is "en"', function () {
+        test('returns the English page URL', function (assert) {
+          // given
+          const service = this.owner.lookup('service:url');
+          const expectedAccessibilityUrl = 'https://pix.org/en-gb/accessibility';
+          service.currentDomain = { getExtension: sinon.stub().returns('org') };
+          service.intl = { t: sinon.stub().returns('en') };
+
+          // when
+          const accessibilityUrl = service.accessibilityUrl;
+
+          // then
+          assert.strictEqual(accessibilityUrl, expectedAccessibilityUrl);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'on est connecté sur Pix App international en français, le lien “Accessibilité” dans le footer de Pix App mène à une erreur.

## :robot: Proposition
Apporter une solution comme dans la PR #5603 

Dans l'URL service de Pix App :
* Gérer les différents URL en fonction du [top-level domain, ou TLD](https://fr.wikipedia.org/wiki/Domaine_de_premier_niveau)
*  Ajouter la locale `/fr` dans l'URL pour app.pix.org lorsque la langue active est le français

## :rainbow: Remarques
RAS.

## :100: Pour tester

1. **Se connecter à Pix App international (.org)**
2. Cliquer sur le lien `Accessibilité` situé en bas de page
3. Vérifier que l'on est bien redirigé sur `https://pix.fr/accessibilite/` et que l'on obtient pas un message d'erreur.
4. Changer la langue pour `Anglais` dans la rubrique Mon compte
5. Cliquer sur le lien `Accessibility` situé en bas de page
6. Vérifier que l'on est bien redirigé sur `https://pix.org/accessibility/` et que l'on obtient pas un message d'erreur.

1. **Se connecter à Pix App France (.fr)**
2. Cliquer sur le lien `Accessibilité` situé en bas de page
3. Vérifier que l'on est bien redirigé sur `https://pix.fr/accessibilite/` et que l'on obtient pas un message d'erreur.