### PR TITLE
[FEATURE][MON-PIX] Modifier le message d'erreur lors d'un refus de partage de données entre Pôle Emploi et Pix (PIX-7335)

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -985,7 +985,7 @@
         "invalid-email": "Your email address is invalid.",
         "login-unauthorized-error": "There was an error in the email address or password entered.",
         "account-conflict": "Ce compte est déjà associé à cet organisme. Veuillez vous connecter avec un autre compte ou contacter le support.",
-        "data-sharing-refused": "You have declined to share your information with us."
+        "data-sharing-refused": "We inform you that the transmission of your data, specified on the previous page, is essential to access and use the service."
       }
     },
     "oidc-reconciliation": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -985,7 +985,7 @@
         "invalid-email": "Votre adresse e-mail n’est pas valide.",
         "login-unauthorized-error": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects.",
         "account-conflict": "Ce compte est déjà associé à cet organisme. Veuillez vous connecter avec un autre compte ou contacter le support.",
-        "data-sharing-refused": "Vous avez refusé de partager vos informations avec nous."
+        "data-sharing-refused": "Nous vous informons que la transmission de vos données, précisées à la page précédente, est indispensable pour pouvoir accéder au service et l'utiliser."
       }
     },
     "oidc-reconciliation": {


### PR DESCRIPTION
## :unicorn: Problème

Le message d'erreur affiché lors d'un refus de partage de données entre Pôle Emploi et Pix n'est pas bien formulé.
> Vous avez refusé de partager vos informations avec nous.

## :robot: Proposition

Modifier la traduction actuelle par :
> Nous vous informons que la transmission de vos données, précisées à la page précédente, est indispensable pour pouvoir accéder au service et l'utiliser.

## :rainbow: Remarques

RAS

## :100: Pour tester

⚠️ A tester uniquement en local

- Se connecter à Pix App
- Cliquer sur le bouton `Se connecter avec pôle emploi`
- Se connecter avec l'un des utilisateurs (**andreia** ou **Emilie)** fourni dans le jeu de données de pôle emploi (voir confluence)
- ⚠️ **Ne pas cliquer sur `Se souvenir de ma décision`**
- Cliquer sur le bouton `Refuser`
- Constater que vous arrivez sur la page d'erreur générique avec le nouveau message d'erreur que nous avons défini
