### PR TITLE
[FEATURE]: Ajouter une modale de confirmation de suppression dans le tableau de paliers (PIX-7331)

### DIFF
--- a/admin/app/components/target-profiles/stages/stage.hbs
+++ b/admin/app/components/target-profiles/stages/stage.hbs
@@ -30,11 +30,38 @@
         @isBorderVisible={{true}}
         @size="small"
         @iconBefore="trash"
-        @triggerAction={{fn @deleteStage @stage}}
+        @triggerAction={{this.toggleModal}}
         class="stages-table-actions-delete"
       >
         Supprimer
       </PixButton>
+      <PixModal
+        @title="Confirmer la suppression"
+        @showModal={{this.showModal}}
+        @onCloseButtonClick={{this.toggleModal}}
+      >
+        <:content>
+          <p>
+            Êtes-vous sûr de vouloir supprimer le
+            {{#if @stage.isTypeLevel}}
+              niveau
+              {{@stage.level}}
+            {{else}}
+              seuil
+              {{@stage.threshold}}
+            {{/if}}
+            <b>{{@stage.title}} </b>?
+          </p>
+        </:content>
+        <:footer>
+          <PixButton @backgroundColor="transparent-light" @isBorderVisible={{true}} @triggerAction={{this.toggleModal}}>
+            Annuler
+          </PixButton>
+          <PixButton @backgroundColor="red" @isBorderVisible={{true}} @triggerAction={{fn @deleteStage @stage}}>
+            Valider
+          </PixButton>
+        </:footer>
+      </PixModal>
     {{/unless}}
   </td>
 </tr>

--- a/admin/app/components/target-profiles/stages/stage.js
+++ b/admin/app/components/target-profiles/stages/stage.js
@@ -1,6 +1,14 @@
 import Component from '@glimmer/component';
-
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 export default class Stage extends Component {
+  @tracked showModal = false;
+
+  @action
+  toggleModal() {
+    this.showModal = !this.showModal;
+  }
+
   get isDefaultStage() {
     return (
       (this.args.stage.isTypeLevel && this.args.stage.level === 0) ||

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -78,15 +78,14 @@ module('Acceptance | Target Profile Insights', function (hooks) {
         // given
         server.create('stage', { id: 100, title: 'premier palier', targetProfile });
         server.create('stage', { id: 101, title: 'deuxième palier', targetProfile });
-
         // when
         const screen = await visit('/target-profiles/1');
         await clickByName('Clés de lecture');
 
         // then
         assert.strictEqual(currentURL(), '/target-profiles/1/insights');
-        assert.dom(screen.getByText('premier palier')).exists();
-        assert.dom(screen.getByText('deuxième palier')).exists();
+        assert.dom(screen.getAllByText('premier palier')[0]).exists();
+        assert.dom(screen.getAllByText('deuxième palier')[0]).exists();
       });
 
       test('it should display stage details when clicking on "Voir détail"', async function (assert) {
@@ -172,10 +171,10 @@ module('Acceptance | Target Profile Insights', function (hooks) {
 
           // then
           assert.true(firstStageLevelButton.hasAttributes('aria-disabled', 'true'));
-          assert.dom(screen.getByText('mon premier palier')).exists();
-          assert.dom(screen.getByText('mon deuxième palier')).exists();
-          assert.dom(screen.getByText('3')).exists();
-          assert.dom(screen.getByText('0')).exists();
+          assert.dom(screen.getAllByText('mon premier palier')[0]).exists();
+          assert.dom(screen.getAllByText('mon deuxième palier')[0]).exists();
+          assert.dom(screen.getAllByText('3')[0]).exists();
+          assert.dom(screen.getAllByText('0')[0]).exists();
           assert.dom(screen.getByText('mon message un')).exists();
           assert.dom(screen.getByText('mon message deux')).exists();
           assert.dom(screen.queryByText('Enregistrer')).doesNotExist();
@@ -261,10 +260,10 @@ module('Acceptance | Target Profile Insights', function (hooks) {
 
           // then
           assert.true(firstStageThresholdInput.hasAttributes('value', '0'));
-          assert.dom(screen.getByText('mon premier palier')).exists();
-          assert.dom(screen.getByText('mon deuxième palier')).exists();
-          assert.dom(screen.getByText(0)).exists();
-          assert.dom(screen.getByText(50)).exists();
+          assert.dom(screen.getAllByText('mon premier palier')[0]).exists();
+          assert.dom(screen.getAllByText('mon deuxième palier')[0]).exists();
+          assert.dom(screen.getAllByText(0)[0]).exists();
+          assert.dom(screen.getAllByText(50)[0]).exists();
           assert.dom(screen.getByText('mon message 1')).exists();
           assert.dom(screen.getByText('mon message 2')).exists();
           assert.dom(screen.queryByText('Enregistrer')).doesNotExist();

--- a/admin/tests/integration/components/target-profiles/stages_test.js
+++ b/admin/tests/integration/components/target-profiles/stages_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { find } from '@ember/test-helpers';
+import { find, click } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
 import EmberObject from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
@@ -67,7 +67,7 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       // given
       const stage = EmberObject.create({
         id: 1,
-        threshold: 100,
+        threshold: 0,
         title: 'My title',
         message: 'My message',
       });
@@ -79,6 +79,57 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       // then
       assert.dom(screen.queryByRole('radio', { name: 'Palier par seuil' })).doesNotExist();
       assert.dom(screen.queryByRole('radio', { name: 'Palier par niveau' })).doesNotExist();
+      assert.dom(screen.queryByRole('button', { name: /Supprimer/ })).doesNotExist();
+      assert.dom(screen.getByText('Voir détail')).exists();
+    });
+
+    test('it shoud display delete button on a stage', async function (assert) {
+      // given
+      const stage1 = EmberObject.create({
+        id: 1,
+        threshold: 0,
+        title: 'My title',
+        message: 'My message',
+      });
+      const stage2 = EmberObject.create({
+        id: 1,
+        threshold: 20,
+        title: 'My second stage title',
+        message: 'My second stage message',
+      });
+      this.set('model', { stages: [stage1, stage2], isNewFormat: true });
+
+      // when
+      const screen = await render(hbs`<TargetProfiles::Stages @targetProfile={{this.model}} />`);
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: /Supprimer/ })).exists();
+    });
+
+    test('it should display modal when deleting a stage', async function (assert) {
+      // given
+      const stage1 = EmberObject.create({
+        id: 1,
+        threshold: 0,
+        title: 'My title',
+        message: 'My message',
+      });
+      const stage2 = EmberObject.create({
+        id: 1,
+        threshold: 20,
+        title: 'My second stage title',
+        message: 'My second stage message',
+      });
+      this.set('model', { stages: [stage1, stage2], isNewFormat: true });
+
+      // when
+      const screen = await render(hbs`<TargetProfiles::Stages @targetProfile={{this.model}} />`);
+      await click(screen.getByRole('button', { name: /Supprimer/ }));
+      await screen.findByRole('dialog');
+
+      // then
+      assert.dom(screen.getByText('Confirmer la suppression')).exists();
+      assert.dom(screen.getByRole('button', { name: 'Valider' })).exists();
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
La suppression était trop facile, une suppression par erreur est vite arrivée.

## :robot: Proposition
Ajouter une modale de confirmation de suppression

## :rainbow: Remarques
Bonsoir

## :100: Pour tester
- se connecter à PixAdmin
- aller sur la page des Profiles cibles
- sélectionner un profile cible
- se rendre sur l'onglet "clés de lecture"
- créer et supprimer des paliers
- bon amusement 🎉 