### PR TITLE
[FEATURE] Ajout de l'en-tête d'information avec certificabilité pour Orga sans import (PIX-7290)

### DIFF
--- a/api/db/seeds/data/campaign-participations-builder.js
+++ b/api/db/seeds/data/campaign-participations-builder.js
@@ -126,9 +126,9 @@ function participateToAssessmentCampaign({ databaseBuilder, campaignId, user, or
   return campaignParticipationId;
 }
 
-function participateToProfilesCollectionCampaign({ databaseBuilder, campaignId, user, organizationLearnerId, status, isImprovingOldParticipation = false, deleted = false, isCertifiable = null }) {
+function participateToProfilesCollectionCampaign({ databaseBuilder, campaignId, user, organizationLearnerId, status, isImprovingOldParticipation = false, deleted = false, isCertifiable = null, sharedAt = null }) {
   const today = new Date();
-  const sharedAt = status === SHARED ? today : null;
+  sharedAt = status === SHARED && sharedAt === null ? today : sharedAt;
   const deletedAt = deleted ? today : null;
   const deletedBy = deleted ? PIX_SUPER_ADMIN_ID : null;
 

--- a/api/db/seeds/data/campaigns-pro-builder.js
+++ b/api/db/seeds/data/campaigns-pro-builder.js
@@ -426,21 +426,23 @@ function _buildAssessmentParticipations({ databaseBuilder, users }) {
 }
 
 function _buildProfilesCollectionParticipations({ databaseBuilder, users }) {
-  const userIdsNotShared = [users[1], users[2], users[3], users[4], users[5], users[6], users[7], users[8]];
-  const userIdsShared = [users[0], users[9], users[10], users[11], users[12]];
+  const today = new Date();
+  const sharedAt = new Date(today.setMonth(today.getMonth() - 1));
   const certifRegularUser1 = { id: CERTIF_REGULAR_USER1_ID, createdAt: new Date('2022-02-04') };
   const certifRegularUser2 = { id: CERTIF_REGULAR_USER2_ID, createdAt: new Date('2022-02-05') };
   const certifRegularUser3 = { id: CERTIF_REGULAR_USER3_ID, createdAt: new Date('2022-02-05') };
   const certifRegularUser4 = { id: CERTIF_REGULAR_USER4_ID, createdAt: new Date('2022-02-06') };
   const certifRegularUser5 = { id: CERTIF_REGULAR_USER5_ID, createdAt: new Date('2022-02-07') };
-  const userIdsCertifiable = [users[10].id, users[11].id, users[12].id];
+  const userIdsNotShared = [users[1], users[2], users[3], users[4], users[5], users[6], users[7], users[8]];
+  const userIdsShared = [users[0], users[9], users[10], users[11], users[12]];
+  const userIdsCertifiable = [users[10].id, users[11].id, users[12].id, certifRegularUser1.id, certifRegularUser2.id, certifRegularUser3.id];
 
   [certifRegularUser1, certifRegularUser2, certifRegularUser3, certifRegularUser4, certifRegularUser5].forEach((certifUser, index) => {
     databaseBuilder.factory.buildOrganizationLearner({ lastName: `Certif${index}`, firstName: `User${index}`, id: certifUser.id, userId: certifUser.id, organizationId: PRO_COMPANY_ID });
   });
 
   [...userIdsNotShared, certifRegularUser4, certifRegularUser5].forEach((user) => participateToProfilesCollectionCampaign({ databaseBuilder, campaignId: 6, user, organizationLearnerId: user.id, status: TO_SHARE }));
-  [...userIdsShared, certifRegularUser1, certifRegularUser2, certifRegularUser3].forEach((user) => participateToProfilesCollectionCampaign({ databaseBuilder, campaignId: 6, user, organizationLearnerId: user.id, status: SHARED }));
+  [...userIdsShared, certifRegularUser1, certifRegularUser2, certifRegularUser3].forEach((user) => participateToProfilesCollectionCampaign({ databaseBuilder, campaignId: 6, user, organizationLearnerId: user.id, status: SHARED, sharedAt }));
 
   //multiple sendings profiles collection campaign
   userIdsShared.forEach((user) => participateToProfilesCollectionCampaign({ databaseBuilder, campaignId: 18, user, organizationLearnerId: user.id, status: SHARED, isCertifiable: userIdsCertifiable.includes(user.id) }));

--- a/api/lib/domain/read-models/organization-learner-follow-up/OrganizationLearner.js
+++ b/api/lib/domain/read-models/organization-learner-follow-up/OrganizationLearner.js
@@ -1,5 +1,16 @@
 class OrganizationLearner {
-  constructor({ id, firstName, lastName, division, email, username, authenticationMethods, group } = {}) {
+  constructor({
+    id,
+    firstName,
+    lastName,
+    division,
+    email,
+    username,
+    authenticationMethods,
+    group,
+    isCertifiable,
+    certifiableAt,
+  } = {}) {
     this.id = id;
     this.firstName = firstName;
     this.lastName = lastName;
@@ -8,6 +19,8 @@ class OrganizationLearner {
     this.group = group;
     this.username = username;
     this.authenticationMethods = authenticationMethods;
+    this.isCertifiable = isCertifiable;
+    this.certifiableAt = isCertifiable ? certifiableAt : null;
   }
 }
 

--- a/api/lib/infrastructure/repositories/organization-learner-follow-up/organization-learner-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-follow-up/organization-learner-repository.js
@@ -1,25 +1,52 @@
 const { knex } = require('../../../../db/knex-database-connection.js');
 const { NotFoundError } = require('../../../domain/errors.js');
 const OrganizationLearner = require('../../../domain/read-models/organization-learner-follow-up/OrganizationLearner.js');
+const CampaignTypes = require('../../../domain/models/CampaignTypes.js');
+const CampaignParticipationStatuses = require('../../../domain/models/CampaignParticipationStatuses.js');
+
+function _buildIsCertifiable(queryBuilder, organizationLearnerId) {
+  queryBuilder
+    .distinct('organization-learners.id')
+    .select(
+      'organization-learners.id as organizationLearnerId',
+      knex.raw(
+        'FIRST_VALUE("isCertifiable") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "isCertifiable"'
+      ),
+      knex.raw(
+        'FIRST_VALUE("sharedAt") OVER(PARTITION BY "organization-learners"."id" ORDER BY "campaign-participations"."sharedAt" DESC) AS "certifiableAt"'
+      )
+    )
+    .from('organization-learners')
+    .join('campaign-participations', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
+    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+    .where('campaign-participations.status', CampaignParticipationStatuses.SHARED)
+    .where('campaigns.type', CampaignTypes.PROFILES_COLLECTION)
+    .where('organization-learners.id', organizationLearnerId)
+    .where('campaign-participations.deletedAt', null);
+}
 
 async function get(organizationLearnerId) {
-  const row = await knex('organization-learners')
+  const row = await knex
+    .with('subquery', (qb) => _buildIsCertifiable(qb, organizationLearnerId))
     .select(
       'organization-learners.id',
       'organization-learners.firstName',
       'organization-learners.lastName',
       'division',
       'group',
+      'subquery.isCertifiable',
+      'subquery.certifiableAt',
       knex.raw('array_remove(ARRAY_AGG("identityProvider"), NULL) AS "authenticationMethods"'),
       'users.email',
       'users.username'
     )
+    .from('organization-learners')
     .where('organization-learners.id', organizationLearnerId)
+    .leftJoin('subquery', 'subquery.organizationLearnerId', 'organization-learners.id')
     .leftJoin('authentication-methods', 'authentication-methods.userId', 'organization-learners.userId')
     .leftJoin('users', 'organization-learners.userId', 'users.id')
-    .groupBy('organization-learners.id', 'users.id')
+    .groupBy('organization-learners.id', 'users.id', 'subquery.isCertifiable', 'subquery.certifiableAt')
     .first();
-
   if (row) {
     return new OrganizationLearner(row);
   }

--- a/api/lib/infrastructure/serializers/jsonapi/organization-learner-follow-up/organization-learner-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-learner-follow-up/organization-learner-serializer.js
@@ -3,7 +3,17 @@ const { Serializer } = require('jsonapi-serializer');
 module.exports = {
   serialize(organizationLearner) {
     return new Serializer('organization-learner', {
-      attributes: ['lastName', 'firstName', 'email', 'username', 'authenticationMethods', 'division', 'group'],
+      attributes: [
+        'lastName',
+        'firstName',
+        'email',
+        'username',
+        'authenticationMethods',
+        'division',
+        'group',
+        'isCertifiable',
+        'certifiableAt',
+      ],
     }).serialize(organizationLearner);
   },
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-learner-follow-up/organization-learner-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-learner-follow-up/organization-learner-serializer_test.js
@@ -15,6 +15,8 @@ describe('Unit | Serializer | JSONAPI | organization-learner-serializer', functi
         authenticationMethods: ['PIX', 'GAR'],
         division: 'ABC',
         group: 'AE',
+        isCertifiable: true,
+        certifiableAt: '2022-03-01',
       });
 
       const expectedSerializedOrganizationLearner = {
@@ -29,6 +31,8 @@ describe('Unit | Serializer | JSONAPI | organization-learner-serializer', functi
             'authentication-methods': organizationLearner.authenticationMethods,
             division: organizationLearner.division,
             group: organizationLearner.group,
+            'is-certifiable': organizationLearner.isCertifiable,
+            'certifiable-at': organizationLearner.certifiableAt,
           },
         },
       };

--- a/orga/app/components/ui/learner-header-info.hbs
+++ b/orga/app/components/ui/learner-header-info.hbs
@@ -1,15 +1,27 @@
 <Ui::InformationWrapper>
-  <:default>
-    {{#if @groupName}}
-      <Ui::Information>
-        <:title>
-          {{@groupName}}
-        </:title>
-        <:content>
-          {{this.group}}
-        </:content>
-      </Ui::Information>
-    {{/if}}
+  {{#if @isCertifiable}}
+    <Ui::Information>
+      <:title>
+        <Ui::IsCertifiable @isCertifiable={{@isCertifiable}} />
+      </:title>
+      <:content>
+        <span class="information__content--gray">
+          <Ui::Date @date={{@certifiableAt}} />
+        </span>
+      </:content>
+    </Ui::Information>
+  {{/if}}
+  {{#if @groupName}}
+    <Ui::Information>
+      <:title>
+        {{@groupName}}
+      </:title>
+      <:content>
+        {{this.group}}
+      </:content>
+    </Ui::Information>
+  {{/if}}
+  {{#if (gt this.connectionMethods.length 0)}}
     <Ui::Information>
       <:title>
         {{t "pages.sco-organization-participants.table.column.login-method"}}
@@ -18,5 +30,6 @@
         {{this.connectionMethods}}
       </:content>
     </Ui::Information>
-  </:default>
+  {{/if}}
+
 </Ui::InformationWrapper>

--- a/orga/app/components/ui/learner-header-info.js
+++ b/orga/app/components/ui/learner-header-info.js
@@ -20,12 +20,14 @@ export default class LearnerHeaderInfo extends Component {
   get connectionMethods() {
     const connectionMethodsList = [];
 
-    if (this.args.organizationLearner.email) connectionMethodsList.push(this.intl.t(CONNECTION_TYPES['email']));
-    if (this.args.organizationLearner.username)
-      connectionMethodsList.push(this.intl.t(CONNECTION_TYPES['identifiant']));
-    if (this.args.organizationLearner?.authenticationMethods.includes('GAR'))
-      connectionMethodsList.push(this.intl.t(CONNECTION_TYPES['mediacentre']));
-    if (connectionMethodsList.length === 0) connectionMethodsList.push(this.intl.t(CONNECTION_TYPES['empty']));
+    const learner = this.args.organizationLearner;
+    if (learner) {
+      if (learner.email) connectionMethodsList.push(this.intl.t(CONNECTION_TYPES['email']));
+      if (learner.username) connectionMethodsList.push(this.intl.t(CONNECTION_TYPES['identifiant']));
+      if (learner.authenticationMethods.includes('GAR'))
+        connectionMethodsList.push(this.intl.t(CONNECTION_TYPES['mediacentre']));
+      if (connectionMethodsList.length === 0) connectionMethodsList.push(this.intl.t(CONNECTION_TYPES['empty']));
+    }
 
     return connectionMethodsList.join(', ');
   }

--- a/orga/app/models/organization-learner.js
+++ b/orga/app/models/organization-learner.js
@@ -18,6 +18,8 @@ export default class OrganizationLearner extends Model {
   @attr('string') group;
   @attr('string') email;
   @attr authenticationMethods;
+  @attr('boolean') isCertifiable;
+  @attr('date', { allowNull: true }) certifiableAt;
 
   get connectionMethods() {
     const messages = [];

--- a/orga/app/styles/components/previous-page-button.scss
+++ b/orga/app/styles/components/previous-page-button.scss
@@ -1,6 +1,5 @@
 .previous-page-button {
   display: flex;
-  flex: auto;
   align-items: center;
 
   &__return-button {

--- a/orga/app/styles/components/ui/information.scss
+++ b/orga/app/styles/components/ui/information.scss
@@ -1,12 +1,13 @@
 .information-wrapper {
   display: flex;
-  margin: 0;
+  margin-left: $spacing-xxl;
 }
 
 .information {
   padding: 0 $spacing-xs;
   border-left: 1px solid $pix-neutral-22;
   font-size: 0.875rem;
+  text-align: center;
 
   &__title {
     margin-bottom: $spacing-xs;
@@ -16,7 +17,12 @@
   &__content {
     color: $pix-neutral-90;
     margin: 0;
+
+    &--gray {
+      color: $pix-neutral-50;
+    }
   }
+
 
   &:first-of-type {
     padding-left: 0;

--- a/orga/app/styles/pages/authenticated/organization-participants/organization-participant.scss
+++ b/orga/app/styles/pages/authenticated/organization-participants/organization-participant.scss
@@ -1,5 +1,7 @@
 .learner-header {
-  margin-bottom: $spacing-m;
+  display: flex;
+  margin: $spacing-m 0;
+  justify-content: flex-start;
 
   &-title {
     text-transform: capitalize;

--- a/orga/app/templates/authenticated/organization-participants/organization-participant.hbs
+++ b/orga/app/templates/authenticated/organization-participants/organization-participant.hbs
@@ -8,6 +8,7 @@
     >
       {{t "common.fullname" firstName=@model.firstName lastName=@model.lastName}}
     </Ui::PreviousPageButton>
+    <Ui::LearnerHeaderInfo @isCertifiable={{@model.isCertifiable}} @certifiableAt={{@model.certifiableAt}} />
   </header>
   {{outlet}}
 </article>

--- a/orga/tests/integration/components/ui/learner-header-info_test.js
+++ b/orga/tests/integration/components/ui/learner-header-info_test.js
@@ -39,4 +39,34 @@ module('Integration | Component | Ui::LearnerHeaderInfo', function (hooks) {
     assert.notContains('3E');
     assert.contains('Adresse e-mail');
   });
+
+  test('it renders learner header information when learner is certifiable', async function (assert) {
+    const isCertifiable = true;
+    const certifiableAt = '2023-01-01';
+
+    this.set('isCertifiable', isCertifiable);
+    this.set('certifiableAt', certifiableAt);
+
+    await render(
+      hbs`<Ui::LearnerHeaderInfo @isCertifiable={{this.isCertifiable}} @certifiableAt={{this.certifiableAt}} />`
+    );
+
+    assert.contains('Certifiable');
+    assert.contains('01/01/2023');
+  });
+
+  test('it does not render learner division header information when learner is not certifiable', async function (assert) {
+    const isCertifiable = false;
+    const certifiableAt = null;
+
+    this.set('isCertifiable', isCertifiable);
+    this.set('certifiableAt', certifiableAt);
+
+    await render(
+      hbs`<Ui::LearnerHeaderInfo @isCertifiable={{this.isCertifiable}} @certifiableAt={{this.certifiableAt}} />`
+    );
+
+    assert.notContains('Certifiable');
+    assert.notContains('01/01/2023');
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la consolidation de l’activité du prescrit, nous avons créé [une nouvelle page détaillant l’activité d’un prescrit](https://1024pix.atlassian.net/browse/PIX-6062). Cette page inclut [un en-tête](https://1024pix.atlassian.net/browse/PIX-6145) comportant des informations qui varient selon le type de prescrit : groupe ou classe, méthode de connexion. Nous allons y ajouter la certificabilité quand elle est connue.

## :robot: Proposition
Sur la page de détail des participants, afficher le composant d’en-tête auquel on a ajouté le tag de certificabilité.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Se connecter à Pix-Orga avec une Organisation sans import.
- Aller dans la liste des participants.
- Vérifier que sur la page d'un participant certifiable, l'en tête avec le tag certifiable apparait.
- Vérifier que sur la page d'un participant non-certifiable, l'en tête avec le tag certifiable n'est pas présent.
