### PR TITLE
[BUGFIX] Corriger les liens dans le footer et sur la page d'invitation sur Pix Orga (PIX-7178)

### DIFF
--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -51,19 +51,31 @@ export default class Url extends Service {
   }
 
   get legalNoticeUrl() {
-    return this._computeShowcaseWebsiteUrl(this.SHOWCASE_WEBSITE_LOCALE_PATH.LEGAL_NOTICE);
+    const domainExtension = this.currentDomain.getExtension();
+    const { en, fr } = this.SHOWCASE_WEBSITE_LOCALE_PATH.LEGAL_NOTICE;
+
+    return this._computeShowcaseWebsiteUrl({ domainExtension, en, fr });
   }
 
   get cguUrl() {
-    return this._computeShowcaseWebsiteUrl(this.SHOWCASE_WEBSITE_LOCALE_PATH.CGU);
+    const domainExtension = this.currentDomain.getExtension();
+    const { en, fr } = this.SHOWCASE_WEBSITE_LOCALE_PATH.CGU;
+
+    return this._computeShowcaseWebsiteUrl({ domainExtension, en, fr });
   }
 
   get dataProtectionPolicyUrl() {
-    return this._computeShowcaseWebsiteUrl(this.SHOWCASE_WEBSITE_LOCALE_PATH.DATA_PROTECTION_POLICY);
+    const domainExtension = this.currentDomain.getExtension();
+    const { en, fr } = this.SHOWCASE_WEBSITE_LOCALE_PATH.DATA_PROTECTION_POLICY;
+
+    return this._computeShowcaseWebsiteUrl({ domainExtension, en, fr });
   }
 
   get accessibilityUrl() {
-    return this._computeShowcaseWebsiteUrl(this.SHOWCASE_WEBSITE_LOCALE_PATH.ACCESSIBILITY);
+    const domainExtension = this.currentDomain.getExtension();
+    const { en, fr } = this.SHOWCASE_WEBSITE_LOCALE_PATH.ACCESSIBILITY;
+
+    return this._computeShowcaseWebsiteUrl({ domainExtension, en, fr });
   }
 
   get forgottenPasswordUrl() {
@@ -75,10 +87,12 @@ export default class Url extends Service {
     return url;
   }
 
-  _computeShowcaseWebsiteUrl({ en: englishPath, fr: frenchPath }) {
+  _computeShowcaseWebsiteUrl({ domainExtension, en: englishPath, fr: frenchPath }) {
     const currentLanguage = this.intl.t('current-lang');
 
-    if (this.isFrenchDomainExtension) return `${PIX_FR_DOMAIN}${frenchPath}`;
+    if (domainExtension === FRENCH_DOMAIN_EXTENSION) {
+      return `${PIX_FR_DOMAIN}${frenchPath}`;
+    }
 
     return currentLanguage === FRENCH_DOMAIN_EXTENSION
       ? `${PIX_ORG_DOMAIN_FR_LOCALE}${frenchPath}`

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -3,10 +3,32 @@ import Service, { inject as service } from '@ember/service';
 import ENV from 'pix-orga/config/environment';
 
 const FRENCH_DOMAIN_EXTENSION = 'fr';
+const PIX_FR_DOMAIN = 'https://pix.fr';
+const PIX_ORG_DOMAIN_FR_LOCALE = 'https://pix.org/fr';
+const PIX_ORG_DOMAIN_EN_LOCALE = 'https://pix.org/en-gb';
 
 export default class Url extends Service {
   @service currentDomain;
   @service intl;
+
+  SHOWCASE_WEBSITE_LOCALE_PATH = {
+    ACCESSIBILITY: {
+      en: '/accessibility-pix-orga',
+      fr: '/accessibilite-pix-orga',
+    },
+    CGU: {
+      en: '/terms-and-conditions',
+      fr: '/conditions-generales-d-utilisation',
+    },
+    DATA_PROTECTION_POLICY: {
+      en: '/personal-data-protection-policy',
+      fr: '/politique-protection-donnees-personnelles-app',
+    },
+    LEGAL_NOTICE: {
+      en: '/legal-notice',
+      fr: '/mentions-legales',
+    },
+  };
 
   definedCampaignsRootUrl = ENV.APP.CAMPAIGNS_ROOT_URL;
   pixAppUrlWithoutExtension = ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION;
@@ -29,41 +51,19 @@ export default class Url extends Service {
   }
 
   get legalNoticeUrl() {
-    const currentLanguage = this.intl.t('current-lang');
-
-    if (this.isFrenchDomainExtension) return 'https://pix.fr/mentions-legales';
-
-    return currentLanguage === 'fr' ? 'https://pix.org/fr/mentions-legales' : 'https://pix.org/en-gb/legal-notice';
+    return this._computeShowcaseWebsiteUrl(this.SHOWCASE_WEBSITE_LOCALE_PATH.LEGAL_NOTICE);
   }
 
   get cguUrl() {
-    const currentLanguage = this.intl.t('current-lang');
-
-    if (this.isFrenchDomainExtension) return 'https://pix.fr/conditions-generales-d-utilisation';
-
-    return currentLanguage === 'fr'
-      ? 'https://pix.org/fr/conditions-generales-d-utilisation'
-      : 'https://pix.org/en-gb/terms-and-conditions';
+    return this._computeShowcaseWebsiteUrl(this.SHOWCASE_WEBSITE_LOCALE_PATH.CGU);
   }
 
   get dataProtectionPolicyUrl() {
-    const currentLanguage = this.intl.t('current-lang');
-
-    if (this.isFrenchDomainExtension) return 'https://pix.fr/politique-protection-donnees-personnelles-app';
-
-    return currentLanguage === 'fr'
-      ? 'https://pix.org/fr/politique-protection-donnees-personnelles-app'
-      : 'https://pix.org/en-gb/personal-data-protection-policy';
+    return this._computeShowcaseWebsiteUrl(this.SHOWCASE_WEBSITE_LOCALE_PATH.DATA_PROTECTION_POLICY);
   }
 
   get accessibilityUrl() {
-    const currentLanguage = this.intl.t('current-lang');
-
-    if (this.isFrenchDomainExtension) return 'https://pix.fr/accessibilite-pix-orga';
-
-    return currentLanguage === 'fr'
-      ? 'https://pix.org/fr/accessibilite-pix-orga'
-      : 'https://pix.org/en-gb/accessibility-pix-orga';
+    return this._computeShowcaseWebsiteUrl(this.SHOWCASE_WEBSITE_LOCALE_PATH.ACCESSIBILITY);
   }
 
   get forgottenPasswordUrl() {
@@ -73,5 +73,15 @@ export default class Url extends Service {
       url += '?lang=en';
     }
     return url;
+  }
+
+  _computeShowcaseWebsiteUrl({ en: englishPath, fr: frenchPath }) {
+    const currentLanguage = this.intl.t('current-lang');
+
+    if (this.isFrenchDomainExtension) return `${PIX_FR_DOMAIN}${frenchPath}`;
+
+    return currentLanguage === FRENCH_DOMAIN_EXTENSION
+      ? `${PIX_ORG_DOMAIN_FR_LOCALE}${frenchPath}`
+      : `${PIX_ORG_DOMAIN_EN_LOCALE}${englishPath}`;
   }
 }

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -30,28 +30,40 @@ export default class Url extends Service {
 
   get legalNoticeUrl() {
     const currentLanguage = this.intl.t('current-lang');
-    if (currentLanguage === 'en') return 'https://pix.org/en-gb/legal-notice';
-    return `https://pix.${this.currentDomain.getExtension()}/mentions-legales`;
+
+    if (this.isFrenchDomainExtension) return 'https://pix.fr/mentions-legales';
+
+    return currentLanguage === 'fr' ? 'https://pix.org/fr/mentions-legales' : 'https://pix.org/en-gb/legal-notice';
   }
 
   get cguUrl() {
     const currentLanguage = this.intl.t('current-lang');
-    if (currentLanguage === 'en') return 'https://pix.org/en-gb/terms-and-conditions';
-    return `https://pix.${this.currentDomain.getExtension()}/conditions-generales-d-utilisation`;
+
+    if (this.isFrenchDomainExtension) return 'https://pix.fr/conditions-generales-d-utilisation';
+
+    return currentLanguage === 'fr'
+      ? 'https://pix.org/fr/conditions-generales-d-utilisation'
+      : 'https://pix.org/en-gb/terms-and-conditions';
   }
 
   get dataProtectionPolicyUrl() {
     const currentLanguage = this.intl.t('current-lang');
-    if (currentLanguage === 'en') return 'https://pix.org/en-gb/personal-data-protection-policy';
-    return `https://pix.${this.currentDomain.getExtension()}/politique-protection-donnees-personnelles-app`;
+
+    if (this.isFrenchDomainExtension) return 'https://pix.fr/politique-protection-donnees-personnelles-app';
+
+    return currentLanguage === 'fr'
+      ? 'https://pix.org/fr/politique-protection-donnees-personnelles-app'
+      : 'https://pix.org/en-gb/personal-data-protection-policy';
   }
 
   get accessibilityUrl() {
     const currentLanguage = this.intl.t('current-lang');
-    if (currentLanguage === 'en') {
-      return 'https://pix.org/en-gb/accessibility-pix-orga';
-    }
-    return `https://pix.${this.currentDomain.getExtension()}/accessibilite-pix-orga`;
+
+    if (this.isFrenchDomainExtension) return 'https://pix.fr/accessibilite-pix-orga';
+
+    return currentLanguage === 'fr'
+      ? 'https://pix.org/fr/accessibilite-pix-orga'
+      : 'https://pix.org/en-gb/accessibility-pix-orga';
   }
 
   get forgottenPasswordUrl() {

--- a/orga/tests/integration/components/layout/footer_test.js
+++ b/orga/tests/integration/components/layout/footer_test.js
@@ -22,14 +22,14 @@ module('Integration | Component | Layout::Footer', function (hooks) {
   test('should display legal notice link', async function (assert) {
     // given
     const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+    service.currentDomain = { getExtension: sinon.stub().returns('org') };
 
     // when
     const screen = await renderScreen(hbs`<Layout::Footer />}`);
 
     // then
     assert.dom(screen.getByText('Mentions légales')).exists();
-    assert.dom('a[href="https://pix.fr/mentions-legales"]').exists();
+    assert.dom('a[href="https://pix.org/fr/mentions-legales"]').exists();
   });
 
   test('should display accessibility link', async function (assert) {

--- a/orga/tests/unit/services/url_test.js
+++ b/orga/tests/unit/services/url_test.js
@@ -121,7 +121,7 @@ module('Unit | Service | url', function (hooks) {
     test('should get "pix.org" french url when current language is fr', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      const expectedUrl = 'https://pix.org/mentions-legales';
+      const expectedUrl = 'https://pix.org/fr/mentions-legales';
       service.currentDomain = { getExtension: sinon.stub().returns('org') };
       service.intl = { t: sinon.stub().returns('fr') };
 
@@ -164,7 +164,7 @@ module('Unit | Service | url', function (hooks) {
     test('should get "pix.org" french url when current language is fr', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.org/politique-protection-donnees-personnelles-app';
+      const expectedCguUrl = 'https://pix.org/fr/politique-protection-donnees-personnelles-app';
       service.currentDomain = { getExtension: sinon.stub().returns('org') };
       service.intl = { t: sinon.stub().returns('fr') };
 
@@ -207,7 +207,7 @@ module('Unit | Service | url', function (hooks) {
     test('should get "pix.org" french url when current language is fr', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      const expectedCguUrl = 'https://pix.org/conditions-generales-d-utilisation';
+      const expectedCguUrl = 'https://pix.org/fr/conditions-generales-d-utilisation';
       service.currentDomain = { getExtension: sinon.stub().returns('org') };
       service.intl = { t: sinon.stub().returns('fr') };
 
@@ -250,7 +250,7 @@ module('Unit | Service | url', function (hooks) {
     test('should get "pix.org" in french when current language is fr', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
-      const expectedUrl = 'https://pix.org/accessibilite-pix-orga';
+      const expectedUrl = 'https://pix.org/fr/accessibilite-pix-orga';
       service.currentDomain = { getExtension: sinon.stub().returns('org') };
       service.intl = { t: sinon.stub().returns('fr') };
 

--- a/orga/tests/unit/services/url_test.js
+++ b/orga/tests/unit/services/url_test.js
@@ -8,7 +8,7 @@ module('Unit | Service | url', function (hooks) {
   setupIntl(hooks);
 
   module('#isFrenchDomainExtension', function () {
-    test('should have a frenchDomainExtension when the current domain contains pix.fr', function (assert) {
+    test('returns true when the current domain contains pix.fr', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       service.currentDomain = { getExtension: sinon.stub().returns('fr') };
@@ -20,7 +20,7 @@ module('Unit | Service | url', function (hooks) {
       assert.true(domainExtension);
     });
 
-    test('should not have frenchDomainExtension when the current domain contains pix.org', function (assert) {
+    test('returns false when the current domain contains pix.org', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       service.currentDomain = { getExtension: sinon.stub().returns('org') };
@@ -34,7 +34,7 @@ module('Unit | Service | url', function (hooks) {
   });
 
   module('#campaignsRootUrl', function () {
-    test('should get default campaigns root url when is defined', function (assert) {
+    test('returns default campaigns root url when is defined', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       service.definedCampaignsRootUrl = 'pix.test.fr';
@@ -46,7 +46,7 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(campaignsRootUrl, service.definedCampaignsRootUrl);
     });
 
-    test('should get "pix.test" url when current domain contains pix.test', function (assert) {
+    test('returns "pix.test" url when current domain contains pix.test', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedCampaignsRootUrl = 'https://app.pix.test/campagnes/';
@@ -62,7 +62,7 @@ module('Unit | Service | url', function (hooks) {
   });
 
   module('#homeUrl', function () {
-    test('should call intl to get first locale configured', function (assert) {
+    test('calls intl to get first locale configured', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       sinon.spy(this.intl, 'get');
@@ -74,7 +74,7 @@ module('Unit | Service | url', function (hooks) {
       assert.ok(this.intl.get.calledWith('primaryLocale'));
     });
 
-    test('should return home url with current locale', function (assert) {
+    test('returns home url with current locale', function (assert) {
       // given
       const currentLocale = 'en';
       this.intl.setLocale([currentLocale, 'fr']);
@@ -91,7 +91,7 @@ module('Unit | Service | url', function (hooks) {
   });
 
   module('#legalNoticeUrl', function () {
-    test('should get "pix.fr" url when current domain contains pix.fr', function (assert) {
+    test('returns "pix.fr" url when current domain contains pix.fr', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.fr/mentions-legales';
@@ -104,7 +104,7 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(url, expectedUrl);
     });
 
-    test('should get "pix.org" english url when current language is en', function (assert) {
+    test('returns "pix.org" english url when current language is en', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.org/en-gb/legal-notice';
@@ -118,7 +118,7 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(url, expectedUrl);
     });
 
-    test('should get "pix.org" french url when current language is fr', function (assert) {
+    test('returns "pix.org" french url when current language is fr', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.org/fr/mentions-legales';
@@ -134,7 +134,7 @@ module('Unit | Service | url', function (hooks) {
   });
 
   module('#dataProtectionPolicyUrl', function () {
-    test('should get "pix.fr" url when current domain contains pix.fr', function (assert) {
+    test('returns "pix.fr" url when current domain contains pix.fr', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
@@ -147,7 +147,7 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(cguUrl, expectedCguUrl);
     });
 
-    test('should get "pix.org" english url when current language is en', function (assert) {
+    test('returns "pix.org" english url when current language is en', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
@@ -161,7 +161,7 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(cguUrl, expectedCguUrl);
     });
 
-    test('should get "pix.org" french url when current language is fr', function (assert) {
+    test('returns "pix.org" french url when current language is fr', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.org/fr/politique-protection-donnees-personnelles-app';
@@ -177,7 +177,7 @@ module('Unit | Service | url', function (hooks) {
   });
 
   module('#cguUrl', function () {
-    test('should get "pix.fr" url when current domain contains pix.fr', function (assert) {
+    test('returns "pix.fr" url when current domain contains pix.fr', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
@@ -190,7 +190,7 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(cguUrl, expectedCguUrl);
     });
 
-    test('should get "pix.org" english url when current language is en', function (assert) {
+    test('returns "pix.org" english url when current language is en', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.org/en-gb/terms-and-conditions';
@@ -204,7 +204,7 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(cguUrl, expectedCguUrl);
     });
 
-    test('should get "pix.org" french url when current language is fr', function (assert) {
+    test('returns "pix.org" french url when current language is fr', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.org/fr/conditions-generales-d-utilisation';
@@ -220,7 +220,7 @@ module('Unit | Service | url', function (hooks) {
   });
 
   module('#accessibilityUrl', function () {
-    test('should get "pix.fr" when current domain contains pix.fr', function (assert) {
+    test('returns "pix.fr" when current domain contains pix.fr', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.fr/accessibilite-pix-orga';
@@ -233,7 +233,7 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(url, expectedUrl);
     });
 
-    test('should get "pix.org" in english when current language is en', function (assert) {
+    test('returns "pix.org" in english when current language is en', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.org/en-gb/accessibility-pix-orga';
@@ -247,7 +247,7 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(url, expectedUrl);
     });
 
-    test('should get "pix.org" in french when current language is fr', function (assert) {
+    test('returns "pix.org" in french when current language is fr', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.org/fr/accessibilite-pix-orga';

--- a/orga/tests/unit/services/url_test.js
+++ b/orga/tests/unit/services/url_test.js
@@ -118,7 +118,7 @@ module('Unit | Service | url', function (hooks) {
       assert.strictEqual(url, expectedUrl);
     });
 
-    test('returns "pix.org" french url when current language is fr', function (assert) {
+    test('returns "pix.org" french url when current language is fr and domain extension is .org', function (assert) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.org/fr/mentions-legales';


### PR DESCRIPTION
## :unicorn: Problème
Certains liens sur Pix Orga en langue fr vers le site vitrine renvoient vers une page 404. 
La liste :  
- “Accessibilité” et "Mentions légales" dans le footer.
- "Conditions d'utilisation de Pix" et et “politique de confidentialité” sur la page d'invitation lors de la création d'un compte.

## :robot: Proposition
Corriger les liens.

## :rainbow: Remarques
Gestions des urls du site vitrine à uniformiser entre chaque app ?

## :100: Pour tester
### Test non régression sur Pix Orga domain .fr
- Aller sur https://orga-pr5765.review.pix.fr/rejoindre?invitationId=100048&code=INVIABC123
- Cliquer sur les liens _conditions d'utilisation de pix_ et _politique de confidentialité_ sur la page fonctionnent.
- Aller sur https://orga-pr5765.review.pix.fr/connexion et se connecter avec le compte sup.admin@example.net.
- Vérifie que les liens dans le footer sont aussi fonctionnels.

### Test sur Pix Orga domain .org locale fr
- Même procédure de test qu'avant mais avec https://orga-pr5765.review.pix.org/rejoindre?invitationId=100048&code=INVIABC123 comme lien d'invitation et https://orga-pr5765.review.pix.org/connexion pour la connexion.  
### Test sur Pix Orga domain .org locale en
- Aller sur https://orga-pr5765.review.pix.org/rejoindre?invitationId=100048&code=INVIABC123&lang=en
- Cliquer sur les liens _Pix terms of use_ et _personal data protection policy_ sur la page fonctionnent.
- Aller sur https://orga-pr5765.review.pix.org/connexion et se connecter avec le compte sup.admin@example.net.
- Ajouter `?lang=en` à l'url après connexion (ex: https://orga-pr5765.review.pix.org/campagnes/les-miennes?lang=en)
- Vérifie que les liens dans le footer sont aussi fonctionnels.
