### PR TITLE
[FEATURE] Onglet "Candidats" d'une session en anglais (PIX-6670)

### DIFF
--- a/certif/app/components/certification-candidate-details-modal.hbs
+++ b/certif/app/components/certification-candidate-details-modal.hbs
@@ -113,7 +113,7 @@
   <:footer>
     <PixButton
       @triggerAction={{@closeModal}}
-      aria-label="{{t 'pages.sessions.candidates.detail-modal.actions.close-extra-information'}}"
+      aria-label="{{t 'pages.sessions.detail.candidates.detail-modal.actions.close-extra-information'}}"
     >{{t "common.actions.close"}}</PixButton>
   </:footer>
 </PixModal>

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -128,7 +128,9 @@
                       <PixIconButton
                         @icon="trash-alt"
                         {{on "click" (fn this.deleteCertificationCandidate candidate)}}
-                        aria-label="Supprimer le candidat {{candidate.firstName}} {{candidate.lastName}}"
+                        aria-label="{{t
+                          'pages.sessions.detail.candidates.list.actions.delete.extra-information'
+                        }} {{candidate.firstName}} {{candidate.lastName}}"
                         class="certification-candidates-actions__delete-button"
                         @withBackground={{true}}
                       />

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -1,7 +1,8 @@
 <div class="panel">
   <div class="panel-header">
     <h3 class="panel-header__title">
-      Liste des candidats ({{@certificationCandidates.length}})
+      {{t "pages.sessions.detail.candidates.list.title"}}
+      ({{@certificationCandidates.length}})
     </h3>
     {{#if @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
       <PixButtonLink
@@ -9,7 +10,7 @@
         @model={{@sessionId}}
         class="enrolled-candidate__add-students"
       >
-        Inscrire des candidats
+        {{t "pages.sessions.detail.candidates.list.actions.inscription-multiple.label"}}
       </PixButtonLink>
     {{else}}
       <PixButton
@@ -18,7 +19,7 @@
         @triggerAction={{this.openNewCertificationCandidateModal}}
         @size="small"
       >
-        Inscrire un candidat
+        {{t "pages.sessions.detail.candidates.list.actions.inscription.label"}}
       </PixButton>
     {{/if}}
   </div>
@@ -27,43 +28,50 @@
       <table class="certification-candidates-table-cpf-toggle-enabled">
         <caption class="sr-only">
           {{#if @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-            {{t "pages.sessions.enrolled-candidates.without-details-description"}}
+            {{t "pages.sessions.detail.candidates.list.without-details-description"}}
           {{else}}
-            {{t "pages.sessions.enrolled-candidates.with-details-description"}}
+            {{t "pages.sessions.detail.candidates.list.with-details-description"}}
           {{/if}}
         </caption>
         <thead>
           <tr>
             <th class="certification-candidates-table__column-last-name">
-              Nom de naissance
+              {{t "pages.sessions.detail.candidates.list.columns.lastname"}}
             </th>
             <th class="certification-candidates-table__column-first-name">
-              Prénom
+              {{t "pages.sessions.detail.candidates.list.columns.firstname"}}
             </th>
             <th class="certification-candidates-table__column-birthdate">
-              Date de naissance
+              {{t "pages.sessions.detail.candidates.list.columns.birth-date"}}
             </th>
             {{#if @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
               <th class="certification-candidates-table__birth-city">
-                Commune de naissance
+                {{t "pages.sessions.detail.candidates.list.columns.birth-city"}}
               </th>
               <th>
-                Pays de naissance
+                {{t "pages.sessions.detail.candidates.list.columns.birth-country"}}
               </th>
             {{/if}}
             {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-              <th class="certification-candidates-table__recipient-email">E-mail du destinataire des résultats
-                (formateur, enseignant...)</th>
+              <th class="certification-candidates-table__recipient-email">
+                {{t "pages.sessions.detail.candidates.list.columns.recipient-email"}}
+              </th>
             {{/unless}}
             {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-              <th class="certification-candidates-table__external-id">Identifiant externe</th>
+              <th class="certification-candidates-table__external-id">
+                {{t "pages.sessions.detail.candidates.list.columns.external-id"}}
+              </th>
             {{/unless}}
-            <th class="certification-candidates-table__column-time">Temps majoré</th>
+            <th class="certification-candidates-table__column-time">
+              {{t "pages.sessions.detail.candidates.list.columns.extratime"}}
+            </th>
             {{#if @shouldDisplayPaymentOptions}}
-              <th class="certification-candidates-table__payment-options">Tarification part Pix</th>
+              <th class="certification-candidates-table__payment-options">
+                {{t "pages.sessions.detail.candidates.list.columns.pricing"}}
+              </th>
             {{/if}}
             {{#if @displayComplementaryCertification}}
-              <th>Certification complémentaire</th>
+              <th>{{t "pages.sessions.detail.candidates.list.columns.additional-certification"}}</th>
             {{/if}}
           </tr>
         </thead>
@@ -103,9 +111,11 @@
                         type="button"
                         class="button--showed-as-link"
                         {{on "click" (fn this.openCertificationCandidateDetailsModal candidate)}}
-                        aria-label="Voir le détail du candidat {{candidate.firstName}} {{candidate.lastName}}"
+                        aria-label="{{t
+                          'pages.sessions.detail.candidates.list.actions.details.extra-information'
+                        }} {{candidate.firstName}} {{candidate.lastName}}"
                       >
-                        Voir le détail
+                        {{t "pages.sessions.detail.candidates.list.actions.details.label"}}
                       </button>
                     </div>
                   {{/unless}}
@@ -116,13 +126,15 @@
                           <PixIconButton
                             @icon="trash-alt"
                             class="certification-candidates-actions__delete-button--disabled"
-                            aria-label="Supprimer le candidat {{candidate.firstName}} {{candidate.lastName}}"
+                            aria-label="{{t
+                              'pages.sessions.detail.candidates.list.actions.delete.extra-information'
+                            }} {{candidate.firstName}} {{candidate.lastName}}"
                             aria-disabled="true"
                             aria-describedby="tooltip-delete-student-button"
                             @withBackground={{true}}
                           />
                         </:triggerElement>
-                        <:tooltip>Ce candidat a déjà rejoint la session. Vous ne pouvez pas le supprimer.</:tooltip>
+                        <:tooltip>{{t "pages.sessions.detail.candidates.list.actions.delete.tooltip"}}</:tooltip>
                       </PixTooltip>
                     {{else}}
                       <PixIconButton
@@ -144,7 +156,7 @@
       </table>
     {{else}}
       <div class="table__empty content-text">
-        <p>En attente de candidats</p>
+        <p>{{t "pages.sessions.detail.candidates.list.empty"}}</p>
       </div>
     {{/if}}
   </div>

--- a/certif/app/components/import-candidates.hbs
+++ b/certif/app/components/import-candidates.hbs
@@ -4,19 +4,20 @@
       <div class="panel-actions__header-icon">
         <FaIcon @icon="info" />
       </div>
-      <h3 class="panel-actions__header-title">Inscrire des candidats</h3>
+      <h3 class="panel-actions__header-title">{{t "pages.sessions.detail.candidates.panel-actions.title"}}</h3>
     </div>
     <div class="panel-actions__action-row">
       <div class="panel-actions__action-icon">
         <FaIcon @icon="file-download" />
       </div>
       <div class="panel-actions__description">
-        <h4 class="panel-actions__title">Télécharger le modèle de liste des candidats</h4>
-        <p class="panel-actions-description__information">Pour inscrire des candidats à la session, renseignez leurs
-          informations (Nom, Prénom, …) dans ce document.
-          <br />
-          Lors du premier téléchargement, le modèle de liste des candidats est vide. Il contiendra ensuite les
-          informations des candidats inscrits à la session.
+        <h4 class="panel-actions__title">{{t
+            "pages.sessions.detail.candidates.panel-actions.actions.download.extra-information"
+          }}</h4>
+        <p class="panel-actions-description__information">{{t
+            "pages.sessions.detail.candidates.panel-actions.actions.download.description"
+            htmlSafe=true
+          }}
         </p>
       </div>
       <div class="panel-actions__button">
@@ -26,8 +27,7 @@
           rel="noopener noreferrer"
           download
         >
-          Télécharger (.ods)&nbsp;
-          <FaIcon @icon="file-download" />
+          {{t "pages.sessions.detail.candidates.panel-actions.actions.download.label"}}
         </PixButtonLink>
       </div>
     </div>
@@ -37,18 +37,16 @@
           <FaIcon @icon="cloud-upload-alt" />
         </div>
         <div class="panel-actions__description">
-          <h4 class="panel-actions__title">Importer la liste des candidats</h4>
+          <h4 class="panel-actions__title">{{t
+              "pages.sessions.detail.candidates.panel-actions.actions.upload.extra-information"
+            }}</h4>
           <p class="panel-actions-description__information">
-            Sélectionnez la liste des candidats préalablement remplie.
-            <br />
-            <strong>
-              Attention, tout nouvel import efface la liste des candidats existante.
-            </strong>
+            {{t "pages.sessions.detail.candidates.panel-actions.actions.upload.description" htmlSafe=true}}
           </p>
         </div>
         <div class="panel-actions__button">
           <PixButtonUpload @id="upload-attendance-sheet" @onChange={{this.importCertificationCandidates}} accept=".ods">
-            Importer (.ods)&nbsp;<FaIcon @icon="cloud-upload-alt" />
+            {{t "pages.sessions.detail.candidates.panel-actions.actions.upload.label"}}
           </PixButtonUpload>
         </div>
       {{else}}
@@ -57,8 +55,7 @@
         </div>
         <div class="panel-actions__description">
           <strong class="panel-actions__warning">
-            La session a débuté, vous ne pouvez plus importer une liste de candidats.<br />Si vous souhaitez modifier la
-            liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous.
+            {{t "pages.sessions.detail.candidates.panel-actions.warning" htmlSafe=true}}
           </strong>
         </div>
       {{/if}}

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -331,7 +331,7 @@
   </:content>
   <:footer>
     <PixButton
-      aria-label={{t "pages.sessions.candidates.add-modal.actions.close-extra-information"}}
+      aria-label={{t "pages.sessions.detail.candidates.add-modal.actions.close-extra-information"}}
       @triggerAction={{@closeModal}}
       @backgroundColor="transparent-light"
       @isBorderVisible="true"

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -9,6 +9,7 @@ import { inject as service } from '@ember/service';
 
 export default class CertificationCandidatesController extends Controller {
   @service currentUser;
+  @service intl;
 
   @alias('model.session') currentSession;
   @alias('model.certificationCandidates') certificationCandidates;
@@ -16,7 +17,9 @@ export default class CertificationCandidatesController extends Controller {
   @alias('model.countries') countries;
 
   get pageTitle() {
-    return `Candidats | Session ${this.currentSession.id} | Pix Certif`;
+    return `${this.intl.t('pages.sessions.detail.candidates.page-title')} | Session ${
+      this.currentSession.id
+    } | Pix Certif`;
   }
 
   @computed('certificationCandidates', 'certificationCandidates.@each.isLinked')

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -4,10 +4,12 @@ import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from '../helpers/test-init';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { visit } from '@1024pix/ember-testing-library';
+import { setupIntl } from 'ember-intl/test-support/index';
 
 module('Acceptance | Session Details Certification Candidates', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   hooks.afterEach(function () {
     const notificationMessagesService = this.owner.lookup('service:notifications');
@@ -270,6 +272,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
 
         // when
         const screen = await visit(`/sessions/${sessionWithoutCandidates.id}/candidats`);
+        screen.debug;
         await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
 
         // then

--- a/certif/tests/integration/components/enrolled-candidates_test.js
+++ b/certif/tests/integration/components/enrolled-candidates_test.js
@@ -37,7 +37,9 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
     // then
     assert
       .dom(
-        screen.getByRole('table', { name: this.intl.t('pages.sessions.enrolled-candidates.with-details-description') })
+        screen.getByRole('table', {
+          name: this.intl.t('pages.sessions.detail.candidates.list.with-details-description'),
+        })
       )
       .exists();
   });

--- a/certif/tests/integration/components/import-candidates_test.js
+++ b/certif/tests/integration/components/import-candidates_test.js
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | import-candidates', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it renders texts about Feuille émargement', async function (assert) {
     // given

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -254,6 +254,69 @@
         }
       },
       "detail": {
+        "candidates": {
+          "add-modal": {
+            "actions": {
+              "close-extra-information": "Close add candidate window modal"
+            }
+          },
+          "detail-modal": {
+            "actions": {
+              "close-extra-information": "Close candidate's detail window modal"
+            }
+          },
+          "list": {
+            "title": "Candidates' list",
+            "actions": {
+              "delete": {
+                "extra-information": "Delete the candidate",
+                "tooltip": "This candidate has already joined the session, you can’t delete them."
+              },
+              "inscription": {
+                "label": "Enrol a candidate"
+              },
+              "inscription-multiple": {
+                "label": "Enrol candidates"
+              },
+              "details": {
+                "extra-information": "See the candidate’s details",
+                "label": "See details"
+              }
+            },
+            "columns": {
+              "additional-certification": "Additional certification",
+              "birth-city": "Birth city",
+              "birth-country": "Birth country",
+              "birth-date": "Date of birth",
+              "recipient-email": "Email of the results' recipient (instructor, teacher…)",
+              "external-id": "External ID",
+              "extratime": "Extra time",
+              "lastname": "Birth name",
+              "firstname": "First name",
+              "pricing": "Pricing of Pix’s share"
+            },
+            "with-details-description": "List of candidates enrolled in the session, ordered by birth name, with a link to see the candidate’s details and the possibility to delete a candidate in the last column.",
+            "empty": "Awaiting candidates",
+            "without-details-description": "List of candidates enrolled in the session, ordered by birth name, with the possibility to delete a candidate in the last column."
+          },
+          "panel-actions": {
+            "title": "Enrol candidates",
+            "actions": {
+              "download": {
+                "description": "To enrol candidates in the session, fill in their details (Last name, First name, …) in this document.. <br />When you first download the template for the candidates' list, it will be blank. Afterwards, it will contain the details of the candidates enrolled in the session.",
+                "extra-information": "Download the template for the candidates' list",
+                "label": "Download (.ods)"
+              },
+              "upload": {
+                "description": "Select the candidates' list previously filled in.<br /><strong>Warning, any new upload deletes the existing candidates' list.</strong>",
+                "extra-information": "Upload the candidates' list",
+                "label": "Upload (.ods)"
+              }
+            },
+            "warning": "The session has begun, you can’t upload a candidates' list anymore.<br />If you want to edit the list, you can enrol a candidate directly in the table below."
+          },
+          "page-title": "Candidates"
+        },
         "date": "Date",
         "datetime": "Starting time (local time)",
         "downloads": {
@@ -307,18 +370,6 @@
             "copy-password": "Copy the invigilator’s session password",
             "label": "Session password",
             "invigilator": "Invigilator"
-          }
-        }
-      },
-      "candidates": {
-        "detail-modal": {
-          "actions": {
-            "close-extra-information": "Close candidate's detail window modal"
-          }
-        },
-        "add-modal": {
-          "actions": {
-            "close-extra-information": "Close add candidate window modal"
           }
         }
       },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -126,10 +126,6 @@
       "actions": {
         "return": "Revenir à la liste des sessions"
       },
-      "enrolled-candidates": {
-        "without-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec la possibilité de supprimer un candidat dans la dernière colonne.",
-        "with-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec un lien pour voir les détails du candidat et la possibilité de supprimer un candidat dans la dernière colonne."
-      },
       "finalize": {
         "finished-test-list-description": "Liste des candidats qui ont fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.",
         "unfinished-test-list-description": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon."
@@ -253,6 +249,70 @@
         }
       },
       "detail": {
+        "title": "Session {sessionId}",
+        "candidates": {
+          "add-modal": {
+            "actions": {
+              "close-extra-information": "Fermer la modale d'ajout de candidat"
+            }
+          },
+          "detail-modal": {
+            "actions": {
+              "close-extra-information": "Fermer la fenêtre de détail du candidat"
+            }
+          },
+          "list": {
+            "title": "Liste des candidats",
+            "actions": {
+              "delete": {
+                "extra-information": "Supprimer le candidat",
+                "tooltip": "Ce candidat a déjà rejoint la session. Vous ne pouvez pas le supprimer."
+              },
+              "inscription": {
+                "label": "Inscrire un candidat"
+              },
+              "inscription-multiple": {
+                "label": "Inscrire des candidats"
+              },
+              "details": {
+                "extra-information": "Voir le détail du candidat",
+                "label": "Voir le détail"
+              }
+            },
+            "columns": {
+              "additional-certification": "Certification complémentaire",
+              "birth-city": "Commune de naissance",
+              "birth-country": "Pays de naissance",
+              "birth-date": "Date de naissance",
+              "recipient-email": "E-mail du destinataire des résultats (formateur, enseignant...)",
+              "external-id": "Identifiant externe",
+              "extratime": "Temps majoré",
+              "lastname": "Nom de naissance",
+              "firstname": "Prénom",
+              "pricing": "Tarification part Pix"
+            },
+            "with-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec un lien pour voir les détails du candidat et la possibilité de supprimer un candidat dans la dernière colonne.",
+            "empty": "En attente de candidats",
+            "without-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec la possibilité de supprimer un candidat dans la dernière colonne."
+          },
+          "panel-actions": {
+            "title": "Inscrire des candidats",
+            "actions": {
+              "download": {
+                "description": "Pour inscrire des candidats à la session, renseignez leurs informations (Nom, Prénom, …) dans ce document. <br />Lors du premier téléchargement, le modèle de liste des candidats est vide. Il contiendra ensuite les informations des candidats inscrits à la session.",
+                "extra-information": "Télécharger le modèle de liste des candidats",
+                "label": "Télécharger (.ods)"
+              },
+              "upload": {
+                "description": "Sélectionnez la liste des candidats préalablement remplie.<br /><strong>Attention, tout nouvel import efface la liste des candidats existante.</strong>",
+                "extra-information": "Importer la liste des candidats",
+                "label": "Importer (.ods)"
+              }
+            },
+            "warning": "La session a débuté, vous ne pouvez plus importer une liste de candidats.<br />Si vous souhaitez modifier la liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous."
+          },
+          "page-title": "Candidats"
+        },
         "date": "Date",
         "datetime": "Heure de début (heure locale)",
         "downloads": {
@@ -275,7 +335,6 @@
           "details": "Détails",
           "candidates": "Candidats"
         },
-        "title": "Session {sessionId}",
         "panel-clea": {
           "title": "Des candidats ont obtenu le certificat CléA numérique",
           "description": "Pour générer les certificats CléA numérique, téléchargez la liste des candidats, complétez-la, enregistrez-la au format .xlsx puis importez-la sur la ",
@@ -306,18 +365,6 @@
             "copy-password": "Copier le mot de passe de session pour le surveillant",
             "label": "Mot de passe de session",
             "invigilator": "Surveillant"
-          }
-        }
-      },
-      "candidates": {
-        "detail-modal": {
-          "actions": {
-            "close-extra-information": "Fermer la fenêtre de détail du candidat"
-          }
-        },
-        "add-modal": {
-          "actions": {
-            "close-extra-information": "Fermer la modale d'ajout de candidat"
           }
         }
       },


### PR DESCRIPTION
## :unicorn: Problème
Une fois que l'utilisateur anglophone a accédé au détail d’une des sessions de certification, il clique alors sur l’onglet “Candidats” pour accéder à la liste des candidats de la session concernée.

Toutes les informations sont en français.

## :robot: Proposition
Traduire la page “Candidats” en anglais :

- Candidats : Candidates
- Inscrire des candidats = Enrol candidates
- Télécharger le modèle de liste des candidats = Download the template for the candidates' list
- Pour inscrire des candidats à la session, renseignez leurs informations (Nom, Prénom, …) dans ce document. = To enrol candidates in the session, fill in their details (Last name, First name, …) in this document.
- Lors du premier téléchargement, le modèle de liste des candidats est vide. Il contiendra ensuite les informations des candidats inscrits à la session. = When you first download the template for the candidates' list, it will be blank. Afterwards, it will contain the details of the candidates enrolled in the session.
- Télécharger (.ods) = Download (.ods)
- Importer la liste des candidats = Upload the candidates' list
- Sélectionnez la liste des candidats préalablement remplie. = Select the candidates' list previously filled in.
- Attention, tout nouvel import efface la liste des candidats existante. = Warning, any new upload deletes the existing candidates' list.
- Importer (.ods) = Upload (.ods)
- La session a débuté, vous ne pouvez plus importer une liste de candidats. = The session has begun, you can’t upload a candidates' list anymore.
- Si vous souhaitez modifier la liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous. = If you want to edit the list, you can enrol a candidate directly in the table below.
- Liste des candidats = Candidates' list
- Nom de naissance = Birth name
- Prénom = First name
- Date de naissance = Date of birth
- E-mail du destinataire des résultats (formateur, enseignant...) = Email of the results' recipient (instructor, teacher…)
- Identifiant externe = External ID
- Temps majoré = Extra time
- Tarification part Pix = Pricing of Pix’s share
- Certifications complémentaires = Additional certification
- Inscrire un candidat = Enrol a candidate
- Voir le détail = See details

## :100: Pour tester
Se connecter sur Pix Certif avec certifsup@example.net
Passer ?lang=en dans l'url
Cliquer sur une session, puis sur l'onglet "Candidates"
Constater que tous les éléments sont traduits