### PR TITLE
[BUGFIX] Consultation de Résultat thématique - Problème d'affichage du contenu du tableau

### DIFF
--- a/admin/app/components/target-profiles/badges.hbs
+++ b/admin/app/components/target-profiles/badges.hbs
@@ -15,21 +15,22 @@
       <tbody>
         {{#each @badges as |badge|}}
           <tr aria-label="Informations du badge {{badge.title}}">
-            <td>{{badge.id}}</td>
-            <td><img src={{badge.imageUrl}} alt={{badge.altMessage}} /></td>
-            <td>{{badge.key}}</td>
+            <td class="table__column table__column--id">{{badge.id}}</td>
+            <td class="badges-table__image"><img src={{badge.imageUrl}} alt={{badge.altMessage}} /></td>
+            <td class="key-table">{{badge.key}}</td>
             <td>{{badge.title}}</td>
             <td>{{badge.message}}</td>
             <td>
               <Common::TickOrCross @isTrue={{badge.isAlwaysVisible}} />
             </td>
-            <td>
+            <td class="badges-table__actions">
               <PixButtonLink
                 @backgroundColor="transparent-light"
                 @isBorderVisible={{true}}
                 @route="authenticated.target-profiles.target-profile.badges.badge"
                 @size="small"
                 @model={{badge.id}}
+                class="badges-table-actions__button"
                 aria-label="Détails du badge {{badge.title}}"
               >Voir détail</PixButtonLink>
               <PixButton

--- a/admin/app/styles/components/target-profiles/badges.scss
+++ b/admin/app/styles/components/target-profiles/badges.scss
@@ -1,5 +1,4 @@
 .badges-table {
-
   &__id {
     width: 110px;
   }
@@ -29,6 +28,23 @@
   }
 }
 
+.badges-table-actions {
+
+  &__button {
+    width: 100%;
+
+    &--delete {
+      margin-top: 8px;
+      display: flex;
+      justify-content: space-between;
+    }
+  }
+}
+
 .badges-table-actions-delete {
   margin-top: $spacing-xs;
+}
+
+.key-table {
+  word-wrap: break-word;
 }


### PR DESCRIPTION
## :unicorn: Problème
Sur la page clé de lecture d’un profil cible au niveau de pix admin, au niveau des résultats thématiques, lorsque la clé d’un RT possède trop de caractères, le texte superpose celui du nom. Il faudrait faire un retour à la ligne pour éviter le chevauchement.
Il y a également un problème d’affichage d’image.

## :robot: Proposition
Fix des images et retour à la ligne pour les clé d'un RT si il est trop long.


## :100: Pour tester
Aller sur la page clé de lecture d’un profil cible au niveau de pix admin, au niveau des résultats thématiques.
