### PR TITLE
[FEATURE] Ajoute un fil d'ariane sur les pages de détails d'une participation (PIX-7294)

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-orga/campaign-management.feature
@@ -24,7 +24,7 @@ Fonctionnalité: Gestion des Campagnes
     Alors je vois 2 sujets
     Et je vois que le sujet "Capitales" est "Très recommandé"
     Et je vois que le sujet "Philosophes" est "Assez recommandé"
-    Lorsque je retourne au détail de la campagne
+    Lorsque je clique sur "Campagne de la Néra"
     Et je clique sur "Résultats (1)"
     Alors je vois la moyenne des résultats à 50%
     Lorsque je clique sur "Analyse"

--- a/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
@@ -89,10 +89,6 @@ Then(`je vois que le sujet {string} est {string}`, (tubeName, recommendationLeve
   cy.contains(tubeName).closest('[aria-label="Sujet"]').get(`[aria-label="${recommendationLevel}"]`);
 });
 
-When(`je retourne au détail de la campagne`, () => {
-  cy.get('[aria-label="Retour"]').click();
-});
-
 When('je clique sur le bouton "Associer"', () => {
   cy.contains('button', 'Associer').click();
 });

--- a/orga/app/components/participant/assessment/header.hbs
+++ b/orga/app/components/participant/assessment/header.hbs
@@ -1,12 +1,5 @@
 <header class="navigation">
-  <Ui::PreviousPageButton
-    @route="authenticated.campaigns.campaign.activity"
-    @routeId={{@campaign.id}}
-    @backButtonAriaLabel={{t "common.actions.back"}}
-    aria-label={{t "pages.campaign.name"}}
-  >
-    {{@campaign.name}}
-  </Ui::PreviousPageButton>
+  <Ui::Breadcrumb @links={{this.breadcrumbLinks}} />
 </header>
 
 <section class="panel panel--header">

--- a/orga/app/components/participant/assessment/header.js
+++ b/orga/app/components/participant/assessment/header.js
@@ -1,9 +1,34 @@
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 
 export default class Header extends Component {
+  @service intl;
+
   get displayBadges() {
     const { campaign, participation } = this.args;
     return campaign.hasBadges && participation.badges.length > 0;
+  }
+
+  get breadcrumbLinks() {
+    return [
+      {
+        route: 'authenticated.campaigns',
+        label: this.intl.t('navigation.main.campaigns'),
+      },
+      {
+        route: 'authenticated.campaigns.campaign.activity',
+        label: this.args.campaign.name,
+        model: this.args.campaign.id,
+      },
+      {
+        route: 'authenticated.campaigns.participant-assessment',
+        label: this.intl.t('pages.assessment-individual-results.breadcrumb-current-page-label', {
+          firstName: this.args.participation.firstName,
+          lastName: this.args.participation.lastName,
+        }),
+        models: [this.args.campaign.id, this.args.participation.id],
+      },
+    ];
   }
 
   get valuePercentage() {

--- a/orga/app/components/participant/profile/header.hbs
+++ b/orga/app/components/participant/profile/header.hbs
@@ -1,12 +1,5 @@
 <header class="navigation">
-  <Ui::PreviousPageButton
-    @route="authenticated.campaigns.campaign.activity"
-    @routeId={{@campaign.id}}
-    @backButtonAriaLabel={{t "common.actions.back"}}
-    aria-label={{t "pages.campaign.name"}}
-  >
-    {{@campaign.name}}
-  </Ui::PreviousPageButton>
+  <Ui::Breadcrumb @links={{this.breadcrumbLinks}} />
 </header>
 
 <section class="panel panel--header">

--- a/orga/app/components/participant/profile/header.js
+++ b/orga/app/components/participant/profile/header.js
@@ -1,0 +1,28 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class Header extends Component {
+  @service intl;
+
+  get breadcrumbLinks() {
+    return [
+      {
+        route: 'authenticated.campaigns',
+        label: this.intl.t('navigation.main.campaigns'),
+      },
+      {
+        route: 'authenticated.campaigns.campaign.activity',
+        label: this.args.campaign.name,
+        model: this.args.campaign.id,
+      },
+      {
+        route: 'authenticated.campaigns.participant-profile',
+        label: this.intl.t('pages.profiles-individual-results.breadcrumb-current-page-label', {
+          firstName: this.args.campaignProfile.firstName,
+          lastName: this.args.campaignProfile.lastName,
+        }),
+        models: [this.args.campaign.id, this.args.campaignParticipationId],
+      },
+    ];
+  }
+}

--- a/orga/app/components/ui/breadcrumb.hbs
+++ b/orga/app/components/ui/breadcrumb.hbs
@@ -1,0 +1,21 @@
+<nav aria-label={{t "common.breadcrumb"}} class="breadcrumb">
+  <ol>
+    {{#each this.links as |link|}}
+      <li>
+        {{#if link.models}}
+          <LinkTo @route="{{link.route}}" @models={{link.models}} aria-current={{link.ariaCurrent}}>
+            {{link.label}}
+          </LinkTo>
+        {{else if link.model}}
+          <LinkTo @route="{{link.route}}" @model={{link.model}} aria-current={{link.ariaCurrent}}>
+            {{link.label}}
+          </LinkTo>
+        {{else}}
+          <LinkTo @route="{{link.route}}" aria-current={{link.ariaCurrent}}>
+            {{link.label}}
+          </LinkTo>
+        {{/if}}
+      </li>
+    {{/each}}
+  </ol>
+</nav>

--- a/orga/app/components/ui/breadcrumb.js
+++ b/orga/app/components/ui/breadcrumb.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+
+export default class Breadcrumb extends Component {
+  get links() {
+    return this.args.links.map((link, index) => ({
+      ...link,
+      label: link.label?.trim(),
+      ariaCurrent: index === this.args.links.length - 1 ? 'page' : false,
+    }));
+  }
+}

--- a/orga/app/routes/authenticated/campaigns/participant-profile.js
+++ b/orga/app/routes/authenticated/campaigns/participant-profile.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 import { inject as service } from '@ember/service';
+
 export default class ProfileRoute extends Route {
   @service router;
   @service store;
@@ -11,6 +12,7 @@ export default class ProfileRoute extends Route {
       return await RSVP.hash({
         campaign: this.store.findRecord('campaign', campaignId),
         campaignProfile: this.store.queryRecord('campaign-profile', { campaignId, campaignParticipationId }),
+        campaignParticipationId,
       });
     } catch (error) {
       this.send('error', error, this.router.replaceWith('not-found', params.campaign_id));

--- a/orga/app/styles/components/ui/breadcrumb.scss
+++ b/orga/app/styles/components/ui/breadcrumb.scss
@@ -1,0 +1,38 @@
+.breadcrumb {
+
+  ol {
+    display: flex;
+    flex-wrap: wrap;
+    list-style: none;
+  }
+
+  li {
+    font-size: 0.875rem;
+  }
+
+  li:not(:last-child) {
+    color: $pix-neutral-50;
+  }
+
+  li:not(:first-child) {
+    margin-left: 0.25rem;
+  }
+
+  li:last-child {
+    color: $pix-neutral-70;
+  }
+
+  li:not(:last-child)::after {
+    display: inline-block;
+    margin: 0 .375rem;
+    content: '';
+    width: 0.4375rem;
+    height: 0.4375rem;
+    border: .0625rem solid $pix-neutral-45;
+    border-left: 0;
+    border-bottom: 0;
+    transform: rotate(45deg);
+  }
+}
+
+

--- a/orga/app/styles/components/ui/index.scss
+++ b/orga/app/styles/components/ui/index.scss
@@ -1,3 +1,4 @@
+@import 'breadcrumb';
 @import 'cards';
 @import 'chart';
 @import 'empty-state';

--- a/orga/app/templates/authenticated/campaigns/participant-profile.hbs
+++ b/orga/app/templates/authenticated/campaigns/participant-profile.hbs
@@ -2,7 +2,11 @@
 {{page-title this.pageTitle}}
 
 <article class="profile">
-  <Participant::Profile::Header @campaign={{@model.campaign}} @campaignProfile={{@model.campaignProfile}} />
+  <Participant::Profile::Header
+    @campaign={{@model.campaign}}
+    @campaignProfile={{@model.campaignProfile}}
+    @campaignParticipationId={{@model.campaignParticipationId}}
+  />
 
   <Participant::Profile::Table
     @competences={{@model.campaignProfile.sortedCompetences}}

--- a/orga/tests/acceptance/campaign-activity_test.js
+++ b/orga/tests/acceptance/campaign-activity_test.js
@@ -65,15 +65,6 @@ module('Acceptance | Campaign Activity', function (hooks) {
         assert.strictEqual(currentURL(), '/campagnes/2/profils/1');
       });
     });
-
-    test('it could return on list of participants', async function (assert) {
-      // when
-      await visit('/campagnes/1/evaluations/1');
-      await clickByName('Retour');
-
-      // then
-      assert.strictEqual(currentURL(), '/campagnes/1');
-    });
   });
 
   module('when prescriber reset filters', function () {

--- a/orga/tests/acceptance/campaign-participants-individual-results_test.js
+++ b/orga/tests/acceptance/campaign-participants-individual-results_test.js
@@ -1,14 +1,18 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
+import { currentURL, click } from '@ember/test-helpers';
 import authenticateSession from '../helpers/authenticate-session';
 import { createUserWithMembershipAndTermsOfServiceAccepted, createPrescriberByUser } from '../helpers/test-init';
+import { within } from '@testing-library/dom';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { visit as visitScreen } from '@1024pix/ember-testing-library';
+import { clickByName, visit as visitScreen } from '@1024pix/ember-testing-library';
+import setupIntl from '../helpers/setup-intl';
 
 module('Acceptance | Campaign Participants Individual Results', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   hooks.beforeEach(async () => {
     const user = createUserWithMembershipAndTermsOfServiceAccepted();
@@ -17,6 +21,43 @@ module('Acceptance | Campaign Participants Individual Results', function (hooks)
     server.create('campaign', { id: 1 });
 
     await authenticateSession(user.id);
+  });
+
+  test('it should go to campaigns', async function (assert) {
+    // given
+    const campaignAssessmentParticipationResult = server.create(
+      'campaign-assessment-participation-result',
+      'withCompetenceResults',
+      { id: 1, campaignId: 1 }
+    );
+    server.create('campaign-assessment-participation', { id: 1, campaignId: 1, campaignAssessmentParticipationResult });
+
+    // when
+    await visitScreen('/campagnes/1/evaluations/1');
+    await click(
+      within(document.querySelector('main')).getByRole('link', { name: this.intl.t('navigation.main.campaigns') })
+    );
+
+    // then
+    assert.strictEqual(currentURL(), '/campagnes/les-miennes');
+  });
+
+  test('it should go to CampagneEtPrairie', async function (assert) {
+    // given
+    const campaignAssessmentParticipationResult = server.create(
+      'campaign-assessment-participation-result',
+      'withCompetenceResults',
+      { id: 1, campaignId: 1 }
+    );
+    server.create('campaign-assessment-participation', { id: 1, campaignId: 1, campaignAssessmentParticipationResult });
+    server.create('campaign', { id: 1, name: 'CampagneEtPrairie' });
+
+    // when
+    await visitScreen('/campagnes/1/evaluations/1');
+    await clickByName('CampagneEtPrairie');
+
+    // then
+    assert.strictEqual(currentURL(), '/campagnes/1');
   });
 
   test('[a11y] it should contain accessibility aria-label nav', async function (assert) {

--- a/orga/tests/acceptance/profile_test.js
+++ b/orga/tests/acceptance/profile_test.js
@@ -1,15 +1,18 @@
 import { module, test } from 'qunit';
-import { visit, currentURL } from '@ember/test-helpers';
-import { clickByName } from '@1024pix/ember-testing-library';
+import { visit, currentURL, click } from '@ember/test-helpers';
+import { clickByName, visit as visitScreen } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import authenticateSession from '../helpers/authenticate-session';
 import { createUserWithMembershipAndTermsOfServiceAccepted, createPrescriberByUser } from '../helpers/test-init';
+import { within } from '@testing-library/dom';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import setupIntl from '../helpers/setup-intl';
 
 module('Acceptance | Campaign Profile', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   hooks.beforeEach(async () => {
     const user = createUserWithMembershipAndTermsOfServiceAccepted();
@@ -18,13 +21,29 @@ module('Acceptance | Campaign Profile', function (hooks) {
     await authenticateSession(user.id);
   });
 
-  test('it allows user to return to campaign activity page', async function (assert) {
+  test('it should go to campaigns', async function (assert) {
+    // given
     server.create('campaign', { id: 1 });
     server.create('campaignProfile', { campaignId: 1, campaignParticipationId: 1 });
 
     // when
-    await visit('/campagnes/1/profils/1');
-    await clickByName('Retour');
+    await visitScreen('/campagnes/1/profils/1');
+    await click(
+      within(document.querySelector('main')).getByRole('link', { name: this.intl.t('navigation.main.campaigns') })
+    );
+
+    // then
+    assert.strictEqual(currentURL(), '/campagnes/les-miennes');
+  });
+
+  test('it should go to CampagneEtPrairie', async function (assert) {
+    // given
+    server.create('campaign', { id: 1, name: 'CampagneEtPrairie' });
+    server.create('campaignProfile', { campaignId: 1, campaignParticipationId: 1 });
+
+    // when
+    await visitScreen('/campagnes/1/profils/1');
+    await clickByName('CampagneEtPrairie');
 
     // then
     assert.strictEqual(currentURL(), '/campagnes/1');

--- a/orga/tests/integration/components/ui/breadcrumb_test.js
+++ b/orga/tests/integration/components/ui/breadcrumb_test.js
@@ -1,0 +1,47 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import { render } from '@1024pix/ember-testing-library';
+import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
+
+module('Integration | Component | Ui | Breadcrumb', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  class RoutingStub extends Service {
+    generateURL() {
+      return '/';
+    }
+  }
+
+  hooks.beforeEach(function () {
+    // Stubbing internal routing service of Ember because LinkTo needs it and we don't want to use the application router :/
+    this.owner.register('service:-routing', RoutingStub);
+  });
+
+  test('it should display breadcrumbs with given item', async function (assert) {
+    this.set('links', [
+      {
+        route: 'authenticated.campaigns',
+        label: 'Campagnes',
+      },
+      {
+        route: 'authenticated.campaigns.campaign',
+        label: 'Campagne n°1',
+        model: 1,
+      },
+      {
+        route: 'authenticated.campaigns.participant-assessment',
+        label: 'Participation de Luna Akajoua',
+        models: [1, 4],
+      },
+    ]);
+
+    // when
+    const screen = await render(hbs`<Ui::Breadcrumb @links={{this.links}} />`);
+
+    // then
+    assert.dom(screen.getByRole('link', { name: 'Campagnes', current: false })).exists();
+    assert.dom(screen.getByRole('link', { name: 'Campagne n°1', current: false })).exists();
+    assert.dom(screen.getByRole('link', { name: 'Participation de Luna Akajoua', current: 'page' })).exists();
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -784,6 +784,7 @@
     },
     "profiles-individual-results": {
       "title": "Profile of {firstName} {lastName}",
+      "breadcrumb-current-page-label": "Participation of {firstName} {lastName}",
       "certifiable": "Eligible for certification",
       "competences-certifiables": "COMP. ELIGIBLE FOR CERTIFICATION",
       "pix": "PIX",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -190,7 +190,8 @@
         "percent": "percentage"
       },
       "thematic-results": "Thematic results: {value, number}"
-    }
+    },
+    "breadcrumb": "Breadcrumb"
   },
   "navigation": {
     "credits": {
@@ -722,7 +723,7 @@
         "column": {
           "first-name": "First name",
           "last-name": {
-            "label" : "Last name",
+            "label": "Last name",
             "ariaLabelDefaultSort": "The table is currently not sorted by last name. Click to sort by alphabetical order.",
             "ariaLabelSortUp": "The table is sorted by last name, in alphabetical order. Click to sort by reverse alphabetical order.",
             "ariaLabelSortDown": "The table is sorted by last name, in reverse alphabetical order. Click to sort by alphabetical order."
@@ -930,7 +931,7 @@
             }
           },
           "last-name": {
-            "label" : "Last name",
+            "label": "Last name",
             "ariaLabelDefaultSort": "The table is currently not sorted by last name. Click to sort by alphabetical order.",
             "ariaLabelSortUp": "The table is sorted by last name, in alphabetical order. Click to sort by reverse alphabetical order.",
             "ariaLabelSortDown": "The table is sorted by last name, in reverse alphabetical order. Click to sort by alphabetical order."
@@ -980,7 +981,7 @@
           "first-name": "First name",
           "group": "Groups",
           "last-name": {
-            "label" : "Last name",
+            "label": "Last name",
             "ariaLabelDefaultSort": "The table is currently not sorted by last name. Click to sort by alphabetical order.",
             "ariaLabelSortUp": "The table is sorted by last name, in alphabetical order. Click to sort by reverse alphabetical order.",
             "ariaLabelSortDown": "The table is sorted by last name, in reverse alphabetical order. Click to sort by alphabetical order."

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -233,6 +233,7 @@
   "pages": {
     "assessment-individual-results": {
       "title": "Results of {firstName} {lastName}",
+      "breadcrumb-current-page-label": "Participation of {firstName} {lastName}",
       "badges": "Thematic results",
       "progression": "Progression",
       "result": "Result",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -233,6 +233,7 @@
   "pages": {
     "assessment-individual-results": {
       "title": "Résultats de {firstName} {lastName}",
+      "breadcrumb-current-page-label": "Participation de {firstName} {lastName}",
       "badges": "Résultats Thématiques",
       "progression": "Avancement",
       "result": "Résultat",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -190,7 +190,8 @@
       },
       "subjects": "Sujets : {value, number}",
       "thematic-results": "Résultats thématiques : {value, number}"
-    }
+    },
+    "breadcrumb": "Fil d'ariane"
   },
   "navigation": {
     "credits": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -784,6 +784,7 @@
     },
     "profiles-individual-results": {
       "title": "Profil de {firstName} {lastName}",
+      "breadcrumb-current-page-label": "Participation de {firstName} {lastName}",
       "certifiable": "Certifiable",
       "competences-certifiables": "COMP. CERTIFIABLES",
       "pix": "PIX",


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la consolidation de l’activité du prescrit, nous avons créé [une nouvelle page détaillant l’activité d’un prescrit](https://1024pix.atlassian.net/browse/PIX-6062). Cette page inclut un tableau qui liste les participations du prescrit.
Nous allons rendre chacune de ces participations cliquable, pour permettre au prescripteur de consulter facilement et rapidement le détail de cette participation en renvoyant sur la page dédiée : campagnes > campagne X > participation de X (https://orga.pix.fr/campagnes/campaignId/evaluations/participationId/resultats )

Comme il y aura plusieurs accès possible à cette page, l'utilisateur risque d'être perdu et de ne pas savoir où il se trouve dans l'application.

## :robot: Proposition
il faut expliciter l’arborescence de Pix Orga pour que le user sache s’il veut revenir en arrière via son device/navigateur ou en arrière dans la campagne via le fil d’Arianne.

## :100: Pour tester
Accéder au détail d'une participation de campagne (collecte de profil et évaluation) : 
- Le bouton de retour sur la campagne, et son nom, ne sont plus affichés.
- Le fil d'Ariane est affiché en haut à gauche de la page. Il indique : Campagnes > <nom de la campagne> Participation de <Prénom et nom du participant>
- Les liens permettent bien d'accéder aux pages Campagnes, Détail de la campagne et Détail de la participation.
- Concernant l'accessibilité, le fil d'Ariane est renseigné comme un composant de navigation nommé "Fil d'Ariane" (et "Breadcrumb" en anglais) et l'élément courant est identifié (aria-current="page"). 