### PR TITLE
[FEATURE] Ne pas afficher les boutons d'import en masses des sessions pour les anglophones sur Pix Certif (PIX-7348).

### DIFF
--- a/certif/app/components/no-session-panel.js
+++ b/certif/app/components/no-session-panel.js
@@ -4,12 +4,22 @@ import { inject as service } from '@ember/service';
 export default class PanelHeader extends Component {
   @service featureToggles;
   @service currentUser;
+  @service currentDomain;
+  @service intl;
 
   get isScoManagingStudents() {
     return this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents;
   }
 
   get shouldRenderImportTemplateButton() {
-    return this.featureToggles.featureToggles.isMassiveSessionManagementEnabled && !this.isScoManagingStudents;
+    const topLevelDomain = this.currentDomain.getExtension();
+    const currentLanguage = this.intl.t('current-lang');
+    const isOrgTldAndEnglishCurrentLanguage = topLevelDomain === 'org' && currentLanguage === 'en';
+
+    return (
+      this.featureToggles.featureToggles.isMassiveSessionManagementEnabled &&
+      !this.isScoManagingStudents &&
+      !isOrgTldAndEnglishCurrentLanguage
+    );
   }
 }

--- a/certif/app/components/sessions/panel-header.js
+++ b/certif/app/components/sessions/panel-header.js
@@ -4,11 +4,18 @@ import { inject as service } from '@ember/service';
 export default class PanelHeader extends Component {
   @service featureToggles;
   @service currentUser;
+  @service currentDomain;
+  @service intl;
 
   get shouldRenderImportTemplateButton() {
+    const topLevelDomain = this.currentDomain.getExtension();
+    const currentLanguage = this.intl.t('current-lang');
+    const isOrgTldAndEnglishCurrentLanguage = topLevelDomain === 'org' && currentLanguage === 'en';
+
     return (
       this.featureToggles.featureToggles.isMassiveSessionManagementEnabled &&
-      !this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents
+      !this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents &&
+      !isOrgTldAndEnglishCurrentLanguage
     );
   }
 }

--- a/certif/app/routes/authenticated/sessions/import.js
+++ b/certif/app/routes/authenticated/sessions/import.js
@@ -5,13 +5,20 @@ export default class ImportRoute extends Route {
   @service featureToggles;
   @service router;
   @service currentUser;
+  @service currentDomain;
+  @service intl;
 
   beforeModel() {
     const { isMassiveSessionManagementEnabled } = this.featureToggles.featureToggles;
 
+    const topLevelDomain = this.currentDomain.getExtension();
+    const currentLanguage = this.intl.t('current-lang');
+    const isOrgTldAndEnglishCurrentLanguage = topLevelDomain === 'org' && currentLanguage === 'en';
+
     if (
       !isMassiveSessionManagementEnabled ||
-      this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents
+      this.currentUser.currentAllowedCertificationCenterAccess.isScoManagingStudents ||
+      isOrgTldAndEnglishCurrentLanguage
     ) {
       return this.router.replaceWith('authenticated.sessions.list');
     }

--- a/certif/tests/unit/components/no-session-panel_test.js
+++ b/certif/tests/unit/components/no-session-panel_test.js
@@ -1,0 +1,123 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import sinon from 'sinon';
+
+module('Unit | Component | no-session-panel', function (hooks) {
+  setupTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('component:no-session-panel');
+  });
+
+  module('#shouldRenderImportTemplateButton', function () {
+    module('when top level domain is org', function () {
+      module('when current language is french', function () {
+        test('should render import template button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+            type: 'SUP',
+            isRelatedToManagingStudentsOrganization: false,
+          });
+
+          class CurrentUserStub extends Service {
+            currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+          }
+          class FeatureTogglesStub extends Service {
+            featureToggles = { isMassiveSessionManagementEnabled: sinon.stub().returns(true) };
+          }
+          class CurrentDomainStub extends Service {
+            getExtension = sinon.stub().returns('org');
+          }
+          class IntlStub extends Service {
+            t = sinon.stub().returns('fr');
+          }
+
+          this.owner.register('service:current-domain', CurrentDomainStub);
+          this.owner.register('service:featureToggles', FeatureTogglesStub);
+          this.owner.register('service:current-user', CurrentUserStub);
+          this.owner.register('service:intl', IntlStub);
+
+          // when
+          const isRenderImportTemplateButton = component.shouldRenderImportTemplateButton;
+
+          // then
+          assert.true(isRenderImportTemplateButton);
+        });
+      });
+      module('when current language is english', function () {
+        test('should not render import template button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+            type: 'SUP',
+            isRelatedToManagingStudentsOrganization: false,
+          });
+
+          class CurrentUserStub extends Service {
+            currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+          }
+          class FeatureTogglesStub extends Service {
+            featureToggles = { isMassiveSessionManagementEnabled: sinon.stub().returns(true) };
+          }
+          class CurrentDomainStub extends Service {
+            getExtension = sinon.stub().returns('org');
+          }
+          class IntlStub extends Service {
+            t = sinon.stub().returns('en');
+          }
+
+          this.owner.register('service:current-domain', CurrentDomainStub);
+          this.owner.register('service:featureToggles', FeatureTogglesStub);
+          this.owner.register('service:current-user', CurrentUserStub);
+          this.owner.register('service:intl', IntlStub);
+
+          // when
+          const isRenderImportTemplateButton = component.shouldRenderImportTemplateButton;
+
+          // then
+          assert.false(isRenderImportTemplateButton);
+        });
+      });
+    });
+
+    module('when top level domain is fr', function () {
+      test('should render import template button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+          type: 'SUP',
+          isRelatedToManagingStudentsOrganization: false,
+        });
+
+        class CurrentUserStub extends Service {
+          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+        }
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isMassiveSessionManagementEnabled: sinon.stub().returns(true) };
+        }
+        class CurrentDomainStub extends Service {
+          getExtension = sinon.stub().returns('fr');
+        }
+        class IntlStub extends Service {
+          t = sinon.stub().returns('fr');
+        }
+
+        this.owner.register('service:current-domain', CurrentDomainStub);
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+        this.owner.register('service:current-user', CurrentUserStub);
+        this.owner.register('service:intl', IntlStub);
+
+        // when
+        const isRenderImportTemplateButton = component.shouldRenderImportTemplateButton;
+
+        // then
+        assert.true(isRenderImportTemplateButton);
+      });
+    });
+  });
+});

--- a/certif/tests/unit/components/sessions/panel-header_test.js
+++ b/certif/tests/unit/components/sessions/panel-header_test.js
@@ -1,0 +1,123 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+import sinon from 'sinon';
+
+module('Unit | Component | sessions | panel-header', function (hooks) {
+  setupTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function () {
+    component = createGlimmerComponent('component:sessions/panel-header');
+  });
+
+  module('#shouldRenderImportTemplateButton', function () {
+    module('when top level domain is org', function () {
+      module('when current language is french', function () {
+        test('should render import template button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+            type: 'SUP',
+            isRelatedToManagingStudentsOrganization: false,
+          });
+
+          class CurrentUserStub extends Service {
+            currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+          }
+          class FeatureTogglesStub extends Service {
+            featureToggles = { isMassiveSessionManagementEnabled: sinon.stub().returns(true) };
+          }
+          class CurrentDomainStub extends Service {
+            getExtension = sinon.stub().returns('org');
+          }
+          class IntlStub extends Service {
+            t = sinon.stub().returns('fr');
+          }
+
+          this.owner.register('service:current-domain', CurrentDomainStub);
+          this.owner.register('service:featureToggles', FeatureTogglesStub);
+          this.owner.register('service:current-user', CurrentUserStub);
+          this.owner.register('service:intl', IntlStub);
+
+          // when
+          const isRenderImportTemplateButton = component.shouldRenderImportTemplateButton;
+
+          // then
+          assert.true(isRenderImportTemplateButton);
+        });
+      });
+      module('when current language is english', function () {
+        test('should not render import template button', async function (assert) {
+          // given
+          const store = this.owner.lookup('service:store');
+          const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+            type: 'SUP',
+            isRelatedToManagingStudentsOrganization: false,
+          });
+
+          class CurrentUserStub extends Service {
+            currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+          }
+          class FeatureTogglesStub extends Service {
+            featureToggles = { isMassiveSessionManagementEnabled: sinon.stub().returns(true) };
+          }
+          class CurrentDomainStub extends Service {
+            getExtension = sinon.stub().returns('org');
+          }
+          class IntlStub extends Service {
+            t = sinon.stub().returns('en');
+          }
+
+          this.owner.register('service:current-domain', CurrentDomainStub);
+          this.owner.register('service:featureToggles', FeatureTogglesStub);
+          this.owner.register('service:current-user', CurrentUserStub);
+          this.owner.register('service:intl', IntlStub);
+
+          // when
+          const isRenderImportTemplateButton = component.shouldRenderImportTemplateButton;
+
+          // then
+          assert.false(isRenderImportTemplateButton);
+        });
+      });
+    });
+
+    module('when top level domain is fr', function () {
+      test('should render import template button', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+          type: 'SUP',
+          isRelatedToManagingStudentsOrganization: false,
+        });
+
+        class CurrentUserStub extends Service {
+          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+        }
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isMassiveSessionManagementEnabled: sinon.stub().returns(true) };
+        }
+        class CurrentDomainStub extends Service {
+          getExtension = sinon.stub().returns('fr');
+        }
+        class IntlStub extends Service {
+          t = sinon.stub().returns('fr');
+        }
+
+        this.owner.register('service:current-domain', CurrentDomainStub);
+        this.owner.register('service:featureToggles', FeatureTogglesStub);
+        this.owner.register('service:current-user', CurrentUserStub);
+        this.owner.register('service:intl', IntlStub);
+
+        // when
+        const isRenderImportTemplateButton = component.shouldRenderImportTemplateButton;
+
+        // then
+        assert.true(isRenderImportTemplateButton);
+      });
+    });
+  });
+});

--- a/certif/tests/unit/routes/authenticated/sessions/import_test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/import_test.js
@@ -1,0 +1,130 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import Service from '@ember/service';
+
+module('Unit | Route | authenticated/sessions/import', function (hooks) {
+  setupTest(hooks);
+
+  module('when top level domain is org', function () {
+    module('when current language is french', function () {
+      test('it should not redirect to sessions list page', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+          type: 'SUP',
+          isRelatedToManagingStudentsOrganization: false,
+        });
+
+        class CurrentUserStub extends Service {
+          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+        }
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isMassiveSessionManagementEnabled: sinon.stub().returns(true) };
+        }
+        class CurrentDomainStub extends Service {
+          getExtension = sinon.stub().returns('org');
+        }
+        class IntlStub extends Service {
+          t = sinon.stub().returns('fr');
+        }
+        class RouterStub extends Service {
+          replaceWith = sinon.stub().resolves();
+        }
+
+        this.owner.register('service:router', RouterStub);
+        this.owner.register('service:feature-toggles', FeatureTogglesStub);
+        this.owner.register('service:current-domain', CurrentDomainStub);
+        this.owner.register('service:intl', IntlStub);
+        this.owner.register('service:current-user', CurrentUserStub);
+        const route = this.owner.lookup('route:authenticated/sessions/import');
+
+        // when
+        route.beforeModel();
+
+        // then
+        assert.notOk(route.router.replaceWith.calledWith('authenticated.sessions.list'));
+      });
+    });
+
+    module('when current language is english', function () {
+      test('it should redirect to sessions list page', async function (assert) {
+        // given
+        const store = this.owner.lookup('service:store');
+        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+          type: 'SUP',
+          isRelatedToManagingStudentsOrganization: false,
+        });
+
+        class CurrentUserStub extends Service {
+          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+        }
+        class FeatureTogglesStub extends Service {
+          featureToggles = { isMassiveSessionManagementEnabled: sinon.stub().returns(true) };
+        }
+        class CurrentDomainStub extends Service {
+          getExtension = sinon.stub().returns('org');
+        }
+        class IntlStub extends Service {
+          t = sinon.stub().returns('en');
+        }
+        class RouterStub extends Service {
+          replaceWith = sinon.stub().resolves();
+        }
+
+        this.owner.register('service:router', RouterStub);
+        this.owner.register('service:feature-toggles', FeatureTogglesStub);
+        this.owner.register('service:current-domain', CurrentDomainStub);
+        this.owner.register('service:intl', IntlStub);
+        this.owner.register('service:current-user', CurrentUserStub);
+        const route = this.owner.lookup('route:authenticated/sessions/import');
+
+        // when
+        route.beforeModel();
+
+        // then
+        assert.ok(route.router.replaceWith.calledWith('authenticated.sessions.list'));
+      });
+    });
+  });
+
+  module('when top level domain is fr', function () {
+    test('it should not redirect to sessions list page', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+        type: 'SUP',
+        isRelatedToManagingStudentsOrganization: false,
+      });
+
+      class CurrentUserStub extends Service {
+        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+      }
+      class FeatureTogglesStub extends Service {
+        featureToggles = { isMassiveSessionManagementEnabled: sinon.stub().returns(true) };
+      }
+      class CurrentDomainStub extends Service {
+        getExtension = sinon.stub().returns('fr');
+      }
+      class IntlStub extends Service {
+        t = sinon.stub().returns('fr');
+      }
+      class RouterStub extends Service {
+        replaceWith = sinon.stub().resolves();
+      }
+
+      this.owner.register('service:router', RouterStub);
+      this.owner.register('service:feature-toggles', FeatureTogglesStub);
+      this.owner.register('service:current-domain', CurrentDomainStub);
+      this.owner.register('service:intl', IntlStub);
+      this.owner.register('service:current-user', CurrentUserStub);
+      const route = this.owner.lookup('route:authenticated/sessions/import');
+
+      // when
+      route.beforeModel();
+
+      // then
+      assert.notOk(route.router.replaceWith.calledWith('authenticated.sessions.list'));
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Actuellement l'import en masse des sessions est disponible seulement sous feature toggle, en domaine fr comme en org. 

Or cette fonctionnalité complexe n’a pas encore été déployée ni testée par les utilisateurs francophones habitués à Pix Certif.
Les utilisateurs anglophones n’auront pas besoin de cette fonctionnalité dès le début de leur utilisation de Pix Certif.

## :robot: Proposition
Empêcher l'accès à la fonctionnalité aux utilisateurs de Pix Certif en domaine org/en.

## :100: Pour tester

- Se connecter sur Pix Certif en domaine FR (et avec le feature toggle actif)
- Constater que les boutons pour créer plusieurs sessions sont visibles
  - Bouton visible lorsqu'il n'y a aucune session dans la liste
  - Autre bouton en haut à droite quand il y a des sessions
- Se déconnecter pour passer en domaine ORG / fr
- Constater que les boutons pour créer plusieurs sessions sont visibles
- Passer `?lang=en` dans l'url
- Constater que les boutons ne sont plus visibles
- Tenter un /sessions/import dans l'url et s'assurer que ça ne mène pas à la page.