### PR TITLE
[BUGFIX] Convertir le temps majoré en decimal lors de l'import des sessions en masse sur Pix Certif (PIX-7351)

### DIFF
--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -222,6 +222,10 @@ class CertificationCandidate {
   isBillingModePrepaid() {
     return this.billingMode === CertificationCandidate.BILLING_MODES.PREPAID;
   }
+
+  convertExtraTimePercentageToDecimal() {
+    this.extraTimePercentage = this.extraTimePercentage / 100;
+  }
 }
 
 CertificationCandidate.BILLING_MODES = BILLING_MODES;

--- a/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
+++ b/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
@@ -48,6 +48,12 @@ module.exports = {
   }) {
     const certificationCandidateErrors = [];
 
+    if (_isExtraTimePercentageBelowOne(candidate.extraTimePercentage)) {
+      certificationCandidateErrors.push('Temps majoré doit être supérieur à 1');
+    } else {
+      candidate.convertExtraTimePercentageToDecimal();
+    }
+
     const validationErrors = candidate.validateForMassSessionImport(isSco);
     if (validationErrors) {
       certificationCandidateErrors.push(...validationErrors);
@@ -77,6 +83,10 @@ module.exports = {
     };
   },
 };
+
+function _isExtraTimePercentageBelowOne(extraTimePercentage) {
+  return extraTimePercentage && extraTimePercentage < 1;
+}
 
 function _hasSessionInfo(session) {
   return session.address || session.room || session.date || session.time || session.examiner;

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -163,7 +163,7 @@ function _getDataFromColumnNames({ csvLineKeys, headers, line }) {
         outputFormat: 'YYYY-MM-DD',
       });
     } else if (key === 'extraTimePercentage') {
-      data[key] = headerKeyInCurrentLine !== '' ? parseInt(headerKeyInCurrentLine) : null;
+      data[key] = headerKeyInCurrentLine !== '' ? headerKeyInCurrentLine : null;
     } else if (key === 'prepaymentCode') {
       data[key] = headerKeyInCurrentLine !== '' ? headerKeyInCurrentLine : null;
     } else {

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -984,4 +984,19 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       expect(certificationCandidate.isGranted('PIX+')).to.be.false;
     });
   });
+
+  describe('convertExtraTimePercentageToDecimal', function () {
+    it('should convert extraTimePercentageToDecimal integer to decimal', function () {
+      // given
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({
+        extraTimePercentage: 20,
+      });
+
+      // when
+      certificationCandidate.convertExtraTimePercentageToDecimal();
+
+      // when / then
+      expect(certificationCandidate.extraTimePercentage).to.equal(0.2);
+    });
+  });
 });

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -278,6 +278,25 @@ describe('Unit | Service | sessions import validation Service', function () {
       });
     });
 
+    context('when candidate has extra time percentage below 1', function () {
+      it('should return a certificationCandidateErrors containing the specific error ', async function () {
+        // given
+        const candidate = _buildValidCandidateData();
+        candidate.extraTimePercentage = '0.20';
+
+        certificationCpfService.getBirthInformation.resolves(CpfBirthInformationValidation.success({}));
+
+        // when
+        const { certificationCandidateErrors } =
+          await sessionsImportValidationService.getValidatedCandidateBirthInformation({
+            candidate,
+          });
+
+        // then
+        expect(certificationCandidateErrors).to.deep.equal(['Temps majoré doit être supérieur à 1']);
+      });
+    });
+
     context('when candidate has missing billing information', function () {
       context('when the parsed candidate is not sco', function () {
         it('should return an certificationCandidateErrors containing billing mode errors', async function () {

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -84,6 +84,8 @@ export default class ImportController extends Controller {
     }
     if (this.errorsReport?.length > 0) {
       this.isImportInError = true;
+    } else {
+      this.isImportInError = false;
     }
     this.isImportStepOne = false;
     this.removeImport();


### PR DESCRIPTION
## :unicorn: Problème
Lors de l’import en masse de plusieurs sessions, le template d’import a été complété avec plusieurs sessions dont une avec un candidat bénéficiant d’un temps majoré.

Le temps majoré a été rempli selon le même format de pourcentage que sur l’ods utilisé pour importer une liste de candidat dans une session déjà créée, soit avec 33%.

L’import échoue avec une erreur 400.


## :robot: Proposition
Convertir le temps majoré côté back dès la déserialisation du csv 33% => 0.33

## :100: Pour tester

- Dans pix-certif:
  - Creer des sessions en masse via le csv suivant et constater que l'import réussi

```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
,Site 1,Salle 1,01/04/2023,14:00,surveillant 1,,toto,tata,01/01/2000,M,75115,,,FRANCE,,,,33%,Gratuite,,,
```

   - Creer des sessions en masse via le csv suivant et constater l'erreur de formateur de temps majoré ressort dans l'étape de validation

```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
,Site 1,Salle 1,01/04/2023,14:00,surveillant 1,,toto,tata,01/01/2000,M,75115,,,FRANCE,,,,0.33,Gratuite,,,
```