### PR TITLE
[BUGFIX] Améliorer l'affichage des adresses emails des membres des Centres de Certification dans Pix Admin (PIX-7135)

### DIFF
--- a/admin/app/components/certification-centers/memberships-section.hbs
+++ b/admin/app/components/certification-centers/memberships-section.hbs
@@ -35,9 +35,9 @@
                     {{certificationCenterMembership.user.id}}
                   </LinkTo>
                 </td>
-                <td>{{certificationCenterMembership.user.firstName}}</td>
-                <td>{{certificationCenterMembership.user.lastName}}</td>
-                <td>{{certificationCenterMembership.user.email}}</td>
+                <td class="member-information">{{certificationCenterMembership.user.firstName}}</td>
+                <td class="member-information">{{certificationCenterMembership.user.lastName}}</td>
+                <td class="member-information">{{certificationCenterMembership.user.email}}</td>
                 <td>
                   {{dayjs-format certificationCenterMembership.createdAt "DD-MM-YYYY - HH:mm:ss"}}
                 </td>

--- a/admin/app/styles/components/member-item.scss
+++ b/admin/app/styles/components/member-item.scss
@@ -32,3 +32,7 @@
 .pix-select-in-table {
   max-width: 100%;
 }
+
+.member-information {
+  overflow-wrap: break-word;
+}


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, dans Pix Admin, les adresses email des membres des Centres de Certification chevauchent la colonne suivante lorsqu'elles sont longues. Ce qui rend la lecture illisible. 
<img width="1396" alt="Capture d’écran 2023-03-06 à 16 14 34" src="https://user-images.githubusercontent.com/82950611/223160115-753c7e61-0e9d-4277-821b-6e30387fe059.png">


## :robot: Proposition
Faire en sorte que les adresses emails trop longues s'affichent sur plusieurs lignes.
<img width="1392" alt="Capture d’écran 2023-03-06 à 16 31 24" src="https://user-images.githubusercontent.com/82950611/223160736-1234a03b-98c5-4f6a-abcb-aa86728a4b38.png">


## :rainbow: Remarques
Ajout de la nouvelle classe sur les colonnes `Nom` et `Prénom` pour prévenir un cas similaire.

## :100: Pour tester

1. Ajouter un utilisateur avec une longue adresse email en BDD et l'ajouter à un centre de certification
2. Se connecter à Pix Admin en locale
3. Se rendre sur la page du centre de certification dans lequel le nouvel utilisateur a été ajouté
4. Vérifier que l'affichage de l'adresse email ne chevauche pas la colonne suivante


