### PR TITLE
[BUGFIX] Rendre visible le lien du numéro de session sur Pix Admin (PIX-7133).

### DIFF
--- a/admin/app/components/certifications/info-field.hbs
+++ b/admin/app/components/certifications/info-field.hbs
@@ -14,7 +14,7 @@
   {{else}}
     <p>{{@label}}</p>
     {{#if @linkRoute}}
-      <LinkTo @route={{@linkRoute}} @model={{@value}}>
+      <LinkTo @route={{@linkRoute}} @model={{@value}} class="certification-info-field__link">
         {{this.valueWithSuffix}}
       </LinkTo>
     {{else}}

--- a/admin/app/styles/authenticated/certifications/certification/informations.scss
+++ b/admin/app/styles/authenticated/certifications/certification/informations.scss
@@ -19,11 +19,6 @@
     &:last-child {
       margin: 0;
     }
-
-    a:hover {
-      color: $pix-neutral-0;
-      text-decoration: none;
-    }
   }
 
   &__card {
@@ -40,12 +35,12 @@
       padding-bottom: 0.5em;
       flex-wrap: wrap;
       border-bottom: 1px solid $pix-neutral-20;
-      
-    
+
+
       &:last-of-type {
         border-bottom: none;
       }
-    
+
       :first-child:not(button) {
         font-weight: bold;
         min-width: 16em;

--- a/admin/app/styles/components/certification-info-field.scss
+++ b/admin/app/styles/components/certification-info-field.scss
@@ -26,4 +26,12 @@
   &__suffix {
     margin-left: 10px;
   }
+
+  &__link {
+    color: $pix-primary;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 }

--- a/admin/app/styles/components/certification-issue-report.scss
+++ b/admin/app/styles/components/certification-issue-report.scss
@@ -29,7 +29,7 @@
     &__resolution-message {
       font-family: $font-roboto;
       font-weight: $font-light;
-      color: $pix-neutral-30;
+      color: $pix-neutral-50;
     }
   }
 }

--- a/admin/app/styles/components/certification-issue-reports.scss
+++ b/admin/app/styles/components/certification-issue-reports.scss
@@ -14,7 +14,7 @@
 
     &--with-action-required {
       background-color: $pix-warning-10;
-      color: $pix-secondary-60;
+      color: $pix-secondary-70;
     }
 
     &--without-action-required {

--- a/admin/app/templates/authenticated/certifications.hbs
+++ b/admin/app/templates/authenticated/certifications.hbs
@@ -5,7 +5,12 @@
     <h1 class="page-title"> Certifications </h1>
     <div class="page-actions">
       <form class="form-inline" {{on "submit" this.loadCertification}}>
-        <Input placeholder="Identifiant" @type="text" @value={{this.inputId}} />
+        <Input
+          placeholder="Identifiant"
+          aria-label="Rechercher une session avec un identifiant"
+          @type="text"
+          @value={{this.inputId}}
+        />
         <PixButton @size="small" @type="submit">Charger</PixButton>
       </form>
     </div>

--- a/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/informations_test.js
@@ -42,6 +42,18 @@ module('Acceptance | Route | routes/authenticated/certifications/certification |
     });
   });
 
+  test('it displays header information', async function (assert) {
+    // given
+    await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+
+    // when
+    const screen = await visit(`/certifications/${certification.id}`);
+
+    // then
+    assert.dom(screen.getByRole('heading', { name: 'Certifications' })).exists();
+    assert.dom(screen.getByRole('textbox', { name: 'Rechercher une session avec un identifiant' })).exists();
+  });
+
   module('certification information read', function () {
     test('it displays candidate information', async function (assert) {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Suite à la montée en version Pix UI, l’affichage de certains liens a été modifié.

Sur la page d'infos d’une certification, un lien de numéro de session est également a été impacté et s'affiche en blanc lorsque qu'on passe en hover dessus.

## :robot: Proposition
Rendre de nouveau visible ce lien.

## :rainbow: Remarques
Des améliorations d'accessibilité ont été apportés : 
- Ajout d'un aria-label pour un champ qui ne possédait pas de label
- Amélioration des contrastes insuffisants 

## :100: Pour tester

- Se connecter sur Pix Admin avec superadmin@example.net
- Cliquer sur le bouton Certification du menu à gauche
- Entrer un identifiant de certification valide 106652
- Constater que le bouton est bleu et souligné en hover
<img width="288" alt="Capture d’écran 2023-03-07 à 09 57 48" src="https://user-images.githubusercontent.com/58915422/223375055-e9b099f6-d077-40be-8b7b-3e4e9bd4d759.png">
- Lancer Wave et constater que la page n'a pas d'erreur (le menu n'a pas été traité dans cette PR)
