### PR TITLE
[FEATURE][ADMIN] Obtenir la liste des utilisateurs triés par le prénom, nom et id lors d'une recherche (PIX-7136)

### DIFF
--- a/api/db/seeds/data/users-builder.js
+++ b/api/db/seeds/data/users-builder.js
@@ -203,6 +203,31 @@ function usersBuilder({ databaseBuilder }) {
     lastTermsOfServiceValidatedAt: null,
   };
   databaseBuilder.factory.buildUser.withRawPassword(userWithLastTermsOfServiceNotValidated);
+
+  databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Alex',
+    lastName: 'Térieur',
+    email: 'alex.terieur@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+  });
+  databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Alain',
+    lastName: 'Térieur',
+    email: 'alain.terieur2@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+  });
+  databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Alain',
+    lastName: 'Térieur',
+    email: 'alain.terieur1@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+  });
+  databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Hin',
+    lastName: 'Térieur',
+    email: 'hin.terieur@example.net',
+    rawPassword: DEFAULT_PASSWORD,
+  });
 }
 
 module.exports = {

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -129,7 +129,9 @@ module.exports = {
   },
 
   async findPaginatedFiltered({ filter, page }) {
-    const query = knex('users').where((qb) => _setSearchFiltersForQueryBuilder(filter, qb));
+    const query = knex('users')
+      .where((qb) => _setSearchFiltersForQueryBuilder(filter, qb))
+      .orderBy([{ column: 'firstName', order: 'asc' }, { column: 'lastName', order: 'asc' }, { column: 'id' }]);
     const { results, pagination } = await fetchPage(query, page);
 
     const users = results.map((userDTO) => new User(userDTO));

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -164,6 +164,50 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
           expect(matchingUsers[0]).to.be.an.instanceOf(User);
           expect(pagination).to.deep.equal(expectedPagination);
         });
+
+        it('returns an array of users sorted by first name, last name and id', async function () {
+          // Given
+          const filter = {};
+          const page = { number: 1, size: 10 };
+
+          const alexTerieur = databaseBuilder.factory.buildUser({ firstName: 'Alex', lastName: 'Térieur' });
+          const alainTerieur2 = databaseBuilder.factory.buildUser({
+            id: 300302,
+            firstName: 'Alain',
+            lastName: 'Térieur',
+          });
+          const alainTerieur1 = databaseBuilder.factory.buildUser({
+            id: 300301,
+            firstName: 'Alain',
+            lastName: 'Térieur',
+          });
+          const justinPtipeu = databaseBuilder.factory.buildUser({ firstName: 'Justin', lastName: 'Ptipeu' });
+          await databaseBuilder.commit();
+
+          // when
+          const { models: matchingUsers, pagination } = await userRepository.findPaginatedFiltered({ filter, page });
+
+          // then
+          const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 4 };
+
+          expect(matchingUsers).to.exist;
+          expect(matchingUsers).to.have.lengthOf(4);
+          expect(matchingUsers[0].id).to.equal(alainTerieur1.id);
+          expect(`${matchingUsers[0].firstName} ${matchingUsers[0].lastName}`).to.equal(
+            `${alainTerieur1.firstName} ${alainTerieur1.lastName}`
+          );
+          expect(matchingUsers[1].id).to.equal(alainTerieur2.id);
+          expect(`${matchingUsers[1].firstName} ${matchingUsers[1].lastName}`).to.equal(
+            `${alainTerieur2.firstName} ${alainTerieur2.lastName}`
+          );
+          expect(`${matchingUsers[2].firstName} ${matchingUsers[2].lastName}`).to.equal(
+            `${alexTerieur.firstName} ${alexTerieur.lastName}`
+          );
+          expect(`${matchingUsers[3].firstName} ${matchingUsers[3].lastName}`).to.equal(
+            `${justinPtipeu.firstName} ${justinPtipeu.lastName}`
+          );
+          expect(pagination).to.deep.equal(expectedPagination);
+        });
       });
 
       context('when there are lots of users (> 10) in the database', function () {


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, après une recherche, la liste des résultats n'est pas triée. Il n'existe aucun moyen via l'interface de définir une option de tri.

## :robot: Proposition

Par défaut, faire le tri de manière alphabétique sur le prénom et le nom de l'utilisateur, ainsi que l'ID technique lors de la requête à la base de données. Ajouter le tri sur l'ID technique permet de savoir dans quel ordre les comptes ont été créés.

## :rainbow: Remarques

Dans une version suivante, nous permettrons à l'utilisateur de modifier ce comportement par défaut.

## :100: Pour tester

- Se connecter sur Pix Admin avec le compte `superadmin`
- Aller sur l'onglet `Utilisateurs`
- Faites une recherche sur le nom `Térieur`
- Constater une liste de 3 utilisateurs triée par le prénom et ID
- Nettoyer l'état de la recherche en cliquant sur le bouton X en haut à droite
- Faites une nouvelle recherche sur le prénom `FirstName`
- Constater une liste d'utilisateurs triée par prénom et nom et ID
