### PR TITLE
[TECH] Ajouter un champ "locale" dans la table "users" (PIX-6905)

### DIFF
--- a/api/db/migrations/20230307144120_add-locale-column-to-users-table.js
+++ b/api/db/migrations/20230307144120_add-locale-column-to-users-table.js
@@ -1,0 +1,18 @@
+const TABLE_NAME = 'users';
+const COLUMN_NAME = 'locale';
+
+exports.up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.string(COLUMN_NAME).defaultTo(null);
+  });
+
+  return knex.raw(
+    `ALTER TABLE "users" ADD CONSTRAINT "users_locale_check" CHECK ( "locale" IN ('fr', 'en', 'fr-FR', 'fr-BE') )`
+  );
+};
+
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn(COLUMN_NAME);
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, il est impossible d'enregistrer une locale (par exemple `fr-BE`, `fr`, etc.) comme préférence pour un utilisateur.

## :robot: Proposition

* Ajouter un script de migration pour ajouter un nouveau champ `locale` dans la table `users`.
* Mettre une contrainte sur ce champ `locale` autorisant uniquement certaines valeurs de locales.

  Les seules valeurs de locales autorisées sont les valeurs qui correspondent aux locales actuellement disponibles dans Pix. De plus ces valeurs doivent être au _format canonique BCP 47_ tel que décrit dans l’[ADR _Logique et stratégie de gestion des paramètres régionaux et des langues (locales & languages)_](https://github.com/1024pix/pix/blob/dev/docs/adr/0040-locales-languages.md). Ainsi il faudra donc mettre à jour le schéma de la BDD à  chaque ajout de nouvelle traduction. Cette contrainte est la garantie qu'aucune valeur non supportée ou dans un format différent (par exemple différence de casse) n'arrivera jamais en BDD. Le code des applications pourra donc être le plus simple possible.

## :rainbow: Remarques

RAS

## :100: Pour tester

⚠️ Test à faire en local

- Exécuter une migration via la commande `npm run db:migrate`
- Constater que la migration s'est bien passée
- Constater en base de données qu'une nouvelle colonne `locale` est présente
- Constater avec des requêtes SQL qu'on peut bien positionner pour la locale d'un utilisateur les valeurs suivantes :
   * `fr`
   * `en`
   * `fr-FR`
   * `fr-BE`
- Constater avec des requêtes SQL qu'on ne peut pas positionner pour la locale d'un utilisateur d'autres valeurs que les valeurs `fr`, `en`, `fr-FR`, `fr-BE`. Constater donc par exemple qu'on ne peut pas positionner des valeurs comme :
   * `fr-fr`
   * `fr-be`
  * `en-us`
  * `en-gb`
  * `en-GB`
- Exécuter un rollback de la migration via la commande `npm run db:rollback:latest`
- Constater que le rollback de la migration s'est bien passé
- Constater en base de données que la colonne `locale` n'est plus présente