### PR TITLE
[FEATURE] Ajout de l'en-tête d'information avec certificabilité pour Orga Sco (PIX-7284)

### DIFF
--- a/orga/app/components/sco-organization-participant/list.hbs
+++ b/orga/app/components/sco-organization-participant/list.hbs
@@ -135,7 +135,7 @@
             <td class="ellipsis">{{student.division}}</td>
             <td class="sco-organization-participant-list-page__authentication-methods">
               {{#each student.authenticationMethods as |authenticationMethod|}}
-                <p>{{t authenticationMethod}}</p>
+                <p>{{t (get this.connectionTypes authenticationMethod)}}</p>
               {{/each}}
             </td>
             <td class="table__column--center">{{student.participationCount}}</td>

--- a/orga/app/components/sco-organization-participant/list.js
+++ b/orga/app/components/sco-organization-participant/list.js
@@ -2,7 +2,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { CONNECTION_TYPES } from '../../models/sco-organization-participant';
+import { CONNECTION_TYPES } from '../../helpers/connection-types';
 export default class ScoList extends Component {
   @service currentUser;
   @service intl;
@@ -24,6 +24,10 @@ export default class ScoList extends Component {
       label: name,
       value: name,
     }));
+  }
+
+  get connectionTypes() {
+    return CONNECTION_TYPES;
   }
 
   get connectionTypesOptions() {

--- a/orga/app/components/ui/learner-header-info.hbs
+++ b/orga/app/components/ui/learner-header-info.hbs
@@ -17,7 +17,7 @@
         {{@groupName}}
       </:title>
       <:content>
-        {{this.group}}
+        {{@group}}
       </:content>
     </Ui::Information>
   {{/if}}

--- a/orga/app/components/ui/learner-header-info.js
+++ b/orga/app/components/ui/learner-header-info.js
@@ -10,13 +10,7 @@ const CONNECTION_TYPES = {
 };
 export default class LearnerHeaderInfo extends Component {
   @service intl;
-  constructor() {
-    super(...arguments);
-  }
 
-  get group() {
-    return this.args.organizationLearner.division;
-  }
   get connectionMethods() {
     const connectionMethodsList = [];
 

--- a/orga/app/components/ui/learner-header-info.js
+++ b/orga/app/components/ui/learner-header-info.js
@@ -1,28 +1,14 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
+import { CONNECTION_TYPES } from '../../helpers/connection-types';
 
-const CONNECTION_TYPES = {
-  empty: 'pages.sco-organization-participants.connection-types.empty',
-  none: 'pages.sco-organization-participants.connection-types.none',
-  email: 'pages.sco-organization-participants.connection-types.email',
-  identifiant: 'pages.sco-organization-participants.connection-types.identifiant',
-  mediacentre: 'pages.sco-organization-participants.connection-types.mediacentre',
-};
 export default class LearnerHeaderInfo extends Component {
   @service intl;
 
   get connectionMethods() {
-    const connectionMethodsList = [];
-
-    const learner = this.args.organizationLearner;
-    if (learner) {
-      if (learner.email) connectionMethodsList.push(this.intl.t(CONNECTION_TYPES['email']));
-      if (learner.username) connectionMethodsList.push(this.intl.t(CONNECTION_TYPES['identifiant']));
-      if (learner.authenticationMethods.includes('GAR'))
-        connectionMethodsList.push(this.intl.t(CONNECTION_TYPES['mediacentre']));
-      if (connectionMethodsList.length === 0) connectionMethodsList.push(this.intl.t(CONNECTION_TYPES['empty']));
+    if (this.args.authenticationMethods) {
+      return this.args.authenticationMethods.map((element) => this.intl.t(CONNECTION_TYPES[element])).join(', ');
     }
-
-    return connectionMethodsList.join(', ');
+    return null;
   }
 }

--- a/orga/app/helpers/connection-types.js
+++ b/orga/app/helpers/connection-types.js
@@ -1,0 +1,7 @@
+export const CONNECTION_TYPES = {
+  empty: 'pages.sco-organization-participants.connection-types.empty',
+  none: 'pages.sco-organization-participants.connection-types.none',
+  email: 'pages.sco-organization-participants.connection-types.email',
+  identifiant: 'pages.sco-organization-participants.connection-types.identifiant',
+  mediacentre: 'pages.sco-organization-participants.connection-types.mediacentre',
+};

--- a/orga/app/models/organization-learner.js
+++ b/orga/app/models/organization-learner.js
@@ -1,12 +1,12 @@
 import Model, { attr } from '@ember-data/model';
 import { inject as service } from '@ember/service';
 
-export const CONNECTION_TYPES = {
-  empty: 'components.connection-types.empty',
-  none: 'components.connection-types.none',
-  email: 'components.connection-types.email',
-  identifiant: 'components.connection-types.identifiant',
-  mediacentre: 'components.connection-types.mediacentre',
+const CONNECTION_TYPES = {
+  empty: 'pages.sco-organization-participants.connection-types.empty',
+  none: 'pages.sco-organization-participants.connection-types.none',
+  email: 'pages.sco-organization-participants.connection-types.email',
+  identifiant: 'pages.sco-organization-participants.connection-types.identifiant',
+  mediacentre: 'pages.sco-organization-participants.connection-types.mediacentre',
 };
 export default class OrganizationLearner extends Model {
   @service intl;

--- a/orga/app/models/organization-learner.js
+++ b/orga/app/models/organization-learner.js
@@ -1,16 +1,6 @@
 import Model, { attr } from '@ember-data/model';
-import { inject as service } from '@ember/service';
 
-const CONNECTION_TYPES = {
-  empty: 'pages.sco-organization-participants.connection-types.empty',
-  none: 'pages.sco-organization-participants.connection-types.none',
-  email: 'pages.sco-organization-participants.connection-types.email',
-  identifiant: 'pages.sco-organization-participants.connection-types.identifiant',
-  mediacentre: 'pages.sco-organization-participants.connection-types.mediacentre',
-};
 export default class OrganizationLearner extends Model {
-  @service intl;
-
   @attr('string') lastName;
   @attr('string') firstName;
   @attr('string') username;
@@ -21,14 +11,13 @@ export default class OrganizationLearner extends Model {
   @attr('boolean') isCertifiable;
   @attr('date', { allowNull: true }) certifiableAt;
 
-  get connectionMethods() {
-    const messages = [];
+  get authenticationMethodsList() {
+    const connectionMethodsList = [];
 
-    if (this.email) messages.push(this.intl.t(CONNECTION_TYPES['email']));
-    if (this.username) messages.push(this.intl.t(CONNECTION_TYPES['identifiant']));
-    if (this.authenticationMethods.includes('GAR')) messages.push(this.intl.t(CONNECTION_TYPES['mediacentre']));
-    if (messages.length === 0) messages.push(this.intl.t(CONNECTION_TYPES['empty']));
-
-    return messages.join(', ');
+    if (this.email) connectionMethodsList.push('email');
+    if (this.username) connectionMethodsList.push('identifiant');
+    if (this.authenticationMethods.includes('GAR')) connectionMethodsList.push('mediacentre');
+    if (connectionMethodsList.length === 0) connectionMethodsList.push('empty');
+    return connectionMethodsList;
   }
 }

--- a/orga/app/models/sco-organization-participant.js
+++ b/orga/app/models/sco-organization-participant.js
@@ -1,13 +1,5 @@
 import Model, { belongsTo, attr } from '@ember-data/model';
 
-export const CONNECTION_TYPES = {
-  empty: 'pages.sco-organization-participants.connection-types.empty',
-  none: 'pages.sco-organization-participants.connection-types.none',
-  email: 'pages.sco-organization-participants.connection-types.email',
-  identifiant: 'pages.sco-organization-participants.connection-types.identifiant',
-  mediacentre: 'pages.sco-organization-participants.connection-types.mediacentre',
-};
-
 export default class ScoOrganizationParticipant extends Model {
   @attr('string') lastName;
   @attr('string') firstName;
@@ -36,10 +28,10 @@ export default class ScoOrganizationParticipant extends Model {
   get authenticationMethods() {
     const messages = [];
 
-    if (!this.isAssociated) messages.push(CONNECTION_TYPES['empty']);
-    if (this.hasEmail) messages.push(CONNECTION_TYPES['email']);
-    if (this.hasUsername) messages.push(CONNECTION_TYPES['identifiant']);
-    if (this.isAuthenticatedFromGar) messages.push(CONNECTION_TYPES['mediacentre']);
+    if (!this.isAssociated) messages.push('empty');
+    if (this.hasEmail) messages.push('email');
+    if (this.hasUsername) messages.push('identifiant');
+    if (this.isAuthenticatedFromGar) messages.push('mediacentre');
 
     return messages;
   }

--- a/orga/app/styles/components/ui/information.scss
+++ b/orga/app/styles/components/ui/information.scss
@@ -1,6 +1,7 @@
 .information-wrapper {
   display: flex;
   margin-left: $spacing-xxl;
+  align-items: center;
 }
 
 .information {

--- a/orga/app/templates/authenticated/sco-organization-participants/sco-organization-participant.hbs
+++ b/orga/app/templates/authenticated/sco-organization-participants/sco-organization-participant.hbs
@@ -15,7 +15,7 @@
     <Ui::LearnerHeaderInfo
       @groupName={{t "components.group.SCO"}}
       @group={{@model.organizationLearner.division}}
-      @organizationLearner={{@model.organizationLearner}}
+      @authenticationMethods={{@model.organizationLearner.authenticationMethodsList}}
       @isCertifiable={{@model.organizationLearner.isCertifiable}}
       @certifiableAt={{@model.organizationLearner.certifiableAt}}
     />

--- a/orga/app/templates/authenticated/sco-organization-participants/sco-organization-participant.hbs
+++ b/orga/app/templates/authenticated/sco-organization-participants/sco-organization-participant.hbs
@@ -14,6 +14,7 @@
     </Ui::PreviousPageButton>
     <Ui::LearnerHeaderInfo
       @groupName={{t "components.group.SCO"}}
+      @group={{@model.organizationLearner.division}}
       @organizationLearner={{@model.organizationLearner}}
     />
   </header>

--- a/orga/app/templates/authenticated/sco-organization-participants/sco-organization-participant.hbs
+++ b/orga/app/templates/authenticated/sco-organization-participants/sco-organization-participant.hbs
@@ -16,6 +16,8 @@
       @groupName={{t "components.group.SCO"}}
       @group={{@model.organizationLearner.division}}
       @organizationLearner={{@model.organizationLearner}}
+      @isCertifiable={{@model.organizationLearner.isCertifiable}}
+      @certifiableAt={{@model.organizationLearner.certifiableAt}}
     />
   </header>
   {{outlet}}

--- a/orga/tests/integration/components/ui/learner-header-info_test.js
+++ b/orga/tests/integration/components/ui/learner-header-info_test.js
@@ -27,21 +27,24 @@ module('Integration | Component | Ui::LearnerHeaderInfo', function (hooks) {
   });
 
   test('it renders learner header information when there is a connection method', async function (assert) {
-    const connectionMethods = this.intl.t('pages.sco-organization-participants.connection-types.email');
+    const authenticationMethods = ['email'];
 
-    this.set('connectionMethods', connectionMethods);
+    this.set('authenticationMethods', authenticationMethods);
 
-    const screen = await render(hbs`<Ui::LearnerHeaderInfo @connectionMethods={{this.connectionMethods}} />`);
+    const screen = await render(hbs`<Ui::LearnerHeaderInfo @authenticationMethods={{this.authenticationMethods}} />`);
 
     assert.strictEqual(
       screen.getByRole('term').textContent.trim(),
       this.intl.t('pages.sco-organization-participants.table.column.login-method')
     );
-    assert.strictEqual(screen.getByRole('definition').textContent.trim(), this.connectionMethods);
+    assert.strictEqual(
+      screen.getByRole('definition').textContent.trim(),
+      this.intl.t('pages.sco-organization-participants.connection-types.email')
+    );
   });
 
   test('it does not renders learner header information when there is no connection method', async function (assert) {
-    const screen = await render(hbs`<Ui::LearnerHeaderInfo @connectionMethods={{this.connectionMethods}} />`);
+    const screen = await render(hbs`<Ui::LearnerHeaderInfo @authenticationMethods={{this.authenticationMethods}} />`);
 
     assert.strictEqual(
       screen.queryByText(this.intl.t('pages.sco-organization-participants.table.column.login-method')),

--- a/orga/tests/integration/components/ui/learner-header-info_test.js
+++ b/orga/tests/integration/components/ui/learner-header-info_test.js
@@ -1,43 +1,56 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Ui::LearnerHeaderInfo', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders learner header information when there is a group', async function (assert) {
-    const organizationLearner = {
-      email: 'organizationlearner@example.net',
-      division: '3E',
-      authenticationMethods: [],
-    };
-    const groupName = 'Groupe';
+  test('it renders learner header information when there is a groupName', async function (assert) {
+    const groupName = this.intl.t('components.group.SCO');
+    const group = '3E';
 
     this.set('groupName', groupName);
-    this.set('organizationLearner', organizationLearner);
+    this.set('group', group);
 
-    await render(
-      hbs`<Ui::LearnerHeaderInfo @organizationLearner={{this.organizationLearner}} @groupName={{this.groupName}} />`
-    );
+    const screen = await render(hbs`<Ui::LearnerHeaderInfo @group={{this.group}} @groupName={{this.groupName}} />`);
 
-    assert.contains('3E');
-    assert.contains('Adresse e-mail');
-    assert.contains('Groupe');
+    assert.strictEqual(screen.getByRole('term').textContent.trim(), this.groupName);
+    assert.strictEqual(screen.getByRole('definition').textContent.trim(), this.group);
   });
 
   test('it does not render learner division header information when there is no groupName', async function (assert) {
-    const organizationLearner = {
-      email: 'organizationlearner@example.net',
-      authenticationMethods: [],
-    };
+    const screen = await render(hbs`<Ui::LearnerHeaderInfo />`);
 
-    this.set('organizationLearner', organizationLearner);
+    assert.strictEqual(screen.queryByText(this.intl.t('components.group.SCO')), null);
+    assert.strictEqual(screen.queryByText('3E'), null);
+  });
 
-    await render(hbs`<Ui::LearnerHeaderInfo @organizationLearner={{this.organizationLearner}} />`);
+  test('it renders learner header information when there is a connection method', async function (assert) {
+    const connectionMethods = this.intl.t('pages.sco-organization-participants.connection-types.email');
 
-    assert.notContains('3E');
-    assert.contains('Adresse e-mail');
+    this.set('connectionMethods', connectionMethods);
+
+    const screen = await render(hbs`<Ui::LearnerHeaderInfo @connectionMethods={{this.connectionMethods}} />`);
+
+    assert.strictEqual(
+      screen.getByRole('term').textContent.trim(),
+      this.intl.t('pages.sco-organization-participants.table.column.login-method')
+    );
+    assert.strictEqual(screen.getByRole('definition').textContent.trim(), this.connectionMethods);
+  });
+
+  test('it does not renders learner header information when there is no connection method', async function (assert) {
+    const screen = await render(hbs`<Ui::LearnerHeaderInfo @connectionMethods={{this.connectionMethods}} />`);
+
+    assert.strictEqual(
+      screen.queryByText(this.intl.t('pages.sco-organization-participants.table.column.login-method')),
+      null
+    );
+    assert.strictEqual(
+      screen.queryByText(this.intl.t('pages.sco-organization-participants.connection-types.email')),
+      null
+    );
   });
 
   test('it renders learner header information when learner is certifiable', async function (assert) {
@@ -47,26 +60,32 @@ module('Integration | Component | Ui::LearnerHeaderInfo', function (hooks) {
     this.set('isCertifiable', isCertifiable);
     this.set('certifiableAt', certifiableAt);
 
-    await render(
+    const screen = await render(
       hbs`<Ui::LearnerHeaderInfo @isCertifiable={{this.isCertifiable}} @certifiableAt={{this.certifiableAt}} />`
     );
 
-    assert.contains('Certifiable');
-    assert.contains('01/01/2023');
+    assert.strictEqual(
+      screen.getByRole('term').textContent.trim(),
+      this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible')
+    );
+    assert.strictEqual(screen.getByRole('definition').textContent.trim(), '01/01/2023');
   });
 
-  test('it does not render learner division header information when learner is not certifiable', async function (assert) {
+  test('it does not render learner header information about certificability when learner is not certifiable', async function (assert) {
     const isCertifiable = false;
     const certifiableAt = null;
 
     this.set('isCertifiable', isCertifiable);
     this.set('certifiableAt', certifiableAt);
 
-    await render(
+    const screen = await render(
       hbs`<Ui::LearnerHeaderInfo @isCertifiable={{this.isCertifiable}} @certifiableAt={{this.certifiableAt}} />`
     );
 
-    assert.notContains('Certifiable');
-    assert.notContains('01/01/2023');
+    assert.strictEqual(
+      screen.queryByText(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible')),
+      null
+    );
+    assert.strictEqual(screen.queryByText('01/01/2023'), null);
   });
 });

--- a/orga/tests/unit/models/sco-organization-participant_test.js
+++ b/orga/tests/unit/models/sco-organization-participant_test.js
@@ -12,7 +12,7 @@ module('Unit | Model | sco-organization-participant', function (hooks) {
         // when
         const model = store.createRecord('sco-organization-participant', organizationScoParticipant);
         // then
-        assert.deepEqual(model.authenticationMethods, ['pages.sco-organization-participants.connection-types.empty']);
+        assert.deepEqual(model.authenticationMethods, ['empty']);
       });
     });
 
@@ -30,9 +30,7 @@ module('Unit | Model | sco-organization-participant', function (hooks) {
           // when
           const model = store.createRecord('sco-organization-participant', organizationScoParticipant);
           // then
-          assert.deepEqual(model.authenticationMethods, [
-            'pages.sco-organization-participants.connection-types.identifiant',
-          ]);
+          assert.deepEqual(model.authenticationMethods, ['identifiant']);
         });
         test('it should return Adresse e-mail message key when identified by email', function (assert) {
           // given
@@ -46,7 +44,7 @@ module('Unit | Model | sco-organization-participant', function (hooks) {
           // when
           const model = store.createRecord('sco-organization-participant', organizationScoParticipant);
           // then
-          assert.deepEqual(model.authenticationMethods, ['pages.sco-organization-participants.connection-types.email']);
+          assert.deepEqual(model.authenticationMethods, ['email']);
         });
         test('it should return Mediacentre message key when identified from GAR', function (assert) {
           // given
@@ -60,9 +58,7 @@ module('Unit | Model | sco-organization-participant', function (hooks) {
           // when
           const model = store.createRecord('sco-organization-participant', organizationScoParticipant);
           // then
-          assert.deepEqual(model.authenticationMethods, [
-            'pages.sco-organization-participants.connection-types.mediacentre',
-          ]);
+          assert.deepEqual(model.authenticationMethods, ['mediacentre']);
         });
       });
 
@@ -81,10 +77,7 @@ module('Unit | Model | sco-organization-participant', function (hooks) {
           // when
           const model = store.createRecord('sco-organization-participant', organizationScoParticipant);
           // then
-          assert.deepEqual(model.authenticationMethods, [
-            'pages.sco-organization-participants.connection-types.email',
-            'pages.sco-organization-participants.connection-types.identifiant',
-          ]);
+          assert.deepEqual(model.authenticationMethods, ['email', 'identifiant']);
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la consolidation de l’activité du prescrit, nous avons créé [une nouvelle page détaillant l’activité d’un prescrit](https://1024pix.atlassian.net/browse/PIX-6062). Cette page inclut [un en-tête](https://1024pix.atlassian.net/browse/PIX-6145) comportant des informations qui varient selon le type de prescrit : groupe ou classe, méthode de connexion. Nous allons y ajouter la certificabilité quand elle est connue.

## :robot: Proposition
Suivant la maquette, [dans le cadre des élèves](https://1024pix.atlassian.net/browse/PIX-6147), déplacer le composant d’en-tête sur la gauche, à côté du nom du prescrit, et y ajouter la mention certifiable le cas échéant.

## :rainbow: Remarques
Suite de [cette PR](https://github.com/1024pix/pix/pull/5764), pour orga sco cette fois.

## :100: Pour tester

- Se connecter à Pix-Orga avec une Organisation Sco.
- Aller dans la liste des élèves.
- Vérifier que sur la page d'un élève certifiable, l'en tête avec le tag certifiable apparait.
- Vérifier que sur la page d'un élève non-certifiable, l'en tête avec le tag certifiable n'est pas présent.