### PR TITLE
[FEATURE] Ajout de l'en-tête d'information avec certificabilité pour Orga Sup (PIX-7289)

### DIFF
--- a/orga/app/components/ui/information.hbs
+++ b/orga/app/components/ui/information.hbs
@@ -1,8 +1,8 @@
-<div class="information">
+<div class="information" ...attributes>
   <dt class="information__title">
     {{yield to="title"}}
   </dt>
-  <dd class="information__content">
+  <dd class="information__content {{@contentClass}}">
     {{yield to="content"}}
   </dd>
 </div>

--- a/orga/app/components/ui/learner-header-info.hbs
+++ b/orga/app/components/ui/learner-header-info.hbs
@@ -1,11 +1,11 @@
 <Ui::InformationWrapper>
   {{#if @isCertifiable}}
-    <Ui::Information>
+    <Ui::Information @contentClass="information--certifiable">
       <:title>
         <Ui::IsCertifiable @isCertifiable={{@isCertifiable}} />
       </:title>
       <:content>
-        <span class="information__content--gray">
+        <span class="information__content--date">
           <Ui::Date @date={{@certifiableAt}} />
         </span>
       </:content>

--- a/orga/app/styles/components/ui/information.scss
+++ b/orga/app/styles/components/ui/information.scss
@@ -1,10 +1,12 @@
 .information-wrapper {
   display: flex;
   margin-left: $spacing-xxl;
-  align-items: center;
 }
 
 .information {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
   padding: 0 $spacing-xs;
   border-left: 1px solid $pix-neutral-22;
   font-size: 0.875rem;
@@ -19,11 +21,16 @@
     color: $pix-neutral-90;
     margin: 0;
 
-    &--gray {
+
+    &--date {
+      font-size: 0.75rem;
       color: $pix-neutral-50;
     }
   }
 
+  &--certifiable {
+    padding-bottom: $spacing-xxs;
+  }
 
   &:first-of-type {
     padding-left: 0;

--- a/orga/app/templates/authenticated/sup-organization-participants/sup-organization-participant.hbs
+++ b/orga/app/templates/authenticated/sup-organization-participants/sup-organization-participant.hbs
@@ -8,6 +8,12 @@
     >
       {{t "common.fullname" firstName=@model.firstName lastName=@model.lastName}}
     </Ui::PreviousPageButton>
+    <Ui::LearnerHeaderInfo
+      @groupName={{t "components.group.SUP"}}
+      @group={{@model.group}}
+      @isCertifiable={{@model.isCertifiable}}
+      @certifiableAt={{@model.certifiableAt}}
+    />
   </header>
   {{outlet}}
 </article>


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la consolidation de l’activité du prescrit, nous avons créé [une nouvelle page détaillant l’activité d’un prescrit](https://1024pix.atlassian.net/browse/PIX-6062). Cette page inclut [un en-tête](https://1024pix.atlassian.net/browse/PIX-6145) comportant des informations qui varient selon le type de prescrit : groupe ou classe, méthode de connexion. Nous allons y ajouter la certificabilité quand elle est connue.

## :robot: Proposition
Sur la page de détail des étudiants, afficher le composant d’en-tête auquel on a ajouté le tag de certificabilité.

## :rainbow: Remarques
⚠️ Dépendant de [ce ticket](https://github.com/1024pix/pix/pull/5780)
Suite de [cette PR](https://github.com/1024pix/pix/pull/5780), pour orga sup cette fois.

## :100: Pour tester

- Se connecter à Pix-Orga avec une Organisation Sup.
- Aller dans la liste des étudiants.
- Vérifier que sur la page d'un étudiant certifiable, l'en tête avec le tag certifiable apparait.
- Vérifier que sur la page d'un étudiant non-certifiable, l'en tête avec le tag certifiable n'est pas présent.
