### PR TITLE
[BUGFIX] Une erreur est levée lors de l'arrêt de l'api (PIX-7202)

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -7,7 +7,7 @@ const createServer = require('./server');
 const logger = require('./lib/infrastructure/logger');
 const { disconnect } = require('./db/knex-database-connection');
 const cache = require('./lib/infrastructure/caches/learning-content-cache');
-const temporaryStorage = require('./lib/infrastructure/temporary-storage/index');
+const { temporaryStorage } = require('./lib/infrastructure/temporary-storage/index');
 const redisMonitor = require('./lib/infrastructure/utils/redis-monitor');
 
 let server;


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'arrêt du serveur, une erreur est levée. 
C'est une régression depuis https://github.com/1024pix/pix/pull/5777.

## :robot: Proposition
Corriger la cause, à savoir un import incorrect

## :rainbow: Remarques
Il n'y a pas de test automatisé

## :100: Pour tester
Démarrer le serveur en local
Envoyer SIGQUIT avec Ctlr-C
Vérifier qu'aucune erreur n'est renvoyée