### PR TITLE
[FEATURE] Gestion des erreurs bloquantes sur l'import des sessions en masse (PIX-6963).

### DIFF
--- a/api/lib/domain/constants/certification-candidates-errors.js
+++ b/api/lib/domain/constants/certification-candidates-errors.js
@@ -1,0 +1,111 @@
+module.exports.CERTIFICATION_CANDIDATES_ERRORS = {
+  CANDIDATE_BILLING_MODE_MUST_BE_A_STRING: {
+    code: 'CANDIDATE_BILLING_MODE_MUST_BE_A_STRING',
+    getMessage: () => '',
+  },
+  CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY: {
+    code: 'CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY',
+    getMessage: () => '',
+  },
+  CANDIDATE_BILLING_MODE_NOT_VALID: {
+    code: 'CANDIDATE_BILLING_MODE_NOT_VALID',
+    getMessage: () => '',
+  },
+  CANDIDATE_BILLING_MODE_REQUIRED: {
+    code: 'CANDIDATE_BILLING_MODE_REQUIRED',
+    getMessage: () => '',
+  },
+  CANDIDATE_BIRTHDATE_REQUIRED: {
+    code: 'CANDIDATE_BIRTHDATE_REQUIRED',
+    getMessage: () => '',
+  },
+  CANDIDATE_BIRTHDATE_FORMAT_INCORRECT: {
+    code: 'CANDIDATE_BIRTHDATE_FORMAT_INCORRECT',
+    getMessage: () => '',
+  },
+  CANDIDATE_BIRTH_CITY_REQUIRED: {
+    code: 'CANDIDATE_BIRTH_CITY_REQUIRED',
+    getMessage: () => 'Le champ ville est obligatoire.',
+  },
+  CANDIDATE_BIRTH_COUNTRY_NOT_FOUND: {
+    code: 'CANDIDATE_BIRTH_COUNTRY_NOT_FOUND',
+    getMessage: ({ birthCountry }) => `Le pays "${birthCountry}" n'a pas été trouvé.`,
+  },
+  CANDIDATE_BIRTH_COUNTRY_REQUIRED: {
+    code: 'CANDIDATE_BIRTH_COUNTRY_REQUIRED',
+    getMessage: () => 'Le champ pays est obligatoire.',
+  },
+  CANDIDATE_BIRTH_INSEE_CODE_INVALID: {
+    code: 'CANDIDATE_BIRTH_INSEE_CODE_INVALID',
+    getMessage: ({ birthINSEECode }) => `Le code INSEE "${birthINSEECode}" n'est pas valide.`,
+  },
+  CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_EXCLUSIVE: {
+    code: 'CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_EXCLUSIVE',
+    getMessage: () => "Le champ commune de naissance ne doit pas être renseigné lorsqu'un code INSEE est renseigné.",
+  },
+  CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED: {
+    code: 'CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED',
+    getMessage: () => 'Le champ code postal ou code INSEE doit être renseigné.',
+  },
+  CANDIDATE_BIRTH_POSTAL_CODE_NOT_FOUND: {
+    code: 'CANDIDATE_BIRTH_POSTAL_CODE_NOT_FOUND',
+    getMessage: ({ birthPostalCode }) => `Le code postal "${birthPostalCode}" n'est pas valide.`,
+  },
+  CANDIDATE_BIRTH_POSTAL_CODE_CITY_INVALID: {
+    code: 'CANDIDATE_BIRTH_POSTAL_CODE_CITY_INVALID',
+    getMessage: ({ birthPostalCode, birthCity }) =>
+      `Le code postal "${birthPostalCode}" ne correspond pas à la ville "${birthCity}"`,
+  },
+  CANDIDATE_EMAIL_REQUIRED: {
+    code: 'CANDIDATE_EMAIL_REQUIRED',
+    getMessage: () => '',
+  },
+  CANDIDATE_EXTERNAL_ID_REQUIRED: {
+    code: 'CANDIDATE_EXTERNAL_ID_REQUIRED',
+    getMessage: () => '',
+  },
+  CANDIDATE_EXTRA_TIME_PERCENTAGE_REQUIRED: {
+    code: 'CANDIDATE_EXTRA_TIME_PERCENTAGE_REQUIRED',
+    getMessage: () => '',
+  },
+  CANDIDATE_FIRST_NAME_REQUIRED: {
+    code: 'CANDIDATE_FIRST_NAME_REQUIRED',
+    getMessage: () => '',
+  },
+  CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID: {
+    code: 'CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID',
+    getMessage: () => 'La valeur du code INSEE doit être "99" pour un pays étranger.',
+  },
+  CANDIDATE_LAST_NAME_REQUIRED: {
+    code: 'CANDIDATE_LAST_NAME_REQUIRED',
+    getMessage: () => '',
+  },
+  CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION: {
+    code: 'CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION',
+    getMessage: () => '',
+  },
+  CANDIDATE_POSTAL_CODE_ON_FOREIGN_COUNTRY_MUST_BE_EMPTY: {
+    code: 'CANDIDATE_POSTAL_CODE_ON_FOREIGN_COUNTRY_MUST_BE_EMPTY',
+    getMessage: () => 'Le champ code postal ne doit pas être renseigné pour un pays étranger.',
+  },
+  CANDIDATE_PREPAYMENT_CODE_REQUIRED: {
+    code: 'CANDIDATE_PREPAYMENT_CODE_REQUIRED',
+    getMessage: () => '',
+  },
+  CANDIDATE_RESULT_RECIPIENT_EMAIL_REQUIRED: {
+    code: 'CANDIDATE_RESULT_RECIPIENT_EMAIL_REQUIRED',
+    getMessage: () => '',
+  },
+  CANDIDATE_SESSION_ID_REQUIRED: {
+    code: 'CANDIDATE_SESSION_ID_REQUIRED',
+    getMessage: () => '',
+  },
+  CANDIDATE_SEX_NOT_VALID: {
+    code: 'CANDIDATE_SEX_NOT_VALID',
+    getMessage: () => '',
+  },
+  CANDIDATE_SEX_REQUIRED: {
+    code: 'CANDIDATE_SEX_REQUIRED',
+    getMessage: () => '',
+  },
+};

--- a/api/lib/domain/constants/certification-candidates-errors.js
+++ b/api/lib/domain/constants/certification-candidates-errors.js
@@ -64,6 +64,14 @@ module.exports.CERTIFICATION_CANDIDATES_ERRORS = {
     code: 'CANDIDATE_EXTERNAL_ID_REQUIRED',
     getMessage: () => '',
   },
+  CANDIDATE_EXTRA_TIME_BELOW_ONE: {
+    code: 'CANDIDATE_EXTRA_TIME_BELOW_ONE',
+    getMessage: () => `Le temps majoré doit être un pourcentage.`,
+  },
+  CANDIDATE_EXTRA_TIME_INTEGER: {
+    code: 'CANDIDATE_EXTRA_TIME_INTEGER',
+    getMessage: () => `Le temps majoré doit être un nombre entier.`,
+  },
   CANDIDATE_EXTRA_TIME_PERCENTAGE_REQUIRED: {
     code: 'CANDIDATE_EXTRA_TIME_PERCENTAGE_REQUIRED',
     getMessage: () => '',

--- a/api/lib/domain/constants/sessions-errors.js
+++ b/api/lib/domain/constants/sessions-errors.js
@@ -1,0 +1,50 @@
+module.exports.CERTIFICATION_SESSIONS_ERRORS = {
+  INFORMATION_NOT_ALLOWED_WITH_SESSION_ID: {
+    code: 'INFORMATION_NOT_ALLOWED_WITH_SESSION_ID',
+    getMessage: () => `Merci de ne pas renseigner les informations de session`,
+  },
+  CANDIDATE_NOT_ALLOWED_FOR_STARTED_SESSION: {
+    code: 'CANDIDATE_NOT_ALLOWED_FOR_STARTED_SESSION',
+    getMessage: () => `Impossible d'ajouter un candidat à une session qui a déjà commencé.`,
+  },
+  SESSION_WITH_DATE_AND_TIME_ALREADY_EXISTS: {
+    code: 'SESSION_WITH_DATE_AND_TIME_ALREADY_EXISTS',
+    getMessage: ({ session }) => `Session happening on ${session.date} at ${session.time} already exists`,
+  },
+  SESSION_SCHEDULED_IN_THE_PAST: {
+    code: 'SESSION_SCHEDULED_IN_THE_PAST',
+    getMessage: () => `Une session ne peut pas être programmée dans le passé`,
+  },
+  DUPLICATE_CANDIDATE_NOT_ALLOWED_IN_SESSION: {
+    code: 'DUPLICATE_CANDIDATE_NOT_ALLOWED_IN_SESSION',
+    getMessage: () => `Une session contient au moins un élève en double.`,
+  },
+  SESSION_ADDRESS_REQUIRED: {
+    code: 'SESSION_ADDRESS_REQUIRED',
+    getMessage: () => 'Veuillez indiquer un nom de site.',
+  },
+  SESSION_ROOM_REQUIRED: {
+    code: 'SESSION_ROOM_REQUIRED',
+    getMessage: () => 'Veuillez indiquer un nom de salle.',
+  },
+  SESSION_DATE_REQUIRED: {
+    code: 'SESSION_DATE_REQUIRED',
+    getMessage: () => 'Veuillez indiquer une date de début.',
+  },
+  SESSION_DATE_NOT_VALID: {
+    code: 'SESSION_DATE_NOT_VALID',
+    getMessage: () => 'Veuillez indiquer une date de début valide.',
+  },
+  SESSION_TIME_REQUIRED: {
+    code: 'SESSION_TIME_REQUIRED',
+    getMessage: () => 'Veuillez indiquer une heure de début.',
+  },
+  SESSION_TIME_NOT_VALID: {
+    code: 'SESSION_TIME_NOT_VALID',
+    getMessage: () => 'Veuillez indiquer une heure de début valide.',
+  },
+  SESSION_EXAMINER_REQUIRED: {
+    code: 'SESSION_EXAMINER_REQUIRED',
+    getMessage: () => 'Veuillez indiquer un(e) surveillant(e).',
+  },
+};

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -8,6 +8,7 @@ const {
   CertificationCandidatePersonalInfoFieldMissingError,
   CertificationCandidatePersonalInfoWrongFormat,
 } = require('../errors.js');
+const { CERTIFICATION_CANDIDATES_ERRORS } = require('../constants/certification-candidates-errors');
 
 const BILLING_MODES = {
   FREE: 'FREE',
@@ -54,51 +55,51 @@ const certificationCandidateValidationJoiSchema_v1_5 = Joi.object({
 
 const certificationCandidateValidationForMassImportJoiSchema = Joi.object({
   firstName: Joi.string().required().empty(['', null]).messages({
-    'any.required': 'CANDIDATE_FIRST_NAME_REQUIRED',
+    'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FIRST_NAME_REQUIRED.code,
   }),
   lastName: Joi.string().required().empty(['', null]).messages({
-    'any.required': 'CANDIDATE_LAST_NAME_REQUIRED',
+    'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_LAST_NAME_REQUIRED.code,
   }),
   sex: Joi.string().valid('M', 'F').required().empty(['', null]).messages({
-    'any.required': 'CANDIDATE_SEX_REQUIRED',
-    'any.only': 'CANDIDATE_SEX_NOT_VALID',
+    'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SEX_REQUIRED.code,
+    'any.only': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SEX_NOT_VALID.code,
   }),
   birthINSEECode: Joi.alternatives().conditional('birthPostalCode', {
     is: Joi.string().empty(['', null]).required(),
     then: Joi.string().empty(['', null]).forbidden().messages({
-      'any.unknown': 'CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_ARE_EXCLUSIVE',
+      'any.unknown': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_EXCLUSIVE.code,
     }),
     otherwise: Joi.string().empty(['', null]).required().messages({
-      'any.required': 'CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED',
+      'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED.code,
     }),
   }),
   birthCountry: Joi.string().required().empty(['', null]).messages({
-    'any.required': 'CANDIDATE_BIRTH_COUNTRY_REQUIRED',
+    'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_REQUIRED.code,
   }),
   email: Joi.string().email().allow(null).empty('').optional().messages({
-    'string.empty': 'CANDIDATE_EMAIL_REQUIRED',
+    'string.empty': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EMAIL_REQUIRED.code,
   }),
   resultRecipientEmail: Joi.string().email().empty(['', null]).optional().messages({
-    'string.empty': 'CANDIDATE_RESULT_RECIPIENT_EMAIL_REQUIRED',
+    'string.empty': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_RESULT_RECIPIENT_EMAIL_REQUIRED.code,
   }),
   externalId: Joi.string().allow(null).empty(['', null]).optional().messages({
-    'string.empty': 'CANDIDATE_EXTERNAL_ID_REQUIRED',
+    'string.empty': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTERNAL_ID_REQUIRED.code,
   }),
   birthdate: Joi.date().format('YYYY-MM-DD').greater('1900-01-01').required().empty(['', null]).messages({
-    'any.required': 'CANDIDATE_BIRTHDATE_REQUIRED',
-    'date.format': 'CANDIDATE_INCORRECT_BIRTHDATE_FORMAT',
+    'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_REQUIRED.code,
+    'date.format': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_FORMAT_INCORRECT.code,
   }),
   extraTimePercentage: Joi.number().allow(null).optional().messages({
-    'number.base': 'CANDIDATE_EXTRA_TIME_PERCENTAGE_REQUIRED',
+    'number.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_PERCENTAGE_REQUIRED.code,
   }),
   sessionId: Joi.when('$isSessionsMassImport', {
     is: false,
     then: Joi.number().required().empty(['', null]).messages({
-      'string.empty': 'CANDIDATE_SESSION_ID_REQUIRED',
+      'string.empty': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SESSION_ID_REQUIRED.code,
     }),
   }),
   complementaryCertifications: Joi.array().max(1).required().messages({
-    'array.max': 'CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION',
+    'array.max': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION.code,
   }),
   billingMode: Joi.when('$isSco', {
     is: false,
@@ -107,18 +108,18 @@ const certificationCandidateValidationForMassImportJoiSchema = Joi.object({
       .required()
       .empty(['', null])
       .messages({
-        'any.required': 'CANDIDATE_BILLING_MODE_REQUIRED',
-        'string.base': 'CANDIDATE_BILLING_MUST_BE_A_STRING',
-        'any.only': 'CANDIDATE_BILLING_MODE_NOT_VALID',
+        'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_REQUIRED.code,
+        'string.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_MUST_BE_A_STRING.code,
+        'any.only': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_NOT_VALID.code,
       }),
   }),
   prepaymentCode: Joi.when('billingMode', {
     is: 'PREPAID',
     then: Joi.string().required().empty(['', null]).messages({
-      'string.empty': 'CANDIDATE_PREPAYMENT_CODE_REQUIRED',
+      'string.empty': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_REQUIRED.code,
     }),
     otherwise: Joi.valid(null).messages({
-      'any.only': 'CANDIDATE_BILLING_MODE_MUST_BE_EMPTY',
+      'any.only': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY.code,
     }),
   }),
 });

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -89,9 +89,14 @@ const certificationCandidateValidationForMassImportJoiSchema = Joi.object({
     'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_REQUIRED.code,
     'date.format': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_FORMAT_INCORRECT.code,
   }),
-  extraTimePercentage: Joi.number().allow(null).optional().messages({
+  extraTimePercentage: Joi.number().integer().allow(null).optional().min(1).max(100).messages({
     'number.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_PERCENTAGE_REQUIRED.code,
+    'any.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_PERCENTAGE_REQUIRED.code,
+    'number.min': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_BELOW_ONE.code,
+    'number.max': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_BELOW_ONE.code,
+    'number.integer': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_INTEGER.code,
   }),
+
   sessionId: Joi.when('$isSessionsMassImport', {
     is: false,
     then: Joi.number().required().empty(['', null]).messages({

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -1,5 +1,6 @@
 const isNil = require('lodash/isNil');
 const endsWith = require('lodash/endsWith');
+const snakeCase = require('lodash/snakeCase');
 const BaseJoi = require('joi');
 const JoiDate = require('@joi/date');
 const Joi = BaseJoi.extend(JoiDate);
@@ -161,7 +162,7 @@ class CertificationCandidate {
     }
   }
 
-  validateForMassSessionImport(isSco = false) {
+  validateForMassSessionImport({ isSco = false, line }) {
     const { error } = certificationCandidateValidationJoiSchema_v1_5.validate(this, {
       abortEarly: false,
       allowUnknown: true,
@@ -173,7 +174,10 @@ class CertificationCandidate {
     if (error) {
       return error.details.map((detail) => {
         const { key, why } = InvalidCertificationCandidate.fromJoiErrorDetail(detail);
-        return key ? `${key} ${why}` : `${why}`;
+        const whyErrorFormated = snakeCase(why).toUpperCase();
+        const keyErrorFormated = snakeCase(key).toUpperCase();
+
+        return key ? { code: `${keyErrorFormated}_${whyErrorFormated}`, line } : { code: `${whyErrorFormated}`, line };
       });
     }
   }

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -63,16 +63,13 @@ const certificationCandidateValidationForMassImportJoiSchema = Joi.object({
     'any.required': 'CANDIDATE_SEX_REQUIRED',
     'any.only': 'CANDIDATE_SEX_NOT_VALID',
   }),
-  birthPostalCode: Joi.string().empty(['', null]).required().messages({
-    'any.required': 'CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED',
-  }),
   birthINSEECode: Joi.alternatives().conditional('birthPostalCode', {
-    is: Joi.exist(),
-    then: Joi.valid(null).messages({
-      'any.only': 'CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_INVALID',
+    is: Joi.string().empty(['', null]).required(),
+    then: Joi.string().empty(['', null]).forbidden().messages({
+      'any.unknown': 'CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_ARE_EXCLUSIVE',
     }),
     otherwise: Joi.string().empty(['', null]).required().messages({
-      'any.required': 'CANDIDATE_BIRTH_INSEE_CODE_REQUIRED',
+      'any.required': 'CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED',
     }),
   }),
   birthCountry: Joi.string().required().empty(['', null]).messages({

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -53,23 +53,29 @@ const certificationCandidateValidationJoiSchema_v1_5 = Joi.object({
 );
 
 const certificationCandidateValidationForMassImportJoiSchema = Joi.object({
-  firstName: Joi.string().required().empty(null).messages({
+  firstName: Joi.string().required().empty(['', null]).messages({
     'any.required': 'CANDIDATE_FIRST_NAME_REQUIRED',
   }),
-  lastName: Joi.string().required().empty(null).messages({
+  lastName: Joi.string().required().empty(['', null]).messages({
     'any.required': 'CANDIDATE_LAST_NAME_REQUIRED',
   }),
   sex: Joi.string().valid('M', 'F').required().empty(['', null]).messages({
     'any.required': 'CANDIDATE_SEX_REQUIRED',
     'any.only': 'CANDIDATE_SEX_NOT_VALID',
   }),
-  birthPostalCode: Joi.string().empty(['', null]).messages({
-    'string.empty': 'CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED',
+  birthPostalCode: Joi.string().empty(['', null]).required().messages({
+    'any.required': 'CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED',
   }),
-  birthINSEECode: Joi.string().empty(['', null]).messages({
-    'string.empty': 'CANDIDATE_BIRTH_INSEE_CODE_REQUIRED',
+  birthINSEECode: Joi.alternatives().conditional('birthPostalCode', {
+    is: Joi.exist(),
+    then: Joi.valid(null).messages({
+      'any.only': 'CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_INVALID',
+    }),
+    otherwise: Joi.string().empty(['', null]).required().messages({
+      'any.required': 'CANDIDATE_BIRTH_INSEE_CODE_REQUIRED',
+    }),
   }),
-  birthCountry: Joi.string().required().empty(null).messages({
+  birthCountry: Joi.string().required().empty(['', null]).messages({
     'any.required': 'CANDIDATE_BIRTH_COUNTRY_REQUIRED',
   }),
   email: Joi.string().email().allow(null).empty('').optional().messages({
@@ -81,7 +87,7 @@ const certificationCandidateValidationForMassImportJoiSchema = Joi.object({
   externalId: Joi.string().allow(null).empty(['', null]).optional().messages({
     'string.empty': 'CANDIDATE_EXTERNAL_ID_REQUIRED',
   }),
-  birthdate: Joi.date().format('YYYY-MM-DD').greater('1900-01-01').required().empty(null).messages({
+  birthdate: Joi.date().format('YYYY-MM-DD').greater('1900-01-01').required().empty(['', null]).messages({
     'any.required': 'CANDIDATE_BIRTHDATE_REQUIRED',
     'date.format': 'CANDIDATE_INCORRECT_BIRTHDATE_FORMAT',
   }),
@@ -118,18 +124,7 @@ const certificationCandidateValidationForMassImportJoiSchema = Joi.object({
       'any.only': 'CANDIDATE_BILLING_MODE_MUST_BE_EMPTY',
     }),
   }),
-})
-  .assert(
-    '.birthPostalCode',
-    Joi.when('..birthINSEECode', {
-      is: Joi.exist(),
-      then: Joi.valid(null),
-      otherwise: Joi.string().required(),
-    })
-  )
-  .message({
-    'object.assert': 'CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_INVALID',
-  });
+});
 
 const certificationCandidateParticipationJoiSchema = Joi.object({
   id: Joi.any().allow(null).optional(),

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -240,7 +240,7 @@ class CertificationCandidate {
     }
   }
 
-  validateForMassSessionImport({ isSco = false, line }) {
+  validateForMassSessionImport(isSco = false) {
     const { error } = certificationCandidateValidationForMassImportJoiSchema.validate(this, {
       abortEarly: false,
       allowUnknown: true,
@@ -250,7 +250,7 @@ class CertificationCandidate {
       },
     });
     if (error) {
-      return error.details.map(({ message }) => ({ code: message, line }));
+      return error.details.map(({ message }) => message);
     }
   }
 

--- a/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
+++ b/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
@@ -65,7 +65,7 @@ module.exports = {
     });
 
     if (cpfBirthInformation.hasFailed()) {
-      certificationCandidateErrors.push(cpfBirthInformation.message);
+      _addToErrorList({ errorList: certificationCandidateErrors, line, codes: [cpfBirthInformation.code] });
     }
 
     return {

--- a/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
+++ b/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
@@ -65,7 +65,14 @@ module.exports = {
     });
 
     if (cpfBirthInformation.hasFailed()) {
-      _addToErrorList({ errorList: certificationCandidateErrors, line, codes: [cpfBirthInformation.code] });
+      if (
+        _isErrorNotDuplicated({
+          certificationCandidateErrors,
+          errorCode: cpfBirthInformation.code,
+        })
+      ) {
+        _addToErrorList({ errorList: certificationCandidateErrors, line, codes: [cpfBirthInformation.code] });
+      }
     }
 
     return {
@@ -79,6 +86,10 @@ module.exports = {
     };
   },
 };
+
+function _isErrorNotDuplicated({ certificationCandidateErrors, errorCode }) {
+  return !certificationCandidateErrors.some((error) => errorCode === error.code);
+}
 
 function _addToErrorList({ errorList, line, codes = [] }) {
   const errors = codes.map((code) => ({ code, line }));

--- a/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
+++ b/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
@@ -104,7 +104,7 @@ async function _createValidCertificationCandidates({
     const domainCertificationCandidate = new CertificationCandidate({
       ...certificationCandidate,
       sessionId,
-      billingMode,
+      billingMode: billingMode || certificationCandidate.billingMode,
     });
 
     const { certificationCandidateErrors, cpfBirthInformation } =

--- a/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
+++ b/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
@@ -35,6 +35,7 @@ module.exports = async function validateSessions({
 
     const sessionsErrors = await sessionsImportValidationService.validateSession({
       session,
+      line: sessionDTO.line,
       sessionRepository,
       certificationCourseRepository,
     });
@@ -111,6 +112,7 @@ async function _createValidCertificationCandidates({
         candidate: domainCertificationCandidate,
         isSco,
         isSessionsMassImport: true,
+        line: certificationCandidate.line,
         certificationCpfCountryRepository,
         certificationCpfCityRepository,
       });

--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -1,6 +1,9 @@
-const Joi = require('joi');
+const BaseJoi = require('joi');
+const JoiDate = require('@joi/date');
+const Joi = BaseJoi.extend(JoiDate);
 const { statuses } = require('../models/Session.js');
 const { types } = require('../models/CertificationCenter.js');
+const { CERTIFICATION_SESSIONS_ERRORS } = require('../constants/sessions-errors');
 
 const { EntityValidationError } = require('../errors.js');
 const identifiersType = require('../../domain/types/identifiers-type.js');
@@ -9,61 +12,62 @@ const validationConfiguration = { abortEarly: false, allowUnknown: true };
 
 const sessionValidationJoiSchema = Joi.object({
   address: Joi.string().required().messages({
-    'string.base': 'Veuillez indiquer un nom de site.',
-    'string.empty': 'Veuillez indiquer un nom de site.',
+    'string.base': CERTIFICATION_SESSIONS_ERRORS.SESSION_ADDRESS_REQUIRED.getMessage(),
+    'string.empty': CERTIFICATION_SESSIONS_ERRORS.SESSION_ADDRESS_REQUIRED.getMessage(),
   }),
 
   room: Joi.string().required().messages({
-    'string.base': 'Veuillez indiquer un nom de salle.',
-    'string.empty': 'Veuillez indiquer un nom de salle.',
+    'string.base': CERTIFICATION_SESSIONS_ERRORS.SESSION_ROOM_REQUIRED.getMessage(),
+    'string.empty': CERTIFICATION_SESSIONS_ERRORS.SESSION_ROOM_REQUIRED.getMessage(),
   }),
 
   date: Joi.string().isoDate().required().messages({
-    'string.empty': 'Veuillez indiquer une date de début.',
+    'string.empty': CERTIFICATION_SESSIONS_ERRORS.SESSION_DATE_REQUIRED.getMessage(),
   }),
 
   time: Joi.string()
     .pattern(/^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$/)
     .required()
     .messages({
-      'string.base': 'Veuillez indiquer une heure de début.',
-      'string.empty': 'Veuillez indiquer une heure de début.',
-      'string.pattern.base': 'Veuillez indiquer une heure de début.',
+      'string.base': CERTIFICATION_SESSIONS_ERRORS.SESSION_TIME_REQUIRED.getMessage(),
+      'string.empty': CERTIFICATION_SESSIONS_ERRORS.SESSION_TIME_REQUIRED.getMessage(),
+      'string.pattern.base': CERTIFICATION_SESSIONS_ERRORS.SESSION_TIME_REQUIRED.getMessage(),
     }),
 
   examiner: Joi.string().required().messages({
-    'string.base': 'Veuillez indiquer un(e) surveillant(e).',
-    'string.empty': 'Veuillez indiquer un(e) surveillant(e).',
+    'string.base': CERTIFICATION_SESSIONS_ERRORS.SESSION_EXAMINER_REQUIRED.getMessage(),
+    'string.empty': CERTIFICATION_SESSIONS_ERRORS.SESSION_EXAMINER_REQUIRED.getMessage(),
   }),
 });
 
 const sessionValidationForMassImportJoiSchema = Joi.object({
   address: Joi.string().required().messages({
-    'string.base': 'SESSION_ADDRESS_REQUIRED',
-    'string.empty': 'SESSION_ADDRESS_REQUIRED',
+    'string.base': CERTIFICATION_SESSIONS_ERRORS.SESSION_ADDRESS_REQUIRED.code,
+    'string.empty': CERTIFICATION_SESSIONS_ERRORS.SESSION_ADDRESS_REQUIRED.code,
   }),
 
   room: Joi.string().required().messages({
-    'string.base': 'SESSION_ROOM_REQUIRED',
-    'string.empty': 'SESSION_ROOM_REQUIRED',
+    'string.base': CERTIFICATION_SESSIONS_ERRORS.SESSION_ROOM_REQUIRED.code,
+    'string.empty': CERTIFICATION_SESSIONS_ERRORS.SESSION_ROOM_REQUIRED.code,
   }),
 
-  date: Joi.string().isoDate().required().messages({
-    'string.empty': 'SESSION_DATE_REQUIRED',
+  date: Joi.date().format('YYYY-MM-DD').required().empty(['', null]).messages({
+    'any.required': CERTIFICATION_SESSIONS_ERRORS.SESSION_DATE_REQUIRED.code,
+    'date.format': CERTIFICATION_SESSIONS_ERRORS.SESSION_DATE_NOT_VALID.code,
   }),
 
   time: Joi.string()
     .pattern(/^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$/)
     .required()
     .messages({
-      'string.base': 'SESSION_TIME_REQUIRED',
-      'string.empty': 'SESSION_TIME_REQUIRED',
-      'string.pattern.base': 'SESSION_TIME_REQUIRED',
+      'string.base': CERTIFICATION_SESSIONS_ERRORS.SESSION_TIME_REQUIRED.code,
+      'string.empty': CERTIFICATION_SESSIONS_ERRORS.SESSION_TIME_REQUIRED.code,
+      'string.pattern.base': CERTIFICATION_SESSIONS_ERRORS.SESSION_TIME_NOT_VALID.code,
     }),
 
   examiner: Joi.string().required().messages({
-    'string.base': 'SESSION_EXAMINER_REQUIRED',
-    'string.empty': 'SESSION_EXAMINER_REQUIRED',
+    'string.base': CERTIFICATION_SESSIONS_ERRORS.SESSION_EXAMINER_REQUIRED.code,
+    'string.empty': CERTIFICATION_SESSIONS_ERRORS.SESSION_EXAMINER_REQUIRED.code,
   }),
 });
 
@@ -87,10 +91,10 @@ module.exports = {
     }
   },
 
-  validateForMassSessionImport(session, line) {
+  validateForMassSessionImport(session) {
     const { error } = sessionValidationForMassImportJoiSchema.validate(session, validationConfiguration);
     if (error) {
-      return error.details.map(({ message }) => ({ code: message, line }));
+      return error.details.map(({ message }) => message);
     }
   },
 

--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -37,6 +37,36 @@ const sessionValidationJoiSchema = Joi.object({
   }),
 });
 
+const sessionValidationForMassImportJoiSchema = Joi.object({
+  address: Joi.string().required().messages({
+    'string.base': 'SESSION_ADDRESS_REQUIRED',
+    'string.empty': 'SESSION_ADDRESS_REQUIRED',
+  }),
+
+  room: Joi.string().required().messages({
+    'string.base': 'SESSION_ROOM_REQUIRED',
+    'string.empty': 'SESSION_ROOM_REQUIRED',
+  }),
+
+  date: Joi.string().isoDate().required().messages({
+    'string.empty': 'SESSION_DATE_REQUIRED',
+  }),
+
+  time: Joi.string()
+    .pattern(/^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$/)
+    .required()
+    .messages({
+      'string.base': 'SESSION_TIME_REQUIRED',
+      'string.empty': 'SESSION_TIME_REQUIRED',
+      'string.pattern.base': 'SESSION_TIME_REQUIRED',
+    }),
+
+  examiner: Joi.string().required().messages({
+    'string.base': 'SESSION_EXAMINER_REQUIRED',
+    'string.empty': 'SESSION_EXAMINER_REQUIRED',
+  }),
+});
+
 const sessionFiltersValidationSchema = Joi.object({
   id: identifiersType.sessionId.optional(),
   status: Joi.string()
@@ -54,6 +84,13 @@ module.exports = {
     const { error } = sessionValidationJoiSchema.validate(session, validationConfiguration);
     if (error) {
       throw EntityValidationError.fromJoiErrors(error.details);
+    }
+  },
+
+  validateForMassSessionImport(session, line) {
+    const { error } = sessionValidationForMassImportJoiSchema.validate(session, validationConfiguration);
+    if (error) {
+      return error.details.map(({ message }) => ({ code: message, line }));
     }
   },
 

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -30,9 +30,12 @@ function deserializeForSessionsImport(parsedCsvData) {
   const csvLineKeys = Object.keys(headers);
 
   _verifyHeaders({ csvLineKeys, headers, parsedCsvLine: parsedCsvData[0] });
+  let lineCount = 1;
 
   parsedCsvData.forEach((line) => {
     const data = _getDataFromColumnNames({ csvLineKeys, headers, line });
+    data.line = lineCount;
+    lineCount++;
 
     let currentParsedSession;
     if (_hasSessionInformation(data)) {
@@ -46,15 +49,18 @@ function deserializeForSessionsImport(parsedCsvData) {
       if (!currentParsedSession) {
         currentParsedSession = {
           sessionId: data.sessionId,
+          line: data.line,
           certificationCandidates: [],
         };
         sessions.push(currentParsedSession);
       }
     } else {
-      if (sessions.at(-1)) {
-        currentParsedSession = sessions.at(-1);
+      const previousLineSession = sessions.at(-1);
+      if (previousLineSession) {
+        currentParsedSession = previousLineSession;
       } else {
         currentParsedSession = emptySession;
+        currentParsedSession.line = data.line;
         sessions.push(currentParsedSession);
       }
     }
@@ -229,7 +235,7 @@ function _hasCandidateInformation({ lastName, firstName, birthdate, sex, billing
   );
 }
 
-function _createSession({ sessionId, address, room, date, time, examiner, description }) {
+function _createSession({ sessionId, address, room, date, time, examiner, description, line }) {
   const uniqueKey = _generateUniqueKey({ address, room, date, time });
 
   return {
@@ -241,6 +247,7 @@ function _createSession({ sessionId, address, room, date, time, examiner, descri
     time,
     examiner: examiner ? [examiner] : [],
     description,
+    line,
     certificationCandidates: [],
   };
 }
@@ -261,6 +268,7 @@ function _createCandidate({
   prepaymentCode,
   sex,
   complementaryCertifications,
+  line,
 }) {
   return {
     lastName,
@@ -278,6 +286,7 @@ function _createCandidate({
     prepaymentCode,
     sex,
     complementaryCertifications,
+    line,
   };
 }
 

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -30,12 +30,11 @@ function deserializeForSessionsImport(parsedCsvData) {
   const csvLineKeys = Object.keys(headers);
 
   _verifyHeaders({ csvLineKeys, headers, parsedCsvLine: parsedCsvData[0] });
-  let lineCount = 1;
 
-  parsedCsvData.forEach((line) => {
-    const data = _getDataFromColumnNames({ csvLineKeys, headers, line });
-    data.line = lineCount;
-    lineCount++;
+  parsedCsvData.forEach((lineDTO, index) => {
+    const dataFromColumnName = _getDataFromColumnNames({ csvLineKeys, headers, line: lineDTO });
+    const FIRST_DATA_LINE = 2;
+    const data = { ...dataFromColumnName, line: index + FIRST_DATA_LINE };
 
     let currentParsedSession;
     if (_hasSessionInformation(data)) {

--- a/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-validate-sessions_test.js
+++ b/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-validate-sessions_test.js
@@ -118,7 +118,12 @@ describe('Acceptance | Controller | certification-centers-controller-post-valida
               sessionsCount: 2,
               sessionsWithoutCandidatesCount: 0,
               candidatesCount: 2,
-              errorsReport: ['Merci de ne pas renseigner les informations de session pour la session: 1234'],
+              errorsReport: [
+                {
+                  code: 'INFORMATION_NOT_ALLOWED_WITH_SESSION_ID',
+                  line: 3,
+                },
+              ],
             });
           });
         });

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -393,13 +393,11 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
     context('when all required fields are presents', function () {
       it('should return nothing', function () {
         // given
+        const isSco = true;
         const certificationCandidate = buildCertificationCandidate(validAttributes);
 
         // when
-        const report = certificationCandidate.validateForMassSessionImport({
-          isSco: true,
-          line: certificationCandidate.line,
-        });
+        const report = certificationCandidate.validateForMassSessionImport(isSco);
 
         // then
         expect(report).to.be.undefined;
@@ -421,7 +419,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         const report = certificationCandidate.validateForMassSessionImport({ line: 1 });
 
         // then
-        expect(report).to.deep.equal([{ code: `${expectedCode}`, line: 1 }]);
+        expect(report).to.deep.equal([`${expectedCode}`]);
       });
 
       it(`should return a report when field ${field} is null`, async function () {
@@ -429,12 +427,10 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         const certificationCandidate = buildCertificationCandidate({ ...validAttributes, [field]: null });
 
         // when
-        const report = certificationCandidate.validateForMassSessionImport({
-          line: 1,
-        });
+        const report = certificationCandidate.validateForMassSessionImport({});
 
         // then
-        expect(report).to.deep.equal([{ code: `${expectedCode}`, line: 1 }]);
+        expect(report).to.deep.equal([expectedCode]);
       });
     });
 
@@ -445,11 +441,10 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       // when
       const report = certificationCandidate.validateForMassSessionImport({
         isSco: true,
-        line: 1,
       });
 
       // then
-      expect(report).to.deep.equal([{ code: 'CANDIDATE_INCORRECT_BIRTHDATE_FORMAT', line: 1 }]);
+      expect(report).to.deep.equal(['CANDIDATE_INCORRECT_BIRTHDATE_FORMAT']);
     });
 
     it('should return a report when birthdate is null', async function () {
@@ -463,7 +458,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       });
 
       // then
-      expect(report).to.deep.equal([{ code: 'CANDIDATE_BIRTHDATE_REQUIRED', line: 1 }]);
+      expect(report).to.deep.equal(['CANDIDATE_BIRTHDATE_REQUIRED']);
     });
 
     it('should return a report when field extraTimePercentage is not a number', async function () {
@@ -480,52 +475,47 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       });
 
       //then
-      expect(report).to.deep.equal([{ code: 'CANDIDATE_EXTRA_TIME_PERCENTAGE_REQUIRED', line: 1 }]);
+      expect(report).to.deep.equal(['CANDIDATE_EXTRA_TIME_PERCENTAGE_REQUIRED']);
     });
 
     it('should return a report when sex is neither M nor F', async function () {
       // given
+      const isSco = true;
       const certificationCandidate = buildCertificationCandidate({ ...validAttributes, sex: 'something_else' });
 
       // when
-      const report = certificationCandidate.validateForMassSessionImport({
-        isSco: true,
-        line: 1,
-      });
+      const report = certificationCandidate.validateForMassSessionImport(isSco);
 
       // then
-      expect(report).to.deep.equal([{ code: 'CANDIDATE_SEX_NOT_VALID', line: 1 }]);
+      expect(report).to.deep.equal(['CANDIDATE_SEX_NOT_VALID']);
     });
 
     it('should return a report when sex is null', async function () {
       // given
+      const isSco = true;
       const certificationCandidate = buildCertificationCandidate({ ...validAttributes, sex: null });
 
       // when
-      const report = certificationCandidate.validateForMassSessionImport({
-        isSco: true,
-        line: 1,
-      });
+      const report = certificationCandidate.validateForMassSessionImport(isSco);
 
       // then
-      expect(report).to.deep.equal([{ code: 'CANDIDATE_SEX_REQUIRED', line: 1 }]);
+      expect(report).to.deep.equal(['CANDIDATE_SEX_REQUIRED']);
     });
 
     it('should return a report when a candidate is added with multiple complementary certifications', async function () {
       // given
+      const isSco = true;
+
       const certificationCandidate = buildCertificationCandidate({
         ...validAttributes,
         complementaryCertifications: [Symbol('1'), Symbol('2')],
       });
 
       // when
-      const report = certificationCandidate.validateForMassSessionImport({
-        isSco: true,
-        line: 1,
-      });
+      const report = certificationCandidate.validateForMassSessionImport(isSco);
 
       // then
-      expect(report).to.deep.equal([{ code: 'CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION', line: 1 }]);
+      expect(report).to.deep.equal(['CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION']);
     });
 
     context('when the certification center is SCO', function () {
@@ -539,10 +529,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
           const isSco = true;
 
           // when
-          const report = certificationCandidate.validateForMassSessionImport({
-            isSco,
-            line: 1,
-          });
+          const report = certificationCandidate.validateForMassSessionImport(isSco);
 
           // then
           expect(report).to.be.undefined;
@@ -561,13 +548,10 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
           });
 
           // when
-          const report = certificationCandidate.validateForMassSessionImport({
-            isSco,
-            line: 1,
-          });
+          const report = certificationCandidate.validateForMassSessionImport(isSco);
 
           // then
-          expect(report).to.deep.equal([{ code: 'CANDIDATE_BILLING_MODE_REQUIRED', line: 1 }]);
+          expect(report).to.deep.equal(['CANDIDATE_BILLING_MODE_REQUIRED']);
         });
       });
 
@@ -581,13 +565,10 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
           const isSco = false;
 
           // when
-          const report = certificationCandidate.validateForMassSessionImport({
-            isSco,
-            line: 1,
-          });
+          const report = certificationCandidate.validateForMassSessionImport(isSco);
 
           // then
-          expect(report).to.deep.equal([{ code: 'CANDIDATE_BILLING_MODE_NOT_VALID', line: 1 }]);
+          expect(report).to.deep.equal(['CANDIDATE_BILLING_MODE_NOT_VALID']);
         });
       });
 
@@ -596,6 +577,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         ['FREE', 'PAID', 'PREPAID'].forEach((billingMode) => {
           it(`should return nothing for ${billingMode}`, async function () {
             // given
+            const isSco = true;
             const certificationCandidate = domainBuilder.buildCertificationCandidate({
               ...validAttributes,
               billingMode,
@@ -603,10 +585,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
             });
 
             // when
-            const report = certificationCandidate.validateForMassSessionImport({
-              isSco: true,
-              line: 1,
-            });
+            const report = certificationCandidate.validateForMassSessionImport(isSco);
 
             // then
             expect(report).to.be.undefined;
@@ -618,6 +597,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         context('when prepaymentCode is not null', function () {
           it('should return a report', async function () {
             // given
+            const isSco = true;
             const certificationCandidate = domainBuilder.buildCertificationCandidate({
               ...validAttributes,
               billingMode: 'PAID',
@@ -625,13 +605,10 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
             });
 
             // when
-            const report = certificationCandidate.validateForMassSessionImport({
-              isSco: true,
-              line: 1,
-            });
+            const report = certificationCandidate.validateForMassSessionImport(isSco);
 
             // then
-            expect(report).to.deep.equal([{ code: 'CANDIDATE_BILLING_MODE_MUST_BE_EMPTY', line: 1 }]);
+            expect(report).to.deep.equal(['CANDIDATE_BILLING_MODE_MUST_BE_EMPTY']);
           });
         });
       });
@@ -672,7 +649,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         });
 
         // then
-        expect(report).to.deep.equal([{ code: 'CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_INVALID', line: 1 }]);
+        expect(report).to.deep.equal(['CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_INVALID']);
       });
 
       it('should return a report if birthPostalCode and birthInseeCode are present', async function () {
@@ -689,7 +666,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         });
 
         // then
-        expect(report).to.deep.equal([{ code: 'CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_INVALID', line: 1 }]);
+        expect(report).to.deep.equal(['CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_INVALID']);
       });
 
       it('should return nothing if birthPostalCode is present and birthInseeCode is empty', async function () {
@@ -745,10 +722,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         });
 
         // then
-        expect(report).to.deep.equal([
-          { code: 'CANDIDATE_FIRST_NAME_REQUIRED', line: 1 },
-          { code: 'CANDIDATE_BIRTHDATE_REQUIRED', line: 1 },
-        ]);
+        expect(report).to.deep.equal(['CANDIDATE_FIRST_NAME_REQUIRED', 'CANDIDATE_BIRTHDATE_REQUIRED']);
       });
     });
   });

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -356,367 +356,6 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         expect(call).to.not.throw();
       });
 
-      describe('validateForMassSessionImport', function () {
-        const buildCertificationCandidate = (attributes) => new CertificationCandidate(attributes);
-
-        const validAttributes = {
-          firstName: 'Oren',
-          lastName: 'Ishii',
-          sex: 'F',
-          birthPostalCode: '75001',
-          birthINSEECode: '',
-          birthCountry: 'France',
-          birthdate: '2010-01-01',
-          sessionId: 123,
-          resultRecipientEmail: 'orga@example.net',
-          billingMode: 'FREE',
-          line: 1,
-        };
-
-        context('when all required fields are presents', function () {
-          it('should return nothing', function () {
-            // given
-            const certificationCandidate = buildCertificationCandidate(validAttributes);
-
-            // when
-            const report = certificationCandidate.validateForMassSessionImport({
-              isSco: true,
-              line: certificationCandidate.line,
-            });
-
-            // then
-            expect(report).to.be.undefined;
-          });
-        });
-
-        // eslint-disable-next-line mocha/no-setup-in-describe
-        ['firstName', 'lastName', 'birthCountry', 'birthdate'].forEach((field) => {
-          it(`should return a report when field ${field} is not present`, async function () {
-            // given
-            const certificationCandidate = buildCertificationCandidate({ ...validAttributes, [field]: undefined });
-
-            // when
-            const report = certificationCandidate.validateForMassSessionImport(certificationCandidate);
-
-            // then
-            expect(report).to.deep.equal([{ code: `${snakeCase(field).toUpperCase()}_REQUIRED`, line: 1 }]);
-          });
-
-          it(`should return a report when field ${field} is null`, async function () {
-            // given
-            const certificationCandidate = buildCertificationCandidate({ ...validAttributes, [field]: null });
-
-            // when
-            const report = certificationCandidate.validateForMassSessionImport({
-              isSco: true,
-              line: certificationCandidate.line,
-            });
-
-            // then
-            expect(report).to.deep.equal([{ code: `${snakeCase(field).toUpperCase()}_REQUIRED`, line: 1 }]);
-          });
-        });
-
-        it('should return a report when birthdate is not a valid format', async function () {
-          // given
-          const certificationCandidate = buildCertificationCandidate({ ...validAttributes, birthdate: '2020/02/01' });
-
-          // when
-          const report = certificationCandidate.validateForMassSessionImport({
-            isSco: true,
-            line: certificationCandidate.line,
-          });
-
-          // then
-          expect(report).to.deep.equal([{ code: 'BIRTHDATE_DATE_FORMAT', line: 1 }]);
-        });
-
-        it('should return a report when birthdate is null', async function () {
-          // given
-          const certificationCandidate = buildCertificationCandidate({ ...validAttributes, birthdate: null });
-
-          // when
-          const report = certificationCandidate.validateForMassSessionImport({
-            isSco: true,
-            line: certificationCandidate.line,
-          });
-
-          // then
-          expect(report).to.deep.equal([{ code: 'BIRTHDATE_REQUIRED', line: 1 }]);
-        });
-
-        it('should return a report when field extraTimePercentage is not a number', async function () {
-          // given
-          const certificationCandidate = buildCertificationCandidate({
-            ...validAttributes,
-            extraTimePercentage: 'salut',
-          });
-
-          // when
-          const report = certificationCandidate.validateForMassSessionImport({
-            isSco: true,
-            line: certificationCandidate.line,
-          });
-
-          //then
-          expect(report).to.deep.equal([{ code: 'EXTRA_TIME_PERCENTAGE_NOT_A_NUMBER', line: 1 }]);
-        });
-
-        it('should return a report when sex is neither M nor F', async function () {
-          // given
-          const certificationCandidate = buildCertificationCandidate({ ...validAttributes, sex: 'something_else' });
-
-          // when
-          const report = certificationCandidate.validateForMassSessionImport({
-            isSco: true,
-            line: certificationCandidate.line,
-          });
-
-          // then
-          expect(report).to.deep.equal([{ code: 'SEX_NOT_A_SEX_CODE', line: 1 }]);
-        });
-
-        it('should return a report when sex is null', async function () {
-          // given
-          const certificationCandidate = buildCertificationCandidate({ ...validAttributes, sex: null });
-
-          // when
-          const report = certificationCandidate.validateForMassSessionImport({
-            isSco: true,
-            line: certificationCandidate.line,
-          });
-
-          // then
-          expect(report).to.deep.equal([{ code: 'SEX_REQUIRED', line: 1 }]);
-        });
-
-        it('should return a report when a candidate is added with multiple complementary certifications', async function () {
-          // given
-          const certificationCandidate = buildCertificationCandidate({
-            ...validAttributes,
-            complementaryCertifications: [Symbol('1'), Symbol('2')],
-          });
-
-          // when
-          const report = certificationCandidate.validateForMassSessionImport({
-            isSco: true,
-            line: certificationCandidate.line,
-          });
-
-          // then
-          expect(report).to.deep.equal([
-            { code: 'COMPLEMENTARY_CERTIFICATIONS_ONLY_ONE_COMPLEMENTARY_CERTIFICATION', line: 1 },
-          ]);
-        });
-
-        context('when the certification center is SCO', function () {
-          context('when the billing mode is null', function () {
-            it('should return nothing', async function () {
-              // given
-              const certificationCandidate = domainBuilder.buildCertificationCandidate({
-                ...validAttributes,
-                billingMode: null,
-              });
-              const isSco = true;
-
-              // when
-              const report = certificationCandidate.validateForMassSessionImport({
-                isSco,
-                line: certificationCandidate.line,
-              });
-
-              // then
-              expect(report).to.be.undefined;
-            });
-          });
-        });
-
-        context('when the certification center is not SCO', function () {
-          context('when the billing mode is not provided', function () {
-            it('should return a report', async function () {
-              // given
-              const isSco = false;
-              const certificationCandidate = domainBuilder.buildCertificationCandidate({
-                ...validAttributes,
-                billingMode: null,
-              });
-
-              // when
-              const report = certificationCandidate.validateForMassSessionImport({
-                isSco,
-                line: certificationCandidate.line,
-              });
-
-              // then
-              expect(report).to.deep.equal([
-                { code: 'BILLING_MODE_REQUIRED', line: 1 },
-                { code: 'BILLING_MODE_NOT_A_STRING', line: 1 },
-              ]);
-            });
-          });
-
-          it('should return a report if billingMode is not an expected value', async function () {
-            // given
-            const certificationCandidate = domainBuilder.buildCertificationCandidate({
-              ...validAttributes,
-              billingMode: 'NOT_ALLOWED_VALUE',
-            });
-            const isSco = false;
-
-            // when
-            const report = certificationCandidate.validateForMassSessionImport({
-              isSco,
-              line: certificationCandidate.line,
-            });
-
-            // then
-            expect(report).to.deep.equal([{ code: 'BILLING_MODE_NOT_A_BILLING_MODE', line: 1 }]);
-          });
-
-          context('when billing mode is in the expected values', function () {
-            // eslint-disable-next-line mocha/no-setup-in-describe
-            ['FREE', 'PAID', 'PREPAID'].forEach((billingMode) => {
-              it(`should return nothing for ${billingMode}`, async function () {
-                // given
-                const certificationCandidate = domainBuilder.buildCertificationCandidate({
-                  ...validAttributes,
-                  billingMode,
-                  prepaymentCode: billingMode === CertificationCandidate.BILLING_MODES.PREPAID ? '12345' : undefined,
-                });
-
-                // when
-                const report = certificationCandidate.validateForMassSessionImport({
-                  isSco: true,
-                  line: certificationCandidate.line,
-                });
-
-                // then
-                expect(report).to.be.undefined;
-              });
-            });
-          });
-
-          context('when billingMode is not PREPAID', function () {
-            it('should return a report if prepaymentCode is not null', async function () {
-              // given
-              const certificationCandidate = domainBuilder.buildCertificationCandidate({
-                ...validAttributes,
-                billingMode: 'PAID',
-                prepaymentCode: 'NOT_NULL',
-              });
-
-              // when
-              const report = certificationCandidate.validateForMassSessionImport({
-                isSco: true,
-                line: certificationCandidate.line,
-              });
-
-              // then
-              expect(report).to.deep.equal([{ code: 'PREPAYMENT_CODE_PREPAYMENT_CODE_NOT_NULL', line: 1 }]);
-            });
-          });
-
-          context('when billingMode is PREPAID', function () {
-            it('should return nothing if prepaymentCode is not null', function () {
-              // given
-              const certificationCandidate = domainBuilder.buildCertificationCandidate({
-                ...validAttributes,
-                billingMode: 'PREPAID',
-                prepaymentCode: 'NOT_NULL',
-              });
-
-              // when
-              const report = certificationCandidate.validateForMassSessionImport({
-                isSco: true,
-                line: certificationCandidate.line,
-              });
-
-              // then
-              expect(report).to.be.undefined;
-            });
-          });
-        });
-
-        context('birthPostalCode and birthInseeCode', function () {
-          it('should return a report if both birthPostalCode and birthInseeCode are not present', async function () {
-            // given
-            const certificationCandidate = domainBuilder.buildCertificationCandidate({
-              ...validAttributes,
-              birthPostalCode: null,
-              birthINSEECode: null,
-            });
-
-            // when
-            const report = certificationCandidate.validateForMassSessionImport({
-              isSco: true,
-              line: certificationCandidate.line,
-            });
-
-            // then
-            expect(report).to.deep.equal([{ code: 'BIRTH_POSTAL_CODE_BIRTH_INSEE_CODE_INVALID', line: 1 }]);
-          });
-
-          it('should return nothing if birthPostalCode is present and birthInseeCode is empty', async function () {
-            // given
-            const certificationCandidate = domainBuilder.buildCertificationCandidate({
-              ...validAttributes,
-              birthPostalCode: '75000',
-              birthINSEECode: '',
-            });
-
-            // when
-            const report = certificationCandidate.validateForMassSessionImport({
-              isSco: true,
-              line: certificationCandidate.line,
-            });
-
-            // then
-            expect(report).to.be.undefined;
-          });
-
-          it('should return nothing if birthInseeCode is present and birthPostalCode is empty', async function () {
-            // given
-            const certificationCandidate = domainBuilder.buildCertificationCandidate({
-              ...validAttributes,
-              birthPostalCode: '',
-              birthINSEECode: '75115',
-            });
-
-            // when
-            const report = certificationCandidate.validateForMassSessionImport({
-              isSco: true,
-              line: certificationCandidate.line,
-            });
-
-            // then
-            expect(report).to.be.undefined;
-          });
-        });
-
-        context('when there are multiple errors', function () {
-          it('should return multiple message', function () {
-            // given
-            const certificationCandidate = buildCertificationCandidate({
-              ...validAttributes,
-              firstName: undefined,
-              birthdate: undefined,
-            });
-
-            // when
-            const report = certificationCandidate.validateForMassSessionImport({
-              isSco: true,
-              line: certificationCandidate.line,
-            });
-
-            // then
-            expect(report).to.deep.equal([
-              { code: 'FIRST_NAME_REQUIRED', line: 1 },
-              { code: 'BIRTHDATE_REQUIRED', line: 1 },
-            ]);
-          });
-        });
-      });
-
       it('should not throw an error if birthInseeCode is present and birthPostalCode is empty', async function () {
         // given
         const certificationCandidate = domainBuilder.buildCertificationCandidate({
@@ -732,6 +371,367 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
         // then
         expect(call).to.not.throw();
+      });
+    });
+  });
+
+  describe('validateForMassSessionImport', function () {
+    const buildCertificationCandidate = (attributes) => new CertificationCandidate(attributes);
+
+    const validAttributes = {
+      firstName: 'Oren',
+      lastName: 'Ishii',
+      sex: 'F',
+      birthPostalCode: '75001',
+      birthINSEECode: '',
+      birthCountry: 'France',
+      birthdate: '2010-01-01',
+      sessionId: 123,
+      resultRecipientEmail: 'orga@example.net',
+      billingMode: 'FREE',
+      line: 1,
+    };
+
+    context('when all required fields are presents', function () {
+      it('should return nothing', function () {
+        // given
+        const certificationCandidate = buildCertificationCandidate(validAttributes);
+
+        // when
+        const report = certificationCandidate.validateForMassSessionImport({
+          isSco: true,
+          line: certificationCandidate.line,
+        });
+
+        // then
+        expect(report).to.be.undefined;
+      });
+    });
+
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    ['firstName', 'lastName', 'birthCountry', 'birthdate'].forEach((field) => {
+      it(`should return a report when field ${field} is not present`, async function () {
+        // given
+        const certificationCandidate = buildCertificationCandidate({ ...validAttributes, [field]: undefined });
+
+        // when
+        const report = certificationCandidate.validateForMassSessionImport(certificationCandidate);
+
+        // then
+        expect(report).to.deep.equal([{ code: `${snakeCase(field).toUpperCase()}_REQUIRED`, line: 1 }]);
+      });
+
+      it(`should return a report when field ${field} is null`, async function () {
+        // given
+        const certificationCandidate = buildCertificationCandidate({ ...validAttributes, [field]: null });
+
+        // when
+        const report = certificationCandidate.validateForMassSessionImport({
+          isSco: true,
+          line: certificationCandidate.line,
+        });
+
+        // then
+        expect(report).to.deep.equal([{ code: `${snakeCase(field).toUpperCase()}_REQUIRED`, line: 1 }]);
+      });
+    });
+
+    it('should return a report when birthdate is not a valid format', async function () {
+      // given
+      const certificationCandidate = buildCertificationCandidate({ ...validAttributes, birthdate: '2020/02/01' });
+
+      // when
+      const report = certificationCandidate.validateForMassSessionImport({
+        isSco: true,
+        line: certificationCandidate.line,
+      });
+
+      // then
+      expect(report).to.deep.equal([{ code: 'BIRTHDATE_DATE_FORMAT', line: 1 }]);
+    });
+
+    it('should return a report when birthdate is null', async function () {
+      // given
+      const certificationCandidate = buildCertificationCandidate({ ...validAttributes, birthdate: null });
+
+      // when
+      const report = certificationCandidate.validateForMassSessionImport({
+        isSco: true,
+        line: certificationCandidate.line,
+      });
+
+      // then
+      expect(report).to.deep.equal([{ code: 'BIRTHDATE_REQUIRED', line: 1 }]);
+    });
+
+    it('should return a report when field extraTimePercentage is not a number', async function () {
+      // given
+      const certificationCandidate = buildCertificationCandidate({
+        ...validAttributes,
+        extraTimePercentage: 'salut',
+      });
+
+      // when
+      const report = certificationCandidate.validateForMassSessionImport({
+        isSco: true,
+        line: certificationCandidate.line,
+      });
+
+      //then
+      expect(report).to.deep.equal([{ code: 'EXTRA_TIME_PERCENTAGE_NOT_A_NUMBER', line: 1 }]);
+    });
+
+    it('should return a report when sex is neither M nor F', async function () {
+      // given
+      const certificationCandidate = buildCertificationCandidate({ ...validAttributes, sex: 'something_else' });
+
+      // when
+      const report = certificationCandidate.validateForMassSessionImport({
+        isSco: true,
+        line: certificationCandidate.line,
+      });
+
+      // then
+      expect(report).to.deep.equal([{ code: 'SEX_NOT_A_SEX_CODE', line: 1 }]);
+    });
+
+    it('should return a report when sex is null', async function () {
+      // given
+      const certificationCandidate = buildCertificationCandidate({ ...validAttributes, sex: null });
+
+      // when
+      const report = certificationCandidate.validateForMassSessionImport({
+        isSco: true,
+        line: certificationCandidate.line,
+      });
+
+      // then
+      expect(report).to.deep.equal([{ code: 'SEX_REQUIRED', line: 1 }]);
+    });
+
+    it('should return a report when a candidate is added with multiple complementary certifications', async function () {
+      // given
+      const certificationCandidate = buildCertificationCandidate({
+        ...validAttributes,
+        complementaryCertifications: [Symbol('1'), Symbol('2')],
+      });
+
+      // when
+      const report = certificationCandidate.validateForMassSessionImport({
+        isSco: true,
+        line: certificationCandidate.line,
+      });
+
+      // then
+      expect(report).to.deep.equal([
+        { code: 'COMPLEMENTARY_CERTIFICATIONS_ONLY_ONE_COMPLEMENTARY_CERTIFICATION', line: 1 },
+      ]);
+    });
+
+    context('when the certification center is SCO', function () {
+      context('when the billing mode is null', function () {
+        it('should return nothing', async function () {
+          // given
+          const certificationCandidate = domainBuilder.buildCertificationCandidate({
+            ...validAttributes,
+            billingMode: null,
+          });
+          const isSco = true;
+
+          // when
+          const report = certificationCandidate.validateForMassSessionImport({
+            isSco,
+            line: certificationCandidate.line,
+          });
+
+          // then
+          expect(report).to.be.undefined;
+        });
+      });
+    });
+
+    context('when the certification center is not SCO', function () {
+      context('when the billing mode is not provided', function () {
+        it('should return a report', async function () {
+          // given
+          const isSco = false;
+          const certificationCandidate = domainBuilder.buildCertificationCandidate({
+            ...validAttributes,
+            billingMode: null,
+          });
+
+          // when
+          const report = certificationCandidate.validateForMassSessionImport({
+            isSco,
+            line: certificationCandidate.line,
+          });
+
+          // then
+          expect(report).to.deep.equal([
+            { code: 'BILLING_MODE_REQUIRED', line: 1 },
+            { code: 'BILLING_MODE_NOT_A_STRING', line: 1 },
+          ]);
+        });
+      });
+
+      it('should return a report if billingMode is not an expected value', async function () {
+        // given
+        const certificationCandidate = domainBuilder.buildCertificationCandidate({
+          ...validAttributes,
+          billingMode: 'NOT_ALLOWED_VALUE',
+        });
+        const isSco = false;
+
+        // when
+        const report = certificationCandidate.validateForMassSessionImport({
+          isSco,
+          line: certificationCandidate.line,
+        });
+
+        // then
+        expect(report).to.deep.equal([{ code: 'BILLING_MODE_NOT_A_BILLING_MODE', line: 1 }]);
+      });
+
+      context('when billing mode is in the expected values', function () {
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        ['FREE', 'PAID', 'PREPAID'].forEach((billingMode) => {
+          it(`should return nothing for ${billingMode}`, async function () {
+            // given
+            const certificationCandidate = domainBuilder.buildCertificationCandidate({
+              ...validAttributes,
+              billingMode,
+              prepaymentCode: billingMode === CertificationCandidate.BILLING_MODES.PREPAID ? '12345' : undefined,
+            });
+
+            // when
+            const report = certificationCandidate.validateForMassSessionImport({
+              isSco: true,
+              line: certificationCandidate.line,
+            });
+
+            // then
+            expect(report).to.be.undefined;
+          });
+        });
+      });
+
+      context('when billingMode is not PREPAID', function () {
+        it('should return a report if prepaymentCode is not null', async function () {
+          // given
+          const certificationCandidate = domainBuilder.buildCertificationCandidate({
+            ...validAttributes,
+            billingMode: 'PAID',
+            prepaymentCode: 'NOT_NULL',
+          });
+
+          // when
+          const report = certificationCandidate.validateForMassSessionImport({
+            isSco: true,
+            line: certificationCandidate.line,
+          });
+
+          // then
+          expect(report).to.deep.equal([{ code: 'PREPAYMENT_CODE_PREPAYMENT_CODE_NOT_NULL', line: 1 }]);
+        });
+      });
+
+      context('when billingMode is PREPAID', function () {
+        it('should return nothing if prepaymentCode is not null', function () {
+          // given
+          const certificationCandidate = domainBuilder.buildCertificationCandidate({
+            ...validAttributes,
+            billingMode: 'PREPAID',
+            prepaymentCode: 'NOT_NULL',
+          });
+
+          // when
+          const report = certificationCandidate.validateForMassSessionImport({
+            isSco: true,
+            line: certificationCandidate.line,
+          });
+
+          // then
+          expect(report).to.be.undefined;
+        });
+      });
+    });
+
+    context('birthPostalCode and birthInseeCode', function () {
+      it('should return a report if both birthPostalCode and birthInseeCode are not present', async function () {
+        // given
+        const certificationCandidate = domainBuilder.buildCertificationCandidate({
+          ...validAttributes,
+          birthPostalCode: null,
+          birthINSEECode: null,
+        });
+
+        // when
+        const report = certificationCandidate.validateForMassSessionImport({
+          isSco: true,
+          line: certificationCandidate.line,
+        });
+
+        // then
+        expect(report).to.deep.equal([{ code: 'BIRTH_POSTAL_CODE_BIRTH_INSEE_CODE_INVALID', line: 1 }]);
+      });
+
+      it('should return nothing if birthPostalCode is present and birthInseeCode is empty', async function () {
+        // given
+        const certificationCandidate = domainBuilder.buildCertificationCandidate({
+          ...validAttributes,
+          birthPostalCode: '75000',
+          birthINSEECode: '',
+        });
+
+        // when
+        const report = certificationCandidate.validateForMassSessionImport({
+          isSco: true,
+          line: certificationCandidate.line,
+        });
+
+        // then
+        expect(report).to.be.undefined;
+      });
+
+      it('should return nothing if birthInseeCode is present and birthPostalCode is empty', async function () {
+        // given
+        const certificationCandidate = domainBuilder.buildCertificationCandidate({
+          ...validAttributes,
+          birthPostalCode: '',
+          birthINSEECode: '75115',
+        });
+
+        // when
+        const report = certificationCandidate.validateForMassSessionImport({
+          isSco: true,
+          line: certificationCandidate.line,
+        });
+
+        // then
+        expect(report).to.be.undefined;
+      });
+    });
+
+    context('when there are multiple errors', function () {
+      it('should return multiple message', function () {
+        // given
+        const certificationCandidate = buildCertificationCandidate({
+          ...validAttributes,
+          firstName: undefined,
+          birthdate: undefined,
+        });
+
+        // when
+        const report = certificationCandidate.validateForMassSessionImport({
+          isSco: true,
+          line: certificationCandidate.line,
+        });
+
+        // then
+        expect(report).to.deep.equal([
+          { code: 'FIRST_NAME_REQUIRED', line: 1 },
+          { code: 'BIRTHDATE_REQUIRED', line: 1 },
+        ]);
       });
     });
   });

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -389,6 +389,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       sessionId: 123,
       resultRecipientEmail: 'orga@example.net',
       billingMode: 'FREE',
+      extraTimePercentage: 1,
     };
 
     context('when all required fields are presents', function () {
@@ -478,6 +479,32 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
       //then
       expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_PERCENTAGE_REQUIRED.code]);
+    });
+
+    it('should throw an error when field extraTimePercentage is upper than 100', async function () {
+      const certificationCandidate = buildCertificationCandidate({
+        ...validAttributes,
+        extraTimePercentage: 101,
+      });
+      const isSco = true;
+
+      const report = certificationCandidate.validateForMassSessionImport(isSco);
+
+      // then
+      expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_BELOW_ONE.code]);
+    });
+
+    it('should throw an error when field extraTimePercentage is lower than 1', async function () {
+      const certificationCandidate = buildCertificationCandidate({
+        ...validAttributes,
+        extraTimePercentage: 0,
+      });
+      const isSco = true;
+
+      const report = certificationCandidate.validateForMassSessionImport(isSco);
+
+      // then
+      expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_BELOW_ONE.code]);
     });
 
     it('should return a report when sex is neither M nor F', async function () {

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -647,9 +647,10 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         const report = certificationCandidate.validateForMassSessionImport({
           line: 1,
         });
+        console.log({ report });
 
         // then
-        expect(report).to.deep.equal(['CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_INVALID']);
+        expect(report).to.deep.equal(['CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED']);
       });
 
       it('should return a report if birthPostalCode and birthInseeCode are present', async function () {
@@ -664,9 +665,10 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         const report = certificationCandidate.validateForMassSessionImport({
           line: 1,
         });
+        console.log({ report });
 
         // then
-        expect(report).to.deep.equal(['CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_INVALID']);
+        expect(report).to.deep.equal(['CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_ARE_EXCLUSIVE']);
       });
 
       it('should return nothing if birthPostalCode is present and birthInseeCode is empty', async function () {
@@ -674,7 +676,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         const certificationCandidate = domainBuilder.buildCertificationCandidate({
           ...validAttributes,
           birthPostalCode: '75000',
-          birthINSEECode: '',
+          birthINSEECode: null,
         });
 
         // when
@@ -682,6 +684,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
           isSco: true,
           line: 1,
         });
+        console.log({ report });
 
         // then
         expect(report).to.be.undefined;

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -5,6 +5,7 @@ const {
   CertificationCandidatePersonalInfoFieldMissingError,
   CertificationCandidatePersonalInfoWrongFormat,
 } = require('../../../../lib/domain/errors');
+const { CERTIFICATION_CANDIDATES_ERRORS } = require('../../../../lib/domain/constants/certification-candidates-errors');
 
 describe('Unit | Domain | Models | Certification Candidate', function () {
   describe('constructor', function () {
@@ -404,12 +405,13 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       });
     });
 
-    // eslint-disable-next-line mocha/no-setup-in-describe
+    /* eslint-disable mocha/no-setup-in-describe */
     [
-      { field: 'firstName', expectedCode: 'CANDIDATE_FIRST_NAME_REQUIRED' },
-      { field: 'lastName', expectedCode: 'CANDIDATE_LAST_NAME_REQUIRED' },
-      { field: 'birthCountry', expectedCode: 'CANDIDATE_BIRTH_COUNTRY_REQUIRED' },
-      { field: 'birthdate', expectedCode: 'CANDIDATE_BIRTHDATE_REQUIRED' },
+      { field: 'firstName', expectedCode: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FIRST_NAME_REQUIRED.code },
+      { field: 'lastName', expectedCode: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_LAST_NAME_REQUIRED.code },
+      { field: 'birthCountry', expectedCode: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_REQUIRED.code },
+      { field: 'birthdate', expectedCode: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_REQUIRED.code },
+      /* eslint-enable mocha/no-setup-in-describe */
     ].forEach(({ field, expectedCode }) => {
       it(`should return a report when field ${field} is not present`, async function () {
         // given
@@ -444,7 +446,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       });
 
       // then
-      expect(report).to.deep.equal(['CANDIDATE_INCORRECT_BIRTHDATE_FORMAT']);
+      expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_FORMAT_INCORRECT.code]);
     });
 
     it('should return a report when birthdate is null', async function () {
@@ -458,7 +460,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       });
 
       // then
-      expect(report).to.deep.equal(['CANDIDATE_BIRTHDATE_REQUIRED']);
+      expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_REQUIRED.code]);
     });
 
     it('should return a report when field extraTimePercentage is not a number', async function () {
@@ -475,7 +477,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       });
 
       //then
-      expect(report).to.deep.equal(['CANDIDATE_EXTRA_TIME_PERCENTAGE_REQUIRED']);
+      expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_PERCENTAGE_REQUIRED.code]);
     });
 
     it('should return a report when sex is neither M nor F', async function () {
@@ -487,7 +489,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       const report = certificationCandidate.validateForMassSessionImport(isSco);
 
       // then
-      expect(report).to.deep.equal(['CANDIDATE_SEX_NOT_VALID']);
+      expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SEX_NOT_VALID.code]);
     });
 
     it('should return a report when sex is null', async function () {
@@ -499,7 +501,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       const report = certificationCandidate.validateForMassSessionImport(isSco);
 
       // then
-      expect(report).to.deep.equal(['CANDIDATE_SEX_REQUIRED']);
+      expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SEX_REQUIRED.code]);
     });
 
     it('should return a report when a candidate is added with multiple complementary certifications', async function () {
@@ -515,7 +517,9 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       const report = certificationCandidate.validateForMassSessionImport(isSco);
 
       // then
-      expect(report).to.deep.equal(['CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION']);
+      expect(report).to.deep.equal([
+        CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION.code,
+      ]);
     });
 
     context('when the certification center is SCO', function () {
@@ -551,7 +555,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
           const report = certificationCandidate.validateForMassSessionImport(isSco);
 
           // then
-          expect(report).to.deep.equal(['CANDIDATE_BILLING_MODE_REQUIRED']);
+          expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_REQUIRED.code]);
         });
       });
 
@@ -568,7 +572,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
           const report = certificationCandidate.validateForMassSessionImport(isSco);
 
           // then
-          expect(report).to.deep.equal(['CANDIDATE_BILLING_MODE_NOT_VALID']);
+          expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_NOT_VALID.code]);
         });
       });
 
@@ -608,7 +612,9 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
             const report = certificationCandidate.validateForMassSessionImport(isSco);
 
             // then
-            expect(report).to.deep.equal(['CANDIDATE_BILLING_MODE_MUST_BE_EMPTY']);
+            expect(report).to.deep.equal([
+              CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY.code,
+            ]);
           });
         });
       });
@@ -647,10 +653,11 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         const report = certificationCandidate.validateForMassSessionImport({
           line: 1,
         });
-        console.log({ report });
 
         // then
-        expect(report).to.deep.equal(['CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED']);
+        expect(report).to.deep.equal([
+          CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED.code,
+        ]);
       });
 
       it('should return a report if birthPostalCode and birthInseeCode are present', async function () {
@@ -665,10 +672,11 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         const report = certificationCandidate.validateForMassSessionImport({
           line: 1,
         });
-        console.log({ report });
 
         // then
-        expect(report).to.deep.equal(['CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_ARE_EXCLUSIVE']);
+        expect(report).to.deep.equal([
+          CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_EXCLUSIVE.code,
+        ]);
       });
 
       it('should return nothing if birthPostalCode is present and birthInseeCode is empty', async function () {
@@ -684,7 +692,6 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
           isSco: true,
           line: 1,
         });
-        console.log({ report });
 
         // then
         expect(report).to.be.undefined;
@@ -725,7 +732,10 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         });
 
         // then
-        expect(report).to.deep.equal(['CANDIDATE_FIRST_NAME_REQUIRED', 'CANDIDATE_BIRTHDATE_REQUIRED']);
+        expect(report).to.deep.equal([
+          CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FIRST_NAME_REQUIRED.code,
+          CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_REQUIRED.code,
+        ]);
       });
     });
   });

--- a/api/tests/unit/domain/services/certification-cpf-service_test.js
+++ b/api/tests/unit/domain/services/certification-cpf-service_test.js
@@ -3,6 +3,7 @@ const {
   CpfBirthInformationValidation,
   getBirthInformation,
 } = require('../../../../lib/domain/services/certification-cpf-service');
+const { CERTIFICATION_CANDIDATES_ERRORS } = require('../../../../lib/domain/constants/certification-candidates-errors');
 
 describe('Unit | Service | Certification CPF service', function () {
   let certificationCpfCountryRepository;
@@ -32,7 +33,11 @@ describe('Unit | Service | Certification CPF service', function () {
         });
 
         // then
-        expect(result).to.deep.equal(CpfBirthInformationValidation.failure('Le champ pays est obligatoire.'));
+        expect(result).to.deep.equal(
+          CpfBirthInformationValidation.failure({
+            certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_REQUIRED,
+          })
+        );
       });
     });
 
@@ -58,7 +63,10 @@ describe('Unit | Service | Certification CPF service', function () {
 
         // then
         expect(result).to.deep.equal(
-          CpfBirthInformationValidation.failure(`Le pays "${birthCountry}" n'a pas été trouvé.`)
+          CpfBirthInformationValidation.failure({
+            certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_NOT_FOUND,
+            data: { birthCountry },
+          })
         );
       });
     });
@@ -92,7 +100,11 @@ describe('Unit | Service | Certification CPF service', function () {
           });
 
           // then
-          expect(result).to.deep.equal(CpfBirthInformationValidation.failure('Le champ ville est obligatoire.'));
+          expect(result).to.deep.equal(
+            CpfBirthInformationValidation.failure({
+              certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_CITY_REQUIRED,
+            })
+          );
         });
 
         it('should return a validation failure when postal code is defined', async function () {
@@ -123,9 +135,10 @@ describe('Unit | Service | Certification CPF service', function () {
 
           // then
           expect(result).to.deep.equal(
-            CpfBirthInformationValidation.failure(
-              'Le champ code postal ne doit pas être renseigné pour un pays étranger.'
-            )
+            CpfBirthInformationValidation.failure({
+              certificationCandidateError:
+                CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_POSTAL_CODE_ON_FOREIGN_COUNTRY_MUST_BE_EMPTY,
+            })
           );
         });
 
@@ -157,7 +170,9 @@ describe('Unit | Service | Certification CPF service', function () {
 
           // then
           expect(result).to.deep.equal(
-            CpfBirthInformationValidation.failure('La valeur du code INSEE doit être "99" pour un pays étranger.')
+            CpfBirthInformationValidation.failure({
+              certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID,
+            })
           );
         });
 
@@ -189,7 +204,9 @@ describe('Unit | Service | Certification CPF service', function () {
 
           // then
           expect(result).to.deep.equal(
-            CpfBirthInformationValidation.failure('La valeur du code INSEE doit être "99" pour un pays étranger.')
+            CpfBirthInformationValidation.failure({
+              certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID,
+            })
           );
         });
 
@@ -257,7 +274,10 @@ describe('Unit | Service | Certification CPF service', function () {
 
             // then
             expect(result).to.deep.equal(
-              CpfBirthInformationValidation.failure('Le champ code postal ou code INSEE doit être renseigné.')
+              CpfBirthInformationValidation.failure({
+                certificationCandidateError:
+                  CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED,
+              })
             );
           });
         });
@@ -287,9 +307,10 @@ describe('Unit | Service | Certification CPF service', function () {
 
             // then
             expect(result).to.deep.equal(
-              CpfBirthInformationValidation.failure(
-                'Seul l\'un des champs "Code postal" ou "Code Insee" doit être renseigné.'
-              )
+              CpfBirthInformationValidation.failure({
+                certificationCandidateError:
+                  CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_EXCLUSIVE,
+              })
             );
           });
         });
@@ -363,7 +384,10 @@ describe('Unit | Service | Certification CPF service', function () {
 
             // then
             expect(result).to.deep.equal(
-              CpfBirthInformationValidation.failure(`Le code INSEE "${birthINSEECode}" n'est pas valide.`)
+              CpfBirthInformationValidation.failure({
+                certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_INVALID,
+                data: { birthINSEECode },
+              })
             );
           });
 
@@ -393,9 +417,10 @@ describe('Unit | Service | Certification CPF service', function () {
 
             // then
             expect(result).to.deep.equal(
-              CpfBirthInformationValidation.failure(
-                "Le champ commune de naissance ne doit pas être renseigné lorsqu'un code INSEE est renseigné."
-              )
+              CpfBirthInformationValidation.failure({
+                certificationCandidateError:
+                  CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_EXCLUSIVE,
+              })
             );
           });
         });
@@ -519,7 +544,10 @@ describe('Unit | Service | Certification CPF service', function () {
 
             // then
             expect(result).to.deep.equal(
-              CpfBirthInformationValidation.failure(`Le code postal "${birthPostalCode}" n'est pas valide.`)
+              CpfBirthInformationValidation.failure({
+                certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_POSTAL_CODE_NOT_FOUND,
+                data: { birthPostalCode },
+              })
             );
           });
 
@@ -546,7 +574,11 @@ describe('Unit | Service | Certification CPF service', function () {
             });
 
             // then
-            expect(result).to.deep.equal(CpfBirthInformationValidation.failure('Le champ ville est obligatoire.'));
+            expect(result).to.deep.equal(
+              CpfBirthInformationValidation.failure({
+                certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_CITY_REQUIRED,
+              })
+            );
           });
 
           it('should return a validation failure when postal code does not match city name', async function () {
@@ -580,9 +612,10 @@ describe('Unit | Service | Certification CPF service', function () {
 
             // then
             expect(result).to.deep.equal(
-              CpfBirthInformationValidation.failure(
-                `Le code postal "${birthPostalCode}" ne correspond pas à la ville "${birthCity}"`
-              )
+              CpfBirthInformationValidation.failure({
+                certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_POSTAL_CODE_CITY_INVALID,
+                data: { birthPostalCode, birthCity },
+              })
             );
           });
         });

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -345,28 +345,60 @@ describe('Unit | Service | sessions import validation Service', function () {
 
     context('when candidate has missing billing information', function () {
       context('when the parsed candidate is not sco', function () {
-        it('should return an certificationCandidateErrors containing billing mode errors', async function () {
-          // given
-          const isSco = false;
-          const candidate = _buildValidCandidateData();
-          candidate.billingMode = null;
-          certificationCpfService.getBirthInformation.resolves(CpfBirthInformationValidation.success({ ...candidate }));
+        context('when billing mode is null', function () {
+          it('should return an certificationCandidateErrors containing billing mode errors', async function () {
+            // given
+            const isSco = false;
+            const candidate = _buildValidCandidateData();
+            candidate.billingMode = null;
+            certificationCpfService.getBirthInformation.resolves(
+              CpfBirthInformationValidation.success({ ...candidate })
+            );
 
-          // when
-          const { certificationCandidateErrors } =
-            await sessionsImportValidationService.getValidatedCandidateBirthInformation({
-              candidate,
-              isSco,
-              line: 1,
-            });
+            // when
+            const { certificationCandidateErrors } =
+              await sessionsImportValidationService.getValidatedCandidateBirthInformation({
+                candidate,
+                isSco,
+                line: 1,
+              });
 
-          // then
-          expect(certificationCandidateErrors).to.deep.equal([
-            {
-              code: 'CANDIDATE_BILLING_MODE_REQUIRED',
-              line: 1,
-            },
-          ]);
+            // then
+            expect(certificationCandidateErrors).to.deep.equal([
+              {
+                code: 'CANDIDATE_BILLING_MODE_REQUIRED',
+                line: 1,
+              },
+            ]);
+          });
+        });
+
+        context('when billing mode is missing', function () {
+          it('should return an certificationCandidateErrors containing billing mode errors', async function () {
+            // given
+            const isSco = false;
+            const candidate = _buildValidCandidateData();
+            candidate.billingMode = '';
+            certificationCpfService.getBirthInformation.resolves(
+              CpfBirthInformationValidation.success({ ...candidate })
+            );
+
+            // when
+            const { certificationCandidateErrors } =
+              await sessionsImportValidationService.getValidatedCandidateBirthInformation({
+                candidate,
+                isSco,
+                line: 1,
+              });
+
+            // then
+            expect(certificationCandidateErrors).to.deep.equal([
+              {
+                code: 'CANDIDATE_BILLING_MODE_REQUIRED',
+                line: 1,
+              },
+            ]);
+          });
         });
       });
 

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -326,26 +326,6 @@ describe('Unit | Service | sessions import validation Service', function () {
       });
     });
 
-    context('when candidate has extra time percentage below 1', function () {
-      it('should return a certificationCandidateErrors containing the specific error ', async function () {
-        // given
-        const candidate = _buildValidCandidateData();
-        candidate.extraTimePercentage = '0.20';
-
-        certificationCpfService.getBirthInformation.resolves(CpfBirthInformationValidation.success({}));
-
-        // when
-        const { certificationCandidateErrors } =
-          await sessionsImportValidationService.getValidatedCandidateBirthInformation({
-            line: 1,
-            candidate,
-          });
-
-        // then
-        expect(certificationCandidateErrors).to.deep.equal([{ code: 'CANDIDATE_EXTRA_TIME_BELOW_ONE', line: 1 }]);
-      });
-    });
-
     context('when candidate has missing billing information', function () {
       context('when the parsed candidate is not sco', function () {
         context('when billing mode is null', function () {

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -333,11 +333,12 @@ describe('Unit | Service | sessions import validation Service', function () {
         // when
         const { certificationCandidateErrors } =
           await sessionsImportValidationService.getValidatedCandidateBirthInformation({
+            line: 1,
             candidate,
           });
 
         // then
-        expect(certificationCandidateErrors).to.deep.equal(['Temps majoré doit être supérieur à 1']);
+        expect(certificationCandidateErrors).to.deep.equal([{ code: 'CANDIDATE_EXTRA_TIME_BELOW_ONE', line: 1 }]);
       });
     });
 

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -78,7 +78,12 @@ describe('Unit | Service | sessions import validation Service', function () {
         });
 
         // then
-        expect(sessionErrors).to.deep.equal(["Impossible d'ajouter un candidat à une session qui a déjà commencé."]);
+        expect(sessionErrors).to.deep.equal([
+          {
+            line: 2,
+            code: 'CANDIDATE_NOT_ALLOWED_FOR_STARTED_SESSION',
+          },
+        ]);
       });
     });
 
@@ -97,7 +102,12 @@ describe('Unit | Service | sessions import validation Service', function () {
           });
 
           // then
-          expect(sessionErrors).to.deep.equal(['Une session ne peut pas être programmée dans le passé']);
+          expect(sessionErrors).to.deep.equal([
+            {
+              line: 1,
+              code: 'SESSION_SCHEDULED_IN_THE_PAST',
+            },
+          ]);
         });
       });
     });
@@ -119,7 +129,10 @@ describe('Unit | Service | sessions import validation Service', function () {
 
           // then
           expect(sessionErrors).to.deep.equal([
-            'Merci de ne pas renseigner les informations de session pour la session: 1234',
+            {
+              line: 1,
+              code: 'INFORMATION_NOT_ALLOWED_WITH_SESSION_ID',
+            },
           ]);
         });
       });
@@ -159,7 +172,12 @@ describe('Unit | Service | sessions import validation Service', function () {
         });
 
         // then
-        expect(sessionErrors).to.deep.equal(['Session happening on 2024-03-12 at 14:30 already exists']);
+        expect(sessionErrors).to.deep.equal([
+          {
+            line: 1,
+            code: 'SESSION_WITH_DATE_AND_TIME_ALREADY_EXISTS',
+          },
+        ]);
       });
     });
 
@@ -180,7 +198,12 @@ describe('Unit | Service | sessions import validation Service', function () {
           });
 
           // then
-          expect(sessionErrors).to.deep.equal(['Une session contient au moins un élève en double.']);
+          expect(sessionErrors).to.deep.equal([
+            {
+              line: 1,
+              code: 'DUPLICATE_CANDIDATE_NOT_ALLOWED_IN_SESSION',
+            },
+          ]);
         });
       });
     });
@@ -199,7 +222,12 @@ describe('Unit | Service | sessions import validation Service', function () {
         });
 
         // then
-        expect(sessionErrors).to.deep.equal(['Veuillez indiquer un nom de salle.']);
+        expect(sessionErrors).to.deep.equal([
+          {
+            line: 1,
+            message: 'Veuillez indiquer un nom de salle.',
+          },
+        ]);
       });
     });
 
@@ -219,8 +247,8 @@ describe('Unit | Service | sessions import validation Service', function () {
 
         // then
         expect(sessionErrors).to.have.deep.members([
-          'Veuillez indiquer un nom de salle.',
-          'Veuillez indiquer un nom de site.',
+          { line: 1, message: 'Veuillez indiquer un nom de site.' },
+          { line: 1, message: 'Veuillez indiquer un nom de salle.' },
         ]);
       });
     });
@@ -403,6 +431,7 @@ function _buildValidSessionWithId(sessionId) {
     examiner: null,
     description: null,
     certificationCandidates: null,
+    line: 2,
   });
 }
 
@@ -410,6 +439,7 @@ function _buildValidSessionWithoutId() {
   return domainBuilder.buildSession({
     id: null,
     date: '2024-03-12',
+    line: 1,
   });
 }
 

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -33,6 +33,7 @@ describe('Unit | Service | sessions import validation Service', function () {
             // when
             const sessionErrors = await sessionsImportValidationService.validateSession({
               session,
+              line: 1,
               sessionRepository,
               certificationCourseRepository,
             });
@@ -52,6 +53,7 @@ describe('Unit | Service | sessions import validation Service', function () {
             // when
             const sessionErrors = await sessionsImportValidationService.validateSession({
               session,
+              line: 1,
               sessionRepository,
               certificationCourseRepository,
             });
@@ -73,6 +75,7 @@ describe('Unit | Service | sessions import validation Service', function () {
         // when
         const sessionErrors = await sessionsImportValidationService.validateSession({
           session,
+          line: 2,
           sessionRepository,
           certificationCourseRepository,
         });
@@ -97,6 +100,7 @@ describe('Unit | Service | sessions import validation Service', function () {
           // when
           const sessionErrors = await sessionsImportValidationService.validateSession({
             session,
+            line: 1,
             sessionRepository,
             certificationCourseRepository,
           });
@@ -123,6 +127,7 @@ describe('Unit | Service | sessions import validation Service', function () {
           // when
           const sessionErrors = await sessionsImportValidationService.validateSession({
             session,
+            line: 1,
             sessionRepository,
             certificationCourseRepository,
           });
@@ -148,6 +153,7 @@ describe('Unit | Service | sessions import validation Service', function () {
           // when
           const sessionErrors = await sessionsImportValidationService.validateSession({
             session,
+            line: 1,
             sessionRepository,
             certificationCourseRepository,
           });
@@ -167,6 +173,7 @@ describe('Unit | Service | sessions import validation Service', function () {
         // when
         const sessionErrors = await sessionsImportValidationService.validateSession({
           session,
+          line: 1,
           sessionRepository,
           certificationCourseRepository,
         });
@@ -193,6 +200,7 @@ describe('Unit | Service | sessions import validation Service', function () {
           // when
           const sessionErrors = await sessionsImportValidationService.validateSession({
             session,
+            line: 1,
             sessionRepository,
             certificationCourseRepository,
           });
@@ -217,6 +225,7 @@ describe('Unit | Service | sessions import validation Service', function () {
         // when
         const sessionErrors = await sessionsImportValidationService.validateSession({
           session,
+          line: 1,
           sessionRepository,
           certificationCourseRepository,
         });
@@ -225,7 +234,7 @@ describe('Unit | Service | sessions import validation Service', function () {
         expect(sessionErrors).to.deep.equal([
           {
             line: 1,
-            message: 'Veuillez indiquer un nom de salle.',
+            code: 'SESSION_ROOM_REQUIRED',
           },
         ]);
       });
@@ -241,14 +250,15 @@ describe('Unit | Service | sessions import validation Service', function () {
         // when
         const sessionErrors = await sessionsImportValidationService.validateSession({
           session,
+          line: 1,
           sessionRepository,
           certificationCourseRepository,
         });
 
         // then
         expect(sessionErrors).to.have.deep.members([
-          { line: 1, message: 'Veuillez indiquer un nom de site.' },
-          { line: 1, message: 'Veuillez indiquer un nom de salle.' },
+          { line: 1, code: 'SESSION_ADDRESS_REQUIRED' },
+          { line: 1, code: 'SESSION_ROOM_REQUIRED' },
         ]);
       });
     });
@@ -299,10 +309,16 @@ describe('Unit | Service | sessions import validation Service', function () {
           await sessionsImportValidationService.getValidatedCandidateBirthInformation({
             candidate,
             isSco,
+            line: 1,
           });
 
         // then
-        expect(certificationCandidateErrors).to.deep.equal(['firstName required']);
+        expect(certificationCandidateErrors).to.deep.equal([
+          {
+            code: 'CANDIDATE_FIRST_NAME_REQUIRED',
+            line: 1,
+          },
+        ]);
       });
     });
 
@@ -339,10 +355,16 @@ describe('Unit | Service | sessions import validation Service', function () {
             await sessionsImportValidationService.getValidatedCandidateBirthInformation({
               candidate,
               isSco,
+              line: 1,
             });
 
           // then
-          expect(certificationCandidateErrors).to.deep.equal(['billingMode required', 'billingMode not_a_string']);
+          expect(certificationCandidateErrors).to.deep.equal([
+            {
+              code: 'CANDIDATE_BILLING_MODE_REQUIRED',
+              line: 1,
+            },
+          ]);
         });
       });
 
@@ -431,7 +453,6 @@ function _buildValidSessionWithId(sessionId) {
     examiner: null,
     description: null,
     certificationCandidates: null,
-    line: 2,
   });
 }
 
@@ -439,7 +460,6 @@ function _buildValidSessionWithoutId() {
   return domainBuilder.buildSession({
     id: null,
     date: '2024-03-12',
-    line: 1,
   });
 }
 

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -2,6 +2,7 @@ const { expect, sinon, domainBuilder } = require('../../../../test-helper');
 const sessionsImportValidationService = require('../../../../../lib/domain/services/sessions-mass-import/sessions-import-validation-service');
 const { CpfBirthInformationValidation } = require('../../../../../lib/domain/services/certification-cpf-service');
 const certificationCpfService = require('../../../../../lib/domain/services/certification-cpf-service');
+const noop = require('lodash/noop');
 
 describe('Unit | Service | sessions import validation Service', function () {
   describe('#validateSession', function () {
@@ -405,6 +406,7 @@ describe('Unit | Service | sessions import validation Service', function () {
         const candidate = _buildValidCandidateData();
         const certificationCpfCountryRepository = Symbol();
         const certificationCpfCityRepository = Symbol();
+        const certificationCandidateError = { code: 'CPF_INCORRECT', getMessage: noop };
         certificationCpfService.getBirthInformation
           .withArgs({
             birthCountry: candidate.birthCountry,
@@ -414,7 +416,7 @@ describe('Unit | Service | sessions import validation Service', function () {
             certificationCpfCountryRepository,
             certificationCpfCityRepository,
           })
-          .resolves(CpfBirthInformationValidation.failure('CPF incorrect.'));
+          .resolves(CpfBirthInformationValidation.failure({ certificationCandidateError }));
 
         // when
         const result = await sessionsImportValidationService.getValidatedCandidateBirthInformation({
@@ -422,10 +424,11 @@ describe('Unit | Service | sessions import validation Service', function () {
           isSco: false,
           certificationCpfCountryRepository,
           certificationCpfCityRepository,
+          line: 1,
         });
 
         // then
-        expect(result.certificationCandidateErrors).to.deep.equal(['CPF incorrect.']);
+        expect(result.certificationCandidateErrors).to.deep.equal([{ code: 'CPF_INCORRECT', line: 1 }]);
       });
     });
   });

--- a/api/tests/unit/domain/usecases/add-certification-candidate-to-session_test.js
+++ b/api/tests/unit/domain/usecases/add-certification-candidate-to-session_test.js
@@ -246,7 +246,8 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
             sessionId: null,
             complementaryCertifications: [],
           });
-          const cpfBirthInformationValidation = CpfBirthInformationValidation.failure('Failure message');
+          const certificationCandidateError = { code: '', getMessage: () => 'Failure message' };
+          const cpfBirthInformationValidation = CpfBirthInformationValidation.failure({ certificationCandidateError });
           certificationCandidateRepository.findBySessionIdAndPersonalInfo.resolves([]);
           certificationCpfService.getBirthInformation.resolves(cpfBirthInformationValidation);
           certificationCandidateRepository.saveInSession.resolves();

--- a/api/tests/unit/domain/usecases/correct-candidate-identity-in-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/correct-candidate-identity-in-certification-course_test.js
@@ -113,6 +113,7 @@ describe('Unit | UseCase | correct-candidate-identity-in-certification-course', 
     });
 
     certificationCourseRepository.get.withArgs(4).resolves(certificationCourseToBeModified);
+    const certificationCandidateError = { code: '', getMessage: () => 'Failure message' };
     certificationCpfService.getBirthInformation
       .withArgs({
         birthCountry,
@@ -122,7 +123,7 @@ describe('Unit | UseCase | correct-candidate-identity-in-certification-course', 
         certificationCpfCountryRepository,
         certificationCpfCityRepository,
       })
-      .resolves(CpfBirthInformationValidation.failure('Failure message'));
+      .resolves(CpfBirthInformationValidation.failure({ certificationCandidateError }));
 
     const command = {
       certificationCourseId: 4,

--- a/api/tests/unit/domain/validators/session-validator_test.js
+++ b/api/tests/unit/domain/validators/session-validator_test.js
@@ -15,7 +15,6 @@ describe('Unit | Domain | Validators | session-validator', function () {
       date: '2000-10-20',
       time: '14:30',
       examiner: 'Mister T',
-      line: 1,
     });
   });
 
@@ -162,7 +161,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
   describe('#validateForMassSessionImport', function () {
     context('when validation is successful', function () {
       it('should not throw any error', function () {
-        expect(sessionValidator.validateForMassSessionImport(session)).to.not.throw;
+        expect(sessionValidator.validateForMassSessionImport(session, 1)).to.not.throw;
       });
     });
 
@@ -173,7 +172,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
           session.address = MISSING_VALUE;
 
           // when
-          const report = sessionValidator.validateForMassSessionImport(session);
+          const report = sessionValidator.validateForMassSessionImport(session, 1);
 
           // then
           expect(report).to.deep.equal([
@@ -191,7 +190,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
           session.room = MISSING_VALUE;
 
           // when
-          const report = sessionValidator.validateForMassSessionImport(session);
+          const report = sessionValidator.validateForMassSessionImport(session, 1);
 
           // then
           expect(report).to.deep.equal([
@@ -209,7 +208,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
           session.date = MISSING_VALUE;
 
           // when
-          const report = sessionValidator.validateForMassSessionImport(session);
+          const report = sessionValidator.validateForMassSessionImport(session, 1);
 
           // then
           expect(report).to.deep.equal([
@@ -227,7 +226,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
           session.time = '';
 
           // when
-          const report = sessionValidator.validateForMassSessionImport(session);
+          const report = sessionValidator.validateForMassSessionImport(session, 1);
 
           // then
           expect(report).to.deep.equal([
@@ -243,7 +242,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
           session.time = '14:23:30';
 
           // when
-          const report = sessionValidator.validateForMassSessionImport(session);
+          const report = sessionValidator.validateForMassSessionImport(session, 1);
 
           // then
           expect(report).to.deep.equal([
@@ -261,7 +260,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
           session.examiner = MISSING_VALUE;
 
           // when
-          const report = sessionValidator.validateForMassSessionImport(session);
+          const report = sessionValidator.validateForMassSessionImport(session, 1);
 
           // then
           expect(report).to.deep.equal([

--- a/api/tests/unit/domain/validators/session-validator_test.js
+++ b/api/tests/unit/domain/validators/session-validator_test.js
@@ -175,12 +175,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
           const report = sessionValidator.validateForMassSessionImport(session, 1);
 
           // then
-          expect(report).to.deep.equal([
-            {
-              code: 'SESSION_ADDRESS_REQUIRED',
-              line: 1,
-            },
-          ]);
+          expect(report).to.deep.equal(['SESSION_ADDRESS_REQUIRED']);
         });
       });
 
@@ -193,12 +188,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
           const report = sessionValidator.validateForMassSessionImport(session, 1);
 
           // then
-          expect(report).to.deep.equal([
-            {
-              code: 'SESSION_ROOM_REQUIRED',
-              line: 1,
-            },
-          ]);
+          expect(report).to.deep.equal(['SESSION_ROOM_REQUIRED']);
         });
       });
 
@@ -211,12 +201,18 @@ describe('Unit | Domain | Validators | session-validator', function () {
           const report = sessionValidator.validateForMassSessionImport(session, 1);
 
           // then
-          expect(report).to.deep.equal([
-            {
-              code: 'SESSION_DATE_REQUIRED',
-              line: 1,
-            },
-          ]);
+          expect(report).to.deep.equal(['SESSION_DATE_REQUIRED']);
+        });
+
+        it('should reject with error when date is not valid', function () {
+          // given
+          session.date = '2021-02';
+
+          // when
+          const report = sessionValidator.validateForMassSessionImport(session, 1);
+
+          // then
+          expect(report).to.deep.equal(['SESSION_DATE_NOT_VALID']);
         });
       });
 
@@ -229,12 +225,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
           const report = sessionValidator.validateForMassSessionImport(session, 1);
 
           // then
-          expect(report).to.deep.equal([
-            {
-              code: 'SESSION_TIME_REQUIRED',
-              line: 1,
-            },
-          ]);
+          expect(report).to.deep.equal(['SESSION_TIME_REQUIRED']);
         });
 
         it('should reject with error when time has a format different than HH:MM', function () {
@@ -245,12 +236,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
           const report = sessionValidator.validateForMassSessionImport(session, 1);
 
           // then
-          expect(report).to.deep.equal([
-            {
-              code: 'SESSION_TIME_REQUIRED',
-              line: 1,
-            },
-          ]);
+          expect(report).to.deep.equal(['SESSION_TIME_NOT_VALID']);
         });
       });
 
@@ -263,12 +249,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
           const report = sessionValidator.validateForMassSessionImport(session, 1);
 
           // then
-          expect(report).to.deep.equal([
-            {
-              code: 'SESSION_EXAMINER_REQUIRED',
-              line: 1,
-            },
-          ]);
+          expect(report).to.deep.equal(['SESSION_EXAMINER_REQUIRED']);
         });
       });
     });

--- a/api/tests/unit/domain/validators/session-validator_test.js
+++ b/api/tests/unit/domain/validators/session-validator_test.js
@@ -15,6 +15,7 @@ describe('Unit | Domain | Validators | session-validator', function () {
       date: '2000-10-20',
       time: '14:30',
       examiner: 'Mister T',
+      line: 1,
     });
   });
 
@@ -153,6 +154,122 @@ describe('Unit | Domain | Validators | session-validator', function () {
             // then
             expect(entityValidationErrors).with.deep.property('invalidAttributes', expectedErrors);
           }
+        });
+      });
+    });
+  });
+
+  describe('#validateForMassSessionImport', function () {
+    context('when validation is successful', function () {
+      it('should not throw any error', function () {
+        expect(sessionValidator.validateForMassSessionImport(session)).to.not.throw;
+      });
+    });
+
+    context('when session data validation fails', function () {
+      context('on address attribute', function () {
+        it('should reject with error when address is missing', function () {
+          // given
+          session.address = MISSING_VALUE;
+
+          // when
+          const report = sessionValidator.validateForMassSessionImport(session);
+
+          // then
+          expect(report).to.deep.equal([
+            {
+              code: 'SESSION_ADDRESS_REQUIRED',
+              line: 1,
+            },
+          ]);
+        });
+      });
+
+      context('on room attribute', function () {
+        it('should reject with error when room is missing', async function () {
+          // given
+          session.room = MISSING_VALUE;
+
+          // when
+          const report = sessionValidator.validateForMassSessionImport(session);
+
+          // then
+          expect(report).to.deep.equal([
+            {
+              code: 'SESSION_ROOM_REQUIRED',
+              line: 1,
+            },
+          ]);
+        });
+      });
+
+      context('on date attribute', function () {
+        it('should reject with error when date is missing', function () {
+          // given
+          session.date = MISSING_VALUE;
+
+          // when
+          const report = sessionValidator.validateForMassSessionImport(session);
+
+          // then
+          expect(report).to.deep.equal([
+            {
+              code: 'SESSION_DATE_REQUIRED',
+              line: 1,
+            },
+          ]);
+        });
+      });
+
+      context('on time attribute', function () {
+        it('should reject with error when time is an empty string', function () {
+          // given
+          session.time = '';
+
+          // when
+          const report = sessionValidator.validateForMassSessionImport(session);
+
+          // then
+          expect(report).to.deep.equal([
+            {
+              code: 'SESSION_TIME_REQUIRED',
+              line: 1,
+            },
+          ]);
+        });
+
+        it('should reject with error when time has a format different than HH:MM', function () {
+          // given
+          session.time = '14:23:30';
+
+          // when
+          const report = sessionValidator.validateForMassSessionImport(session);
+
+          // then
+          expect(report).to.deep.equal([
+            {
+              code: 'SESSION_TIME_REQUIRED',
+              line: 1,
+            },
+          ]);
+        });
+      });
+
+      context('on examiner attribute', function () {
+        it('should reject with error when examiner is missing', function () {
+          // given
+          session.examiner = MISSING_VALUE;
+
+          // when
+          const report = sessionValidator.validateForMassSessionImport(session);
+
+          // then
+          expect(report).to.deep.equal([
+            {
+              code: 'SESSION_EXAMINER_REQUIRED',
+              line: 1,
+            },
+          ]);
         });
       });
     });

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -149,6 +149,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
               examiner: 'Paul',
               description: '',
               certificationCandidates: [],
+              line: 1,
             },
           ];
 
@@ -177,6 +178,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                 examiner: 'Big, Jim',
                 description: '',
                 certificationCandidates: [],
+                line: 1,
               },
             ];
 
@@ -208,6 +210,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
               examiner: 'Paul',
               description: '',
               certificationCandidates: [],
+              line: 1,
             },
             {
               sessionId: undefined,
@@ -218,6 +221,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
               examiner: 'Paul',
               description: '',
               certificationCandidates: [],
+              line: 2,
             },
           ];
 
@@ -264,6 +268,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   billingMode: 'Prépayée',
                   prepaymentCode: '43',
                   complementaryCertifications: [],
+                  line: 1,
                 },
                 {
                   lastName: 'Candidat 2',
@@ -281,8 +286,10 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   billingMode: 'Prépayée',
                   prepaymentCode: '43',
                   complementaryCertifications: [],
+                  line: 3,
                 },
               ],
+              line: 1,
             },
             {
               sessionId: undefined,
@@ -309,8 +316,10 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   billingMode: 'Prépayée',
                   prepaymentCode: '43',
                   complementaryCertifications: [],
+                  line: 2,
                 },
               ],
+              line: 2,
             },
           ];
 
@@ -342,6 +351,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
             {
               sessionId: 1,
               examiner: '',
+              line: 1,
               certificationCandidates: [
                 {
                   lastName: 'Candidat 1',
@@ -359,6 +369,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   resultRecipientEmail: 'robindahood@email.fr',
                   sex: 'M',
                   complementaryCertifications: [],
+                  line: 1,
                 },
                 {
                   lastName: 'Candidat 2',
@@ -376,6 +387,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   resultRecipientEmail: 'robindahood@email.fr',
                   sex: 'M',
                   complementaryCertifications: [],
+                  line: 2,
                 },
               ],
             },
@@ -410,6 +422,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
               time: '01:00',
               examiner: 'Paul',
               description: '',
+              line: 1,
               certificationCandidates: [
                 {
                   lastName: 'Pennyworth',
@@ -427,6 +440,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   billingMode: 'Prépayée',
                   prepaymentCode: '43',
                   complementaryCertifications: [],
+                  line: 2,
                 },
               ],
             },
@@ -469,6 +483,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                 time: '01:00',
                 examiner: '',
                 description: '',
+                line: 1,
                 certificationCandidates: [
                   {
                     lastName: 'Pennyworth',
@@ -486,6 +501,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                     prepaymentCode: expectedParsedPrepaymentCode,
                     sex: '',
                     complementaryCertifications: [],
+                    line: 1,
                   },
                 ],
               },
@@ -514,6 +530,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
             time: '01:00',
             examiner: 'Paul',
             description: '',
+            line: 1,
             certificationCandidates: [
               {
                 lastName: 'Candidat 1',
@@ -531,6 +548,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                 resultRecipientEmail: 'robindahood@email.fr',
                 sex: 'M',
                 complementaryCertifications: ['Pix Toto', 'Pix Tata'],
+                line: 1,
               },
             ],
           },
@@ -741,6 +759,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
               time: '01:00',
               examiner: 'Paul',
               description: '',
+              line: 1,
               certificationCandidates: [],
             },
           ];
@@ -754,6 +773,37 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
         });
       });
+    });
+
+    it('should return data with lines', function () {
+      // given
+      const parsedCsvData = [
+        _lineWithSessionIdAndCandidate({
+          sessionId: 1,
+          candidateNumber: 1,
+        }),
+        _lineWithSessionAndCandidate({
+          sessionNumber: 404,
+          candidateNumber: 2,
+        }),
+        _lineWithSessionAndCandidate({
+          sessionNumber: 404,
+          candidateNumber: 3,
+        }),
+        _lineWithCandidateAndNoSession(),
+      ];
+
+      // when
+      const [firstSession, secondSession] = csvSerializer.deserializeForSessionsImport(parsedCsvData);
+
+      // then
+      expect(firstSession.line).to.equal(1);
+      expect(firstSession.certificationCandidates[0].line).to.equal(1);
+
+      expect(secondSession.line).to.equal(2);
+      expect(secondSession.certificationCandidates[0].line).to.equal(2);
+      expect(secondSession.certificationCandidates[1].line).to.equal(3);
+      expect(secondSession.certificationCandidates[2].line).to.equal(4);
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -149,7 +149,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
               examiner: 'Paul',
               description: '',
               certificationCandidates: [],
-              line: 1,
+              line: 2,
             },
           ];
 
@@ -178,7 +178,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                 examiner: 'Big, Jim',
                 description: '',
                 certificationCandidates: [],
-                line: 1,
+                line: 2,
               },
             ];
 
@@ -210,7 +210,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
               examiner: 'Paul',
               description: '',
               certificationCandidates: [],
-              line: 1,
+              line: 2,
             },
             {
               sessionId: undefined,
@@ -221,7 +221,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
               examiner: 'Paul',
               description: '',
               certificationCandidates: [],
-              line: 2,
+              line: 3,
             },
           ];
 
@@ -268,7 +268,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   billingMode: 'Prépayée',
                   prepaymentCode: '43',
                   complementaryCertifications: [],
-                  line: 1,
+                  line: 2,
                 },
                 {
                   lastName: 'Candidat 2',
@@ -286,10 +286,10 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   billingMode: 'Prépayée',
                   prepaymentCode: '43',
                   complementaryCertifications: [],
-                  line: 3,
+                  line: 4,
                 },
               ],
-              line: 1,
+              line: 2,
             },
             {
               sessionId: undefined,
@@ -316,10 +316,10 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   billingMode: 'Prépayée',
                   prepaymentCode: '43',
                   complementaryCertifications: [],
-                  line: 2,
+                  line: 3,
                 },
               ],
-              line: 2,
+              line: 3,
             },
           ];
 
@@ -351,7 +351,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
             {
               sessionId: 1,
               examiner: '',
-              line: 1,
+              line: 2,
               certificationCandidates: [
                 {
                   lastName: 'Candidat 1',
@@ -369,7 +369,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   resultRecipientEmail: 'robindahood@email.fr',
                   sex: 'M',
                   complementaryCertifications: [],
-                  line: 1,
+                  line: 2,
                 },
                 {
                   lastName: 'Candidat 2',
@@ -387,7 +387,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   resultRecipientEmail: 'robindahood@email.fr',
                   sex: 'M',
                   complementaryCertifications: [],
-                  line: 2,
+                  line: 3,
                 },
               ],
             },
@@ -422,7 +422,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
               time: '01:00',
               examiner: 'Paul',
               description: '',
-              line: 1,
+              line: 2,
               certificationCandidates: [
                 {
                   lastName: 'Pennyworth',
@@ -440,7 +440,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                   billingMode: 'Prépayée',
                   prepaymentCode: '43',
                   complementaryCertifications: [],
-                  line: 2,
+                  line: 3,
                 },
               ],
             },
@@ -483,7 +483,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                 time: '01:00',
                 examiner: '',
                 description: '',
-                line: 1,
+                line: 2,
                 certificationCandidates: [
                   {
                     lastName: 'Pennyworth',
@@ -501,7 +501,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                     prepaymentCode: expectedParsedPrepaymentCode,
                     sex: '',
                     complementaryCertifications: [],
-                    line: 1,
+                    line: 2,
                   },
                 ],
               },
@@ -530,7 +530,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
             time: '01:00',
             examiner: 'Paul',
             description: '',
-            line: 1,
+            line: 2,
             certificationCandidates: [
               {
                 lastName: 'Candidat 1',
@@ -548,7 +548,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
                 resultRecipientEmail: 'robindahood@email.fr',
                 sex: 'M',
                 complementaryCertifications: ['Pix Toto', 'Pix Tata'],
-                line: 1,
+                line: 2,
               },
             ],
           },
@@ -759,7 +759,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
               time: '01:00',
               examiner: 'Paul',
               description: '',
-              line: 1,
+              line: 2,
               certificationCandidates: [],
             },
           ];
@@ -797,13 +797,13 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
       const [firstSession, secondSession] = csvSerializer.deserializeForSessionsImport(parsedCsvData);
 
       // then
-      expect(firstSession.line).to.equal(1);
-      expect(firstSession.certificationCandidates[0].line).to.equal(1);
+      expect(firstSession.line).to.equal(2);
+      expect(firstSession.certificationCandidates[0].line).to.equal(2);
 
-      expect(secondSession.line).to.equal(2);
-      expect(secondSession.certificationCandidates[0].line).to.equal(2);
-      expect(secondSession.certificationCandidates[1].line).to.equal(3);
-      expect(secondSession.certificationCandidates[2].line).to.equal(4);
+      expect(secondSession.line).to.equal(3);
+      expect(secondSession.certificationCandidates[0].line).to.equal(3);
+      expect(secondSession.certificationCandidates[1].line).to.equal(4);
+      expect(secondSession.certificationCandidates[2].line).to.equal(5);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
L’utilisateur Pix Certif peut avoir mal rempli son fichier d’import et avoir des erreurs à corriger absolument avant import définitif.

## :robot: Proposition
L’utilisateur visualise le listing des erreurs bloquantes qu’il doit corriger avec le numéro de ligne concerné et le texte de l’erreur correspondante.

https://www.figma.com/file/IWVcwbasXoFUQPhIG097XT/Pix-Certif?node-id=1350%3A26895&t=Oe1eWKR4WKvPsPLx-0

## :rainbow: Remarques
TODO : 
- [x]  validation coté candidat comme celle de la session
- [x]  extraire les numéros des lignes du csv depuis le serializer
- [x]  retourner des erreurs avec des codes et des lignes plutot que des messages
- [x]  gestion coté front à faire dans une autre PR
- [x] ajouter tous les codes erreurs créés dans la doc https://1024pix.atlassian.net/wiki/spaces/PROD/pages/3711795201/Codes+d+erreurs

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
