### PR TITLE
[BUGFIX] Meilleure gestion des erreurs à la connexion, sur la double mire SCO (PIX-7046)

### DIFF
--- a/api/db/seeds/data/user-logins-builder.js
+++ b/api/db/seeds/data/user-logins-builder.js
@@ -1,0 +1,67 @@
+const { DEFAULT_PASSWORD } = require('./users-builder');
+const { SCO_MIDDLE_SCHOOL_ID } = require('./organizations-sco-builder');
+
+function userLoginsBuilder({ databaseBuilder }) {
+  _buildBlockedUser({ databaseBuilder });
+  _buildTemporaryBlockedUser({ databaseBuilder });
+}
+
+function _buildBlockedUser({ databaseBuilder }) {
+  const blockedUser = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Goldi',
+    lastName: 'Locks',
+    email: 'blocked@example.net',
+    username: 'goldi.locks0101',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: false,
+  });
+
+  databaseBuilder.factory.buildOrganizationLearner({
+    firstName: blockedUser.firstName,
+    lastName: blockedUser.lastName,
+    birthdate: '2001-01-01',
+    division: '3A',
+    group: null,
+    sex: null,
+    organizationId: SCO_MIDDLE_SCHOOL_ID,
+    userId: blockedUser.id,
+    nationalStudentId: '123456789GL',
+  });
+
+  databaseBuilder.factory.buildUserLogin({
+    userId: blockedUser.id,
+    failureCount: 49,
+  });
+}
+
+function _buildTemporaryBlockedUser({ databaseBuilder }) {
+  const temporaryBlockedUser = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Little',
+    lastName: 'Bear',
+    email: 'temporary-blocked@example.net',
+    username: 'little.bear0101',
+    rawPassword: DEFAULT_PASSWORD,
+    cgu: false,
+  });
+
+  databaseBuilder.factory.buildOrganizationLearner({
+    firstName: temporaryBlockedUser.firstName,
+    lastName: temporaryBlockedUser.lastName,
+    birthdate: '2001-01-01',
+    division: '3A',
+    group: null,
+    sex: null,
+    organizationId: SCO_MIDDLE_SCHOOL_ID,
+    userId: temporaryBlockedUser.id,
+    nationalStudentId: '123456789LB',
+  });
+
+  databaseBuilder.factory.buildUserLogin({
+    userId: temporaryBlockedUser.id,
+    failureCount: 9,
+  });
+}
+
+module.exports = {
+  userLoginsBuilder,
+};

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -30,6 +30,7 @@ const { badgesBuilder } = require('./data/badges-builder');
 const tagsBuilder = require('./data/tags-builder');
 const { targetProfilesBuilder } = require('./data/target-profiles-builder');
 const { usersBuilder } = require('./data/users-builder');
+const { userLoginsBuilder } = require('./data/user-logins-builder');
 const pixAdminRolesBuilder = require('./data/pix-admin-roles-builder');
 const stagesBuilder = require('./data/stages-builder');
 const { certificationCpfCountryBuilder } = require('./data/certification/certification-cpf-country-builder');
@@ -102,6 +103,8 @@ exports.seed = async (knex) => {
 
   // Création d'envois pole emploi
   poleEmploiSendingsBuilder({ databaseBuilder });
+
+  userLoginsBuilder({ databaseBuilder });
 
   await richTargetProfilesBuilder({ databaseBuilder });
 

--- a/mon-pix/app/components/routes/login-form.hbs
+++ b/mon-pix/app/components/routes/login-form.hbs
@@ -1,17 +1,8 @@
 {{! template-lint-disable no-unknown-arguments-for-builtin-components }}
 
 <div class="login-form">
-  {{#if this.isErrorMessagePresent}}
-    <div id="login-error-message" class="login-form__error-message error-message">{{t
-        "pages.login-or-register.login-form.error"
-      }}</div>
-  {{/if}}
-
-  {{#if this.hasUpdateUserError}}
-    <div
-      id="update-form-error-message"
-      class="login-form__error-message error-message"
-    >{{this.updateErrorMessage}}</div>
+  {{#if this.errorMessage}}
+    <div id="update-form-error-message" class="login-form__error-message error-message">{{this.errorMessage}}</div>
   {{/if}}
 
   <form {{on "submit" this.authenticate}}>


### PR DESCRIPTION
## :unicorn: Problème

L'obligation de changement de mot de passe est bien implémentée mais pas les cas d'utilisateurs bloqués (temporairement ou définitivement).

## :robot: Proposition

Ajouter le traitement des nouveaux codes d'erreur `USER_IS_TEMPORARY_BLOCKED`, `USER_IS_BLOCKED` mais laisser pour l'instant la gestion du `PasswordShouldChange` telle qu'elle est implémentée dans le code.

## :rainbow: Remarques

Une réécriture plus profonde pourra être faite dans le cadre d'un ticket TECH.

## :100: Pour tester

1. Sur Pix App, aller sur la page pour rejoindre une campagne `/campagnes/SCOBADGE1/rejoindre/identification`
3. Utiliser le compte `temporary-blocked@example.net`
4. Entrer un mauvais mot de passe 2 fois et vérifier que le message d'erreur suivant s'affiche : `Vous avez effectué trop de tentatives de connexion. Réessayez plus tard ou cliquez sur mot de passe oublié pour le réinitialiser.`
5.  Utiliser le compte `blocked@example.net`
6. Entrer un mauvais mot de passe 2 fois et vérifier que le message d'erreur suivant s'affiche : `Votre compte est bloqué car vous avez effectué trop de tentatives de connexion. Pour le débloquer, contactez-nous.`