### PR TITLE
[BUGFIX] Une erreur est levée lors de l'arrêt de l'api - Partie 2 (PIX-7202)

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -6,7 +6,7 @@ validateEnvironmentVariables();
 const createServer = require('./server');
 const logger = require('./lib/infrastructure/logger');
 const { disconnect } = require('./db/knex-database-connection');
-const { cache } = require('./lib/infrastructure/caches/learning-content-cache');
+const { learningContentCache } = require('./lib/infrastructure/caches/learning-content-cache');
 
 const { temporaryStorage } = require('./lib/infrastructure/temporary-storage/index');
 const { redisMonitor } = require('./lib/infrastructure/utils/redis-monitor');
@@ -29,7 +29,7 @@ async function _exitOnSignal(signal) {
   logger.info('Closing connexions to database...');
   await disconnect();
   logger.info('Closing connexions to cache...');
-  await cache.quit();
+  await learningContentCache.quit();
   logger.info('Closing connexions to temporary storage...');
   await temporaryStorage.quit();
   logger.info('Closing connexions to redis monitor...');


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'arrêt du serveur, une erreur est levée. 


```
,"id":"OCTO-TOPI:61740:lezxg05k","uri":"http://OCTO-TOPI:3000","address":"0.0.0.0","msg":"server stopped"}
{"level":30,"time":1678294892602,"pid":61740,"hostname":"OCTO-TOPI","msg":"Closing connexions to database..."}
{"level":30,"time":1678294892604,"pid":61740,"hostname":"OCTO-TOPI","msg":"Closing connexions to cache..."}
pix/api/index.js:32
  await cache.quit();
              ^

TypeError: Cannot read properties of undefined (reading 'quit')
    at _exitOnSignal (/home/topi/Documents/OCTO/Missions/Pix/code/repo/pix/api/index.js:32:15)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)

```

C'est une régression depuis https://github.com/1024pix/pix/pull/5777.
La PR https://github.com/1024pix/pix/pull/5783 n'a pas corrigé le problème.

## :robot: Proposition
Utiliser le même nom dans l'import et l'export.

## :rainbow: Remarques
Il n'y a pas de test automatisé

## :100: Pour tester
Démarrer le serveur en local
Envoyer SIGQUIT avec Ctlr-C
Vérifier qu'aucune erreur n'est renvoyée