### PR TITLE
[CHORE] Mise à jour de Pix-Ui dans Pix Orga (PIX-7343)

### DIFF
--- a/orga/app/components/auth/join-request-form.hbs
+++ b/orga/app/components/auth/join-request-form.hbs
@@ -11,6 +11,7 @@
         type="text"
         {{on "focusout" this.validateUai}}
         @errorMessage={{this.uaiValidationMessage}}
+        @validationStatus={{if this.uaiValidationMessage "error" "default"}}
         required={{true}}
         aria-required={{true}}
         autocomplete="off"
@@ -25,6 +26,7 @@
         type="firstName"
         {{on "focusout" this.validateFirstName}}
         @errorMessage={{this.firstNameValidationMessage}}
+        @validationStatus={{if this.firstNameValidationMessage "error" "default"}}
         required={{true}}
         aria-required={{true}}
         autocomplete="given-name"
@@ -39,6 +41,7 @@
         type="lastName"
         {{on "focusout" this.validateLastName}}
         @errorMessage={{this.lastNameValidationMessage}}
+        @validationStatus={{if this.lastNameValidationMessage "error" "default"}}
         required={{true}}
         aria-required={{true}}
         autocomplete="family-name"

--- a/orga/app/components/auth/login-form.hbs
+++ b/orga/app/components/auth/login-form.hbs
@@ -30,6 +30,7 @@
         {{on "focusout" this.validateEmail}}
         {{on "input" this.updateEmail}}
         @errorMessage={{this.emailValidationMessage}}
+        @validationStatus={{if this.emailValidationMessage "error" "default"}}
         required={{true}}
         aria-required={{true}}
         autocomplete="email"
@@ -47,6 +48,7 @@
         {{on "focusout" this.validatePassword}}
         {{on "input" this.validatePassword}}
         @errorMessage={{this.passwordValidationMessage}}
+        @validationStatus={{if this.passwordValidationMessage "error" "default"}}
       />
     </div>
 

--- a/orga/app/components/auth/register-form.hbs
+++ b/orga/app/components/auth/register-form.hbs
@@ -9,6 +9,7 @@
         type="firstName"
         {{on "focusout" this.validateFirstName}}
         @errorMessage={{this.firstNameValidationMessage}}
+        @validationStatus={{if this.firstNameValidationMessage "error" "default"}}
         required={{true}}
         aria-required={{true}}
         autocomplete="given-name"
@@ -23,6 +24,7 @@
         type="lastName"
         {{on "focusout" this.validateLastName}}
         @errorMessage={{this.lastNameValidationMessage}}
+        @validationStatus={{if this.lastNameValidationMessage "error" "default"}}
         required={{true}}
         aria-required={{true}}
         autocomplete="family-name"
@@ -37,6 +39,7 @@
         type="email"
         {{on "focusout" this.validateEmail}}
         @errorMessage={{this.emailValidationMessage}}
+        @validationStatus={{if this.emailValidationMessage "error" "default"}}
         required={{true}}
         aria-required={{true}}
         autocomplete="email"
@@ -54,6 +57,7 @@
         {{on "input" this.validatePassword}}
         {{on "focusout" this.validatePassword}}
         @errorMessage={{this.passwordValidationMessage}}
+        @validationStatus={{if this.passwordValidationMessage "error" "default"}}
       />
     </div>
 

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.0",
-        "@1024pix/pix-ui": "^25.0.0",
+        "@1024pix/pix-ui": "^26.0.0",
         "@1024pix/stylelint-config": "^2.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.13",
@@ -1056,9 +1056,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-25.0.0.tgz",
-      "integrity": "sha512-iaBV6rfcipU11D3RpMCIgMQCvRS/YX29z97zPmxzxj72kUEDF1OXJanWVlY8BUBO9AotPeOwbC0lcbpuHWrXaQ==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-26.1.0.tgz",
+      "integrity": "sha512-UMO7Y0ho+d+yB0dVzTH/3QC40p4JpsbWlq4nh4at7gmqcuSiGy+RWYeku7gq9hJ2XRw1nannTS9zwH3XUVRdEg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -37456,9 +37456,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-25.0.0.tgz",
-      "integrity": "sha512-iaBV6rfcipU11D3RpMCIgMQCvRS/YX29z97zPmxzxj72kUEDF1OXJanWVlY8BUBO9AotPeOwbC0lcbpuHWrXaQ==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-26.1.0.tgz",
+      "integrity": "sha512-UMO7Y0ho+d+yB0dVzTH/3QC40p4JpsbWlq4nh4at7gmqcuSiGy+RWYeku7gq9hJ2XRw1nannTS9zwH3XUVRdEg==",
       "dev": true,
       "requires": {
         "color": "^4.2.3",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.0",
-        "@1024pix/pix-ui": "^26.0.0",
+        "@1024pix/pix-ui": "^28.0.1",
         "@1024pix/stylelint-config": "^2.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.13",
@@ -1056,9 +1056,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-26.1.0.tgz",
-      "integrity": "sha512-UMO7Y0ho+d+yB0dVzTH/3QC40p4JpsbWlq4nh4at7gmqcuSiGy+RWYeku7gq9hJ2XRw1nannTS9zwH3XUVRdEg==",
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-28.0.2.tgz",
+      "integrity": "sha512-IQm6wH8CzSuIresaKaZQTjU/oICAGqek51SXsWu4yOEks8FEzDQDB7lktkKL0MOCwGMA/67daQwpU4j8qDj07w==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -37456,9 +37456,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-26.1.0.tgz",
-      "integrity": "sha512-UMO7Y0ho+d+yB0dVzTH/3QC40p4JpsbWlq4nh4at7gmqcuSiGy+RWYeku7gq9hJ2XRw1nannTS9zwH3XUVRdEg==",
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-28.0.2.tgz",
+      "integrity": "sha512-IQm6wH8CzSuIresaKaZQTjU/oICAGqek51SXsWu4yOEks8FEzDQDB7lktkKL0MOCwGMA/67daQwpU4j8qDj07w==",
       "dev": true,
       "requires": {
         "color": "^4.2.3",

--- a/orga/package.json
+++ b/orga/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.0",
-    "@1024pix/pix-ui": "^26.0.0",
+    "@1024pix/pix-ui": "^28.0.1",
     "@1024pix/stylelint-config": "^2.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.13",

--- a/orga/package.json
+++ b/orga/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.0",
-    "@1024pix/pix-ui": "^25.0.0",
+    "@1024pix/pix-ui": "^26.0.0",
     "@1024pix/stylelint-config": "^2.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.13",

--- a/orga/tests/integration/components/campaign/cards/stage_average_test.js
+++ b/orga/tests/integration/components/campaign/cards/stage_average_test.js
@@ -18,7 +18,7 @@ module('Integration | Component | Campaign::Cards::StageAverage', function (hook
 
     assert.contains(t('cards.participants-average-stages.title'));
     assert
-      .dom(screen.getByLabelText(t('pages.assessment-individual-results.stages.value', { count: 1, total: 2 })))
+      .dom(screen.getByText(t('pages.assessment-individual-results.stages.value', { count: 1, total: 2 })))
       .exists();
   });
 });

--- a/orga/tests/integration/components/campaign/charts/participants-by-stage_test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-stage_test.js
@@ -56,8 +56,8 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStage', functi
 
   test('should render a screen reader message', async function (assert) {
     // then
-    assert.dom(screen.getByLabelText('0 étoile sur 1')).exists();
-    assert.dom(screen.getByLabelText('1 étoile sur 1')).exists();
+    assert.dom(screen.getByText('0 étoile sur 1')).exists();
+    assert.dom(screen.getByText('1 étoile sur 1')).exists();
   });
 
   test('it should not display empty tooltip', async function (assert) {

--- a/orga/tests/integration/components/campaign/stage-stars_test.js
+++ b/orga/tests/integration/components/campaign/stage-stars_test.js
@@ -47,7 +47,7 @@ module('Integration | Component | Campaign::StageStars', function (hooks) {
     const screen = await render(hbs`<Campaign::StageStars @result={{this.result}} @stages={{this.stages}} />`);
 
     // then
-    assert.dom(screen.getByLabelText('1 étoiles sur 2')).exists();
+    assert.dom(screen.getByText('1 étoiles sur 2')).exists();
   });
 
   test('should not display tooltip by default', async function (assert) {

--- a/orga/tests/integration/components/participant/assessment/header_test.js
+++ b/orga/tests/integration/components/participant/assessment/header_test.js
@@ -148,7 +148,7 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
 
           assert.dom(`[aria-label="${t('pages.assessment-individual-results.stages.label')}"]`).exists();
           assert
-            .dom(screen.getByLabelText(t('pages.assessment-individual-results.stages.value', { count: 1, total: 2 })))
+            .dom(screen.getByText(t('pages.assessment-individual-results.stages.value', { count: 1, total: 2 })))
             .exists();
         });
       });


### PR DESCRIPTION
## :unicorn: Problème
Pix ui n'était pas à jour sur Pix Orga.

## :robot: Proposition
Faire la montée de version.

## :rainbow: Remarques
À la version 26, il y a eu un ajout de propriété sur les PinInput pour gérer les messages d'erreurs

## :100: Pour tester
Tester les PixInput de connexion
- page de connexion classique
- page de connexion après avoir reçu un lien d'invitation.
     - Se connecter sur une orga et inviter un nouveau membre
     - Récupérer l'id d'invitation et le code et aller sur l'ur `rejoindre?code=CODE-INVIT&invitationId=ID_INVIT`
- page de récupération/ activation d'orga
     - aller sur la page `/demande-administration-sco`

Pour le reste faire un tour sur  l'appli pour check si tout va bien 

