### PR TITLE
[FEATURE] Récupérer les informations de référentiel des déclencheurs de contenu formatif (PIX-7353)

### DIFF
--- a/api/db/seeds/data/trainings-builder.js
+++ b/api/db/seeds/data/trainings-builder.js
@@ -111,6 +111,26 @@ function trainingBuilder({ databaseBuilder }) {
     prerequisiteThreshold: 0,
     goalThreshold: 0,
   });
+  const trainingTrigger1 = databaseBuilder.factory.buildTrainingTrigger({
+    trainingId: training1.id,
+    threshold: 80,
+    type: 'prerequisite',
+  });
+  databaseBuilder.factory.buildTrainingTriggerTube({
+    trainingTriggerId: trainingTrigger1.id,
+    tubeId: 'recs1vdbHxX8X55G9',
+    level: 2,
+  });
+  databaseBuilder.factory.buildTrainingTriggerTube({
+    trainingTriggerId: trainingTrigger1.id,
+    tubeId: 'reccqGUKgzIOK8f9U',
+    level: 3,
+  });
+  databaseBuilder.factory.buildTrainingTriggerTube({
+    trainingTriggerId: trainingTrigger1.id,
+    tubeId: 'recBbCIEKgrQi7eb6',
+    level: 5,
+  });
   databaseBuilder.factory.buildTargetProfileTraining({
     trainingId: training1.id,
     targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,

--- a/api/lib/domain/models/TrainingTrigger.js
+++ b/api/lib/domain/models/TrainingTrigger.js
@@ -13,12 +13,47 @@ class TrainingTrigger {
     }
     this.type = type;
     this.threshold = threshold;
-    this.areas = areas;
-    this.competences = competences;
-    this.thematics = thematics;
+    this.areas = areas.map((area) => new _Area({ ...area, competences, thematics, triggerTubes }));
   }
 }
 
 TrainingTrigger.types = types;
+
+class _Area {
+  constructor({ id, title, code, color, competences = [], thematics = [], triggerTubes = [] } = {}) {
+    this.id = id;
+    this.title = title;
+    this.code = code;
+    this.color = color;
+
+    this.competences = competences
+      .filter((competence) => competence.areaId === id)
+      .map((competence) => new _Competence({ ...competence, thematics, triggerTubes }));
+  }
+}
+
+class _Competence {
+  constructor({ id, name, index, thematics = [], triggerTubes = [] } = {}) {
+    this.id = id;
+    this.name = name;
+    this.index = index;
+
+    this.thematics = thematics
+      .filter((thematic) => thematic.competenceId === id)
+      .map((thematic) => new _Thematic({ ...thematic, triggerTubes }));
+  }
+}
+
+class _Thematic {
+  constructor({ id, name, index, triggerTubes = [] } = {}) {
+    this.id = id;
+    this.name = name;
+    this.index = index;
+
+    this.triggerTubes = triggerTubes
+      .filter((trainingTriggerTube) => trainingTriggerTube.tube.thematicId === id)
+      .map((trainingTriggerTube) => trainingTriggerTube.id);
+  }
+}
 
 module.exports = TrainingTrigger;

--- a/api/lib/domain/models/TrainingTrigger.js
+++ b/api/lib/domain/models/TrainingTrigger.js
@@ -4,7 +4,7 @@ const types = {
 };
 
 class TrainingTrigger {
-  constructor({ id, trainingId, triggerTubes, type, threshold } = {}) {
+  constructor({ id, trainingId, triggerTubes, type, threshold, areas = [], competences = [], thematics = [] } = {}) {
     this.id = id;
     this.trainingId = trainingId;
     this.triggerTubes = triggerTubes;
@@ -13,6 +13,9 @@ class TrainingTrigger {
     }
     this.type = type;
     this.threshold = threshold;
+    this.areas = areas;
+    this.competences = competences;
+    this.thematics = thematics;
   }
 }
 

--- a/api/lib/domain/models/TrainingTrigger.js
+++ b/api/lib/domain/models/TrainingTrigger.js
@@ -4,8 +4,9 @@ const types = {
 };
 
 class TrainingTrigger {
-  constructor({ id, triggerTubes, type, threshold, areas = [], competences = [], thematics = [] } = {}) {
+  constructor({ id, trainingId, triggerTubes, type, threshold, areas = [], competences = [], thematics = [] } = {}) {
     this.id = id;
+    this.trainingId = trainingId;
     this.triggerTubes = triggerTubes;
     if (!Object.values(types).includes(type)) {
       throw new Error('Invalid trigger type');

--- a/api/lib/domain/models/TrainingTrigger.js
+++ b/api/lib/domain/models/TrainingTrigger.js
@@ -4,9 +4,8 @@ const types = {
 };
 
 class TrainingTrigger {
-  constructor({ id, trainingId, triggerTubes, type, threshold, areas = [], competences = [], thematics = [] } = {}) {
+  constructor({ id, triggerTubes, type, threshold, areas = [], competences = [], thematics = [] } = {}) {
     this.id = id;
-    this.trainingId = trainingId;
     this.triggerTubes = triggerTubes;
     if (!Object.values(types).includes(type)) {
       throw new Error('Invalid trigger type');

--- a/api/lib/infrastructure/repositories/training-trigger-repository.js
+++ b/api/lib/infrastructure/repositories/training-trigger-repository.js
@@ -1,7 +1,11 @@
+const _ = require('lodash');
 const { knex } = require('../../../db/knex-database-connection.js');
 const DomainTransaction = require('../DomainTransaction.js');
 const TrainingTrigger = require('../../domain/models/TrainingTrigger.js');
 const TrainingTriggerTube = require('../../domain/models/TrainingTriggerTube.js');
+const areaRepository = require('./area-repository');
+const competenceRepository = require('./competence-repository');
+const thematicRepository = require('./thematic-repository');
 const tubeRepository = require('./tube-repository');
 const TABLE_NAME = 'training-triggers';
 
@@ -52,23 +56,49 @@ module.exports = {
     const trainingTriggerTubeIds = trainingTriggerTubes.map(({ tubeId }) => tubeId);
     const tubes = await tubeRepository.findByRecordIds(trainingTriggerTubeIds);
 
-    return trainingTriggers.map((trainingTrigger) => {
-      const triggerTubes = trainingTriggerTubes.filter(
-        ({ trainingTriggerId }) => trainingTriggerId === trainingTrigger.id
-      );
-      return _toDomain({ trainingTrigger, triggerTubes, tubes });
-    });
+    return Promise.all(
+      trainingTriggers.map(async (trainingTrigger) => {
+        const triggerTubes = trainingTriggerTubes.filter(
+          ({ trainingTriggerId }) => trainingTriggerId === trainingTrigger.id
+        );
+        return await _toDomain({ trainingTrigger, triggerTubes, tubes });
+      })
+    );
   },
 };
 
-function _toDomain({ trainingTrigger, triggerTubes, tubes = [] }) {
+async function _toDomain({ trainingTrigger, triggerTubes, tubes = [] }) {
+  const learningContent = await _getLearningContent(triggerTubes);
+
   return new TrainingTrigger({
     id: trainingTrigger.id,
-    trainingId: trainingTrigger.trainingId,
     type: trainingTrigger.type,
     threshold: trainingTrigger.threshold,
     triggerTubes: triggerTubes.map(
       ({ id, tubeId, level }) => new TrainingTriggerTube({ id, tube: tubes.find(({ id }) => id === tubeId), level })
     ),
+    areas: learningContent.areas,
+    competences: learningContent.competences,
+    thematics: learningContent.thematics,
   });
+}
+
+async function _getLearningContent(trainingTriggerTubes, locale = 'fr-fr') {
+  const tubeIds = trainingTriggerTubes.map((data) => data.tubeId);
+  const triggerTubes = await tubeRepository.findByRecordIds(tubeIds, locale);
+
+  const thematicIds = _.keys(_.groupBy(triggerTubes, 'thematicId'));
+  const thematics = await thematicRepository.findByRecordIds(thematicIds, locale);
+
+  const competenceIds = _.keys(_.groupBy(thematics, 'competenceId'));
+  const competences = await competenceRepository.findByRecordIds({ competenceIds, locale });
+
+  const areaIds = _.keys(_.groupBy(competences, 'areaId'));
+  const areas = await areaRepository.findByRecordIds({ areaIds, locale });
+
+  return {
+    areas,
+    competences,
+    thematics,
+  };
 }

--- a/api/lib/infrastructure/repositories/training-trigger-repository.js
+++ b/api/lib/infrastructure/repositories/training-trigger-repository.js
@@ -72,6 +72,7 @@ async function _toDomain({ trainingTrigger, triggerTubes, tubes = [] }) {
 
   return new TrainingTrigger({
     id: trainingTrigger.id,
+    trainingId: trainingTrigger.trainingId,
     type: trainingTrigger.type,
     threshold: trainingTrigger.threshold,
     triggerTubes: triggerTubes.map(

--- a/api/lib/infrastructure/serializers/jsonapi/training-trigger-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/training-trigger-serializer.js
@@ -1,12 +1,12 @@
 const { Serializer, Deserializer } = require('jsonapi-serializer');
 
 module.exports = {
-  serialize(training = {}, meta) {
+  serialize(trainingTrigger = {}, meta) {
     return new Serializer('training-triggers', {
-      transform(training) {
+      transform(record) {
         return {
-          ...training,
-          triggerTubes: training.triggerTubes.map((triggerTube) => {
+          ...record,
+          triggerTubes: record.triggerTubes.map((triggerTube) => {
             return {
               ...triggerTube,
               tube: { ...triggerTube.tube },
@@ -14,14 +14,33 @@ module.exports = {
           }),
         };
       },
-      attributes: ['trainingId', 'type', 'threshold', 'triggerTubes'],
+      attributes: ['id', 'trainingId', 'type', 'threshold', 'triggerTubes', 'areas'],
       triggerTubes: {
         ref: 'id',
-        includes: true,
+        included: true,
         attributes: ['id', 'level', 'tube'],
         tube: {
           ref: 'id',
-          attributes: ['id', 'name', 'practicalTitle', 'practicalDescription', 'competences'],
+          attributes: ['id', 'name', 'practicalTitle'],
+        },
+      },
+      areas: {
+        ref: 'id',
+        included: true,
+        attributes: ['title', 'code', 'color', 'competences'],
+        competences: {
+          ref: 'id',
+          included: true,
+          attributes: ['name', 'index', 'thematics'],
+          thematics: {
+            ref: 'id',
+            included: true,
+            attributes: ['name', 'index', 'trainingTriggerTubes'],
+            trainingTriggerTubes: {
+              ref: 'id',
+              included: true,
+            },
+          },
         },
       },
       meta,
@@ -35,7 +54,7 @@ module.exports = {
             return attribute;
         }
       },
-    }).serialize(training);
+    }).serialize(trainingTrigger);
   },
 
   deserialize(payload) {

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -18,30 +18,43 @@ describe('Acceptance | Controller | training-controller', function () {
 
   describe('GET /api/admin/trainings/{trainingId}', function () {
     let learningContent;
-    let tubeName;
+    let areaId;
+    let competenceId;
+    let thematicId;
+    let tubeId;
 
     beforeEach(async function () {
-      tubeName = 'tube0_0';
+      areaId = 'recArea1';
+      competenceId = 'recCompetence1';
+      thematicId = 'recThematic1';
+      tubeId = 'recTube0_0';
+
       learningContent = [
         {
           areas: [
             {
-              id: 'recArea1',
-              titleFrFr: 'area1_Title',
+              id: areaId,
+              titleFr: 'area1_Title',
               color: 'someColor',
               competences: [
                 {
-                  id: 'competenceId',
-                  nameFrFr: 'Mener une recherche et une veille d’information',
+                  id: competenceId,
+                  name: 'Mener une recherche et une veille d’information',
                   index: '1.1',
-                  tubes: [
+                  thematics: [
                     {
-                      id: 'recTube0_0',
-                      name: tubeName,
-                      skills: [
+                      id: thematicId,
+                      name: 'thematic1_Name',
+                      tubes: [
                         {
-                          id: 'skillWeb2Id',
-                          nom: '@web2',
+                          id: tubeId,
+                          name: 'tube1_Name',
+                          skills: [
+                            {
+                              id: 'skillWeb2Id',
+                              nom: '@web2',
+                            },
+                          ],
                         },
                       ],
                     },
@@ -65,7 +78,7 @@ describe('Acceptance | Controller | training-controller', function () {
       const trainingTrigger = databaseBuilder.factory.buildTrainingTrigger({ trainingId });
       const trainingTriggerTube = databaseBuilder.factory.buildTrainingTriggerTube({
         trainingTriggerId: trainingTrigger.id,
-        tubeId: 'recTube0_0',
+        tubeId: tubeId,
       });
       await databaseBuilder.commit();
 
@@ -73,6 +86,7 @@ describe('Acceptance | Controller | training-controller', function () {
         type: 'trainings',
         id: `${trainingId}`,
         attributes: {
+          id: trainingId,
           title: trainingAttributes.title,
           type: trainingAttributes.type,
           link: trainingAttributes.link,
@@ -103,14 +117,27 @@ describe('Acceptance | Controller | training-controller', function () {
       expect(response.result.data.attributes).to.deep.equal(expectedResponse.attributes);
 
       const returnedTube = response.result.included.find((included) => included.type === 'tubes').attributes;
-      expect(returnedTube.name).to.deep.equal(tubeName);
+      expect(returnedTube.id).to.deep.equal(tubeId);
       const returnedTriggerTube = response.result.included.find(
         (included) => included.type === 'trigger-tubes'
       ).attributes;
-      expect(returnedTriggerTube.level).to.deep.equal(trainingTriggerTube.level);
+      expect(returnedTriggerTube.id).to.deep.equal(trainingTriggerTube.id);
+
       const returnedTrigger = response.result.included.find((included) => included.type === 'triggers').attributes;
-      expect(returnedTrigger.type).to.deep.equal(trainingTrigger.type);
-      expect(returnedTrigger.threshold).to.deep.equal(trainingTrigger.threshold);
+      expect(returnedTrigger.id).to.deep.equal(trainingTrigger.id);
+
+      const returnedTriggerArea = response.result.included.find((included) => included.type === 'areas').attributes;
+      expect(returnedTriggerArea.id).to.deep.equal(areaId);
+
+      const returnedTriggerCompetence = response.result.included.find(
+        (included) => included.type === 'competences'
+      ).attributes;
+      expect(returnedTriggerCompetence.id).to.deep.equal(competenceId);
+
+      const returnedTriggerThematic = response.result.included.find(
+        (included) => included.type === 'thematics'
+      ).attributes;
+      expect(returnedTriggerThematic.id).to.deep.equal(thematicId);
     });
   });
 
@@ -302,7 +329,7 @@ describe('Acceptance | Controller | training-controller', function () {
           areas: [
             {
               id: 'recArea1',
-              titleFrFr: 'area1_Title',
+              title: 'area1_Title',
               color: 'someColor',
               competences: [
                 {

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -51,9 +51,25 @@ describe('Integration | Repository | training-repository', function () {
   });
 
   describe('#getWithTriggers', function () {
+    let area1;
+    let competence1;
+    let thematic1;
     let tube;
 
     beforeEach(async function () {
+      area1 = domainBuilder.buildArea({ id: 'recAreaA' });
+      competence1 = domainBuilder.buildCompetence({ id: 'recCompA', areaId: 'recAreaA' });
+      const competenceInAnotherArea = domainBuilder.buildCompetence({ id: 'recCompB', areaId: 'recAreaB' });
+      thematic1 = domainBuilder.buildThematic({
+        id: 'recThemA',
+        name: 'thematic1_name',
+        competenceId: 'recCompA',
+      });
+      const thematicInAnotherCompetence = domainBuilder.buildThematic({
+        id: 'recThemB',
+        name: 'thematic2_name',
+        competenceId: 'anotherCompetence',
+      });
       tube = domainBuilder.buildTube({
         id: 'recTube0',
         name: 'tubeName',
@@ -64,27 +80,26 @@ describe('Integration | Repository | training-repository', function () {
         isMobileCompliant: true,
         isTabletCompliant: true,
         competenceId: 'recCompetence0',
-        thematicId: 'thematicCoucou',
+        thematicId: 'recThemA',
         skillIds: ['skillSuper', 'skillGenial'],
         skills: [],
       });
       const learningContent = {
+        areas: [area1],
+        competences: [competence1, competenceInAnotherArea],
+        thematics: [
+          { id: thematic1.id, name_i18n: { fr: thematic1.name }, competenceId: thematic1.competenceId },
+          {
+            id: thematicInAnotherCompetence.id,
+            name_i18n: { fr: thematicInAnotherCompetence.name },
+            competenceId: thematicInAnotherCompetence.competenceId,
+          },
+        ],
         tubes: [
           {
-            id: 'recTube0',
-            name: 'tubeName',
-            title: 'tubeTitle',
-            description: 'tubeDescription',
-            practicalTitle_i18n: {
-              fr: 'translatedPracticalTitle',
-            },
-            practicalDescription_i18n: {
-              fr: 'translatedPracticalDescription',
-            },
-            isMobileCompliant: true,
-            isTabletCompliant: true,
-            competenceId: 'recCompetence0',
-            thematicId: 'thematicCoucou',
+            id: tube.id,
+            name: tube.name,
+            thematicId: 'recThemA',
             skillIds: ['skillSuper', 'skillGenial'],
           },
         ],
@@ -125,6 +140,12 @@ describe('Integration | Repository | training-repository', function () {
       expect(result.triggers[0].triggerTubes[0].id).to.deep.equal(trainingTriggerTube.id);
       expect(result.triggers[0].triggerTubes[0].tube.name).to.deep.equal(tube.name);
       expect(result.triggers[0].triggerTubes[0].level).to.deep.equal(trainingTriggerTube.level);
+      expect(result.triggers[0].areas).to.have.lengthOf(1);
+      expect(result.triggers[0].areas[0].id).to.equal(area1.id);
+      expect(result.triggers[0].areas[0].competences).to.have.lengthOf(1);
+      expect(result.triggers[0].areas[0].competences[0].id).to.equal(competence1.id);
+      expect(result.triggers[0].areas[0].competences[0].thematics).to.have.lengthOf(1);
+      expect(result.triggers[0].areas[0].competences[0].thematics[0].id).to.equal(thematic1.id);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
@@ -156,6 +156,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
           .first();
         expect(createdTrainingTrigger).to.be.instanceOf(TrainingTrigger);
         expect(createdTrainingTrigger.id).to.equal(trainingTrigger.id);
+        expect(createdTrainingTrigger.trainingId).to.equal(trainingTrigger.trainingId);
         expect(createdTrainingTrigger.type).to.equal(trainingTrigger.type);
         expect(createdTrainingTrigger.threshold).to.equal(trainingTrigger.threshold);
 
@@ -321,6 +322,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
       expect(result).to.have.lengthOf(2);
       expect(result[0]).to.be.instanceOf(TrainingTrigger);
       expect(result[0].id).to.equal(trainingTrigger.id);
+      expect(result[0].trainingId).to.equal(trainingTrigger.trainingId);
       expect(result[0].type).to.equal(trainingTrigger.type);
       expect(result[0].threshold).to.equal(trainingTrigger.threshold);
       expect(result[0].triggerTubes).to.have.lengthOf(1);
@@ -338,6 +340,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
 
       expect(result[1]).to.be.instanceOf(TrainingTrigger);
       expect(result[1].id).to.equal(trainingTrigger2.id);
+      expect(result[1].trainingId).to.equal(trainingTrigger2.trainingId);
       expect(result[1].type).to.equal(trainingTrigger2.type);
       expect(result[1].threshold).to.equal(trainingTrigger2.threshold);
       expect(result[1].triggerTubes).to.have.lengthOf(1);

--- a/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
@@ -1,7 +1,6 @@
 const { expect, databaseBuilder, domainBuilder, knex, mockLearningContent, sinon } = require('../../../test-helper');
 const trainingTriggerRepository = require('../../../../lib/infrastructure/repositories/training-trigger-repository');
-const TrainingTrigger = require('../../../../lib/domain/models/TrainingTrigger');
-const TrainingTriggerTube = require('../../../../lib/domain/models/TrainingTriggerTube');
+const { TrainingTrigger, TrainingTriggerTube } = require('../../../../lib/domain/models');
 const _ = require('lodash');
 
 describe('Integration | Repository | training-trigger-repository', function () {
@@ -19,7 +18,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
       isMobileCompliant: true,
       isTabletCompliant: true,
       competenceId: 'recCompetence0',
-      thematicId: 'thematicCoucou',
+      thematicId: 'recThemA',
       skillIds: ['skillSuper', 'skillGenial'],
       skills: [],
     });
@@ -33,11 +32,49 @@ describe('Integration | Repository | training-trigger-repository', function () {
       isMobileCompliant: true,
       isTabletCompliant: true,
       competenceId: 'recCompetence0',
-      thematicId: 'thematicCoucou',
+      thematicId: 'recThemA',
       skillIds: ['skillSuper', 'skillGenial'],
       skills: [],
     });
     const learningContent = {
+      areas: [
+        {
+          id: 'recAreaA',
+          title_i18n: {
+            fr: 'titleFRA',
+            en: 'titleENA',
+          },
+          color: 'colorA',
+          code: 'codeA',
+          frameworkId: 'fmk1',
+          competenceIds: ['recCompA', 'recCompB'],
+        },
+      ],
+      competences: [
+        {
+          id: 'recCompA',
+          name_i18n: {
+            fr: 'nameFRA',
+            en: 'nameENA',
+          },
+          index: '1',
+          areaId: 'recAreaA',
+          origin: 'Pix',
+          thematicIds: ['recThemA', 'recThemB'],
+        },
+      ],
+      thematics: [
+        {
+          id: 'recThemA',
+          name_i18n: {
+            fr: 'nameFRA',
+            en: 'nameENA',
+          },
+          index: '1',
+          competenceId: 'recCompA',
+          tubeIds: ['recTube1'],
+        },
+      ],
       tubes: [
         {
           id: 'recTube0',
@@ -53,7 +90,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
           isMobileCompliant: true,
           isTabletCompliant: true,
           competenceId: 'recCompetence0',
-          thematicId: 'thematicCoucou',
+          thematicId: 'recThemA',
           skillIds: ['skillSuper', 'skillGenial'],
         },
         {
@@ -70,8 +107,15 @@ describe('Integration | Repository | training-trigger-repository', function () {
           isMobileCompliant: true,
           isTabletCompliant: true,
           competenceId: 'recCompetence0',
-          thematicId: 'thematicCoucou',
+          thematicId: 'recThemA',
           skillIds: ['skillSuper', 'skillGenial'],
+        },
+      ],
+      skills: [
+        {
+          id: 'recSkillTube1',
+          tubeId: 'recTube1',
+          status: 'actif',
         },
       ],
     };
@@ -112,7 +156,6 @@ describe('Integration | Repository | training-trigger-repository', function () {
           .first();
         expect(createdTrainingTrigger).to.be.instanceOf(TrainingTrigger);
         expect(createdTrainingTrigger.id).to.equal(trainingTrigger.id);
-        expect(createdTrainingTrigger.trainingId).to.equal(trainingTrigger.trainingId);
         expect(createdTrainingTrigger.type).to.equal(trainingTrigger.type);
         expect(createdTrainingTrigger.threshold).to.equal(trainingTrigger.threshold);
 
@@ -276,26 +319,39 @@ describe('Integration | Repository | training-trigger-repository', function () {
 
       // then
       expect(result).to.have.lengthOf(2);
-
       expect(result[0]).to.be.instanceOf(TrainingTrigger);
       expect(result[0].id).to.equal(trainingTrigger.id);
-      expect(result[0].trainingId).to.equal(trainingTrigger.trainingId);
       expect(result[0].type).to.equal(trainingTrigger.type);
       expect(result[0].threshold).to.equal(trainingTrigger.threshold);
       expect(result[0].triggerTubes).to.have.lengthOf(1);
       expect(result[0].triggerTubes[0]).to.be.instanceOf(TrainingTriggerTube);
       expect(result[0].triggerTubes[0].tube.id).to.equal(trainingTriggerTube.tubeId);
+      expect(result[0].triggerTubes[0].tube.name).to.equal(tube.name);
+      expect(result[0].triggerTubes[0].tube.practicalTitle).to.equal(tube.practicalTitle);
       expect(result[0].triggerTubes[0].level).to.equal(trainingTriggerTube.level);
+      expect(result[0].areas).to.have.lengthOf(1);
+      expect(result[0].areas[0].id).to.equal('recAreaA');
+      expect(result[0].areas[0].competences).to.have.lengthOf(1);
+      expect(result[0].areas[0].competences[0].id).to.equal('recCompA');
+      expect(result[0].areas[0].competences[0].thematics).to.have.lengthOf(1);
+      expect(result[0].areas[0].competences[0].thematics[0].id).to.equal('recThemA');
 
       expect(result[1]).to.be.instanceOf(TrainingTrigger);
       expect(result[1].id).to.equal(trainingTrigger2.id);
-      expect(result[1].trainingId).to.equal(trainingTrigger2.trainingId);
       expect(result[1].type).to.equal(trainingTrigger2.type);
       expect(result[1].threshold).to.equal(trainingTrigger2.threshold);
       expect(result[1].triggerTubes).to.have.lengthOf(1);
       expect(result[1].triggerTubes[0]).to.be.instanceOf(TrainingTriggerTube);
       expect(result[1].triggerTubes[0].tube.id).to.equal(trainingTriggerTube2.tubeId);
+      expect(result[1].triggerTubes[0].tube.name).to.equal(tube1.name);
+      expect(result[1].triggerTubes[0].tube.practicalTitle).to.equal(tube1.practicalTitle);
       expect(result[1].triggerTubes[0].level).to.equal(trainingTriggerTube2.level);
+      expect(result[1].areas).to.have.lengthOf(1);
+      expect(result[1].areas[0].id).to.equal('recAreaA');
+      expect(result[1].areas[0].competences).to.have.lengthOf(1);
+      expect(result[1].areas[0].competences[0].id).to.equal('recCompA');
+      expect(result[1].areas[0].competences[0].thematics).to.have.lengthOf(1);
+      expect(result[1].areas[0].competences[0].thematics[0].id).to.equal('recThemA');
     });
 
     it('should return empty array when no training trigger found', async function () {

--- a/api/tests/tooling/domain-builder/factory/build-training-trigger.js
+++ b/api/tests/tooling/domain-builder/factory/build-training-trigger.js
@@ -14,6 +14,9 @@ module.exports = function buildTrainingTrigger({
   ],
   type = TrainingTrigger.types.PREREQUISITE,
   threshold = 60,
+  areas = [],
+  competences = [],
+  thematics = [],
 } = {}) {
   return new TrainingTrigger({
     id,
@@ -21,5 +24,8 @@ module.exports = function buildTrainingTrigger({
     triggerTubes,
     type,
     threshold,
+    areas,
+    competences,
+    thematics,
   });
 };

--- a/api/tests/unit/domain/models/TrainingTrigger_test.js
+++ b/api/tests/unit/domain/models/TrainingTrigger_test.js
@@ -18,6 +18,24 @@ describe('Unit | Domain | Models | TrainingTrigger', function () {
       expect(error.message).to.equal('Invalid trigger type');
     });
 
+    it('should have all properties', function () {
+      // given
+      const trainingTrigger = domainBuilder.buildTrainingTrigger({
+        id: 1,
+        type: TrainingTrigger.types.GOAL,
+        trainingId: 100,
+        threshold: 10,
+        areas: [],
+      });
+
+      // then
+      expect(trainingTrigger.id).to.equal(1);
+      expect(trainingTrigger.type).to.equal('goal');
+      expect(trainingTrigger.trainingId).to.equal(100);
+      expect(trainingTrigger.threshold).to.equal(10);
+      expect(trainingTrigger.areas).to.deep.equal([]);
+    });
+
     it('should build learning content tree from parameters', function () {
       // given
       const area1 = domainBuilder.buildArea({ id: 'recArea1' });

--- a/api/tests/unit/domain/models/TrainingTrigger_test.js
+++ b/api/tests/unit/domain/models/TrainingTrigger_test.js
@@ -8,7 +8,7 @@ describe('Unit | Domain | Models | TrainingTrigger', function () {
       const trainingTrigger = domainBuilder.buildTrainingTrigger({ type: TrainingTrigger.types.PREREQUISITE });
 
       // then
-      !expect(trainingTrigger).to.be.instanceOf(TrainingTrigger);
+      expect(trainingTrigger).to.be.instanceOf(TrainingTrigger);
     });
 
     it('should throw an error when type is not valid', async function () {
@@ -16,6 +16,73 @@ describe('Unit | Domain | Models | TrainingTrigger', function () {
       const error = await catchErr(domainBuilder.buildTrainingTrigger)({ type: 'not_valid_type' });
 
       expect(error.message).to.equal('Invalid trigger type');
+    });
+
+    it('should build learning content tree from parameters', function () {
+      // given
+      const area1 = domainBuilder.buildArea({ id: 'recArea1' });
+      const competence1 = domainBuilder.buildCompetence({ id: 'recCompetence1', areaId: 'recArea1' });
+      const competence2InAnotherArea = domainBuilder.buildCompetence({ id: 'recCompetence2', areaId: 'recArea2' });
+      const thematic1 = domainBuilder.buildThematic({ id: 'recThematic1', competenceId: 'recCompetence1' });
+      const thematic2 = domainBuilder.buildThematic({ id: 'recThematic2', competenceId: 'recCompetence1' });
+      const thematic3InAnotherCompetence = domainBuilder.buildThematic({
+        id: 'recThematic3',
+        competenceId: 'recCompetence2',
+      });
+      const tube1 = domainBuilder.buildTube({
+        id: 'recTube1',
+        thematicId: thematic1.id,
+      });
+      const tube2 = domainBuilder.buildTube({
+        id: 'recTube2',
+        thematicId: thematic2.id,
+      });
+      const tube3InAnotherThematic = domainBuilder.buildTube({
+        id: 'recTube3',
+        thematicId: thematic3InAnotherCompetence.id,
+      });
+      const trainingTriggerTube1 = domainBuilder.buildTrainingTriggerTube({
+        id: 'recTrainingTriggerTube1',
+        tube: tube1,
+      });
+      const trainingTriggerTube2 = domainBuilder.buildTrainingTriggerTube({
+        id: 'recTrainingTriggerTube2',
+        tube: tube2,
+      });
+      const trainingTriggerTube3 = domainBuilder.buildTrainingTriggerTube({
+        id: 'recTrainingTriggerTube3',
+        tube: tube3InAnotherThematic,
+      });
+
+      const trainingTrigger = domainBuilder.buildTrainingTrigger({
+        type: TrainingTrigger.types.PREREQUISITE,
+        areas: [area1],
+        competences: [competence1, competence2InAnotherArea],
+        thematics: [thematic1, thematic2, thematic3InAnotherCompetence],
+        triggerTubes: [trainingTriggerTube1, trainingTriggerTube2, trainingTriggerTube3],
+      });
+
+      // then
+      expect(trainingTrigger.areas).to.have.length(1);
+      expect(trainingTrigger.areas[0]).to.have.property('id', area1.id);
+      expect(trainingTrigger.areas[0]).to.have.property('title', area1.title);
+      expect(trainingTrigger.areas[0]).to.have.property('code', area1.code);
+      expect(trainingTrigger.areas[0]).to.have.property('color', area1.color);
+      expect(trainingTrigger.areas[0].competences).to.have.length(1);
+      expect(trainingTrigger.areas[0].competences[0]).to.have.property('id', competence1.id);
+      expect(trainingTrigger.areas[0].competences[0]).to.have.property('name', competence1.name);
+      expect(trainingTrigger.areas[0].competences[0]).to.have.property('index', competence1.index);
+      expect(trainingTrigger.areas[0].competences[0].thematics).to.have.length(2);
+      expect(trainingTrigger.areas[0].competences[0].thematics[0]).to.have.property('id', thematic1.id);
+      expect(trainingTrigger.areas[0].competences[0].thematics[0]).to.have.property('name', thematic1.name);
+      expect(trainingTrigger.areas[0].competences[0].thematics[0]).to.have.property('index', thematic1.index);
+      expect(trainingTrigger.areas[0].competences[0].thematics[0].triggerTubes).to.have.length(1);
+      expect(trainingTrigger.areas[0].competences[0].thematics[0].triggerTubes[0]).to.equal(trainingTriggerTube1.id);
+      expect(trainingTrigger.areas[0].competences[0].thematics[1]).to.have.property('id', thematic2.id);
+      expect(trainingTrigger.areas[0].competences[0].thematics[1]).to.have.property('name', thematic2.name);
+      expect(trainingTrigger.areas[0].competences[0].thematics[1]).to.have.property('index', thematic2.index);
+      expect(trainingTrigger.areas[0].competences[0].thematics[1].triggerTubes).to.have.length(1);
+      expect(trainingTrigger.areas[0].competences[0].thematics[1].triggerTubes[0]).to.equal(trainingTriggerTube2.id);
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-trigger-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-trigger-serializer_test.js
@@ -5,22 +5,68 @@ describe('Unit | Serializer | JSONAPI | training-trigger-serializer', function (
   describe('#serialize', function () {
     it('should convert a training trigger model to JSON', function () {
       // given
-      const trainingTrigger = domainBuilder.buildTrainingTrigger();
+      const id = 12345;
+      const trainingId = 6789;
+      const area1 = domainBuilder.buildArea({ id: 'recArea1' });
+      const competence1 = domainBuilder.buildCompetence({ id: 'recCompetence1', areaId: 'recArea1' });
+      const competenceInAnotherArea = domainBuilder.buildCompetence({ id: 'recCompetence2', areaId: 'recArea2' });
+      const thematic1 = domainBuilder.buildThematic({ id: 'recThematic1', competenceId: 'recCompetence1' });
+      const thematicInAnotherCompetence = domainBuilder.buildThematic({
+        id: 'recThematic2',
+        competenceId: 'anotherCompetence',
+      });
+      const tube1 = domainBuilder.buildTube({
+        id: 'recTube1',
+        thematicId: thematic1.id,
+      });
+      const tubeInAnotherThematic = domainBuilder.buildTube({
+        id: 'recTube2',
+        thematicId: 'anotherThematic',
+      });
+      const trainingTriggerTube1 = domainBuilder.buildTrainingTriggerTube({
+        id: 'recTrainingTriggerTube1',
+        tube: tube1,
+      });
+      const anotherTrainingTriggerTube = domainBuilder.buildTrainingTriggerTube({
+        id: 'recTrainingTriggerTube2',
+        tube: tubeInAnotherThematic,
+      });
+      const trainingTrigger = domainBuilder.buildTrainingTrigger({
+        id,
+        trainingId,
+        areas: [area1],
+        competences: [competence1, competenceInAnotherArea],
+        thematics: [thematic1, thematicInAnotherCompetence],
+        triggerTubes: [trainingTriggerTube1, anotherTrainingTriggerTube],
+      });
 
-      const expectedSerializedTraining = {
+      const expectedSerializedTrainingTrigger = {
         data: {
           attributes: {
+            id,
+            'training-id': trainingId,
             threshold: 60,
-            'training-id': 156,
             type: 'prerequisite',
           },
-          id: '1000',
+          id: `${id}`,
           relationships: {
             'trigger-tubes': {
               data: [
                 {
-                  id: '10002',
+                  id: 'recTrainingTriggerTube1',
                   type: 'trigger-tubes',
+                },
+                {
+                  id: 'recTrainingTriggerTube2',
+                  type: 'trigger-tubes',
+                },
+              ],
+            },
+            areas: {
+              data: [
+                {
+                  id: 'recArea1',
+                  type: 'areas',
                 },
               ],
             },
@@ -30,29 +76,98 @@ describe('Unit | Serializer | JSONAPI | training-trigger-serializer', function (
         included: [
           {
             attributes: {
-              id: 'recTube123',
+              id: 'recTube1',
               name: '@tubeName',
-              'practical-description': 'description pratique',
               'practical-title': 'titre pratique',
             },
-            id: 'recTube123',
+            id: 'recTube1',
             type: 'tubes',
           },
           {
             attributes: {
-              id: 10002,
-              level: 2,
+              id: 'recTrainingTriggerTube1',
+              level: 8,
             },
-            id: '10002',
+            id: 'recTrainingTriggerTube1',
             relationships: {
               tube: {
                 data: {
-                  id: 'recTube123',
+                  id: 'recTube1',
                   type: 'tubes',
                 },
               },
             },
             type: 'trigger-tubes',
+          },
+          {
+            attributes: {
+              id: 'recTube2',
+              name: '@tubeName',
+              'practical-title': 'titre pratique',
+            },
+            id: 'recTube2',
+            type: 'tubes',
+          },
+          {
+            attributes: {
+              id: 'recTrainingTriggerTube2',
+              level: 8,
+            },
+            id: 'recTrainingTriggerTube2',
+            relationships: {
+              tube: {
+                data: {
+                  id: 'recTube2',
+                  type: 'tubes',
+                },
+              },
+            },
+            type: 'trigger-tubes',
+          },
+          {
+            attributes: {
+              index: 0,
+              name: 'My Thematic',
+            },
+            id: 'recThematic1',
+            type: 'thematics',
+          },
+          {
+            attributes: {
+              index: '1.1',
+              name: 'Manger des fruits',
+            },
+            id: 'recCompetence1',
+            relationships: {
+              thematics: {
+                data: [
+                  {
+                    id: 'recThematic1',
+                    type: 'thematics',
+                  },
+                ],
+              },
+            },
+            type: 'competences',
+          },
+          {
+            attributes: {
+              code: 5,
+              color: 'red',
+              title: 'Super domaine',
+            },
+            id: 'recArea1',
+            relationships: {
+              competences: {
+                data: [
+                  {
+                    id: 'recCompetence1',
+                    type: 'competences',
+                  },
+                ],
+              },
+            },
+            type: 'areas',
           },
         ],
       };
@@ -61,7 +176,7 @@ describe('Unit | Serializer | JSONAPI | training-trigger-serializer', function (
       const json = serializer.serialize(trainingTrigger);
 
       // then
-      expect(json).to.deep.equal(expectedSerializedTraining);
+      expect(json).to.deep.equal(expectedSerializedTrainingTrigger);
     });
   });
 
@@ -72,7 +187,6 @@ describe('Unit | Serializer | JSONAPI | training-trigger-serializer', function (
         data: {
           type: 'training-triggers',
           attributes: {
-            trainingId: 123,
             type: 'prerequisite',
             threshold: 30,
             tubes: [{ id: 'recTube123', level: 2 }],
@@ -85,7 +199,6 @@ describe('Unit | Serializer | JSONAPI | training-trigger-serializer', function (
 
       // then
       expect(trainingTrigger).to.deep.equal({
-        trainingId: 123,
         type: 'prerequisite',
         threshold: 30,
         tubes: [{ id: 'recTube123', level: 2 }],


### PR DESCRIPTION
## :unicorn: Problème
Lors de la récupération des données de contenu formatif dans Admin, on ne récupérait pas les informations de référentiel des déclencheurs sauvegardés.

## :robot: Proposition
Mettre à jour les données retournées dans le GET `/api/admin/trainings/TRAINING_ID` et PUT`/api/admin/trainings/TRAINING_ID/triggers`  en y ajoutant les données de référentiel.

## :rainbow: Remarques
- 2 models ont été modifiés : `training` et `training-trigger`
- On se demande s'il est vraiment nécessaire de conserver le serializer`training-trigger`

## :100: Pour tester
- Aller dans Admin en RA 
- Ajouter un déclencheur de contenu formatif et vérifier la réponse du PUT
- Relancer la page de votre contenu formatif et vérifier les données du GET

