### PR TITLE
[TECH] Amélioration de la gestion d'erreur sur la création d'un profil cible avec une organisation inconnue (PIX-7337)

### DIFF
--- a/admin/app/components/target-profiles/create-target-profile-form.hbs
+++ b/admin/app/components/target-profiles/create-target-profile-form.hbs
@@ -41,6 +41,7 @@
           @label="Identifiant de l'organisation de référence : "
           @errorMessage=""
           required={{true}}
+          type="number"
           aria-required={{true}}
           placeholder="7777"
           {{on "change" this.updateOwnerOrganizationId}}

--- a/api/lib/domain/usecases/create-target-profile.js
+++ b/api/lib/domain/usecases/create-target-profile.js
@@ -1,12 +1,21 @@
 const TargetProfileForCreation = require('../models/TargetProfileForCreation.js');
 const learningContentConversionService = require('../services/learning-content/learning-content-conversion-service.js');
-
+const { TargetProfileCannotBeCreated } = require('../errors');
 module.exports = async function createTargetProfile({
   targetProfileCreationCommand,
   domainTransaction,
   targetProfileRepository,
+  organizationRepository,
 }) {
   const targetProfileForCreation = TargetProfileForCreation.fromCreationCommand(targetProfileCreationCommand);
+  try {
+    await organizationRepository.get(targetProfileForCreation.ownerOrganizationId);
+  } catch (error) {
+    throw new TargetProfileCannotBeCreated(
+      `Cannot create target profile for non existant organization id: ${targetProfileForCreation.ownerOrganizationId}`
+    );
+  }
+
   const targetProfileId = await targetProfileRepository.createWithTubes({
     targetProfileForCreation,
     domainTransaction,

--- a/api/tests/acceptance/application/target-profiles/index_test.js
+++ b/api/tests/acceptance/application/target-profiles/index_test.js
@@ -83,6 +83,9 @@ describe('Acceptance | Route | target-profiles', function () {
 
     it('should return 200', async function () {
       // given
+      databaseBuilder.factory.buildOrganization({ id: 1 });
+      await databaseBuilder.commit();
+
       const options = {
         method: 'POST',
         url: '/api/admin/target-profiles',
@@ -96,7 +99,7 @@ describe('Acceptance | Route | target-profiles', function () {
               comment: 'coucou papa',
               'is-public': false,
               'image-url': 'http://some/image.ok',
-              'owner-organization-id': null,
+              'owner-organization-id': '1',
               tubes: [{ id: 'recTube1', level: 5 }],
             },
           },


### PR DESCRIPTION
## :unicorn: Problème
Un message d'erreur générique s'affiche lorsque l'on tente de créer un profil cible avec un identifiant d'organisation inconnu.

## :robot: Proposition
Lorsque l'on positionne un identifiant invalide, l'erreur à la validation doit indiquer qu'aucune organisation ne correspond à l'identifiant fourni.

## :rainbow: Remarques
Le champ de saisie est également limité aux nombres.

## :100: Pour tester
Depuis l'application admin, tenter de créer un profil cible avec un identifiant d'organisation invalide.
↪️ La création échoue et un message indique la raison précise de l'échec.