### PR TITLE
[FEATURE] Mettre le nom du prescrit comme titre sur les détails d'une participation (PIX-7296)

### DIFF
--- a/orga/app/components/participant/assessment/header.hbs
+++ b/orga/app/components/participant/assessment/header.hbs
@@ -2,9 +2,11 @@
   <Ui::Breadcrumb @links={{this.breadcrumbLinks}} />
 </header>
 
+<h1 class="page__title page-title">{{@participation.firstName}} {{@participation.lastName}}</h1>
+
 <section class="panel panel--header">
   <header class="panel-header__headline">
-    <h2 class="panel-header-title">{{@participation.firstName}} {{@participation.lastName}}</h2>
+    <h2 class="panel-header-title">{{@campaign.name}}</h2>
   </header>
 
   <div class="panel-header__body">

--- a/orga/app/components/participant/profile/header.hbs
+++ b/orga/app/components/participant/profile/header.hbs
@@ -2,12 +2,14 @@
   <Ui::Breadcrumb @links={{this.breadcrumbLinks}} />
 </header>
 
+<h1 class="page__title page-title">
+  {{@campaignProfile.firstName}}
+  {{@campaignProfile.lastName}}
+</h1>
+
 <section class="panel panel--header">
   <header class="panel-header__headline">
-    <h2 class="panel-header-title">
-      {{@campaignProfile.firstName}}
-      {{@campaignProfile.lastName}}
-    </h2>
+    <h2 class="panel-header-title">{{@campaign.name}}</h2>
     {{#if (and @campaignProfile.isCertifiable @campaignProfile.isShared)}}
       <PixTag @color="green-light" class="profile-user__certifiable">
         {{t "pages.profiles-individual-results.certifiable"}}

--- a/orga/app/components/ui/learner-header-info.hbs
+++ b/orga/app/components/ui/learner-header-info.hbs
@@ -1,4 +1,4 @@
-<Ui::InformationWrapper>
+<Ui::InformationWrapper class="learner-header-info">
   {{#if @isCertifiable}}
     <Ui::Information @contentClass="information--certifiable">
       <:title>

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -45,6 +45,7 @@
 @import 'components/login-or-register';
 @import 'components/manage-authentication-method-modal';
 @import 'components/participation-filters';
+@import 'components/learner-header-info';
 
 // pages
 @import 'pages/login';
@@ -81,7 +82,8 @@
 @import 'pages/authenticated/team/new';
 @import 'pages/authenticated/terms-of-service';
 
-body, html {
+body,
+html {
   height: 100%;
 }
 

--- a/orga/app/styles/components/learner-header-info.scss
+++ b/orga/app/styles/components/learner-header-info.scss
@@ -1,0 +1,3 @@
+.learner-header-info {
+  margin: $spacing-xxl;
+}

--- a/orga/app/styles/components/ui/information.scss
+++ b/orga/app/styles/components/ui/information.scss
@@ -1,6 +1,5 @@
 .information-wrapper {
   display: flex;
-  margin-left: $spacing-xxl;
 }
 
 .information {

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -14,7 +14,6 @@
 
 .panel-header__headline {
   display: flex;
-  justify-content: center;
   align-items: center;
   width: 100%;
   box-sizing: border-box;

--- a/orga/app/styles/globals/titles.scss
+++ b/orga/app/styles/globals/titles.scss
@@ -22,10 +22,9 @@
 }
 
 .panel-header-title {
-  font-family: $font-open-sans;
-  font-weight: 300;
-  font-size: 2rem;
-  color: $pix-neutral-90;
+  @include subheading;
+
+  color: $pix-neutral-70;
 }
 
 .back-title {


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la consolidation de l’activité du prescrit, la page de détail d’une participation à une campagne va devenir accessible via la liste des participants d'une organisation. On souhaite mettre plus en avant l'identité du prescrit.

## :robot: Proposition
On sort de l'identité du prescrit qui devient le titre de la page et on met le nom de la campagne dans le bloc d'information.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter sur Pix Orga
- Vérifier que le titre est bien le nom du prescrit dans les deux types de campagnes (évaluation, collecte de profils)