### PR TITLE
[FEATURE] Améliorer le disclosure du block de signalisation de problème sur Pix-App (PIX-6862)

### DIFF
--- a/mon-pix/app/components/feedback-panel.hbs
+++ b/mon-pix/app/components/feedback-panel.hbs
@@ -6,19 +6,21 @@
       class="feedback-panel__open-button"
       {{on "click" this.toggleFeedbackForm}}
       disabled={{this.isToggleFeedbackFormDisabled}}
+      aria-expanded={{this.isAriaExpanded}}
+      aria-controls={{this.feedbackPanelId}}
       type="button"
     >
       {{t "pages.challenge.feedback-panel.actions.open-close"}}
     </button>
   </div>
 
-  {{#if this.isFormOpened}}
+  {{#if this.isExpanded}}
     {{#if this.isFormSubmitted}}
-      <div class="feedback-panel__view feedback-panel__view--mercix">
+      <div class="feedback-panel__view feedback-panel__view--mercix" id="feedback-panel-submitted">
         {{t "pages.challenge.feedback-panel.form.status.success" htmlSafe=true}}
       </div>
     {{else}}
-      <div class="feedback-panel__view feedback-panel__view--form">
+      <div class="feedback-panel__view feedback-panel__view--form" id="feedback-panel">
         <div class="feedback-panel__form-description">
         </div>
         {{#if @assessment.isCertification}}

--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -17,11 +17,10 @@ export default class FeedbackPanel extends Component {
   @tracked displayQuestionDropdown = false;
   @tracked displayTextBox = false;
   @tracked emptyTextBoxMessageError = null;
-  @tracked isFormOpened = false;
   @tracked isFormSubmitted = false;
   @tracked nextCategory = null;
   @tracked quickHelpInstructions = null;
-
+  @tracked isExpanded = false;
   _category = null;
   _questions = questions;
   _sendButtonStatus = buttonStatusTypes.unrecorded;
@@ -30,6 +29,14 @@ export default class FeedbackPanel extends Component {
   constructor(owner, args) {
     super(owner, args);
     this._resetPanel();
+  }
+
+  get isAriaExpanded() {
+    return this.isExpanded ? 'true' : 'false';
+  }
+
+  get feedbackPanelId() {
+    return this.isFormSubmitted ? 'feedback-panel-submitted' : 'feedback-panel';
   }
 
   get categories() {
@@ -47,11 +54,11 @@ export default class FeedbackPanel extends Component {
 
   @action
   toggleFeedbackForm() {
-    if (this.isFormOpened) {
-      this.isFormOpened = false;
+    if (this.isExpanded) {
+      this.isExpanded = false;
       this._resetPanel();
     } else {
-      this.isFormOpened = true;
+      this.isExpanded = true;
       this._scrollIntoFeedbackPanel();
     }
   }
@@ -130,7 +137,7 @@ export default class FeedbackPanel extends Component {
     this.emptyTextBoxMessageError = null;
     this._resetForm();
     if (this.args.alwaysOpenForm) {
-      this.isFormOpened = true;
+      this.isExpanded = true;
     }
   }
 

--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -12,12 +12,14 @@
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 
 .feedback-panel__open-button {
+  width: 100%;
   padding: 0;
   color: $pix-neutral-50;
   font-weight: $font-medium;
   font-size: 0.875rem;
   font-family: $font-roboto;
   line-height: 20px;
+  text-align: left;
   background-color: transparent;
   border: none;
   cursor: pointer;

--- a/mon-pix/tests/unit/components/feedback-panel_test.js
+++ b/mon-pix/tests/unit/components/feedback-panel_test.js
@@ -19,12 +19,12 @@ module('Unit | Component | feedback-panel', function (hooks) {
       component.toggleFeedbackForm();
 
       // then
-      assert.true(component.isFormOpened);
+      assert.true(component.isExpanded);
     });
 
     test('should close and reset form', function (assert) {
       // given
-      component.isFormOpened = true;
+      component.isExpanded = true;
       component.emptyTextBoxMessageError = '10, 9, 8, ...';
       component.isFormSubmitted = true;
 
@@ -32,7 +32,7 @@ module('Unit | Component | feedback-panel', function (hooks) {
       component.toggleFeedbackForm();
 
       // then
-      assert.false(component.isFormOpened);
+      assert.false(component.isExpanded);
       assert.false(component.isFormSubmitted);
       assert.notOk(component.emptyTextBoxMessageError);
     });


### PR DESCRIPTION
## :unicorn: Problème
Suite au retour de l'audit d'accessibilité, le bloc de signalisation de problème sur les épreuves manquaient d'infos pour les les lecteur d'écran.

## :robot: Proposition
- Quand le contenu est visible, ajouter une propriété `aria-expanded` à `true`.
- Quand le contenu est caché, ajouter une propriété `aria-expanded` à `false`.
- Spécifié un `aria-controls` sur le bouton qui réfère au bloc du contenu.
(cf https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/)

## :rainbow: Remarques
Quelques propriété css ont été changé pour permettre de pouvoir cliquer sur toute la longueur du bloc de signalisation de problème.

## :100: Pour tester
Vérifier que les attributs sont bien présents. 
Vérifier que la valeur de l'`aria-expanded` change en fonction de l'état affiché/caché du bloc.
Vérifier que l'`aria-controls` et l'`id` change bien selon si le formulaire à été envoyé ou non.
