### PR TITLE
[FEATURE] Déplacer le tag certifiable à côté du nom du prescrit sur la page d'une participation (PIX-7421)

### DIFF
--- a/orga/app/components/participant/profile/header.hbs
+++ b/orga/app/components/participant/profile/header.hbs
@@ -2,21 +2,22 @@
   <Ui::Breadcrumb @links={{this.breadcrumbLinks}} />
 </header>
 
-<h1 class="page__title page-title">
-  {{@campaignProfile.firstName}}
-  {{@campaignProfile.lastName}}
-</h1>
+<header class="prescriber page__title">
+  <h1 class="page-title">
+    {{@campaignProfile.firstName}}
+    {{@campaignProfile.lastName}}
+  </h1>
+  {{#if (and @campaignProfile.isCertifiable @campaignProfile.isShared)}}
+    <PixTag @color="green-light" class="prescriber__certifiable-tag">
+      {{t "pages.profiles-individual-results.certifiable"}}
+    </PixTag>
+  {{/if}}
+</header>
 
 <section class="panel panel--header">
   <header class="panel-header__headline">
     <h2 class="panel-header-title">{{@campaign.name}}</h2>
-    {{#if (and @campaignProfile.isCertifiable @campaignProfile.isShared)}}
-      <PixTag @color="green-light" class="profile-user__certifiable">
-        {{t "pages.profiles-individual-results.certifiable"}}
-      </PixTag>
-    {{/if}}
   </header>
-
   <div class="panel-header__body">
     <Ui::InformationWrapper>
       {{#if @campaignProfile.externalId}}

--- a/orga/app/styles/components/participant/index.scss
+++ b/orga/app/styles/components/participant/index.scss
@@ -1,2 +1,3 @@
 @import 'no-participant-panel';
+@import 'profile';
 @import 'tabs';

--- a/orga/app/styles/components/participant/profile.scss
+++ b/orga/app/styles/components/participant/profile.scss
@@ -1,0 +1,5 @@
+.prescriber {
+  display: flex;
+  align-items: center;
+  gap: $spacing-s;
+}


### PR DESCRIPTION
## :unicorn: Problème
Sur la page de détail d’une participation, [nous venons d’inverser le nom du prescrit et le nom de la campagne](https://1024pix.atlassian.net/browse/PIX-7296). 

Pour les collectes de profils, le chip “certifiable” n’a pas été pris en compte, il est donc affiché à côté du nom de la campagne si le prescrit est certifiable.

## :robot: Proposition
Déplacer aussi le chip “certifiable” pour qu’il s’affiche à côté du nom du prescrit le cas échéant.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- se connecter à Pix Orga
- Se rendre sur une campagne de collecte de profil
- Sélectionner une participation
- Observer le tag "Certifiable" et son emplacement