### PR TITLE
[FEATURE] Modale détail du candidat en anglais (PIX-6671)

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/certification-candidate-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-candidate-serializer.js
@@ -10,7 +10,6 @@ module.exports = {
       transform: function (certificationCandidate) {
         return {
           ...certificationCandidate,
-          billingMode: certificationCandidate.translatedBillingMode,
           isLinked: !_.isNil(certificationCandidate.userId),
         };
       },

--- a/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
+++ b/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
@@ -127,7 +127,7 @@ describe('Acceptance | Controller | session-controller-enroll-students-to-sessio
           data: [
             {
               attributes: {
-                'billing-mode': '',
+                'billing-mode': null,
                 'prepayment-code': null,
                 'birth-city': organizationLearner.birthCity,
                 birthdate: organizationLearner.birthdate,

--- a/api/tests/acceptance/application/session/session-controller-get-certification-candidates_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-certification-candidates_test.js
@@ -57,7 +57,7 @@ describe('Acceptance | Controller | session-controller-get-certification-candida
         expectedCertificationCandidateAAttributes = {
           'first-name': certificationCandidateA.firstName,
           'last-name': certificationCandidateA.lastName,
-          'billing-mode': '',
+          'billing-mode': null,
           'prepayment-code': null,
           birthdate: certificationCandidateA.birthdate,
           'birth-city': certificationCandidateA.birthCity,
@@ -77,7 +77,7 @@ describe('Acceptance | Controller | session-controller-get-certification-candida
         expectedCertificationCandidateBAttributes = {
           'first-name': certificationCandidateB.firstName,
           'last-name': certificationCandidateB.lastName,
-          'billing-mode': '',
+          'billing-mode': null,
           'prepayment-code': null,
           birthdate: certificationCandidateB.birthdate,
           'birth-city': certificationCandidateB.birthCity,

--- a/api/tests/acceptance/application/session/session-controller-post-certification-candidates_test.js
+++ b/api/tests/acceptance/application/session/session-controller-post-certification-candidates_test.js
@@ -123,7 +123,7 @@ describe('Acceptance | Controller | session-controller-post-certification-candid
           'birth-city': certificationCpfCity.name,
           'birth-country': certificationCpfCountry.commonName,
           'birth-province-code': null,
-          'billing-mode': 'Gratuite',
+          'billing-mode': 'FREE',
           'prepayment-code': null,
           'result-recipient-email': certificationCandidate.resultRecipientEmail,
           email: certificationCandidate.email,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-candidate-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-candidate-serializer_test.js
@@ -30,7 +30,7 @@ describe('Unit | Serializer | JSONAPI | certification-candidate-serializer', fun
           attributes: {
             'first-name': certificationCandidate.firstName,
             'last-name': certificationCandidate.lastName,
-            'billing-mode': 'Payante',
+            'billing-mode': 'PAID',
             'prepayment-code': null,
             'birth-city': certificationCandidate.birthCity,
             'birth-province-code': certificationCandidate.birthProvinceCode,

--- a/certif/app/components/certification-candidate-details-modal.hbs
+++ b/certif/app/components/certification-candidate-details-modal.hbs
@@ -41,7 +41,7 @@
           {{t "pages.sessions.detail.candidates.informations.gender"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
-          {{if @candidate.sexLabel @candidate.sexLabel "-"}}
+          {{@candidate.genderLabel}}
         </span>
       </li>
       <li class="certification-candidate-details-modal__row">

--- a/certif/app/components/certification-candidate-details-modal.hbs
+++ b/certif/app/components/certification-candidate-details-modal.hbs
@@ -1,5 +1,5 @@
 <PixModal
-  @title="Détail du candidat"
+  @title={{t "pages.sessions.detail.candidates.detail-modal.title"}}
   @onCloseButtonClick={{@closeModal}}
   class="certification-candidate-details-modal"
   @showModal={{@showModal}}
@@ -7,19 +7,25 @@
   <:content>
     <ul class="certification-candidate-details-modal__list">
       <li class="certification-candidate-details-modal__row">
-        <span class="certification-candidate-details-modal__row__label">Nom</span>
+        <span class="certification-candidate-details-modal__row__label">
+          {{t "pages.sessions.detail.candidates.informations.lastname"}}
+        </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.lastName @candidate.lastName "-"}}
         </span>
       </li>
       <li class="certification-candidate-details-modal__row">
-        <span class="certification-candidate-details-modal__row__label">Prénom</span>
+        <span class="certification-candidate-details-modal__row__label">
+          {{t "pages.sessions.detail.candidates.informations.firstname"}}
+        </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.firstName @candidate.firstName "-"}}
         </span>
       </li>
       <li class="certification-candidate-details-modal__row">
-        <span class="certification-candidate-details-modal__row__label">Date de naissance</span>
+        <span class="certification-candidate-details-modal__row__label">
+          {{t "pages.sessions.detail.candidates.informations.birth-date"}}
+        </span>
         {{#if @candidate.birthdate}}
           <span class="certification-candidate-details-modal__row__value">
             {{dayjs-format @candidate.birthdate "DD/MM/YYYY"}}
@@ -31,69 +37,90 @@
         {{/if}}
       </li>
       <li class="certification-candidate-details-modal__row">
-        <span class="certification-candidate-details-modal__row__label">Sexe</span>
+        <span class="certification-candidate-details-modal__row__label">
+          {{t "pages.sessions.detail.candidates.informations.gender"}}
+        </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.sexLabel @candidate.sexLabel "-"}}
         </span>
       </li>
       <li class="certification-candidate-details-modal__row">
-        <span class="certification-candidate-details-modal__row__label">Commune de naissance</span>
+        <span class="certification-candidate-details-modal__row__label">
+          {{t "pages.sessions.detail.candidates.informations.birth-city"}}
+        </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.birthCity @candidate.birthCity "-"}}
         </span>
       </li>
       <li class="certification-candidate-details-modal__row">
-        <span class="certification-candidate-details-modal__row__label">Code postal de naissance</span>
+        <span class="certification-candidate-details-modal__row__label">
+          {{t "pages.sessions.detail.candidates.informations.birth-city-postcode"}}
+        </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.birthPostalCode @candidate.birthPostalCode "-"}}
         </span>
       </li>
       <li class="certification-candidate-details-modal__row">
-        <span class="certification-candidate-details-modal__row__label">Code INSEE de naissance</span>
+        <span class="certification-candidate-details-modal__row__label">
+          {{t "pages.sessions.detail.candidates.informations.birth-city-insee-code"}}
+        </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.birthInseeCode @candidate.birthInseeCode "-"}}
         </span>
       </li>
       <li class="certification-candidate-details-modal__row">
-        <span class="certification-candidate-details-modal__row__label">Pays de naissance</span>
+        <span class="certification-candidate-details-modal__row__label">
+          {{t "pages.sessions.detail.candidates.informations.birth-country"}}
+        </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.birthCountry @candidate.birthCountry "-"}}
         </span>
       </li>
       <li class="certification-candidate-details-modal__row">
-        <span class="certification-candidate-details-modal__row__label">E-mail du destinataire des résultats (formateur,
-          enseignant...)</span>
+        <span class="certification-candidate-details-modal__row__label">
+          {{t "pages.sessions.detail.candidates.informations.email-results"}}
+        </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.resultRecipientEmail @candidate.resultRecipientEmail "-"}}
         </span>
       </li>
       <li class="certification-candidate-details-modal__row">
-        <span class="certification-candidate-details-modal__row__label">E-mail de convocation</span>
+        <span class="certification-candidate-details-modal__row__label">
+          {{t "pages.sessions.detail.candidates.informations.email-convocation"}}
+        </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.email @candidate.email "-"}}
         </span>
       </li>
       <li class="certification-candidate-details-modal__row">
-        <span class="certification-candidate-details-modal__row__label">Identifiant externe</span>
+        <span class="certification-candidate-details-modal__row__label">
+          {{t "pages.sessions.detail.candidates.informations.external-id"}}
+        </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.externalId @candidate.externalId "-"}}
         </span>
       </li>
       <li class="certification-candidate-details-modal__row">
-        <span class="certification-candidate-details-modal__row__label">Temps majoré (%)</span>
+        <span class="certification-candidate-details-modal__row__label">
+          {{t "pages.sessions.detail.candidates.informations.extratime-percentage"}}
+        </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.extraTimePercentage (format-percentage @candidate.extraTimePercentage) "-"}}
         </span>
       </li>
       {{#if @shouldDisplayPaymentOptions}}
         <li class="certification-candidate-details-modal__row">
-          <span class="certification-candidate-details-modal__row__label">Tarification part Pix</span>
+          <span class="certification-candidate-details-modal__row__label">
+            {{t "pages.sessions.detail.candidates.informations.pricing"}}
+          </span>
           <span class="certification-candidate-details-modal__row__value">
             {{if @candidate.billingMode @candidate.billingMode "-"}}
           </span>
         </li>
         <li class="certification-candidate-details-modal__row">
-          <span class="certification-candidate-details-modal__row__label">Code de prépaiement</span>
+          <span class="certification-candidate-details-modal__row__label">
+            {{t "pages.sessions.detail.candidates.informations.prepayment-code"}}
+          </span>
           <span class="certification-candidate-details-modal__row__value">
             {{if @candidate.prepaymentCode @candidate.prepaymentCode "-"}}
           </span>
@@ -101,7 +128,9 @@
       {{/if}}
       {{#if @displayComplementaryCertification}}
         <li class="certification-candidate-details-modal__row">
-          <span class="certification-candidate-details-modal__row__label">Certification complémentaire</span>
+          <span class="certification-candidate-details-modal__row__label">
+            {{t "pages.sessions.detail.candidates.informations.additional-certification"}}
+          </span>
           <span class="certification-candidate-details-modal__row__value">
             {{if @candidate.complementaryCertifications @candidate.complementaryCertificationsList "-"}}
           </span>

--- a/certif/app/components/certification-candidate-details-modal.hbs
+++ b/certif/app/components/certification-candidate-details-modal.hbs
@@ -114,7 +114,7 @@
             {{t "pages.sessions.detail.candidates.informations.pricing"}}
           </span>
           <span class="certification-candidate-details-modal__row__value">
-            {{if @candidate.billingMode @candidate.billingMode "-"}}
+            {{@candidate.billingModeLabel}}
           </span>
         </li>
         <li class="certification-candidate-details-modal__row">

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -93,7 +93,7 @@
               {{/unless}}
               <td>{{format-percentage candidate.extraTimePercentage}}</td>
               {{#if @shouldDisplayPaymentOptions}}
-                <td>{{candidate.billingMode}}
+                <td>{{candidate.billingModeLabel}}
                   {{candidate.prepaymentCode}}
                 </td>
               {{/if}}

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -36,42 +36,42 @@
         <thead>
           <tr>
             <th class="certification-candidates-table__column-last-name">
-              {{t "pages.sessions.detail.candidates.list.columns.lastname"}}
+              {{t "pages.sessions.detail.candidates.informations.birth-name"}}
             </th>
             <th class="certification-candidates-table__column-first-name">
-              {{t "pages.sessions.detail.candidates.list.columns.firstname"}}
+              {{t "pages.sessions.detail.candidates.informations.firstname"}}
             </th>
             <th class="certification-candidates-table__column-birthdate">
-              {{t "pages.sessions.detail.candidates.list.columns.birth-date"}}
+              {{t "pages.sessions.detail.candidates.informations.birth-date"}}
             </th>
             {{#if @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
               <th class="certification-candidates-table__birth-city">
-                {{t "pages.sessions.detail.candidates.list.columns.birth-city"}}
+                {{t "pages.sessions.detail.candidates.informations.birth-city"}}
               </th>
               <th>
-                {{t "pages.sessions.detail.candidates.list.columns.birth-country"}}
+                {{t "pages.sessions.detail.candidates.informations.birth-country"}}
               </th>
             {{/if}}
             {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
               <th class="certification-candidates-table__recipient-email">
-                {{t "pages.sessions.detail.candidates.list.columns.recipient-email"}}
+                {{t "pages.sessions.detail.candidates.informations.email-results"}}
               </th>
             {{/unless}}
             {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
               <th class="certification-candidates-table__external-id">
-                {{t "pages.sessions.detail.candidates.list.columns.external-id"}}
+                {{t "pages.sessions.detail.candidates.informations.external-id"}}
               </th>
             {{/unless}}
             <th class="certification-candidates-table__column-time">
-              {{t "pages.sessions.detail.candidates.list.columns.extratime"}}
+              {{t "pages.sessions.detail.candidates.informations.extratime"}}
             </th>
             {{#if @shouldDisplayPaymentOptions}}
               <th class="certification-candidates-table__payment-options">
-                {{t "pages.sessions.detail.candidates.list.columns.pricing"}}
+                {{t "pages.sessions.detail.candidates.informations.pricing"}}
               </th>
             {{/if}}
             {{#if @displayComplementaryCertification}}
-              <th>{{t "pages.sessions.detail.candidates.list.columns.additional-certification"}}</th>
+              <th>{{t "pages.sessions.detail.candidates.informations.additional-certification"}}</th>
             {{/if}}
           </tr>
         </thead>

--- a/certif/app/models/certification-candidate.js
+++ b/certif/app/models/certification-candidate.js
@@ -26,18 +26,16 @@ export default class CertificationCandidate extends Model {
     return this.complementaryCertifications.map(({ label }) => label).join(', ');
   }
 
-  get sexLabel() {
-    if (this.sex === 'M') {
-      return 'Homme';
-    }
-    if (this.sex === 'F') {
-      return 'Femme';
-    }
-    return null;
-  }
+  get genderLabel() {
+    const candidateGender = this.sex;
 
-  get complementaryCertificationsList() {
-    return this.complementaryCertifications.map(({ label }) => label).join(', ');
+    if (candidateGender === 'M') {
+      return this.intl.t('pages.sessions.detail.candidates.informations.man');
+    }
+    if (candidateGender === 'F') {
+      return this.intl.t('pages.sessions.detail.candidates.informations.woman');
+    }
+    return '-';
   }
 
   get billingModeLabel() {

--- a/certif/app/models/certification-candidate.js
+++ b/certif/app/models/certification-candidate.js
@@ -1,6 +1,8 @@
 import Model, { attr } from '@ember-data/model';
+import { inject as service } from '@ember/service';
 
 export default class CertificationCandidate extends Model {
+  @service intl;
   @attr('string') firstName;
   @attr('string') lastName;
   @attr('date-only') birthdate;
@@ -20,6 +22,10 @@ export default class CertificationCandidate extends Model {
   @attr('string') prepaymentCode;
   @attr complementaryCertifications;
 
+  get complementaryCertificationsList() {
+    return this.complementaryCertifications.map(({ label }) => label).join(', ');
+  }
+
   get sexLabel() {
     if (this.sex === 'M') {
       return 'Homme';
@@ -32,5 +38,16 @@ export default class CertificationCandidate extends Model {
 
   get complementaryCertificationsList() {
     return this.complementaryCertifications.map(({ label }) => label).join(', ');
+  }
+
+  get billingModeLabel() {
+    const candidateBillingMode = this.billingMode;
+    if (candidateBillingMode) {
+      return this.intl.t(
+        `pages.sessions.detail.candidates.informations.billing-mode.${candidateBillingMode.toLowerCase()}`
+      );
+    }
+
+    return '-';
   }
 }

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -66,15 +66,9 @@ export default function () {
   this.post('/sessions/:id/certification-candidates', function (schema, request) {
     const sessionId = request.params.id;
     const requestBody = JSON.parse(request.requestBody);
-    const translateBillingMode = (billingMode) => {
-      if (billingMode === 'FREE') return 'Gratuite';
-      if (billingMode === 'PAID') return 'Payante';
-      if (billingMode === 'PREPAID') return 'Prépayée';
-    };
     return schema.certificationCandidates.create({
       ...requestBody.data.attributes,
       sessionId,
-      billingMode: translateBillingMode(requestBody.data.attributes['billing-mode']),
     });
   });
 

--- a/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
+++ b/certif/tests/integration/components/certification-candidate-details-modal/certification-candidate-details-modal_test.js
@@ -122,7 +122,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
         birthPostalCode: 76260,
         sex: 'F',
         complementaryCertifications: [],
-        billingMode: 'Prépayée',
+        billingMode: 'PREPAID',
         prepaymentCode: 'prep123',
       });
 
@@ -179,7 +179,7 @@ module('Integration | Component | certification-candidate-details-modal', functi
         birthPostalCode: 76260,
         sex: 'F',
         complementaryCertifications: [],
-        billingMode: 'Prépayée',
+        billingMode: 'PREPAID',
         prepaymentCode: 'prep123',
       });
 

--- a/certif/tests/integration/components/enrolled-candidates_test.js
+++ b/certif/tests/integration/components/enrolled-candidates_test.js
@@ -162,7 +162,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
       // given
       this.set('shouldDisplayPaymentOptions', true);
       const candidate = _buildCertificationCandidate({
-        billingMode: 'Prepayée',
+        billingMode: 'PREPAID',
         prepaymentCode: 'CODE01',
       });
 
@@ -182,7 +182,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
 
       // then
       assert.dom(screen.queryByRole('columnheader', { name: 'Tarification part Pix' })).exists();
-      assert.dom(screen.getByRole('cell', { name: 'Prepayée CODE01' })).exists();
+      assert.dom(screen.getByRole('cell', { name: 'Prépayée CODE01' })).exists();
     });
   });
 
@@ -298,7 +298,7 @@ function _buildCertificationCandidate({
       label: 'Pix+Droit',
     },
   ],
-  billingMode = '',
+  billingMode = null,
   prepaymentCode = null,
 }) {
   return {

--- a/certif/tests/unit/helpers/setup-intl.js
+++ b/certif/tests/unit/helpers/setup-intl.js
@@ -1,0 +1,6 @@
+export default function setupIntlForModels(hooks, locale = ['fr']) {
+  hooks.beforeEach(function () {
+    this.intl = this.owner.lookup('service:intl');
+    this.intl.setLocale(locale);
+  });
+}

--- a/certif/tests/unit/models/certification-candidate_test.js
+++ b/certif/tests/unit/models/certification-candidate_test.js
@@ -30,45 +30,45 @@ module('Unit | Model | certification-candidate', function (hooks) {
     assert.deepEqual(_pickModelData(data), _pickModelData(model));
   });
 
-  module('#get sexLabel', () => {
-    test('it get "Homme" for sex code "M"', function (assert) {
+  module('#get genderLabel', () => {
+    test('should display the correct label for man', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const data = {
         sex: 'M',
       };
+
       // when
-      const model = store.createRecord('certification-candidate', data);
+      const { genderLabel } = store.createRecord('certification-candidate', data);
+
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.sexLabel, 'Homme');
+      assert.strictEqual(genderLabel, 'Homme');
     });
 
-    test('it get "Femme" for sex code "F"', function (assert) {
+    test('should display the correct label for woman', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const data = {
         sex: 'F',
       };
+
       // when
-      const model = store.createRecord('certification-candidate', data);
+      const { genderLabel } = store.createRecord('certification-candidate', data);
+
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.sexLabel, 'Femme');
+      assert.strictEqual(genderLabel, 'Femme');
     });
 
-    test('it get nothing if no sex code', function (assert) {
+    test('should not display any label if there is no gender', function (assert) {
       // given
       const store = this.owner.lookup('service:store');
       const data = {};
+
       // when
-      const model = store.createRecord('certification-candidate', data);
+      const { genderLabel } = store.createRecord('certification-candidate', data);
+
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.sexLabel, null);
+      assert.strictEqual(genderLabel, '-');
     });
   });
 

--- a/certif/tests/unit/models/certification-candidate_test.js
+++ b/certif/tests/unit/models/certification-candidate_test.js
@@ -1,9 +1,11 @@
 import { module, test } from 'qunit';
 import pick from 'lodash/pick';
 import { setupTest } from 'ember-qunit';
+import setupIntlForModels from '../../helpers/setup-intl';
 
 module('Unit | Model | certification-candidate', function (hooks) {
   setupTest(hooks);
+  setupIntlForModels(hooks);
 
   test('it creates a CertificationCandidate', function (assert) {
     // given
@@ -93,6 +95,34 @@ module('Unit | Model | certification-candidate', function (hooks) {
 
       // then
       assert.strictEqual(model.complementaryCertificationsList, 'Pix+Edu, Pix+Droit');
+    });
+  });
+
+  module('#get billingModeLabel', () => {
+    test('should display the billing mode label', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const data = {
+        billingMode: 'PREPAID',
+      };
+      // when
+      const { billingModeLabel } = store.createRecord('certification-candidate', data);
+
+      // then
+      assert.strictEqual(billingModeLabel, 'Prépayée');
+    });
+
+    test('should not display any label if there is no billing mode', function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const data = {
+        billingMode: null,
+      };
+      // when
+      const { billingModeLabel } = store.createRecord('certification-candidate', data);
+
+      // then
+      assert.strictEqual(billingModeLabel, '-');
     });
   });
 

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -268,6 +268,11 @@
           },
           "informations": {
             "additional-certification": "Additional certification",
+            "billing-mode": {
+              "free": "Free",
+              "paid": "Payable",
+              "prepaid": "Prepaid"
+            },
             "birth-city": "Birth city",
             "birth-city-insee-code": "Birth city INSEE code (only for France)",
             "birth-city-postcode": "Birth city postcode",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -287,8 +287,10 @@
             "firstname": "First name",
             "gender": "Gender",
             "lastname": "Last name",
+            "man": "Man",
             "prepayment-code": "Prepayment code",
-            "pricing": "Pricing of Pix’s share"
+            "pricing": "Pricing of Pix’s share",
+            "woman": "Woman"
           },
           "list": {
             "title": "Candidates' list",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -261,9 +261,29 @@
             }
           },
           "detail-modal": {
+            "title": "Candidate’s details",
             "actions": {
               "close-extra-information": "Close candidate's detail window modal"
             }
+          },
+          "informations": {
+            "additional-certification": "Additional certification",
+            "birth-city": "Birth city",
+            "birth-city-insee-code": "Birth city INSEE code (only for France)",
+            "birth-city-postcode": "Birth city postcode",
+            "birth-country": "Birth country",
+            "birth-date": "Date of birth",
+            "birth-name": "Birth name",
+            "email-convocation": "Email for the convocation",
+            "email-results": "Email of the results' recipient (instructor, teacher…)",
+            "external-id": "External user ID",
+            "extratime": "Extra time",
+            "extratime-percentage": "Extra time (%)",
+            "firstname": "First name",
+            "gender": "Gender",
+            "lastname": "Last name",
+            "prepayment-code": "Prepayment code",
+            "pricing": "Pricing of Pix’s share"
           },
           "list": {
             "title": "Candidates' list",
@@ -282,18 +302,6 @@
                 "extra-information": "See the candidate’s details",
                 "label": "See details"
               }
-            },
-            "columns": {
-              "additional-certification": "Additional certification",
-              "birth-city": "Birth city",
-              "birth-country": "Birth country",
-              "birth-date": "Date of birth",
-              "recipient-email": "Email of the results' recipient (instructor, teacher…)",
-              "external-id": "External ID",
-              "extratime": "Extra time",
-              "lastname": "Birth name",
-              "firstname": "First name",
-              "pricing": "Pricing of Pix’s share"
             },
             "with-details-description": "List of candidates enrolled in the session, ordered by birth name, with a link to see the candidate’s details and the possibility to delete a candidate in the last column.",
             "empty": "Awaiting candidates",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -1,11 +1,11 @@
 {
   "common": {
     "actions": {
+      "add": "Ajouter",
       "back": "Retour",
       "cancel": "Annuler",
       "close": "Fermer",
       "continue": "Continuer",
-      "add": "Ajouter",
       "delete": "Supprimer",
       "quit": "Quitter",
       "update": "Modifier"

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -257,9 +257,29 @@
             }
           },
           "detail-modal": {
+            "title": "Détail du candidat",
             "actions": {
               "close-extra-information": "Fermer la fenêtre de détail du candidat"
             }
+          },
+          "informations": {
+            "additional-certification": "Certification complémentaire",
+            "birth-city": "Commune de naissance",
+            "birth-city-insee-code": "Code INSEE de naissance",
+            "birth-city-postcode": "Code postal de naissance",
+            "birth-country": "Pays de naissance",
+            "birth-date": "Date de naissance",
+            "birth-name": "Nom de naissance",
+            "email-convocation": "E-mail de convocation",
+            "email-results": "E-mail du destinataire des résultats (formateur, enseignant...)",
+            "external-id": "Identifiant externe",
+            "extratime": "Temps majoré",
+            "extratime-percentage": "Temps majoré (%)",
+            "firstname": "Prénom",
+            "gender": "Sexe",
+            "lastname": "Nom",
+            "prepayment-code": "Code de prépaiement",
+            "pricing": "Tarification part Pix"
           },
           "list": {
             "title": "Liste des candidats",
@@ -279,20 +299,8 @@
                 "label": "Voir le détail"
               }
             },
-            "columns": {
-              "additional-certification": "Certification complémentaire",
-              "birth-city": "Commune de naissance",
-              "birth-country": "Pays de naissance",
-              "birth-date": "Date de naissance",
-              "recipient-email": "E-mail du destinataire des résultats (formateur, enseignant...)",
-              "external-id": "Identifiant externe",
-              "extratime": "Temps majoré",
-              "lastname": "Nom de naissance",
-              "firstname": "Prénom",
-              "pricing": "Tarification part Pix"
-            },
-            "with-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec un lien pour voir les détails du candidat et la possibilité de supprimer un candidat dans la dernière colonne.",
             "empty": "En attente de candidats",
+            "with-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec un lien pour voir les détails du candidat et la possibilité de supprimer un candidat dans la dernière colonne.",
             "without-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec la possibilité de supprimer un candidat dans la dernière colonne."
           },
           "panel-actions": {
@@ -331,10 +339,6 @@
           }
         },
         "page-title": "Détails",
-        "tabs": {
-          "details": "Détails",
-          "candidates": "Candidats"
-        },
         "panel-clea": {
           "title": "Des candidats ont obtenu le certificat CléA numérique",
           "description": "Pour générer les certificats CléA numérique, téléchargez la liste des candidats, complétez-la, enregistrez-la au format .xlsx puis importez-la sur la ",
@@ -366,6 +370,10 @@
             "label": "Mot de passe de session",
             "invigilator": "Surveillant"
           }
+        },
+        "tabs": {
+          "details": "Détails",
+          "candidates": "Candidats"
         }
       },
       "new": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -264,6 +264,11 @@
           },
           "informations": {
             "additional-certification": "Certification complémentaire",
+            "billing-mode": {
+              "free": "Gratuite",
+              "paid": "Payante",
+              "prepaid": "Prépayée"
+            },
             "birth-city": "Commune de naissance",
             "birth-city-insee-code": "Code INSEE de naissance",
             "birth-city-postcode": "Code postal de naissance",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -283,8 +283,10 @@
             "firstname": "Prénom",
             "gender": "Sexe",
             "lastname": "Nom",
+            "man": "Homme",
             "prepayment-code": "Code de prépaiement",
-            "pricing": "Tarification part Pix"
+            "pricing": "Tarification part Pix",
+            "woman": "Femme"
           },
           "list": {
             "title": "Liste des candidats",


### PR DESCRIPTION
## :unicorn: Problème
Une fois que l'utilisateur anglophone a accédé à la liste des candidats de la session concernée, s’il veut consulter les détails concernant l’un des candidats inscrits à la session, il clique alors sur “Voir le détail” au bout de la ligne du candidat concerné.

Une modale s’ouvre avec les informations souhaitées mais toutes les informations sont en français.

## :robot: Proposition
Traduire la modale de détails d’un candidat en anglais :

- Détails du candidat : Candidate’s details
- Nom : Last name
- Prénom : First name
- Date de naissance : Date of birth
- Sexe : Gender
- Homme : Man
- Femme : Woman
- Commune de naissance : Birth city
- Code postal de naissance : Birth city postcode
- Code INSEE de naissance : Birth city INSEE code (only for France)
- Pays de naissance : Birth country
- E-mail du destinataire des résultats (formateur, enseignant...) : Email of the results' recipient (instructor, teacher…)
- E-mail de convocation : Email for the convocation
- Identifiant externe : External user ID
- Temps majoré (%) : Extra time (%)
- Tarification part Pix : Pricing of Pix’s share
- Payante : Payable
- Gratuite : Free
- Prépayée : Prepaid
- Code de prépaiement : Prepayment code
- Certification complémentaire : Additional certification
- Fermer : Close

## :rainbow: Remarques
La traduction du BillingMode se fait dans le model

## :100: Pour tester
Se connecter sur Pix Certif avec [certifsup@example.net](mailto:certifsup@example.net)
Passer ?lang=en dans l'url
Cliquer sur une session, puis sur l'onglet "Candidates"
Constater que tous les éléments sont traduits
