### PR TITLE
[FEATURE] Conditionner l'affichage des déclencheurs de contenu formatif

### DIFF
--- a/admin/app/components/trainings/create-training-triggers.hbs
+++ b/admin/app/components/trainings/create-training-triggers.hbs
@@ -1,31 +1,57 @@
 <section class="page-section trigger-card">
   <h2 class="trigger-card__title">{{t "pages.trainings.training.triggers.prerequisite.title"}}</h2>
   <p class="trigger-card__description">{{t "pages.trainings.training.triggers.prerequisite.edit.description"}}</p>
-  <PixButtonLink
-    class="trigger-card__toggler"
-    @route="authenticated.trainings.training.triggers.edit"
-    @query={{hash type="prerequisite"}}
-    @backgroundColor="transparent-light"
-    @isBorderVisible={{true}}
-    aria-label={{t "pages.trainings.training.triggers.prerequisite.alternative-title"}}
-    @iconBefore="plus"
-  >
-    {{t "pages.trainings.training.triggers.prerequisite.title"}}
-  </PixButtonLink>
+
+  {{#if @training.prerequesiteTrigger}}
+    Seuil :
+    {{@training.prerequesiteTrigger.threshold}}%
+    {{#each @training.prerequesiteTrigger.triggerTubes as |triggerTube|}}
+      {{!-- <Common::TubesDetails::Tube
+        @id={{triggerTube.tube.id}}
+        @title={{triggerTube.tube.title}}
+        @level={{triggerTube.level}}
+        @mobile={{false}}
+        @tablet={{false}}
+      /> --}}
+      {{triggerTube.tube.name}}
+      {{triggerTube.level}}
+    {{/each}}
+  {{else}}
+    <PixButtonLink
+      class="trigger-card__toggler"
+      @route="authenticated.trainings.training.triggers.edit"
+      @query={{hash type="prerequisite"}}
+      @backgroundColor="transparent-light"
+      @isBorderVisible={{true}}
+      aria-label={{t "pages.trainings.training.triggers.prerequisite.alternative-title"}}
+      @iconBefore="plus"
+    >
+      {{t "pages.trainings.training.triggers.prerequisite.title"}}
+    </PixButtonLink>
+  {{/if}}
 </section>
 
 <section class="page-section trigger-card">
   <h2 class="trigger-card__title">{{t "pages.trainings.training.triggers.goal.title"}}</h2>
-  <p class="trigger-card__description">S{{t "pages.trainings.training.triggers.goal.edit.description"}}</p>
-  <PixButtonLink
-    class="trigger-card__toggler"
-    @route="authenticated.trainings.training.triggers.edit"
-    @query={{hash type="goal"}}
-    @backgroundColor="transparent-light"
-    @isBorderVisible={{true}}
-    aria-label={{t "pages.trainings.training.triggers.goal.alternative-title"}}
-    @iconBefore="plus"
-  >
-    {{t "pages.trainings.training.triggers.goal.title"}}
-  </PixButtonLink>
+  <p class="trigger-card__description">{{t "pages.trainings.training.triggers.goal.edit.description"}}</p>
+
+  {{#if @training.goalTrigger}}
+    Seuil :
+    {{@training.goalTrigger.threshold}}%
+    {{#each @training.goalTrigger.triggerTubes as |triggerTube|}}
+      {{triggerTube.tubeId}}
+    {{/each}}
+  {{else}}
+    <PixButtonLink
+      class="trigger-card__toggler"
+      @route="authenticated.trainings.training.triggers.edit"
+      @query={{hash type="goal"}}
+      @backgroundColor="transparent-light"
+      @isBorderVisible={{true}}
+      aria-label={{t "pages.trainings.training.triggers.goal.alternative-title"}}
+      @iconBefore="plus"
+    >
+      {{t "pages.trainings.training.triggers.goal.title"}}
+    </PixButtonLink>
+  {{/if}}
 </section>

--- a/admin/app/models/training.js
+++ b/admin/app/models/training.js
@@ -33,8 +33,16 @@ export default class Training extends Model {
     }),
   })
   duration;
-  @attr('number') prerequisiteThreshold;
-  @attr('number') goalThreshold;
+
+  @hasMany('triggers') triggers;
+
+  get prerequesiteTrigger() {
+    return this.triggers.findBy('type', 'prerequisite');
+  }
+
+  get goalTrigger() {
+    return this.triggers.findBy('type', 'goal');
+  }
 
   @hasMany('target-profile-summary') targetProfileSummaries;
 

--- a/admin/app/models/trigger-tube.js
+++ b/admin/app/models/trigger-tube.js
@@ -1,0 +1,7 @@
+import Model, { attr, hasMany, belongsTo } from '@ember-data/model';
+
+export default class TriggerTube extends Model {
+  @attr('number') level;
+
+  @belongsTo('tube') tube;
+}

--- a/admin/app/models/trigger.js
+++ b/admin/app/models/trigger.js
@@ -1,8 +1,7 @@
 import Model, { attr, hasMany } from '@ember-data/model';
 
-export default class TrainingTrigger extends Model {
+export default class Trigger extends Model {
   @attr('string') type;
-  @attr('number') trainingId;
   @attr('number') threshold;
-  @hasMany('tube') tubes;
+  @hasMany('trigger-tube') triggerTubes;
 }

--- a/admin/app/templates/authenticated/trainings/training/triggers.hbs
+++ b/admin/app/templates/authenticated/trainings/training/triggers.hbs
@@ -3,5 +3,5 @@
 {{#if this.showTriggersEditForm}}
   {{outlet}}
 {{else if this.canCreateTriggers}}
-  <Trainings::CreateTrainingTriggers />
+  <Trainings::CreateTrainingTriggers @training={{this.model}} />
 {{/if}}

--- a/api/db/seeds/data/trainings-builder.js
+++ b/api/db/seeds/data/trainings-builder.js
@@ -2,7 +2,7 @@ const { TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE } = require('./targe
 
 function trainingBuilder({ databaseBuilder }) {
   const training1 = databaseBuilder.factory.buildTraining({
-    title: 'Apprendre en s\'amusant',
+    title: "Apprendre en s'amusant",
     link: 'http://www.example.net',
     type: 'webinaire',
     duration: '06:00:00',
@@ -40,7 +40,7 @@ function trainingBuilder({ databaseBuilder }) {
     goalThreshold: null,
   });
   const training5 = databaseBuilder.factory.buildTraining({
-    title: 'Manger bun\'s tous les midis',
+    title: "Manger bun's tous les midis",
     link: 'http://www.example5.net',
     type: 'webinaire',
     duration: '06:00:00',
@@ -110,6 +110,26 @@ function trainingBuilder({ databaseBuilder }) {
     locale: 'fr-fr',
     prerequisiteThreshold: 0,
     goalThreshold: 0,
+  });
+  const trainingTrigger1 = databaseBuilder.factory.buildTrainingTrigger({
+    trainingId: training1.id,
+    threshold: 80,
+    type: 'prerequisite',
+  });
+  databaseBuilder.factory.buildTrainingTriggerTube({
+    trainingTriggerId: trainingTrigger1.id,
+    tubeId: 'recs1vdbHxX8X55G9',
+    level: 2,
+  });
+  databaseBuilder.factory.buildTrainingTriggerTube({
+    trainingTriggerId: trainingTrigger1.id,
+    tubeId: 'reccqGUKgzIOK8f9U',
+    level: 3,
+  });
+  databaseBuilder.factory.buildTrainingTriggerTube({
+    trainingTriggerId: trainingTrigger1.id,
+    tubeId: 'recBbCIEKgrQi7eb6',
+    level: 5,
   });
   databaseBuilder.factory.buildTargetProfileTraining({
     trainingId: training1.id,


### PR DESCRIPTION
## :unicorn: Problème
Jusqu'à présent, dans la page de détail d'un contenu formatif, on affiche sans condition les boutons de création de déclencheur.

Or, le but est d'afficher le détail du déclencheur s'il existe.

## :robot: Proposition

Récupérer les données de l'API get `/api/admin/trainings/TRAINING_ID` pour avoir l'information de l'existence de déclencheur pour le contenu formatif visualisé.

## :rainbow: Remarques

Il est nécessaire d'aligner le nomage de propriétés entre le back et le front.
Dans notre cas, on a décidé que les propriétés `triggers` s'appelleraitent `training-triggers`.

## :100: Pour tester

- Visiter la page de détail du contenu formatif "Apprendre en s'amusant"
- Visualiser le détail du déclencheur "Prérequis"
