### PR TITLE
[FEATURE] Conditionner l'affichage des déclencheurs de contenu formatif (PIX-7258)

### DIFF
--- a/admin/app/components/trainings/create-training-triggers.hbs
+++ b/admin/app/components/trainings/create-training-triggers.hbs
@@ -1,31 +1,41 @@
 <section class="page-section trigger-card">
   <h2 class="trigger-card__title">{{t "pages.trainings.training.triggers.prerequisite.title"}}</h2>
   <p class="trigger-card__description">{{t "pages.trainings.training.triggers.prerequisite.edit.description"}}</p>
-  <PixButtonLink
-    class="trigger-card__toggler"
-    @route="authenticated.trainings.training.triggers.edit"
-    @query={{hash type="prerequisite"}}
-    @backgroundColor="transparent-light"
-    @isBorderVisible={{true}}
-    aria-label={{t "pages.trainings.training.triggers.prerequisite.alternative-title"}}
-    @iconBefore="plus"
-  >
-    {{t "pages.trainings.training.triggers.prerequisite.title"}}
-  </PixButtonLink>
+
+  {{#if @training.prerequisiteTrigger}}
+    <p>Un prerequis est défini</p>
+  {{else}}
+    <PixButtonLink
+      class="trigger-card__toggler"
+      @route="authenticated.trainings.training.triggers.edit"
+      @query={{hash type="prerequisite"}}
+      @backgroundColor="transparent-light"
+      @isBorderVisible={{true}}
+      aria-label={{t "pages.trainings.training.triggers.prerequisite.alternative-title"}}
+      @iconBefore="plus"
+    >
+      {{t "pages.trainings.training.triggers.prerequisite.title"}}
+    </PixButtonLink>
+  {{/if}}
 </section>
 
 <section class="page-section trigger-card">
   <h2 class="trigger-card__title">{{t "pages.trainings.training.triggers.goal.title"}}</h2>
   <p class="trigger-card__description">S{{t "pages.trainings.training.triggers.goal.edit.description"}}</p>
-  <PixButtonLink
-    class="trigger-card__toggler"
-    @route="authenticated.trainings.training.triggers.edit"
-    @query={{hash type="goal"}}
-    @backgroundColor="transparent-light"
-    @isBorderVisible={{true}}
-    aria-label={{t "pages.trainings.training.triggers.goal.alternative-title"}}
-    @iconBefore="plus"
-  >
-    {{t "pages.trainings.training.triggers.goal.title"}}
-  </PixButtonLink>
+
+  {{#if @training.goalTrigger}}
+    <p>Un objectif est défini</p>
+  {{else}}
+    <PixButtonLink
+      class="trigger-card__toggler"
+      @route="authenticated.trainings.training.triggers.edit"
+      @query={{hash type="goal"}}
+      @backgroundColor="transparent-light"
+      @isBorderVisible={{true}}
+      aria-label={{t "pages.trainings.training.triggers.goal.alternative-title"}}
+      @iconBefore="plus"
+    >
+      {{t "pages.trainings.training.triggers.goal.title"}}
+    </PixButtonLink>
+  {{/if}}
 </section>

--- a/admin/app/models/training-trigger.js
+++ b/admin/app/models/training-trigger.js
@@ -4,5 +4,6 @@ export default class TrainingTrigger extends Model {
   @attr('string') type;
   @attr('number') trainingId;
   @attr('number') threshold;
-  @hasMany('tube') tubes;
+
+  @hasMany('trigger-tube') triggerTubes;
 }

--- a/admin/app/models/training.js
+++ b/admin/app/models/training.js
@@ -24,7 +24,6 @@ export default class Training extends Model {
   @attr('string') locale;
   @attr('string') editorName;
   @attr('string') editorLogoUrl;
-
   @attr({
     defaultValue: () => ({
       days: 0,
@@ -33,10 +32,17 @@ export default class Training extends Model {
     }),
   })
   duration;
-  @attr('number') prerequisiteThreshold;
-  @attr('number') goalThreshold;
 
+  @hasMany('training-trigger') trainingTriggers;
   @hasMany('target-profile-summary') targetProfileSummaries;
+
+  get prerequisiteTrigger() {
+    return this.trainingTriggers.findBy('type', 'prerequisite');
+  }
+
+  get goalTrigger() {
+    return this.trainingTriggers.findBy('type', 'goal');
+  }
 
   get sortedTargetProfileSummaries() {
     return this.targetProfileSummaries.sortBy('id');

--- a/admin/app/models/trigger-tube.js
+++ b/admin/app/models/trigger-tube.js
@@ -1,0 +1,7 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class TriggerTube extends Model {
+  @attr('number') level;
+
+  @belongsTo('tube') tube;
+}

--- a/admin/app/templates/authenticated/trainings/training/triggers.hbs
+++ b/admin/app/templates/authenticated/trainings/training/triggers.hbs
@@ -3,5 +3,5 @@
 {{#if this.showTriggersEditForm}}
   {{outlet}}
 {{else if this.canCreateTriggers}}
-  <Trainings::CreateTrainingTriggers />
+  <Trainings::CreateTrainingTriggers @training={{this.model}} />
 {{/if}}

--- a/admin/tests/integration/components/trainings/create-training-triggers_test.js
+++ b/admin/tests/integration/components/trainings/create-training-triggers_test.js
@@ -1,0 +1,68 @@
+import { module, test } from 'qunit';
+import { render } from '@1024pix/ember-testing-library';
+import hbs from 'htmlbars-inline-precompile';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
+module('Integration | Component | Trainings::CreateTrainingTriggers', function (hooks) {
+  setupIntlRenderingTest(hooks);
+
+  module("If a goal trigger exists and a prerequisite trigger doesn't exist", function (nestedHook) {
+    nestedHook.beforeEach(function () {
+      this.set('training', {
+        goalTrigger: {
+          type: 'goal',
+        },
+      });
+    });
+
+    test('it should display the prerequisite creation link', async function (assert) {
+      // when
+      const screen = await render(hbs`<Trainings::CreateTrainingTriggers @training={{this.training}} />`);
+
+      // then
+      assert
+        .dom(screen.queryByLabelText(this.intl.t('pages.trainings.training.triggers.prerequisite.alternative-title')))
+        .exists();
+    });
+
+    test('it should not display the goal creation link', async function (assert) {
+      // when
+      const screen = await render(hbs`<Trainings::CreateTrainingTriggers @training={{this.training}} />`);
+
+      // then
+      assert
+        .dom(screen.queryByLabelText(this.intl.t('pages.trainings.training.triggers.goal.alternative-title')))
+        .doesNotExist();
+    });
+  });
+
+  module("If a prerequisite trigger exists and a goal trigger doesn't exist", function (nestedHook) {
+    nestedHook.beforeEach(function () {
+      this.set('training', {
+        prerequisiteTrigger: {
+          type: 'prerequisite',
+        },
+      });
+    });
+
+    test('it should not display the prerequisite creation link', async function (assert) {
+      // when
+      const screen = await render(hbs`<Trainings::CreateTrainingTriggers @training={{this.training}} />`);
+
+      // then
+      assert
+        .dom(screen.queryByLabelText(this.intl.t('pages.trainings.training.triggers.prerequisite.alternative-title')))
+        .doesNotExist();
+    });
+
+    test('it should display the goal creation link', async function (assert) {
+      // when
+      const screen = await render(hbs`<Trainings::CreateTrainingTriggers @training={{this.training}} />`);
+
+      // then
+      assert
+        .dom(screen.queryByLabelText(this.intl.t('pages.trainings.training.triggers.goal.alternative-title')))
+        .exists();
+    });
+  });
+});

--- a/api/lib/domain/models/Training.js
+++ b/api/lib/domain/models/Training.js
@@ -1,5 +1,16 @@
 class Training {
-  constructor({ id, title, link, type, duration, locale, targetProfileIds, editorName, editorLogoUrl, triggers } = {}) {
+  constructor({
+    id,
+    title,
+    link,
+    type,
+    duration,
+    locale,
+    targetProfileIds,
+    editorName,
+    editorLogoUrl,
+    trainingTriggers,
+  } = {}) {
     this.id = id;
     this.title = title;
     this.link = link;
@@ -9,7 +20,7 @@ class Training {
     this.targetProfileIds = targetProfileIds;
     this.editorName = editorName;
     this.editorLogoUrl = editorLogoUrl;
-    this.triggers = triggers;
+    this.trainingTriggers = trainingTriggers;
   }
 }
 

--- a/api/lib/infrastructure/repositories/training-repository.js
+++ b/api/lib/infrastructure/repositories/training-repository.js
@@ -24,7 +24,7 @@ async function get({ trainingId, domainTransaction = DomainTransaction.emptyTran
 async function getWithTriggers({ trainingId, domainTransaction = DomainTransaction.emptyTransaction() }) {
   const training = await get({ trainingId, domainTransaction });
   const trainingTriggers = await trainingTriggerRepository.findByTrainingId({ trainingId, domainTransaction });
-  training.triggers = trainingTriggers;
+  training.trainingTriggers = trainingTriggers;
   return training;
 }
 

--- a/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
@@ -11,7 +11,7 @@ module.exports = {
 
         return {
           ...record,
-          triggers: record.triggers.map((trigger) => {
+          trainingTriggers: record.trainingTriggers.map((trigger) => {
             return {
               ...trigger,
               triggerTubes: trigger.triggerTubes.map((triggerTube) => ({
@@ -31,10 +31,10 @@ module.exports = {
         'type',
         'editorName',
         'editorLogoUrl',
-        'triggers',
+        'trainingTriggers',
         'targetProfileSummaries',
       ],
-      triggers: {
+      trainingTriggers: {
         ref: 'id',
         attributes: ['id', 'trainingId', 'type', 'threshold', 'triggerTubes', 'areas'],
         triggerTubes: {
@@ -74,6 +74,8 @@ module.exports = {
       meta,
       typeForAttribute(attribute) {
         switch (attribute) {
+          case 'trainingTriggers':
+            return 'training-triggers';
           case 'triggerTubes':
             return 'trigger-tubes';
           case 'tube':

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -123,7 +123,9 @@ describe('Acceptance | Controller | training-controller', function () {
       ).attributes;
       expect(returnedTriggerTube.id).to.deep.equal(trainingTriggerTube.id);
 
-      const returnedTrigger = response.result.included.find((included) => included.type === 'triggers').attributes;
+      const returnedTrigger = response.result.included.find(
+        (included) => included.type === 'training-triggers'
+      ).attributes;
       expect(returnedTrigger.id).to.deep.equal(trainingTrigger.id);
 
       const returnedTriggerArea = response.result.included.find((included) => included.type === 'areas').attributes;

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -131,21 +131,21 @@ describe('Integration | Repository | training-repository', function () {
 
       // then
       expect(result).to.be.instanceOf(Training);
-      expect(result.triggers).to.have.lengthOf(1);
-      expect(result.triggers[0]).to.be.instanceOf(TrainingTrigger);
-      expect(result.triggers[0].id).to.deep.equal(trainingTrigger.id);
-      expect(result.triggers[0].threshold).to.deep.equal(trainingTrigger.threshold);
-      expect(result.triggers[0].type).to.deep.equal(trainingTrigger.type);
-      expect(result.triggers[0].triggerTubes).to.have.lengthOf(1);
-      expect(result.triggers[0].triggerTubes[0].id).to.deep.equal(trainingTriggerTube.id);
-      expect(result.triggers[0].triggerTubes[0].tube.name).to.deep.equal(tube.name);
-      expect(result.triggers[0].triggerTubes[0].level).to.deep.equal(trainingTriggerTube.level);
-      expect(result.triggers[0].areas).to.have.lengthOf(1);
-      expect(result.triggers[0].areas[0].id).to.equal(area1.id);
-      expect(result.triggers[0].areas[0].competences).to.have.lengthOf(1);
-      expect(result.triggers[0].areas[0].competences[0].id).to.equal(competence1.id);
-      expect(result.triggers[0].areas[0].competences[0].thematics).to.have.lengthOf(1);
-      expect(result.triggers[0].areas[0].competences[0].thematics[0].id).to.equal(thematic1.id);
+      expect(result.trainingTriggers).to.have.lengthOf(1);
+      expect(result.trainingTriggers[0]).to.be.instanceOf(TrainingTrigger);
+      expect(result.trainingTriggers[0].id).to.deep.equal(trainingTrigger.id);
+      expect(result.trainingTriggers[0].threshold).to.deep.equal(trainingTrigger.threshold);
+      expect(result.trainingTriggers[0].type).to.deep.equal(trainingTrigger.type);
+      expect(result.trainingTriggers[0].triggerTubes).to.have.lengthOf(1);
+      expect(result.trainingTriggers[0].triggerTubes[0].id).to.deep.equal(trainingTriggerTube.id);
+      expect(result.trainingTriggers[0].triggerTubes[0].tube.name).to.deep.equal(tube.name);
+      expect(result.trainingTriggers[0].triggerTubes[0].level).to.deep.equal(trainingTriggerTube.level);
+      expect(result.trainingTriggers[0].areas).to.have.lengthOf(1);
+      expect(result.trainingTriggers[0].areas[0].id).to.equal(area1.id);
+      expect(result.trainingTriggers[0].areas[0].competences).to.have.lengthOf(1);
+      expect(result.trainingTriggers[0].areas[0].competences[0].id).to.equal(competence1.id);
+      expect(result.trainingTriggers[0].areas[0].competences[0].thematics).to.have.lengthOf(1);
+      expect(result.trainingTriggers[0].areas[0].competences[0].thematics[0].id).to.equal(thematic1.id);
     });
   });
 

--- a/api/tests/tooling/domain-builder/factory/build-training.js
+++ b/api/tests/tooling/domain-builder/factory/build-training.js
@@ -12,7 +12,7 @@ module.exports = function buildTraining({
   targetProfileIds = [1],
   editorName = 'Ministère education nationale',
   editorLogoUrl = 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
-  triggers,
+  trainingTriggers,
 } = {}) {
   return new Training({
     id,
@@ -24,6 +24,6 @@ module.exports = function buildTraining({
     targetProfileIds,
     editorName,
     editorLogoUrl,
-    triggers,
+    trainingTriggers,
   });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -39,7 +39,7 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
         thematics: [thematic1, thematicInAnotherCompetence],
         triggerTubes: [trainingTriggerTube1, anotherTrainingTriggerTube],
       });
-      const training = domainBuilder.buildTraining({ id: trainingId, triggers: [trainingTrigger] });
+      const training = domainBuilder.buildTraining({ id: trainingId, trainingTriggers: [trainingTrigger] });
 
       const expectedSerializedTraining = {
         data: {
@@ -64,11 +64,11 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
                 related: '/api/admin/trainings/123/target-profile-summaries',
               },
             },
-            triggers: {
+            'training-triggers': {
               data: [
                 {
                   id: `${trainingTriggerId}`,
-                  type: 'triggers',
+                  type: 'training-triggers',
                 },
               ],
             },
@@ -205,7 +205,7 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
                 ],
               },
             },
-            type: 'triggers',
+            type: 'training-triggers',
           },
         ],
       };


### PR DESCRIPTION
## :unicorn: Problème
Jusqu'à présent, dans la page de détail d'un contenu formatif, on affiche sans condition les boutons de création de déclencheur.

Or, le but est d'afficher le détail du déclencheur s'il existe.

Dans un premier temps, nous allons conditionner l'affichage de ces boutons.

## :robot: Proposition

Récupérer les données de l'API get `/api/admin/trainings/TRAINING_ID` pour avoir l'information de l'existence de déclencheur pour le contenu formatif visualisé.

## :rainbow: Remarques

Il est nécessaire d'aligner le nomage de propriétés entre le back et le front.
Dans notre cas, on a décidé que les propriétés `triggers` s'appelleraitent `training-triggers`.

## :100: Pour tester

- Visiter la page de détail du contenu formatif "Apprendre en s'amusant"
- Visualiser le détail du déclencheur "Prérequis"
