### PR TITLE
[FEATURE] Éviter que le footer soit positionné en dehors de l'écran dans les pages avec peu de contenu (PIX-7437)

### DIFF
--- a/mon-pix/app/styles/components/_footer.scss
+++ b/mon-pix/app/styles/components/_footer.scss
@@ -1,21 +1,16 @@
-.footer {
-  padding: 20px 30px;
+#footer {
+  margin-top: auto;
+}
 
-  &__container {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    max-width: 1280px;
-    margin: auto;
+.footer__container {
+  display: flex;
+  flex-direction: column;
+  max-width: 1280px;
+  padding: $spacing-m 20px;
 
-    @include device-is('desktop') {
-      flex-direction: row;
-      align-items: center;
-    }
-  }
-
-  @include device-is('tablet') {
-    height: 100px;
+  @include device-is('desktop') {
+    flex-direction: row;
+    margin: 0 auto;
   }
 }
 

--- a/mon-pix/app/styles/globals/_layout.scss
+++ b/mon-pix/app/styles/globals/_layout.scss
@@ -3,13 +3,16 @@ body {
   background-color: $pix-neutral-10;
 }
 
-.page-container {
-  max-width: 1240px;
-  margin: 0 auto;
+.body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
-.main {
-  min-height: calc(100vh - 101px - 100px);
+.page-container {
+  width: 100%;
+  max-width: 1240px;
+  margin: 0 auto;
 }
 
 .pix-communication-banner {


### PR DESCRIPTION
## :unicorn: Problème
Dans les écrans ayant peu de contenu à afficher, le footer était positionné en dehors de l'écran.

![image](https://user-images.githubusercontent.com/7335131/225023168-9b7f198b-bf99-4251-b789-abdcd90632da.png)


## :robot: Proposition
Modifier le CSS pour que, dans ces écrans, le footer apparaisse en bas de l'écran.
On en profite pour bien aligner horizontalement le footer avec le reste du contenu.

## :100: Pour tester
- [Visiter Pix App](https://app-pr5807.review.pix.fr/)
- Vérifier que dans la page d'accueil, le footer soit toujours bien positionné.
- Aller dans la page "Mes tutos" et vérifier que le footer est bien collé en bas de page.
