### PR TITLE
[FEATURE] Rendre les participations cliquables sur la page d'un prescrit pour accéder à leurs détails. (PIX-7297)

### DIFF
--- a/api/lib/domain/read-models/OrganizationLearnerParticipation.js
+++ b/api/lib/domain/read-models/OrganizationLearnerParticipation.js
@@ -1,11 +1,12 @@
 class OrganizationLearnerParticipation {
-  constructor({ id, campaignType, campaignName, createdAt, sharedAt, status }) {
+  constructor({ id, campaignType, campaignName, createdAt, sharedAt, status, campaignId }) {
     this.id = id;
     this.campaignType = campaignType;
     this.campaignName = campaignName;
     this.createdAt = createdAt;
     this.sharedAt = sharedAt;
     this.status = status;
+    this.campaignId = campaignId;
   }
 }
 

--- a/api/lib/infrastructure/repositories/organization-learner-activity-repository.js
+++ b/api/lib/infrastructure/repositories/organization-learner-activity-repository.js
@@ -10,13 +10,15 @@ async function get(organizationLearnerId) {
       'campaign-participations.sharedAt',
       'campaign-participations.status',
       'campaigns.name',
-      'campaigns.type'
+      'campaigns.type',
+      'campaign-participations.campaignId'
     )
     .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
     .where('campaign-participations.organizationLearnerId', '=', organizationLearnerId)
     .where('campaign-participations.deletedAt', 'IS', null)
     .where('campaign-participations.isImproved', '=', false)
     .orderBy('campaign-participations.createdAt', 'desc');
+
   const participations = organizationLearnerParticipations.map(
     (participation) =>
       new OrganizationLearnerParticipation({
@@ -26,6 +28,7 @@ async function get(organizationLearnerId) {
         status: participation.status,
         campaignName: participation.name,
         campaignType: participation.type,
+        campaignId: participation.campaignId,
       })
   );
   return new OrganizationLearnerActivity({ organizationLearnerId, participations });

--- a/api/lib/infrastructure/serializers/jsonapi/organization-learner-activity-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-learner-activity-serializer.js
@@ -13,7 +13,7 @@ module.exports = {
       organizationLearnerParticipations: {
         ref: 'id',
         includes: true,
-        attributes: ['campaignType', 'campaignName', 'createdAt', 'sharedAt', 'status'],
+        attributes: ['campaignType', 'campaignName', 'createdAt', 'sharedAt', 'status', 'campaignId'],
       },
       organizationLearnerStatistics: {
         ref: 'campaignType',

--- a/api/tests/integration/infrastructure/repositories/organization-learner-activity-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-learner-activity-repository_test.js
@@ -63,6 +63,7 @@ describe('Integration | Infrastructure | Repository | organization-learner-activ
       expect(organizationLearnerParticipation.sharedAt).to.deep.equal(sharedAt);
       expect(organizationLearnerParticipation.campaignName).to.equal(campaignName);
       expect(organizationLearnerParticipation.campaignType).to.equal(campaignType);
+      expect(organizationLearnerParticipation.campaignId).to.equal(campaignId);
     });
 
     it('Should not return an activity with participations of another organization learner', async function () {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/organization-learner-activity-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/organization-learner-activity-serializer_test.js
@@ -12,6 +12,7 @@ describe('Unit | Serializer | JSONAPI | organization-learner-participation-seria
         participations: [
           new OrganizationLearnerParticipation({
             id: '99999',
+            campaignId: '123',
             campaignType: 'PROFILES_COLLECTION',
             campaignName: 'La 1ère campagne',
             createdAt: '2000-01-01T10:00:00Z',
@@ -20,6 +21,7 @@ describe('Unit | Serializer | JSONAPI | organization-learner-participation-seria
           }),
           new OrganizationLearnerParticipation({
             id: '100000',
+            campaignId: '456',
             campaignType: 'ASSESSMENT',
             campaignName: 'La 2ème campagne',
             createdAt: '2000-03-01T10:00:00Z',
@@ -84,6 +86,7 @@ describe('Unit | Serializer | JSONAPI | organization-learner-participation-seria
             id: '99999',
             type: 'organizationLearnerParticipations',
             attributes: {
+              'campaign-id': '123',
               'campaign-type': 'PROFILES_COLLECTION',
               'campaign-name': 'La 1ère campagne',
               'created-at': '2000-01-01T10:00:00Z',
@@ -95,6 +98,7 @@ describe('Unit | Serializer | JSONAPI | organization-learner-participation-seria
             id: '100000',
             type: 'organizationLearnerParticipations',
             attributes: {
+              'campaign-id': '456',
               'campaign-type': 'ASSESSMENT',
               'campaign-name': 'La 2ème campagne',
               'created-at': '2000-03-01T10:00:00Z',

--- a/orga/app/components/organization-learner/activity/participation-list.hbs
+++ b/orga/app/components/organization-learner/activity/participation-list.hbs
@@ -21,21 +21,7 @@
     </thead>
     <tbody>
       {{#each @participations as |participation|}}
-        <tr aria-label={{t "pages.organization-learner.activity.participation-list.table.row-title"}}>
-          <td class="ellipsis">{{participation.campaignName}}</td>
-          <td class="ellipsis">
-            <OrganizationLearner::Activity::CampaignType @campaignType={{participation.campaignType}} />
-          </td>
-          <td class="table__column--left">
-            <Ui::Date @date="{{participation.createdAt}}" />
-          </td>
-          <td class="table__column--left">
-            <Ui::Date @date="{{participation.sharedAt}}" />
-          </td>
-          <td class="table__column--left">
-            <Ui::ParticipationStatus @status={{participation.status}} @campaignType={{participation.campaignType}} />
-          </td>
-        </tr>
+        <OrganizationLearner::Activity::ParticipationRow @participation={{participation}} />
       {{/each}}
     </tbody>
   </table>

--- a/orga/app/components/organization-learner/activity/participation-row.hbs
+++ b/orga/app/components/organization-learner/activity/participation-row.hbs
@@ -1,0 +1,23 @@
+<tr
+  aria-label={{t "pages.organization-learner.activity.participation-list.table.row-title"}}
+  {{on "click" this.goToParticipationDetail}}
+  class="tr--clickable"
+>
+  <td class="ellipsis">
+    <LinkTo @route={{this.routeName}} @models={{array @participation.campaignId @participation.id}}>
+      {{@participation.campaignName}}
+    </LinkTo>
+  </td>
+  <td class="ellipsis">
+    <OrganizationLearner::Activity::CampaignType @campaignType={{@participation.campaignType}} />
+  </td>
+  <td class="table__column--left">
+    <Ui::Date @date="{{@participation.createdAt}}" />
+  </td>
+  <td class="table__column--left">
+    <Ui::Date @date="{{@participation.sharedAt}}" />
+  </td>
+  <td class="table__column--left">
+    <Ui::ParticipationStatus @status={{@participation.status}} @campaignType={{@participation.campaignType}} />
+  </td>
+</tr>

--- a/orga/app/components/organization-learner/activity/participation-row.js
+++ b/orga/app/components/organization-learner/activity/participation-row.js
@@ -1,0 +1,19 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default class ParticipationRow extends Component {
+  @service router;
+
+  get routeName() {
+    return this.args.participation.campaignType === 'ASSESSMENT'
+      ? 'authenticated.campaigns.participant-assessment'
+      : 'authenticated.campaigns.participant-profile';
+  }
+
+  @action
+  goToParticipationDetail(event) {
+    event.preventDefault();
+    this.router.transitionTo(this.routeName, this.args.participation.campaignId, this.args.participation.id);
+  }
+}

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -2,9 +2,6 @@ import Model, { belongsTo, hasMany, attr } from '@ember-data/model';
 import ENV from 'pix-orga/config/environment';
 import { inject as service } from '@ember/service';
 
-const PROFILES_COLLECTION_TEXT = 'Collecte de profils';
-const ASSESSMENT_TEXT = 'Évaluation';
-
 export default class Campaign extends Model {
   @service store;
 
@@ -63,10 +60,6 @@ export default class Campaign extends Model {
 
   get isTypeAssessment() {
     return this.type === 'ASSESSMENT';
-  }
-
-  get readableType() {
-    return this.isTypeProfilesCollection ? PROFILES_COLLECTION_TEXT : ASSESSMENT_TEXT;
   }
 
   get urlToResult() {

--- a/orga/app/models/organization-learner-participation.js
+++ b/orga/app/models/organization-learner-participation.js
@@ -6,6 +6,7 @@ export default class OrganizationLearnerParticipation extends Model {
   @attr('date') createdAt;
   @attr('date') sharedAt;
   @attr('string') status;
+  @attr('number') campaignId;
 
   @belongsTo('OrganizationLearnerActivity') organizationLearnerActivity;
 }

--- a/orga/app/styles/components/learner-header-info.scss
+++ b/orga/app/styles/components/learner-header-info.scss
@@ -1,3 +1,3 @@
 .learner-header-info {
-  margin: $spacing-xxl;
+  margin-left: $spacing-xxl;
 }

--- a/orga/tests/integration/components/organization-learner/activity/participation-row_test.js
+++ b/orga/tests/integration/components/organization-learner/activity/participation-row_test.js
@@ -1,0 +1,97 @@
+import { module, test } from 'qunit';
+import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
+
+import sinon from 'sinon';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | OrganizationLearner | Activity::ParticipationRow', function (hooks) {
+  setupIntlRenderingTest(hooks);
+  let router;
+
+  hooks.beforeEach(function () {
+    router = this.owner.lookup('service:router');
+    router.transitionTo = sinon.stub();
+  });
+
+  test('it displays participation details', async function (assert) {
+    // given
+    this.participation = {
+      id: '123',
+      campaignType: 'ASSESSMENT',
+      campaignName: 'Ma campagne',
+      createdAt: new Date('2023-02-01'),
+      sharedAt: new Date('2023-03-01'),
+      status: 'SHARED',
+    };
+
+    // when
+    const screen = await render(
+      hbs`<OrganizationLearner::Activity::ParticipationRow @participation={{this.participation}} />`
+    );
+
+    // then
+    assert.dom(screen.getByRole('link', { name: this.participation.campaignName })).exists();
+    assert
+      .dom(
+        screen.getByRole('cell', {
+          name: this.intl.t('pages.organization-learner.activity.participation-list.type.ASSESSMENT'),
+        })
+      )
+      .exists();
+    assert.dom(screen.getByRole('cell', { name: '01/02/2023' })).exists();
+    assert.dom(screen.getByRole('cell', { name: '01/03/2023' })).exists();
+    assert
+      .dom(screen.getByRole('cell', { name: this.intl.t('components.participation-status.SHARED-ASSESSMENT') }))
+      .exists();
+  });
+
+  test('it should transition to assessment detail when campaignType is ASSESSMENT', async function (assert) {
+    // given
+    this.participation = {
+      id: '123',
+      campaignId: '456',
+      campaignType: 'ASSESSMENT',
+      campaignName: 'Ma campagne',
+      createdAt: new Date('2023-02-01'),
+      sharedAt: new Date('2023-03-01'),
+      status: 'SHARED',
+    };
+    this.route = 'authenticated.campaigns.participant-assessment';
+
+    const screen = await render(
+      hbs`<OrganizationLearner::Activity::ParticipationRow @participation={{this.participation}} />`
+    );
+
+    // when
+    await click(await screen.findByRole('cell', { name: '01/02/2023' }));
+
+    // then
+    assert.ok(router.transitionTo.calledWith(this.route, this.participation.campaignId, this.participation.id));
+  });
+
+  test('it should transition to profile collection detail when campaignType is PROFILE_COLLECTION', async function (assert) {
+    // given
+    this.participation = {
+      id: '125',
+      campaignId: '789',
+      campaignType: 'PROFILE_COLLECTION',
+      campaignName: 'Ma campagne',
+      createdAt: new Date('2023-02-01'),
+      sharedAt: new Date('2023-03-01'),
+      status: 'SHARED',
+    };
+    this.route = 'authenticated.campaigns.participant-profile';
+
+    const screen = await render(
+      hbs`<OrganizationLearner::Activity::ParticipationRow @participation={{this.participation}} />`
+    );
+
+    // when
+    await click(await screen.findByRole('cell', { name: '01/02/2023' }));
+
+    // then
+    assert.ok(router.transitionTo.calledWith(this.route, this.participation.campaignId, this.participation.id));
+  });
+});

--- a/orga/tests/unit/components/organization-learner/activity/participation-row_test.js
+++ b/orga/tests/unit/components/organization-learner/activity/participation-row_test.js
@@ -1,0 +1,33 @@
+import { module, test } from 'qunit';
+import createGlimmerComponent from '../../../../helpers/create-glimmer-component';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Component | OrganizationLearner | Activity::ParticipationRow', function (hooks) {
+  setupTest(hooks);
+
+  test('should return route to assessment participation detail', async function (assert) {
+    // given
+    const component = await createGlimmerComponent('component:organization-learner/activity/participation-row');
+    component.args.participation = {
+      campaignType: 'ASSESSMENT',
+    };
+    // when
+    const route = component.routeName;
+
+    // then
+    assert.strictEqual(route, 'authenticated.campaigns.participant-assessment');
+  });
+
+  test('should return route to profile collection participation detail', async function (assert) {
+    // given
+    const component = await createGlimmerComponent('component:organization-learner/activity/participation-row');
+    component.args.participation = {
+      campaignType: 'PROFILE_COLLECTION',
+    };
+    // when
+    const route = component.routeName;
+
+    // then
+    assert.strictEqual(route, 'authenticated.campaigns.participant-profile');
+  });
+});

--- a/orga/tests/unit/models/campaign_test.js
+++ b/orga/tests/unit/models/campaign_test.js
@@ -46,30 +46,6 @@ module('Unit | Model | campaign', function (hooks) {
     });
   });
 
-  module('#readableType', function (hooks) {
-    let store;
-
-    hooks.beforeEach(function () {
-      store = this.owner.lookup('service:store');
-    });
-
-    test('it should compute the readableType property when type is ASSESSMENT', function (assert) {
-      // when
-      const model = store.createRecord('campaign', { type: 'ASSESSMENT' });
-
-      // then
-      assert.strictEqual(model.readableType, 'Évaluation');
-    });
-
-    test('it should compute the readableType property when type is PROFILES_COLLECTION', function (assert) {
-      // when
-      const model = store.createRecord('campaign', { type: 'PROFILES_COLLECTION' });
-
-      // then
-      assert.strictEqual(model.readableType, 'Collecte de profils');
-    });
-  });
-
   module('#hasStages', function () {
     test('returns true while campaign contains stages', function (assert) {
       const store = this.owner.lookup('service:store');


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la consolidation de l’activité du prescrit, nous avons créé [une nouvelle page détaillant l’activité d’un prescrit](https://1024pix.atlassian.net/browse/PIX-6062). Cette page inclut un tableau qui liste les participations du prescrit.
Il faudrait permettre aux prescripteurs d’accéder au détail de ces participations depuis cette page pour qu’ils puissent facilement suivre en détail leurs prescrits.

## :robot: Proposition
Rendre les participations listées dans le tableau de l’activité d’un prescrit cliquables, pour renvoyer sur la page du détail de la participation correspondante.

## :rainbow: Remarques
La feature à été implémentée pour les 3 types d'orgas dans ce ticket.

## :100: Pour tester

**Se connecter à Pix Orga avec les 3 types d'orga :** 
- Aller sur la page participant/élève/étudiant.
- Cliquer sur un prescrit ayant des participations.
- Cliquer sur une participation.
- Verifier qu'on accède bien à la page de détail de cette participation pour le bon prescrit.
