### PR TITLE
[BUGFIX] Ne pas afficher "Classe/Groupe" si cette info n'est pas présente pour le sco & sup. (PIX-7439)

### DIFF
--- a/orga/app/components/ui/learner-header-info.hbs
+++ b/orga/app/components/ui/learner-header-info.hbs
@@ -11,7 +11,7 @@
       </:content>
     </Ui::Information>
   {{/if}}
-  {{#if @groupName}}
+  {{#if @group}}
     <Ui::Information>
       <:title>
         {{@groupName}}

--- a/orga/tests/integration/components/ui/learner-header-info_test.js
+++ b/orga/tests/integration/components/ui/learner-header-info_test.js
@@ -6,89 +6,122 @@ import { hbs } from 'ember-cli-htmlbars';
 module('Integration | Component | Ui::LearnerHeaderInfo', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('it renders learner header information when there is a groupName', async function (assert) {
-    const groupName = this.intl.t('components.group.SCO');
-    const group = '3E';
+  module('#groupName', function () {
+    test('it renders learner header information when there is a groupName', async function (assert) {
+      const groupName = this.intl.t('components.group.SCO');
+      const group = '3E';
 
-    this.set('groupName', groupName);
-    this.set('group', group);
+      this.set('groupName', groupName);
+      this.set('group', group);
 
-    const screen = await render(hbs`<Ui::LearnerHeaderInfo @group={{this.group}} @groupName={{this.groupName}} />`);
+      const screen = await render(hbs`<Ui::LearnerHeaderInfo @group={{this.group}} @groupName={{this.groupName}} />`);
 
-    assert.strictEqual(screen.getByRole('term').textContent.trim(), this.groupName);
-    assert.strictEqual(screen.getByRole('definition').textContent.trim(), this.group);
+      assert.strictEqual(screen.getByRole('term').textContent.trim(), this.groupName);
+      assert.strictEqual(screen.getByRole('definition').textContent.trim(), this.group);
+    });
+
+    test('it does not render learner division header information when there is no group', async function (assert) {
+      const groupName = this.intl.t('components.group.SCO');
+      const group = '';
+
+      this.set('groupName', groupName);
+      this.set('group', group);
+
+      const screen = await render(hbs`<Ui::LearnerHeaderInfo @groupName={{this.groupName}} @group={{this.group}} />`);
+
+      assert.strictEqual(screen.queryByText(groupName), null);
+    });
   });
 
-  test('it does not render learner division header information when there is no groupName', async function (assert) {
-    const screen = await render(hbs`<Ui::LearnerHeaderInfo />`);
+  module('#authenticationMethods', function () {
+    test('it renders learner header information when there is a connection method', async function (assert) {
+      const authenticationMethods = ['email'];
 
-    assert.strictEqual(screen.queryByText(this.intl.t('components.group.SCO')), null);
-    assert.strictEqual(screen.queryByText('3E'), null);
+      this.set('authenticationMethods', authenticationMethods);
+
+      const screen = await render(hbs`<Ui::LearnerHeaderInfo @authenticationMethods={{this.authenticationMethods}} />`);
+
+      assert.strictEqual(
+        screen.getByRole('term').textContent.trim(),
+        this.intl.t('pages.sco-organization-participants.table.column.login-method')
+      );
+      assert.strictEqual(
+        screen.getByRole('definition').textContent.trim(),
+        this.intl.t('pages.sco-organization-participants.connection-types.email')
+      );
+    });
+
+    test('it renders learner header information when there is several connection method', async function (assert) {
+      const authenticationMethods = ['email', 'identifiant'];
+
+      this.set('authenticationMethods', authenticationMethods);
+
+      const screen = await render(hbs`<Ui::LearnerHeaderInfo @authenticationMethods={{this.authenticationMethods}} />`);
+
+      assert.strictEqual(
+        screen.getByRole('term').textContent.trim(),
+        this.intl.t('pages.sco-organization-participants.table.column.login-method')
+      );
+      assert.contains(
+        screen.getByRole('definition').textContent.trim(),
+        this.intl.t('pages.sco-organization-participants.connection-types.email')
+      );
+
+      assert.contains(
+        screen.getByRole('definition').textContent.trim(),
+        this.intl.t('pages.sco-organization-participants.connection-types.identifiant')
+      );
+    });
+
+    test('it does not renders learner header information when there is no connection method', async function (assert) {
+      const screen = await render(hbs`<Ui::LearnerHeaderInfo @authenticationMethods={{this.authenticationMethods}} />`);
+
+      assert.strictEqual(
+        screen.queryByText(this.intl.t('pages.sco-organization-participants.table.column.login-method')),
+        null
+      );
+      assert.strictEqual(
+        screen.queryByText(this.intl.t('pages.sco-organization-participants.connection-types.email')),
+        null
+      );
+    });
   });
 
-  test('it renders learner header information when there is a connection method', async function (assert) {
-    const authenticationMethods = ['email'];
+  module('#certificability', function () {
+    test('it renders learner header information when learner is certifiable', async function (assert) {
+      const isCertifiable = true;
+      const certifiableAt = '2023-01-01';
 
-    this.set('authenticationMethods', authenticationMethods);
+      this.set('isCertifiable', isCertifiable);
+      this.set('certifiableAt', certifiableAt);
 
-    const screen = await render(hbs`<Ui::LearnerHeaderInfo @authenticationMethods={{this.authenticationMethods}} />`);
+      const screen = await render(
+        hbs`<Ui::LearnerHeaderInfo @isCertifiable={{this.isCertifiable}} @certifiableAt={{this.certifiableAt}} />`
+      );
 
-    assert.strictEqual(
-      screen.getByRole('term').textContent.trim(),
-      this.intl.t('pages.sco-organization-participants.table.column.login-method')
-    );
-    assert.strictEqual(
-      screen.getByRole('definition').textContent.trim(),
-      this.intl.t('pages.sco-organization-participants.connection-types.email')
-    );
-  });
+      assert.strictEqual(
+        screen.getByRole('term').textContent.trim(),
+        this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible')
+      );
+      assert.strictEqual(screen.getByRole('definition').textContent.trim(), '01/01/2023');
+    });
 
-  test('it does not renders learner header information when there is no connection method', async function (assert) {
-    const screen = await render(hbs`<Ui::LearnerHeaderInfo @authenticationMethods={{this.authenticationMethods}} />`);
+    test('it does not render learner header information about certificability when learner is not certifiable', async function (assert) {
+      const isCertifiable = false;
+      const certifiableAt = null;
 
-    assert.strictEqual(
-      screen.queryByText(this.intl.t('pages.sco-organization-participants.table.column.login-method')),
-      null
-    );
-    assert.strictEqual(
-      screen.queryByText(this.intl.t('pages.sco-organization-participants.connection-types.email')),
-      null
-    );
-  });
+      this.set('isCertifiable', isCertifiable);
+      this.set('certifiableAt', certifiableAt);
 
-  test('it renders learner header information when learner is certifiable', async function (assert) {
-    const isCertifiable = true;
-    const certifiableAt = '2023-01-01';
+      const screen = await render(
+        hbs`<Ui::LearnerHeaderInfo @isCertifiable={{this.isCertifiable}} @certifiableAt={{this.certifiableAt}} />`
+      );
 
-    this.set('isCertifiable', isCertifiable);
-    this.set('certifiableAt', certifiableAt);
-
-    const screen = await render(
-      hbs`<Ui::LearnerHeaderInfo @isCertifiable={{this.isCertifiable}} @certifiableAt={{this.certifiableAt}} />`
-    );
-
-    assert.strictEqual(
-      screen.getByRole('term').textContent.trim(),
-      this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible')
-    );
-    assert.strictEqual(screen.getByRole('definition').textContent.trim(), '01/01/2023');
-  });
-
-  test('it does not render learner header information about certificability when learner is not certifiable', async function (assert) {
-    const isCertifiable = false;
-    const certifiableAt = null;
-
-    this.set('isCertifiable', isCertifiable);
-    this.set('certifiableAt', certifiableAt);
-
-    const screen = await render(
-      hbs`<Ui::LearnerHeaderInfo @isCertifiable={{this.isCertifiable}} @certifiableAt={{this.certifiableAt}} />`
-    );
-
-    assert.strictEqual(
-      screen.queryByText(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible')),
-      null
-    );
-    assert.strictEqual(screen.queryByText('01/01/2023'), null);
+      assert.strictEqual(
+        screen.queryByText(this.intl.t('pages.sco-organization-participants.table.column.is-certifiable.eligible')),
+        null
+      );
+      assert.strictEqual(screen.queryByText('01/01/2023'), null);
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Sur la page de détail d’un étudiant ([https://orga.pix.fr/etudiants/etudiantId](https://orga.recette.pix.fr/etudiants/106780)), nous avons récemment ajouté un en-tête d’information comportant la certificabilité et le groupe. Cependant, le groupe n’est pas une information obligatoire à l’import, ce qui donne un affichage de "Groupe" sans valeur.

## :robot: Proposition
Quand un étudiant a été importé sans groupe, n’afficher que la certificabilité (le cas échéant).

## :rainbow: Remarques
Valable pour le sup et le sco étant donné que c'est le composant learner header info qui comporte cette condition d'affichage

## :100: Pour tester
**Se connecter à Pix Orga avec une orga sco et/ou sup :** 

- Aller dans la liste des élèves/étudiants. 
- Aller sur la page d'un élève/étudiant n'ayant pas de classe/groupe ( cas possible en RA ?! )
- Vérifier que l'information "Classe/Groupe" n'apparait pas. Seuls les méthodes de connexion (pour le sco uniquement) et si le prescrit est certifiable apparait.