### PR TITLE
[FEATURE] Ajoute un lien vers les détails d'un participant sur les détails d'une participation (PIX-7295)

### DIFF
--- a/api/lib/domain/read-models/CampaignAssessmentParticipation.js
+++ b/api/lib/domain/read-models/CampaignAssessmentParticipation.js
@@ -19,11 +19,13 @@ class CampaignAssessmentParticipation {
     createdAt,
     targetedSkillsCount,
     testedSkillsCount,
+    organizationLearnerId,
     badges = [],
   }) {
     this.userId = userId;
     this.firstName = firstName;
     this.lastName = lastName;
+    this.organizationLearnerId = organizationLearnerId;
     this.campaignParticipationId = campaignParticipationId;
     this.campaignId = campaignId;
     this.participantExternalId = participantExternalId;

--- a/api/lib/domain/read-models/CampaignProfile.js
+++ b/api/lib/domain/read-models/CampaignProfile.js
@@ -9,6 +9,7 @@ class CampaignProfile {
     lastName,
     placementProfile,
     campaignParticipationId,
+    organizationLearnerId,
     campaignId,
     participantExternalId,
     sharedAt,
@@ -20,6 +21,7 @@ class CampaignProfile {
     this.firstName = firstName;
     this.lastName = lastName;
     this.campaignParticipationId = campaignParticipationId;
+    this.organizationLearnerId = organizationLearnerId;
     this.campaignId = campaignId;
     this.externalId = participantExternalId;
     this.sharedAt = sharedAt;

--- a/api/lib/infrastructure/repositories/campaign-assessment-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-assessment-participation-repository.js
@@ -32,6 +32,7 @@ async function _fetchCampaignAssessmentAttributesFromCampaignParticipation(campa
         'campaign-participations.status',
         'campaign-participations.participantExternalId',
         'campaign-participations.masteryRate',
+        'organization-learners.id AS organizationLearnerId',
         'assessments.state AS assessmentState',
         _assessmentRankByCreationDate(),
       ])

--- a/api/lib/infrastructure/repositories/campaign-profile-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-profile-repository.js
@@ -29,6 +29,7 @@ async function _fetchCampaignProfileAttributesFromCampaignParticipation(campaign
       qb.select([
         'campaign-participations.userId',
         'organization-learners.firstName',
+        'organization-learners.id AS organizationLearnerId',
         'organization-learners.lastName',
         'campaign-participations.id AS campaignParticipationId',
         'campaign-participations.campaignId',

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-assessment-participation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-assessment-participation-serializer.js
@@ -19,6 +19,7 @@ module.exports = {
         'badges',
         'campaignAssessmentParticipationResult',
         'campaignAnalysis',
+        'organizationLearnerId',
       ],
       badges: {
         ref: 'id',

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-profile-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-profile-serializer.js
@@ -17,6 +17,7 @@ module.exports = {
         'certifiableCompetencesCount',
         'isCertifiable',
         'competences',
+        'organizationLearnerId',
       ],
       typeForAttribute: (attribute) => {
         if (attribute === 'competences') return 'campaign-profile-competences';

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
@@ -232,6 +232,8 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
     });
 
     context('when there are several organization-learners for the same participant', function () {
+      let organizationLearnerId;
+
       beforeEach(async function () {
         const skill = { id: 'skill', status: 'actif' };
         mockLearningContent({ skills: [skill] });
@@ -240,7 +242,7 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
         campaignId = databaseBuilder.factory.buildAssessmentCampaignForSkills({ organizationId }, [skill]).id;
         const userId = databaseBuilder.factory.buildUser().id;
 
-        const organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
+        organizationLearnerId = databaseBuilder.factory.buildOrganizationLearner({
           organizationId,
           userId,
           firstName: 'John',
@@ -270,13 +272,14 @@ describe('Integration | Repository | Campaign Assessment Participation', functio
         await databaseBuilder.commit();
       });
 
-      it('return the first name and the last name of the correct organization-learner', async function () {
+      it('return the id, first name and the last name of the correct organization-learner', async function () {
         const campaignAssessmentParticipation =
           await campaignAssessmentParticipationRepository.getByCampaignIdAndCampaignParticipationId({
             campaignId,
             campaignParticipationId,
           });
 
+        expect(campaignAssessmentParticipation.organizationLearnerId).to.equal(organizationLearnerId);
         expect(campaignAssessmentParticipation.firstName).to.equal('John');
         expect(campaignAssessmentParticipation.lastName).to.equal('Doe');
       });

--- a/api/tests/integration/infrastructure/repositories/campaign-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profile-repository_test.js
@@ -84,20 +84,21 @@ describe('Integration | Repository | CampaignProfileRepository', function () {
       it('return the first name and last name of the organization learner', async function () {
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
-        const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipationWithOrganizationLearner(
           { firstName: 'Greg', lastName: 'Duboire', organizationId },
           { campaignId }
-        ).id;
+        );
         await databaseBuilder.commit();
 
         const campaignProfile = await CampaignProfileRepository.findProfile({
           campaignId,
-          campaignParticipationId,
+          campaignParticipationId: campaignParticipation.id,
           locale,
         });
 
         expect(campaignProfile.firstName).to.equal('Greg');
         expect(campaignProfile.lastName).to.equal('Duboire');
+        expect(campaignProfile.organizationLearnerId).to.equal(campaignParticipation.organizationLearnerId);
       });
 
       it('return the first name and last name of the current organization learner', async function () {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-assessment-participation-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-assessment-participation-serializer_test.js
@@ -8,6 +8,7 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-participation-serial
   describe('#serialize()', function () {
     let modelCampaignAssessmentParticipation;
     let expectedJsonApi;
+    const organizationLearnerId = 1;
 
     describe('with badges', function () {
       beforeEach(function () {
@@ -25,6 +26,7 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-participation-serial
               'created-at': createdAt,
               'is-shared': true,
               'shared-at': sharedAt,
+              'organization-learner-id': organizationLearnerId,
               'mastery-rate': 0.35,
               progression: 1,
             },
@@ -74,6 +76,7 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-participation-serial
           sharedAt,
           targetedSkillsCount: 20,
           testedSkillsCount: 3,
+          organizationLearnerId,
           masteryRate: 0.35,
           badges: [{ id: 1, title: 'someTitle', altMessage: 'someAltMessage', imageUrl: 'someImageUrl' }],
         });
@@ -104,6 +107,7 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-participation-serial
               'created-at': createdAt,
               'is-shared': true,
               'shared-at': sharedAt,
+              'organization-learner-id': organizationLearnerId,
               'mastery-rate': 0.35,
               progression: 1,
             },
@@ -135,6 +139,7 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-participation-serial
           createdAt,
           status: CampaignParticipationStatuses.SHARED,
           sharedAt,
+          organizationLearnerId,
           targetedSkillsCount: 0,
           testedSkillsCount: 0,
           masteryRate: 0.35,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-profile-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-profile-serializer_test.js
@@ -13,6 +13,7 @@ describe('Unit | Serializer | JSONAPI | campaign-profile-serializer', function (
       // given
       const campaignProfile = new CampaignProfile({
         campaignParticipationId: 9,
+        organizationLearnerId: 1,
         campaignId: 8,
         firstName: 'someFirstName',
         lastName: 'someLastName',
@@ -48,6 +49,7 @@ describe('Unit | Serializer | JSONAPI | campaign-profile-serializer', function (
             'first-name': 'someFirstName',
             'last-name': 'someLastName',
             'campaign-id': 8,
+            'organization-learner-id': 1,
             'external-id': 'anExternalId',
             'pix-score': 12,
             'created-at': '2020-01-01',

--- a/orga/app/components/participant/assessment/header.hbs
+++ b/orga/app/components/participant/assessment/header.hbs
@@ -2,7 +2,15 @@
   <Ui::Breadcrumb @links={{this.breadcrumbLinks}} />
 </header>
 
-<h1 class="page__title page-title">{{@participation.firstName}} {{@participation.lastName}}</h1>
+<header class="page__title">
+  <h1 class="page-title">{{@participation.firstName}} {{@participation.lastName}}</h1>
+  <p class="participant__link">
+    <FaIcon @prefix="far" @icon="user" />
+    <Participant::LinkTo @organizationLearnerId={{@participation.organizationLearnerId}}>
+      {{t "common.actions.link-to-participant"}}
+    </Participant::LinkTo>
+  </p>
+</header>
 
 <section class="panel panel--header">
   <header class="panel-header__headline">

--- a/orga/app/components/participant/assessment/header.js
+++ b/orga/app/components/participant/assessment/header.js
@@ -3,6 +3,11 @@ import { inject as service } from '@ember/service';
 
 export default class Header extends Component {
   @service intl;
+  @service currentUser;
+
+  get organization() {
+    return this.currentUser.organization;
+  }
 
   get displayBadges() {
     const { campaign, participation } = this.args;

--- a/orga/app/components/participant/link-to.hbs
+++ b/orga/app/components/participant/link-to.hbs
@@ -1,0 +1,1 @@
+<LinkTo class="link" @route={{this.route}} @model={{@organizationLearnerId}} ...attributes>{{yield}}</LinkTo>

--- a/orga/app/components/participant/link-to.js
+++ b/orga/app/components/participant/link-to.js
@@ -1,0 +1,15 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class LinkTo extends Component {
+  @service currentUser;
+
+  get route() {
+    if (this.currentUser.organization.isSco) {
+      return 'authenticated.sco-organization-participants.sco-organization-participant';
+    } else if (this.currentUser.organization.isSup) {
+      return 'authenticated.sup-organization-participants.sup-organization-participant';
+    }
+    return 'authenticated.organization-participants.organization-participant';
+  }
+}

--- a/orga/app/components/participant/profile/header.hbs
+++ b/orga/app/components/participant/profile/header.hbs
@@ -2,16 +2,24 @@
   <Ui::Breadcrumb @links={{this.breadcrumbLinks}} />
 </header>
 
-<header class="prescriber page__title">
-  <h1 class="page-title">
-    {{@campaignProfile.firstName}}
-    {{@campaignProfile.lastName}}
-  </h1>
-  {{#if (and @campaignProfile.isCertifiable @campaignProfile.isShared)}}
-    <PixTag @color="green-light" class="prescriber__certifiable-tag">
-      {{t "pages.profiles-individual-results.certifiable"}}
-    </PixTag>
-  {{/if}}
+<header class="campaign-profile page__title">
+  <div class="page-title">
+    <h1>
+      {{@campaignProfile.firstName}}
+      {{@campaignProfile.lastName}}
+    </h1>
+    {{#if (and @campaignProfile.isCertifiable @campaignProfile.isShared)}}
+      <PixTag @color="green-light" class="prescriber__certifiable-tag">
+        {{t "pages.profiles-individual-results.certifiable"}}
+      </PixTag>
+    {{/if}}
+  </div>
+  <p class="participant__link">
+    <FaIcon @prefix="far" @icon="user" />
+    <Participant::LinkTo @organizationLearnerId={{@campaignProfile.organizationLearnerId}}>
+      {{t "common.actions.link-to-participant"}}
+    </Participant::LinkTo>
+  </p>
 </header>
 
 <section class="panel panel--header">

--- a/orga/app/models/campaign-assessment-participation.js
+++ b/orga/app/models/campaign-assessment-participation.js
@@ -3,6 +3,7 @@ import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 export default class CampaignAssessmentParticipation extends Model {
   @attr('string') firstName;
   @attr('string') lastName;
+  @attr('number') organizationLearnerId;
   @attr('number') campaignId;
   @attr('string') participantExternalId;
   @attr('date') createdAt;

--- a/orga/app/models/campaign-profile.js
+++ b/orga/app/models/campaign-profile.js
@@ -7,6 +7,8 @@ export default class CampaignProfile extends Model {
 
   @attr('number') campaignId;
 
+  @attr('number') organizationLearnerId;
+
   @attr('string') externalId;
 
   @attr('date') createdAt;

--- a/orga/app/styles/components/participant/index.scss
+++ b/orga/app/styles/components/participant/index.scss
@@ -1,3 +1,10 @@
 @import 'no-participant-panel';
 @import 'profile';
 @import 'tabs';
+
+.participant {
+  &__link {
+    margin-top: $spacing-xs;
+    color: $pix-primary;
+  }
+}

--- a/orga/app/styles/components/participant/profile.scss
+++ b/orga/app/styles/components/participant/profile.scss
@@ -1,5 +1,7 @@
-.prescriber {
-  display: flex;
-  align-items: center;
-  gap: $spacing-s;
+.campaign-profile {
+  .page-title {
+    display: flex;
+    align-items: center;
+    gap: $spacing-s;
+  }
 }

--- a/orga/config/icons.js
+++ b/orga/config/icons.js
@@ -38,6 +38,6 @@ module.exports = function () {
       'trash-can',
       'redo',
     ],
-    'free-regular-svg-icons': ['circle-check', 'copy', 'trash-can'],
+    'free-regular-svg-icons': ['circle-check', 'copy', 'trash-can', 'user'],
   };
 };

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -251,6 +251,18 @@ export default function () {
 
   this.get('/organizations/:id/participants', findFilteredPaginatedOrganizationParticipants);
 
+  this.get('/organization-learners/:id', (schema, request) => {
+    const participantId = request.params.id;
+
+    return { data: { id: participantId, type: 'organization-learner' } };
+  });
+
+  this.get('/organization-learners/:id/activity', (schema, request) => {
+    const participantId = request.params.id;
+
+    return { data: { id: `${participantId}-activity`, type: 'organization-learner-activity' } };
+  });
+
   this.post('/organizations/:id/sco-organization-learners/import-siecle', (schema, request) => {
     const type = request.requestBody.type;
 

--- a/orga/mirage/factories/campaign-profile.js
+++ b/orga/mirage/factories/campaign-profile.js
@@ -14,6 +14,10 @@ export default Factory.extend({
     return faker.name.title();
   },
 
+  organizationLearnerId() {
+    return 1;
+  },
+
   createdAt() {
     return faker.date.past();
   },

--- a/orga/tests/acceptance/campaign-participants-individual-results_test.js
+++ b/orga/tests/acceptance/campaign-participants-individual-results_test.js
@@ -13,14 +13,30 @@ module('Acceptance | Campaign Participants Individual Results', function (hooks)
   setupApplicationTest(hooks);
   setupMirage(hooks);
   setupIntl(hooks);
+  let user;
 
   hooks.beforeEach(async () => {
-    const user = createUserWithMembershipAndTermsOfServiceAccepted();
+    user = createUserWithMembershipAndTermsOfServiceAccepted();
     createPrescriberByUser(user);
 
     server.create('campaign', { id: 1 });
 
     await authenticateSession(user.id);
+  });
+
+  test('it should go to participant details', async function (assert) {
+    // given
+    const organizationId = user.memberships.models.firstObject.organizationId;
+    server.create('campaign', { id: 1 });
+    server.create('campaignProfile', { campaignId: 1, campaignParticipationId: 1 });
+    server.create('organization-participant', { id: 1, organizationId });
+
+    // when
+    const screen = await visitScreen('/campagnes/1/profils/1');
+    await click(screen.getByRole('link', { name: this.intl.t('common.actions.link-to-participant') }));
+
+    // then
+    assert.strictEqual(currentURL(), '/participants/1');
   });
 
   test('it should go to campaigns', async function (assert) {

--- a/orga/tests/acceptance/profile_test.js
+++ b/orga/tests/acceptance/profile_test.js
@@ -13,12 +13,28 @@ module('Acceptance | Campaign Profile', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
   setupIntl(hooks);
+  let user;
 
   hooks.beforeEach(async () => {
-    const user = createUserWithMembershipAndTermsOfServiceAccepted();
+    user = createUserWithMembershipAndTermsOfServiceAccepted();
     createPrescriberByUser(user);
 
     await authenticateSession(user.id);
+  });
+
+  test('it should go to participant details', async function (assert) {
+    // given
+    const organizationId = user.memberships.models.firstObject.organizationId;
+    server.create('campaign', { id: 1 });
+    server.create('campaignProfile', { campaignId: 1, campaignParticipationId: 1 });
+    server.create('organization-participant', { id: 1, organizationId });
+
+    // when
+    const screen = await visitScreen('/campagnes/1/profils/1');
+    await click(screen.getByRole('link', { name: this.intl.t('common.actions.link-to-participant') }));
+
+    // then
+    assert.strictEqual(currentURL(), '/participants/1');
   });
 
   test('it should go to campaigns', async function (assert) {

--- a/orga/tests/integration/components/participant/assessment/header_test.js
+++ b/orga/tests/integration/components/participant/assessment/header_test.js
@@ -9,6 +9,8 @@ module('Integration | Component | Participant::Assessment::Header', function (ho
 
   hooks.beforeEach(function () {
     this.owner.setupRouter();
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.organization = {};
   });
 
   test('it should display user information', async function (assert) {

--- a/orga/tests/integration/components/participant/profile/header_test.js
+++ b/orga/tests/integration/components/participant/profile/header_test.js
@@ -6,6 +6,11 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Component | Participant::Profile::Header', function (hooks) {
   setupIntlRenderingTest(hooks);
 
+  hooks.beforeEach(function () {
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.organization = {};
+  });
+
   test('it displays user information', async function (assert) {
     this.campaignProfile = {
       firstName: 'Godefroy',

--- a/orga/tests/unit/components/participant/link-to_test.js
+++ b/orga/tests/unit/components/participant/link-to_test.js
@@ -1,0 +1,55 @@
+import { module, test } from 'qunit';
+import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Component | Participant::LinkTo', function (hooks) {
+  setupTest(hooks);
+
+  test('should return route to sco participant details', async function (assert) {
+    // given
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.organization = {
+      isSco: true,
+      isSup: false,
+    };
+    const component = await createGlimmerComponent('component:participant/link-to');
+
+    // when
+    const route = component.route;
+
+    // then
+    assert.strictEqual(route, 'authenticated.sco-organization-participants.sco-organization-participant');
+  });
+
+  test('should return route to sup participant details', async function (assert) {
+    // given
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.organization = {
+      isSco: false,
+      isSup: true,
+    };
+    const component = await createGlimmerComponent('component:participant/link-to');
+
+    // when
+    const route = component.route;
+
+    // then
+    assert.strictEqual(route, 'authenticated.sup-organization-participants.sup-organization-participant');
+  });
+
+  test('should return route to participant details', async function (assert) {
+    // given
+    const currentUser = this.owner.lookup('service:currentUser');
+    currentUser.organization = {
+      isSco: false,
+      isSup: false,
+    };
+    const component = await createGlimmerComponent('component:participant/link-to');
+
+    // when
+    const route = component.route;
+
+    // then
+    assert.strictEqual(route, 'authenticated.organization-participants.organization-participant');
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -144,7 +144,8 @@
       "back": "Back",
       "cancel": "Cancel",
       "close": "Close",
-      "global": "Actions"
+      "global": "Actions",
+      "link-to-participant": "See whole participant's activity"
     },
     "api-error-messages": {
       "bad-request-error": "The data entered was not in the correct format.",
@@ -602,7 +603,7 @@
         "should-change-password": "You currently have a temporary password. <a href=\"{url}\">Reset your password here</a>.",
         "status": {
           "403": "Access to this Pix Orga space is limited to invited members. Each Pix Orga space is managed by an administrator specific to the organisation using it. Please contact your administrator to get invited.",
-          "404":"There was an error in the email address or password entered.",
+          "404": "There was an error in the email address or password entered.",
           "409": "This invitation has been already accepted or cancelled."
         }
       },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -144,7 +144,8 @@
       "back": "Retour",
       "cancel": "Annuler",
       "close": "Fermer",
-      "global": "Actions"
+      "global": "Actions",
+      "link-to-participant": "Voir toute l'activité du participant"
     },
     "api-error-messages": {
       "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la consolidation de l’activité du prescrit, nous avons créé [une nouvelle page détaillant l’activité d’un prescrit](https://1024pix.atlassian.net/browse/PIX-6062). Cette page inclut un tableau qui liste les participations du prescrit.
Via un lien, nous allons rendre cette page également accessible depuis la page de détail d’une participation à une campagne, pour de permettre aux prescripteurs de facilement consulter le reste de l’activité d’un prescrit.

## :robot: Proposition
Ajouter un lien vers la page de l'activité d'un prescrit sur la page de détails d'une participation.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se connecter à PixOrga (avec les comptes PRO, SUP et SCO car les pages d'activité des prescrits sont différentes)
- Aller sur la page d'une participation pour chaque type de campagne (Evaluation et collecte de profil)
- Vérifier la présence du lien "Voir toute l'activité du participant"
- Constater qu'il redirige bien sur la page d'activité du prescrit
