### PR TITLE
[TECH] Ajouter un hash du username dans les logs de l'appel à api/token

### DIFF
--- a/api/lib/infrastructure/plugins/pino.js
+++ b/api/lib/infrastructure/plugins/pino.js
@@ -2,6 +2,7 @@ const config = require('../../config.js');
 const monitoringTools = require('../monitoring-tools.js');
 const hapiPino = require('hapi-pino');
 const logger = require('../logger.js');
+const crypto = require('crypto');
 
 function logObjectSerializer(req) {
   const enhancedReq = {
@@ -11,6 +12,11 @@ function logObjectSerializer(req) {
 
   if (!config.hapi.enableRequestMonitoring) return enhancedReq;
   const context = monitoringTools.getContext();
+  if (context?.request?.route?.path === '/api/token') {
+    const hash = crypto.createHash('sha256');
+    const username = context?.request?.payload?.username;
+    enhancedReq.usernameHash = username ? hash.update(username).digest('hex') : '-';
+  }
 
   return {
     ...enhancedReq,


### PR DESCRIPTION
## :unicorn: Problème
Nous souhaiterions pouvoir détecter immédiatement des appels répétés à `/api/token` qui tenterait de se connecter avec plusieurs usernames d'affilés

## :robot: Proposition
Rajouter un log contenant le hash de username pour pouvoir corréler le nombre de hash à du trafic spécifique

## :rainbow: Remarques
J'ai modifié le logger, parce que je ne suis pas parvenu à identifier un autre endroit ou le faire plus satisfaisant, je suis preneur de suggestions là dessus

## :100: Pour tester
Lancer l'api en local et faire un appel à /api/token, un hash du username utilisé devrait apparaitre dans les logs avec la clé `usernameHash`

```sh
curl 'localhost:3000/api/token' --data-raw 'grant_type=password&username=coucou%40example.net&password=coucou&scope=mon-pix' --compressed

#--- 

"usernameHash": "23b067e15559b821d778b0aac978a3fe5e66478c3bb0c298f2eaaa84efc5c0ff",
```
