### PR TITLE
[FEATURE] Afficher le détail d'un déclencheur de contenu formatif (PIX-7429)

### DIFF
--- a/admin/app/adapters/training-trigger.js
+++ b/admin/app/adapters/training-trigger.js
@@ -12,7 +12,10 @@ export default class TrainingTriggerAdapter extends ApplicationAdapter {
   createRecord(store, type, snapshot) {
     const { adapterOptions } = snapshot;
     const payload = this.serialize(snapshot);
-    payload.data.attributes.tubes = adapterOptions.tubes;
+    payload.data.attributes.tubes = adapterOptions.tubes.map((tube) => ({
+      tubeId: tube.id,
+      level: tube.level,
+    }));
 
     const url = this.buildURL(type.modelName, null, snapshot, 'createRecord');
 

--- a/admin/app/components/badges/capped-tubes-criterion.hbs
+++ b/admin/app/components/badges/capped-tubes-criterion.hbs
@@ -12,5 +12,10 @@
 </p>
 
 {{#each this.areasForView as |area|}}
-  <Common::TubesDetails::Area @title={{area.title}} @color={{area.color}} @competences={{area.competences}} />
+  <Common::TubesDetails::Area
+    @title={{area.title}}
+    @color={{area.color}}
+    @competences={{area.competences}}
+    @displayDeviceCompatibility={{true}}
+  />
 {{/each}}

--- a/admin/app/components/common/tubes-details/area.hbs
+++ b/admin/app/components/common/tubes-details/area.hbs
@@ -2,7 +2,11 @@
   <div class="area-border {{@color}}"></div>
   <PixCollapsible @title="{{@title}}" class="{{@color}} list-competences">
     {{#each @competences as |competence|}}
-      <Common::TubesDetails::Competence @title={{competence.title}} @thematics={{competence.thematics}} />
+      <Common::TubesDetails::Competence
+        @title={{competence.title}}
+        @thematics={{competence.thematics}}
+        @displayDeviceCompatibility={{@displayDeviceCompatibility}}
+      />
     {{/each}}
   </PixCollapsible>
 </div>

--- a/admin/app/components/common/tubes-details/competence.hbs
+++ b/admin/app/components/common/tubes-details/competence.hbs
@@ -14,9 +14,11 @@
             <Table::Header @size="small" scope="col">
               <p>Niveau</p>
             </Table::Header>
-            <Table::Header @size="medium" @align="center" scope="col">
-              <p>Compatibilité</p>
-            </Table::Header>
+            {{#if @displayDeviceCompatibility}}
+              <Table::Header @size="medium" @align="center" scope="col">
+                <p>Compatibilité</p>
+              </Table::Header>
+            {{/if}}
           </tr>
         </thead>
 
@@ -33,6 +35,7 @@
                   @level={{tube.level}}
                   @mobile={{tube.mobile}}
                   @tablet={{tube.tablet}}
+                  @displayDeviceCompatibility={{@displayDeviceCompatibility}}
                 />
               </tr>
             {{/each}}

--- a/admin/app/components/common/tubes-details/tube.hbs
+++ b/admin/app/components/common/tubes-details/tube.hbs
@@ -4,25 +4,27 @@
 <td class="table__column--center" data-testid="level-{{@id}}">
   {{@level}}
 </td>
-<td class="table__column--center">
-  <div
-    class="icon-container"
-    aria-label="{{if @mobile 'compatible mobile' 'incompatible mobile'}}"
-    data-testid="mobile-compliant-{{@id}}"
-  >
-    <FaIcon @icon="mobile-screen-button" class="fa-2x {{if @mobile 'is-responsive'}}" />
-    {{#unless @mobile}}
-      <FaIcon @icon="slash" class="fa-2x not-responsive" />
-    {{/unless}}
-  </div>
-  <div
-    class="icon-container"
-    aria-label="{{if @tablet 'compatible tablette' 'incompatible tablette'}}"
-    data-testid="tablet-compliant-{{@id}}"
-  >
-    <FaIcon @icon="tablet-screen-button" class="fa-2x {{if @tablet 'is-responsive'}}" />
-    {{#unless @tablet}}
-      <FaIcon @icon="slash" class="fa-2x not-responsive" />
-    {{/unless}}
-  </div>
-</td>
+{{#if @displayDeviceCompatibility}}
+  <td class="table__column--center">
+    <div
+      class="icon-container"
+      aria-label="{{if @mobile 'compatible mobile' 'incompatible mobile'}}"
+      data-testid="mobile-compliant-{{@id}}"
+    >
+      <FaIcon @icon="mobile-screen-button" class="fa-2x {{if @mobile 'is-responsive'}}" />
+      {{#unless @mobile}}
+        <FaIcon @icon="slash" class="fa-2x not-responsive" />
+      {{/unless}}
+    </div>
+    <div
+      class="icon-container"
+      aria-label="{{if @tablet 'compatible tablette' 'incompatible tablette'}}"
+      data-testid="tablet-compliant-{{@id}}"
+    >
+      <FaIcon @icon="tablet-screen-button" class="fa-2x {{if @tablet 'is-responsive'}}" />
+      {{#unless @tablet}}
+        <FaIcon @icon="slash" class="fa-2x not-responsive" />
+      {{/unless}}
+    </div>
+  </td>
+{{/if}}

--- a/admin/app/components/target-profiles/details.hbs
+++ b/admin/app/components/target-profiles/details.hbs
@@ -1,5 +1,10 @@
 {{#each @areas as |area|}}
-  <Common::TubesDetails::Area @title={{area.title}} @color={{area.color}} @competences={{area.competences}} />
+  <Common::TubesDetails::Area
+    @title={{area.title}}
+    @color={{area.color}}
+    @competences={{area.competences}}
+    @displayDeviceCompatibility={{true}}
+  />
 {{else}}
   <section class="page-section">
     <div class="table__empty">Profil cible vide.</div>

--- a/admin/app/components/trainings/create-training-triggers.hbs
+++ b/admin/app/components/trainings/create-training-triggers.hbs
@@ -3,7 +3,7 @@
   <p class="trigger-card__description">{{t "pages.trainings.training.triggers.prerequisite.edit.description"}}</p>
 
   {{#if @training.prerequisiteTrigger}}
-    <p>Un prerequis est défini</p>
+    <Trainings::Trigger::Details @areas={{@training.prerequisiteTrigger.areas}} />
   {{else}}
     <PixButtonLink
       class="trigger-card__toggler"
@@ -21,10 +21,10 @@
 
 <section class="page-section trigger-card">
   <h2 class="trigger-card__title">{{t "pages.trainings.training.triggers.goal.title"}}</h2>
-  <p class="trigger-card__description">S{{t "pages.trainings.training.triggers.goal.edit.description"}}</p>
+  <p class="trigger-card__description">{{t "pages.trainings.training.triggers.goal.edit.description"}}</p>
 
   {{#if @training.goalTrigger}}
-    <p>Un objectif est défini</p>
+    <Trainings::Trigger::Details @areas={{@training.goalTrigger.areas}} />
   {{else}}
     <PixButtonLink
       class="trigger-card__toggler"

--- a/admin/app/components/trainings/trigger/details.hbs
+++ b/admin/app/components/trainings/trigger/details.hbs
@@ -1,0 +1,3 @@
+{{#each this.areasList as |area|}}
+  <Common::TubesDetails::Area @title={{area.title}} @color={{area.color}} @competences={{area.competences}} />
+{{/each}}

--- a/admin/app/components/trainings/trigger/details.js
+++ b/admin/app/components/trainings/trigger/details.js
@@ -1,0 +1,44 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class Details extends Component {
+  @service store;
+
+  get areasList() {
+    return this.args.areas.map((area) => this.buildAreaViewModel(area));
+  }
+
+  buildAreaViewModel(area) {
+    return {
+      title: `${area.code} · ${area.title}`,
+      color: area.color,
+      competences: area.competences.sortBy('index').map((competence) => this.buildCompetenceViewModel(competence)),
+    };
+  }
+
+  buildCompetenceViewModel(competence) {
+    return {
+      id: competence.id,
+      title: `${competence.index} ${competence.name}`,
+      thematics: competence.thematics.map((thematic) => this.buildThematicViewModel(thematic)),
+    };
+  }
+
+  buildThematicViewModel(thematic) {
+    return {
+      name: thematic.name,
+      nbTubes: thematic.triggerTubes.length,
+      tubes: thematic.triggerTubes.map((triggerTube) => {
+        return this.buildTubeViewModel(triggerTube.get('tube'), triggerTube.level);
+      }),
+    };
+  }
+
+  buildTubeViewModel(tube, level) {
+    return {
+      id: tube.get('id'),
+      title: `${tube.name} : ${tube.practicalTitle}`,
+      level,
+    };
+  }
+}

--- a/admin/app/models/thematic.js
+++ b/admin/app/models/thematic.js
@@ -4,5 +4,6 @@ export default class Thematic extends Model {
   @attr('string') name;
   @attr() index;
 
+  @hasMany('trigger-tube') triggerTubes;
   @hasMany('tube') tubes;
 }

--- a/admin/app/models/training-trigger.js
+++ b/admin/app/models/training-trigger.js
@@ -5,5 +5,5 @@ export default class TrainingTrigger extends Model {
   @attr('number') trainingId;
   @attr('number') threshold;
 
-  @hasMany('trigger-tube') triggerTubes;
+  @hasMany('area') areas;
 }

--- a/admin/app/models/trigger-tube.js
+++ b/admin/app/models/trigger-tube.js
@@ -3,5 +3,5 @@ import Model, { attr, belongsTo } from '@ember-data/model';
 export default class TriggerTube extends Model {
   @attr('number') level;
 
-  @belongsTo('tube') tube;
+  @belongsTo('tube', { async: false }) tube;
 }

--- a/admin/tests/integration/components/trainings/create-training-triggers_test.js
+++ b/admin/tests/integration/components/trainings/create-training-triggers_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { render } from '@1024pix/ember-testing-library';
+import { render, clickByText } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -8,10 +8,122 @@ module('Integration | Component | Trainings::CreateTrainingTriggers', function (
 
   module("If a goal trigger exists and a prerequisite trigger doesn't exist", function (nestedHook) {
     nestedHook.beforeEach(function () {
+      const store = this.owner.lookup('service:store');
+      const tube1Thematic1Competence1Area1 = store.createRecord('tube', {
+        id: 'tube1Thematic1Competence1Area1ID',
+        name: 'tube1Thematic1Competence1Area1 name',
+        practicalTitle: 'tube1Thematic1Competence1Area1 practicalTitle',
+      });
+      const tube2Thematic1Competence1Area1 = store.createRecord('tube', {
+        id: 'tube2Thematic1Competence1Area1ID',
+        name: 'tube2Thematic1Competence1Area1 name',
+        practicalTitle: 'tube2Thematic1Competence1Area1 practicalTitle',
+      });
+      const tube3Thematic1Competence1Area1 = store.createRecord('tube', {
+        id: 'tube3Thematic1Competence1Area1ID',
+        name: 'tube3Thematic1Competence1Area1 name',
+        practicalTitle: 'tube3Thematic1Competence1Area1 practicalTitle',
+      });
+      const tube4Thematic2Competence1Area1 = store.createRecord('tube', {
+        id: 'tube4Thematic2Competence1Area1ID',
+        name: 'tube4Thematic2Competence1Area1 name',
+        practicalTitle: 'tube4Thematic2Competence1Area1 practicalTitle',
+      });
+      const trainingTriggerTube1 = store.createRecord('trigger-tube', {
+        id: 1,
+        tube: tube1Thematic1Competence1Area1,
+        level: 3,
+      });
+      const trainingTriggerTube2 = store.createRecord('trigger-tube', {
+        id: 2,
+        tube: tube2Thematic1Competence1Area1,
+        level: 1,
+      });
+      const trainingTriggerTube3 = store.createRecord('trigger-tube', {
+        id: 3,
+        tube: tube3Thematic1Competence1Area1,
+        level: 5,
+      });
+      const trainingTriggerTube4 = store.createRecord('trigger-tube', {
+        id: 4,
+        tube: tube4Thematic2Competence1Area1,
+        level: 8,
+      });
+      const thematic1Competence1Area1 = store.createRecord('thematic', {
+        id: 'thematic1Competence1Area1ID',
+        name: 'thematic1Competence1Area1 name',
+        index: 'thematic1Competence1Area1 index',
+        triggerTubes: [trainingTriggerTube1, trainingTriggerTube2, trainingTriggerTube3],
+      });
+      const thematic2Competence1Area1 = store.createRecord('thematic', {
+        id: 'thematic2Competence1Area1ID',
+        name: 'thematic2Competence1Area1 name',
+        index: 'thematic2Competence1Area1 index',
+        triggerTubes: [trainingTriggerTube4],
+      });
+      const competence1Area1 = store.createRecord('competence', {
+        id: 'competence1Area1ID',
+        name: 'competence1Area1 name',
+        index: 'competence1Area1 index',
+        thematics: [thematic1Competence1Area1, thematic2Competence1Area1],
+      });
+      const thematic1Competence2Area1 = store.createRecord('thematic', {
+        id: 'thematic1Competence2Area1ID',
+        name: 'thematic1Competence2Area1 name',
+        index: 'thematic1Competence2Area1 index',
+        triggerTubes: [trainingTriggerTube3],
+      });
+      const competence2Area1 = store.createRecord('competence', {
+        id: 'competence2Area1ID',
+        name: 'competence2Area1 name',
+        index: 'competence2Area1 index',
+        thematics: [thematic1Competence2Area1],
+      });
+      const area1 = store.createRecord('area', {
+        id: 'area1ID',
+        title: 'area1 title',
+        code: 'area1 code',
+        color: 'area1 color',
+        frameworkId: 'frameworkId1',
+        competences: [competence1Area1, competence2Area1],
+      });
+      const tube1Thematic1Competence1Area2 = store.createRecord('tube', {
+        id: 'tube1Thematic1Competence1Area2ID',
+        name: 'tube1Thematic1Competence1Area2 name',
+        practicalTitle: 'tube1Thematic1Competence1Area2 practicalTitle',
+      });
+      const trainingTriggerTubeForArea2 = store.createRecord('trigger-tube', {
+        id: 5,
+        tube: tube1Thematic1Competence1Area2,
+        level: 3,
+      });
+      const thematic1Competence1Area2 = store.createRecord('thematic', {
+        id: 'thematic1Competence1Area2ID',
+        name: 'thematic1Competence1Area2 name',
+        index: 'thematic1Competence1Area2 index',
+        triggerTubes: [trainingTriggerTubeForArea2],
+      });
+      const competence1Area2 = store.createRecord('competence', {
+        id: 'competence1Area2ID',
+        name: 'competence1Area2 name',
+        index: 'competence1Area2 index',
+        thematics: [thematic1Competence1Area2],
+      });
+      const area2 = store.createRecord('area', {
+        id: 'area2ID',
+        title: 'area2 title',
+        code: 'area2 code',
+        color: 'area2 color',
+        frameworkId: 'frameworkId2',
+        competences: [competence1Area2],
+      });
+
+      const trainingTrigger = store.createRecord('training-trigger', {
+        type: 'goal',
+        areas: [area1, area2],
+      });
       this.set('training', {
-        goalTrigger: {
-          type: 'goal',
-        },
+        goalTrigger: trainingTrigger,
       });
     });
 
@@ -33,15 +145,142 @@ module('Integration | Component | Trainings::CreateTrainingTriggers', function (
       assert
         .dom(screen.queryByLabelText(this.intl.t('pages.trainings.training.triggers.goal.alternative-title')))
         .doesNotExist();
+      assert.dom(screen.getByText('area1 code · area1 title')).exists();
+      await clickByText('area1 code · area1 title');
+      assert.dom(screen.getByText('competence1Area1 index competence1Area1 name')).exists();
+      await clickByText('competence1Area1 index competence1Area1 name');
+      assert.dom(screen.getByText('thematic1Competence1Area1 name')).exists();
+      assert
+        .dom(screen.getByText('tube1Thematic1Competence1Area1 name : tube1Thematic1Competence1Area1 practicalTitle'))
+        .exists();
+      assert
+        .dom(screen.getByText('tube2Thematic1Competence1Area1 name : tube2Thematic1Competence1Area1 practicalTitle'))
+        .exists();
+      assert
+        .dom(screen.getByText('tube3Thematic1Competence1Area1 name : tube3Thematic1Competence1Area1 practicalTitle'))
+        .exists();
     });
   });
 
   module("If a prerequisite trigger exists and a goal trigger doesn't exist", function (nestedHook) {
     nestedHook.beforeEach(function () {
+      const store = this.owner.lookup('service:store');
+      const tube1Thematic1Competence1Area1 = store.createRecord('tube', {
+        id: 'tube1Thematic1Competence1Area1ID',
+        name: 'tube1Thematic1Competence1Area1 name',
+        practicalTitle: 'tube1Thematic1Competence1Area1 practicalTitle',
+      });
+      const tube2Thematic1Competence1Area1 = store.createRecord('tube', {
+        id: 'tube2Thematic1Competence1Area1ID',
+        name: 'tube2Thematic1Competence1Area1 name',
+        practicalTitle: 'tube2Thematic1Competence1Area1 practicalTitle',
+      });
+      const tube3Thematic1Competence1Area1 = store.createRecord('tube', {
+        id: 'tube3Thematic1Competence1Area1ID',
+        name: 'tube3Thematic1Competence1Area1 name',
+        practicalTitle: 'tube3Thematic1Competence1Area1 practicalTitle',
+      });
+      const tube4Thematic2Competence1Area1 = store.createRecord('tube', {
+        id: 'tube4Thematic2Competence1Area1ID',
+        name: 'tube4Thematic2Competence1Area1 name',
+        practicalTitle: 'tube4Thematic2Competence1Area1 practicalTitle',
+      });
+      const trainingTriggerTube1 = store.createRecord('trigger-tube', {
+        id: 1,
+        tube: tube1Thematic1Competence1Area1,
+        level: 3,
+      });
+      const trainingTriggerTube2 = store.createRecord('trigger-tube', {
+        id: 2,
+        tube: tube2Thematic1Competence1Area1,
+        level: 1,
+      });
+      const trainingTriggerTube3 = store.createRecord('trigger-tube', {
+        id: 3,
+        tube: tube3Thematic1Competence1Area1,
+        level: 5,
+      });
+      const trainingTriggerTube4 = store.createRecord('trigger-tube', {
+        id: 4,
+        tube: tube4Thematic2Competence1Area1,
+        level: 8,
+      });
+      const thematic1Competence1Area1 = store.createRecord('thematic', {
+        id: 'thematic1Competence1Area1ID',
+        name: 'thematic1Competence1Area1 name',
+        index: 'thematic1Competence1Area1 index',
+        triggerTubes: [trainingTriggerTube1, trainingTriggerTube2, trainingTriggerTube3],
+      });
+      const thematic2Competence1Area1 = store.createRecord('thematic', {
+        id: 'thematic2Competence1Area1ID',
+        name: 'thematic2Competence1Area1 name',
+        index: 'thematic2Competence1Area1 index',
+        triggerTubes: [trainingTriggerTube4],
+      });
+      const competence1Area1 = store.createRecord('competence', {
+        id: 'competence1Area1ID',
+        name: 'competence1Area1 name',
+        index: 'competence1Area1 index',
+        thematics: [thematic1Competence1Area1, thematic2Competence1Area1],
+      });
+      const thematic1Competence2Area1 = store.createRecord('thematic', {
+        id: 'thematic1Competence2Area1ID',
+        name: 'thematic1Competence2Area1 name',
+        index: 'thematic1Competence2Area1 index',
+        triggerTubes: [trainingTriggerTube3],
+      });
+      const competence2Area1 = store.createRecord('competence', {
+        id: 'competence2Area1ID',
+        name: 'competence2Area1 name',
+        index: 'competence2Area1 index',
+        thematics: [thematic1Competence2Area1],
+      });
+      const area1 = store.createRecord('area', {
+        id: 'area1ID',
+        title: 'area1 title',
+        code: 'area1 code',
+        color: 'area1 color',
+        frameworkId: 'frameworkId1',
+        competences: [competence1Area1, competence2Area1],
+      });
+      const tube1Thematic1Competence1Area2 = store.createRecord('tube', {
+        id: 'tube1Thematic1Competence1Area2ID',
+        name: 'tube1Thematic1Competence1Area2 name',
+        practicalTitle: 'tube1Thematic1Competence1Area2 practicalTitle',
+      });
+      const trainingTriggerTubeForArea2 = store.createRecord('trigger-tube', {
+        id: 5,
+        tube: tube1Thematic1Competence1Area2,
+        level: 3,
+      });
+
+      const thematic1Competence1Area2 = store.createRecord('thematic', {
+        id: 'thematic1Competence1Area2ID',
+        name: 'thematic1Competence1Area2 name',
+        index: 'thematic1Competence1Area2 index',
+        triggerTubes: [trainingTriggerTubeForArea2],
+      });
+      const competence1Area2 = store.createRecord('competence', {
+        id: 'competence1Area2ID',
+        name: 'competence1Area2 name',
+        index: 'competence1Area2 index',
+        thematics: [thematic1Competence1Area2],
+      });
+      const area2 = store.createRecord('area', {
+        id: 'area2ID',
+        title: 'area2 title',
+        code: 'area2 code',
+        color: 'area2 color',
+        frameworkId: 'frameworkId2',
+        competences: [competence1Area2],
+      });
+
+      const trainingTrigger = store.createRecord('training-trigger', {
+        type: 'prerequisite',
+        areas: [area1, area2],
+      });
       this.set('training', {
-        prerequisiteTrigger: {
-          type: 'prerequisite',
-        },
+        prerequisiteTrigger: trainingTrigger,
       });
     });
 
@@ -53,6 +292,29 @@ module('Integration | Component | Trainings::CreateTrainingTriggers', function (
       assert
         .dom(screen.queryByLabelText(this.intl.t('pages.trainings.training.triggers.prerequisite.alternative-title')))
         .doesNotExist();
+      assert.dom(screen.getByText('area1 code · area1 title')).exists();
+      await clickByText('area1 code · area1 title');
+      assert.dom(screen.getByText('competence1Area1 index competence1Area1 name')).exists();
+      await clickByText('competence1Area1 index competence1Area1 name');
+      assert.dom(screen.getByText('thematic1Competence1Area1 name')).exists();
+      assert
+        .dom(screen.getByText('tube1Thematic1Competence1Area1 name : tube1Thematic1Competence1Area1 practicalTitle'))
+        .exists();
+      assert
+        .dom(screen.getByText('tube2Thematic1Competence1Area1 name : tube2Thematic1Competence1Area1 practicalTitle'))
+        .exists();
+      assert
+        .dom(screen.getByText('tube3Thematic1Competence1Area1 name : tube3Thematic1Competence1Area1 practicalTitle'))
+        .exists();
+
+      assert.dom(screen.getByText('area2 code · area2 title')).exists();
+      await clickByText('area2 code · area2 title');
+      assert.dom(screen.getByText('competence1Area2 index competence1Area2 name')).exists();
+      await clickByText('competence1Area2 index competence1Area2 name');
+      assert.dom(screen.getByText('thematic1Competence1Area2 name')).exists();
+      assert
+        .dom(screen.getByText('tube1Thematic1Competence1Area2 name : tube1Thematic1Competence1Area2 practicalTitle'))
+        .exists();
     });
 
     test('it should display the goal creation link', async function (assert) {

--- a/admin/tests/unit/adapters/training-trigger_test.js
+++ b/admin/tests/unit/adapters/training-trigger_test.js
@@ -36,13 +36,16 @@ module('Unit | Adapter | TrainingTrigger', function (hooks) {
     test('should trigger PUT request with correct payload', async function (assert) {
       // given
       sinon.stub(adapter, 'urlForCreateRecord').returns('https://example.net');
-      const attributesWithoutTubes = { type: 'prerequisite', threshold: 10 };
+      const attributesWithoutTubes = { type: 'prerequisite', threshold: 10, trainingId };
       const expectedPayload = {
         data: {
           data: {
             attributes: {
               ...attributesWithoutTubes,
-              tubes,
+              tubes: [
+                { tubeId: 1, level: 2 },
+                { tubeId: 2, level: 4 },
+              ],
             },
           },
         },
@@ -53,6 +56,8 @@ module('Unit | Adapter | TrainingTrigger', function (hooks) {
         adapterOptions: { tubes, trainingId },
         serialize: sinon.stub().returns({ data: { attributes: attributesWithoutTubes } }),
       });
+
+      console.log(adapter.ajax.calledWith(`https://example.net`, 'PUT', expectedPayload));
 
       // then
       assert.ok(adapter.ajax.calledWith(`https://example.net`, 'PUT', expectedPayload));

--- a/api/lib/application/trainings/index.js
+++ b/api/lib/application/trainings/index.js
@@ -207,7 +207,7 @@ exports.register = async (server) => {
                 threshold: Joi.number().min(0).max(100).required(),
                 tubes: Joi.array().items(
                   Joi.object({
-                    id: identifiersType.tubeId.required(),
+                    tubeId: identifiersType.tubeId.required(),
                     level: Joi.number().min(0).max(8).required(),
                   })
                 ),

--- a/api/lib/domain/models/TrainingTrigger.js
+++ b/api/lib/domain/models/TrainingTrigger.js
@@ -7,7 +7,6 @@ class TrainingTrigger {
   constructor({ id, trainingId, triggerTubes, type, threshold, areas = [], competences = [], thematics = [] } = {}) {
     this.id = id;
     this.trainingId = trainingId;
-    this.triggerTubes = triggerTubes;
     if (!Object.values(types).includes(type)) {
       throw new Error('Invalid trigger type');
     }
@@ -50,9 +49,7 @@ class _Thematic {
     this.name = name;
     this.index = index;
 
-    this.triggerTubes = triggerTubes
-      .filter((trainingTriggerTube) => trainingTriggerTube.tube.thematicId === id)
-      .map((trainingTriggerTube) => trainingTriggerTube.id);
+    this.triggerTubes = triggerTubes.filter((trainingTriggerTube) => trainingTriggerTube.tube.thematicId === id);
   }
 }
 

--- a/api/lib/infrastructure/repositories/training-trigger-repository.js
+++ b/api/lib/infrastructure/repositories/training-trigger-repository.js
@@ -27,19 +27,21 @@ module.exports = {
 
     await knexConn('training-trigger-tubes').where({ trainingTriggerId: trainingTrigger.id }).delete();
 
-    const trainingTubesToCreate = triggerTubesForCreation.map(({ id, level }) => {
+    const trainingTriggerTubesToCreate = triggerTubesForCreation.map(({ tubeId, level }) => {
       return {
         trainingTriggerId: trainingTrigger.id,
-        tubeId: id,
+        tubeId,
         level,
       };
     });
 
-    const createdTriggerTubes = await knexConn('training-trigger-tubes').insert(trainingTubesToCreate).returning('*');
+    const createdTrainingTriggerTubes = await knexConn('training-trigger-tubes')
+      .insert(trainingTriggerTubesToCreate)
+      .returning('*');
 
-    const tubes = await tubeRepository.findByRecordIds(createdTriggerTubes.map(({ tubeId }) => tubeId));
+    const tubes = await tubeRepository.findByRecordIds(createdTrainingTriggerTubes.map(({ tubeId }) => tubeId));
 
-    return _toDomain({ trainingTrigger, triggerTubes: createdTriggerTubes, tubes });
+    return _toDomain({ trainingTrigger, triggerTubes: createdTrainingTriggerTubes, tubes });
   },
 
   async findByTrainingId({ trainingId, domainTransaction = DomainTransaction.emptyTransaction() }) {

--- a/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
@@ -9,18 +9,7 @@ module.exports = {
         duration.hours = duration.hours || 0;
         duration.minutes = duration.minutes || 0;
 
-        return {
-          ...record,
-          trainingTriggers: record.trainingTriggers.map((trigger) => {
-            return {
-              ...trigger,
-              triggerTubes: trigger.triggerTubes.map((triggerTube) => ({
-                ...triggerTube,
-                tube: { ...triggerTube.tube },
-              })),
-            };
-          }),
-        };
+        return JSON.parse(JSON.stringify(record));
       },
       attributes: [
         'id',
@@ -36,18 +25,10 @@ module.exports = {
       ],
       trainingTriggers: {
         ref: 'id',
-        attributes: ['id', 'trainingId', 'type', 'threshold', 'triggerTubes', 'areas'],
-        triggerTubes: {
-          ref: 'id',
-          included: true,
-          attributes: ['id', 'level', 'tube'],
-          tube: {
-            ref: 'id',
-            attributes: ['id', 'name', 'practicalTitle'],
-          },
-        },
+        attributes: ['id', 'trainingId', 'type', 'threshold', 'areas'],
         areas: {
           ref: 'id',
+          included: true,
           attributes: ['id', 'title', 'code', 'color', 'competences'],
           competences: {
             ref: 'id',
@@ -57,6 +38,16 @@ module.exports = {
               ref: 'id',
               included: true,
               attributes: ['id', 'name', 'index', 'triggerTubes'],
+              triggerTubes: {
+                ref: 'id',
+                included: true,
+                attributes: ['id', 'level', 'tube'],
+                tube: {
+                  ref: 'id',
+                  included: true,
+                  attributes: ['id', 'name', 'practicalTitle'],
+                },
+              },
             },
           },
         },

--- a/api/lib/infrastructure/serializers/jsonapi/training-trigger-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/training-trigger-serializer.js
@@ -4,26 +4,9 @@ module.exports = {
   serialize(trainingTrigger = {}, meta) {
     return new Serializer('training-triggers', {
       transform(record) {
-        return {
-          ...record,
-          triggerTubes: record.triggerTubes.map((triggerTube) => {
-            return {
-              ...triggerTube,
-              tube: { ...triggerTube.tube },
-            };
-          }),
-        };
+        return JSON.parse(JSON.stringify(record));
       },
-      attributes: ['id', 'trainingId', 'type', 'threshold', 'triggerTubes', 'areas'],
-      triggerTubes: {
-        ref: 'id',
-        included: true,
-        attributes: ['id', 'level', 'tube'],
-        tube: {
-          ref: 'id',
-          attributes: ['id', 'name', 'practicalTitle'],
-        },
-      },
+      attributes: ['id', 'trainingId', 'type', 'threshold', 'areas'],
       areas: {
         ref: 'id',
         included: true,
@@ -35,10 +18,16 @@ module.exports = {
           thematics: {
             ref: 'id',
             included: true,
-            attributes: ['name', 'index', 'trainingTriggerTubes'],
-            trainingTriggerTubes: {
+            attributes: ['name', 'index', 'triggerTubes'],
+            triggerTubes: {
               ref: 'id',
               included: true,
+              attributes: ['id', 'level', 'tube'],
+              tube: {
+                ref: 'id',
+                included: true,
+                attributes: ['id', 'name', 'practicalTitle'],
+              },
             },
           },
         },

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -323,29 +323,39 @@ describe('Acceptance | Controller | training-controller', function () {
   describe('PUT /api/admin/trainings/{trainingId}/triggers', function () {
     let learningContent;
     let tubeName;
+    let tubeId;
+    let areaId;
+    let competenceId;
+    let thematicId;
 
     beforeEach(async function () {
       tubeName = 'tube0_0';
+      tubeId = 'recTube0_0';
+      areaId = 'recArea1';
+      competenceId = 'recCompetence1';
+      thematicId = 'recThematic1';
+
       learningContent = [
         {
           areas: [
             {
-              id: 'recArea1',
-              title: 'area1_Title',
+              id: areaId,
+              titleFr: 'area1_Title',
               color: 'someColor',
               competences: [
                 {
-                  id: 'competenceId',
-                  nameFrFr: 'Mener une recherche et une veille d’information',
+                  id: competenceId,
+                  name: 'Mener une recherche et une veille d’information',
                   index: '1.1',
-                  tubes: [
+                  thematics: [
                     {
-                      id: 'recTube0_0',
-                      name: tubeName,
-                      skills: [
+                      id: thematicId,
+                      name: 'thematic1_Name',
+                      tubes: [
                         {
-                          id: 'skillWeb2Id',
-                          nom: '@web2',
+                          id: tubeId,
+                          name: tubeName,
+                          skills: [],
                         },
                       ],
                     },
@@ -370,7 +380,7 @@ describe('Acceptance | Controller | training-controller', function () {
       // given
       const superAdmin = await insertUserWithRoleSuperAdmin();
       const trainingId = databaseBuilder.factory.buildTraining().id;
-      const tube = { id: 'recTube0_0', level: 2 };
+      const tube = { tubeId: 'recTube0_0', level: 2 };
       await databaseBuilder.commit();
 
       const options = {
@@ -386,7 +396,7 @@ describe('Acceptance | Controller | training-controller', function () {
               trainingId: `${trainingId}`,
               type: 'prerequisite',
               threshold: 30,
-              tubes: [{ id: `${tube.id}`, level: `${tube.level}` }],
+              tubes: [{ tubeId: `${tube.tubeId}`, level: `${tube.level}` }],
             },
           },
         },
@@ -412,11 +422,12 @@ describe('Acceptance | Controller | training-controller', function () {
       expect(response.result.data.id).to.exist;
       expect(response.result.data.attributes.type).to.deep.equal(expectedResponse.data.attributes.type);
       expect(response.result.data.attributes.threshold).to.deep.equal(expectedResponse.data.attributes.threshold);
+      expect(response.result.included).to.exists;
       expect(response.result.included.find(({ type }) => type === 'trigger-tubes').attributes.level).to.equal(
         tube.level
       );
       const returnedTube = response.result.included.find(({ type }) => type === 'tubes').attributes;
-      expect(returnedTube.id).to.equal(tube.id);
+      expect(returnedTube.id).to.equal(tube.tubeId);
       expect(returnedTube.name).to.equal(tubeName);
     });
   });

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -136,16 +136,22 @@ describe('Integration | Repository | training-repository', function () {
       expect(result.trainingTriggers[0].id).to.deep.equal(trainingTrigger.id);
       expect(result.trainingTriggers[0].threshold).to.deep.equal(trainingTrigger.threshold);
       expect(result.trainingTriggers[0].type).to.deep.equal(trainingTrigger.type);
-      expect(result.trainingTriggers[0].triggerTubes).to.have.lengthOf(1);
-      expect(result.trainingTriggers[0].triggerTubes[0].id).to.deep.equal(trainingTriggerTube.id);
-      expect(result.trainingTriggers[0].triggerTubes[0].tube.name).to.deep.equal(tube.name);
-      expect(result.trainingTriggers[0].triggerTubes[0].level).to.deep.equal(trainingTriggerTube.level);
       expect(result.trainingTriggers[0].areas).to.have.lengthOf(1);
       expect(result.trainingTriggers[0].areas[0].id).to.equal(area1.id);
       expect(result.trainingTriggers[0].areas[0].competences).to.have.lengthOf(1);
       expect(result.trainingTriggers[0].areas[0].competences[0].id).to.equal(competence1.id);
       expect(result.trainingTriggers[0].areas[0].competences[0].thematics).to.have.lengthOf(1);
       expect(result.trainingTriggers[0].areas[0].competences[0].thematics[0].id).to.equal(thematic1.id);
+      expect(result.trainingTriggers[0].areas[0].competences[0].thematics[0].triggerTubes).to.have.lengthOf(1);
+      expect(result.trainingTriggers[0].areas[0].competences[0].thematics[0].triggerTubes[0].id).to.deep.equal(
+        trainingTriggerTube.id
+      );
+      expect(result.trainingTriggers[0].areas[0].competences[0].thematics[0].triggerTubes[0].tube.name).to.deep.equal(
+        tube.name
+      );
+      expect(result.trainingTriggers[0].areas[0].competences[0].thematics[0].triggerTubes[0].level).to.deep.equal(
+        trainingTriggerTube.level
+      );
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
@@ -1,11 +1,21 @@
-const { expect, databaseBuilder, domainBuilder, knex, mockLearningContent, sinon } = require('../../../test-helper');
+const {
+  expect,
+  databaseBuilder,
+  domainBuilder,
+  knex,
+  mockLearningContent,
+  learningContentBuilder,
+  sinon,
+} = require('../../../test-helper');
 const trainingTriggerRepository = require('../../../../lib/infrastructure/repositories/training-trigger-repository');
 const { TrainingTrigger, TrainingTriggerTube } = require('../../../../lib/domain/models');
 const _ = require('lodash');
 
 describe('Integration | Repository | training-trigger-repository', function () {
+  let learningContent;
   let tube;
   let tube1;
+  let tube2;
 
   beforeEach(async function () {
     tube = domainBuilder.buildTube({
@@ -17,7 +27,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
       practicalDescription: 'translatedPracticalDescription',
       isMobileCompliant: true,
       isTabletCompliant: true,
-      competenceId: 'recCompetence0',
+      competenceId: 'recCompA',
       thematicId: 'recThemA',
       skillIds: ['skillSuper', 'skillGenial'],
       skills: [],
@@ -31,95 +41,53 @@ describe('Integration | Repository | training-trigger-repository', function () {
       practicalDescription: 'translatedPracticalDescription',
       isMobileCompliant: true,
       isTabletCompliant: true,
-      competenceId: 'recCompetence0',
+      competenceId: 'recCompA',
       thematicId: 'recThemA',
       skillIds: ['skillSuper', 'skillGenial'],
       skills: [],
     });
-    const learningContent = {
-      areas: [
-        {
-          id: 'recAreaA',
-          title_i18n: {
-            fr: 'titleFRA',
-            en: 'titleENA',
+    tube2 = domainBuilder.buildTube({
+      id: 'recTube2',
+      name: 'tubeName2',
+      title: 'tubeTitle2',
+      description: 'tubeDescription2',
+      practicalTitle: 'translatedPracticalTitle',
+      practicalDescription: 'translatedPracticalDescription',
+      isMobileCompliant: true,
+      isTabletCompliant: true,
+      competenceId: 'recCompA',
+      thematicId: 'recThemA',
+      skillIds: ['skillSuper', 'skillGenial'],
+      skills: [],
+    });
+
+    learningContent = [
+      {
+        areas: [
+          {
+            id: 'recAreaA',
+            titleFr: 'area1_Title',
+            color: 'someColor',
+            competences: [
+              {
+                id: 'recCompA',
+                name: 'Mener une recherche et une veille d’information',
+                index: '1.1',
+                thematics: [
+                  {
+                    id: 'recThemA',
+                    name: 'thematic1_Name',
+                    tubes: [tube, tube1, tube2],
+                  },
+                ],
+              },
+            ],
           },
-          color: 'colorA',
-          code: 'codeA',
-          frameworkId: 'fmk1',
-          competenceIds: ['recCompA', 'recCompB'],
-        },
-      ],
-      competences: [
-        {
-          id: 'recCompA',
-          name_i18n: {
-            fr: 'nameFRA',
-            en: 'nameENA',
-          },
-          index: '1',
-          areaId: 'recAreaA',
-          origin: 'Pix',
-          thematicIds: ['recThemA', 'recThemB'],
-        },
-      ],
-      thematics: [
-        {
-          id: 'recThemA',
-          name_i18n: {
-            fr: 'nameFRA',
-            en: 'nameENA',
-          },
-          index: '1',
-          competenceId: 'recCompA',
-          tubeIds: ['recTube1'],
-        },
-      ],
-      tubes: [
-        {
-          id: 'recTube0',
-          name: 'tubeName',
-          title: 'tubeTitle',
-          description: 'tubeDescription',
-          practicalTitle_i18n: {
-            fr: 'translatedPracticalTitle',
-          },
-          practicalDescription_i18n: {
-            fr: 'translatedPracticalDescription',
-          },
-          isMobileCompliant: true,
-          isTabletCompliant: true,
-          competenceId: 'recCompetence0',
-          thematicId: 'recThemA',
-          skillIds: ['skillSuper', 'skillGenial'],
-        },
-        {
-          id: 'recTube1',
-          name: 'tubeName1',
-          title: 'tubeTitle1',
-          description: 'tubeDescription1',
-          practicalTitle_i18n: {
-            fr: 'translatedPracticalTitle',
-          },
-          practicalDescription_i18n: {
-            fr: 'translatedPracticalDescription',
-          },
-          isMobileCompliant: true,
-          isTabletCompliant: true,
-          competenceId: 'recCompetence0',
-          thematicId: 'recThemA',
-          skillIds: ['skillSuper', 'skillGenial'],
-        },
-      ],
-      skills: [
-        {
-          id: 'recSkillTube1',
-          tubeId: 'recTube1',
-          status: 'actif',
-        },
-      ],
-    };
-    mockLearningContent(learningContent);
+        ],
+      },
+    ];
+    const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
+    mockLearningContent(learningContentObjects);
   });
 
   describe('#createOrUpdate', function () {
@@ -131,9 +99,9 @@ describe('Integration | Repository | training-trigger-repository', function () {
     context('when trigger does not exist', function () {
       it('should create training trigger', async function () {
         // when
-        const tubes = [
-          { id: tube.id, level: 2 },
-          { id: tube1.id, level: 4 },
+        const triggerTubes = [
+          { tubeId: tube.id, level: 2 },
+          { tubeId: tube1.id, level: 4 },
         ];
         const type = TrainingTrigger.types.PREREQUISITE;
         const threshold = 20;
@@ -142,7 +110,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
 
         const createdTrainingTrigger = await trainingTriggerRepository.createOrUpdate({
           trainingId,
-          triggerTubesForCreation: tubes,
+          triggerTubesForCreation: triggerTubes,
           type,
           threshold,
         });
@@ -159,6 +127,12 @@ describe('Integration | Repository | training-trigger-repository', function () {
         expect(createdTrainingTrigger.trainingId).to.equal(trainingTrigger.trainingId);
         expect(createdTrainingTrigger.type).to.equal(trainingTrigger.type);
         expect(createdTrainingTrigger.threshold).to.equal(trainingTrigger.threshold);
+        expect(createdTrainingTrigger.areas).to.have.lengthOf(1);
+        expect(createdTrainingTrigger.areas[0].id).to.equal('recAreaA');
+        expect(createdTrainingTrigger.areas[0].competences).to.have.lengthOf(1);
+        expect(createdTrainingTrigger.areas[0].competences[0].id).to.equal('recCompA');
+        expect(createdTrainingTrigger.areas[0].competences[0].thematics).to.have.lengthOf(1);
+        expect(createdTrainingTrigger.areas[0].competences[0].thematics[0].id).to.equal('recThemA');
 
         const trainingTriggerTubes = await knex('training-trigger-tubes')
           .where({
@@ -166,7 +140,8 @@ describe('Integration | Repository | training-trigger-repository', function () {
           })
           .orderBy('tubeId', 'asc');
 
-        const createdTrainingTriggerTubes = _.sortBy(createdTrainingTrigger.triggerTubes, 'id');
+        const createdTrainingTriggerTubes = createdTrainingTrigger.areas[0].competences[0].thematics[0].triggerTubes;
+        expect(createdTrainingTriggerTubes).to.have.lengthOf(2);
         expect(createdTrainingTriggerTubes[0]).to.be.instanceOf(TrainingTriggerTube);
         expect(createdTrainingTriggerTubes[0].id).to.deep.equal(trainingTriggerTubes[0].id);
         expect(createdTrainingTriggerTubes[0].tube.id).to.deep.equal(trainingTriggerTubes[0].tubeId);
@@ -197,33 +172,35 @@ describe('Integration | Repository | training-trigger-repository', function () {
 
       it('should update it', async function () {
         // given
-        const tubes = [
-          { id: 'tubeId1', level: 2 },
-          { id: 'tubeId2', level: 4 },
+        const triggerTubes = [
+          { tubeId: 'recTube0', level: 2 },
+          { tubeId: 'recTube1', level: 4 },
         ];
 
         const trainingTrigger = databaseBuilder.factory.buildTrainingTrigger({ updatedAt: new Date('2020-01-01') });
         databaseBuilder.factory.buildTrainingTriggerTube({
           trainingTriggerId: trainingTrigger.id,
-          tubeId: tubes[0].id,
-          level: tubes[0].level,
+          tubeId: triggerTubes[0].tubeId,
+          level: triggerTubes[0].level,
         });
         databaseBuilder.factory.buildTrainingTriggerTube({
           trainingTriggerId: trainingTrigger.id,
-          tubeId: tubes[1].id,
-          level: tubes[1].level,
+          tubeId: triggerTubes[1].tubeId,
+          level: triggerTubes[1].level,
         });
         await databaseBuilder.commit();
 
-        tubes[0].level = 4;
-        tubes.push({ id: 'tubeId3', level: 6 });
+        const newTrainingTriggerTube = { tubeId: 'recTube2', level: 6 };
+
+        triggerTubes[0].level = 4;
+        triggerTubes.push(newTrainingTriggerTube);
 
         // when
         const updatedTrainingTrigger = await trainingTriggerRepository.createOrUpdate({
           threshold: 42,
           trainingId: trainingTrigger.trainingId,
           type: trainingTrigger.type,
-          triggerTubesForCreation: tubes,
+          triggerTubesForCreation: triggerTubes,
         });
 
         // then
@@ -236,9 +213,16 @@ describe('Integration | Repository | training-trigger-repository', function () {
         expect(updatedTrainingTrigger).to.be.instanceOf(TrainingTrigger);
         expect(updatedTrainingTrigger.threshold).to.equal(42);
 
-        const updatedTrainingTriggerTubes = _.sortBy(updatedTrainingTrigger.triggerTubes, 'id');
+        expect(updatedTrainingTrigger.areas).to.have.lengthOf(1);
+        expect(updatedTrainingTrigger.areas[0].competences).to.have.lengthOf(1);
+        expect(updatedTrainingTrigger.areas[0].competences[0].thematics).to.have.lengthOf(1);
+
+        const updatedTrainingTriggerTubes = _.sortBy(
+          updatedTrainingTrigger.areas[0].competences[0].thematics[0].triggerTubes,
+          'id'
+        );
+        expect(updatedTrainingTriggerTubes).to.have.lengthOf(trainingTriggerTubes.length);
         expect(updatedTrainingTriggerTubes[0].level).to.deep.equal(trainingTriggerTubes[0].level);
-        expect(updatedTrainingTriggerTubes).to.be.lengthOf(trainingTriggerTubes.length);
 
         const updatedTrainingTriggerDTO = await knex('training-triggers')
           .where({ id: updatedTrainingTrigger.id })
@@ -249,35 +233,35 @@ describe('Integration | Repository | training-trigger-repository', function () {
 
       it('should remove no longer needed tubes', async function () {
         // given
-        const tubes = [
-          { id: 'tubeId1', level: 2 },
-          { id: 'tubeId2', level: 4 },
+        const triggerTubes = [
+          { tubeId: 'recTube0', level: 2 },
+          { tubeId: 'recTube1', level: 4 },
         ];
         const trainingTrigger = databaseBuilder.factory.buildTrainingTrigger();
         databaseBuilder.factory.buildTrainingTriggerTube({
           trainingTriggerId: trainingTrigger.id,
-          tubeId: tubes[0].id,
-          level: tubes[0].level,
+          tubeId: triggerTubes[0].tubeId,
+          level: triggerTubes[0].level,
         });
         databaseBuilder.factory.buildTrainingTriggerTube({
           trainingTriggerId: trainingTrigger.id,
-          tubeId: tubes[1].id,
-          level: tubes[1].level,
+          tubeId: triggerTubes[1].tubeId,
+          level: triggerTubes[1].level,
         });
 
         const anotherTrainingTriggerId = databaseBuilder.factory.buildTrainingTrigger().id;
         const anotherTrainingTriggerTube = databaseBuilder.factory.buildTrainingTriggerTube({
           trainingTriggerId: anotherTrainingTriggerId,
-          tubeId: tubes[0].id,
-          level: tubes[0].level,
+          tubeId: triggerTubes[0].tubeId,
+          level: triggerTubes[0].level,
         });
         await databaseBuilder.commit();
 
         // when
-        tubes.pop();
+        triggerTubes.pop();
         const updatedTrainingTrigger = await trainingTriggerRepository.createOrUpdate({
           trainingId: trainingTrigger.trainingId,
-          triggerTubesForCreation: tubes,
+          triggerTubesForCreation: triggerTubes,
           type: trainingTrigger.type,
           threshold: trainingTrigger.threshold,
         });
@@ -288,7 +272,11 @@ describe('Integration | Repository | training-trigger-repository', function () {
         });
 
         expect(trainingTriggerTubes).to.have.lengthOf(1);
-        expect(updatedTrainingTrigger.triggerTubes).to.have.lengthOf(1);
+
+        expect(updatedTrainingTrigger.areas).to.have.lengthOf(1);
+        expect(updatedTrainingTrigger.areas[0].competences).to.have.lengthOf(1);
+        expect(updatedTrainingTrigger.areas[0].competences[0].thematics).to.have.lengthOf(1);
+        expect(updatedTrainingTrigger.areas[0].competences[0].thematics[0].triggerTubes).to.have.lengthOf(1);
 
         const othersTrainingTubes = await knex('training-trigger-tubes').where({ id: anotherTrainingTriggerTube.id });
         expect(othersTrainingTubes).to.have.lengthOf(1);
@@ -325,36 +313,44 @@ describe('Integration | Repository | training-trigger-repository', function () {
       expect(result[0].trainingId).to.equal(trainingTrigger.trainingId);
       expect(result[0].type).to.equal(trainingTrigger.type);
       expect(result[0].threshold).to.equal(trainingTrigger.threshold);
-      expect(result[0].triggerTubes).to.have.lengthOf(1);
-      expect(result[0].triggerTubes[0]).to.be.instanceOf(TrainingTriggerTube);
-      expect(result[0].triggerTubes[0].tube.id).to.equal(trainingTriggerTube.tubeId);
-      expect(result[0].triggerTubes[0].tube.name).to.equal(tube.name);
-      expect(result[0].triggerTubes[0].tube.practicalTitle).to.equal(tube.practicalTitle);
-      expect(result[0].triggerTubes[0].level).to.equal(trainingTriggerTube.level);
       expect(result[0].areas).to.have.lengthOf(1);
       expect(result[0].areas[0].id).to.equal('recAreaA');
       expect(result[0].areas[0].competences).to.have.lengthOf(1);
       expect(result[0].areas[0].competences[0].id).to.equal('recCompA');
       expect(result[0].areas[0].competences[0].thematics).to.have.lengthOf(1);
       expect(result[0].areas[0].competences[0].thematics[0].id).to.equal('recThemA');
+      expect(result[0].areas[0].competences[0].thematics[0].triggerTubes).to.have.lengthOf(1);
+      expect(result[0].areas[0].competences[0].thematics[0].triggerTubes[0]).to.be.instanceOf(TrainingTriggerTube);
+      expect(result[0].areas[0].competences[0].thematics[0].triggerTubes[0].tube.id).to.equal(
+        trainingTriggerTube.tubeId
+      );
+      expect(result[0].areas[0].competences[0].thematics[0].triggerTubes[0].tube.name).to.equal(tube.name);
+      expect(result[0].areas[0].competences[0].thematics[0].triggerTubes[0].tube.practicalTitle).to.equal(
+        tube.practicalTitle
+      );
+      expect(result[0].areas[0].competences[0].thematics[0].triggerTubes[0].level).to.equal(trainingTriggerTube.level);
 
       expect(result[1]).to.be.instanceOf(TrainingTrigger);
       expect(result[1].id).to.equal(trainingTrigger2.id);
       expect(result[1].trainingId).to.equal(trainingTrigger2.trainingId);
       expect(result[1].type).to.equal(trainingTrigger2.type);
       expect(result[1].threshold).to.equal(trainingTrigger2.threshold);
-      expect(result[1].triggerTubes).to.have.lengthOf(1);
-      expect(result[1].triggerTubes[0]).to.be.instanceOf(TrainingTriggerTube);
-      expect(result[1].triggerTubes[0].tube.id).to.equal(trainingTriggerTube2.tubeId);
-      expect(result[1].triggerTubes[0].tube.name).to.equal(tube1.name);
-      expect(result[1].triggerTubes[0].tube.practicalTitle).to.equal(tube1.practicalTitle);
-      expect(result[1].triggerTubes[0].level).to.equal(trainingTriggerTube2.level);
       expect(result[1].areas).to.have.lengthOf(1);
       expect(result[1].areas[0].id).to.equal('recAreaA');
       expect(result[1].areas[0].competences).to.have.lengthOf(1);
       expect(result[1].areas[0].competences[0].id).to.equal('recCompA');
       expect(result[1].areas[0].competences[0].thematics).to.have.lengthOf(1);
       expect(result[1].areas[0].competences[0].thematics[0].id).to.equal('recThemA');
+      expect(result[1].areas[0].competences[0].thematics[0].triggerTubes).to.have.lengthOf(1);
+      expect(result[1].areas[0].competences[0].thematics[0].triggerTubes[0]).to.be.instanceOf(TrainingTriggerTube);
+      expect(result[1].areas[0].competences[0].thematics[0].triggerTubes[0].tube.id).to.equal(
+        trainingTriggerTube2.tubeId
+      );
+      expect(result[1].areas[0].competences[0].thematics[0].triggerTubes[0].tube.name).to.equal(tube1.name);
+      expect(result[1].areas[0].competences[0].thematics[0].triggerTubes[0].tube.practicalTitle).to.equal(
+        tube1.practicalTitle
+      );
+      expect(result[1].areas[0].competences[0].thematics[0].triggerTubes[0].level).to.equal(trainingTriggerTube2.level);
     });
 
     it('should return empty array when no training trigger found', async function () {

--- a/api/tests/unit/application/trainings/index_test.js
+++ b/api/tests/unit/application/trainings/index_test.js
@@ -969,7 +969,7 @@ describe('Unit | Router | training-router', function () {
             trainingId: 123,
             type: 'prerequisite',
             threshold: 30,
-            tubes: [{ id: 'recTube123', level: 2 }],
+            tubes: [{ tubeId: 'recTube123', level: 2 }],
           },
         },
       };

--- a/api/tests/unit/domain/models/TrainingTrigger_test.js
+++ b/api/tests/unit/domain/models/TrainingTrigger_test.js
@@ -95,12 +95,18 @@ describe('Unit | Domain | Models | TrainingTrigger', function () {
       expect(trainingTrigger.areas[0].competences[0].thematics[0]).to.have.property('name', thematic1.name);
       expect(trainingTrigger.areas[0].competences[0].thematics[0]).to.have.property('index', thematic1.index);
       expect(trainingTrigger.areas[0].competences[0].thematics[0].triggerTubes).to.have.length(1);
-      expect(trainingTrigger.areas[0].competences[0].thematics[0].triggerTubes[0]).to.equal(trainingTriggerTube1.id);
+      expect(trainingTrigger.areas[0].competences[0].thematics[0].triggerTubes[0]).to.have.property(
+        'id',
+        trainingTriggerTube1.id
+      );
       expect(trainingTrigger.areas[0].competences[0].thematics[1]).to.have.property('id', thematic2.id);
       expect(trainingTrigger.areas[0].competences[0].thematics[1]).to.have.property('name', thematic2.name);
       expect(trainingTrigger.areas[0].competences[0].thematics[1]).to.have.property('index', thematic2.index);
       expect(trainingTrigger.areas[0].competences[0].thematics[1].triggerTubes).to.have.length(1);
-      expect(trainingTrigger.areas[0].competences[0].thematics[1].triggerTubes[0]).to.equal(trainingTriggerTube2.id);
+      expect(trainingTrigger.areas[0].competences[0].thematics[1].triggerTubes[0]).to.have.property(
+        'id',
+        trainingTriggerTube2.id
+      );
     });
   });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -103,37 +103,21 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
           },
           {
             attributes: {
-              id: 'recTube2',
-              name: '@tubeName',
-              'practical-title': 'titre pratique',
-            },
-            id: 'recTube2',
-            type: 'tubes',
-          },
-          {
-            attributes: {
-              id: 'recTrainingTriggerTube2',
-              level: 8,
-            },
-            id: 'recTrainingTriggerTube2',
-            relationships: {
-              tube: {
-                data: {
-                  id: 'recTube2',
-                  type: 'tubes',
-                },
-              },
-            },
-            type: 'trigger-tubes',
-          },
-          {
-            attributes: {
               id: 'recThematic1',
               index: 0,
               name: 'My Thematic',
-              'trigger-tubes': ['recTrainingTriggerTube1'],
             },
             id: 'recThematic1',
+            relationships: {
+              'trigger-tubes': {
+                data: [
+                  {
+                    id: 'recTrainingTriggerTube1',
+                    type: 'trigger-tubes',
+                  },
+                ],
+              },
+            },
             type: 'thematics',
           },
           {
@@ -184,18 +168,6 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
             },
             id: `${trainingTriggerId}`,
             relationships: {
-              'trigger-tubes': {
-                data: [
-                  {
-                    id: 'recTrainingTriggerTube1',
-                    type: 'trigger-tubes',
-                  },
-                  {
-                    id: 'recTrainingTriggerTube2',
-                    type: 'trigger-tubes',
-                  },
-                ],
-              },
               areas: {
                 data: [
                   {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-trigger-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-trigger-serializer_test.js
@@ -50,18 +50,6 @@ describe('Unit | Serializer | JSONAPI | training-trigger-serializer', function (
           },
           id: `${id}`,
           relationships: {
-            'trigger-tubes': {
-              data: [
-                {
-                  id: 'recTrainingTriggerTube1',
-                  type: 'trigger-tubes',
-                },
-                {
-                  id: 'recTrainingTriggerTube2',
-                  type: 'trigger-tubes',
-                },
-              ],
-            },
             areas: {
               data: [
                 {
@@ -101,33 +89,13 @@ describe('Unit | Serializer | JSONAPI | training-trigger-serializer', function (
           },
           {
             attributes: {
-              id: 'recTube2',
-              name: '@tubeName',
-              'practical-title': 'titre pratique',
-            },
-            id: 'recTube2',
-            type: 'tubes',
-          },
-          {
-            attributes: {
-              id: 'recTrainingTriggerTube2',
-              level: 8,
-            },
-            id: 'recTrainingTriggerTube2',
-            relationships: {
-              tube: {
-                data: {
-                  id: 'recTube2',
-                  type: 'tubes',
-                },
-              },
-            },
-            type: 'trigger-tubes',
-          },
-          {
-            attributes: {
               index: 0,
               name: 'My Thematic',
+            },
+            relationships: {
+              'trigger-tubes': {
+                data: [{ id: 'recTrainingTriggerTube1', type: 'trigger-tubes' }],
+              },
             },
             id: 'recThematic1',
             type: 'thematics',


### PR DESCRIPTION
## :unicorn: Problème

Jusqu'à présent, si un déclencheur de contenu formatif existe, on affiche simplement un message pour l'indiquer.

## :robot: Proposition

On souhaite afficher le détail complet des sujets et leur niveau permettant de déclencher l'affichage du contenu formatif.

## :100: Pour tester

- [Aller sur la RA](https://admin-pr5813.review.pix.fr/)
- Dans un contenu formatif, ajouter un déclencheur
- Recharger la page
- Visualiser le détail de ce déclencheur
