### PR TITLE
[FEATURE] Gérer un message d'erreur spécifique si l'utilisateur rédemarre une certification avec un autre compte (PIX-6874)

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -742,7 +742,11 @@ class MissingUserAccountError extends DomainError {
 }
 
 class UnexpectedUserAccountError extends DomainError {
-  constructor({ message = "Ce compte utilisateur n'est pas celui qui est attendu.", code, meta }) {
+  constructor({
+    message = "Ce compte utilisateur n'est pas celui qui est attendu.",
+    code = 'UNEXPECTED_USER_ACCOUNT',
+    meta,
+  }) {
     super(message);
     this.code = code;
     this.meta = meta;

--- a/api/lib/domain/usecases/authenticate-external-user.js
+++ b/api/lib/domain/usecases/authenticate-external-user.js
@@ -33,7 +33,6 @@ async function authenticateExternalUser({
 
       throw new UnexpectedUserAccountError({
         message: undefined,
-        code: 'UNEXPECTED_USER_ACCOUNT',
         meta: { value: authenticationMethod.value },
       });
     }

--- a/api/lib/domain/usecases/link-user-to-session-certification-candidate.js
+++ b/api/lib/domain/usecases/link-user-to-session-certification-candidate.js
@@ -1,12 +1,12 @@
 const _ = require('lodash');
 const CertificationCandidate = require('../models/CertificationCandidate.js');
 const {
-  CertificationCandidateAlreadyLinkedToUserError,
   CertificationCandidateByPersonalInfoNotFoundError,
   MatchingReconciledStudentNotFoundError,
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   UserAlreadyLinkedToCandidateInSessionError,
   SessionNotAccessible,
+  UnexpectedUserAccountError,
 } = require('../errors.js');
 const UserLinkedToCertificationCandidate = require('../events/UserLinkedToCertificationCandidate.js');
 const UserAlreadyLinkedToCertificationCandidate = require('../events/UserAlreadyLinkedToCertificationCandidate.js');
@@ -67,7 +67,7 @@ module.exports = async function linkUserToSessionCertificationCandidate({
   if (certificationCandidate.isLinkedToUserId(userId)) {
     return new UserAlreadyLinkedToCertificationCandidate();
   } else {
-    throw new CertificationCandidateAlreadyLinkedToUserError();
+    throw new UnexpectedUserAccountError({});
   }
 };
 

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -43,9 +43,7 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
   });
 
   if (!certificationCandidate) {
-    throw new UnexpectedUserAccountError({
-      code: 'UNEXPECTED_USER_ACCOUNT',
-    });
+    throw new UnexpectedUserAccountError({});
   }
 
   const existingCertificationCourse =

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -7,6 +7,7 @@ const {
   SessionNotAccessible,
   CandidateNotAuthorizedToJoinSessionError,
   CandidateNotAuthorizedToResumeCertificationTestError,
+  UnexpectedUserAccountError,
 } = require('../errors.js');
 const { features } = require('../../config.js');
 const bluebird = require('bluebird');
@@ -40,6 +41,12 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
     userId,
     sessionId,
   });
+
+  if (!certificationCandidate) {
+    throw new UnexpectedUserAccountError({
+      code: 'UNEXPECTED_USER_ACCOUNT',
+    });
+  }
 
   const existingCertificationCourse =
     await certificationCourseRepository.findOneCertificationCourseByUserIdAndSessionId({

--- a/api/scripts/data-generation/generate-certif-cli.js
+++ b/api/scripts/data-generation/generate-certif-cli.js
@@ -7,7 +7,7 @@ const bluebird = require('bluebird');
 const maxBy = require('lodash/maxBy');
 const logger = require('../../lib/infrastructure/logger');
 const { getNewSessionCode } = require('../../lib/domain/services/session-code-service');
-const temporaryStorage = require('../../lib/infrastructure/temporary-storage/index');
+const { temporaryStorage } = require('../../lib/infrastructure/temporary-storage/index');
 const {
   makeUserPixCertifiable,
   makeUserPixDroitCertifiable,
@@ -17,7 +17,7 @@ const {
 const DatabaseBuilder = require('../../db/database-builder/database-builder');
 const databaseBuffer = require('../../db/database-builder/database-buffer');
 const databaseBuilder = new DatabaseBuilder({ knex, emptyFirst: false });
-const { cache } = require('../../lib/infrastructure/caches/learning-content-cache');
+const { learningContentCache } = require('../../lib/infrastructure/caches/learning-content-cache');
 const { SHARED } = require('../../lib/domain/models/CampaignParticipationStatuses');
 
 /**
@@ -427,7 +427,7 @@ async function _disconnect() {
   logger.info('Closing connexions to PG...');
   await disconnect();
   logger.info('Closing connexions to cache...');
-  await cache.quit();
+  await learningContentCache.quit();
   await temporaryStorage.quit();
   logger.info('Exiting process gracefully...');
 }

--- a/api/tests/acceptance/application/session/session-controller-create-certification-candidate-participation_test.js
+++ b/api/tests/acceptance/application/session/session-controller-create-certification-candidate-participation_test.js
@@ -12,10 +12,10 @@ describe('Acceptance | Controller | session-controller-create-certification-cand
   describe('#createCandidateParticipation', function () {
     let options;
     let payload;
-    let userId;
+    const userId = 99;
 
     beforeEach(function () {
-      userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildUser({ id: userId });
       options = {
         method: 'POST',
         url: '/api/sessions/1/candidate-participation',
@@ -250,21 +250,23 @@ describe('Acceptance | Controller | session-controller-create-certification-cand
 
           context('when the candidate is linked to the another user than the requesting user', function () {
             beforeEach(function () {
+              databaseBuilder.factory.buildUser({ id: 101 });
               databaseBuilder.factory.buildCertificationCandidate({
                 firstName: 'José',
                 lastName: 'Bové',
                 birthdate: '2000-01-01',
                 sessionId,
+                userId: 101,
               });
               return databaseBuilder.commit();
             });
 
-            it('should respond with 403 forbidden', async function () {
+            it('should respond with 409 wrong account status code', async function () {
               // when
               const response = await server.inject(options);
 
               // then
-              expect(response.statusCode).to.equal(403);
+              expect(response.statusCode).to.equal(409);
             });
           });
         });

--- a/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
@@ -1,12 +1,12 @@
 const { catchErr, expect, sinon, domainBuilder } = require('../../../test-helper');
 const linkUserToSessionCertificationCandidate = require('../../../../lib/domain/usecases/link-user-to-session-certification-candidate');
 const {
-  CertificationCandidateAlreadyLinkedToUserError,
   CertificationCandidateByPersonalInfoNotFoundError,
   MatchingReconciledStudentNotFoundError,
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   UserAlreadyLinkedToCandidateInSessionError,
   SessionNotAccessible,
+  UnexpectedUserAccountError,
 } = require('../../../../lib/domain/errors');
 const UserLinkedToCertificationCandidate = require('../../../../lib/domain/events/UserLinkedToCertificationCandidate');
 const UserAlreadyLinkedToCertificationCandidate = require('../../../../lib/domain/events/UserAlreadyLinkedToCertificationCandidate');
@@ -190,7 +190,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
               });
 
               // then
-              expect(err).to.be.instanceOf(CertificationCandidateAlreadyLinkedToUserError);
+              expect(err).to.be.instanceOf(UnexpectedUserAccountError);
             });
           });
         });

--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -14,6 +14,10 @@ function _isMatchingReconciledStudentNotFoundError(err) {
   return _get(err, 'errors[0].code') === 'MATCHING_RECONCILED_STUDENT_NOT_FOUND';
 }
 
+function _isWrongAccount(err) {
+  return _get(err, 'errors[0].status') === '409' && _get(err, 'errors[0].code') === 'UNEXPECTED_USER_ACCOUNT';
+}
+
 function _isSessionNotAccessibleError(err) {
   return _get(err, 'errors[0].status') === '412';
 }
@@ -106,11 +110,13 @@ export default class CertificationJoiner extends Component {
       }
 
       if (_isMatchingReconciledStudentNotFoundError(err)) {
-        this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.wrong-account');
+        this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.wrong-account-sco');
         this.errorMessageLink = {
-          label: this.intl.t('pages.certification-joiner.error-messages.wrong-account-link'),
+          label: this.intl.t('pages.certification-joiner.error-messages.wrong-account-sco-link'),
           url: 'https://support.pix.org/fr/support/solutions/articles/15000047880',
         };
+      } else if (_isWrongAccount(err)) {
+        this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.wrong-account');
       } else if (_isSessionNotAccessibleError(err)) {
         this.errorMessage = this.intl.t('pages.certification-joiner.error-messages.session-not-accessible');
       } else {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -275,8 +275,9 @@
           "check-personal-info": "Check with the invigilator that your personal information matches the sign-in sheet."
         },
         "session-not-accessible": "The session you are trying to join is no longer available.",
-        "wrong-account": "You are currently using an account that is not linked to your school/organisation.\nLog in to the account you used to complete your customised tests or ask the invigilator for help.",
-        "wrong-account-link": "How to find the account linked to the school/organisation ?"
+        "wrong-account": "The information entered matches a candidate enrolled in the session and already logged in with another account. Please check that you are logged into the account that started the exam.",
+        "wrong-account-sco": "You are currently using an account that is not linked to your school/organisation.\nLog in to the account you used to complete your customised tests or ask the invigilator for help.",
+        "wrong-account-sco-link": "How to find the account linked to the school/organisation ?"
       },
       "first-title": "Join a session",
       "form": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -275,8 +275,9 @@
           "check-personal-info": "Vérifiez auprès du surveillant la correspondance de vos informations personnelles avec la feuille d'émargement."
         },
         "session-not-accessible": "La session que vous tentez de rejoindre n'est plus accessible.",
-        "wrong-account": "Vous utilisez actuellement un compte qui n'est pas lié à votre établissement.\nConnectez vous au compte avec lequel vous avez effectué vos parcours ou demandez de l'aide au surveillant.",
-        "wrong-account-link": "Comment trouver le compte lié à l'établissement ?"
+        "wrong-account": "Les informations saisies correspondent à un.e candidat.e inscrit.e à la session et déjà connecté.e avec un autre compte. Vérifiez que vous êtes connecté.e au compte qui a démarré la certification.",
+        "wrong-account-sco": "Vous utilisez actuellement un compte qui n'est pas lié à votre établissement.\nConnectez vous au compte avec lequel vous avez effectué vos parcours ou demandez de l'aide au surveillant.",
+        "wrong-account-sco-link": "Comment trouver le compte lié à l'établissement ?"
       },
       "first-title": "Rejoindre une session",
       "form": {


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'utilisateur démarre une certification, puis reviens avec un autre compte. Il n'y a pas de message spécifique

![Screenshot 2023-03-15 at 10 29 35](https://user-images.githubusercontent.com/3769147/225321859-0ddac479-7201-4f40-bdfb-f481396b6e9a.png)

## :robot: Proposition
Afficher un message specifique

## :rainbow: Remarques
Le ticket porte sur le probleme de redemarrage de certification avec le mauvais compte mais qui arrive à la 2nde etape de l'inscription

![Screenshot 2023-03-15 at 11 02 38](https://user-images.githubusercontent.com/3769147/225322289-eb8b08a1-eaf6-4a0c-ba74-eeefe5bac9af.png)

On leve maintenant une exception pour le logging mais nous n'avons pas pu reproduire le problème fonctionnellement


## :100: Pour tester
Rentrer les information pour demarrer une certification avec certif1@example.net
Se connecter  avec certif2@example.net, demarrer la meme certification et se rendre compte du message d'erreur
