### PR TITLE
[FEATURE] Traduction de la page Equipe de Pix Certif (PIX-6682).

### DIFF
--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -430,9 +430,9 @@
       }
     },
     "team": {
-      "title": "Équipe",
-      "last-name": "Nom",
-      "first-name": "Prénom",
+      "title": "Team",
+      "last-name": "Last name",
+      "first-name": "First name",
       "referer": "Référent",
       "pix-referer": "Référent Pix",
       "update-referer-button": "Changer de référent",


### PR DESCRIPTION
## :unicorn: Problème
On souhaite traduire l'ensemble de l'application Pix Certif, on s'occupe ici de la page Equipe.

## :robot: Proposition
Traduire les champs suivants : Equipe, Nom, Prénom.
On laisse de côté la partie concernant les référents de centres de certif qui seront faits dans un ticket suivant : https://1024pix.atlassian.net/browse/PIX-6683

## :rainbow: Remarques
C'est court mais c'est pas plus mal.

## :100: Pour tester
- Lancer Pix Certif
- Utiliser l'extension .org puis rajouter ?lang=en à la fin de l'URL pour basculer l'application en anglais.
- Aller sur la page Team
- Constater que le titre de la page, le Nom et le Prénom sont traduits par Team, Last Name et First Name.