### PR TITLE
[FEATURE] Traduire la page de modification de session (PIX-6674).

### DIFF
--- a/certif/app/controllers/authenticated/sessions/update.js
+++ b/certif/app/controllers/authenticated/sessions/update.js
@@ -7,9 +7,10 @@ import { inject as service } from '@ember/service';
 export default class SessionsUpdateController extends Controller {
   @alias('model') session;
   @service router;
+  @service intl;
 
   get pageTitle() {
-    return "Modification d'une session | Session ${this.session.id} | Pix Certif";
+    return `${this.intl.t('pages.sessions.update.page-title')} | Session ${this.session.id} | Pix Certif`;
   }
 
   @action

--- a/certif/app/templates/authenticated/sessions/update.hbs
+++ b/certif/app/templates/authenticated/sessions/update.hbs
@@ -1,18 +1,16 @@
 {{page-title this.pageTitle replace=true}}
 <div>
-  <h1 class="page__title page-title">Modification d'une session de certification</h1>
+  <h1 class="page__title page-title">{{t "pages.sessions.update.title"}}</h1>
 
   <form {{on "submit" this.updateSession}} class="session-form">
     <p class="session-form__mandatory-information">
-      Les champs marqués de
-      <abbr title="obligatoire" class="mandatory-mark">*</abbr>
-      sont obligatoires.
+      {{t "pages.sessions.new.required-fields" htmlSafe=true}}
     </p>
 
     <div class="session-form__field">
       <label for="session-address" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        Nom du site
+        {{t "pages.sessions.update.address"}}
       </label>
       <Input
         id="session-address"
@@ -32,7 +30,7 @@
     <div class="session-form__field">
       <label for="session-room" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        Nom de la salle
+        {{t "pages.sessions.update.room"}}
       </label>
       <Input
         id="session-room"
@@ -52,7 +50,7 @@
     <div class="session-form__field">
       <label for="session-date" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        Date de début
+        {{t "pages.sessions.update.date"}}
       </label>
       <EmberFlatpickr
         id="session-date"
@@ -75,7 +73,7 @@
     <div class="session-form__field">
       <label for="session-time" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        Heure de début (heure locale)
+        {{t "pages.sessions.update.time"}}
       </label>
       <EmberFlatpickr
         id="session-time"
@@ -100,7 +98,7 @@
     <div class="session-form__field">
       <label for="session-examiner" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        Surveillant(s)
+        {{t "pages.sessions.update.examiner"}}
       </label>
       <Input
         id="session-examiner"
@@ -118,7 +116,7 @@
     </div>
 
     <div class="session-form__field">
-      <label for="session-description" class="label">Observations</label>
+      <label for="session-description" class="label">{{t "pages.sessions.update.description"}}</label>
       <Textarea
         id="session-description"
         name="session-description"
@@ -136,14 +134,14 @@
           @triggerAction={{this.cancel}}
           @backgroundColor="transparent-light"
           @isBorderVisible="true"
-          aria-label="Annuler la modification de la session et retourner vers la page précédente"
+          aria-label={{t "pages.sessions.update.actions.cancel-extra-information"}}
         >
           {{t "common.actions.cancel"}}
         </PixButton>
       </li>
       <li>
         <PixButton @type="submit">
-          Modifier la session
+          {{t "pages.sessions.update.actions.edit-session"}}
         </PixButton>
       </li>
     </ul>

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -403,6 +403,21 @@
         "required-fields": "The fields marked by <abbr title=\"required\" class=\"mandatory-mark\">*</abbr> are required.",
         "room": "Room name",
         "time": "Starting time (local time)"
+      },
+      "update": {
+        "title": "Certification session change",
+        "actions": {
+          "cancel-extra-information": "Cancel the session change and return to the previous page",
+          "edit-session": "Edit the session"
+        },
+        "address": "Location name",
+        "date": "Starting date",
+        "description": "Observations",
+        "examiner": "Invigilator(s)",
+        "page-title": "Certification session change",
+        "required-fields": "The fields marked by <abbr title=\"required\" class=\"mandatory-mark\">*</abbr> are required.",
+        "room": "Room name",
+        "time": "Starting time (local time)"
       }
     },
     "session-supervising": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -398,7 +398,21 @@
         "required-fields": "Les champs marqués de <abbr title=\"obligatoire\" class=\"mandatory-mark\">*</abbr> sont obligatoires.",
         "room": "Nom de la salle",
         "time": "Heure de début (heure locale)"
-      }
+      },
+      "update": {
+        "title": "Modification d'une session de certification",
+        "actions": {
+          "cancel-extra-information": "Annuler la modification de la session et retourner vers la page précédente",
+          "edit-session": "Modifier la session"
+        },
+        "address": "Nom du site",
+        "date": "Date de début",
+        "description": "Observations",
+        "examiner": "Surveillant(s)",
+        "page-title": "Modification d'une session de certification",
+        "required-fields": "Les champs marqués de <abbr title=\"obligatoire\" class=\"mandatory-mark\">*</abbr> sont obligatoires.",
+        "room": "Nom de la salle",
+        "time": "Heure de début (heure locale)"}
     },
     "session-supervising": {
       "header": {


### PR DESCRIPTION
## :unicorn: Problème
On souhaite traduire l'ensemble de l'application Pix Certif, on s'occupe ici de la page de modification de session.

## :robot: Proposition
Traduire la page de “Modification d’une session de certification” en anglais :
- Modification d'une session de certification : Certification session change
- Les champs marqués de * sont obligatoires. : The fields marked by * are required.
- Nom du site : Location name
- Nom de la salle : Room name
- Date de début : Starting date
- Heure de début (heure locale) : Starting time (local time)
- Surveillant(s) : Invigilator(s)
- Observations : Observations
- Annuler : Cancel
- Modifier la session : Edit the session

## :100: Pour tester
- Lancer Pix Certif.
- Utiliser l'extension .org puis rajouter ?lang=en à la fin de l'URL pour basculer l'application en anglais.
- Aller sur la page de modification d'une session existante.
- Constater que les champs sont traduits.