### PR TITLE
[FEATURE] Améliorer l'accessibilité de la page de détail d'un participant et d'une campagne (PIX-6899)

### DIFF
--- a/orga/app/components/campaign/charts/participants-by-status.hbs
+++ b/orga/app/components/campaign/charts/participants-by-status.hbs
@@ -31,6 +31,7 @@
       {{/each}}
     </ul>
 
+    <h2 class="screen-reader-only">{{t "charts.participants-by-status.a11y-title"}}</h2>
     <ul class="screen-reader-only">
       {{#each this.datasets as |dataset|}}
         <li>{{dataset.a11y}}</li>

--- a/orga/app/components/organization-learner/activity/participation-row.hbs
+++ b/orga/app/components/organization-learner/activity/participation-row.hbs
@@ -12,10 +12,10 @@
     <OrganizationLearner::Activity::CampaignType @campaignType={{@participation.campaignType}} />
   </td>
   <td class="table__column--left">
-    <Ui::Date @date="{{@participation.createdAt}}" />
+    <Ui::Date @date={{@participation.createdAt}} />
   </td>
   <td class="table__column--left">
-    <Ui::Date @date="{{@participation.sharedAt}}" />
+    <Ui::Date @date={{@participation.sharedAt}} />
   </td>
   <td class="table__column--left">
     <Ui::ParticipationStatus @status={{@participation.status}} @campaignType={{@participation.campaignType}} />

--- a/orga/app/components/ui/date.hbs
+++ b/orga/app/components/ui/date.hbs
@@ -1,1 +1,6 @@
-{{if @date (dayjs-format @date "DD/MM/YYYY") "–"}}
+{{#if @date}}
+  {{dayjs-format @date "DD/MM/YYYY"}}
+{{else}}
+  <span aria-hidden="true">-</span>
+  <span class="screen-reader-only">{{t "components.date.no-date"}}</span>
+{{/if}}

--- a/orga/app/templates/authenticated/organization-participants/organization-participant.hbs
+++ b/orga/app/templates/authenticated/organization-participants/organization-participant.hbs
@@ -3,7 +3,11 @@
     <Ui::PreviousPageButton
       @route="authenticated.organization-participants"
       @backButtonAriaLabel={{t "common.actions.back"}}
-      aria-label={{t "pages.organization-learner.header.aria-label-title"}}
+      aria-label={{t
+        "pages.organization-learner.header.aria-labe-title"
+        firstName=@model.firstName
+        lastName=@model.lastName
+      }}
       class="learner-header-title"
     >
       {{t "common.fullname" firstName=@model.firstName lastName=@model.lastName}}

--- a/orga/app/templates/authenticated/sco-organization-participants/sco-organization-participant.hbs
+++ b/orga/app/templates/authenticated/sco-organization-participants/sco-organization-participant.hbs
@@ -3,7 +3,11 @@
     <Ui::PreviousPageButton
       @route="authenticated.sco-organization-participants"
       @backButtonAriaLabel={{t "common.actions.back"}}
-      aria-label={{t "pages.organization-learner.header.aria-label-title"}}
+      aria-label={{t
+        "pages.organization-learner.header.aria-label-title"
+        firstName=@model.organizationLearner.firstName
+        lastName=@model.organizationLearner.lastName
+      }}
       class="learner-header-title"
     >
       {{t

--- a/orga/app/templates/authenticated/sup-organization-participants/sup-organization-participant.hbs
+++ b/orga/app/templates/authenticated/sup-organization-participants/sup-organization-participant.hbs
@@ -3,7 +3,11 @@
     <Ui::PreviousPageButton
       @route="authenticated.sup-organization-participants"
       @backButtonAriaLabel={{t "common.actions.back"}}
-      aria-label={{t "pages.organization-learner.header.aria-label-title"}}
+      aria-label={{t
+        "pages.organization-learner.header.aria-label-title"
+        firstName=@model.firstName
+        lastName=@model.lastName
+      }}
       class="learner-header-title"
     >
       {{t "common.fullname" firstName=@model.firstName lastName=@model.lastName}}

--- a/orga/tests/integration/components/ui/date_test.js
+++ b/orga/tests/integration/components/ui/date_test.js
@@ -17,9 +17,9 @@ module('Integration | Component | Ui | Date', function (hooks) {
 
   test('it should display a dash if no date is given', async function (assert) {
     // when
-    await render(hbs`<Ui::Date />`);
+    const screen = await render(hbs`<Ui::Date />`);
 
     // then
-    assert.contains('–');
+    assert.dom(screen.getByText(this.intl.t('components.date.no-date'))).exists();
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -675,7 +675,7 @@
         "title": "Activity",
         "assessment-summary": "Customised tests participations summary",
         "profile-collection-summary": "Profile collection participations summary",
-        "participations-title": "Participations",
+        "participations-title": "List of all the participations",
         "participation-list": {
           "table": {
             "column": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -694,7 +694,7 @@
         }
       },
       "header": {
-        "aria-label-title": "Participant's name"
+        "aria-label-title": "Detail page of {firstName} {lastName}"
       }
     },
     "organization-participants": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1165,6 +1165,9 @@
     }
   },
   "components": {
+    "date":{
+      "no-date": "No date yet"
+    },
     "participation-status": {
       "STARTED-ASSESSMENT": "In progress",
       "TO_SHARE-ASSESSMENT": "Pending results",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -673,7 +673,7 @@
         },
         "empty-state": "No activity yet. As soon as {organizationLearnerFirstName} {organizationLearnerLastName} participates in a campaign, you will be able to follow their progress here.",
         "title": "Activity",
-        "assessment-summary": "Assessment participations summary",
+        "assessment-summary": "Customised tests participations summary",
         "profile-collection-summary": "Profile collection participations summary",
         "participations-title": "Participations",
         "participation-list": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -121,7 +121,8 @@
         "shared-profile-tooltip": "Submitted profiles: These participants have submitted their profiles."
       },
       "loader": "Loading statuses distribution",
-      "title": "Statuses"
+      "title": "Statuses",
+      "a11y-title": "Detail by participation status"
     },
     "participants-by-day": {
       "labels-a11y": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -694,7 +694,7 @@
         }
       },
       "header": {
-        "aria-label-title": "Nom du participant"
+        "aria-label-title": "Page de détail de {firstName} {lastName}"
       }
     },
     "organization-participants": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -121,7 +121,8 @@
         "shared-profile-tooltip": "Profils reçus : Ces participants ont envoyé leurs profils."
       },
       "loader": "Chargement des proportions par statut",
-      "title": "Statuts"
+      "title": "Statuts",
+      "screen-reader-only-title": "Détail par statut"
     },
     "participants-by-day": {
       "labels-a11y": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -673,8 +673,8 @@
         },
         "empty-state": "Aucune activité pour l’instant ! Envoyez une campagne à {organizationLearnerFirstName} {organizationLearnerLastName} et commencez à suivre sa progression.",
         "title": "Activité",
-        "assessment-summary": "Résumé des participations aux campagnes d'évaluation",
-        "profile-collection-summary": "Résumé des participations aux campagnes de collection de profil",
+        "assessment-summary": "Récapitulatif des participations aux campagnes d'évaluation",
+        "profile-collection-summary": "Récapitulatif des participations aux campagnes de collecte de profil",
         "participations-title": "Participations",
         "participation-list": {
           "table": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1165,6 +1165,9 @@
     }
   },
   "components": {
+    "date":{
+      "no-date": "Pas encore de date"
+    },
     "participation-status": {
       "STARTED-ASSESSMENT": "En cours",
       "TO_SHARE-ASSESSMENT": "En attente d'envoi",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -675,7 +675,7 @@
         "title": "Activité",
         "assessment-summary": "Récapitulatif des participations aux campagnes d'évaluation",
         "profile-collection-summary": "Récapitulatif des participations aux campagnes de collecte de profil",
-        "participations-title": "Participations",
+        "participations-title": "Liste de toutes les participations",
         "participation-list": {
           "table": {
             "column": {


### PR DESCRIPTION
## :unicorn: Problème
L'ensemble des informations présentent dans ces deux pages ne sont pas accessibles à l'ensemble des utilisateurs. EN effet, les utilisateurs de lecteurs d'écran ne peuvent lire une partie de ce qui se trouve sur leur écran.

## :robot: Proposition
- [x] Mettre un aria label plus complet sur le H1 : “Nom du participant” → “Page de détail de <Prénom><Nom>”

- [x] Changer dans toute la page “Résumé des participations” en “Récapitulatif des participations” et “collection de profil” en “collecte de profil”

- [x] Ajouter un aria-label sur le titre (dt) du composant IndicatorCard. Pour ici positionner “Total des participations aux campagnes d'évaluation” (/”collecte de profils”).

- [x] Sur la liste du détail des stats par statut, mettre une description : “Détail par statut”

- [x] Modifier le h2 “participations” en “Liste de toutes les participations”

- [x] Sur les dates, ajouter une texte personnalisable quand il n’y a pas de date → @Arnaud de Coninck Texte à déterminer ici.

## :rainbow: Remarques
RAS

## :100: Pour tester
- Se connecter à Pix Orga
- Se rendre sur la page de détail d'une campagne
- Vérifier ce que lit le lecteur d'écran
- Se rendre sur la page de détail d'un utilisateur
- Vérifier tout ce qui se trouve dans la catégorie "Proposition" ci-dessus.