### PR TITLE
[FEATURE] Affichages des erreurs bloquantes lors de l'import de session en masse (PIX-7412)

### DIFF
--- a/api/lib/domain/constants/certification-candidates-errors.js
+++ b/api/lib/domain/constants/certification-candidates-errors.js
@@ -15,6 +15,10 @@ module.exports.CERTIFICATION_CANDIDATES_ERRORS = {
     code: 'CANDIDATE_BILLING_MODE_REQUIRED',
     getMessage: () => '',
   },
+  CANDIDATE_BILLING_MODE_MUST_BE_EMPTY: {
+    code: 'CANDIDATE_BILLING_MODE_MUST_BE_EMPTY',
+    getMessage: () => '',
+  },
   CANDIDATE_BIRTHDATE_REQUIRED: {
     code: 'CANDIDATE_BIRTHDATE_REQUIRED',
     getMessage: () => '',

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -117,11 +117,14 @@ const certificationCandidateValidationForMassImportJoiSchema = Joi.object({
         'string.base': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_MUST_BE_A_STRING.code,
         'any.only': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_NOT_VALID.code,
       }),
+    otherwise: Joi.valid(null).messages({
+      'any.only': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_MUST_BE_EMPTY.code,
+    }),
   }),
   prepaymentCode: Joi.when('billingMode', {
     is: 'PREPAID',
     then: Joi.string().required().empty(['', null]).messages({
-      'string.empty': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_REQUIRED.code,
+      'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_REQUIRED.code,
     }),
     otherwise: Joi.valid(null).messages({
       'any.only': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY.code,

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -395,11 +395,10 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
     context('when all required fields are presents', function () {
       it('should return nothing', function () {
         // given
-        const isSco = true;
         const certificationCandidate = buildCertificationCandidate(validAttributes);
 
         // when
-        const report = certificationCandidate.validateForMassSessionImport(isSco);
+        const report = certificationCandidate.validateForMassSessionImport();
 
         // then
         expect(report).to.be.undefined;
@@ -419,7 +418,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         const certificationCandidate = buildCertificationCandidate({ ...validAttributes, [field]: undefined });
 
         // when
-        const report = certificationCandidate.validateForMassSessionImport({ line: 1 });
+        const report = certificationCandidate.validateForMassSessionImport();
 
         // then
         expect(report).to.deep.equal([`${expectedCode}`]);
@@ -430,7 +429,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         const certificationCandidate = buildCertificationCandidate({ ...validAttributes, [field]: null });
 
         // when
-        const report = certificationCandidate.validateForMassSessionImport({});
+        const report = certificationCandidate.validateForMassSessionImport();
 
         // then
         expect(report).to.deep.equal([expectedCode]);
@@ -442,9 +441,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       const certificationCandidate = buildCertificationCandidate({ ...validAttributes, birthdate: '2020/02/01' });
 
       // when
-      const report = certificationCandidate.validateForMassSessionImport({
-        isSco: true,
-      });
+      const report = certificationCandidate.validateForMassSessionImport();
 
       // then
       expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_FORMAT_INCORRECT.code]);
@@ -455,10 +452,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       const certificationCandidate = buildCertificationCandidate({ ...validAttributes, birthdate: null });
 
       // when
-      const report = certificationCandidate.validateForMassSessionImport({
-        isSco: true,
-        line: 1,
-      });
+      const report = certificationCandidate.validateForMassSessionImport();
 
       // then
       expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_REQUIRED.code]);
@@ -472,10 +466,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
       });
 
       // when
-      const report = certificationCandidate.validateForMassSessionImport({
-        isSco: true,
-        line: 1,
-      });
+      const report = certificationCandidate.validateForMassSessionImport();
 
       //then
       expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_PERCENTAGE_REQUIRED.code]);
@@ -486,9 +477,8 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         ...validAttributes,
         extraTimePercentage: 101,
       });
-      const isSco = true;
 
-      const report = certificationCandidate.validateForMassSessionImport(isSco);
+      const report = certificationCandidate.validateForMassSessionImport();
 
       // then
       expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_BELOW_ONE.code]);
@@ -499,9 +489,8 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         ...validAttributes,
         extraTimePercentage: 0,
       });
-      const isSco = true;
 
-      const report = certificationCandidate.validateForMassSessionImport(isSco);
+      const report = certificationCandidate.validateForMassSessionImport();
 
       // then
       expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EXTRA_TIME_BELOW_ONE.code]);
@@ -509,11 +498,10 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
     it('should return a report when sex is neither M nor F', async function () {
       // given
-      const isSco = true;
       const certificationCandidate = buildCertificationCandidate({ ...validAttributes, sex: 'something_else' });
 
       // when
-      const report = certificationCandidate.validateForMassSessionImport(isSco);
+      const report = certificationCandidate.validateForMassSessionImport();
 
       // then
       expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SEX_NOT_VALID.code]);
@@ -521,11 +509,10 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
     it('should return a report when sex is null', async function () {
       // given
-      const isSco = true;
       const certificationCandidate = buildCertificationCandidate({ ...validAttributes, sex: null });
 
       // when
-      const report = certificationCandidate.validateForMassSessionImport(isSco);
+      const report = certificationCandidate.validateForMassSessionImport();
 
       // then
       expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SEX_REQUIRED.code]);
@@ -533,15 +520,13 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
     it('should return a report when a candidate is added with multiple complementary certifications', async function () {
       // given
-      const isSco = true;
-
       const certificationCandidate = buildCertificationCandidate({
         ...validAttributes,
         complementaryCertifications: [Symbol('1'), Symbol('2')],
       });
 
       // when
-      const report = certificationCandidate.validateForMassSessionImport(isSco);
+      const report = certificationCandidate.validateForMassSessionImport();
 
       // then
       expect(report).to.deep.equal([
@@ -564,6 +549,23 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
 
           // then
           expect(report).to.be.undefined;
+        });
+      });
+
+      context('when the billing mode is not null', function () {
+        it('should return a report', async function () {
+          // given
+          const certificationCandidate = domainBuilder.buildCertificationCandidate({
+            ...validAttributes,
+            billingMode: 'FREE',
+          });
+          const isSco = true;
+
+          // when
+          const report = certificationCandidate.validateForMassSessionImport(isSco);
+
+          // then
+          expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BILLING_MODE_MUST_BE_EMPTY.code]);
         });
       });
     });
@@ -608,7 +610,6 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         ['FREE', 'PAID', 'PREPAID'].forEach((billingMode) => {
           it(`should return nothing for ${billingMode}`, async function () {
             // given
-            const isSco = true;
             const certificationCandidate = domainBuilder.buildCertificationCandidate({
               ...validAttributes,
               billingMode,
@@ -616,7 +617,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
             });
 
             // when
-            const report = certificationCandidate.validateForMassSessionImport(isSco);
+            const report = certificationCandidate.validateForMassSessionImport();
 
             // then
             expect(report).to.be.undefined;
@@ -628,7 +629,6 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         context('when prepaymentCode is not null', function () {
           it('should return a report', async function () {
             // given
-            const isSco = true;
             const certificationCandidate = domainBuilder.buildCertificationCandidate({
               ...validAttributes,
               billingMode: 'PAID',
@@ -636,7 +636,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
             });
 
             // when
-            const report = certificationCandidate.validateForMassSessionImport(isSco);
+            const report = certificationCandidate.validateForMassSessionImport();
 
             // then
             expect(report).to.deep.equal([
@@ -656,13 +656,25 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
           });
 
           // when
-          const report = certificationCandidate.validateForMassSessionImport({
-            isSco: true,
-            line: 1,
-          });
+          const report = certificationCandidate.validateForMassSessionImport();
 
           // then
           expect(report).to.be.undefined;
+        });
+
+        it('should return report if prepaymentCode is null', function () {
+          // given
+          const certificationCandidate = domainBuilder.buildCertificationCandidate({
+            ...validAttributes,
+            billingMode: 'PREPAID',
+            prepaymentCode: '',
+          });
+
+          // when
+          const report = certificationCandidate.validateForMassSessionImport();
+
+          // then
+          expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_REQUIRED.code]);
         });
       });
     });
@@ -677,9 +689,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         });
 
         // when
-        const report = certificationCandidate.validateForMassSessionImport({
-          line: 1,
-        });
+        const report = certificationCandidate.validateForMassSessionImport();
 
         // then
         expect(report).to.deep.equal([
@@ -696,9 +706,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         });
 
         // when
-        const report = certificationCandidate.validateForMassSessionImport({
-          line: 1,
-        });
+        const report = certificationCandidate.validateForMassSessionImport();
 
         // then
         expect(report).to.deep.equal([
@@ -715,10 +723,7 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         });
 
         // when
-        const report = certificationCandidate.validateForMassSessionImport({
-          isSco: true,
-          line: 1,
-        });
+        const report = certificationCandidate.validateForMassSessionImport();
 
         // then
         expect(report).to.be.undefined;
@@ -728,15 +733,13 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
         // given
         const certificationCandidate = domainBuilder.buildCertificationCandidate({
           ...validAttributes,
+          billingMode: 'FREE',
           birthPostalCode: '',
           birthINSEECode: '75115',
         });
 
         // when
-        const report = certificationCandidate.validateForMassSessionImport({
-          isSco: true,
-          line: 1,
-        });
+        const report = certificationCandidate.validateForMassSessionImport();
 
         // then
         expect(report).to.be.undefined;
@@ -750,13 +753,11 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
           ...validAttributes,
           firstName: undefined,
           birthdate: undefined,
+          billingMode: 'FREE',
         });
 
         // when
-        const report = certificationCandidate.validateForMassSessionImport({
-          isSco: true,
-          line: 1,
-        });
+        const report = certificationCandidate.validateForMassSessionImport();
 
         // then
         expect(report).to.deep.equal([

--- a/certif/app/components/import/step-one-section.hbs
+++ b/certif/app/components/import/step-one-section.hbs
@@ -1,28 +1,22 @@
 <p>{{t "pages.sessions.import.step-one.instructions.title"}}</p>
-<PixCollapsible
-  @title={{t "pages.sessions.import.step-one.instructions.creation.title"}}
-  @iconTitle="plus"
-  class="import-page_section--instructions"
->
-  {{t "pages.sessions.import.step-one.instructions.creation.list"}}
-  <ul>
-    <li>{{t "pages.sessions.import.step-one.instructions.creation.list-with-candidates" htmlSafe=true}}</li>
-    <li>{{t "pages.sessions.import.step-one.instructions.creation.list-without-candidates" htmlSafe=true}}</li>
-  </ul>
-</PixCollapsible>
-<PixCollapsible
-  @title={{t "pages.sessions.import.step-one.instructions.edition.title"}}
-  @iconTitle="plus"
-  class="import-page__section--instructions"
->
-  <ul>
-    <li>{{t "pages.sessions.import.step-one.instructions.edition.replace" htmlSafe=true}}</li>
-    <li>{{t "pages.sessions.import.step-one.instructions.edition.subscription" htmlSafe=true}}</li>
-  </ul>
-  <PixMessage @type="warning" @withIcon={{true}}>
-    {{t "pages.sessions.import.step-one.instructions.edition.warning"}}
-  </PixMessage>
-</PixCollapsible>
+<div class="import-page_section--instructions">
+  <PixCollapsible @title={{t "pages.sessions.import.step-one.instructions.creation.title"}} @iconTitle="plus">
+    {{t "pages.sessions.import.step-one.instructions.creation.list"}}
+    <ul>
+      <li>{{t "pages.sessions.import.step-one.instructions.creation.list-with-candidates" htmlSafe=true}}</li>
+      <li>{{t "pages.sessions.import.step-one.instructions.creation.list-without-candidates" htmlSafe=true}}</li>
+    </ul>
+  </PixCollapsible>
+  <PixCollapsible @title={{t "pages.sessions.import.step-one.instructions.edition.title"}} @iconTitle="plus">
+    <ul>
+      <li>{{t "pages.sessions.import.step-one.instructions.edition.replace" htmlSafe=true}}</li>
+      <li>{{t "pages.sessions.import.step-one.instructions.edition.subscription" htmlSafe=true}}</li>
+    </ul>
+    <PixMessage @type="warning" @withIcon={{true}}>
+      {{t "pages.sessions.import.step-one.instructions.edition.warning"}}
+    </PixMessage>
+  </PixCollapsible>
+</div>
 
 <section class="import-page__section--download panel">
   <div class="import-page__section--download__button">

--- a/certif/app/components/import/step-two-section.hbs
+++ b/certif/app/components/import/step-two-section.hbs
@@ -17,16 +17,23 @@
     <span class="import-page-section__information">
       {{t "pages.sessions.import.step-two.blocking-errors.information"}}
     </span>
-    <PixCollapsible
-      @titleIcon="circle-exclamation"
-      @title={{t "pages.sessions.import.step-two.blocking-errors.title" errorsReportCount=@errorsReportCount}}
-      @iconTitle="plus"
-      class="import-page-section__circle-exclamation-icon"
-    >
-      <PixMessage @type="error">
-        <p>{{@errorsReport}}</p>
-      </PixMessage>
-    </PixCollapsible>
+    <div>
+      <PixCollapsible
+        @titleIcon="circle-exclamation"
+        @title={{t "pages.sessions.import.step-two.blocking-errors.title" errorsReportCount=@errorsReportCount}}
+        @iconTitle="plus"
+        class="import-page-section__collapsible-header"
+      >
+        {{#each this.translatedErrorReport as |report|}}
+          <PixMessage @type="error">
+            <p>{{t "pages.sessions.import.step-two.blocking-errors.line"}}
+              {{report.line}}
+              :
+              {{report.message}}</p>
+          </PixMessage>
+        {{/each}}
+      </PixCollapsible>
+    </div>
     <PixButton
       class="import-page__section--confirm-button"
       aria-label={{t "pages.sessions.import.step-two.actions.import-again.extra-information"}}

--- a/certif/app/components/import/step-two-section.js
+++ b/certif/app/components/import/step-two-section.js
@@ -1,0 +1,17 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class StepTwoSectionComponent extends Component {
+  @service intl;
+
+  get translatedErrorReport() {
+    return this.args.errorsReport.map((errorReport) => ({
+      line: errorReport.line,
+      message: _translatedErrorCodeToMessage(this.intl, errorReport.code),
+    }));
+  }
+}
+
+function _translatedErrorCodeToMessage(intl, code) {
+  return intl.t(`pages.sessions.import.step-two.blocking-errors.errors.${code}`);
+}

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -9,35 +9,38 @@
     margin-bottom: 8px;
   }
 
-  .pix-collapsible:not(:last-child) {
-    margin-bottom: 8px;
-  }
+  &_section--instructions {
+    .pix-collapsible {
+      margin-bottom: 8px;
+    }
 
-  .pix-collapsible,
-  .pix-collapsible__title {
-    border-radius: 8px;
-    color: $pix-neutral-70;
-    font-size: 14px;
-    font-weight: $font-light;
-  }
+    .pix-collapsible,
+    .pix-collapsible__title {
+      border-radius: 8px;
+      color: $pix-neutral-70;
+      font-size: 14px;
+      font-weight: $font-light;
+    }
 
-  .pix-collapsible__title:not(.pix-collapsible__title--uncollapsed):focus {
-    background-color: inherit;
-  }
+    .pix-collapsible__title[aria-expanded=true] {
+      background-color: inherit;
+      border-radius: 8px 8px 0 0;
+    }
 
-  .pix-collapsible__title--uncollapsed {
-    border-radius: 8px 8px 0 0;
-  }
+    .pix-collapsible__title--uncollapsed {
+      border-radius: 8px 8px 0 0;
+    }
 
-  .pix-collapsible__content {
-    line-height: 20px;
-    padding: 14px 16px;
-  }
+    .pix-collapsible__content {
+      line-height: 20px;
+      padding: 14px 16px;
+    }
 
-  .pix-collapsible ul {
-    list-style: disc;
-    margin-top: 6px;
-    margin-left: 24px;
+    .pix-collapsible ul {
+      list-style: disc;
+      margin-top: 6px;
+      margin-left: 24px;
+    }
   }
 
   .pix-collapsible .pix-message {
@@ -183,7 +186,11 @@
     font-weight: $font-medium;
   }
 
-  &__circle-exclamation-icon {
+  &__collapsible-header {
+    .pix-collapsible-title__label {
+      font-size: 1rem;
+      font-weight: 400;
+    }
     .pix-collapsible-title__icon {
       color: $pix-error-70;
     }

--- a/certif/tests/integration/components/sessions-import/step-two-section_test.js
+++ b/certif/tests/integration/components/sessions-import/step-two-section_test.js
@@ -4,7 +4,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 
-module('Integration | Component | step-two-section', function (hooks) {
+module('Integration | Component | Import::StepTwoSection', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   test('it renders the count of sessions and candidates', async function (assert) {
@@ -15,7 +15,7 @@ module('Integration | Component | step-two-section', function (hooks) {
 
     // when
     const { getByText } = await render(
-      hbs`<Import::StepTwoSection @sessionsCount="{{this.sessionsCount}}" @sessionsWithoutCandidatesCount="{{this.sessionsWithoutCandidatesCount}}"  @candidatesCount="{{this.candidatesCount}}" />`
+      hbs`<Import::StepTwoSection @sessionsCount={{this.sessionsCount}} @sessionsWithoutCandidatesCount={{this.sessionsWithoutCandidatesCount}}  @candidatesCount={{this.candidatesCount}} />`
     );
 
     // then
@@ -24,25 +24,103 @@ module('Integration | Component | step-two-section', function (hooks) {
   });
 
   module('when the imported file contains errors', function () {
-    test('it renders an errors report', async function (assert) {
-      // given
-      this.set('isImportInError', true);
-      this.set('errorsReport', ['Fichier invalide']);
-      this.set('errorsReportCount', 1);
+    [
+      { error: 'CANDIDATE_FIRST_NAME_REQUIRED', expectedMessage: 'Champ obligatoire "Prénom" manquant' },
+      { error: 'CANDIDATE_LAST_NAME_REQUIRED', expectedMessage: 'Champ obligatoire "Nom de famille" manquant' },
+      { error: 'CANDIDATE_SEX_REQUIRED', expectedMessage: 'Champ obligatoire "Sexe" manquant' },
+      { error: 'CANDIDATE_SEX_NOT_VALID', expectedMessage: 'Champ sexe format incorrect, format accepté "M"/"F"' },
+      {
+        error: 'CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_EXCLUSIVE',
+        expectedMessage: 'Renseigner soit un code INSEE soit un code postal et un nom de commune de naissance.',
+      },
+      {
+        error: 'CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED',
+        expectedMessage: 'Champ obligatoire "Code postal" OU "Code INSEE" manquant',
+      },
+      { error: 'CANDIDATE_BIRTH_COUNTRY_REQUIRED', expectedMessage: 'Champ obligatoire "Pays de naissance" manquant' },
+      { error: 'CANDIDATE_BIRTH_COUNTRY_NOT_FOUND', expectedMessage: 'Pays de naissance non trouvé' },
+      { error: 'CANDIDATE_BIRTHDATE_REQUIRED', expectedMessage: 'Champ obligatoire "Date de naissance" manquant' },
+      {
+        error: 'CANDIDATE_BIRTHDATE_FORMAT_INCORRECT',
+        expectedMessage: 'Format de date incorrect, champ "Date de naissance", format accepté JJ/MM/AAAA',
+      },
+      { error: 'CANDIDATE_EXTRA_TIME_BELOW_ONE', expectedMessage: 'Format temps majoré incorrect, format accepté XX%' },
+      { error: 'CANDIDATE_EXTRA_TIME_INTEGER', expectedMessage: 'Format temps majoré incorrect, format accepté XX%' },
+      {
+        error: 'CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION',
+        expectedMessage: "Inscription possible qu'à une seule certification complémentaire par candidat.",
+      },
+      {
+        error: 'CANDIDATE_BILLING_MODE_REQUIRED',
+        expectedMessage: 'Champ obligatoire "Tarification par Pix" manquant',
+      },
+      {
+        error: 'CANDIDATE_BILLING_MODE_NOT_VALID',
+        expectedMessage:
+          'Format tarification part Pix incorrect, formats acceptés "Gratuite", "Payante" ou "Prépayée".',
+      },
+      {
+        error: 'CANDIDATE_PREPAYMENT_CODE_REQUIRED',
+        expectedMessage:
+          'Champ obligatoire "Code de prépaiement" manquant, doit être renseigné en cas de "Tarification par Pix" "Prépayée"',
+      },
+      {
+        error: 'CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY',
+        expectedMessage: 'Champ "Code de prépaiement" doit rester vide',
+      },
+      {
+        error: 'CANDIDATE_NOT_ALLOWED_FOR_STARTED_SESSION',
+        expectedMessage: 'Edition des candidats impossible, N° de session correspond à une session déjà démarrée',
+      },
+      {
+        error: 'DUPLICATE_CANDIDATE_NOT_ALLOWED_IN_SESSION',
+        expectedMessage: 'Candidat inscrit plusieurs fois à cette session',
+      },
+      { error: 'SESSION_ADDRESS_REQUIRED', expectedMessage: 'Champ obligatoire "Nom du site" manquant' },
+      { error: 'SESSION_ROOM_REQUIRED', expectedMessage: 'Champ obligatoire "Nom de la salle" manquant' },
+      { error: 'SESSION_DATE_REQUIRED', expectedMessage: 'Champ obligatoire "Date de session" manquant' },
+      {
+        error: 'SESSION_DATE_NOT_VALID',
+        expectedMessage: 'Format de date incorrect, champ "Date de session", format accepté JJ/MM/AAAA',
+      },
+      { error: 'SESSION_TIME_REQUIRED', expectedMessage: 'Champ obligatoire "Heure de début" manquant' },
+      {
+        error: 'SESSION_TIME_NOT_VALID',
+        expectedMessage: 'Format d\'heure incorrect, champ "Heure de début", format accepté HH:MM',
+      },
+      { error: 'SESSION_EXAMINER_REQUIRED', expectedMessage: 'Champ obligatoire "Surveillant(s)" manquant' },
+      {
+        error: 'SESSION_WITH_DATE_AND_TIME_ALREADY_EXISTS',
+        expectedMessage:
+          'Session déjà créée avec ces critères, pour ajouter des candidats n’indiquer que le N°, pas les informations de session.',
+      },
+      {
+        error: 'SESSION_SCHEDULED_IN_THE_PAST',
+        expectedMessage: 'Date et/ou heure indiquées antérieures à la date du jour.',
+      },
+      {
+        error: 'INFORMATION_NOT_ALLOWED_WITH_SESSION_ID',
+        expectedMessage: 'Numéro de session fourni, veuillez supprimer les informations de session associées.',
+      },
+    ].forEach(function ({ error, expectedMessage }) {
+      test('it renders a report', async function (assert) {
+        // given
+        this.set('isImportInError', true);
+        this.set('errorsReport', [{ line: '5', code: error }]);
+        this.set('errorsReportCount', 1);
 
-      // when
-      const screen = await render(
-        hbs`<Import::StepTwoSection
-            @isImportInError="{{this.isImportInError}}"
-            @errorsReport="{{this.errorsReport}}"
-            @errorsReportCount="{{this.errorsReportCount}}"
-            />`
-      );
+        // when
+        const { getByText, getByRole } = await render(hbs`<Import::StepTwoSection
+          @isImportInError={{this.isImportInError}}
+          @errorsReport={{this.errorsReport}}
+          @errorsReportCount={{this.errorsReportCount}}
+          />`);
 
-      await click(screen.getByRole('button', { name: '1 erreur bloquante' }));
+        await click(getByRole('button', { name: '1 erreur bloquante' }));
 
-      // then
-      assert.dom(screen.getByText('Fichier invalide')).exists();
+        // then
+        assert.dom(getByText(`Ligne 5 : ${expectedMessage}`)).exists();
+      });
     });
 
     test('it renders a button to return to step one', async function (assert) {
@@ -50,7 +128,7 @@ module('Integration | Component | step-two-section', function (hooks) {
       this.set('isImportInError', true);
 
       // when
-      const { getByRole } = await render(hbs`<Import::StepTwoSection @isImportInError="{{this.isImportInError}}" />`);
+      const { getByRole } = await render(hbs`<Import::StepTwoSection @isImportInError={{this.isImportInError}} />`);
 
       // then
       assert

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -177,7 +177,39 @@
         "step-two": {
           "blocking-errors": {
             "title": "{errorsReportCount} {errorsReportCount, plural,one {erreur bloquante} other {erreurs bloquantes}}",
-            "information": "Veuillez corriger toutes les erreurs bloquantes avant de re-importer le fichier .csv :"
+            "information": "Veuillez corriger toutes les erreurs bloquantes avant de re-importer le fichier .csv :",
+            "line": "Line",
+            "errors": {
+              "CANDIDATE_FIRST_NAME_REQUIRED": "Champ obligatoire \"Prénom\" manquant",
+              "CANDIDATE_LAST_NAME_REQUIRED": "Champ obligatoire \"Nom de famille\" manquant",
+              "CANDIDATE_SEX_REQUIRED": "Champ obligatoire \"Sexe\" manquant",
+              "CANDIDATE_SEX_NOT_VALID": "Champ sexe format incorrect, format accepté \"M\"/\"F\"",
+              "CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_EXCLUSIVE": " Renseigner soit un code INSEE soit un code postal et un nom de commune de naissance.",
+              "CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED": "Champ obligatoire \"Code postal\" OU \"Code INSEE\" manquant",
+              "CANDIDATE_BIRTH_COUNTRY_REQUIRED": "Champ obligatoire \"Pays de naissance\" manquant",
+              "CANDIDATE_BIRTH_COUNTRY_NOT_FOUND": "Pays de naissance non trouvé",
+              "CANDIDATE_BIRTHDATE_REQUIRED": "Champ obligatoire \"Date de naissance\" manquant",
+              "CANDIDATE_BIRTHDATE_FORMAT_INCORRECT": "Format de date incorrect, champ \"Date de naissance\", format accepté JJ/MM/AAAA",
+              "CANDIDATE_EXTRA_TIME_BELOW_ONE": "Format temps majoré incorrect, format accepté XX%",
+              "CANDIDATE_EXTRA_TIME_INTEGER": "Format temps majoré incorrect, format accepté XX%",
+              "CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION": "Inscription possible qu'à une seule certification complémentaire par candidat.",
+              "CANDIDATE_BILLING_MODE_REQUIRED": "Champ obligatoire \"Tarification par Pix\" manquant",
+              "CANDIDATE_BILLING_MODE_NOT_VALID": "Format tarification part Pix incorrect, formats acceptés \"Gratuite\", \"Payante\" ou \"Prépayée\".",
+              "CANDIDATE_PREPAYMENT_CODE_REQUIRED": "Champ obligatoire \"Code de prépaiement\" manquant, doit être renseigné en cas de \"Tarification par Pix\" \"Prépayée\"",
+              "CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY": "Champ \"Code de prépaiement\" doit rester vide",
+              "CANDIDATE_NOT_ALLOWED_FOR_STARTED_SESSION": "Edition des candidats impossible, N° de session correspond à une session déjà démarrée",
+              "DUPLICATE_CANDIDATE_NOT_ALLOWED_IN_SESSION": "Candidat inscrit plusieurs fois à cette session",
+              "SESSION_ADDRESS_REQUIRED": "Champ obligatoire \"Nom du site\" manquant",
+              "SESSION_ROOM_REQUIRED": "Champ obligatoire \"Nom de la salle\" manquant",
+              "SESSION_DATE_REQUIRED": "Champ obligatoire \"Date de session\" manquant",
+              "SESSION_DATE_NOT_VALID": "Format de date incorrect, champ \"Date de session\", format accepté JJ/MM/AAAA",
+              "SESSION_TIME_REQUIRED": "Champ obligatoire \"Heure de début\" manquant",
+              "SESSION_TIME_NOT_VALID": "Format d'heure incorrect, champ \"Heure de début\", format accepté HH:MM",
+              "SESSION_EXAMINER_REQUIRED": "Champ obligatoire \"Surveillant(s)\" manquant",
+              "SESSION_WITH_DATE_AND_TIME_ALREADY_EXISTS": "Session déjà créée avec ces critères, pour ajouter des candidats n’indiquer que le N°, pas les informations de session.",
+              "SESSION_SCHEDULED_IN_THE_PAST": "Date et/ou heure indiquées antérieures à la date du jour.",
+              "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées."
+            }
           },
           "actions": {
             "import-again": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -173,7 +173,39 @@
         "step-two": {
           "blocking-errors": {
             "title": "{errorsReportCount} {errorsReportCount, plural,one {erreur bloquante} other {erreurs bloquantes}}",
-            "information": "Veuillez corriger toutes les erreurs bloquantes avant de re-importer le fichier .csv :"
+            "information": "Veuillez corriger toutes les erreurs bloquantes avant de re-importer le fichier .csv :",
+            "line": "Ligne",
+            "errors": {
+              "CANDIDATE_FIRST_NAME_REQUIRED": "Champ obligatoire \"Prénom\" manquant",
+              "CANDIDATE_LAST_NAME_REQUIRED": "Champ obligatoire \"Nom de famille\" manquant",
+              "CANDIDATE_SEX_REQUIRED": "Champ obligatoire \"Sexe\" manquant",
+              "CANDIDATE_SEX_NOT_VALID": "Champ sexe format incorrect, format accepté \"M\"/\"F\"",
+              "CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_EXCLUSIVE": " Renseigner soit un code INSEE soit un code postal et un nom de commune de naissance.",
+              "CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED": "Champ obligatoire \"Code postal\" OU \"Code INSEE\" manquant",
+              "CANDIDATE_BIRTH_COUNTRY_REQUIRED": "Champ obligatoire \"Pays de naissance\" manquant",
+              "CANDIDATE_BIRTH_COUNTRY_NOT_FOUND": "Pays de naissance non trouvé",
+              "CANDIDATE_BIRTHDATE_REQUIRED": "Champ obligatoire \"Date de naissance\" manquant",
+              "CANDIDATE_BIRTHDATE_FORMAT_INCORRECT": "Format de date incorrect, champ \"Date de naissance\", format accepté JJ/MM/AAAA",
+              "CANDIDATE_EXTRA_TIME_BELOW_ONE": "Format temps majoré incorrect, format accepté XX%",
+              "CANDIDATE_EXTRA_TIME_INTEGER": "Format temps majoré incorrect, format accepté XX%",
+              "CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION": "Inscription possible qu'à une seule certification complémentaire par candidat.",
+              "CANDIDATE_BILLING_MODE_REQUIRED": "Champ obligatoire \"Tarification par Pix\" manquant",
+              "CANDIDATE_BILLING_MODE_NOT_VALID": "Format tarification part Pix incorrect, formats acceptés \"Gratuite\", \"Payante\" ou \"Prépayée\".",
+              "CANDIDATE_PREPAYMENT_CODE_REQUIRED": "Champ obligatoire \"Code de prépaiement\" manquant, doit être renseigné en cas de \"Tarification par Pix\" \"Prépayée\"",
+              "CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY": "Champ \"Code de prépaiement\" doit rester vide",
+              "CANDIDATE_NOT_ALLOWED_FOR_STARTED_SESSION": "Edition des candidats impossible, N° de session correspond à une session déjà démarrée",
+              "DUPLICATE_CANDIDATE_NOT_ALLOWED_IN_SESSION": "Candidat inscrit plusieurs fois à cette session",
+              "SESSION_ADDRESS_REQUIRED": "Champ obligatoire \"Nom du site\" manquant",
+              "SESSION_ROOM_REQUIRED": "Champ obligatoire \"Nom de la salle\" manquant",
+              "SESSION_DATE_REQUIRED": "Champ obligatoire \"Date de session\" manquant",
+              "SESSION_DATE_NOT_VALID": "Format de date incorrect, champ \"Date de session\", format accepté JJ/MM/AAAA",
+              "SESSION_TIME_REQUIRED": "Champ obligatoire \"Heure de début\" manquant",
+              "SESSION_TIME_NOT_VALID": "Format d'heure incorrect, champ \"Heure de début\", format accepté HH:MM",
+              "SESSION_EXAMINER_REQUIRED": "Champ obligatoire \"Surveillant(s)\" manquant",
+              "SESSION_WITH_DATE_AND_TIME_ALREADY_EXISTS": "Session déjà créée avec ces critères, pour ajouter des candidats n’indiquer que le N°, pas les informations de session.",
+              "SESSION_SCHEDULED_IN_THE_PAST": "Date et/ou heure indiquées antérieures à la date du jour.",
+              "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées."
+            }
           },
           "actions": {
             "import-again": {


### PR DESCRIPTION
## :unicorn: Problème
La création une à une de ses sessions de certification et l'import de ses candidats session par session pose des risques d’erreur trop important en plus d’être une tâche chronophage pour les CDC avec beaucoup de sessions et de candidats.

La gestion massive des sessions va lui permettre d’importer un fichier avec plusieurs sessions à créer et des candidats à inscrire dans plusieurs sessions.

L’utilisateur Pix Certif peut avoir mal rempli son fichier d’import et avoir des erreurs à corriger absolument avant import définitif.


## :robot: Proposition
L’utilisateur visualise le listing des erreurs bloquantes qu’il doit corriger avec le numéro de ligne concerné et le texte de l’erreur correspondante

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Dans pix Certif, importer une session à l'aide du csv suivant

```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
,mlkmlkmlk,pomlk,03/05/2025,14:00,surv,,toto1,tata,01/01/2000,M,75115,,,FRANCE,,,,33,Gratuite,toto,,
,,,,,,,,tata,01/01/2000,T,75115,,,,,,,,Gratuite,,,
,,,,,,,toto3,tata,01/01/2000,M,75115,,,FRANCE,,,,,Prépayée,,,
```


- Constater l'affichage suivant 

![image](https://user-images.githubusercontent.com/37305474/225571292-ba9610cf-643f-45a0-9bb1-6513e44090c1.png)
