### PR TITLE
[BUGFIX] Corriger l'affichage du PixSelect dans la page Certifications de Pix Orga (PIX-7478)

### DIFF
--- a/orga/app/styles/pages/authenticated/campaigns/create-form.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/create-form.scss
@@ -31,6 +31,7 @@
       width: 360px !important;
     }
 
+    // TODO : Remove after update fix on PIX UI
     &__dropdown {
       overflow-x: hidden;
     }

--- a/orga/app/styles/pages/authenticated/certifications.scss
+++ b/orga/app/styles/pages/authenticated/certifications.scss
@@ -3,7 +3,12 @@
   flex-direction: column;
   padding: $spacing-s 0 0 $spacing-s;
   width: 100%;
-  margin-bottom: 20px;
+  margin-bottom: $spacing-l;
+
+  // TODO : Remove after update fix on PIX UI
+  .pix-select__dropdown {
+    overflow-x: hidden;
+  }
 
   &__tabs {
     display: flex;
@@ -21,32 +26,11 @@
 
   &__action {
     display: flex;
-    flex-direction: row;
     flex-wrap: wrap;
     align-items: flex-end;
     min-width: 100%;
-    margin-bottom: 40px;
-
-    label {
-      color: $pix-neutral-90;
-      margin-left: 2px;
-      min-width: 100%;
-      padding: 4px 0;
-    }
-
-    .pix-select {
-      margin-right: $spacing-xs;
-      min-width: 7rem;
-      margin-left: $spacing-xs;
-
-      &__dropdown {
-        min-width: 7rem;
-      }
-    }
-
-    > button {
-      margin-left: $spacing-xs;
-    }
+    margin-bottom: $spacing-xl;
+    gap: $spacing-s;
   }
 
   .pix-message {


### PR DESCRIPTION
## :unicorn: Problème
Le poids du CSS a eu des effet indésirable sur des composant importé

## :robot: Proposition
Rendre le poid CSS plus léger afin de n'impacter que ce qui nous intéresse

## :rainbow: Remarques
Une PR sur PixUI va être fait pour corriger le scroll du Pix Select

## :100: Pour tester
Vérifier que sur Pix Orga connecter en SCO, l'affichage dans l'onglet certifications est correct