### PR TITLE
[FEATURE] Traduction formulaire connection espace surveillant (PIX-6679)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -398,6 +398,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.EmailModificationDemandNotFoundOrExpiredError) {
     return new HttpErrors.ForbiddenError(error.message, error.code);
   }
+  if (error instanceof DomainErrors.InvalidSessionSupervisingLoginError) {
+    return new HttpErrors.ForbiddenError(error.message, error.code);
+  }
 
   if (error instanceof DomainErrors.TargetProfileCannotBeCreated) {
     return new HttpErrors.UnprocessableEntityError(error.message);

--- a/api/lib/domain/constants/session-supervising.js
+++ b/api/lib/domain/constants/session-supervising.js
@@ -1,0 +1,6 @@
+module.exports.SESSION_SUPERVISING = {
+  INCORRECT_DATA: {
+    code: 'INCORRECT_DATA',
+    getMessage: () => `Le numéro de session et/ou le mot de passe saisis sont incorrects.`,
+  },
+};

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -1,3 +1,5 @@
+const { SESSION_SUPERVISING } = require('./constants/session-supervising');
+
 class DomainError extends Error {
   constructor(message, code, meta) {
     super(message);
@@ -1211,8 +1213,11 @@ class EmailModificationDemandNotFoundOrExpiredError extends DomainError {
 }
 
 class InvalidSessionSupervisingLoginError extends DomainError {
-  constructor(message = 'Le numéro de session et/ou le mot de passe saisis sont incorrects.') {
-    super(message);
+  constructor(
+    message = SESSION_SUPERVISING.INCORRECT_DATA.getMessage(),
+    code = SESSION_SUPERVISING.INCORRECT_DATA.code
+  ) {
+    super(message, code);
   }
 }
 

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -18,6 +18,7 @@ const {
   UserHasAlreadyLeftSCO,
   OrganizationLearnerAlreadyLinkedToInvalidUserError,
   InvalidVerificationCodeError,
+  InvalidSessionSupervisingLoginError,
   EmailModificationDemandNotFoundOrExpiredError,
   CandidateNotAuthorizedToJoinSessionError,
   CandidateNotAuthorizedToResumeCertificationTestError,
@@ -42,6 +43,7 @@ const {
 const HttpErrors = require('../../../lib/application/http-errors.js');
 
 const { handle } = require('../../../lib/application/error-manager');
+const { SESSION_SUPERVISING } = require('../../../lib/domain/constants/session-supervising');
 
 describe('Unit | Application | ErrorManager', function () {
   describe('#handle', function () {
@@ -344,6 +346,22 @@ describe('Unit | Application | ErrorManager', function () {
 
       // then
       expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(error.message, error.code);
+    });
+
+    it('should instantiate ForbiddenError when InvalidSessionSupervisingLoginError', async function () {
+      // given
+      const error = new InvalidSessionSupervisingLoginError();
+      sinon.stub(HttpErrors, 'ForbiddenError');
+      const params = { request: {}, h: hFake, error };
+
+      // when
+      await handle(params.request, params.h, params.error);
+
+      // then
+      expect(HttpErrors.ForbiddenError).to.have.been.calledWithExactly(
+        SESSION_SUPERVISING.INCORRECT_DATA.getMessage(),
+        SESSION_SUPERVISING.INCORRECT_DATA.code
+      );
     });
 
     it('should instantiate BadRequestError when OrganizationLearnerAlreadyLinkedToInvalidUserError', async function () {

--- a/certif/app/components/login-session-supervisor-form.hbs
+++ b/certif/app/components/login-session-supervisor-form.hbs
@@ -2,11 +2,11 @@
 
   <img src="/illu-espace-surveillant.svg" alt="" role="presentation" />
 
-  <h1 class="login-session-supervisor-form__title">Espace Surveillant</h1>
+  <h1 class="login-session-supervisor-form__title">{{t "pages.session-supervising.login.form.title"}}</h1>
 
-  <h2 class="login-session-supervisor-form__subtitle">Surveiller une session</h2>
+  <h2 class="login-session-supervisor-form__subtitle">{{t "pages.session-supervising.login.form.sub-title"}}</h2>
 
-  <p class="login-session-supervisor-form__required-fields-notice">Tous les champs sont obligatoires.</p>
+  <p class="login-session-supervisor-form__required-fields-notice">{{t "common.form.mandatory-all-fields"}}</p>
 
   {{#if this.errorMessage}}
     <p
@@ -18,23 +18,29 @@
   {{/if}}
 
   <form class="login-session-supervisor-form__form" {{on "submit" this.superviseSession}}>
-    <PixInput @id="session-id" @label="Numéro de la session" type="number" {{on "input" this.setSessionId}} />
+    <PixInput
+      @id="session-id"
+      @label={{t "pages.session-supervising.login.form.session-number"}}
+      type="number"
+      {{on "input" this.setSessionId}}
+    />
 
     <PixInputPassword
       @id="session-password"
-      @label="Mot de passe de la session"
-      @information="Exemple : C-12345"
+      @label={{t "pages.session-supervising.login.form.session-password.label"}}
+      @ariaLabel={{t "pages.session-supervising.login.form.session-password.aria-label"}}
+      @information={{t "pages.session-supervising.login.form.example"}}
       @prefix="C-"
       placeholder="XXXXXX"
       {{on "input" this.setSupervisorPassword}}
     />
 
     <PixButton @type="submit">
-      Surveiller la session
+      {{t "pages.session-supervising.login.form.actions.invigilate"}}
     </PixButton>
   </form>
 
   <p class="login-session-supervisor-form__description">
-    Le mot de passe de la session à surveiller vous a été communiqué par un administrateur Pix Certif.
+    {{t "pages.session-supervising.login.form.description"}}
   </p>
 </div>

--- a/certif/app/components/login-session-supervisor-form.js
+++ b/certif/app/components/login-session-supervisor-form.js
@@ -1,9 +1,11 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 import get from 'lodash/get';
 
 export default class LoginSessionSupervisorForm extends Component {
+  @service intl;
   @tracked errorMessage = null;
   sessionId;
   supervisorPassword;
@@ -23,7 +25,7 @@ export default class LoginSessionSupervisorForm extends Component {
     event.preventDefault();
 
     if (!this.sessionId || !this.supervisorPassword) {
-      this._displayError('Les champs "Numéro de la session" et "Mot de passe de session" sont obligatoires.');
+      this._displayError(this.intl.t('pages.session-supervising.login.form.errors.mandatory-fields'));
       return;
     }
 
@@ -33,8 +35,13 @@ export default class LoginSessionSupervisorForm extends Component {
         supervisorPassword: this.supervisorPassword,
       });
     } catch (error) {
-      const errorMessage = get(error, 'errors[0].detail');
-      this._displayError(errorMessage);
+      let errorMessage = get(error, 'errors[0].detail');
+      const errorCode = get(error, 'errors[0].code');
+      if (errorCode === 'INCORRECT_DATA') {
+        errorMessage = this.intl.t('pages.session-supervising.login.form.errors.incorrect-data');
+      }
+
+      return this._displayError(errorMessage);
     }
   }
 

--- a/certif/app/templates/login-session-supervisor.hbs
+++ b/certif/app/templates/login-session-supervisor.hbs
@@ -1,4 +1,4 @@
-{{page-title "Connexion à l'espace surveillant"}}
+{{page-title (t "pages.session-supervising.login.title")}}
 <div class="login-session-supervisor-page">
   <div class="login-session-supervisor-page-content">
     <LoginSessionSupervisorForm @onFormSubmit={{this.authenticateSupervisor}} />
@@ -8,7 +8,7 @@
         {{this.currentUserEmail}}
       </span>
       <LinkTo class="login-session-supervisor-page-content__logout" @route="logout">
-        Changer de compte
+        {{t "pages.session-supervising.login.form.actions.switch-account"}}
       </LinkTo>
     </div>
   </div>

--- a/certif/app/templates/session-supervising-error.hbs
+++ b/certif/app/templates/session-supervising-error.hbs
@@ -1,16 +1,15 @@
-{{page-title "Erreur d'accès à la surveillance de session"}}
+{{page-title (t "pages.session-supervising-error.title")}}
 
 <div class="session-supervising-error-page">
   <div class="session-supervising-error-page__panel">
     <img src="/images/supervisor_no-access.svg" alt="" role="presentation" />
-    <h1 class="session-supervising-error-page__panel__title">Une erreur est survenue</h1>
+    <h1 class="session-supervising-error-page__panel__title">{{t "common.api-error-messages.internal-error"}}</h1>
     <p class="session-supervising-error-page__panel__subtitle">
-      Pour accéder à cette session, cliquez sur le bouton "Surveiller une session" et renseignez les informations de la
-      session
+      {{t "pages.session-supervising-error.description"}}
     </p>
 
     <PixButtonLink @route="login-session-supervisor" class="session-supervising-error-page__panel__button">
-      Surveiller une session
+      {{t "pages.session-supervising.login.form.sub-title"}}
     </PixButtonLink>
   </div>
 </div>

--- a/certif/tests/integration/components/login-session-supervisor-form_test.js
+++ b/certif/tests/integration/components/login-session-supervisor-form_test.js
@@ -3,11 +3,13 @@ import { setupRenderingTest } from 'ember-qunit';
 import { click, fillIn } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
+import setupIntl from '../../helpers/setup-intl';
 
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | login-session-supervisor-form', function (hooks) {
   setupRenderingTest(hooks);
+  setupIntl(hooks);
 
   test('it should render supervisor login form', async function (assert) {
     // when

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -17,7 +17,8 @@
       "login-unauthorized-error": "There was an error in the email address or password entered.",
       "login-user-temporary-blocked-error": "You have reached too many failed login attempts. Please try again later or <a href=\"{url}\">reset your password here</a>.",
       "login-user-blocked-error": "Your account has reached the maximum number of failed login attempts and has been temporarily blocked. Please <a href=\"{url}\">contact us</a> to unblock it.",
-      "gateway-timeout-error": "The service is being slow. Please try again later."
+      "gateway-timeout-error": "The service is being slow. Please try again later.",
+      "internal-error": "An error occurred"
     },
     "form": {
       "mandatory-all-fields": "All fields are required."
@@ -468,6 +469,28 @@
       }
     },
     "session-supervising": {
+      "login": {
+        "title": "Log into the invigilator's portal",
+        "form": {
+          "title": "Invigilator’s portal",
+          "sub-title": "Invigilate a session",
+          "description": "The password for the session to be invigilated has been revealed to you by a Pix Certif administrator",
+          "session-number": "Session number",
+          "session-password": {
+            "label": "Session password",
+            "aria-label": "Show password"
+          },
+          "example": "Example : C-12345",
+          "errors": {
+            "mandatory-fields": "The fields “Session number” and “Session password” are required.",
+            "incorrect-data": "The session number and/or the session password entered are incorrect."
+          },
+          "actions": {
+            "invigilate": "Invigilate the session",
+            "switch-account": "Switch accounts"
+          }
+        }
+      },
       "header": {
         "actions": {
           "exit-extra-information": "Exit the invigilation of session {sessionId}"
@@ -512,6 +535,10 @@
           "error": "Une erreur est survenue, {firstName} {lastName} n'a a pu être autorisé à reprendre son test."
         }
       }
+    },
+    "session-supervising-error": {
+      "title": "Access error to the session's invigilation",
+      "description": "To access this session, click on the \"Invigilate a session\" button and fill in the details of the session"
     },
     "team": {
       "title": "Team",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -17,7 +17,8 @@
       "login-unauthorized-error": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects.",
       "login-user-temporary-blocked-error": "Vous avez effectué trop de tentatives de connexion. Réessayez plus tard ou cliquez sur <a href=\"{url}\">mot de passe oublié</a> pour le réinitialiser.",
       "login-user-blocked-error": "Votre compte est bloqué car vous avez effectué trop de tentatives de connexion. Pour le débloquer, <a href=\"{url}\">contactez-nous</a>.",
-      "gateway-timeout-error": "Le service subit des ralentissements. Veuillez réessayer ultérieurement."
+      "gateway-timeout-error": "Le service subit des ralentissements. Veuillez réessayer ultérieurement.",
+      "internal-error": "Une erreur est survenue"
     },
     "form": {
       "mandatory-all-fields": "Tous les champs sont obligatoires."
@@ -459,9 +460,32 @@
         "page-title": "Modification d'une session de certification",
         "required-fields": "Les champs marqués de <abbr title=\"obligatoire\" class=\"mandatory-mark\">*</abbr> sont obligatoires.",
         "room": "Nom de la salle",
-        "time": "Heure de début (heure locale)"}
+        "time": "Heure de début (heure locale)"
+      }
     },
     "session-supervising": {
+      "login": {
+        "title": "Connexion à l'espace surveillant",
+        "form": {
+          "title": "Espace Surveillant",
+          "sub-title": "Surveiller une session",
+          "description": "Le mot de passe de la session à surveiller vous a été communiqué par un administrateur Pix Certif",
+          "session-number": "Numéro de la session",
+          "session-password": {
+            "label": "Mot de passe de la session",
+            "aria-label": "Afficher le mot de passe"
+          },
+          "example": "Exemple : C-12345",
+          "errors": {
+            "mandatory-fields": "Les champs \"Numéro de la session\" et \"Mot de passe de session\" sont obligatoires.",
+            "incorrect-data": "Le numéro de session et/ou le mot de passe saisis sont incorrects."
+          },
+          "actions": {
+            "invigilate": "Surveiller la session",
+            "switch-account": "Changer de compte"
+          }
+        }
+      },
       "header": {
         "actions": {
           "exit-extra-information": "Quitter la surveillance de la session {sessionId}"
@@ -506,6 +530,10 @@
           "error": "Une erreur est survenue, {firstName} {lastName} n'a a pu être autorisé à reprendre son test."
         }
       }
+    },
+    "session-supervising-error": {
+      "title": "Erreur d'accès à la surveillance de session",
+      "description": "Pour accéder à cette session, cliquez sur le bouton \"Surveiller une session\" et renseignez les informations de la session"
     },
     "team": {
       "title": "Équipe",


### PR DESCRIPTION
## :unicorn: Problème
Afin d'élargir le champ de prospection et de développement de Pix, et plus précisément de sa certification, à l’international, il nous faut permettre une utilisation de Pix Certif par un utilisateur anglophone.

Une fois connecté sur Pix Certif, un utilisateur anglophone dispose d’un menu à gauche qui lui propose notamment de cliquer sur “Espace surveillant” pour accéder à l’outil de surveillance de session.

Une page de connexion est alors proposée à l’utilisateur.

Toutes les informations sont en français.

## :robot: Proposition
Traduire la page de connection à l'espace surveillant


## :100: Pour tester
- Sur Pix Certif en Anglais
  - Se connecter à l'espace surveillant et constater l'affichage suivant 
  
  
![image](https://user-images.githubusercontent.com/37305474/225875319-0cb851f0-78ba-49a2-876d-63a748f7bff7.png)
