### PR TITLE
[BUGFIX] Corriger le problème d'espacement sur la page de détail d'une compétence sur Pix-App (PIX-7327)

### DIFF
--- a/mon-pix/app/components/scorecard-details.hbs
+++ b/mon-pix/app/components/scorecard-details.hbs
@@ -65,7 +65,7 @@
 
         {{#if this.displayImprovingButton}}
           <PixButton
-            class="scorecard-details__improve-button"
+            class="scorecard-details__improve-button button--big"
             @shape="rounded"
             @backgroundColor="green"
             @triggerAction={{this.improveCompetenceEvaluation}}

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -71,7 +71,7 @@
 
   &__resume-or-start-button,
   &__improve-button {
-    margin: $spacing-m 0;
+    margin-top: $spacing-m;
   }
 
   &__reset-button {


### PR DESCRIPTION
## :unicorn: Problème
Il y avait un problème d'espacement sur le bouton "Commencer", "Reprendre" et "Retenter"
![image](https://user-images.githubusercontent.com/49011144/225673314-e92f436b-705a-4009-822c-9ab83361599d.png)

## :robot: Proposition
Corriger l'espacement. 

## :100: Pour tester
Vérifier sur les pages de détails d'une compéténce l'espacement des boutons "Commencer", "Reprendre" et "Retenter"
