### PR TITLE
[FEATURE] Traduire la modale d'inscription individuelle d'un candidat en anglais sur Pix Certif (PIX-6672)

### DIFF
--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -5,8 +5,11 @@ import EmberObject, { action } from '@ember/object';
 import get from 'lodash/get';
 import toNumber from 'lodash/toNumber';
 
+const TRANSLATE_PREFIX = 'pages.sessions.detail.candidates';
+
 export default class EnrolledCandidates extends Component {
   @service store;
+  @service intl;
   @service notifications;
   @tracked candidatesInStaging = [];
   @tracked newCandidate = {};
@@ -21,11 +24,11 @@ export default class EnrolledCandidates extends Component {
 
     try {
       await certificationCandidate.destroyRecord({ adapterOptions: { sessionId } });
-      this.notifications.success('Le candidat a été supprimé avec succès.');
+      this.notifications.success(this.intl.t(`${TRANSLATE_PREFIX}.add-modal.notifications.success-remove`));
     } catch (err) {
-      let errorText = "Une erreur s'est produite lors de la suppression du candidat";
+      let errorText = this.intl.t(`${TRANSLATE_PREFIX}.add-modal.notifications.error-remove-unknown`);
       if (get(err, 'errors[0].code') === 403) {
-        errorText = 'Ce candidat a déjà rejoint la session. Vous ne pouvez pas le supprimer.';
+        errorText = this.intl.t(`${TRANSLATE_PREFIX}.add-modal.notifications.error-remove-already-in`);
       }
       this.notifications.error(errorText);
     }
@@ -105,7 +108,7 @@ export default class EnrolledCandidates extends Component {
         adapterOptions: { registerToSession: true, sessionId: this.args.sessionId },
       });
       this.args.reloadCertificationCandidate();
-      this.notifications.success('Le candidat a été inscrit avec succès.');
+      this.notifications.success(this.intl.t(`${TRANSLATE_PREFIX}.add-modal.notifications.success-add`));
       return true;
     } catch (err) {
       if (this._hasConflict(err)) {
@@ -165,12 +168,12 @@ export default class EnrolledCandidates extends Component {
   }
 
   _handleDuplicateError(certificationCandidate) {
-    const errorText = "Ce candidat est déjà dans la liste, vous ne pouvez pas l'ajouter à nouveau.";
+    const errorText = this.intl.t(`${TRANSLATE_PREFIX}.add-modal.notifications.error-add-duplicate`);
     this._handleSavingError(errorText, certificationCandidate);
   }
 
   _handleUnknownSavingError(certificationCandidate) {
-    const errorText = "Une erreur s'est produite lors de l'ajout du candidat.";
+    const errorText = this.intl.t(`${TRANSLATE_PREFIX}.add-modal.notifications.error-add-unknown`);
     this._handleSavingError(errorText, certificationCandidate);
   }
 

--- a/certif/tests/unit/components/enrolled-candidates_test.js
+++ b/certif/tests/unit/components/enrolled-candidates_test.js
@@ -3,9 +3,11 @@ import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import setupIntl from '../../helpers/setup-intl';
 
 module('Unit | Component | enrolled-candidates', function (hooks) {
   setupTest(hooks);
+  setupIntl(hooks);
 
   let component;
 

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -362,10 +362,10 @@
             "info-panel": "If this field isn’t filled in, the results won't be transmitted by email for the affected candidate(s).<br />The candidate will see their results displayed directly on their Pix account.",
             "prepayment-information": "Prepayment code information",
             "prepayment-tooltip": "Required in particular when purchasing combined credits)<br />It must be comprised of the organisation’s SIRET and of the invoice’s number. Ex : 12345678912345/FACT12345.<br />If you don’t have an invoice, a prepayment code must be set with Pix.",
-            "required-fields": "The fields marked by <span class='required-field-indicator'>*</span>are required.",
+            "required-fields": "The fields marked by <span class=\"required-field-indicator\">*</span> are required.",
             "notifications": {
               "success-add": "The candidate has been successfully enrolled.",
-              "success-remove": "The candidate has been successfully deleted./The candidates have been successfully deleted.",
+              "success-remove": "The candidate has been successfully deleted.Ï",
               "error-add-duplicate": "This candidate is already in the list, you can't add them again.",
               "error-add-unknown": "An error occurred while adding the candidate.",
               "error-remove-already-in": "This candidate has already joined the session, you can’t delete them.",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -357,13 +357,19 @@
               "close-extra-information": "Close add candidate window modal",
               "enrol-the-candidate": "Enrol the candidate"
             },
-            "title": "Inscrire un candidat",
+            "title": "Enrol a candidate",
+            "complementary-certification-none": "None",
             "info-panel": "If this field isn’t filled in, the results won't be transmitted by email for the affected candidate(s).<br />The candidate will see their results displayed directly on their Pix account.",
             "prepayment-information": "Prepayment code information",
             "prepayment-tooltip": "Required in particular when purchasing combined credits)<br />It must be comprised of the organisation’s SIRET and of the invoice’s number. Ex : 12345678912345/FACT12345.<br />If you don’t have an invoice, a prepayment code must be set with Pix.",
+            "required-fields": "The fields marked by <span class='required-field-indicator'>*</span>are required.",
             "notifications": {
-              "add-success": "The candidate has been successfully enrolled.",
-              "remove-success": "The candidate has been successfully deleted."
+              "success-add": "The candidate has been successfully enrolled.",
+              "success-remove": "The candidate has been successfully deleted./The candidates have been successfully deleted.",
+              "error-add-duplicate": "This candidate is already in the list, you can't add them again.",
+              "error-add-unknown": "An error occurred while adding the candidate.",
+              "error-remove-already-in": "This candidate has already joined the session, you can’t delete them.",
+              "error-remove-unknown": "An error occurred while deleting the candidate."
             }
           },
           "detail-modal": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -362,14 +362,14 @@
             "info-panel": "Si le champ n’est pas renseigné, les résultats ne seront pas transmis par mail pour le/les candidats concernés.<br />Le candidat verra ses résultats affichés directement sur son compte Pix.",
             "prepayment-information": "Information du code de prépaiement",
             "prepayment-tooltip": "(Requis notamment dans le cas d'un achat de crédits combinés)<br />Doit être composé du SIRET de l’organisation et du numéro de facture. Ex : 12345678912345/FACT12345'.<br/>Si vous ne possédez pas de facture, un code de prépaiement doit être établi avec Pix.",
-            "required-fields": "Les champs marqués de <span class='required-field-indicator'>*</span>sont obligatoires.",
+            "required-fields": "Les champs marqués de <span class=\"required-field-indicator\">*</span> sont obligatoires.",
             "notifications": {
               "success-add": "Le candidat a été inscrit avec succès.",
               "success-remove": "Le candidat a été supprimé avec succès.",
               "error-add-duplicate": "Ce candidat est déjà dans la liste, vous ne pouvez pas l'ajouter à nouveau.",
               "error-add-unknown": "Une erreur s'est produite lors de l'ajout du candidat.",
               "error-remove-already-in": "Ce candidat a déjà rejoint la session. Vous ne pouvez pas le supprimer.",
-              "error-remove-unknown": "Une erreur s'est produite lors de la suppression du candidat"
+              "error-remove-unknown": "Une erreur s'est produite lors de la suppression du candidat."
             }
           },
           "detail-modal": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -358,12 +358,18 @@
               "close-extra-information": "Fermer la modale d'ajout de candidat",
               "enrol-the-candidate": "Inscrire le candidat"
             },
+            "complementary-certification-none": "Aucune",
             "info-panel": "Si le champ n’est pas renseigné, les résultats ne seront pas transmis par mail pour le/les candidats concernés.<br />Le candidat verra ses résultats affichés directement sur son compte Pix.",
             "prepayment-information": "Information du code de prépaiement",
             "prepayment-tooltip": "(Requis notamment dans le cas d'un achat de crédits combinés)<br />Doit être composé du SIRET de l’organisation et du numéro de facture. Ex : 12345678912345/FACT12345'.<br/>Si vous ne possédez pas de facture, un code de prépaiement doit être établi avec Pix.",
+            "required-fields": "Les champs marqués de <span class='required-field-indicator'>*</span>sont obligatoires.",
             "notifications": {
-              "add-success": "Le candidat a été inscrit avec succès.",
-              "remove-success": "Le candidat a été supprimé avec succès."
+              "success-add": "Le candidat a été inscrit avec succès.",
+              "success-remove": "Le candidat a été supprimé avec succès.",
+              "error-add-duplicate": "Ce candidat est déjà dans la liste, vous ne pouvez pas l'ajouter à nouveau.",
+              "error-add-unknown": "Une erreur s'est produite lors de l'ajout du candidat.",
+              "error-remove-already-in": "Ce candidat a déjà rejoint la session. Vous ne pouvez pas le supprimer.",
+              "error-remove-unknown": "Une erreur s'est produite lors de la suppression du candidat"
             }
           },
           "detail-modal": {


### PR DESCRIPTION
## :unicorn: Problème
Afin d'élargir le champ de prospection et de développement de Pix, et plus précisément de sa certification, à l’international, il nous faut permettre une utilisation de Pix Certif par un utilisateur anglophone.

Une fois que l'utilisateur anglophone a accédé à la liste des candidats sur l’onglet “Candidats” de la session concernée, s’il veut ajouter un candidat à la session, il clique sur le bouton “Inscrire un candidat”.

## :robot: Proposition
Voir les traductions dans le ticket : https://1024pix.atlassian.net/jira/software/c/projects/PIX/boards/91?modal=detail&selectedIssue=PIX-6672

## :rainbow: Remarques

Les 2 derniers commits sont des commits pour réorganiser le fichier de traduction.
L'avant-dernier, `Standardisation for requirement field`, normalise l'affichage des astérisques dans les champs obligatoires. Il y avait une différence sur la page de création d'un candidat, j'ai repris la façon de faire utilisée ailleurs dans l'appli, qui corresponde aux normes W3C et au design system.

Pour la réorganisation :
- déplacement des labels de formulaires de `pages. ...` à `common.labels`

## :100: Pour tester
Se connecter sur Pix Certif avec [certifsup@example.net](mailto:certifsup@example.net)
Passer ?lang=en dans l'url
Cliquer sur une session, puis sur l'onglet "Candidates", puis "Créer un candidat"
Constater que tous les éléments sont traduits
