### PR TITLE
[BUGFIX] Corrige le message de succès lors de l'import en masse  (PIX-7481)

### DIFF
--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -246,43 +246,86 @@ module('Acceptance | Session Import', function (hooks) {
               assert.strictEqual(currentURL(), '/sessions/liste');
             });
 
-            test('it should display a success notification', async function (assert) {
-              // given
-              const blob = new Blob(['foo']);
-              const file = new File([blob], 'fichier.csv');
-              this.server.post('/certification-centers/:id/sessions/validate-for-mass-import', () => {
-                return new Response(
-                  200,
-                  {},
-                  { sessionsCount: 2, sessionsWithoutCandidatesCount: 1, candidatesCount: 3 }
-                );
-              });
+            module('when there is one session', function () {
+              test('it should display a success notification', async function (assert) {
+                // given
+                const blob = new Blob(['foo']);
+                const file = new File([blob], 'fichier.csv');
+                this.server.post('/certification-centers/:id/sessions/validate-for-mass-import', () => {
+                  return new Response(
+                    200,
+                    {},
+                    { sessionsCount: 1, sessionsWithoutCandidatesCount: 1, candidatesCount: 1 }
+                  );
+                });
 
-              this.server.post('/certification-centers/:id/sessions/confirm-for-mass-import', () => {
-                return new Response(
-                  200,
-                  {},
-                  { sessionsCount: 2, sessionsWithoutCandidatesCount: 1, candidatesCount: 3 }
-                );
-              });
+                this.server.post('/certification-centers/:id/sessions/confirm-for-mass-import', () => {
+                  return new Response(
+                    200,
+                    {},
+                    { sessionsCount: 1, sessionsWithoutCandidatesCount: 1, candidatesCount: 3 }
+                  );
+                });
 
-              // when
-              screen = await visit('/sessions/import');
-              const input = screen.getByLabelText('Importer le modèle complété');
-              await triggerEvent(input, 'change', { files: [file] });
-              const importButton = screen.getByRole('button', { name: 'Continuer' });
-              await click(importButton);
-              const confirmButton = screen.getByRole('button', { name: 'Finaliser la création/édition' });
-              await click(confirmButton);
+                // when
+                screen = await visit('/sessions/import');
+                const input = screen.getByLabelText('Importer le modèle complété');
+                await triggerEvent(input, 'change', { files: [file] });
+                const importButton = screen.getByRole('button', { name: 'Continuer' });
+                await click(importButton);
+                const confirmButton = screen.getByRole('button', { name: 'Finaliser la création/édition' });
+                await click(confirmButton);
 
-              // then
-              assert
-                .dom(
-                  screen.getByText(
-                    'Succès ! 2 sessions dont 1 session sans candidat créé et 3 candidats créés ou édités'
+                // then
+                assert
+                  .dom(
+                    screen.getByText(
+                      'Succès ! 1 session dont 1 session sans candidat créée et 1 candidat créé ou édité'
+                    )
                   )
-                )
-                .exists();
+                  .exists();
+              });
+            });
+
+            module('when there is more than one session', function () {
+              test('it should display a pluralized success notification', async function (assert) {
+                // given
+                const blob = new Blob(['foo']);
+                const file = new File([blob], 'fichier.csv');
+                this.server.post('/certification-centers/:id/sessions/validate-for-mass-import', () => {
+                  return new Response(
+                    200,
+                    {},
+                    { sessionsCount: 2, sessionsWithoutCandidatesCount: 1, candidatesCount: 3 }
+                  );
+                });
+
+                this.server.post('/certification-centers/:id/sessions/confirm-for-mass-import', () => {
+                  return new Response(
+                    200,
+                    {},
+                    { sessionsCount: 2, sessionsWithoutCandidatesCount: 1, candidatesCount: 3 }
+                  );
+                });
+
+                // when
+                screen = await visit('/sessions/import');
+                const input = screen.getByLabelText('Importer le modèle complété');
+                await triggerEvent(input, 'change', { files: [file] });
+                const importButton = screen.getByRole('button', { name: 'Continuer' });
+                await click(importButton);
+                const confirmButton = screen.getByRole('button', { name: 'Finaliser la création/édition' });
+                await click(confirmButton);
+
+                // then
+                assert
+                  .dom(
+                    screen.getByText(
+                      'Succès ! 2 sessions dont 1 session sans candidat créées et 3 candidats créés ou édités'
+                    )
+                  )
+                  .exists();
+              });
             });
           });
         });

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -223,7 +223,7 @@
           "sessions-and-empty-sessions-count": "{sessionsCount} {sessionsCount, plural,one {session} other {sessions}} dont {sessionsWithoutCandidatesCount} {sessionsWithoutCandidatesCount, plural,one {session} other {sessions}} sans candidat",
           "candidates-count": "{candidatesCount} {candidatesCount, plural,one {candidat} other {candidats}}"
         },
-        "success": "Succès ! {sessionsCount} {sessionsCount, plural, one {session} other {sessions}} dont {sessionsWithoutCandidatesCount} {sessionsWithoutCandidatesCount, plural, one {session} other {sessions}} sans candidat créé et {candidatesCount} {candidatesCount, plural, one {candidat créé ou édité} other {candidats créés ou édités}}"
+        "success": "Succès ! {sessionsCount} {sessionsCount, plural, one {session} other {sessions}} dont {sessionsWithoutCandidatesCount} {sessionsWithoutCandidatesCount, plural, one {session} other {sessions}} sans candidat {sessionsCount, plural, one {créée} other {créées}} et {candidatesCount} {candidatesCount, plural, one {candidat créé ou édité} other {candidats créés ou édités}}"
       },
       "list": {
         "title": "Sessions de certification",


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'affichage du message de succes de l'import en masse, le verbe "créer" n'est pas bien accordé

## :robot: Proposition
Avec la pluralization:
“Succès ! 3 sessions dont 2 sessions sans candidat créées et 2 candidats créés ou édités”
“Succès ! 1 session dont 0 session sans candidat créée et 2 candidats créés ou édités”


## :rainbow: Remarques


## :100: Pour tester
Test un import avec une session et un autre avec 2 sessions, s'assurer que le message est correct