### PR TITLE
[FEATURE] Traduire l'espace surveillant en anglais (PIX-6706).

### DIFF
--- a/certif/app/components/session-supervising/candidate-list.hbs
+++ b/certif/app/components/session-supervising/candidate-list.hbs
@@ -1,16 +1,17 @@
 <div class="session-supervising-candidate-list-background">
   {{#if @candidates}}
     <div class="session-supervising-candidate-list">
-      <h1 class="session-supervising-candidate-list__title">Candidats</h1>
-      <p class="session-supervising-candidate-list__description">Cochez chaque candidat présent dans la salle de test
-        pour l'autoriser à commencer son test de certification.</p>
+      <h1 class="session-supervising-candidate-list__title">{{t "common.candidate.candidates"}}</h1>
+      <p class="session-supervising-candidate-list__description">{{t
+          "pages.session-supervising.candidate-list.indicate-candidates-attendance"
+        }}</p>
       <div class="session-supervising-candidate-list__search">
         <FaIcon @icon="search" class="search-icon" />
         <PixInput
           class="search-input"
           @id="search-candidate"
-          @ariaLabel="Rechercher un candidat"
-          placeholder="Rechercher un candidat"
+          @ariaLabel={{t "pages.session-supervising.candidate-list.search-candidate"}}
+          placeholder={{t "pages.session-supervising.candidate-list.search-candidate"}}
           @value={{this.filter}}
           {{on "input" this.setFilter}}
         />
@@ -19,7 +20,7 @@
           @backgroundColor="transparent-light"
           @isBorderVisible={{false}}
           @triggerAction={{this.emptySearchInput}}
-          aria-label="Vider le champ"
+          aria-label={{t "pages.session-supervising.candidate-list.clear-field"}}
           class="empty-button"
         >
           <FaIcon @icon="times" />
@@ -48,6 +49,8 @@
       alt=""
       role="presentation"
     />
-    <p class="session-supervising-candidate-list__empty-message">Aucun candidat inscrit à cette session</p>
+    <p class="session-supervising-candidate-list__empty-message">{{t
+        "pages.session-supervising.candidate-list.no-candidate"
+      }}</p>
   {{/if}}
 </div>

--- a/certif/app/components/session-supervising/header.hbs
+++ b/certif/app/components/session-supervising/header.hbs
@@ -1,6 +1,6 @@
 <div class="session-supervising-header">
   <PixButton
-    aria-label="Quitter la surveillance de la session {{@session.id}}"
+    aria-label={{t "pages.session-supervising.header.actions.exit-extra-information" sessionId=@session.id}}
     @size="small"
     @triggerAction={{this.askUserToConfirmLeaving}}
     @backgroundColor="transparent-light"
@@ -8,7 +8,7 @@
     class="session-supervising-header__quit"
   >
     <FaIcon @icon="sign-out-alt" />
-    {{t "common.actions.quit"}}
+    {{t "common.actions.exit"}}
   </PixButton>
   <h1 class="session-supervising-header__title">{{t
       "pages.session-supervising.header.session-id"
@@ -30,7 +30,9 @@
       {{@session.room}}
     </p>
     <p class="session-supervising-header__line">
-      <span class="session-supervising-header__label">{{t "pages.session-supervising.header.supervisor"}}</span>
+      <span class="session-supervising-header__label">{{t
+          "pages.session-supervising.header.multiple-supervisor"
+        }}</span>
       {{@session.examiner}}
     </p>
     <p class="session-supervising-header__line">

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -21,6 +21,9 @@
     },
     "form": {
       "mandatory-all-fields": "All fields are required."
+    },
+    "candidate": {
+      "candidates": "Candidates"
     }
   },
   "current-lang": "en",
@@ -466,7 +469,11 @@
         "supervisor": "Supervisor"
       },
       "candidate-list": {
-        "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} authorized {authorizedToStartCandidates, plural,one {candidate} other {candidates}}"
+        "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidate} other {candidates}} selected",
+        "clear-field": "Clear the field",
+        "indicate-candidates-attendance": "Check off each candidate present in the room to allow them to start their Pix certification exam.",
+        "no-candidate": "No candidate enrolled in this session",
+        "search-candidate": "Search for a candidate"
       },
       "candidate-in-list": {
         "extra-time": "Extra time",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -456,10 +456,9 @@
       "header": {
         "session-id": "Session {sessionId}",
         "center-name": "Center name",
-        "center-name-full": "Center name",
         "room": "Room",
         "supervisor": "Supervisor",
-        "multiple-supervisor": "Supervisor(s)",
+        "multiple-supervisor": "Invigilator(s)",
         "access-code": "Access code (candidates)"
       },
       "candidate-list": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -8,7 +8,8 @@
       "add": "Add",
       "delete": "Delete",
       "quit": "Quit",
-      "update": "Edit"
+      "update": "Edit",
+      "exit": "Exit"
     },
     "api-error-messages": {
       "bad-request-error": "The data entered was not in the correct format.",
@@ -454,12 +455,15 @@
     },
     "session-supervising": {
       "header": {
-        "session-id": "Session {sessionId}",
-        "center-name": "Center name",
-        "room": "Room",
-        "supervisor": "Supervisor",
+        "actions": {
+          "exit-extra-information": "Exit the invigilation of session {sessionId}"
+        },
+        "access-code": "Access code (candidates)",
+        "center-name": "Location",
         "multiple-supervisor": "Invigilator(s)",
-        "access-code": "Access code (candidates)"
+        "room": "Room",
+        "session-id": "Session {sessionId}",
+        "supervisor": "Supervisor"
       },
       "candidate-list": {
         "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} authorized {authorizedToStartCandidates, plural,one {candidate} other {candidates}}"

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -8,7 +8,8 @@
       "continue": "Continuer",
       "delete": "Supprimer",
       "quit": "Quitter",
-      "update": "Modifier"
+      "update": "Modifier",
+      "exit": "Quitter"
     },
     "api-error-messages": {
       "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
@@ -448,12 +449,15 @@
     },
     "session-supervising": {
       "header": {
-        "session-id": "Session {sessionId}",
+        "actions": {
+          "exit-extra-information": "Quitter la surveillance de la session {sessionId}"
+        },
+        "access-code": "Code d'accès (candidats)",
         "center-name": "Site",
-        "room": "Salle",
-        "supervisor": "Surveillant",
         "multiple-supervisor": "Surveillant(s)",
-        "access-code": "Code d'accès (candidats)"
+        "room": "Salle",
+        "session-id": "Session {sessionId}",
+        "supervisor": "Surveillant"
       },
       "candidate-list": {
         "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidat sélectionné} other {candidats sélectionnés}}"

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -21,6 +21,9 @@
     },
     "form": {
       "mandatory-all-fields": "Tous les champs sont obligatoires."
+    },
+    "candidate": {
+      "candidates": "Candidats"
     }
   },
   "current-lang": "fr",
@@ -460,7 +463,11 @@
         "supervisor": "Surveillant"
       },
       "candidate-list": {
-        "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidat sélectionné} other {candidats sélectionnés}}"
+        "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidat sélectionné} other {candidats sélectionnés}}",
+        "clear-field": "Vider le champ",
+        "indicate-candidates-attendance": "Cochez chaque candidat présent dans la salle de test pour l'autoriser à commencer son test de certification.",
+        "no-candidate": "Aucun candidat inscrit à cette session",
+        "search-candidate": "Rechercher un candidat"
       },
       "candidate-in-list": {
         "extra-time": "Temps majoré",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -450,7 +450,6 @@
       "header": {
         "session-id": "Session {sessionId}",
         "center-name": "Site",
-        "center-name-full": "Nom du site",
         "room": "Salle",
         "supervisor": "Surveillant",
         "multiple-supervisor": "Surveillant(s)",


### PR DESCRIPTION
## :unicorn: Problème
On souhaite traduire l'ensemble de l'application Pix Certif et on s'occupe ici de la page principale de l'espace surveillant.

## :robot: Proposition
Appliquer les traductions suivantes : 
- Session : Session
- Quitter : Exit
- Site : Location (⚠ pas Center)
- Salle : Room
- Surveillant(s) : Invigilator(s) (⚠ pas Supervisor)
- Code d'accès (candidats) : Access code (candidates)
- Candidats : Candidates
- Cochez chaque candidat présent dans la salle de test pour l'autoriser à commencer son test de certification. : Check off each candidate present in the room to allow them to start their Pix certification exam.
- 0/2 candidat(s) sélectionné(s) : 0/2 candidate(s) selected
- Temps majoré : Extra time
- Autoriser la reprise du test : Allow to resume the test
- Terminer le test : Finish the test
- En cours : In progress
- Autorisé à reprendre : Allowed to resume
- Terminé : Finished
- Début : Start

## :100: Pour tester
- Lancer Pix Certif
- Changer l'extension .fr de l'URL en .org puis rajouter le paramètre ?lang=en à la fin de l'url.
- Se connecter à l'espace surveillant d'une session ayant des candidats.
- Constater que les traductions sont correctes.
- Sélectionner des candidats pour vérifier que le message de sélection des candidats fonctionne correctement. (Singulier, pluriel).
- Se connecter à l'espace surveillant d'une session n'ayant aucun candidat.
- Vérifier que le message informant qu'aucun candidat n'est inscrit à cette session est correct.