### PR TITLE
[FEATURE] Gestion des erreurs non bloquantes (PIX-6962)

### DIFF
--- a/api/lib/domain/constants/sessions-errors.js
+++ b/api/lib/domain/constants/sessions-errors.js
@@ -47,4 +47,8 @@ module.exports.CERTIFICATION_SESSIONS_ERRORS = {
     code: 'SESSION_EXAMINER_REQUIRED',
     getMessage: () => 'Veuillez indiquer un(e) surveillant(e).',
   },
+  EMPTY_SESSION: {
+    code: 'EMPTY_SESSION',
+    getMessage: () => '',
+  },
 };

--- a/api/lib/domain/models/SessionMassImportReport.js
+++ b/api/lib/domain/models/SessionMassImportReport.js
@@ -1,16 +1,44 @@
 class SessionMassImportReport {
   constructor({
     cachedValidatedSessionsKey,
-    sessionsCount,
-    sessionsWithoutCandidatesCount,
-    candidatesCount,
-    errorsReport,
+    sessionsCount = 0,
+    sessionsWithoutCandidatesCount = 0,
+    candidatesCount = 0,
+    blockingErrorReports = [],
+    nonBlockingErrorReports = [],
   } = {}) {
     this.cachedValidatedSessionsKey = cachedValidatedSessionsKey;
     this.sessionsCount = sessionsCount;
     this.sessionsWithoutCandidatesCount = sessionsWithoutCandidatesCount;
     this.candidatesCount = candidatesCount;
-    this.errorsReport = errorsReport;
+    this.blockingErrorReports = blockingErrorReports;
+    this.nonBlockingErrorReports = nonBlockingErrorReports;
+  }
+
+  get isValid() {
+    return this.blockingErrorReports.length === 0;
+  }
+
+  addBlockingErrorReports(errors) {
+    if (errors?.length) {
+      this.blockingErrorReports.push(...errors);
+    }
+  }
+  addNonBlockingErrorReports(errors) {
+    if (errors?.length) {
+      this.nonBlockingErrorReports.push(...errors);
+    }
+  }
+
+  updateSessionsCounters(sessions) {
+    this.sessionsWithoutCandidatesCount = sessions.filter(
+      (session) => session.certificationCandidates.length === 0
+    ).length;
+    this.sessionsCount = sessions.length;
+    this.candidatesCount = sessions.reduce(
+      (currentCandidateCount, currentSession) => currentCandidateCount + currentSession.certificationCandidates.length,
+      0
+    );
   }
 }
 

--- a/api/lib/domain/models/SessionMassImportReport.js
+++ b/api/lib/domain/models/SessionMassImportReport.js
@@ -4,29 +4,22 @@ class SessionMassImportReport {
     sessionsCount = 0,
     sessionsWithoutCandidatesCount = 0,
     candidatesCount = 0,
-    blockingErrorReports = [],
-    nonBlockingErrorReports = [],
+    errorReports = [],
   } = {}) {
     this.cachedValidatedSessionsKey = cachedValidatedSessionsKey;
     this.sessionsCount = sessionsCount;
     this.sessionsWithoutCandidatesCount = sessionsWithoutCandidatesCount;
     this.candidatesCount = candidatesCount;
-    this.blockingErrorReports = blockingErrorReports;
-    this.nonBlockingErrorReports = nonBlockingErrorReports;
+    this.errorReports = errorReports;
   }
 
   get isValid() {
-    return this.blockingErrorReports.length === 0;
+    return !this.errorReports.some(({ blocking }) => blocking);
   }
 
-  addBlockingErrorReports(errors) {
+  addErrorReports(errors) {
     if (errors?.length) {
-      this.blockingErrorReports.push(...errors);
-    }
-  }
-  addNonBlockingErrorReports(errors) {
-    if (errors?.length) {
-      this.nonBlockingErrorReports.push(...errors);
+      this.errorReports.push(...errors);
     }
   }
 

--- a/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
+++ b/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
@@ -101,6 +101,20 @@ module.exports = {
       },
     };
   },
+
+  checkNonBlockingErrors({ session, line }) {
+    const nonBlockingErrorReports = [];
+
+    if (session.certificationCandidates.length === 0) {
+      _addToErrorList({
+        errorList: nonBlockingErrorReports,
+        line,
+        codes: [CERTIFICATION_SESSIONS_ERRORS.EMPTY_SESSION.code],
+      });
+    }
+
+    return nonBlockingErrorReports;
+  },
 };
 
 function _isErrorNotDuplicated({ certificationCandidateErrors, errorCode }) {

--- a/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
+++ b/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
@@ -45,7 +45,14 @@ module.exports = {
       _addToErrorList({ errorList: sessionErrors, line, codes: errorCodes });
     }
 
-    if (session.certificationCandidates?.length) {
+    if (session.certificationCandidates.length === 0) {
+      _addToErrorList({
+        errorList: sessionErrors,
+        line,
+        codes: [CERTIFICATION_SESSIONS_ERRORS.EMPTY_SESSION.code],
+        blocking: false,
+      });
+    } else {
       if (_hasDuplicateCertificationCandidates(session.certificationCandidates)) {
         _addToErrorList({
           errorList: sessionErrors,
@@ -101,28 +108,14 @@ module.exports = {
       },
     };
   },
-
-  checkNonBlockingErrors({ session, line }) {
-    const nonBlockingErrorReports = [];
-
-    if (session.certificationCandidates.length === 0) {
-      _addToErrorList({
-        errorList: nonBlockingErrorReports,
-        line,
-        codes: [CERTIFICATION_SESSIONS_ERRORS.EMPTY_SESSION.code],
-      });
-    }
-
-    return nonBlockingErrorReports;
-  },
 };
 
 function _isErrorNotDuplicated({ certificationCandidateErrors, errorCode }) {
   return !certificationCandidateErrors.some((error) => errorCode === error.code);
 }
 
-function _addToErrorList({ errorList, line, codes = [] }) {
-  const errors = codes.map((code) => ({ code, line }));
+function _addToErrorList({ errorList, line, codes = [], blocking = true }) {
+  const errors = codes.map((code) => ({ code, line, blocking }));
   errorList.push(...errors);
 }
 

--- a/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
+++ b/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
@@ -39,14 +39,7 @@ module.exports = async function validateSessions({
       certificationCourseRepository,
     });
 
-    sessionsMassImportReport.addBlockingErrorReports(sessionsErrors);
-
-    const nonBlockingErrors = sessionsImportValidationService.checkNonBlockingErrors({
-      session,
-      line: sessionDTO.line,
-    });
-
-    sessionsMassImportReport.addNonBlockingErrorReports(nonBlockingErrors);
+    sessionsMassImportReport.addErrorReports(sessionsErrors);
 
     if (session.certificationCandidates.length) {
       const { certificationCandidates } = session;
@@ -108,7 +101,7 @@ async function _createValidCertificationCandidates({
       });
 
     if (certificationCandidateErrors?.length > 0) {
-      sessionsMassImportReport.addBlockingErrorReports(certificationCandidateErrors);
+      sessionsMassImportReport.addErrorReports(certificationCandidateErrors);
     } else {
       domainCertificationCandidate.updateBirthInformation(cpfBirthInformation);
 

--- a/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
+++ b/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
@@ -41,6 +41,13 @@ module.exports = async function validateSessions({
 
     sessionsMassImportReport.addBlockingErrorReports(sessionsErrors);
 
+    const nonBlockingErrors = sessionsImportValidationService.checkNonBlockingErrors({
+      session,
+      line: sessionDTO.line,
+    });
+
+    sessionsMassImportReport.addNonBlockingErrorReports(nonBlockingErrors);
+
     if (session.certificationCandidates.length) {
       const { certificationCandidates } = session;
       const validatedCertificationCandidates = await _createValidCertificationCandidates({

--- a/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
+++ b/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
@@ -18,8 +18,7 @@ module.exports = async function validateSessions({
   certificationCourseRepository,
 }) {
   const { name: certificationCenter, isSco } = await certificationCenterRepository.get(certificationCenterId);
-  let cachedValidatedSessionsKey;
-  const errorsReport = [];
+  const sessionsMassImportReport = new SessionMassImportReport();
 
   const validatedSessions = await bluebird.mapSeries(sessions, async (sessionDTO) => {
     const { sessionId } = sessionDTO;
@@ -40,9 +39,7 @@ module.exports = async function validateSessions({
       certificationCourseRepository,
     });
 
-    if (sessionsErrors?.length) {
-      errorsReport.push(...sessionsErrors);
-    }
+    sessionsMassImportReport.addBlockingErrorReports(sessionsErrors);
 
     if (session.certificationCandidates.length) {
       const { certificationCandidates } = session;
@@ -50,7 +47,7 @@ module.exports = async function validateSessions({
         certificationCandidates,
         sessionId,
         isSco,
-        errorsReport,
+        sessionsMassImportReport,
         certificationCpfCountryRepository,
         certificationCpfCityRepository,
         complementaryCertificationRepository,
@@ -62,29 +59,15 @@ module.exports = async function validateSessions({
     return session;
   });
 
-  if (!errorsReport.length) {
-    cachedValidatedSessionsKey = await temporarySessionsStorageForMassImportService.save({
+  if (sessionsMassImportReport.isValid) {
+    const cachedValidatedSessionsKey = await temporarySessionsStorageForMassImportService.save({
       sessions: validatedSessions,
       userId,
     });
+    sessionsMassImportReport.cachedValidatedSessionsKey = cachedValidatedSessionsKey;
   }
 
-  const sessionsWithoutCandidatesCount = validatedSessions.filter(
-    (session) => session.certificationCandidates.length === 0
-  ).length;
-  const sessionsCount = validatedSessions.length;
-  const candidatesCount = validatedSessions.reduce(
-    (currentCandidateCount, currentSession) => currentCandidateCount + currentSession.certificationCandidates.length,
-    0
-  );
-
-  const sessionsMassImportReport = new SessionMassImportReport({
-    cachedValidatedSessionsKey,
-    sessionsCount,
-    sessionsWithoutCandidatesCount,
-    candidatesCount,
-    errorsReport,
-  });
+  sessionsMassImportReport.updateSessionsCounters(validatedSessions);
 
   return sessionsMassImportReport;
 };
@@ -93,7 +76,7 @@ async function _createValidCertificationCandidates({
   certificationCandidates,
   sessionId,
   isSco,
-  errorsReport,
+  sessionsMassImportReport,
   certificationCpfCountryRepository,
   certificationCpfCityRepository,
   complementaryCertificationRepository,
@@ -117,8 +100,8 @@ async function _createValidCertificationCandidates({
         certificationCpfCityRepository,
       });
 
-    if (certificationCandidateErrors?.length) {
-      errorsReport.push(...certificationCandidateErrors);
+    if (certificationCandidateErrors?.length > 0) {
+      sessionsMassImportReport.addBlockingErrorReports(certificationCandidateErrors);
     } else {
       domainCertificationCandidate.updateBirthInformation(cpfBirthInformation);
 

--- a/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-validate-sessions_test.js
+++ b/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-validate-sessions_test.js
@@ -63,8 +63,14 @@ describe('Acceptance | Controller | certification-centers-controller-post-valida
         expect(response.statusCode).to.equal(200);
         expect(_checkIfValidUUID(response.result.cachedValidatedSessionsKey)).to.be.true;
         expect(omit(response.result, 'cachedValidatedSessionsKey')).to.deep.equal({
+          blockingErrorReports: [],
           candidatesCount: 0,
-          errorsReport: [],
+          nonBlockingErrorReports: [
+            {
+              code: 'EMPTY_SESSION',
+              line: 2,
+            },
+          ],
           sessionsCount: 1,
           sessionsWithoutCandidatesCount: 1,
         });
@@ -118,12 +124,13 @@ describe('Acceptance | Controller | certification-centers-controller-post-valida
               sessionsCount: 2,
               sessionsWithoutCandidatesCount: 0,
               candidatesCount: 2,
-              errorsReport: [
+              blockingErrorReports: [
                 {
                   code: 'INFORMATION_NOT_ALLOWED_WITH_SESSION_ID',
                   line: 3,
                 },
               ],
+              nonBlockingErrorReports: [],
             });
           });
         });

--- a/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-validate-sessions_test.js
+++ b/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-validate-sessions_test.js
@@ -63,12 +63,12 @@ describe('Acceptance | Controller | certification-centers-controller-post-valida
         expect(response.statusCode).to.equal(200);
         expect(_checkIfValidUUID(response.result.cachedValidatedSessionsKey)).to.be.true;
         expect(omit(response.result, 'cachedValidatedSessionsKey')).to.deep.equal({
-          blockingErrorReports: [],
           candidatesCount: 0,
-          nonBlockingErrorReports: [
+          errorReports: [
             {
               code: 'EMPTY_SESSION',
               line: 2,
+              blocking: false,
             },
           ],
           sessionsCount: 1,
@@ -124,13 +124,13 @@ describe('Acceptance | Controller | certification-centers-controller-post-valida
               sessionsCount: 2,
               sessionsWithoutCandidatesCount: 0,
               candidatesCount: 2,
-              blockingErrorReports: [
+              errorReports: [
                 {
                   code: 'INFORMATION_NOT_ALLOWED_WITH_SESSION_ID',
                   line: 3,
+                  blocking: true,
                 },
               ],
-              nonBlockingErrorReports: [],
             });
           });
         });

--- a/api/tests/unit/domain/models/SessionMassImportReport_test.js
+++ b/api/tests/unit/domain/models/SessionMassImportReport_test.js
@@ -2,62 +2,32 @@ const SessionMassImportReport = require('../../../../lib/domain/models/SessionMa
 const { expect } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | SessionMassImportReport', function () {
-  context('#addBlockingErrorsReports', function () {
+  context('#addErrorsReports', function () {
     context('when there are reports', function () {
       it('should add blocking errors reports', function () {
         // given
         const sessionMassImportReport = new SessionMassImportReport({
-          blockingErrorReports: [0],
+          errorReports: [0],
         });
 
         // when
-        sessionMassImportReport.addBlockingErrorReports([1, 2, 3]);
+        sessionMassImportReport.addErrorReports([1, 2, 3]);
 
         // then
-        expect(sessionMassImportReport.blockingErrorReports.length).to.equal(4);
+        expect(sessionMassImportReport.errorReports.length).to.equal(4);
       });
     });
 
     context('when there are no reports', function () {
       it('should do nothing', function () {
         // given
-        const sessionMassImportReport = new SessionMassImportReport({ blockingErrorReports: [0] });
+        const sessionMassImportReport = new SessionMassImportReport({ errorReports: [0] });
 
         // when
-        sessionMassImportReport.addBlockingErrorReports();
+        sessionMassImportReport.addErrorReports();
 
         // then
-        expect(sessionMassImportReport.blockingErrorReports.length).to.equal(1);
-      });
-    });
-  });
-
-  context('#addNonBlockingErrorReports', function () {
-    context('when there are reports', function () {
-      it('should add blocking errors reports', function () {
-        // given
-        const sessionMassImportReport = new SessionMassImportReport({
-          nonBlockingErrorReports: [0],
-        });
-
-        // when
-        sessionMassImportReport.addNonBlockingErrorReports([1, 2, 3]);
-
-        // then
-        expect(sessionMassImportReport.nonBlockingErrorReports.length).to.equal(4);
-      });
-    });
-
-    context('when there are no reports', function () {
-      it('should do nothing', function () {
-        // given
-        const sessionMassImportReport = new SessionMassImportReport({ nonBlockingErrorReports: [0] });
-
-        // when
-        sessionMassImportReport.addNonBlockingErrorReports();
-
-        // then
-        expect(sessionMassImportReport.nonBlockingErrorReports.length).to.equal(1);
+        expect(sessionMassImportReport.errorReports.length).to.equal(1);
       });
     });
   });
@@ -67,8 +37,7 @@ describe('Unit | Domain | Models | SessionMassImportReport', function () {
       it('should return false', function () {
         // given
         const sessionMassImportReport = new SessionMassImportReport({
-          nonBlockingErrorReports: [1],
-          blockingErrorReports: [1],
+          errorReports: [{ blocking: true }],
         });
 
         // when
@@ -79,12 +48,26 @@ describe('Unit | Domain | Models | SessionMassImportReport', function () {
       });
     });
 
-    context('when there are no blocking error reports', function () {
+    context('when there are non blocking error reports', function () {
       it('should return true', function () {
         // given
         const sessionMassImportReport = new SessionMassImportReport({
-          nonBlockingErrorReports: [1],
-          blockingErrorReports: [],
+          errorReports: [{ blocking: false }],
+        });
+
+        // when
+        const isValid = sessionMassImportReport.isValid;
+
+        // then
+        expect(isValid).to.be.true;
+      });
+    });
+
+    context('when there are no error reports', function () {
+      it('should return true', function () {
+        // given
+        const sessionMassImportReport = new SessionMassImportReport({
+          errorReports: [],
         });
 
         // when

--- a/api/tests/unit/domain/models/SessionMassImportReport_test.js
+++ b/api/tests/unit/domain/models/SessionMassImportReport_test.js
@@ -1,0 +1,142 @@
+const SessionMassImportReport = require('../../../../lib/domain/models/SessionMassImportReport');
+const { expect } = require('../../../test-helper');
+
+describe('Unit | Domain | Models | SessionMassImportReport', function () {
+  context('#addBlockingErrorsReports', function () {
+    context('when there are reports', function () {
+      it('should add blocking errors reports', function () {
+        // given
+        const sessionMassImportReport = new SessionMassImportReport({
+          blockingErrorReports: [0],
+        });
+
+        // when
+        sessionMassImportReport.addBlockingErrorReports([1, 2, 3]);
+
+        // then
+        expect(sessionMassImportReport.blockingErrorReports.length).to.equal(4);
+      });
+    });
+
+    context('when there are no reports', function () {
+      it('should do nothing', function () {
+        // given
+        const sessionMassImportReport = new SessionMassImportReport({ blockingErrorReports: [0] });
+
+        // when
+        sessionMassImportReport.addBlockingErrorReports();
+
+        // then
+        expect(sessionMassImportReport.blockingErrorReports.length).to.equal(1);
+      });
+    });
+  });
+
+  context('#addNonBlockingErrorReports', function () {
+    context('when there are reports', function () {
+      it('should add blocking errors reports', function () {
+        // given
+        const sessionMassImportReport = new SessionMassImportReport({
+          nonBlockingErrorReports: [0],
+        });
+
+        // when
+        sessionMassImportReport.addNonBlockingErrorReports([1, 2, 3]);
+
+        // then
+        expect(sessionMassImportReport.nonBlockingErrorReports.length).to.equal(4);
+      });
+    });
+
+    context('when there are no reports', function () {
+      it('should do nothing', function () {
+        // given
+        const sessionMassImportReport = new SessionMassImportReport({ nonBlockingErrorReports: [0] });
+
+        // when
+        sessionMassImportReport.addNonBlockingErrorReports();
+
+        // then
+        expect(sessionMassImportReport.nonBlockingErrorReports.length).to.equal(1);
+      });
+    });
+  });
+
+  context('#isValid', function () {
+    context('when there are blocking error reports', function () {
+      it('should return false', function () {
+        // given
+        const sessionMassImportReport = new SessionMassImportReport({
+          nonBlockingErrorReports: [1],
+          blockingErrorReports: [1],
+        });
+
+        // when
+        const isValid = sessionMassImportReport.isValid;
+
+        // then
+        expect(isValid).to.be.false;
+      });
+    });
+
+    context('when there are no blocking error reports', function () {
+      it('should return true', function () {
+        // given
+        const sessionMassImportReport = new SessionMassImportReport({
+          nonBlockingErrorReports: [1],
+          blockingErrorReports: [],
+        });
+
+        // when
+        const isValid = sessionMassImportReport.isValid;
+
+        // then
+        expect(isValid).to.be.true;
+      });
+    });
+
+    context('#updateSessionsCounter', function () {
+      context('when there is no session', function () {
+        it('should update sessionsWithoutCandidatesCount, sessionsCount, candidatesCount to 0', function () {
+          // given
+          const sessionMassImportReport = new SessionMassImportReport({});
+          const sessions = [];
+
+          // when
+          sessionMassImportReport.updateSessionsCounters(sessions);
+
+          // then
+          expect(sessionMassImportReport.sessionsCount).to.equal(0);
+          expect(sessionMassImportReport.sessionsWithoutCandidatesCount).to.equal(0);
+          expect(sessionMassImportReport.candidatesCount).to.equal(0);
+        });
+      });
+
+      context('when there are sessions', function () {
+        it('should update sessionsWithoutCandidatesCount, sessionsCount, candidatesCount to 0', function () {
+          // given
+          const sessionMassImportReport = new SessionMassImportReport({});
+          const sessions = [
+            {
+              certificationCandidates: [1, 2, 3],
+            },
+            {
+              certificationCandidates: [1],
+            },
+            {
+              certificationCandidates: [],
+            },
+          ];
+
+          // when
+          sessionMassImportReport.updateSessionsCounters(sessions);
+
+          // then
+          expect(sessionMassImportReport.sessionsCount).to.equal(3);
+          expect(sessionMassImportReport.sessionsWithoutCandidatesCount).to.equal(1);
+          expect(sessionMassImportReport.candidatesCount).to.equal(4);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -5,6 +5,7 @@ const certificationCpfService = require('../../../../../lib/domain/services/cert
 const {
   CERTIFICATION_CANDIDATES_ERRORS,
 } = require('../../../../../lib/domain/constants/certification-candidates-errors');
+const { CERTIFICATION_SESSIONS_ERRORS } = require('../../../../../lib/domain/constants/sessions-errors');
 const noop = require('lodash/noop');
 
 describe('Unit | Service | sessions import validation Service', function () {
@@ -479,6 +480,26 @@ describe('Unit | Service | sessions import validation Service', function () {
 
         // then
         expect(result.certificationCandidateErrors).to.deep.equal([{ code: 'CPF_INCORRECT', line: 1 }]);
+      });
+    });
+  });
+
+  describe('#checkNonBlockingErrors', function () {
+    describe('when session is empty', function () {
+      it('should return an errorReport that contains an empty session error', function () {
+        // given
+        const sessionData = _createValidSessionData();
+
+        // when
+        const result = sessionsImportValidationService.checkNonBlockingErrors({ session: sessionData, line: 3 });
+
+        // then
+        expect(result).to.deep.equal([
+          {
+            line: 3,
+            code: CERTIFICATION_SESSIONS_ERRORS.EMPTY_SESSION.code,
+          },
+        ]);
       });
     });
   });

--- a/api/tests/unit/domain/usecases/sessions-mass-import/validate-sessions_test.js
+++ b/api/tests/unit/domain/usecases/sessions-mass-import/validate-sessions_test.js
@@ -43,14 +43,17 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
       // given
       const userId = 1234;
       const cachedValidatedSessionsKey = 'uuid';
-      const validSessionData = createValidSessionData();
+      const validSessionData = _createValidSessionData();
+
       const sessions = [
         {
           ...validSessionData,
+          line: 2,
           room: 'Salle 1',
         },
         {
           ...validSessionData,
+          line: 3,
           room: 'Salle 2',
         },
       ];
@@ -73,6 +76,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           certificationCenterId,
           certificationCenter: certificationCenterName,
           accessCode,
+          certificationCandidates: [],
           supervisorPassword: sinon.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/),
         }),
         new Session({
@@ -80,6 +84,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           certificationCenterId,
           certificationCenter: certificationCenterName,
           accessCode,
+          certificationCandidates: [],
           supervisorPassword: sinon.match(/^[2346789BCDFGHJKMPQRTVWXY]{5}$/),
         }),
       ];
@@ -95,7 +100,16 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         sessionsWithoutCandidatesCount: 2,
         candidatesCount: 0,
         blockingErrorReports: [],
-        nonBlockingErrorReports: [],
+        nonBlockingErrorReports: [
+          {
+            code: 'EMPTY_SESSION',
+            line: 2,
+          },
+          {
+            code: 'EMPTY_SESSION',
+            line: 3,
+          },
+        ],
       });
     });
 
@@ -103,9 +117,9 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
       it('should validate the candidates in the session', async function () {
         // given
         const cachedValidatedSessionsKey = 'uuid';
-        const candidate1 = createValidCandidateData(1);
-        const candidate2 = createValidCandidateData(2);
-        const candidate3 = createValidCandidateData(3);
+        const candidate1 = _createValidCandidateData(1);
+        const candidate2 = _createValidCandidateData(2);
+        const candidate3 = _createValidCandidateData(3);
         const userId = 1234;
         const sessions = [
           {
@@ -191,7 +205,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
     it('should not save in temporary storage', async function () {
       // given
       sessionsImportValidationService.validateSession.resolves(['Veuillez indiquer un nom de site.']);
-      const validSessionData = createValidSessionData();
+      const validSessionData = _createValidSessionData();
 
       const sessions = [
         {
@@ -215,8 +229,8 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
     context('when at least one of the sessions is not valid', function () {
       it('should return sessionsMassImportReport', async function () {
         // given
-        const validSessionData = createValidSessionData();
-        const candidate = createValidCandidateData();
+        const validSessionData = _createValidSessionData();
+        const candidate = _createValidCandidateData();
 
         const sessions = [
           {
@@ -255,7 +269,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
   });
 });
 
-function createValidSessionData() {
+function _createValidSessionData() {
   return {
     sessionId: undefined,
     address: 'Site 1',
@@ -268,7 +282,7 @@ function createValidSessionData() {
   };
 }
 
-function createValidCandidateData(candidateNumber = 2) {
+function _createValidCandidateData(candidateNumber = 2) {
   return {
     lastName: `Candidat ${candidateNumber}`,
     firstName: `Candidat ${candidateNumber}`,

--- a/api/tests/unit/domain/usecases/sessions-mass-import/validate-sessions_test.js
+++ b/api/tests/unit/domain/usecases/sessions-mass-import/validate-sessions_test.js
@@ -94,7 +94,8 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
         sessionsCount: 2,
         sessionsWithoutCandidatesCount: 2,
         candidatesCount: 0,
-        errorsReport: [],
+        blockingErrorReports: [],
+        nonBlockingErrorReports: [],
       });
     });
 
@@ -179,7 +180,8 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           sessionsCount: 2,
           sessionsWithoutCandidatesCount: 0,
           candidatesCount: 3,
-          errorsReport: [],
+          blockingErrorReports: [],
+          nonBlockingErrorReports: [],
         });
       });
     });
@@ -243,7 +245,8 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           sessionsCount: 1,
           sessionsWithoutCandidatesCount: 0,
           candidatesCount: 1,
-          errorsReport: ['Veuillez indiquer un nom de site.', 'lastName required'],
+          blockingErrorReports: ['Veuillez indiquer un nom de site.', 'lastName required'],
+          nonBlockingErrorReports: [],
         });
 
         expect(complementaryCertificationRepository.getByLabel).to.not.have.been.called;

--- a/certif/app/components/import/step-one-section.hbs
+++ b/certif/app/components/import/step-one-section.hbs
@@ -59,21 +59,12 @@
     </div>
   {{/if}}
 
-  <ul class="import-page__section--link-buttons">
-    <li>
-      <PixButtonLink
-        @route="authenticated.sessions.list"
-        @backgroundColor="transparent-light"
-        @isBorderVisible={{true}}
-      >
-        {{t "common.actions.cancel"}}
-      </PixButtonLink>
-    </li>
-    <li>
-      <PixButton @triggerAction={{@validateSessions}} @isDisabled={{@isImportDisabled}}>
-        {{t "common.actions.continue"}}
-      </PixButton>
-    </li>
-  </ul>
-
+  <div class="import-page__section--link-buttons">
+    <PixButtonLink @route="authenticated.sessions.list" @backgroundColor="transparent-light" @isBorderVisible={{true}}>
+      {{t "common.actions.cancel"}}
+    </PixButtonLink>
+    <PixButton @triggerAction={{@validateSessions}} @isDisabled={{@isImportDisabled}}>
+      {{t "common.actions.continue"}}
+    </PixButton>
+  </div>
 </section>

--- a/certif/app/components/import/step-two-section.hbs
+++ b/certif/app/components/import/step-two-section.hbs
@@ -41,7 +41,7 @@
       </PixCollapsible>
     </div>
   {{/if}}
-  {{#if @isImportInError}}
+  {{#if (gt this.blockingErrorReportsCount 0)}}
     <span class="import-page-section__information">
       {{t "pages.sessions.import.step-two.blocking-errors.information"}}
     </span>
@@ -65,16 +65,47 @@
         {{/each}}
       </PixCollapsible>
     </div>
-    <PixButton
-      class="import-page__section--confirm-button"
-      aria-label={{t "pages.sessions.import.step-two.actions.import-again.extra-information"}}
-      @triggerAction={{@toggleStepOne}}
-    >
-      {{t "pages.sessions.import.step-two.actions.import-again.label"}}
-    </PixButton>
-  {{else}}
-    <PixButton class="import-page__section--confirm-button" @triggerAction={{@createSessions}}>
-      {{t "pages.sessions.import.step-two.actions.confirm.label"}}
-    </PixButton>
   {{/if}}
+
+  <ul class="import-page__section--link-buttons">
+    {{#if this.hasOnlyNonBlockingErrorReports}}
+      <li>
+        <PixButton
+          @backgroundColor="yellow"
+          class="import-page__section--confirm-button--non-blocking"
+          @triggerAction={{@createSessions}}
+        >
+          {{t "pages.sessions.import.step-two.actions.confirm-with-warning.label"}}
+        </PixButton>
+      </li>
+      <li>
+        <PixButton
+          @backgroundColor="transparent-light"
+          @isBorderVisible="true"
+          @triggerAction={{@toggleStepOne}}
+          aria-label={{t "pages.sessions.import.step-two.actions.import-again.extra-information"}}
+        >
+
+          {{t "pages.sessions.import.step-two.actions.import-again.label"}}
+        </PixButton></li>
+    {{/if}}
+    {{#if (gt this.blockingErrorReportsCount 0)}}
+      <li>
+        <PixButton
+          class="import-page__section--confirm-button"
+          aria-label={{t "pages.sessions.import.step-two.actions.import-again.extra-information"}}
+          @triggerAction={{@toggleStepOne}}
+        >
+          {{t "pages.sessions.import.step-two.actions.import-again.label"}}
+        </PixButton>
+      </li>
+    {{/if}}
+    {{#if this.noErrorBlockingOrNot}}
+      <li>
+        <PixButton class="import-page__section--confirm-button" @triggerAction={{@createSessions}}>
+          {{t "pages.sessions.import.step-two.actions.confirm.label"}}
+        </PixButton>
+      </li>
+    {{/if}}
+  </ul>
 </section>

--- a/certif/app/components/import/step-two-section.hbs
+++ b/certif/app/components/import/step-two-section.hbs
@@ -100,7 +100,7 @@
         </PixButton>
       </li>
     {{/if}}
-    {{#if this.noErrorBlockingOrNot}}
+    {{#if this.noError}}
       <li>
         <PixButton class="import-page__section--confirm-button" @triggerAction={{@createSessions}}>
           {{t "pages.sessions.import.step-two.actions.confirm.label"}}

--- a/certif/app/components/import/step-two-section.hbs
+++ b/certif/app/components/import/step-two-section.hbs
@@ -13,6 +13,34 @@
         {{t "pages.sessions.import.step-two.candidates-count" candidatesCount=@candidatesCount}}</li>
     </ul>
   </PixMessage>
+  {{#if (gt this.nonBlockingErrorReportsCount 0)}}
+    <span class="import-page-section__information">
+      {{t
+        "pages.sessions.import.step-two.non-blocking-errors.information"
+        nonBlockingErrorReportsCount=this.nonBlockingErrorReportsCount
+      }}
+    </span>
+    <div>
+      <PixCollapsible
+        @titleIcon="triangle-exclamation"
+        @title={{t
+          "pages.sessions.import.step-two.non-blocking-errors.title"
+          nonBlockingErrorReportsCount=this.nonBlockingErrorReportsCount
+        }}
+        @iconTitle="plus"
+        class="import-page-section__collapsible-header--non-blocking"
+      >
+        {{#each this.translatedNonBlockingErrorReport as |report|}}
+          <PixMessage @type="warning">
+            <p>{{t "pages.sessions.import.step-two.non-blocking-errors.line"}}
+              {{report.line}}
+              :
+              {{report.message}}</p>
+          </PixMessage>
+        {{/each}}
+      </PixCollapsible>
+    </div>
+  {{/if}}
   {{#if @isImportInError}}
     <span class="import-page-section__information">
       {{t "pages.sessions.import.step-two.blocking-errors.information"}}
@@ -22,12 +50,12 @@
         @titleIcon="circle-exclamation"
         @title={{t
           "pages.sessions.import.step-two.blocking-errors.title"
-          blockingErrorReportsCount=@blockingErrorReportsCount
+          blockingErrorReportsCount=this.blockingErrorReportsCount
         }}
         @iconTitle="plus"
-        class="import-page-section__collapsible-header"
+        class="import-page-section__collapsible-header--blocking"
       >
-        {{#each this.translatedErrorReport as |report|}}
+        {{#each this.translatedBlockingErrorReport as |report|}}
           <PixMessage @type="error">
             <p>{{t "pages.sessions.import.step-two.blocking-errors.line"}}
               {{report.line}}

--- a/certif/app/components/import/step-two-section.hbs
+++ b/certif/app/components/import/step-two-section.hbs
@@ -67,45 +67,38 @@
     </div>
   {{/if}}
 
-  <ul class="import-page__section--link-buttons">
+  <div class="import-page__section--link-buttons">
     {{#if this.hasOnlyNonBlockingErrorReports}}
-      <li>
-        <PixButton
-          @backgroundColor="yellow"
-          class="import-page__section--confirm-button--non-blocking"
-          @triggerAction={{@createSessions}}
-        >
-          {{t "pages.sessions.import.step-two.actions.confirm-with-warning.label"}}
-        </PixButton>
-      </li>
-      <li>
-        <PixButton
-          @backgroundColor="transparent-light"
-          @isBorderVisible="true"
-          @triggerAction={{@toggleStepOne}}
-          aria-label={{t "pages.sessions.import.step-two.actions.import-again.extra-information"}}
-        >
+      <PixButton
+        @backgroundColor="yellow"
+        class="import-page__section--confirm-button--non-blocking"
+        @triggerAction={{@createSessions}}
+      >
+        {{t "pages.sessions.import.step-two.actions.confirm-with-warning.label"}}
+      </PixButton>
+      <PixButton
+        @backgroundColor="transparent-light"
+        @isBorderVisible="true"
+        @triggerAction={{@toggleStepOne}}
+        aria-label={{t "pages.sessions.import.step-two.actions.import-again.extra-information"}}
+      >
 
-          {{t "pages.sessions.import.step-two.actions.import-again.label"}}
-        </PixButton></li>
+        {{t "pages.sessions.import.step-two.actions.import-again.label"}}
+      </PixButton>
     {{/if}}
     {{#if (gt this.blockingErrorReportsCount 0)}}
-      <li>
-        <PixButton
-          class="import-page__section--confirm-button"
-          aria-label={{t "pages.sessions.import.step-two.actions.import-again.extra-information"}}
-          @triggerAction={{@toggleStepOne}}
-        >
-          {{t "pages.sessions.import.step-two.actions.import-again.label"}}
-        </PixButton>
-      </li>
+      <PixButton
+        class="import-page__section--confirm-button"
+        aria-label={{t "pages.sessions.import.step-two.actions.import-again.extra-information"}}
+        @triggerAction={{@toggleStepOne}}
+      >
+        {{t "pages.sessions.import.step-two.actions.import-again.label"}}
+      </PixButton>
     {{/if}}
     {{#if this.noError}}
-      <li>
-        <PixButton class="import-page__section--confirm-button" @triggerAction={{@createSessions}}>
-          {{t "pages.sessions.import.step-two.actions.confirm.label"}}
-        </PixButton>
-      </li>
+      <PixButton class="import-page__section--confirm-button" @triggerAction={{@createSessions}}>
+        {{t "pages.sessions.import.step-two.actions.confirm.label"}}
+      </PixButton>
     {{/if}}
-  </ul>
+  </div>
 </section>

--- a/certif/app/components/import/step-two-section.hbs
+++ b/certif/app/components/import/step-two-section.hbs
@@ -20,7 +20,10 @@
     <div>
       <PixCollapsible
         @titleIcon="circle-exclamation"
-        @title={{t "pages.sessions.import.step-two.blocking-errors.title" errorsReportCount=@errorsReportCount}}
+        @title={{t
+          "pages.sessions.import.step-two.blocking-errors.title"
+          blockingErrorReportsCount=@blockingErrorReportsCount
+        }}
         @iconTitle="plus"
         class="import-page-section__collapsible-header"
       >

--- a/certif/app/components/import/step-two-section.js
+++ b/certif/app/components/import/step-two-section.js
@@ -5,28 +5,47 @@ export default class StepTwoSectionComponent extends Component {
   @service intl;
 
   get translatedBlockingErrorReport() {
-    return this.args.blockingErrorReports.map(({ line, code }) => ({
+    const blockingErrorReports = this._blockingErrors;
+
+    return blockingErrorReports.map(({ line, code }) => ({
       line,
       message: _translatedErrorCodeToMessage(this.intl, code),
     }));
   }
   get translatedNonBlockingErrorReport() {
-    return this.args.nonBlockingErrorReports.map(({ line, code }) => ({
+    const nonBlockingErrors = this._nonBlockingErrors;
+
+    return nonBlockingErrors.map(({ line, code }) => ({
       line,
       message: _translatedNonBlockingErrorCodeToMessage(this.intl, code),
     }));
   }
 
   get blockingErrorReportsCount() {
-    return this.args.blockingErrorReports?.length;
+    const blockingErrorReports = this._blockingErrors;
+
+    return blockingErrorReports?.length;
   }
 
   get nonBlockingErrorReportsCount() {
-    return this.args.nonBlockingErrorReports?.length;
+    const nonBlockingErrorReports = this._nonBlockingErrors;
+
+    return nonBlockingErrorReports?.length;
   }
 
-  get noErrorBlockingOrNot() {
-    return !(this.args.nonBlockingErrorReports?.length || this.args.blockingErrorReports?.length);
+  get noError() {
+    const blockingErrorReports = this._blockingErrors;
+    const nonBlockingErrorReports = this._nonBlockingErrors;
+
+    return !(nonBlockingErrorReports?.length || blockingErrorReports?.length);
+  }
+
+  get _blockingErrors() {
+    return this.args.errorReports.filter((error) => error.blocking);
+  }
+
+  get _nonBlockingErrors() {
+    return this.args.errorReports.filter((error) => !error.blocking);
   }
 
   get hasOnlyNonBlockingErrorReports() {

--- a/certif/app/components/import/step-two-section.js
+++ b/certif/app/components/import/step-two-section.js
@@ -5,9 +5,9 @@ export default class StepTwoSectionComponent extends Component {
   @service intl;
 
   get translatedErrorReport() {
-    return this.args.errorsReport.map((errorReport) => ({
-      line: errorReport.line,
-      message: _translatedErrorCodeToMessage(this.intl, errorReport.code),
+    return this.args.blockingErrorReports.map(({ line, code }) => ({
+      line,
+      message: _translatedErrorCodeToMessage(this.intl, code),
     }));
   }
 }

--- a/certif/app/components/import/step-two-section.js
+++ b/certif/app/components/import/step-two-section.js
@@ -4,14 +4,32 @@ import { inject as service } from '@ember/service';
 export default class StepTwoSectionComponent extends Component {
   @service intl;
 
-  get translatedErrorReport() {
+  get translatedBlockingErrorReport() {
     return this.args.blockingErrorReports.map(({ line, code }) => ({
       line,
       message: _translatedErrorCodeToMessage(this.intl, code),
     }));
   }
+  get translatedNonBlockingErrorReport() {
+    return this.args.nonBlockingErrorReports.map(({ line, code }) => ({
+      line,
+      message: _translatedNonBlockingErrorCodeToMessage(this.intl, code),
+    }));
+  }
+
+  get blockingErrorReportsCount() {
+    return this.args.blockingErrorReports?.length;
+  }
+
+  get nonBlockingErrorReportsCount() {
+    return this.args.nonBlockingErrorReports?.length;
+  }
 }
 
 function _translatedErrorCodeToMessage(intl, code) {
   return intl.t(`pages.sessions.import.step-two.blocking-errors.errors.${code}`);
+}
+
+function _translatedNonBlockingErrorCodeToMessage(intl, code) {
+  return intl.t(`pages.sessions.import.step-two.non-blocking-errors.errors.${code}`);
 }

--- a/certif/app/components/import/step-two-section.js
+++ b/certif/app/components/import/step-two-section.js
@@ -24,6 +24,14 @@ export default class StepTwoSectionComponent extends Component {
   get nonBlockingErrorReportsCount() {
     return this.args.nonBlockingErrorReports?.length;
   }
+
+  get noErrorBlockingOrNot() {
+    return !(this.args.nonBlockingErrorReports?.length || this.args.blockingErrorReports?.length);
+  }
+
+  get hasOnlyNonBlockingErrorReports() {
+    return this.blockingErrorReportsCount === 0 && this.nonBlockingErrorReportsCount > 0;
+  }
 }
 
 function _translatedErrorCodeToMessage(intl, code) {

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -22,8 +22,7 @@ export default class ImportController extends Controller {
   @tracked sessionsWithoutCandidatesCount;
   @tracked candidatesCount;
 
-  @tracked blockingErrorReports;
-  @tracked nonBlockingErrorReports;
+  @tracked errorReports;
   @tracked isImportInError = false;
 
   get fileName() {
@@ -68,23 +67,16 @@ export default class ImportController extends Controller {
         sessionsWithoutCandidatesCount,
         candidatesCount,
         cachedValidatedSessionsKey,
-        blockingErrorReports,
-        nonBlockingErrorReports,
+        errorReports,
       } = await adapter.validateSessionsForMassImport(this.file, certificationCenterId);
       this.sessionsCount = sessionsCount;
       this.sessionsWithoutCandidatesCount = sessionsWithoutCandidatesCount;
       this.candidatesCount = candidatesCount;
       this.cachedValidatedSessionsKey = cachedValidatedSessionsKey;
-      this.blockingErrorReports = blockingErrorReports;
-      this.nonBlockingErrorReports = nonBlockingErrorReports;
+      this.errorReports = errorReports;
     } catch (errors) {
       this.notifications.error(errors.errors[0].detail);
       return;
-    }
-    if (this.blockingErrorReports?.length > 0) {
-      this.isImportInError = true;
-    } else {
-      this.isImportInError = false;
     }
     this.isImportStepOne = false;
     this.removeImport();

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -22,15 +22,20 @@ export default class ImportController extends Controller {
   @tracked sessionsWithoutCandidatesCount;
   @tracked candidatesCount;
 
-  @tracked errorsReport;
+  @tracked blockingErrorReports;
+  @tracked nonBlockingErrorReports;
   @tracked isImportInError = false;
 
   get fileName() {
     return this.file.name;
   }
 
-  get errorsReportCount() {
-    return this.errorsReport?.length;
+  get blockingErrorReportsCount() {
+    return this.blockingErrorReports?.length;
+  }
+
+  get nonBlockingErrorReportsCount() {
+    return this.nonBlockingErrorReports?.length;
   }
 
   @action
@@ -71,18 +76,20 @@ export default class ImportController extends Controller {
         sessionsWithoutCandidatesCount,
         candidatesCount,
         cachedValidatedSessionsKey,
-        errorsReport,
+        blockingErrorReports,
+        nonBlockingErrorReports,
       } = await adapter.validateSessionsForMassImport(this.file, certificationCenterId);
       this.sessionsCount = sessionsCount;
       this.sessionsWithoutCandidatesCount = sessionsWithoutCandidatesCount;
       this.candidatesCount = candidatesCount;
       this.cachedValidatedSessionsKey = cachedValidatedSessionsKey;
-      this.errorsReport = errorsReport;
+      this.blockingErrorReports = blockingErrorReports;
+      this.nonBlockingErrorReports = nonBlockingErrorReports;
     } catch (errors) {
       this.notifications.error(errors.errors[0].detail);
       return;
     }
-    if (this.errorsReport?.length > 0) {
+    if (this.blockingErrorReports?.length > 0) {
       this.isImportInError = true;
     } else {
       this.isImportInError = false;

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -30,14 +30,6 @@ export default class ImportController extends Controller {
     return this.file.name;
   }
 
-  get blockingErrorReportsCount() {
-    return this.blockingErrorReports?.length;
-  }
-
-  get nonBlockingErrorReportsCount() {
-    return this.nonBlockingErrorReports?.length;
-  }
-
   @action
   async downloadSessionImportTemplate() {
     const certificationCenterId = this.currentUser.currentAllowedCertificationCenterAccess.id;

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -22,7 +22,7 @@
       font-weight: $font-light;
     }
 
-    .pix-collapsible__title[aria-expanded=true] {
+    .pix-collapsible__title[aria-expanded='true'] {
       background-color: inherit;
       border-radius: 8px 8px 0 0;
     }
@@ -109,6 +109,7 @@
 
       li:first-of-type {
         margin-bottom: 8px;
+        
         img {
           margin-right: 8px;
           vertical-align: top;
@@ -152,7 +153,7 @@
     width: fit-content;
     border: 1px solid $pix-neutral-15;
     border-radius: 8px;
-    box-shadow: 0px 4px 8px 0px rgba(7, 20, 46, 0.08);
+    box-shadow: 0 4px 8px 0 rgba($pix-neutral-110, 8%);
     background-color: $pix-neutral-10;
     color: $pix-neutral-70;
     font-size: 1rem;
@@ -191,9 +192,9 @@
       font-size: 1rem;
       font-weight: 400;
     }
+
     .pix-collapsible-title__icon {
       color: $pix-error-70;
     }
   }
 }
-

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -109,7 +109,7 @@
 
       li:first-of-type {
         margin-bottom: 8px;
-        
+
         img {
           margin-right: 8px;
           vertical-align: top;
@@ -187,14 +187,23 @@
     font-weight: $font-medium;
   }
 
-  &__collapsible-header {
+  &__collapsible-header--blocking,
+  &__collapsible-header--non-blocking {
     .pix-collapsible-title__label {
       font-size: 1rem;
       font-weight: 400;
     }
+  }
 
+  &__collapsible-header--blocking {
     .pix-collapsible-title__icon {
       color: $pix-error-70;
+    }
+  }
+
+  &__collapsible-header--non-blocking {
+    .pix-collapsible-title__icon {
+      color: $pix-warning-40;
     }
   }
 }

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -40,9 +40,7 @@
       @sessionsCount={{this.sessionsCount}}
       @sessionsWithoutCandidatesCount={{this.sessionsWithoutCandidatesCount}}
       @candidatesCount={{this.candidatesCount}}
-      @isImportInError={{this.isImportInError}}
-      @blockingErrorReports={{this.blockingErrorReports}}
-      @nonBlockingErrorReports={{this.nonBlockingErrorReports}}
+      @errorReports={{this.errorReports}}
       @createSessions={{this.createSessions}}
       @toggleStepOne={{this.toggleStepOne}}
     />

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -42,8 +42,8 @@
       @candidatesCount={{this.candidatesCount}}
       @isImportInError={{this.isImportInError}}
       @blockingErrorReports={{this.blockingErrorReports}}
+      @nonBlockingErrorReports={{this.nonBlockingErrorReports}}
       @createSessions={{this.createSessions}}
-      @blockingErrorReportsCount={{this.blockingErrorReportsCount}}
       @toggleStepOne={{this.toggleStepOne}}
     />
   {{/if}}

--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -41,9 +41,9 @@
       @sessionsWithoutCandidatesCount={{this.sessionsWithoutCandidatesCount}}
       @candidatesCount={{this.candidatesCount}}
       @isImportInError={{this.isImportInError}}
-      @errorsReport={{this.errorsReport}}
+      @blockingErrorReports={{this.blockingErrorReports}}
       @createSessions={{this.createSessions}}
-      @errorsReportCount={{this.errorsReportCount}}
+      @blockingErrorReportsCount={{this.blockingErrorReportsCount}}
       @toggleStepOne={{this.toggleStepOne}}
     />
   {{/if}}

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -194,21 +194,6 @@ module('Acceptance | Session Import', function (hooks) {
             assert.dom(screen.getByText('2 sessions dont 1 session sans candidat')).exists();
             assert.dom(screen.getByText('3 candidats')).exists();
             assert.dom(screen.queryByLabelText('fichier.csv')).doesNotExist();
-          });
-
-          test('it should display a confirm button', async function (assert) {
-            // given
-            const blob = new Blob(['foo']);
-            const file = new File([blob], 'fichier.csv');
-
-            // when
-            screen = await visit('/sessions/import');
-            const input = screen.getByLabelText('Importer le modèle complété');
-            await triggerEvent(input, 'change', { files: [file] });
-            const importButton = screen.getByRole('button', { name: 'Continuer' });
-            await click(importButton);
-
-            // then
             assert.dom(screen.getByRole('button', { name: 'Finaliser la création/édition' })).exists();
           });
 

--- a/certif/tests/integration/components/sessions-import/step-two-section_test.js
+++ b/certif/tests/integration/components/sessions-import/step-two-section_test.js
@@ -12,10 +12,11 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
     this.set('sessionsCount', 2);
     this.set('sessionsWithoutCandidatesCount', 0);
     this.set('candidatesCount', 12);
+    this.set('errorReports', []);
 
     // when
     const { getByText } = await render(
-      hbs`<Import::StepTwoSection @sessionsCount={{this.sessionsCount}} @sessionsWithoutCandidatesCount={{this.sessionsWithoutCandidatesCount}}  @candidatesCount={{this.candidatesCount}} />`
+      hbs`<Import::StepTwoSection @sessionsCount={{this.sessionsCount}} @sessionsWithoutCandidatesCount={{this.sessionsWithoutCandidatesCount}}  @candidatesCount={{this.candidatesCount}} @errorReports={{this.errorReports}}/>`
     );
 
     // then
@@ -105,11 +106,11 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
     ].forEach(function ({ error, expectedMessage }) {
       test('it renders a report', async function (assert) {
         // given
-        this.set('blockingErrorReports', [{ line: '5', code: error }]);
+        this.set('errorReports', [{ line: '5', code: error, blocking: true }]);
 
         // when
         const { getByText, getByRole } = await render(hbs`<Import::StepTwoSection
-          @blockingErrorReports={{this.blockingErrorReports}}
+          @errorReports={{this.errorReports}}
           />`);
 
         await click(getByRole('button', { name: '1 erreur bloquante' }));
@@ -121,13 +122,13 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
 
     test('it renders a button to return to step one', async function (assert) {
       // given
-      this.set('blockingErrorReports', [{ line: 1, code: 'CANDIDATE_FIRST_NAME_REQUIRED' }]);
-      this.set('nonBlockingErrorReports', [{ line: 2, code: 'EMPTY_SESSION' }]);
+      this.set('errorReports', [
+        { line: 1, code: 'CANDIDATE_FIRST_NAME_REQUIRED', blocking: true },
+        { line: 2, code: 'EMPTY_SESSION', blocking: false },
+      ]);
 
       // when
-      const { getByRole } = await render(
-        hbs`<Import::StepTwoSection @blockingErrorReports={{this.blockingErrorReports}} @nonBlockingErrorReports={{this.nonBlockingErrorReports}} />`
-      );
+      const { getByRole } = await render(hbs`<Import::StepTwoSection @errorReports={{this.errorReports}} />`);
 
       // then
       assert
@@ -143,12 +144,12 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
     }) {
       test('it renders a report', async function (assert) {
         // given
-        this.set('nonBlockingErrorReports', [{ line: '5', code: error }]);
-        this.set('blockingErrorReports', []);
+        this.set('errorReports', [{ line: '5', code: error, blocking: false }]);
 
         // when
-        const { getByText, getByRole } = await render(hbs`<Import::StepTwoSection
-          @nonBlockingErrorReports={{this.nonBlockingErrorReports}} @blockingErrorReports={{this.blockingErrorReports}} />`);
+        const { getByText, getByRole } = await render(
+          hbs`<Import::StepTwoSection @errorReports={{this.errorReports}}/>`
+        );
 
         await click(getByRole('button', { name: '1 point d’attention non bloquant' }));
 
@@ -159,13 +160,10 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
 
     test('it renders a button to return to step one', async function (assert) {
       // given
-      this.set('nonBlockingErrorReports', [{ line: 2, code: 'EMPTY_SESSION' }]);
-      this.set('blockingErrorReports', []);
+      this.set('errorReports', [{ line: 2, code: 'EMPTY_SESSION', blocking: false }]);
 
       // when
-      const { getByRole } = await render(
-        hbs`<Import::StepTwoSection @nonBlockingErrorReports={{this.nonBlockingErrorReports}} @blockingErrorReports={{this.blockingErrorReports}} />`
-      );
+      const { getByRole } = await render(hbs`<Import::StepTwoSection @errorReports={{this.errorReports}} />`);
 
       // then
       assert
@@ -175,13 +173,10 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
 
     test('it renders a button to create the sessions', async function (assert) {
       // given
-      this.set('nonBlockingErrorReports', [{ line: 2, code: 'EMPTY_SESSION' }]);
-      this.set('blockingErrorReports', []);
+      this.set('errorReports', [{ line: 2, code: 'EMPTY_SESSION', blocking: false }]);
 
       // when
-      const { getByRole } = await render(
-        hbs`<Import::StepTwoSection @nonBlockingErrorReports={{this.nonBlockingErrorReports}} @blockingErrorReports={{this.blockingErrorReports}} />`
-      );
+      const { getByRole } = await render(hbs`<Import::StepTwoSection @errorReports={{this.errorReports}} />`);
 
       // then
       assert.dom(getByRole('button', { name: 'Finaliser quand même la création/édition' })).exists();
@@ -191,13 +186,10 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
   module('when the imported file contains no errors', function () {
     test('it renders a button to create the sessions', async function (assert) {
       // given
-      this.set('nonBlockingErrorReports', []);
-      this.set('blockingErrorReports', []);
+      this.set('errorReports', []);
 
       // when
-      const { getByRole } = await render(
-        hbs`<Import::StepTwoSection @nonBlockingErrorReports={{this.nonBlockingErrorReports}} @blockingErrorReports={{this.blockingErrorReports}} />`
-      );
+      const { getByRole } = await render(hbs`<Import::StepTwoSection @errorReports={{this.errorReports}} />`);
 
       // then
       assert.dom(getByRole('button', { name: 'Finaliser la création/édition' })).exists();

--- a/certif/tests/integration/components/sessions-import/step-two-section_test.js
+++ b/certif/tests/integration/components/sessions-import/step-two-section_test.js
@@ -105,15 +105,11 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
     ].forEach(function ({ error, expectedMessage }) {
       test('it renders a report', async function (assert) {
         // given
-        this.set('isImportInError', true);
         this.set('blockingErrorReports', [{ line: '5', code: error }]);
-        this.set('blockingErrorReportsCount', 1);
 
         // when
         const { getByText, getByRole } = await render(hbs`<Import::StepTwoSection
-          @isImportInError={{this.isImportInError}}
           @blockingErrorReports={{this.blockingErrorReports}}
-          @blockingErrorReportsCount={{this.blockingErrorReportsCount}}
           />`);
 
         await click(getByRole('button', { name: '1 erreur bloquante' }));
@@ -125,15 +121,86 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
 
     test('it renders a button to return to step one', async function (assert) {
       // given
-      this.set('isImportInError', true);
+      this.set('blockingErrorReports', [{ line: 1, code: 'CANDIDATE_FIRST_NAME_REQUIRED' }]);
+      this.set('nonBlockingErrorReports', [{ line: 2, code: 'EMPTY_SESSION' }]);
 
       // when
-      const { getByRole } = await render(hbs`<Import::StepTwoSection @isImportInError={{this.isImportInError}} />`);
+      const { getByRole } = await render(
+        hbs`<Import::StepTwoSection @blockingErrorReports={{this.blockingErrorReports}} @nonBlockingErrorReports={{this.nonBlockingErrorReports}} />`
+      );
 
       // then
       assert
         .dom(getByRole('button', { name: "Revenir à l'étape précédente pour importer le fichier à nouveau" }))
         .exists();
+    });
+  });
+
+  module('when the imported file contains non blocking errors', function () {
+    [{ error: 'EMPTY_SESSION', expectedMessage: 'La session ne contient pas de candidat.' }].forEach(function ({
+      error,
+      expectedMessage,
+    }) {
+      test('it renders a report', async function (assert) {
+        // given
+        this.set('nonBlockingErrorReports', [{ line: '5', code: error }]);
+        this.set('blockingErrorReports', []);
+
+        // when
+        const { getByText, getByRole } = await render(hbs`<Import::StepTwoSection
+          @nonBlockingErrorReports={{this.nonBlockingErrorReports}} @blockingErrorReports={{this.blockingErrorReports}} />`);
+
+        await click(getByRole('button', { name: '1 point d’attention non bloquant' }));
+
+        // then
+        assert.dom(getByText(`Ligne 5 : ${expectedMessage}`)).exists();
+      });
+    });
+
+    test('it renders a button to return to step one', async function (assert) {
+      // given
+      this.set('nonBlockingErrorReports', [{ line: 2, code: 'EMPTY_SESSION' }]);
+      this.set('blockingErrorReports', []);
+
+      // when
+      const { getByRole } = await render(
+        hbs`<Import::StepTwoSection @nonBlockingErrorReports={{this.nonBlockingErrorReports}} @blockingErrorReports={{this.blockingErrorReports}} />`
+      );
+
+      // then
+      assert
+        .dom(getByRole('button', { name: "Revenir à l'étape précédente pour importer le fichier à nouveau" }))
+        .exists();
+    });
+
+    test('it renders a button to create the sessions', async function (assert) {
+      // given
+      this.set('nonBlockingErrorReports', [{ line: 2, code: 'EMPTY_SESSION' }]);
+      this.set('blockingErrorReports', []);
+
+      // when
+      const { getByRole } = await render(
+        hbs`<Import::StepTwoSection @nonBlockingErrorReports={{this.nonBlockingErrorReports}} @blockingErrorReports={{this.blockingErrorReports}} />`
+      );
+
+      // then
+      assert.dom(getByRole('button', { name: 'Finaliser quand même la création/édition' })).exists();
+    });
+  });
+
+  module('when the imported file contains no errors', function () {
+    test('it renders a button to create the sessions', async function (assert) {
+      // given
+      this.set('nonBlockingErrorReports', []);
+      this.set('blockingErrorReports', []);
+
+      // when
+      const { getByRole } = await render(
+        hbs`<Import::StepTwoSection @nonBlockingErrorReports={{this.nonBlockingErrorReports}} @blockingErrorReports={{this.blockingErrorReports}} />`
+      );
+
+      // then
+      assert.dom(getByRole('button', { name: 'Finaliser la création/édition' })).exists();
     });
   });
 });

--- a/certif/tests/integration/components/sessions-import/step-two-section_test.js
+++ b/certif/tests/integration/components/sessions-import/step-two-section_test.js
@@ -106,14 +106,14 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
       test('it renders a report', async function (assert) {
         // given
         this.set('isImportInError', true);
-        this.set('errorsReport', [{ line: '5', code: error }]);
-        this.set('errorsReportCount', 1);
+        this.set('blockingErrorReports', [{ line: '5', code: error }]);
+        this.set('blockingErrorReportsCount', 1);
 
         // when
         const { getByText, getByRole } = await render(hbs`<Import::StepTwoSection
           @isImportInError={{this.isImportInError}}
-          @errorsReport={{this.errorsReport}}
-          @errorsReportCount={{this.errorsReportCount}}
+          @blockingErrorReports={{this.blockingErrorReports}}
+          @blockingErrorReportsCount={{this.blockingErrorReportsCount}}
           />`);
 
         await click(getByRole('button', { name: '1 erreur bloquante' }));

--- a/certif/tests/unit/controllers/authenticated/sessions/import_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/import_test.js
@@ -247,25 +247,5 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
       // then
       assert.ok(controller.router.transitionTo.calledWith('authenticated.sessions.list'));
     });
-
-    test('should return the number of blocking errors', async function (assert) {
-      // given
-      controller.blockingErrorReports = [1, 2, 3];
-      // when
-      const count = await controller.blockingErrorReportsCount();
-
-      // then
-      assert.ok(count).to.equals(3);
-    });
-
-    test('should return the number of non blocking errors', async function (assert) {
-      // given
-      controller.nonBlockingErrorReports = [1, 2, 3];
-      // when
-      const count = await controller.nonBlockingErrorReportsCount();
-
-      // then
-      assert.ok(count).to.equals(3);
-    });
   });
 });

--- a/certif/tests/unit/controllers/authenticated/sessions/import_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/import_test.js
@@ -247,5 +247,25 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
       // then
       assert.ok(controller.router.transitionTo.calledWith('authenticated.sessions.list'));
     });
+
+    test('should return the number of blocking errors', async function (assert) {
+      // given
+      controller.blockingErrorReports = [1, 2, 3];
+      // when
+      const count = await controller.blockingErrorReportsCount();
+
+      // then
+      assert.ok(count).to.equals(3);
+    });
+
+    test('should return the number of non blocking errors', async function (assert) {
+      // given
+      controller.nonBlockingErrorReports = [1, 2, 3];
+      // when
+      const count = await controller.nonBlockingErrorReportsCount();
+
+      // then
+      assert.ok(count).to.equals(3);
+    });
   });
 });

--- a/certif/tests/unit/controllers/authenticated/sessions/import_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/import_test.js
@@ -154,44 +154,6 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
       sinon.assert.calledOnce(controller.notifications.error);
       assert.ok(controller);
     });
-
-    module('when previous validation has failed', function () {
-      test('should set isImportInError to false on second validation success', async function (assert) {
-        // given
-        controller.isImportInError = true;
-        const store = this.owner.lookup('service:store');
-        const adapter = store.adapterFor('validate-sessions-for-mass-import');
-        const sessionsImportStub = sinon.stub(adapter, 'validateSessionsForMassImport');
-        sessionsImportStub.resolves({});
-        const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
-          id: 123,
-        });
-
-        class CurrentUserStub extends Service {
-          currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
-        }
-
-        this.owner.register('service:current-user', CurrentUserStub);
-        const token = 'a token';
-
-        controller.file = Symbol('file 1');
-
-        controller.session = {
-          isAuthenticated: true,
-          data: {
-            authenticated: {
-              access_token: token,
-            },
-          },
-        };
-
-        // when
-        await controller.validateSessions();
-
-        // then
-        assert.false(controller.isImportInError);
-      });
-    });
   });
 
   module('#createSessions', function () {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -219,7 +219,9 @@
             "title": "{nonBlockingErrorReportsCount} {nonBlockingErrorReportsCount, plural,one {Point d’attention non bloquant} other {Points d’attention non bloquants}}",
             "information": "Nous avons détecté {nonBlockingErrorReportsCount, plural,one {un point d’attention non bloquant} other {des points d’attention non bloquants}} lors de l’import, consultez-{nonBlockingErrorReportsCount, plural,one {le} other {les}} avant de procéder à la création ou l’édition de vos sessions :",
             "line": "Line",
-            "errors": {}
+            "errors": {
+              "EMPTY_SESSION": "La session ne contient pas de candidat. "
+            }
           },
           "actions": {
             "import-again": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -180,7 +180,7 @@
         },
         "step-two": {
           "blocking-errors": {
-            "title": "{errorsReportCount} {errorsReportCount, plural,one {erreur bloquante} other {erreurs bloquantes}}",
+            "title": "{blockingErrorReportsCount} {blockingErrorReportsCount, plural,one {erreur bloquante} other {erreurs bloquantes}}",
             "information": "Veuillez corriger toutes les erreurs bloquantes avant de re-importer le fichier .csv :",
             "line": "Line",
             "errors": {
@@ -214,6 +214,12 @@
               "SESSION_SCHEDULED_IN_THE_PAST": "Date et/ou heure indiquées antérieures à la date du jour.",
               "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées."
             }
+          },
+          "non-blocking-errors": {
+            "title": "{nonBlockingErrorReportsCount} {nonBlockingErrorReportsCount, plural,one {Point d’attention non bloquant} other {Points d’attention non bloquants}}",
+            "information": "Nous avons détecté {nonBlockingErrorReportsCount, plural,one {un point d’attention non bloquant} other {des points d’attention non bloquants}} lors de l’import, consultez-{nonBlockingErrorReportsCount, plural,one {le} other {les}} avant de procéder à la création ou l’édition de vos sessions :",
+            "line": "Line",
+            "errors": {}
           },
           "actions": {
             "import-again": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -230,6 +230,9 @@
             },
             "confirm": {
               "label": "Finaliser la création/édition"
+            },
+            "confirm-with-warning": {
+              "label": "Finaliser quand même la création/édition"
             }
           },
           "sessions-and-empty-sessions-count": "{sessionsCount} {sessionsCount, plural,one {session} other {sessions}} including {sessionsWithoutCandidatesCount} {sessionsWithoutCandidatesCount, plural,one {session} other {sessions}} without candidates",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -216,7 +216,7 @@
             "information": "Nous avons détecté {nonBlockingErrorReportsCount, plural,one {un point d’attention non bloquant} other {des points d’attention non bloquants}} lors de l’import, consultez-{nonBlockingErrorReportsCount, plural,one {le} other {les}} avant de procéder à la création ou l’édition de vos sessions :",
             "line": "Ligne",
             "errors": {
-              "EMPTY_SESSION": "La session ne contient pas de candidat. "
+              "EMPTY_SESSION": "La session ne contient pas de candidat."
             }
           },
           "actions": {
@@ -226,6 +226,9 @@
             },
             "confirm": {
               "label": "Finaliser la création/édition"
+            },
+            "confirm-with-warning": {
+              "label": "Finaliser quand même la création/édition"
             }
           },
           "sessions-and-empty-sessions-count": "{sessionsCount} {sessionsCount, plural,one {session} other {sessions}} dont {sessionsWithoutCandidatesCount} {sessionsWithoutCandidatesCount, plural,one {session} other {sessions}} sans candidat",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -214,8 +214,10 @@
           "non-blocking-errors": {
             "title": "{nonBlockingErrorReportsCount} {nonBlockingErrorReportsCount, plural,one {point d’attention non bloquant} other {points d’attention non bloquants}}",
             "information": "Nous avons détecté {nonBlockingErrorReportsCount, plural,one {un point d’attention non bloquant} other {des points d’attention non bloquants}} lors de l’import, consultez-{nonBlockingErrorReportsCount, plural,one {le} other {les}} avant de procéder à la création ou l’édition de vos sessions :",
-            "line": "Line",
-            "errors": {}
+            "line": "Ligne",
+            "errors": {
+              "EMPTY_SESSION": "La session ne contient pas de candidat. "
+            }
           },
           "actions": {
             "import-again": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -176,7 +176,7 @@
         },
         "step-two": {
           "blocking-errors": {
-            "title": "{errorsReportCount} {errorsReportCount, plural,one {erreur bloquante} other {erreurs bloquantes}}",
+            "title": "{blockingErrorReportsCount} {blockingErrorReportsCount, plural,one {erreur bloquante} other {erreurs bloquantes}}",
             "information": "Veuillez corriger toutes les erreurs bloquantes avant de re-importer le fichier .csv :",
             "line": "Ligne",
             "errors": {
@@ -210,6 +210,12 @@
               "SESSION_SCHEDULED_IN_THE_PAST": "Date et/ou heure indiquées antérieures à la date du jour.",
               "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées."
             }
+          },
+          "non-blocking-errors": {
+            "title": "{nonBlockingErrorReportsCount} {nonBlockingErrorReportsCount, plural,one {point d’attention non bloquant} other {points d’attention non bloquants}}",
+            "information": "Nous avons détecté {nonBlockingErrorReportsCount, plural,one {un point d’attention non bloquant} other {des points d’attention non bloquants}} lors de l’import, consultez-{nonBlockingErrorReportsCount, plural,one {le} other {les}} avant de procéder à la création ou l’édition de vos sessions :",
+            "line": "Line",
+            "errors": {}
           },
           "actions": {
             "import-again": {


### PR DESCRIPTION
## :unicorn: Problème
L’utilisateur Pix Certif peut créer des sessions “vides” c’est-à-dire sans candidats pour l’instant. Il ne procéderait aux inscriptions que dans un deuxième temps lors d’un second import en masse.

L’utilisateur Pix Certif peut s'être trompé en créant une/des session(s) vide(s) alors qu’il pensait avoir renseigné des candidats.

## :robot: Proposition
Générer une erreur non bloquante afin d’avertir l’utilisateur qu’il a créé une ou plusieurs sessions sans candidats. Si son souhait se confirme il peut procéder à la finalisation de son import sans avoir à le modifier, s’il s’agit d’une erreur, il peut ainsi corriger son fichier avant de réimporter.

## :rainbow: Remarques
Nous aurions pu gérer une seule liste d'erreur avec des filtres bloquants/non bloquants plutôt que d'avoir 2 listes.

## :100: Pour tester
Creer des sessions sans erreur: s'assurer qu'on peut valider
Creer des sessions avec erreur: s'assurer qu'on peut relancer l'import
Creer des sessions avec erreur non bloquante (1 session sans candidat): s'assurer que l'erreur s'affiche et  qu'on peut relancer l'import ou valider
```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
,11 rue des églantines,Site008,27/01/2028,15:00,José,observations,,,,,,,,,,,,,,,,
```

