### PR TITLE
[BUGFIX] Les paginations de Pix App ne sont pas traduites (PIX-7433)

### DIFF
--- a/mon-pix/app/templates/authenticated/user-trainings.hbs
+++ b/mon-pix/app/templates/authenticated/user-trainings.hbs
@@ -18,6 +18,7 @@
         <PixPagination
           @pagination={{@model.trainings.meta.pagination}}
           @pageOptions={{this.pageOptions}}
+          @locale={{t "current-lang"}}
           @isCondensed="true"
         />
       </div>

--- a/mon-pix/app/templates/authenticated/user-tutorials/recommended.hbs
+++ b/mon-pix/app/templates/authenticated/user-tutorials/recommended.hbs
@@ -17,6 +17,7 @@
         <PixPagination
           @pagination={{@model.recommendedTutorials.meta.pagination}}
           @pageOptions={{this.pageOptions}}
+          @locale="{{t 'current-lang'}}"
           @isCondensed="true"
         />
       </div>

--- a/mon-pix/app/templates/authenticated/user-tutorials/saved.hbs
+++ b/mon-pix/app/templates/authenticated/user-tutorials/saved.hbs
@@ -11,6 +11,7 @@
         <PixPagination
           @pagination={{@model.savedTutorials.meta.pagination}}
           @pageOptions={{this.pageOptions}}
+          @locale="{{t 'current-lang'}}"
           @isCondensed="true"
         />
       </div>

--- a/mon-pix/tests/acceptance/user-trainings_test.js
+++ b/mon-pix/tests/acceptance/user-trainings_test.js
@@ -34,9 +34,7 @@ module('Acceptance | mes-formations', function (hooks) {
       await visit('/mes-formations');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/mes-formations');
+      assert.strictEqual(currentURL(), '/mes-formations');
       assert.dom('.user-trainings-banner__title').exists();
       assert.ok(find('.user-trainings-banner__title').textContent.includes('Mes formations'));
       assert.dom('.user-trainings-banner__description').exists();
@@ -48,7 +46,10 @@ module('Acceptance | mes-formations', function (hooks) {
       assert.dom('.user-trainings-content__container').exists();
       assert.dom('.user-trainings-content-list__item').exists();
       assert.dom('.user-trainings-content-list__item').exists({ count: 2 });
-      assert.dom('.pix-pagination__navigation').exists();
+
+      const pixPaginationTextContent = find('.pix-pagination__navigation').textContent;
+      assert.ok(pixPaginationTextContent.includes('2 éléments'));
+      assert.ok(pixPaginationTextContent.includes('Page 1 / 1'));
     });
   });
 });

--- a/mon-pix/tests/acceptance/user-tutorials/recommended_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials/recommended_test.js
@@ -9,6 +9,7 @@ import { waitForDialog } from '../../helpers/wait-for';
 module('Acceptance | User-tutorials | Recommended', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+
   let user;
 
   hooks.beforeEach(async function () {
@@ -28,7 +29,10 @@ module('Acceptance | User-tutorials | Recommended', function (hooks) {
       //then
       assert.dom('.tutorial-card').exists();
       assert.dom('.tutorial-card').exists({ count: 10 });
-      assert.ok(find('.pix-pagination__navigation').textContent.includes('Page 1 / 10'));
+
+      const pixPaginationTextContent = find('.pix-pagination__navigation').textContent;
+      assert.ok(pixPaginationTextContent.includes('100 éléments'));
+      assert.ok(pixPaginationTextContent.includes('Page 1 / 10'));
     });
 
     module('when a tutorial is not already saved', function () {

--- a/mon-pix/tests/acceptance/user-tutorials/saved_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials/saved_test.js
@@ -23,7 +23,10 @@ module('Acceptance | User-tutorials | Saved', function (hooks) {
       await visit('/mes-tutos/enregistres');
       assert.dom('.tutorial-card').exists();
       assert.dom('.tutorial-card').exists({ count: 10 });
-      assert.ok(find('.pix-pagination__navigation').textContent.includes('Page 1 / 10'));
+
+      const pixPaginationTextContent = find('.pix-pagination__navigation').textContent;
+      assert.ok(pixPaginationTextContent.includes('100 éléments'));
+      assert.ok(pixPaginationTextContent.includes('Page 1 / 10'));
     });
 
     module('when user clicking save again', function () {


### PR DESCRIPTION
## :unicorn: Problème
La pagination des pages "Mes tutoriels" et "Mes formations" n'est jamais traduite en anglais. Nous avons oublié d'utiliser de passer au composant `PixPagination` la locale souhaitée.

## :robot: Proposition
Bien passer le paramètre nécessaire pour appliquer la traduction.

## :rainbow: Remarques
Je ne suis pas super satisfait des tests auto qu'on a dessus mais on a encore jamais eu le cas de figure (à ma connaissance) de mocker la locale utilisée en acceptance. Je n'ai pas trouvé de moyen pour le faire :( (`this.intl.setLocale` et stubber le service `intl` n'ont pas l'air de fonctionner).

## :100: Pour tester
1. Aller sur les RA de Pix App sur .fr et .org.
2. Vérifier que les paginations de "Mes tutoriels" et "Mes formations" sont bien dans la langue de l'utilisateur
3. Sur .org, changer sa langue et retourner sur les 2 écrans pour revérifier que tout est ok.
