### PR TITLE
[FEATURE] Rendre cliquable le fil d'ariane des contenus formatifs sur Pix-Admin (PIX-7390)

### DIFF
--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -3,8 +3,9 @@
     <p>
       <LinkTo @route="authenticated.target-profiles.target-profile.insights">{{@targetProfile.name}}</LinkTo>
       <span class="wire">&nbsp;>&nbsp;</span>
-      Résultat thématique
-      {{@badge.id}}
+      <h1>Résultat thématique
+        {{@badge.id}}
+      </h1>
     </p>
   </div>
 </header>
@@ -12,7 +13,7 @@
 <main class="page-body">
   <section class="page-section">
     <div class="page-section__header">
-      <h1 class="page-section__title">{{@badge.name}}</h1>
+      <h2 class="page-section__title">{{@badge.name}}</h2>
     </div>
     <div class="page-section__details badge-data">
       <div class="badge-data__image">

--- a/admin/app/components/campaigns/details.hbs
+++ b/admin/app/components/campaigns/details.hbs
@@ -1,6 +1,6 @@
 <section class="page-section">
   <div class="campaign-title">
-    <h1>{{@campaign.name}}</h1>
+    <h2>{{@campaign.name}}</h2>
     <PixTag @color={{"blue"}} @compact="true" class="campaign-title__tag">{{@campaign.totalParticipationsCount}}
       participants</PixTag>
     <PixTag @color={{"green"}} @compact="true">

--- a/admin/app/components/campaigns/update.hbs
+++ b/admin/app/components/campaigns/update.hbs
@@ -1,5 +1,5 @@
 <section class="page-section">
-  <h1>{{@campaign.name}}</h1>
+  <h2>{{@campaign.name}}</h2>
   <br />
 
   <form class="form" {{on "submit" this.update}}>

--- a/admin/app/components/certification-centers/creation-form.hbs
+++ b/admin/app/components/certification-centers/creation-form.hbs
@@ -56,7 +56,7 @@
     />
 
     <section>
-      <h1 class="habilitations-title">Habilitations aux certifications complémentaires</h1>
+      <h2 class="habilitations-title">Habilitations aux certifications complémentaires</h2>
       <ul class="form-field habilitations-checkbox-list">
         {{#each @habilitations as |habilitation index|}}
           <li class="habilitation-entry">

--- a/admin/app/components/certification-centers/information-view.hbs
+++ b/admin/app/components/certification-centers/information-view.hbs
@@ -1,5 +1,5 @@
 <div class="certification-center-information__display">
-  <h1 class="certification-center-information__display__name">{{@certificationCenter.name}}</h1>
+  <h2 class="certification-center-information__display__name">{{@certificationCenter.name}}</h2>
   <div class="property">
     <label class="field__label">Type :</label>
     <span>{{@certificationCenter.typeLabel}}</span><br />

--- a/admin/app/components/organizations/information-section-view.hbs
+++ b/admin/app/components/organizations/information-section-view.hbs
@@ -1,5 +1,5 @@
 <div class="organization__data">
-  <h1 class="organization__name">{{@organization.name}}</h1>
+  <h2 class="organization__name">{{@organization.name}}</h2>
 
   {{#if @organization.tags}}
     <ul class="organization-tags-list">

--- a/admin/app/components/stages/stage.hbs
+++ b/admin/app/components/stages/stage.hbs
@@ -3,8 +3,9 @@
     <p>
       <LinkTo @route="authenticated.target-profiles.target-profile.insights">{{@targetProfile.name}}</LinkTo>
       <span class="wire">&nbsp;>&nbsp;</span>
-      Palier
-      {{@stage.id}}
+      <h1>Palier
+        {{@stage.id}}
+      </h1>
     </p>
   </div>
 </header>

--- a/admin/app/components/target-profiles/target-profile.hbs
+++ b/admin/app/components/target-profiles/target-profile.hbs
@@ -3,7 +3,7 @@
   <div class="page-title">
     <LinkTo @route="authenticated.target-profiles.list">Tous les profils cibles</LinkTo>
     <span class="wire">&nbsp;>&nbsp;</span>
-    {{@model.name}}
+    <h1>{{@model.name}}</h1>
   </div>
 </header>
 
@@ -15,7 +15,7 @@
   {{else}}
     <section class="page-section">
       <div class="page-section__header">
-        <h1 class="page-section__title target-profile__title">{{@model.name}}</h1>
+        <h2 class="page-section__title target-profile__title">{{@model.name}}</h2>
         <TargetProfiles::Category @category={{@model.category}} />
       </div>
       <div class="page-section__container">

--- a/admin/app/styles/authenticated/campaigns/get.scss
+++ b/admin/app/styles/authenticated/campaigns/get.scss
@@ -13,7 +13,7 @@
 .campaign-title {
   display: flex;
 
-  & h1 {
+  & h2 {
     margin-right: 8px;
   }
 

--- a/admin/app/styles/authenticated/sessions/list.scss
+++ b/admin/app/styles/authenticated/sessions/list.scss
@@ -2,11 +2,6 @@
   display: flex;
   flex-direction: column;
 
-  &__title {
-    font-size: 1rem;
-    font-weight: bold;
-  }
-
   &__navbar {
     margin: 10px;
     margin-top: 20px;

--- a/admin/app/styles/globals/page.scss
+++ b/admin/app/styles/globals/page.scss
@@ -23,6 +23,12 @@
         color: $pix-primary;
       }
 
+      h1 {
+        display: inline;
+        font-size: 1rem;
+        font-weight: bold;
+      }
+
       .wire {
         color: $pix-neutral-45;
       }

--- a/admin/app/templates/authenticated/campaigns/campaign.hbs
+++ b/admin/app/templates/authenticated/campaigns/campaign.hbs
@@ -9,8 +9,9 @@
       @model={{@model.organizationId}}
     >{{@model.organizationName}}</LinkTo>
     <span class="wire">&nbsp;>&nbsp;</span>
-    Campagne
-    {{@model.name}}
+    <h1>Campagne
+      {{@model.name}}
+    </h1>
   </div>
 </header>
 

--- a/admin/app/templates/authenticated/certification-centers/get.hbs
+++ b/admin/app/templates/authenticated/certification-centers/get.hbs
@@ -4,7 +4,7 @@
     <LinkTo @route="authenticated.certification-centers.list"><span id="link-to-certification-centers-page">Tous les
         centres de certification</span></LinkTo>
     <span class="wire">&nbsp;>&nbsp;</span>
-    {{@model.certificationCenter.name}}
+    <h1>{{@model.certificationCenter.name}}</h1>
   </div>
 </header>
 

--- a/admin/app/templates/authenticated/certification-centers/new.hbs
+++ b/admin/app/templates/authenticated/certification-centers/new.hbs
@@ -1,7 +1,7 @@
 {{page-title "Nouveau Centre de certif"}}
 <header class="page-header">
   <div class="page-title">
-    Nouveau centre de certification
+    <h1>Nouveau centre de certification</h1>
   </div>
 </header>
 

--- a/admin/app/templates/authenticated/organizations/get.hbs
+++ b/admin/app/templates/authenticated/organizations/get.hbs
@@ -2,7 +2,7 @@
   <div class="page-title">
     <LinkTo @route="authenticated.organizations.list">Toutes les organisations</LinkTo>
     <span class="wire">&nbsp;>&nbsp;</span>
-    {{@model.name}}
+    <h1>{{@model.name}}</h1>
   </div>
 </header>
 

--- a/admin/app/templates/authenticated/organizations/new.hbs
+++ b/admin/app/templates/authenticated/organizations/new.hbs
@@ -1,7 +1,7 @@
 {{page-title "Nouvelle orga"}}
 <header class="page-header">
   <div class="page-title">
-    Nouvelle organisation
+    <h1>Nouvelle organisation</h1>
   </div>
 </header>
 

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -1,6 +1,8 @@
 {{page-title "Toutes les sessions"}}
 <header class="session-list">
-  <h1 class="page-header session-list__title">Sessions de certifications</h1>
+  <div class="page-header">
+    <h1 class="page-title">Toutes les sessions de certifications</h1>
+  </div>
   <nav class="navbar session-list__navbar">
     <LinkTo @route="authenticated.sessions.list.with-required-action" class="navbar-item">
       Sessions à traiter ({{this.sessionsWithRequiredActionCount}})

--- a/admin/app/templates/authenticated/sessions/session.hbs
+++ b/admin/app/templates/authenticated/sessions/session.hbs
@@ -1,7 +1,11 @@
 {{! template-lint-disable require-input-label }}
 {{page-title "Session " @model.id}}
 <header class="page-header">
-  <h1 class="page-title session-list__title">Sessions de certification</h1>
+  <div class="page-title">
+    <LinkTo @route="authenticated.sessions.list">Toutes les sessions de certification</LinkTo>
+    <FaIcon @icon="chevron-right" />
+    <h1>Sessions de certification</h1>
+  </div>
   <div class="page-actions">
     <form class="form-inline" {{on "submit" this.loadSession}}>
       <Input

--- a/admin/app/templates/authenticated/target-profiles/new.hbs
+++ b/admin/app/templates/authenticated/target-profiles/new.hbs
@@ -1,7 +1,7 @@
 {{page-title "Nouveau profil cible"}}
 <header class="page-header">
   <div class="page-title">
-    Nouveau profil cible
+    <h1>Nouveau profil cible</h1>
   </div>
 </header>
 

--- a/admin/app/templates/authenticated/trainings/new.hbs
+++ b/admin/app/templates/authenticated/trainings/new.hbs
@@ -3,7 +3,7 @@
   <div class="page-title">
     <LinkTo @route="authenticated.trainings.list">Tous les contenus formatifs</LinkTo>
     <FaIcon @icon="chevron-right" />
-    Création du contenu
+    <h1>Création du contenu</h1>
   </div>
 </header>
 

--- a/admin/app/templates/authenticated/trainings/new.hbs
+++ b/admin/app/templates/authenticated/trainings/new.hbs
@@ -1,7 +1,7 @@
 {{page-title "Nouveau contenu formatif"}}
 <header class="page-header">
   <div class="page-title">
-    Contenus Formatifs
+    <LinkTo @route="authenticated.trainings.list">Tous les contenus formatifs</LinkTo>
     <FaIcon @icon="chevron-right" />
     Création du contenu
   </div>

--- a/admin/app/templates/authenticated/trainings/training.hbs
+++ b/admin/app/templates/authenticated/trainings/training.hbs
@@ -3,10 +3,11 @@
 {{! template-lint-disable no-redundant-landmark-role }}
 <header class="page-header" role="banner">
   <div class="page-title">
-    Contenus Formatifs
+    <LinkTo @route="authenticated.trainings.list">Tous les contenus formatifs</LinkTo>
     <FaIcon @icon="chevron-right" />
-    Détail du contenu formatif
-    {{@model.id}}
+    <h1>Détail du contenu formatif
+      {{@model.id}}
+    </h1>
   </div>
 </header>
 

--- a/admin/app/templates/authenticated/users/get.hbs
+++ b/admin/app/templates/authenticated/users/get.hbs
@@ -3,7 +3,7 @@
   <div class="page-title">
     <LinkTo @route="authenticated.users.list"><span id="link-to-users-page">Tous les utilisateurs</span></LinkTo>
     <span class="wire">&nbsp;>&nbsp;</span>
-    {{@model.id}}
+    <h1>Utilisateur {{@model.id}}</h1>
   </div>
 </header>
 

--- a/admin/tests/acceptance/authenticated/campaigns/campaign-page_test.js
+++ b/admin/tests/acceptance/authenticated/campaigns/campaign-page_test.js
@@ -31,7 +31,7 @@ module('Acceptance | Campaign Page', function (hooks) {
 
       // then
       assert.strictEqual(currentURL(), '/campaigns/1/participations');
-      assert.dom(screen.getByRole('heading', { name: 'Campaign name' })).exists();
+      assert.dom(screen.getByRole('heading', { name: 'Campaign name', level: 2 })).exists();
     });
   });
 });

--- a/admin/tests/acceptance/authenticated/certification-centers/form_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/form_test.js
@@ -47,7 +47,7 @@ module('Acceptance | Certification Centers | Form', function (hooks) {
 
     // then
     assert.strictEqual(currentURL(), '/certification-centers/99');
-    assert.dom(screen.getByRole('heading', { name })).exists();
+    assert.dom(screen.getByRole('heading', { name, level: 2 })).exists();
     assert.dom(screen.getByText(type.label)).exists();
     assert.dom(screen.getByText(externalId)).exists();
 

--- a/admin/tests/acceptance/authenticated/certification-centers/get_test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get_test.js
@@ -40,7 +40,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
     const screen = await visit(`/certification-centers/${certificationCenter.id}`);
 
     // then
-    assert.dom(screen.getByRole('heading', { name: 'Center 1' })).exists();
+    assert.dom(screen.getByRole('heading', { name: 'Center 1', level: 2 })).exists();
     assert.dom(screen.getByText('ABCDEF')).exists();
     assert.dom(screen.getByText('Établissement scolaire')).exists();
   });
@@ -135,7 +135,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
 
       // then
       assert.dom(screen.getByText('Habilitations aux certifications complémentaires')).exists();
-      assert.dom(screen.getByRole('heading', { name: 'nouveau nom' })).exists();
+      assert.dom(screen.getByRole('heading', { name: 'nouveau nom', level: 2 })).exists();
       assert.dom(screen.getByText('Établissement supérieur')).exists();
       assert.dom(screen.getByText('nouvel identifiant externe')).exists();
       assert.dom(screen.getByText('Nom du : Justin Ptipeu')).exists();
@@ -167,7 +167,7 @@ module('Acceptance | authenticated/certification-centers/get', function (hooks) 
       assert.dom(screen.getByLabelText('Habilité pour Pix+Surf')).exists();
       assert.dom(screen.getByLabelText('Non-habilité pour Pix+Autre')).exists();
       assert.dom(screen.getByText('Habilitations aux certifications complémentaires')).exists();
-      assert.dom(screen.getByRole('heading', { name: 'Centre des réussites' })).exists();
+      assert.dom(screen.getByRole('heading', { name: 'Centre des réussites', level: 2 })).exists();
       assert.dom(screen.getByText('Centre de certification mis à jour avec succès.')).exists();
     });
 

--- a/admin/tests/acceptance/authenticated/organizations/information-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management_test.js
@@ -29,7 +29,7 @@ module('Acceptance | Organizations | Information management', function (hooks) {
       await clickByName('Enregistrer', { exact: true });
 
       // then
-      assert.dom(screen.getByRole('heading', { name: 'newOrganizationName' })).exists();
+      assert.dom(screen.getByRole('heading', { name: 'newOrganizationName', level: 2 })).exists();
       assert.dom(screen.getByText('Nom du DPO : Bru No')).exists();
       assert.dom(screen.getByText('Adresse e-mail du DPO : bru.no@example.net')).exists();
     });

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/creation_test.js
@@ -75,7 +75,7 @@ module('Acceptance | Target profile creation', function (hooks) {
       // then
       assert.strictEqual(currentURL(), '/target-profiles/1/details');
       await _unfoldLearningContent();
-      assert.dom(screen.getByRole('heading', { name: 'Un profil cible, et vite !' })).exists();
+      assert.dom(screen.getByRole('heading', { name: 'Un profil cible, et vite !', level: 2 })).exists();
       let isMobileCompliant = screen.getByTestId('mobile-compliant-tube_f1_a1_c1_th1_tu1').getAttribute('aria-label');
       let isTabletCompliant = screen.getByTestId('tablet-compliant-tube_f1_a1_c1_th1_tu1').getAttribute('aria-label');
       assert.deepEqual(

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/management_test.js
@@ -76,7 +76,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
       const screen = await visit('/target-profiles/1');
 
       // then
-      assert.dom(screen.getByRole('heading', { name: 'Profil Cible Fantastix' })).exists();
+      assert.dom(screen.getByRole('heading', { name: 'Profil Cible Fantastix', level: 2 })).exists();
       assert.dom(screen.getByText('Thématiques')).exists();
       assert.dom(screen.getByText('ID : 1')).exists();
       assert.dom(screen.getByText('Public : Oui')).exists();
@@ -110,7 +110,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
 
       // then
       assert.strictEqual(currentURL(), '/target-profiles/1/details');
-      assert.dom(screen.getByRole('heading', { name: 'nom modifié' })).exists();
+      assert.dom(screen.getByRole('heading', { name: 'nom modifié', level: 2 })).exists();
       assert.dom(screen.queryByText('Enregistrer')).doesNotExist();
       await clickByName('Éditer');
       assert.dom(screen.getByDisplayValue('description modifiée')).exists();
@@ -134,7 +134,7 @@ module('Acceptance | Target Profile Management', function (hooks) {
 
       // then
       assert.strictEqual(currentURL(), '/target-profiles/1/details');
-      assert.dom(screen.getByRole('heading', { name: 'Nom à éditer' })).exists();
+      assert.dom(screen.getByRole('heading', { name: 'Nom à éditer', level: 2 })).exists();
       assert.dom(screen.queryByText('Enregistrer')).doesNotExist();
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Le fil d'ariane des contenus formatifs n'était pas cliquable.

## :robot: Proposition
Ajouter un lien sur le fil d'ariane permettant de revenir à la page d'avant sur la liste des contenus formatifs.

## :rainbow: Remarques
J'en ai profité pour uniformiser les titres dans le fil d'ariane sur toutes les pages pour être davantage cohérent.
J'en ai également profité pour ajouter un lien de retour sur la liste des sessions de certifications dans le fil d'ariane.

## :100: Pour tester
Tester que le lien renvoie bien sur les contenus formatifs.