### PR TITLE
[FEATURE] Rendre les urls des contenus formatifs cliquable sur Pix-Admin (PIX-7389)

### DIFF
--- a/admin/app/components/trainings/training-details-card.hbs
+++ b/admin/app/components/trainings/training-details-card.hbs
@@ -3,7 +3,16 @@
     <h1 class="training-details-card__title">{{@training.title}}</h1>
     <dl class="training-details-card__details">
       <dt class="training-details-card__details-label">Publié sur&nbsp;:&nbsp;</dt>
-      <dd class="training-details-card__details-value">{{@training.link}}</dd>
+      <dd class="training-details-card__details-value">
+        <a
+          href={{@training.link}}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="{{@training.link}} (nouvelle fenêtre)"
+        >
+          {{@training.link}}
+        </a>
+      </dd>
       <dt class="training-details-card__details-label">Type de contenu&nbsp;:&nbsp;</dt>
       <dd class="training-details-card__details-value">{{@training.type}}</dd>
       <dt class="training-details-card__details-label">Durée&nbsp;:&nbsp;</dt>


### PR DESCRIPTION
## :unicorn: Problème
On ne pouvait pas se rendre sur les urls de contenus formatifs qui étaient inscrites en dures.

## :robot: Proposition
Permettre la redirection sur ces contenus formatifs.

## :100: Pour tester
Vérifier que au clic sur l'url de la formation, on est bien redirigé sur la page de la formation.
