### PR TITLE
[FEATURE] Création d'un script pour intervertir deux codes de campagnes (PIX-7445)

### DIFF
--- a/api/db/database-builder/factory/build-campaign.js
+++ b/api/db/database-builder/factory/build-campaign.js
@@ -9,7 +9,7 @@ const _ = require('lodash');
 module.exports = function buildCampaign({
   id = databaseBuffer.getNextId(),
   name = 'Name',
-  code = 'ABC456TTY',
+  code,
   title = 'Title',
   idPixLabel = 'IdPixLabel',
   externalIdHelpImageUrl = null,
@@ -40,6 +40,8 @@ module.exports = function buildCampaign({
   organizationId = _.isNil(organizationId) ? buildOrganization().id : organizationId;
   creatorId = _.isUndefined(creatorId) ? buildUser().id : creatorId;
   ownerId = _.isUndefined(ownerId) ? buildUser().id : ownerId;
+  // Because of unicity constraint if no code is given we set the unique id as campaign code.
+  code = _.isUndefined(code) ? id.toString() : code;
 
   const values = {
     id,

--- a/api/db/migrations/20230316155007_add-unicity-constraint-on-column-code-campaign.js
+++ b/api/db/migrations/20230316155007_add-unicity-constraint-on-column-code-campaign.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'campaigns';
+
+exports.up = function (knex) {
+  return knex.schema.alterTable(TABLE_NAME, function (t) {
+    t.unique('code');
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropUnique('code');
+  });
+};

--- a/api/db/seeds/data/certification/badge-acquisition-builder.js
+++ b/api/db/seeds/data/certification/badge-acquisition-builder.js
@@ -34,6 +34,7 @@ const { SHARED } = CampaignParticipationStatuses;
 function badgeAcquisitionBuilder({ databaseBuilder }) {
   _buildBadgeAcquisition({
     campaignName: 'Campagne PixEmploiClea V1',
+    campaignCode: 'CAMPCLEA1',
     targetProfileId: TARGET_PROFILE_PIX_EMPLOI_CLEA_ID,
     userId: CERTIF_REGULAR_USER1_ID,
     badgeId: PIX_EMPLOI_CLEA_BADGE_ID_V1,
@@ -41,6 +42,7 @@ function badgeAcquisitionBuilder({ databaseBuilder }) {
   });
   _buildBadgeAcquisition({
     campaignName: 'Campagne PixEmploiClea V2',
+    campaignCode: 'CAMPCLEA2',
     targetProfileId: TARGET_PROFILE_PIX_EMPLOI_CLEA_ID_V2,
     userId: CERTIF_SUCCESS_USER_ID,
     badgeId: PIX_EMPLOI_CLEA_BADGE_ID_V2,
@@ -48,6 +50,7 @@ function badgeAcquisitionBuilder({ databaseBuilder }) {
   });
   _buildBadgeAcquisition({
     campaignName: 'Campagne PixEmploiClea V3',
+    campaignCode: 'CAMPCLEA3',
     targetProfileId: TARGET_PROFILE_PIX_EMPLOI_CLEA_ID_V3,
     userId: CERTIF_SUCCESS_USER_ID,
     badgeId: PIX_EMPLOI_CLEA_BADGE_ID_V3,
@@ -55,6 +58,7 @@ function badgeAcquisitionBuilder({ databaseBuilder }) {
   });
   _buildBadgeAcquisition({
     campaignName: 'Campagne PixEmploiClea V3',
+    campaignCode: 'CAMPCLEA4',
     targetProfileId: TARGET_PROFILE_PIX_EMPLOI_CLEA_ID_V3,
     userId: CERTIF_FAILURE_USER_ID,
     badgeId: PIX_EMPLOI_CLEA_BADGE_ID_V3,
@@ -62,6 +66,7 @@ function badgeAcquisitionBuilder({ databaseBuilder }) {
   });
   _buildBadgeAcquisition({
     campaignName: 'Campagne Edu Formation Initiale 2nd degré',
+    campaignCode: 'CAMPEDU01',
     targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_2ND_DEGRE,
     userId: CERTIF_EDU_FORMATION_INITIALE_2ND_DEGRE_USER_ID,
     badgeId: PIX_EDU_FORMATION_INITIALE_2ND_DEGRE_CONFIRME_BADGE_ID,
@@ -69,6 +74,7 @@ function badgeAcquisitionBuilder({ databaseBuilder }) {
   });
   _buildBadgeAcquisition({
     campaignName: 'Campagne Edu Formation Continue 2nd degré',
+    campaignCode: 'CAMPEDU02',
     targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE,
     userId: CERTIF_EDU_FORMATION_CONTINUE_2ND_DEGRE_USER_ID,
     badgeId: PIX_EDU_FORMATION_CONTINUE_2ND_DEGRE_AVANCE_BADGE_ID,
@@ -76,6 +82,7 @@ function badgeAcquisitionBuilder({ databaseBuilder }) {
   });
   _buildBadgeAcquisition({
     campaignName: 'Campagne Edu Formation Initiale 1er degré',
+    campaignCode: 'CAMPEDU03',
     targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_INITIALE_1ER_DEGRE,
     userId: CERTIF_EDU_FORMATION_INITIALE_1ER_DEGRE_USER_ID,
     badgeId: PIX_EDU_FORMATION_INITIALE_1ER_DEGRE_CONFIRME_BADGE_ID,
@@ -83,6 +90,7 @@ function badgeAcquisitionBuilder({ databaseBuilder }) {
   });
   _buildBadgeAcquisition({
     campaignName: 'Campagne Edu Formation Continue 1er degré',
+    campaignCode: 'CAMPEDU04',
     targetProfileId: TARGET_PROFILE_PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE,
     userId: CERTIF_EDU_FORMATION_CONTINUE_1ER_DEGRE_USER_ID,
     badgeId: PIX_EDU_FORMATION_CONTINUE_1ER_DEGRE_AVANCE_BADGE_ID,
@@ -94,9 +102,10 @@ module.exports = {
   badgeAcquisitionBuilder,
 };
 
-function _buildBadgeAcquisition({ campaignName, targetProfileId, userId, badgeId, databaseBuilder }) {
+function _buildBadgeAcquisition({ campaignName, campaignCode, targetProfileId, userId, badgeId, databaseBuilder }) {
   const campaignParticipationId = _buildRequiredCampaignData({
     campaignName,
+    campaignCode,
     targetProfileId,
     userId,
     databaseBuilder,
@@ -108,9 +117,10 @@ function _buildBadgeAcquisition({ campaignName, targetProfileId, userId, badgeId
   });
 }
 
-function _buildRequiredCampaignData({ campaignName, targetProfileId, userId, databaseBuilder }) {
+function _buildRequiredCampaignData({ campaignName, campaignCode, targetProfileId, userId, databaseBuilder }) {
   const campaignId = databaseBuilder.factory.buildCampaign({
     name: campaignName,
+    code: campaignCode,
     type: 'ASSESSMENT',
     targetProfileId,
     organizationId: PRO_COMPANY_ID,

--- a/api/db/seeds/data/certification/complementary-certification-course-results-builder.js
+++ b/api/db/seeds/data/certification/complementary-certification-course-results-builder.js
@@ -23,6 +23,7 @@ const { SHARED } = CampaignParticipationStatuses;
 function complementaryCertificationCourseResultsBuilder({ databaseBuilder }) {
   const campaignId = databaseBuilder.factory.buildCampaign({
     name: 'Campagne Pix+Droit',
+    code: 'PIXPLUS01',
     type: 'ASSESSMENT',
     targetProfileId: TARGET_PROFILE_PIX_DROIT_ID,
     organizationId: SUP_UNIVERSITY_ID,

--- a/api/scripts/prod/swap-campaign-codes.js
+++ b/api/scripts/prod/swap-campaign-codes.js
@@ -1,0 +1,31 @@
+const { knex } = require('../../db/knex-database-connection');
+const DomainTransaction = require('../../lib/infrastructure/DomainTransaction');
+const { disconnect } = require('../../db/knex-database-connection');
+
+async function swapCampaignCodes(campaignId, otherCampaignId) {
+  const { code: campaignCode } = await knex('campaigns').where({ id: campaignId }).first();
+  const { code: otherCampaignCode } = await knex('campaigns').where({ id: otherCampaignId }).first();
+
+  await DomainTransaction.execute(async (domainTransaction) => {
+    await domainTransaction.knexTransaction('campaigns').where({ id: campaignId }).update({ code: otherCampaignCode });
+    await domainTransaction.knexTransaction('campaigns').where({ id: otherCampaignId }).update({ code: campaignCode });
+  });
+}
+
+const isLaunchedFromCommandLine = require.main === module;
+
+(async () => {
+  if (isLaunchedFromCommandLine) {
+    try {
+      await swapCampaignCodes(process.argv[2], process.argv[3]);
+      console.log('done');
+    } catch (error) {
+      console.error(error);
+      process.exitCode = 1;
+    } finally {
+      await disconnect();
+    }
+  }
+})();
+
+module.exports = { swapCampaignCodes };

--- a/api/scripts/prod/swap-campaign-codes.js
+++ b/api/scripts/prod/swap-campaign-codes.js
@@ -1,12 +1,16 @@
 const { knex } = require('../../db/knex-database-connection');
+const { generate } = require('../../lib/domain/services/campaigns/campaign-code-generator');
 const DomainTransaction = require('../../lib/infrastructure/DomainTransaction');
+const campaignRepository = require('../../lib/infrastructure/repositories/campaign-repository');
 const { disconnect } = require('../../db/knex-database-connection');
 
 async function swapCampaignCodes(campaignId, otherCampaignId) {
+  const temporaryCode = await generate(campaignRepository);
   const { code: campaignCode } = await knex('campaigns').where({ id: campaignId }).first();
   const { code: otherCampaignCode } = await knex('campaigns').where({ id: otherCampaignId }).first();
 
   await DomainTransaction.execute(async (domainTransaction) => {
+    await domainTransaction.knexTransaction('campaigns').where({ id: otherCampaignId }).update({ code: temporaryCode });
     await domainTransaction.knexTransaction('campaigns').where({ id: campaignId }).update({ code: otherCampaignCode });
     await domainTransaction.knexTransaction('campaigns').where({ id: otherCampaignId }).update({ code: campaignCode });
   });

--- a/api/tests/integration/scripts/prod/swap-campaign-codes_test.js
+++ b/api/tests/integration/scripts/prod/swap-campaign-codes_test.js
@@ -1,0 +1,17 @@
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const { swapCampaignCodes } = require('../../../../scripts/prod/swap-campaign-codes.js');
+
+describe('Integration | Scripts | swap-campaign-codes', function () {
+  it('should swap campaign codes', async function () {
+    const campaignId = databaseBuilder.factory.buildCampaign({ code: 'OLDCODE' }).id;
+    const otherCampaignId = databaseBuilder.factory.buildCampaign({ code: 'NEWCODE' }).id;
+    await databaseBuilder.commit();
+    await swapCampaignCodes(campaignId, otherCampaignId);
+
+    const { code: campaignCode } = await knex('campaigns').where({ id: campaignId }).first();
+    const { code: otherCampaignCode } = await knex('campaigns').where({ id: otherCampaignId }).first();
+
+    expect(campaignCode).equal('NEWCODE');
+    expect(otherCampaignCode).equal('OLDCODE');
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre du déploiement de Pix auprès de Pôle emploi, de nouveaux profils cibles sont créés pour évaluer les participants sur de nouveaux sujets, avec de nouveaux résultats thématiques afin de permettre au conseillers PE de mieux accompagner leurs publics.

Cela implique de créer de nouvelles campagnes (recette et prod), ce qui va générer de nouveaux codes, hors côté PE tout est conçu en intégrant le code de campagne “PIXEMPLOI” à différents endroits. PE ne souhaite pas mettre à jour leurs interfaces avec un nouveau code à chaque création de nouvelle campagne, nous allons donc devoir changer le code des nouvelles campagnes en PIXEMPLOI à chaque fois.

## :robot: Proposition
Créer un script pour permettre d'échanger le code de deux campagnes de manière sécurisée, en swapant les codes de la campagne actuelle (PIXEMPLOI) et le code de la nouvelle campagne (généré aléatoirement à sa création) pour que la nouvelle campagne utilise bien le code pérenne PIXEMPLOI.

## :rainbow: Remarques
Beaucoup de tests ont du être corrigés suite à l'ajout de la contrainte d'unicité sur les codes de campagnes.

## :100: Pour tester
Lancer le script avec deux id de campagnes, et vérifier que les codes de campagnes ont été intervertis.
Vérifier que les tests passent
