### PR TITLE
[FEATURE] Visualiser le seuil et le nombre de sujets d'un déclencheur de contenu formatif (PIX-7260)

### DIFF
--- a/admin/app/components/trainings/create-training-triggers.hbs
+++ b/admin/app/components/trainings/create-training-triggers.hbs
@@ -3,6 +3,10 @@
     <span>{{t "pages.trainings.training.triggers.prerequisite.title"}}</span>
     {{#if @training.prerequisiteTrigger}}
       <strong class="trigger-card__threshold">Seuil&nbsp;: {{@training.prerequisiteTrigger.threshold}}%</strong>
+      <PixTag class="trigger-card__tubes-count" @color="grey-light">
+        {{@training.prerequisiteTrigger.tubesCount}}
+        sujets
+      </PixTag>
     {{/if}}
   </h2>
   <p class="trigger-card__description">{{t "pages.trainings.training.triggers.prerequisite.edit.description"}}</p>
@@ -29,6 +33,10 @@
     <span>{{t "pages.trainings.training.triggers.goal.title"}}</span>
     {{#if @training.goalTrigger}}
       <strong class="trigger-card__threshold">Seuil&nbsp;: {{@training.goalTrigger.threshold}}%</strong>
+      <PixTag class="trigger-card__tubes-count" @color="grey-light">
+        {{@training.goalTrigger.tubesCount}}
+        sujets
+      </PixTag>
     {{/if}}
   </h2>
   <p class="trigger-card__description">{{t "pages.trainings.training.triggers.goal.edit.description"}}</p>

--- a/admin/app/components/trainings/create-training-triggers.hbs
+++ b/admin/app/components/trainings/create-training-triggers.hbs
@@ -1,5 +1,10 @@
 <section class="page-section trigger-card">
-  <h2 class="trigger-card__title">{{t "pages.trainings.training.triggers.prerequisite.title"}}</h2>
+  <h2 class="trigger-card__title">
+    <span>{{t "pages.trainings.training.triggers.prerequisite.title"}}</span>
+    {{#if @training.prerequisiteTrigger}}
+      <strong class="trigger-card__threshold">Seuil&nbsp;: {{@training.prerequisiteTrigger.threshold}}%</strong>
+    {{/if}}
+  </h2>
   <p class="trigger-card__description">{{t "pages.trainings.training.triggers.prerequisite.edit.description"}}</p>
 
   {{#if @training.prerequisiteTrigger}}
@@ -20,9 +25,13 @@
 </section>
 
 <section class="page-section trigger-card">
-  <h2 class="trigger-card__title">{{t "pages.trainings.training.triggers.goal.title"}}</h2>
+  <h2 class="trigger-card__title">
+    <span>{{t "pages.trainings.training.triggers.goal.title"}}</span>
+    {{#if @training.goalTrigger}}
+      <strong class="trigger-card__threshold">Seuil&nbsp;: {{@training.goalTrigger.threshold}}%</strong>
+    {{/if}}
+  </h2>
   <p class="trigger-card__description">{{t "pages.trainings.training.triggers.goal.edit.description"}}</p>
-
   {{#if @training.goalTrigger}}
     <Trainings::Trigger::Details @areas={{@training.goalTrigger.areas}} />
   {{else}}

--- a/admin/app/models/training-trigger.js
+++ b/admin/app/models/training-trigger.js
@@ -4,6 +4,7 @@ export default class TrainingTrigger extends Model {
   @attr('string') type;
   @attr('number') trainingId;
   @attr('number') threshold;
+  @attr('number') tubesCount;
 
   @hasMany('area') areas;
 }

--- a/admin/app/styles/components/trainings/training-triggers-tab.scss
+++ b/admin/app/styles/components/trainings/training-triggers-tab.scss
@@ -9,7 +9,20 @@
     @include subheading;
 
     font-weight: 500;
+    display: flex;
+    align-items: baseline;
     margin-bottom: $spacing-xs;
+  }
+
+  &__threshold {
+    color: $pix-neutral-90;
+    font-size: 1rem;
+    line-height: 1.5;
+    margin-left: $spacing-s;
+  }
+
+  &__tubes-count {
+    margin-left: auto;
   }
 
   &__description {

--- a/admin/tests/integration/components/trainings/create-training-triggers_test.js
+++ b/admin/tests/integration/components/trainings/create-training-triggers_test.js
@@ -121,6 +121,7 @@ module('Integration | Component | Trainings::CreateTrainingTriggers', function (
       const trainingTrigger = store.createRecord('training-trigger', {
         type: 'goal',
         areas: [area1, area2],
+        threshold: 19,
       });
       this.set('training', {
         goalTrigger: trainingTrigger,
@@ -145,6 +146,7 @@ module('Integration | Component | Trainings::CreateTrainingTriggers', function (
       assert
         .dom(screen.queryByLabelText(this.intl.t('pages.trainings.training.triggers.goal.alternative-title')))
         .doesNotExist();
+      assert.dom(screen.getByText('Seuil : 19%')).exists();
       assert.dom(screen.getByText('area1 code · area1 title')).exists();
       await clickByText('area1 code · area1 title');
       assert.dom(screen.getByText('competence1Area1 index competence1Area1 name')).exists();
@@ -278,6 +280,7 @@ module('Integration | Component | Trainings::CreateTrainingTriggers', function (
       const trainingTrigger = store.createRecord('training-trigger', {
         type: 'prerequisite',
         areas: [area1, area2],
+        threshold: 20,
       });
       this.set('training', {
         prerequisiteTrigger: trainingTrigger,
@@ -292,6 +295,7 @@ module('Integration | Component | Trainings::CreateTrainingTriggers', function (
       assert
         .dom(screen.queryByLabelText(this.intl.t('pages.trainings.training.triggers.prerequisite.alternative-title')))
         .doesNotExist();
+      assert.dom(screen.getByText('Seuil : 20%')).exists();
       assert.dom(screen.getByText('area1 code · area1 title')).exists();
       await clickByText('area1 code · area1 title');
       assert.dom(screen.getByText('competence1Area1 index competence1Area1 name')).exists();

--- a/admin/tests/integration/components/trainings/create-training-triggers_test.js
+++ b/admin/tests/integration/components/trainings/create-training-triggers_test.js
@@ -122,6 +122,7 @@ module('Integration | Component | Trainings::CreateTrainingTriggers', function (
         type: 'goal',
         areas: [area1, area2],
         threshold: 19,
+        tubesCount: 5,
       });
       this.set('training', {
         goalTrigger: trainingTrigger,
@@ -147,6 +148,7 @@ module('Integration | Component | Trainings::CreateTrainingTriggers', function (
         .dom(screen.queryByLabelText(this.intl.t('pages.trainings.training.triggers.goal.alternative-title')))
         .doesNotExist();
       assert.dom(screen.getByText('Seuil : 19%')).exists();
+      assert.dom(screen.getByText('5 sujets')).exists();
       assert.dom(screen.getByText('area1 code · area1 title')).exists();
       await clickByText('area1 code · area1 title');
       assert.dom(screen.getByText('competence1Area1 index competence1Area1 name')).exists();
@@ -281,6 +283,7 @@ module('Integration | Component | Trainings::CreateTrainingTriggers', function (
         type: 'prerequisite',
         areas: [area1, area2],
         threshold: 20,
+        tubesCount: 4,
       });
       this.set('training', {
         prerequisiteTrigger: trainingTrigger,
@@ -296,6 +299,7 @@ module('Integration | Component | Trainings::CreateTrainingTriggers', function (
         .dom(screen.queryByLabelText(this.intl.t('pages.trainings.training.triggers.prerequisite.alternative-title')))
         .doesNotExist();
       assert.dom(screen.getByText('Seuil : 20%')).exists();
+      assert.dom(screen.getByText('4 sujets')).exists();
       assert.dom(screen.getByText('area1 code · area1 title')).exists();
       await clickByText('area1 code · area1 title');
       assert.dom(screen.getByText('competence1Area1 index competence1Area1 name')).exists();

--- a/api/lib/domain/models/TrainingTrigger.js
+++ b/api/lib/domain/models/TrainingTrigger.js
@@ -12,6 +12,7 @@ class TrainingTrigger {
     }
     this.type = type;
     this.threshold = threshold;
+    this.tubesCount = triggerTubes.length;
     this.areas = areas.map((area) => new _Area({ ...area, competences, thematics, triggerTubes }));
   }
 }

--- a/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
@@ -25,7 +25,7 @@ module.exports = {
       ],
       trainingTriggers: {
         ref: 'id',
-        attributes: ['id', 'trainingId', 'type', 'threshold', 'areas'],
+        attributes: ['id', 'trainingId', 'type', 'threshold', 'areas', 'tubesCount'],
         areas: {
           ref: 'id',
           included: true,

--- a/api/lib/infrastructure/serializers/jsonapi/training-trigger-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/training-trigger-serializer.js
@@ -6,7 +6,7 @@ module.exports = {
       transform(record) {
         return JSON.parse(JSON.stringify(record));
       },
-      attributes: ['id', 'trainingId', 'type', 'threshold', 'areas'],
+      attributes: ['id', 'trainingId', 'type', 'threshold', 'areas', 'tubesCount'],
       areas: {
         ref: 'id',
         included: true,

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -127,6 +127,7 @@ describe('Acceptance | Controller | training-controller', function () {
         (included) => included.type === 'training-triggers'
       ).attributes;
       expect(returnedTrigger.id).to.deep.equal(trainingTrigger.id);
+      expect(returnedTrigger['tubes-count']).to.equal(1);
 
       const returnedTriggerArea = response.result.included.find((included) => included.type === 'areas').attributes;
       expect(returnedTriggerArea.id).to.deep.equal(areaId);

--- a/api/tests/unit/domain/models/TrainingTrigger_test.js
+++ b/api/tests/unit/domain/models/TrainingTrigger_test.js
@@ -34,6 +34,7 @@ describe('Unit | Domain | Models | TrainingTrigger', function () {
       expect(trainingTrigger.trainingId).to.equal(100);
       expect(trainingTrigger.threshold).to.equal(10);
       expect(trainingTrigger.areas).to.deep.equal([]);
+      expect(trainingTrigger.tubesCount).to.equal(1);
     });
 
     it('should build learning content tree from parameters', function () {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -165,6 +165,7 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
               'training-id': trainingId,
               threshold: 60,
               type: 'prerequisite',
+              'tubes-count': 2,
             },
             id: `${trainingTriggerId}`,
             relationships: {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-trigger-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-trigger-serializer_test.js
@@ -47,6 +47,7 @@ describe('Unit | Serializer | JSONAPI | training-trigger-serializer', function (
             'training-id': trainingId,
             threshold: 60,
             type: 'prerequisite',
+            'tubes-count': 2,
           },
           id: `${id}`,
           relationships: {


### PR DESCRIPTION
## :unicorn: Problème

À la visualisation d'un déclencheur de contenu formatif existant, il nous manquait les informations de pourcentage de seuil et du nombre de sujets sélectionnés.

## :robot: Proposition

Ajouter ces informations dans le template de page.

## :rainbow: Remarques

Volontairement, le design ne correspond pas exactement à celui présent sur Figma, pour des raisons d'alignement avec l'existant.

## :100: Pour tester

- Aller sur la RA
- Visiter le premier contenu formatif
- Visualiser au niveau du titre du déclencheur formatif le pourcentage de seuil et le nombre de sujets sélectionnés
