### PR TITLE
[BUGFIX] Afficher le déclencheur après sa création (PIX-7501).

### DIFF
--- a/admin/app/controllers/authenticated/trainings/training/triggers/edit.js
+++ b/admin/app/controllers/authenticated/trainings/training/triggers/edit.js
@@ -41,7 +41,7 @@ export default class TrainingEditTriggersController extends Controller {
     try {
       const data = Object.fromEntries(new FormData(event.target).entries());
       await this.store
-        .createRecord('training-trigger', { ...data, type: this.type })
+        .createRecord('training-trigger', { ...data, type: this.type, training: this.model.training })
         .save({ adapterOptions: { tubes: this.selectedTubes, trainingId: this.model.training.id } });
       this.notifications.success('Le déclencheur a été créé avec succès.');
       this.goBackToTraining();

--- a/admin/app/models/training-trigger.js
+++ b/admin/app/models/training-trigger.js
@@ -1,10 +1,10 @@
-import Model, { attr, hasMany } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class TrainingTrigger extends Model {
   @attr('string') type;
-  @attr('number') trainingId;
   @attr('number') threshold;
   @attr('number') tubesCount;
 
+  @belongsTo('training') training;
   @hasMany('area') areas;
 }

--- a/admin/mirage/serializers/training-trigger.js
+++ b/admin/mirage/serializers/training-trigger.js
@@ -1,6 +1,6 @@
 import ApplicationSerializer from './application';
 
-const include = ['tubes'];
+const include = ['areas'];
 
 export default ApplicationSerializer.extend({
   include,

--- a/admin/tests/acceptance/authenticated/trainings/edit-triggers_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/edit-triggers_test.js
@@ -107,6 +107,8 @@ module('Acceptance | Trainings | Triggers edit', function (hooks) {
 
       // then
       assert.strictEqual(currentURL(), `/trainings/${trainingId}/triggers`);
+      assert.dom(screen.getByText('Seuil : 20%', { exact: false })).exists();
+      assert.dom(screen.getByText('2 sujets', { exact: false })).exists();
     });
 
     module('when admin member is "SUPPORT"', function () {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lorsque nous créons le déclencheur d'un contenu formatif sur Pix Admin, nous ne le voyons pas tant que nous rechargeons pas la page. 

## :robot: Proposition
Le déclencheur ne s'affichait pas car on ne disait pas à Ember Data que celui-ci était lié au contenu formatif en question.

## :rainbow: Remarques
Nous avons revu la route mirage et ajouté le test qui va bien. 

![Screenshot 2023-03-21 at 14 55 10](https://user-images.githubusercontent.com/26384707/226628560-e20cf984-d8f7-4206-ad58-8e70be6a9e17.gif)


## :100: Pour tester
- Se connecter à Pix Admin
- Aller sur les contenus formatifs
- Ajouter un déclencheur et constater qu'après la création nous pouvons directement voir le détail du déclencheur