### PR TITLE
[BUGFIX] Correction crash dans le script de cache refresh

### DIFF
--- a/api/scripts/refresh-cache.js
+++ b/api/scripts/refresh-cache.js
@@ -3,7 +3,7 @@
 const dotenv = require('dotenv');
 dotenv.config();
 const logger = require('../lib/infrastructure/logger');
-const { cache } = require('../lib/infrastructure/caches/learning-content-cache');
+const { learningContentCache } = require('../lib/infrastructure/caches/learning-content-cache');
 
 const learningContentDatasource = require('../lib/infrastructure/datasources/learning-content/datasource');
 
@@ -14,4 +14,4 @@ learningContentDatasource
     logger.info('Learning Content refreshed');
   })
   .catch((e) => logger.error('Error while reloading cache', e))
-  .finally(() => cache.quit());
+  .finally(() => learningContentCache.quit());


### PR DESCRIPTION
## :unicorn: Problème
On a l'erreur suivante dans le script cache refresh :
```
/home/nico/git/pix/pix/api/scripts/refresh-cache.js:17
  .finally(() => cache.quit());
                       ^

TypeError: Cannot read properties of undefined (reading 'quit')
    at /home/nico/git/pix/pix/api/scripts/refresh-cache.js:17:24
    at <anonymous>
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

## :robot: Proposition
Corriger l'import du cache.

## :rainbow: Remarques
N/A

## :100: Pour tester
Lancer `npm run cache:refresh`