### PR TITLE
[BUGFIX] Corrige l'affichage du message de changement de mot de passe sur certif

### DIFF
--- a/certif/app/utils/intl/missing-message.js
+++ b/certif/app/utils/intl/missing-message.js
@@ -1,0 +1,3 @@
+export default function missingMessage(key, locales) {
+  throw new Error(`[ember-intl] Missing translation for key: "${key}" for locales: "${locales}"`);
+}

--- a/certif/config/ember-intl.js
+++ b/certif/config/ember-intl.js
@@ -68,7 +68,7 @@ module.exports = function (/* environment */) {
      * @type {Boolean}
      * @default "false"
      */
-    errorOnMissingTranslations: false,
+    errorOnMissingTranslations: true,
 
     /**
      * Removes empty translations from the build output.

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -54,7 +54,7 @@ module.exports = function (environment) {
         },
         SHOULD_CHANGE_PASSWORD: {
           CODE: '401',
-          I18N_KEY: 'pages.login-form.errors.should-change-password',
+          I18N_KEY: 'pages.login.errors.should-change-password',
         },
         USER_IS_TEMPORARY_BLOCKED: {
           CODE: '403',

--- a/certif/tests/integration/components/add-student-list_test.js
+++ b/certif/tests/integration/components/add-student-list_test.js
@@ -1,13 +1,13 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
 import { render } from '@1024pix/ember-testing-library';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | add-student-list', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   const ADD_BUTTON_SELECTOR = '.bottom-action-bar__actions--add-button';
   let notificationMessagesService;

--- a/certif/tests/integration/components/certif-checkbox_test.js
+++ b/certif/tests/integration/components/certif-checkbox_test.js
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import sinon from 'sinon';
 import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | certif-checkbox', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   [
     { state: 'checked', classes: ['checkbox--checked'] },

--- a/certif/tests/integration/components/certification-candidate-in-staging-item_test.js
+++ b/certif/tests/integration/components/certification-candidate-in-staging-item_test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import Object from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 async function renderComponent() {
   await render(hbs`<CertificationCandidateInStagingItem
@@ -15,7 +15,7 @@ async function renderComponent() {
 }
 
 module('Integration | Component | certification-candidate-in-staging-item', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   let saveStub;
   let cancelStub;

--- a/certif/tests/integration/components/communication-banner_test.js
+++ b/certif/tests/integration/components/communication-banner_test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
 import { click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import ENV from 'pix-certif/config/environment';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | communication-banner', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   const originalBannerContent = ENV.APP.BANNER.CONTENT;
   const originalBannerType = ENV.APP.BANNER.TYPE;

--- a/certif/tests/integration/components/formbuilder-link-step_test.js
+++ b/certif/tests/integration/components/formbuilder-link-step_test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 import config from 'pix-certif/config/environment';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | SessionFinalization::FormbuilderLinkStep', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it renders', async function (assert) {
     // given

--- a/certif/tests/integration/components/issue-report-modal/add-issue-report-modal_test.js
+++ b/certif/tests/integration/components/issue-report-modal/add-issue-report-modal_test.js
@@ -1,5 +1,4 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { click } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 
@@ -12,8 +11,10 @@ import {
   categoryToCode,
 } from 'pix-certif/models/certification-issue-report';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | add-issue-report-modal', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it show candidate informations in title', async function (assert) {
     // given

--- a/certif/tests/integration/components/issue-report-modal/candidate-information-change-certification-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/candidate-information-change-certification-issue-report-fields_test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import { certificationIssueReportSubcategories } from 'pix-certif/models/certification-issue-report';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | candidate-information-change-certification-issue-report-fields', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   const INPUT_RADIO_SELECTOR = '#input-radio-for-category-candidate-information-change';
   const TEXTAREA_SELECTOR = '#text-area-for-category-candidate-information-change';

--- a/certif/tests/integration/components/issue-report-modal/fraud-certification-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/fraud-certification-issue-report-fields_test.js
@@ -1,13 +1,13 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { click } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
-
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | issue-report-modal/fraud-certification-issue-report-fields', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it should call toggle function on click radio button', async function (assert) {
     // given

--- a/certif/tests/integration/components/issue-report-modal/in-challenge-certification-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/in-challenge-certification-issue-report-fields_test.js
@@ -1,5 +1,4 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { click } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
@@ -12,9 +11,10 @@ import {
   subcategoryToLabel,
 } from 'pix-certif/models/certification-issue-report';
 import { RadioButtonCategoryWithSubcategoryAndQuestionNumber } from 'pix-certif/components/issue-report-modal/add-issue-report-modal';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | in-challenge-certification-issue-report-fields', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it should call toggle function on click radio button', async function (assert) {
     // given

--- a/certif/tests/integration/components/issue-report-modal/issue-report-modal_test.js
+++ b/certif/tests/integration/components/issue-report-modal/issue-report-modal_test.js
@@ -1,13 +1,13 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | issue-report-modal', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it show candidate information in title', async function (assert) {
     // given

--- a/certif/tests/integration/components/issue-report-modal/non-blocking-candidate-issue-certification-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/non-blocking-candidate-issue-certification-issue-report-fields_test.js
@@ -1,14 +1,14 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { click } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module(
   'Integration | Component | issue-report-modal/non-blocking-candidate-issue-certification-issue-report-fields',
   function (hooks) {
-    setupRenderingTest(hooks);
+    setupIntlRenderingTest(hooks);
 
     test('it should call toggle function on click radio button', async function (assert) {
       // given

--- a/certif/tests/integration/components/issue-report-modal/non-blocking-technical-issue-certification-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/non-blocking-technical-issue-certification-issue-report-fields_test.js
@@ -1,14 +1,14 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { click } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module(
   'Integration | Component | issue-report-modal/non-blocking-technical-issue-certification-issue-report-fields',
   function (hooks) {
-    setupRenderingTest(hooks);
+    setupIntlRenderingTest(hooks);
 
     test('it should call toggle function on click radio button', async function (assert) {
       // given

--- a/certif/tests/integration/components/issue-report-modal/signature-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/signature-issue-report-fields_test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-
 import sinon from 'sinon';
 
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | signature-issue-report-fields', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   const INPUT_RADIO_SELECTOR = '#input-radio-for-category-signature-issue';
   const TEXTAREA_SELECTOR = '#text-area-for-category-signature-issue';

--- a/certif/tests/integration/components/issue-reports-modal_test.js
+++ b/certif/tests/integration/components/issue-reports-modal_test.js
@@ -1,5 +1,4 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { click } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
@@ -11,9 +10,10 @@ import {
   categoryToLabel,
   subcategoryToLabel,
 } from 'pix-certif/models/certification-issue-report';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | issue-reports-modal', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it show candidate information in title', async function (assert) {
     // given

--- a/certif/tests/integration/components/login-form_test.js
+++ b/certif/tests/integration/components/login-form_test.js
@@ -104,7 +104,7 @@ module('Integration | Component | login-form', function (hooks) {
     await click(screen.getByRole('button', { name: 'Je me connecte' }));
 
     // then
-    const expectedErrorMessage = this.intl.t('pages.login-form.errors.should-change-password', {
+    const expectedErrorMessage = this.intl.t('pages.login.errors.should-change-password', {
       url: 'https://app.pix.localhost/mot-de-passe-oublie',
       htmlSafe: true,
     });

--- a/certif/tests/integration/components/login-session-supervisor-form_test.js
+++ b/certif/tests/integration/components/login-session-supervisor-form_test.js
@@ -1,15 +1,13 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { click, fillIn } from '@ember/test-helpers';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
-import setupIntl from '../../helpers/setup-intl';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | login-session-supervisor-form', function (hooks) {
-  setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it should render supervisor login form', async function (assert) {
     // when

--- a/certif/tests/integration/components/members-list_test.js
+++ b/certif/tests/integration/components/members-list_test.js
@@ -1,14 +1,12 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
-import setupIntl from '../../helpers/setup-intl';
 import Service from '@ember/service';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | members-list', function (hooks) {
-  setupRenderingTest(hooks);
-  setupIntl(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it should show members firstName and lastName', async function (assert) {
     // given

--- a/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-details-modal/new-certification-candidate-modal_test.js
@@ -1,13 +1,13 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { click, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | new-certification-candidate-modal', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(async function () {
     const store = this.owner.lookup('service:store');

--- a/certif/tests/integration/components/session-finalization-step-container_test.js
+++ b/certif/tests/integration/components/session-finalization-step-container_test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | session-finalization-step-container', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it renders', async function (assert) {
     // when

--- a/certif/tests/integration/components/session-finalization/complementary-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/complementary-information-step_test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
-import { setupRenderingTest } from 'ember-qunit';
 import { click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | SessionFinalization::ComplementaryInformationStep', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('on click on incident during certification session checkbox, it should call toggleIncidentDuringCertificationSession', async function (assert) {
     // given

--- a/certif/tests/integration/components/session-finalization/examiner-global-comment-step_test.js
+++ b/certif/tests/integration/components/session-finalization/examiner-global-comment-step_test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
-import { setupRenderingTest } from 'ember-qunit';
 import { render, click, fillIn } from '@ember/test-helpers';
 import Object from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | SessionFinalization::ExaminerGlobalCommentStep', function (hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it renders the radio buttons', async function (assert) {
     // given

--- a/certif/tests/unit/controllers/authenticated/sessions/import_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/import_test.js
@@ -2,9 +2,11 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import Service from '@ember/service';
+import setupIntlForModels from '../../../helpers/setup-intl';
 
 module('Unit | Controller | authenticated/sessions/import', function (hooks) {
   setupTest(hooks);
+  setupIntlForModels(hooks);
 
   let controller;
 

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -131,10 +131,6 @@
       "actions": {
         "return": "Return to the sessions list"
       },
-      "enrolled-candidates": {
-        "without-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec la possibilité de supprimer un candidat dans la dernière colonne.",
-        "with-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec un lien pour voir les détails du candidat et la possibilité de supprimer un candidat dans la dernière colonne."
-      },
       "finalize": {
         "finished-test-list-description": "Liste des candidats qui ont fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.",
         "unfinished-test-list-description": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon."


### PR DESCRIPTION
## :unicorn: Problème
Le message de changement de mot de passe sur certif n'est pas correct, la clef de traduction n'existe pas.

## :robot: Proposition
Corriger la clef de traduction.

## :100: Pour tester
1. Aller sur la page de connexion
2. Avec la console de dev, changer le type d'input de l'email en text
3. Se connecter avec le compte username123/Password123
4. Voir le message s'afficher
