### PR TITLE
[FEATURE] Préparation de la recommandation de contenu formatif - partie 1 (PIX-7502).  

### DIFF
--- a/api/lib/domain/services/training-recommendation.js
+++ b/api/lib/domain/services/training-recommendation.js
@@ -1,0 +1,7 @@
+function getCappedSkills({ skills, cappedLevel }) {
+  return skills.filter((skill) => skill.difficulty <= cappedLevel);
+}
+
+module.exports = {
+  getCappedSkills,
+};

--- a/api/tests/unit/domain/services/training-recommendation_test.js
+++ b/api/tests/unit/domain/services/training-recommendation_test.js
@@ -1,0 +1,37 @@
+const { getCappedSkills } = require('../../../../lib/domain/services/training-recommendation');
+const { expect, domainBuilder } = require('../../../test-helper');
+
+describe('Unit | Service | Training Recommendation', function () {
+  describe('#getCappedSkills', function () {
+    it('should return capped skills for given tube level', function () {
+      // given
+      const skillLevel1 = domainBuilder.buildSkill({ id: 'recSkill1', difficulty: 1 });
+      const skillLevel2 = domainBuilder.buildSkill({ id: 'recSkill2', difficulty: 2 });
+      const skillLevel3 = domainBuilder.buildSkill({ id: 'recSkill3', difficulty: 3 });
+
+      const skills = [skillLevel3, skillLevel2, skillLevel1];
+      const cappedLevel = 2;
+
+      // when
+      const cappedSkills = getCappedSkills({ skills, cappedLevel });
+
+      // then
+      expect(cappedSkills).to.deep.equal([skillLevel2, skillLevel1]);
+    });
+
+    it('should return empty array when no skills corresponds for given tube level', function () {
+      // given
+      const skillLevel2 = domainBuilder.buildSkill({ id: 'recSkill2', difficulty: 2 });
+      const skillLevel3 = domainBuilder.buildSkill({ id: 'recSkill3', difficulty: 3 });
+
+      const skills = [skillLevel3, skillLevel2];
+      const cappedLevel = 1;
+
+      // when
+      const cappedSkills = getCappedSkills({ skills, cappedLevel });
+
+      // then
+      expect(cappedSkills).to.be.empty;
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, la recommandation de contenu formatif n'est pour l'instant pas intelligente. En effet, nous recommandons juste les CF liés au profil cible de la campagne, ce qui n'apporte pas de valeurs à l'utilisateur car il ne sait pas ce qui est pertinent pour lui.

## :robot: Proposition
Faire un algorithme de recommandation basé sur les déclencheurs que nous avons déjà implémenté. 
Cette PR a pour but de récupérer les acquis (skill) plafonnés par le niveau d'un sujet (tube). 

## :rainbow: Remarques
Cette PR n'est pas testable manuellement. Il s'agit d'une première brique technique pour l'algo

## :100: Pour tester
CI OK