### PR TITLE
[FEATURE] Préparation de la recommandation de contenu formatif - partie 2 (PIX-7503).

### DIFF
--- a/api/lib/domain/services/training-recommendation.js
+++ b/api/lib/domain/services/training-recommendation.js
@@ -2,6 +2,12 @@ function getCappedSkills({ skills, cappedLevel }) {
   return skills.filter((skill) => skill.difficulty <= cappedLevel);
 }
 
+function getCappedKnowledgeElements({ knowledgeElements, cappedSkills }) {
+  const skillIds = cappedSkills.map((skill) => skill.id);
+  return knowledgeElements.filter((knowledgeElement) => skillIds.includes(knowledgeElement.skillId));
+}
+
 module.exports = {
   getCappedSkills,
+  getCappedKnowledgeElements,
 };

--- a/api/tests/unit/domain/services/training-recommendation_test.js
+++ b/api/tests/unit/domain/services/training-recommendation_test.js
@@ -1,4 +1,7 @@
-const { getCappedSkills } = require('../../../../lib/domain/services/training-recommendation');
+const {
+  getCappedSkills,
+  getCappedKnowledgeElements,
+} = require('../../../../lib/domain/services/training-recommendation');
 const { expect, domainBuilder } = require('../../../test-helper');
 
 describe('Unit | Service | Training Recommendation', function () {
@@ -32,6 +35,45 @@ describe('Unit | Service | Training Recommendation', function () {
 
       // then
       expect(cappedSkills).to.be.empty;
+    });
+  });
+  describe('#getCappedKnowledgeElements', function () {
+    it('should return capped knowledge elements for given capped skills', function () {
+      // given
+      const skillLevel1 = domainBuilder.buildSkill({ id: 'recSkill1', difficulty: 1 });
+      const skillLevel2 = domainBuilder.buildSkill({ id: 'recSkill2', difficulty: 2 });
+
+      const cappedSkills = [skillLevel1, skillLevel2];
+
+      const knowledgeElement1 = domainBuilder.buildKnowledgeElement({ skillId: skillLevel1.id });
+      const knowledgeElement2 = domainBuilder.buildKnowledgeElement({ skillId: skillLevel2.id });
+      const knowledgeElement3 = domainBuilder.buildKnowledgeElement({ skillId: 'anotherSkillId' });
+
+      const knowledgeElements = [knowledgeElement1, knowledgeElement2, knowledgeElement3];
+
+      // when
+      const cappedKnowledgeElements = getCappedKnowledgeElements({ knowledgeElements, cappedSkills });
+
+      // then
+      expect(cappedKnowledgeElements).to.deep.equal([knowledgeElement1, knowledgeElement2]);
+    });
+
+    it('should return empty array when no knowledge elements corresponds for given capped skills', function () {
+      // given
+      const skillLevel1 = domainBuilder.buildSkill({ id: 'recSkill1', difficulty: 1 });
+      const skillLevel2 = domainBuilder.buildSkill({ id: 'recSkill2', difficulty: 2 });
+
+      const cappedSkills = [skillLevel1, skillLevel2];
+
+      const knowledgeElement3 = domainBuilder.buildKnowledgeElement({ skillId: 'anotherSkillId' });
+
+      const knowledgeElements = [knowledgeElement3];
+
+      // when
+      const cappedKnowledgeElements = getCappedKnowledgeElements({ knowledgeElements, cappedSkills });
+
+      // then
+      expect(cappedKnowledgeElements).to.be.empty;
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, la recommandation de contenu formatif n'est pour l'instant pas intelligente. En effet, nous recommandons juste les CF liés au profil cible de la campagne, ce qui n'apporte pas de valeurs à l'utilisateur car il ne sait pas ce qui est pertinent pour lui.

## :robot: Proposition
Faire un algorithme de recommandation basé sur les déclencheurs que nous avons déjà implémenté. 
Cette PR a pour but de récupérer les éléments de connaissance (knowledge elements) plafonnés par le niveau des acquis reliés aux sujets du contenu formatif. 

## :rainbow: Remarques
Cette PR n'est pas testable manuellement. Il s'agit d'une première brique technique pour l'algo

## :100: Pour tester
CI OK