### PR TITLE
[FEATURE] Préparation de la recommandation de contenu formatif - partie 3 (PIX-7504).

### DIFF
--- a/api/lib/domain/services/training-recommendation.js
+++ b/api/lib/domain/services/training-recommendation.js
@@ -7,7 +7,12 @@ function getCappedKnowledgeElements({ knowledgeElements, cappedSkills }) {
   return knowledgeElements.filter((knowledgeElement) => skillIds.includes(knowledgeElement.skillId));
 }
 
+function getValidatedKnowledgeElementsCount({ knowledgeElements }) {
+  return knowledgeElements.filter((knowledgeElement) => knowledgeElement.isValidated).length;
+}
+
 module.exports = {
   getCappedSkills,
   getCappedKnowledgeElements,
+  getValidatedKnowledgeElementsCount,
 };

--- a/api/tests/unit/domain/services/training-recommendation_test.js
+++ b/api/tests/unit/domain/services/training-recommendation_test.js
@@ -1,8 +1,10 @@
 const {
   getCappedSkills,
   getCappedKnowledgeElements,
+  getValidatedKnowledgeElementsCount,
 } = require('../../../../lib/domain/services/training-recommendation');
 const { expect, domainBuilder } = require('../../../test-helper');
+const { KnowledgeElement } = require('../../../../lib/domain/models');
 
 describe('Unit | Service | Training Recommendation', function () {
   describe('#getCappedSkills', function () {
@@ -37,6 +39,7 @@ describe('Unit | Service | Training Recommendation', function () {
       expect(cappedSkills).to.be.empty;
     });
   });
+
   describe('#getCappedKnowledgeElements', function () {
     it('should return capped knowledge elements for given capped skills', function () {
       // given
@@ -74,6 +77,47 @@ describe('Unit | Service | Training Recommendation', function () {
 
       // then
       expect(cappedKnowledgeElements).to.be.empty;
+    });
+  });
+
+  describe('#getValidatedKnowledgeElementsCount', function () {
+    it('should return count of validated knowledge elements for given knowledge elements', function () {
+      // given
+      const knowledgeElementValidated1 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+      });
+      const knowledgeElementValidated2 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+      });
+      const knowledgeElementInvalidated = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.INVALIDATED,
+      });
+
+      const knowledgeElements = [knowledgeElementValidated1, knowledgeElementValidated2, knowledgeElementInvalidated];
+
+      // when
+      const validatedKnowledgeElementsCount = getValidatedKnowledgeElementsCount({ knowledgeElements });
+
+      // then
+      expect(validatedKnowledgeElementsCount).to.equal(2);
+    });
+
+    it('should return 0 when no validated knowledge elements corresponds for given knowledge elements', function () {
+      // given
+      const knowledgeElementInvalidated1 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.INVALIDATED,
+      });
+      const knowledgeElementInvalidated2 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.INVALIDATED,
+      });
+
+      const knowledgeElements = [knowledgeElementInvalidated1, knowledgeElementInvalidated2];
+
+      // when
+      const validatedKnowledgeElementsCount = getValidatedKnowledgeElementsCount({ knowledgeElements });
+
+      // then
+      expect(validatedKnowledgeElementsCount).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, la recommandation de contenu formatif n'est pour l'instant pas intelligente. En effet, nous recommandons juste les CF liés au profil cible de la campagne, ce qui n'apporte pas de valeurs à l'utilisateur car il ne sait pas ce qui est pertinent pour lui.

## :robot: Proposition
Faire un algorithme de recommandation basé sur les déclencheurs que nous avons déjà implémenté. 
Cette PR a pour but de récupérer le nombre d'éléments de connaissance (knowledge elements) validés.

## :rainbow: Remarques
Cette PR n'est pas testable manuellement. Il s'agit d'une première brique technique pour l'algo

## :100: Pour tester
CI OK