### PR TITLE
[BUGFIX] Afficher les messages d'erreur des champs pour la création et la modification de session (PIX-7161).

### DIFF
--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -21,8 +21,9 @@ const sessionValidationJoiSchema = Joi.object({
     'string.empty': CERTIFICATION_SESSIONS_ERRORS.SESSION_ROOM_REQUIRED.getMessage(),
   }),
 
-  date: Joi.string().isoDate().required().messages({
-    'string.empty': CERTIFICATION_SESSIONS_ERRORS.SESSION_DATE_REQUIRED.getMessage(),
+  date: Joi.date().format('YYYY-MM-DD').required().empty(['', null]).messages({
+    'any.required': CERTIFICATION_SESSIONS_ERRORS.SESSION_DATE_REQUIRED.getMessage(),
+    'date.format': CERTIFICATION_SESSIONS_ERRORS.SESSION_DATE_NOT_VALID.getMessage(),
   }),
 
   time: Joi.string()

--- a/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
@@ -1,9 +1,6 @@
 const { Serializer } = require('jsonapi-serializer');
 const _ = require('lodash');
 
-const { WrongDateFormatError } = require('../../../domain/errors.js');
-const { isValidDate } = require('../../utils/date-utils.js');
-
 const Session = require('../../../domain/models/Session.js');
 
 module.exports = {
@@ -65,9 +62,6 @@ module.exports = {
 
   deserialize(json) {
     const attributes = json.data.attributes;
-    if (!isValidDate(attributes.date, 'YYYY-MM-DD')) {
-      throw new WrongDateFormatError();
-    }
 
     const result = new Session({
       id: json.data.id,


### PR DESCRIPTION
## :unicorn: Problème
Régression constatée suite https://1024pix.atlassian.net/browse/PIX-7029 

L’utilisateur Pix Certif peut créer une nouvelle session en renseignant les différents champs requis après avoir cliqué sur “Créer une session” au dessus de la liste des sessions.

Il peut également modifier les informations d’une session déjà créée en passant par la page “Détails” d’une session et en cliquant sur “Modifier”.

S’il manque un des champs obligatoires, une erreur doit s’afficher et ce n'est pour le moment pas le cas.

## :robot: Proposition
Afficher les messages d'erreur liés aux champs quand ces champs sont vides ou incorrects.

## :100: Pour tester
- Lancer Pix Certif (par ex avec certifsup@example.net)
- Cliquer sur "Créer une session" afin d'arriver sur la page de création de session. 
- Cliquer sur "Créer la session" avant de remplir les champs. Un message d'erreur s'affiche sous chacun de ces champs.
- Remplir les champs avec des valeurs incorrectes ou en laisser certains vides puis cliquer de nouveau sur "Créer la session" afin de constater que les erreurs s'affichent uniquement sous les champs concernés.
- Aller sur la page de modification d'une session et réaliser les étapes de la création de session, afin de constater la présence des mêmes messages d'erreur.