### PR TITLE
[FEATURE] Préparation de la recommandation de contenu formatif - partie 4 (PIX-7505)

### DIFF
--- a/api/lib/domain/services/training-recommendation.js
+++ b/api/lib/domain/services/training-recommendation.js
@@ -11,8 +11,16 @@ function getValidatedKnowledgeElementsCount({ knowledgeElements }) {
   return knowledgeElements.filter((knowledgeElement) => knowledgeElement.isValidated).length;
 }
 
+function getValidatedKnowledgeElementsPercentage({ knowledgeElements }) {
+  if (knowledgeElements.length === 0) return 0;
+
+  const validatedKnowledgeElementsCount = getValidatedKnowledgeElementsCount({ knowledgeElements });
+  return Math.round((validatedKnowledgeElementsCount / knowledgeElements.length) * 100);
+}
+
 module.exports = {
   getCappedSkills,
   getCappedKnowledgeElements,
   getValidatedKnowledgeElementsCount,
+  getValidatedKnowledgeElementsPercentage,
 };

--- a/api/tests/unit/domain/services/training-recommendation_test.js
+++ b/api/tests/unit/domain/services/training-recommendation_test.js
@@ -2,9 +2,11 @@ const {
   getCappedSkills,
   getCappedKnowledgeElements,
   getValidatedKnowledgeElementsCount,
+  getValidatedKnowledgeElementsPercentage,
 } = require('../../../../lib/domain/services/training-recommendation');
 const { expect, domainBuilder } = require('../../../test-helper');
 const { KnowledgeElement } = require('../../../../lib/domain/models');
+const _ = require('lodash');
 
 describe('Unit | Service | Training Recommendation', function () {
   describe('#getCappedSkills', function () {
@@ -118,6 +120,57 @@ describe('Unit | Service | Training Recommendation', function () {
 
       // then
       expect(validatedKnowledgeElementsCount).to.equal(0);
+    });
+  });
+
+  describe('#getValidatedKnowledgeElementsPercentage', function () {
+    const testCases = [
+      {
+        validatedKnowledgeElementsCount: 0,
+        invalidatedKnowledgeElementsCount: 0,
+        expectedPercentage: 0,
+      },
+      {
+        validatedKnowledgeElementsCount: 1,
+        invalidatedKnowledgeElementsCount: 1,
+        expectedPercentage: 50,
+      },
+      {
+        validatedKnowledgeElementsCount: 2,
+        invalidatedKnowledgeElementsCount: 1,
+        expectedPercentage: 67,
+      },
+      {
+        validatedKnowledgeElementsCount: 1,
+        invalidatedKnowledgeElementsCount: 2,
+        expectedPercentage: 33,
+      },
+    ];
+
+    // eslint-disable-next-line mocha/no-setup-in-describe
+    testCases.forEach(({ validatedKnowledgeElementsCount, invalidatedKnowledgeElementsCount, expectedPercentage }) => {
+      it(`should return ${expectedPercentage} percentage of validated knowledge elements for given knowledge elements`, function () {
+        // given
+        const validatedKnowledgeElements = _.times(validatedKnowledgeElementsCount, () =>
+          domainBuilder.buildKnowledgeElement({
+            status: KnowledgeElement.StatusType.VALIDATED,
+          })
+        );
+
+        const invalidatedKnowledgeElements = _.times(invalidatedKnowledgeElementsCount, () =>
+          domainBuilder.buildKnowledgeElement({
+            status: KnowledgeElement.StatusType.INVALIDATED,
+          })
+        );
+
+        const knowledgeElements = [...validatedKnowledgeElements, ...invalidatedKnowledgeElements];
+
+        // when
+        const validatedKnowledgeElementsPercentage = getValidatedKnowledgeElementsPercentage({ knowledgeElements });
+
+        // then
+        expect(validatedKnowledgeElementsPercentage).to.equal(expectedPercentage);
+      });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, la recommandation de contenu formatif n'est pour l'instant pas intelligente. En effet, nous recommandons juste les CF liés au profil cible de la campagne, ce qui n'apporte pas de valeurs à l'utilisateur car il ne sait pas ce qui est pertinent pour lui.

## :robot: Proposition
Faire un algorithme de recommandation basé sur les déclencheurs que nous avons déjà implémenté. 
Cette PR a pour but de calculer le pourcentage d'acquis validés par rapport au total des acquis du contenu formatif .

## :rainbow: Remarques
Cette PR n'est pas testable manuellement. Il s'agit d'une première brique technique pour l'algo

## :100: Pour tester
CI OK