### PR TITLE
[TECH] Normalisation des fichiers de traductions (PIX-7511)

### DIFF
--- a/certif/app/components/auth/login-or-register.hbs
+++ b/certif/app/components/auth/login-or-register.hbs
@@ -15,7 +15,7 @@
             @backgroundColor="transparent-light"
             @isBorderVisible={{true}}
           >
-            {{t "pages.login-or-register.register-form.button"}}
+            {{t "pages.login-or-register.register-form.actions.login"}}
           </PixButton>
         {{/unless}}
         <div

--- a/certif/app/components/auth/register-form.hbs
+++ b/certif/app/components/auth/register-form.hbs
@@ -1,10 +1,10 @@
 <div class="register-form">
   <form {{on "submit" this.register}}>
-    <p class="login-form__information">{{t "common.forms.mandatory-all-fields"}}</p>
+    <p class="login-form__information">{{t "common.form-errors.mandatory-all-fields"}}</p>
     <div class="input-container">
       <PixInput
         @id="register-firstName"
-        @label={{t "common.forms.common-labels.firstname.label"}}
+        @label={{t "common.labels.candidate.firstname"}}
         name="firstName"
         type="firstName"
         {{on "focusout" this.validateFirstName}}
@@ -19,7 +19,7 @@
     <div class="input-container">
       <PixInput
         @id="register-lastName"
-        @label={{t "common.forms.common-labels.lastname.label"}}
+        @label={{t "common.labels.candidate.lastname"}}
         name="lastName"
         type="lastName"
         {{on "focusout" this.validateLastName}}
@@ -34,7 +34,7 @@
     <div class="input-container">
       <PixInput
         @id="register-email"
-        @label={{t "common.forms.login-labels.email.label"}}
+        @label={{t "common.forms.login.email"}}
         name="email"
         type="email"
         {{on "focusout" this.validateEmail}}
@@ -50,7 +50,7 @@
       <PixInputPassword
         @id="register-password"
         name="password"
-        @label={{t "common.forms.login-labels.password.label"}}
+        @label={{t "common.forms.login.password"}}
         autocomplete="current-password"
         required={{true}}
         aria-required={{true}}

--- a/certif/app/components/auth/register-form.hbs
+++ b/certif/app/components/auth/register-form.hbs
@@ -1,6 +1,6 @@
 <div class="register-form">
   <form {{on "submit" this.register}}>
-    <p class="login-form__information">{{t "common.form.mandatory-all-fields"}}</p>
+    <p class="login-form__information">{{t "common.forms.mandatory-all-fields"}}</p>
     <div class="input-container">
       <PixInput
         @id="register-firstName"

--- a/certif/app/components/auth/register-form.hbs
+++ b/certif/app/components/auth/register-form.hbs
@@ -4,7 +4,7 @@
     <div class="input-container">
       <PixInput
         @id="register-firstName"
-        @label={{t "pages.login-or-register.register-form.fields.first-name.label"}}
+        @label={{t "common.forms.common-labels.firstname.label"}}
         name="firstName"
         type="firstName"
         {{on "focusout" this.validateFirstName}}
@@ -19,7 +19,7 @@
     <div class="input-container">
       <PixInput
         @id="register-lastName"
-        @label={{t "pages.login-or-register.register-form.fields.last-name.label"}}
+        @label={{t "common.forms.common-labels.lastname.label"}}
         name="lastName"
         type="lastName"
         {{on "focusout" this.validateLastName}}
@@ -34,7 +34,7 @@
     <div class="input-container">
       <PixInput
         @id="register-email"
-        @label={{t "pages.login-or-register.register-form.fields.email.label"}}
+        @label={{t "common.forms.login-labels.email.label"}}
         name="email"
         type="email"
         {{on "focusout" this.validateEmail}}
@@ -50,7 +50,7 @@
       <PixInputPassword
         @id="register-password"
         name="password"
-        @label={{t "pages.login-or-register.register-form.fields.password.label"}}
+        @label={{t "common.forms.login-labels.password.label"}}
         autocomplete="current-password"
         required={{true}}
         aria-required={{true}}
@@ -93,7 +93,7 @@
 
     <div class="input-container">
       <PixButton @type="submit" @isLoading={{this.isLoading}} class="register-form__submit-button">
-        {{t "pages.login-or-register.register-form.fields.button.label"}}
+        {{t "pages.login-or-register.register-form.actions.login-button"}}
       </PixButton>
     </div>
 

--- a/certif/app/components/auth/register-form.js
+++ b/certif/app/components/auth/register-form.js
@@ -102,9 +102,9 @@ export default class RegisterForm extends Component {
       const status = get(response, 'errors[0].status');
 
       if (status === '422') {
-        this.errorMessage = this.intl.t('common.forms.login-labels.email.error-already-exists');
+        this.errorMessage = this.intl.t('common.form-errors.email.already-exists');
       } else {
-        this.errorMessage = this.intl.t('common.forms.error-default');
+        this.errorMessage = this.intl.t('common.form-errors.default');
       }
 
       await userRecord?.deleteRecord();
@@ -123,7 +123,7 @@ export default class RegisterForm extends Component {
 
     if (isInvalidInput) {
       this.validation.password.status = STATUSES.ERROR;
-      this.validation.password.message = this.intl.t('common.forms.login-labels.password.error-format');
+      this.validation.password.message = this.intl.t('common.form-errors.password.format');
     } else {
       this.validation.password.status = STATUSES.SUCCESS;
     }
@@ -138,7 +138,7 @@ export default class RegisterForm extends Component {
 
     if (isInvalidInput) {
       this.validation.email.status = STATUSES.ERROR;
-      this.validation.email.message = this.intl.t('common.forms.login-labels.email.error-format');
+      this.validation.email.message = this.intl.t('common.form-errors.email.format');
     } else {
       this.validation.email.status = STATUSES.SUCCESS;
     }
@@ -153,7 +153,7 @@ export default class RegisterForm extends Component {
 
     if (isInvalidInput) {
       this.validation.firstName.status = STATUSES.ERROR;
-      this.validation.firstName.message = this.intl.t('common.forms.common-labels.firstname.error-mandatory');
+      this.validation.firstName.message = this.intl.t('common.form-errors.firstname.mandatory');
     } else {
       this.validation.firstName.status = STATUSES.SUCCESS;
     }
@@ -168,7 +168,7 @@ export default class RegisterForm extends Component {
 
     if (isInvalidInput) {
       this.validation.lastName.status = STATUSES.ERROR;
-      this.validation.lastName.message = this.intl.t('common.forms.common-labels.lastname.error-mandatory');
+      this.validation.lastName.message = this.intl.t('common.form-errors.lastname.mandatory');
     } else {
       this.validation.lastName.status = STATUSES.SUCCESS;
     }

--- a/certif/app/components/auth/register-form.js
+++ b/certif/app/components/auth/register-form.js
@@ -102,9 +102,9 @@ export default class RegisterForm extends Component {
       const status = get(response, 'errors[0].status');
 
       if (status === '422') {
-        this.errorMessage = this.intl.t('pages.login-or-register.register-form.errors.email-already-exists');
+        this.errorMessage = this.intl.t('common.forms.login-labels.email.error-already-exists');
       } else {
-        this.errorMessage = this.intl.t('pages.login-or-register.register-form.errors.default');
+        this.errorMessage = this.intl.t('common.forms.error-default');
       }
 
       await userRecord?.deleteRecord();
@@ -123,7 +123,7 @@ export default class RegisterForm extends Component {
 
     if (isInvalidInput) {
       this.validation.password.status = STATUSES.ERROR;
-      this.validation.password.message = this.intl.t('pages.login-or-register.register-form.fields.password.error');
+      this.validation.password.message = this.intl.t('common.forms.login-labels.password.error-format');
     } else {
       this.validation.password.status = STATUSES.SUCCESS;
     }
@@ -138,7 +138,7 @@ export default class RegisterForm extends Component {
 
     if (isInvalidInput) {
       this.validation.email.status = STATUSES.ERROR;
-      this.validation.email.message = this.intl.t('pages.login-or-register.register-form.fields.email.error');
+      this.validation.email.message = this.intl.t('common.forms.login-labels.email.error-format');
     } else {
       this.validation.email.status = STATUSES.SUCCESS;
     }
@@ -153,7 +153,7 @@ export default class RegisterForm extends Component {
 
     if (isInvalidInput) {
       this.validation.firstName.status = STATUSES.ERROR;
-      this.validation.firstName.message = this.intl.t('pages.login-or-register.register-form.fields.first-name.error');
+      this.validation.firstName.message = this.intl.t('common.forms.common-labels.firstname.error-mandatory');
     } else {
       this.validation.firstName.status = STATUSES.SUCCESS;
     }
@@ -168,7 +168,7 @@ export default class RegisterForm extends Component {
 
     if (isInvalidInput) {
       this.validation.lastName.status = STATUSES.ERROR;
-      this.validation.lastName.message = this.intl.t('pages.login-or-register.register-form.fields.last-name.error');
+      this.validation.lastName.message = this.intl.t('common.forms.common-labels.lastname.error-mandatory');
     } else {
       this.validation.lastName.status = STATUSES.SUCCESS;
     }

--- a/certif/app/components/auth/toggable-login-form.hbs
+++ b/certif/app/components/auth/toggable-login-form.hbs
@@ -1,5 +1,5 @@
 <form class="login-form" {{on "submit" this.authenticate}}>
-  <p class="login-form__information">{{t "common.form.mandatory-all-fields"}}</p>
+  <p class="login-form__information">{{t "common.forms.mandatory-all-fields"}}</p>
 
   <PixInput
     @id="login-email"

--- a/certif/app/components/auth/toggable-login-form.hbs
+++ b/certif/app/components/auth/toggable-login-form.hbs
@@ -3,7 +3,7 @@
 
   <PixInput
     @id="login-email"
-    @label={{t "pages.login-or-register.login-form.fields.email.label"}}
+    @label={{t "common.forms.login-labels.email.label"}}
     name="login"
     type="email"
     {{on "focusout" this.validateEmail}}
@@ -18,7 +18,7 @@
   <PixInputPassword
     @id="login-password"
     name="password"
-    @label={{t "pages.login-or-register.login-form.fields.password.label"}}
+    @label={{t "common.forms.login-labels.password.label"}}
     autocomplete="current-password"
     required={{true}}
     aria-required={{true}}
@@ -41,7 +41,7 @@
   <div>
     <div class="login-form__forgotten-password">
       <a href={{this.forgottenPasswordUrl}} target="_blank" rel="noopener noreferrer" class="link">
-        {{t "pages.login-or-register.login-form.fields.password.forgot-password"}}
+        {{t "common.forms.login-labels.password.forgot-password"}}
       </a>
     </div>
   </div>

--- a/certif/app/components/auth/toggable-login-form.hbs
+++ b/certif/app/components/auth/toggable-login-form.hbs
@@ -1,9 +1,9 @@
 <form class="login-form" {{on "submit" this.authenticate}}>
-  <p class="login-form__information">{{t "common.forms.mandatory-all-fields"}}</p>
+  <p class="login-form__information">{{t "common.form-errors.mandatory-all-fields"}}</p>
 
   <PixInput
     @id="login-email"
-    @label={{t "common.forms.login-labels.email.label"}}
+    @label={{t "common.forms.login.email"}}
     name="login"
     type="email"
     {{on "focusout" this.validateEmail}}
@@ -18,7 +18,7 @@
   <PixInputPassword
     @id="login-password"
     name="password"
-    @label={{t "common.forms.login-labels.password.label"}}
+    @label={{t "common.forms.login.password"}}
     autocomplete="current-password"
     required={{true}}
     aria-required={{true}}
@@ -41,7 +41,7 @@
   <div>
     <div class="login-form__forgotten-password">
       <a href={{this.forgottenPasswordUrl}} target="_blank" rel="noopener noreferrer" class="link">
-        {{t "common.forms.login-labels.password.forgot-password"}}
+        {{t "common.forms.login.forgot-password"}}
       </a>
     </div>
   </div>

--- a/certif/app/components/auth/toggable-login-form.js
+++ b/certif/app/components/auth/toggable-login-form.js
@@ -112,7 +112,7 @@ export default class ToggableLoginForm extends Component {
 
     if (isInvalidInput) {
       this.validation.password.status = STATUSES.ERROR;
-      this.validation.password.message = this.intl.t('common.forms.login-labels.password.error-mandatory');
+      this.validation.password.message = this.intl.t('common.form-errors.password.mandatory');
     } else {
       this.validation.password.status = STATUSES.SUCCESS;
     }
@@ -127,7 +127,7 @@ export default class ToggableLoginForm extends Component {
 
     if (isInvalidInput) {
       this.validation.email.status = STATUSES.ERROR;
-      this.validation.email.message = this.intl.t('common.forms.login-labels.email.error-format');
+      this.validation.email.message = this.intl.t('common.form-errors.email.format');
     } else {
       this.validation.email.status = STATUSES.SUCCESS;
     }

--- a/certif/app/components/auth/toggable-login-form.js
+++ b/certif/app/components/auth/toggable-login-form.js
@@ -112,7 +112,7 @@ export default class ToggableLoginForm extends Component {
 
     if (isInvalidInput) {
       this.validation.password.status = STATUSES.ERROR;
-      this.validation.password.message = this.intl.t('pages.login-or-register.login-form.fields.password.error');
+      this.validation.password.message = this.intl.t('common.forms.login-labels.password.error-mandatory');
     } else {
       this.validation.password.status = STATUSES.SUCCESS;
     }
@@ -127,7 +127,7 @@ export default class ToggableLoginForm extends Component {
 
     if (isInvalidInput) {
       this.validation.email.status = STATUSES.ERROR;
-      this.validation.email.message = this.intl.t('pages.login-or-register.login-form.fields.email.error');
+      this.validation.email.message = this.intl.t('common.forms.login-labels.email.error-format');
     } else {
       this.validation.email.status = STATUSES.SUCCESS;
     }

--- a/certif/app/components/certification-candidate-details-modal.hbs
+++ b/certif/app/components/certification-candidate-details-modal.hbs
@@ -8,7 +8,7 @@
     <ul class="certification-candidate-details-modal__list">
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "pages.sessions.detail.candidates.informations.lastname"}}
+          {{t "common.forms.labels.birth-name"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.lastName @candidate.lastName "-"}}
@@ -16,7 +16,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "pages.sessions.detail.candidates.informations.firstname"}}
+          {{t "common.forms.labels.firstname"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.firstName @candidate.firstName "-"}}
@@ -24,7 +24,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "pages.sessions.detail.candidates.informations.birth-date"}}
+          {{t "common.forms.labels.birth-date"}}
         </span>
         {{#if @candidate.birthdate}}
           <span class="certification-candidate-details-modal__row__value">
@@ -38,7 +38,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "pages.sessions.detail.candidates.informations.gender"}}
+          {{t "common.forms.labels.gender.title"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{@candidate.genderLabel}}
@@ -46,7 +46,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "pages.sessions.detail.candidates.informations.birth-city"}}
+          {{t "common.forms.labels.birth-city"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.birthCity @candidate.birthCity "-"}}
@@ -54,7 +54,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "pages.sessions.detail.candidates.informations.birth-city-postcode"}}
+          {{t "common.forms.labels.birth-city-postcode"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.birthPostalCode @candidate.birthPostalCode "-"}}
@@ -62,7 +62,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "pages.sessions.detail.candidates.informations.birth-city-insee-code"}}
+          {{t "common.forms.labels.birth-city-insee-code"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.birthInseeCode @candidate.birthInseeCode "-"}}
@@ -70,7 +70,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "pages.sessions.detail.candidates.informations.birth-country"}}
+          {{t "common.forms.labels.birth-country"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.birthCountry @candidate.birthCountry "-"}}
@@ -78,7 +78,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "pages.sessions.detail.candidates.informations.email-results"}}
+          {{t "common.forms.certification-labels.email-results"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.resultRecipientEmail @candidate.resultRecipientEmail "-"}}
@@ -86,7 +86,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "pages.sessions.detail.candidates.informations.email-convocation"}}
+          {{t "common.forms.certification-labels.email-convocation"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.email @candidate.email "-"}}
@@ -94,7 +94,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "pages.sessions.detail.candidates.informations.external-id"}}
+          {{t "common.forms.certification-labels.external-id"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.externalId @candidate.externalId "-"}}
@@ -102,7 +102,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "pages.sessions.detail.candidates.informations.extratime-percentage"}}
+          {{t "common.forms.certification-labels.extratime-percentage"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.extraTimePercentage (format-percentage @candidate.extraTimePercentage) "-"}}
@@ -111,7 +111,7 @@
       {{#if @shouldDisplayPaymentOptions}}
         <li class="certification-candidate-details-modal__row">
           <span class="certification-candidate-details-modal__row__label">
-            {{t "pages.sessions.detail.candidates.informations.pricing"}}
+            {{t "common.forms.certification-labels.pricing"}}
           </span>
           <span class="certification-candidate-details-modal__row__value">
             {{@candidate.billingModeLabel}}
@@ -119,7 +119,7 @@
         </li>
         <li class="certification-candidate-details-modal__row">
           <span class="certification-candidate-details-modal__row__label">
-            {{t "pages.sessions.detail.candidates.informations.prepayment-code"}}
+            {{t "common.forms.certification-labels.prepayment-code"}}
           </span>
           <span class="certification-candidate-details-modal__row__value">
             {{if @candidate.prepaymentCode @candidate.prepaymentCode "-"}}
@@ -129,7 +129,7 @@
       {{#if @displayComplementaryCertification}}
         <li class="certification-candidate-details-modal__row">
           <span class="certification-candidate-details-modal__row__label">
-            {{t "pages.sessions.detail.candidates.informations.additional-certification"}}
+            {{t "common.forms.certification-labels.additional-certification"}}
           </span>
           <span class="certification-candidate-details-modal__row__value">
             {{if @candidate.complementaryCertifications @candidate.complementaryCertificationsList "-"}}

--- a/certif/app/components/certification-candidate-details-modal.hbs
+++ b/certif/app/components/certification-candidate-details-modal.hbs
@@ -8,7 +8,7 @@
     <ul class="certification-candidate-details-modal__list">
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "common.forms.common-labels.birth-name"}}
+          {{t "common.labels.candidate.birth-name"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.lastName @candidate.lastName "-"}}
@@ -16,7 +16,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "common.forms.common-labels.firstname.label"}}
+          {{t "common.labels.candidate.firstname"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.firstName @candidate.firstName "-"}}
@@ -24,7 +24,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "common.forms.common-labels.birth-date"}}
+          {{t "common.labels.candidate.birth-date"}}
         </span>
         {{#if @candidate.birthdate}}
           <span class="certification-candidate-details-modal__row__value">
@@ -38,7 +38,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "common.forms.common-labels.gender.title"}}
+          {{t "common.labels.candidate.gender.title"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{@candidate.genderLabel}}
@@ -46,7 +46,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "common.forms.common-labels.birth-city"}}
+          {{t "common.labels.candidate.birth-city"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.birthCity @candidate.birthCity "-"}}
@@ -54,7 +54,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "common.forms.common-labels.birth-city-postcode"}}
+          {{t "common.labels.candidate.birth-city-postcode"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.birthPostalCode @candidate.birthPostalCode "-"}}
@@ -62,7 +62,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "common.forms.common-labels.birth-city-insee-code"}}
+          {{t "common.labels.candidate.birth-city-insee-code"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.birthInseeCode @candidate.birthInseeCode "-"}}
@@ -70,7 +70,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "common.forms.common-labels.birth-country"}}
+          {{t "common.labels.candidate.birth-country"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.birthCountry @candidate.birthCountry "-"}}

--- a/certif/app/components/certification-candidate-details-modal.hbs
+++ b/certif/app/components/certification-candidate-details-modal.hbs
@@ -8,7 +8,7 @@
     <ul class="certification-candidate-details-modal__list">
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "common.forms.labels.birth-name"}}
+          {{t "common.forms.common-labels.birth-name"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.lastName @candidate.lastName "-"}}
@@ -16,7 +16,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "common.forms.labels.firstname"}}
+          {{t "common.forms.common-labels.firstname.label"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.firstName @candidate.firstName "-"}}
@@ -24,7 +24,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "common.forms.labels.birth-date"}}
+          {{t "common.forms.common-labels.birth-date"}}
         </span>
         {{#if @candidate.birthdate}}
           <span class="certification-candidate-details-modal__row__value">
@@ -38,7 +38,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "common.forms.labels.gender.title"}}
+          {{t "common.forms.common-labels.gender.title"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{@candidate.genderLabel}}
@@ -46,7 +46,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "common.forms.labels.birth-city"}}
+          {{t "common.forms.common-labels.birth-city"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.birthCity @candidate.birthCity "-"}}
@@ -54,7 +54,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "common.forms.labels.birth-city-postcode"}}
+          {{t "common.forms.common-labels.birth-city-postcode"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.birthPostalCode @candidate.birthPostalCode "-"}}
@@ -62,7 +62,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "common.forms.labels.birth-city-insee-code"}}
+          {{t "common.forms.common-labels.birth-city-insee-code"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.birthInseeCode @candidate.birthInseeCode "-"}}
@@ -70,7 +70,7 @@
       </li>
       <li class="certification-candidate-details-modal__row">
         <span class="certification-candidate-details-modal__row__label">
-          {{t "common.forms.labels.birth-country"}}
+          {{t "common.forms.common-labels.birth-country"}}
         </span>
         <span class="certification-candidate-details-modal__row__value">
           {{if @candidate.birthCountry @candidate.birthCountry "-"}}

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -36,42 +36,42 @@
         <thead>
           <tr>
             <th class="certification-candidates-table__column-last-name">
-              {{t "pages.sessions.detail.candidates.informations.birth-name"}}
+              {{t "common.forms.labels.birth-name"}}
             </th>
             <th class="certification-candidates-table__column-first-name">
-              {{t "pages.sessions.detail.candidates.informations.firstname"}}
+              {{t "common.forms.labels.firstname"}}
             </th>
             <th class="certification-candidates-table__column-birthdate">
-              {{t "pages.sessions.detail.candidates.informations.birth-date"}}
+              {{t "common.forms.labels.birth-date"}}
             </th>
             {{#if @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
               <th class="certification-candidates-table__birth-city">
-                {{t "pages.sessions.detail.candidates.informations.birth-city"}}
+                {{t "common.forms.labels.birth-city"}}
               </th>
               <th>
-                {{t "pages.sessions.detail.candidates.informations.birth-country"}}
+                {{t "common.forms.labels.birth-country"}}
               </th>
             {{/if}}
             {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
               <th class="certification-candidates-table__recipient-email">
-                {{t "pages.sessions.detail.candidates.informations.email-results"}}
+                {{t "common.forms.certification-labels.email-results"}}
               </th>
             {{/unless}}
             {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
               <th class="certification-candidates-table__external-id">
-                {{t "pages.sessions.detail.candidates.informations.external-id"}}
+                {{t "common.forms.certification-labels.external-id"}}
               </th>
             {{/unless}}
             <th class="certification-candidates-table__column-time">
-              {{t "pages.sessions.detail.candidates.informations.extratime"}}
+              {{t "common.forms.certification-labels.extratime"}}
             </th>
             {{#if @shouldDisplayPaymentOptions}}
               <th class="certification-candidates-table__payment-options">
-                {{t "pages.sessions.detail.candidates.informations.pricing"}}
+                {{t "common.forms.certification-labels.pricing"}}
               </th>
             {{/if}}
             {{#if @displayComplementaryCertification}}
-              <th>{{t "pages.sessions.detail.candidates.informations.additional-certification"}}</th>
+              <th>{{t "common.forms.certification-labels.additional-certification"}}</th>
             {{/if}}
           </tr>
         </thead>

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -36,20 +36,20 @@
         <thead>
           <tr>
             <th class="certification-candidates-table__column-last-name">
-              {{t "common.forms.common-labels.birth-name"}}
+              {{t "common.labels.candidate.birth-name"}}
             </th>
             <th class="certification-candidates-table__column-first-name">
-              {{t "common.forms.common-labels.firstname.label"}}
+              {{t "common.labels.candidate.firstname"}}
             </th>
             <th class="certification-candidates-table__column-birthdate">
-              {{t "common.forms.common-labels.birth-date"}}
+              {{t "common.labels.candidate.birth-date"}}
             </th>
             {{#if @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
               <th class="certification-candidates-table__birth-city">
-                {{t "common.forms.common-labels.birth-city"}}
+                {{t "common.labels.candidate.birth-city"}}
               </th>
               <th>
-                {{t "common.forms.common-labels.birth-country"}}
+                {{t "common.labels.candidate.birth-country"}}
               </th>
             {{/if}}
             {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -36,20 +36,20 @@
         <thead>
           <tr>
             <th class="certification-candidates-table__column-last-name">
-              {{t "common.forms.labels.birth-name"}}
+              {{t "common.forms.common-labels.birth-name"}}
             </th>
             <th class="certification-candidates-table__column-first-name">
-              {{t "common.forms.labels.firstname"}}
+              {{t "common.forms.common-labels.firstname.label"}}
             </th>
             <th class="certification-candidates-table__column-birthdate">
-              {{t "common.forms.labels.birth-date"}}
+              {{t "common.forms.common-labels.birth-date"}}
             </th>
             {{#if @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
               <th class="certification-candidates-table__birth-city">
-                {{t "common.forms.labels.birth-city"}}
+                {{t "common.forms.common-labels.birth-city"}}
               </th>
               <th>
-                {{t "common.forms.labels.birth-country"}}
+                {{t "common.forms.common-labels.birth-country"}}
               </th>
             {{/if}}
             {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}

--- a/certif/app/components/login-form.hbs
+++ b/certif/app/components/login-form.hbs
@@ -23,13 +23,13 @@
     <form class="login-main__form" {{on "submit" this.authenticate}}>
 
       <p class="login-main-form__mandatory-information paragraph">
-        {{t "pages.login.form.mandatory-fields"}}
+        {{t "common.forms.mandatory-all-fields"}}
       </p>
 
       <PixInput
         @id="login-email"
         name="login"
-        @label={{t "pages.login.form.email-address"}}
+        @label={{t "common.forms.labels.email"}}
         autocomplete="email"
         type="email"
         required="true"

--- a/certif/app/components/login-form.hbs
+++ b/certif/app/components/login-form.hbs
@@ -3,7 +3,7 @@
   <header class="login__header">
     <img src="/pix-certif-logo.svg" alt="Pix Certif" />
 
-    <h1 class="login-header__title">{{t "pages.login.login"}}</h1>
+    <h1 class="login-header__title">{{t "pages.login.title"}}</h1>
 
     <p class="login-header__information paragraph">
       {{t "pages.login.accessible-to"}}
@@ -29,7 +29,7 @@
       <PixInput
         @id="login-email"
         name="login"
-        @label={{t "common.forms.labels.email"}}
+        @label={{t "common.forms.login-labels.email.label"}}
         autocomplete="email"
         type="email"
         required="true"
@@ -39,7 +39,7 @@
       <PixInputPassword
         @id="login-password"
         name="password"
-        @label={{t "pages.login.form.password"}}
+        @label={{t "common.forms.login-labels.password.label"}}
         autocomplete="current-password"
         required="true"
         {{on "input" this.setPassword}}
@@ -52,12 +52,12 @@
       {{/if}}
 
       <PixButton @type="submit">
-        {{t "pages.login.form.button"}}
+        {{t "pages.login.actions.login.label"}}
       </PixButton>
 
       <div class="login-main-form__forgotten-password">
         <a href="https://app.pix.fr/mot-de-passe-oublie" target="_blank" rel="noopener noreferrer">{{t
-            "pages.login.form.forgotten-password"
+            "common.forms.login-labels.password.forgot-password"
           }}</a>
       </div>
     </form>

--- a/certif/app/components/login-form.hbs
+++ b/certif/app/components/login-form.hbs
@@ -23,13 +23,13 @@
     <form class="login-main__form" {{on "submit" this.authenticate}}>
 
       <p class="login-main-form__mandatory-information paragraph">
-        {{t "common.forms.mandatory-all-fields"}}
+        {{t "common.form-errors.mandatory-all-fields"}}
       </p>
 
       <PixInput
         @id="login-email"
         name="login"
-        @label={{t "common.forms.login-labels.email.label"}}
+        @label={{t "common.forms.login.email"}}
         autocomplete="email"
         type="email"
         required="true"
@@ -39,7 +39,7 @@
       <PixInputPassword
         @id="login-password"
         name="password"
-        @label={{t "common.forms.login-labels.password.label"}}
+        @label={{t "common.forms.login.password"}}
         autocomplete="current-password"
         required="true"
         {{on "input" this.setPassword}}
@@ -57,7 +57,7 @@
 
       <div class="login-main-form__forgotten-password">
         <a href="https://app.pix.fr/mot-de-passe-oublie" target="_blank" rel="noopener noreferrer">{{t
-            "common.forms.login-labels.password.forgot-password"
+            "common.forms.login.forgot-password"
           }}</a>
       </div>
     </form>

--- a/certif/app/components/login-session-supervisor-form.hbs
+++ b/certif/app/components/login-session-supervisor-form.hbs
@@ -6,7 +6,7 @@
 
   <h2 class="login-session-supervisor-form__subtitle">{{t "pages.session-supervising.login.form.sub-title"}}</h2>
 
-  <p class="login-session-supervisor-form__required-fields-notice">{{t "common.forms.mandatory-all-fields"}}</p>
+  <p class="login-session-supervisor-form__required-fields-notice">{{t "common.form-errors.mandatory-all-fields"}}</p>
 
   {{#if this.errorMessage}}
     <p

--- a/certif/app/components/login-session-supervisor-form.hbs
+++ b/certif/app/components/login-session-supervisor-form.hbs
@@ -6,7 +6,7 @@
 
   <h2 class="login-session-supervisor-form__subtitle">{{t "pages.session-supervising.login.form.sub-title"}}</h2>
 
-  <p class="login-session-supervisor-form__required-fields-notice">{{t "common.form.mandatory-all-fields"}}</p>
+  <p class="login-session-supervisor-form__required-fields-notice">{{t "common.forms.mandatory-all-fields"}}</p>
 
   {{#if this.errorMessage}}
     <p

--- a/certif/app/components/members-list.hbs
+++ b/certif/app/components/members-list.hbs
@@ -4,8 +4,8 @@
       <table>
         <thead>
           <tr>
-            <th class="table__column table__column--medium">{{t "common.forms.labels.lastname"}}</th>
-            <th class="table__column table__column--medium">{{t "common.forms.labels.firstname"}}</th>
+            <th class="table__column table__column--medium">{{t "common.forms.common-labels.lastname.label"}}</th>
+            <th class="table__column table__column--medium">{{t "common.forms.common-labels.firstname.label"}}</th>
             {{#if this.shouldDisplayRefererColumn}}
               <th class="table__column table__column--medium">{{t "pages.team.referer"}}</th>
             {{/if}}

--- a/certif/app/components/members-list.hbs
+++ b/certif/app/components/members-list.hbs
@@ -4,8 +4,8 @@
       <table>
         <thead>
           <tr>
-            <th class="table__column table__column--medium">{{t "common.forms.common-labels.lastname.label"}}</th>
-            <th class="table__column table__column--medium">{{t "common.forms.common-labels.firstname.label"}}</th>
+            <th class="table__column table__column--medium">{{t "common.labels.candidate.lastname"}}</th>
+            <th class="table__column table__column--medium">{{t "common.labels.candidate.firstname"}}</th>
             {{#if this.shouldDisplayRefererColumn}}
               <th class="table__column table__column--medium">{{t "pages.team.referer"}}</th>
             {{/if}}

--- a/certif/app/components/members-list.hbs
+++ b/certif/app/components/members-list.hbs
@@ -4,8 +4,8 @@
       <table>
         <thead>
           <tr>
-            <th class="table__column table__column--medium">{{t "pages.team.last-name"}}</th>
-            <th class="table__column table__column--medium">{{t "pages.team.first-name"}}</th>
+            <th class="table__column table__column--medium">{{t "common.forms.labels.lastname"}}</th>
+            <th class="table__column table__column--medium">{{t "common.forms.labels.firstname"}}</th>
             {{#if this.shouldDisplayRefererColumn}}
               <th class="table__column table__column--medium">{{t "pages.team.referer"}}</th>
             {{/if}}

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -18,7 +18,7 @@
       <div class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double">
         <label for="last-name" class="label">
           <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-          Nom de famille
+          {{t "common.forms.common-labels.birth-name"}}
         </label>
         <Input
           id="last-name"

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -1,5 +1,5 @@
 <PixModal
-  @title="Inscrire un candidat"
+  @title={{t "pages.sessions.detail.candidates.detail-modal.title"}}
   @onCloseButtonClick={{@closeModal}}
   class="new-certification-candidate-modal"
   @showModal={{@showModal}}
@@ -12,14 +12,12 @@
     >
 
       <p class="new-certification-candidate-modal__form__required-fields-mention">
-        Les champs marqués de
-        <span class="required-field-indicator">*</span>
-        sont obligatoires.
+        {{t "common.forms.mandatory-fields" htmlSafe=true}}
       </p>
 
       <div class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double">
         <label for="last-name" class="label">
-          <span class="required-field-indicator">*</span>
+          <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
           Nom de famille
         </label>
         <Input
@@ -35,8 +33,8 @@
 
       <div class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double">
         <label for="first-name" class="label">
-          <span class="required-field-indicator">*</span>
-          Prénom
+          <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+          {{t "common.forms.labels.firstname"}}
         </label>
         <Input
           id="first-name"
@@ -51,8 +49,8 @@
       <div class="new-certification-candidate-modal__form__field">
         <fieldset>
           <legend class="label">
-            <span class="required-field-indicator">*</span>
-            Sexe
+            <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+            {{t "common.forms.labels.gender.title"}}
           </legend>
           <div class="radio-button-container">
             <input
@@ -63,7 +61,9 @@
               required
               {{on "click" (fn @updateCandidateData @candidateData "sex")}}
             />
-            <label class="radio-button-label" for="female">Femme</label>
+            <label class="radio-button-label" for="female">
+              {{t "common.forms.labels.gender.woman"}}
+            </label>
             <input
               type="radio"
               id="male"
@@ -71,15 +71,17 @@
               name="sex"
               {{on "click" (fn @updateCandidateData @candidateData "sex")}}
             />
-            <label class="radio-button-label" for="male">Homme</label>
+            <label class="radio-button-label" for="male">
+              {{t "common.forms.labels.gender.man"}}
+            </label>
           </div>
         </fieldset>
       </div>
 
       <div class="new-certification-candidate-modal__form__field">
         <label for="birthdate" class="label">
-          <span class="required-field-indicator">*</span>
-          Date de naissance
+          <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+          {{t "common.forms.labels.birth-date"}}
         </label>
         <OneWayDateMask
           required
@@ -94,8 +96,8 @@
 
       <div class="new-certification-candidate-modal__form__field">
         <label for="birth-country" class="label">
-          <span class="required-field-indicator">*</span>
-          Pays de naissance
+          <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+          {{t "common.forms.labels.birth-country"}}
         </label>
         <PixSelect
           @id="birth-country"
@@ -112,8 +114,8 @@
         <div class="new-certification-candidate-modal__form__field">
           <fieldset>
             <legend class="label">
-              <span class="required-field-indicator">*</span>
-              Code géographique de naissance
+              <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+              {{t "common.forms.labels.birth-geographical-code"}}
             </legend>
             <div class="radio-button-container">
               <input
@@ -125,7 +127,9 @@
                 {{on "click" (fn this.selectBirthGeoCodeOption "insee")}}
                 required
               />
-              <label class="radio-button-label" for="insee-code-choice">Code INSEE</label>
+              <label class="radio-button-label" for="insee-code-choice">
+                {{t "common.forms.labels.insee-code"}}
+              </label>
               <input
                 type="radio"
                 id="postal-code-choice"
@@ -133,7 +137,9 @@
                 value="postal"
                 {{on "click" (fn this.selectBirthGeoCodeOption "postal")}}
               />
-              <label class="radio-button-label" for="postal-code-choice">Code postal</label>
+              <label class="radio-button-label" for="postal-code-choice">
+                {{t "common.forms.labels.postcode"}}
+              </label>
             </div>
           </fieldset>
         </div>
@@ -142,8 +148,8 @@
       {{#if this.isBirthInseeCodeRequired}}
         <div class="new-certification-candidate-modal__form__field">
           <label for="birth-insee-code" class="label">
-            <span class="required-field-indicator">*</span>
-            Code INSEE de naissance
+            <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+            {{t "common.forms.labels.birth-city-insee-code"}}
           </label>
           <Input
             id="birth-insee-code"
@@ -162,8 +168,8 @@
           class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
         >
           <label for="birth-postal-code" class="label">
-            <span class="required-field-indicator">*</span>
-            Code postal de naissance
+            <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+            {{t "common.forms.labels.birth-city-postcode"}}
           </label>
           <Input
             id="birth-postal-code"
@@ -182,8 +188,8 @@
           class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
         >
           <label for="birth-city" class="label">
-            <span class="required-field-indicator">*</span>
-            Commune de naissance
+            <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+            {{t "common.forms.labels.birth-city"}}
           </label>
           <Input
             id="birth-city"
@@ -197,7 +203,7 @@
       {{/if}}
 
       <div class="new-certification-candidate-modal__form__field">
-        <label for="external-id" class="label">Identifiant externe</label>
+        <label for="external-id" class="label">{{t "common.forms.certification-labels.external-id"}}</label>
         <Input
           id="external-id"
           @type="text"
@@ -208,7 +214,9 @@
       </div>
 
       <div class="new-certification-candidate-modal__form__field">
-        <label for="extra-time-percentage" class="label">Temps majoré (%)</label>
+        <label for="extra-time-percentage" class="label">
+          {{t "common.forms.certification-labels.extratime-percentage"}}
+        </label>
         <Input
           id="extra-time-percentage"
           @type="number"
@@ -219,8 +227,9 @@
       </div>
 
       <div id="recipient-email-container" class="new-certification-candidate-modal__form__field">
-        <label for="result-recipient-email" class="label">E-mail du destinataire des résultats (formateur,
-          enseignant...)</label>
+        <label for="result-recipient-email" class="label">
+          {{t "common.forms.certification-labels.email-results"}}
+        </label>
         <Input
           id="result-recipient-email"
           @type="email"
@@ -230,13 +239,14 @@
         />
         <div class="new-certification-candidate-modal__form__field__info-panel">
           <FaIcon @icon="info-circle" />
-          <span>Si le champ n’est pas renseigné, les résultats ne seront pas transmis par mail pour le/les candidats
-            concernés.<br />Le candidat verra ses résultats affichés directement sur son compte Pix.</span>
+          <span>{{t "pages.sessions.detail.candidates.add-modal.info-panel" htmlSafe=true}}</span>
         </div>
       </div>
 
       <div id="email-container" class="new-certification-candidate-modal__form__field">
-        <label for="email" class="label">E-mail de convocation</label>
+        <label for="email" class="label">
+          {{t "common.forms.certification-labels.email-convocation"}}
+        </label>
         <Input
           id="email"
           @type="email"
@@ -251,15 +261,16 @@
           class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
         >
           <label for="billing-mode" class="label">
-            <span class="required-field-indicator">*</span>
-            Tarification part Pix</label>
+            <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+            {{t "common.forms.certification-labels.pricing"}}
+          </label>
           <PixSelect
             @id="billing-mode"
             class="birth-country-selector"
             @options={{this.billingModeOptions}}
             @onChange={{fn @updateCandidateDataFromValue @candidateData "billingMode"}}
             @value={{@candidateData.billingMode}}
-            @placeholder={{"-- Choisissez --"}}
+            @placeholder={{this.billingMenuPlaceholder}}
             @hideDefaultOption={{true}}
             required
           />
@@ -268,7 +279,7 @@
           class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double new-certification-candidate-modal__form__field__tooltip"
         >
           <label for="prepayment-code" class="label">
-            Code de prépaiement
+            {{t "common.forms.certification-labels.prepayment-code"}}
           </label>
           <PixTooltip @id="tooltip-prepayment-code" @position="left">
             <:triggerElement>
@@ -276,14 +287,11 @@
                 @icon="info-circle"
                 tabindex="0"
                 aria-describedby="tooltip-prepayment-code"
-                aria-label="Information du code de prépaiement"
+                aria-label={{t "pages.sessions.detail.candidates.add-modal.prepayment-information"}}
               />
             </:triggerElement>
             <:tooltip>
-              (Requis notamment dans le cas d'un achat de crédits combinés)<br />
-              Doit être composé du SIRET de l’organisation et du numéro de facture. Ex : 12345678912345/FACT12345'.<br
-              />
-              Si vous ne possédez pas de facture, un code de prépaiement doit être établi avec Pix.
+              {{t "pages.sessions.detail.candidates.add-modal.prepayment-tooltip" htmlSafe=true}}
             </:tooltip>
           </PixTooltip>
           <Input
@@ -298,7 +306,9 @@
 
       {{#if this.complementaryCertifications.length}}
         <div class="new-certification-candidate-modal__form__field">
-          <span class="label">Certification complémentaire</span>
+          <span class="label">
+            {{t "common.forms.certification-labels.additional-certification"}}
+          </span>
           <div class="complementary-certifications-checkbox-list">
             <fieldset id="complementary-certifications">
               <label for="no-complementaryCertification">
@@ -310,7 +320,7 @@
                   value="none"
                   {{on "input" this.updateComplementaryCertification}}
                 />
-                Aucune
+                {{t "common.common.forms.labels.none"}}
               </label>
               {{#each this.complementaryCertifications as |complementaryCertification index|}}
                 <label for={{concat "complementaryCertification_" index}}>
@@ -344,7 +354,7 @@
       @isDisabled={{this.isLoading}}
       form="new-certification-candidate-form"
     >
-      Inscrire le candidat
+      {{t "pages.sessions.detail.candidates.add-modal.actions.enrol-the-candidate"}}
     </PixButton>
   </:footer>
 </PixModal>

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -17,7 +17,7 @@
 
       <div class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double">
         <label for="last-name" class="label">
-          <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+          <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
           {{t "common.forms.common-labels.birth-name"}}
         </label>
         <Input
@@ -33,7 +33,7 @@
 
       <div class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double">
         <label for="first-name" class="label">
-          <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+          <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
           {{t "common.forms.common-labels.firstname.label"}}
         </label>
         <Input
@@ -49,7 +49,7 @@
       <div class="new-certification-candidate-modal__form__field">
         <fieldset>
           <legend class="label">
-            <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+            <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
             {{t "common.forms.common-labels.gender.title"}}
           </legend>
           <div class="radio-button-container">
@@ -80,7 +80,7 @@
 
       <div class="new-certification-candidate-modal__form__field">
         <label for="birthdate" class="label">
-          <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+          <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
           {{t "common.forms.common-labels.birth-date"}}
         </label>
         <OneWayDateMask
@@ -96,7 +96,7 @@
 
       <div class="new-certification-candidate-modal__form__field">
         <label for="birth-country" class="label">
-          <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+          <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
           {{t "common.forms.common-labels.birth-country"}}
         </label>
         <PixSelect
@@ -114,7 +114,7 @@
         <div class="new-certification-candidate-modal__form__field">
           <fieldset>
             <legend class="label">
-              <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+              <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
               {{t "common.forms.common-labels.birth-geographical-code"}}
             </legend>
             <div class="radio-button-container">
@@ -148,7 +148,7 @@
       {{#if this.isBirthInseeCodeRequired}}
         <div class="new-certification-candidate-modal__form__field">
           <label for="birth-insee-code" class="label">
-            <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+            <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
             {{t "common.forms.common-labels.birth-city-insee-code"}}
           </label>
           <Input
@@ -168,7 +168,7 @@
           class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
         >
           <label for="birth-postal-code" class="label">
-            <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+            <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
             {{t "common.forms.common-labels.birth-city-postcode"}}
           </label>
           <Input
@@ -188,7 +188,7 @@
           class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
         >
           <label for="birth-city" class="label">
-            <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+            <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
             {{t "common.forms.common-labels.birth-city"}}
           </label>
           <Input
@@ -261,7 +261,7 @@
           class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double"
         >
           <label for="billing-mode" class="label">
-            <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+            <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
             {{t "common.forms.certification-labels.pricing"}}
           </label>
           <PixSelect

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -18,7 +18,7 @@
       <div class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double">
         <label for="last-name" class="label">
           <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-          {{t "common.forms.common-labels.birth-name"}}
+          {{t "common.labels.candidate.birth-name"}}
         </label>
         <Input
           id="last-name"
@@ -34,7 +34,7 @@
       <div class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double">
         <label for="first-name" class="label">
           <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-          {{t "common.forms.common-labels.firstname.label"}}
+          {{t "common.labels.candidate.firstname"}}
         </label>
         <Input
           id="first-name"
@@ -50,7 +50,7 @@
         <fieldset>
           <legend class="label">
             <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-            {{t "common.forms.common-labels.gender.title"}}
+            {{t "common.labels.candidate.gender.title"}}
           </legend>
           <div class="radio-button-container">
             <input
@@ -62,7 +62,7 @@
               {{on "click" (fn @updateCandidateData @candidateData "sex")}}
             />
             <label class="radio-button-label" for="female">
-              {{t "common.forms.common-labels.gender.woman"}}
+              {{t "common.labels.candidate.gender.woman"}}
             </label>
             <input
               type="radio"
@@ -72,7 +72,7 @@
               {{on "click" (fn @updateCandidateData @candidateData "sex")}}
             />
             <label class="radio-button-label" for="male">
-              {{t "common.forms.common-labels.gender.man"}}
+              {{t "common.labels.candidate.gender.man"}}
             </label>
           </div>
         </fieldset>
@@ -81,7 +81,7 @@
       <div class="new-certification-candidate-modal__form__field">
         <label for="birthdate" class="label">
           <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-          {{t "common.forms.common-labels.birth-date"}}
+          {{t "common.labels.candidate.birth-date"}}
         </label>
         <OneWayDateMask
           required
@@ -97,7 +97,7 @@
       <div class="new-certification-candidate-modal__form__field">
         <label for="birth-country" class="label">
           <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-          {{t "common.forms.common-labels.birth-country"}}
+          {{t "common.labels.candidate.birth-country"}}
         </label>
         <PixSelect
           @id="birth-country"
@@ -115,7 +115,7 @@
           <fieldset>
             <legend class="label">
               <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-              {{t "common.forms.common-labels.birth-geographical-code"}}
+              {{t "common.labels.candidate.birth-geographical-code"}}
             </legend>
             <div class="radio-button-container">
               <input
@@ -128,7 +128,7 @@
                 required
               />
               <label class="radio-button-label" for="insee-code-choice">
-                {{t "common.forms.common-labels.insee-code"}}
+                {{t "common.labels.candidate.insee-code"}}
               </label>
               <input
                 type="radio"
@@ -138,7 +138,7 @@
                 {{on "click" (fn this.selectBirthGeoCodeOption "postal")}}
               />
               <label class="radio-button-label" for="postal-code-choice">
-                {{t "common.forms.common-labels.postcode"}}
+                {{t "common.labels.candidate.postcode"}}
               </label>
             </div>
           </fieldset>
@@ -149,7 +149,7 @@
         <div class="new-certification-candidate-modal__form__field">
           <label for="birth-insee-code" class="label">
             <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-            {{t "common.forms.common-labels.birth-city-insee-code"}}
+            {{t "common.labels.candidate.birth-city-insee-code"}}
           </label>
           <Input
             id="birth-insee-code"
@@ -169,7 +169,7 @@
         >
           <label for="birth-postal-code" class="label">
             <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-            {{t "common.forms.common-labels.birth-city-postcode"}}
+            {{t "common.labels.candidate.birth-city-postcode"}}
           </label>
           <Input
             id="birth-postal-code"
@@ -189,7 +189,7 @@
         >
           <label for="birth-city" class="label">
             <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
-            {{t "common.forms.common-labels.birth-city"}}
+            {{t "common.labels.candidate.birth-city"}}
           </label>
           <Input
             id="birth-city"
@@ -320,7 +320,7 @@
                   value="none"
                   {{on "input" this.updateComplementaryCertification}}
                 />
-                {{t "common.forms.common-labels.none"}}
+                {{t "common.labels.candidate.none"}}
               </label>
               {{#each this.complementaryCertifications as |complementaryCertification index|}}
                 <label for={{concat "complementaryCertification_" index}}>

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -34,7 +34,7 @@
       <div class="new-certification-candidate-modal__form__field new-certification-candidate-modal__form__field-double">
         <label for="first-name" class="label">
           <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-          {{t "common.forms.labels.firstname"}}
+          {{t "common.forms.common-labels.firstname.label"}}
         </label>
         <Input
           id="first-name"
@@ -50,7 +50,7 @@
         <fieldset>
           <legend class="label">
             <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-            {{t "common.forms.labels.gender.title"}}
+            {{t "common.forms.common-labels.gender.title"}}
           </legend>
           <div class="radio-button-container">
             <input
@@ -62,7 +62,7 @@
               {{on "click" (fn @updateCandidateData @candidateData "sex")}}
             />
             <label class="radio-button-label" for="female">
-              {{t "common.forms.labels.gender.woman"}}
+              {{t "common.forms.common-labels.gender.woman"}}
             </label>
             <input
               type="radio"
@@ -72,7 +72,7 @@
               {{on "click" (fn @updateCandidateData @candidateData "sex")}}
             />
             <label class="radio-button-label" for="male">
-              {{t "common.forms.labels.gender.man"}}
+              {{t "common.forms.common-labels.gender.man"}}
             </label>
           </div>
         </fieldset>
@@ -81,7 +81,7 @@
       <div class="new-certification-candidate-modal__form__field">
         <label for="birthdate" class="label">
           <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-          {{t "common.forms.labels.birth-date"}}
+          {{t "common.forms.common-labels.birth-date"}}
         </label>
         <OneWayDateMask
           required
@@ -97,7 +97,7 @@
       <div class="new-certification-candidate-modal__form__field">
         <label for="birth-country" class="label">
           <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-          {{t "common.forms.labels.birth-country"}}
+          {{t "common.forms.common-labels.birth-country"}}
         </label>
         <PixSelect
           @id="birth-country"
@@ -115,7 +115,7 @@
           <fieldset>
             <legend class="label">
               <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-              {{t "common.forms.labels.birth-geographical-code"}}
+              {{t "common.forms.common-labels.birth-geographical-code"}}
             </legend>
             <div class="radio-button-container">
               <input
@@ -128,7 +128,7 @@
                 required
               />
               <label class="radio-button-label" for="insee-code-choice">
-                {{t "common.forms.labels.insee-code"}}
+                {{t "common.forms.common-labels.insee-code"}}
               </label>
               <input
                 type="radio"
@@ -138,7 +138,7 @@
                 {{on "click" (fn this.selectBirthGeoCodeOption "postal")}}
               />
               <label class="radio-button-label" for="postal-code-choice">
-                {{t "common.forms.labels.postcode"}}
+                {{t "common.forms.common-labels.postcode"}}
               </label>
             </div>
           </fieldset>
@@ -149,7 +149,7 @@
         <div class="new-certification-candidate-modal__form__field">
           <label for="birth-insee-code" class="label">
             <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-            {{t "common.forms.labels.birth-city-insee-code"}}
+            {{t "common.forms.common-labels.birth-city-insee-code"}}
           </label>
           <Input
             id="birth-insee-code"
@@ -169,7 +169,7 @@
         >
           <label for="birth-postal-code" class="label">
             <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-            {{t "common.forms.labels.birth-city-postcode"}}
+            {{t "common.forms.common-labels.birth-city-postcode"}}
           </label>
           <Input
             id="birth-postal-code"
@@ -189,7 +189,7 @@
         >
           <label for="birth-city" class="label">
             <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-            {{t "common.forms.labels.birth-city"}}
+            {{t "common.forms.common-labels.birth-city"}}
           </label>
           <Input
             id="birth-city"
@@ -320,7 +320,7 @@
                   value="none"
                   {{on "input" this.updateComplementaryCertification}}
                 />
-                {{t "common.common.forms.labels.none"}}
+                {{t "common.forms.common-labels.none"}}
               </label>
               {{#each this.complementaryCertifications as |complementaryCertification index|}}
                 <label for={{concat "complementaryCertification_" index}}>

--- a/certif/app/components/new-certification-candidate-modal.js
+++ b/certif/app/components/new-certification-candidate-modal.js
@@ -140,9 +140,9 @@ export default class NewCertificationCandidateModal extends Component {
   }
 
   get billingModeOptions() {
-    const freeLabel = this.intl.t('common.forms.certification-labels.billing-mode.free');
-    const paidLabel = this.intl.t('common.forms.certification-labels.billing-mode.paid');
-    const prepaidLabel = this.intl.t('common.forms.certification-labels.billing-mode.prepaid');
+    const freeLabel = this.intl.t('common.labels.billing-mode.free');
+    const paidLabel = this.intl.t('common.labels.billing-mode.paid');
+    const prepaidLabel = this.intl.t('common.labels.billing-mode.prepaid');
 
     return [
       { label: freeLabel, value: 'FREE' },

--- a/certif/app/components/new-certification-candidate-modal.js
+++ b/certif/app/components/new-certification-candidate-modal.js
@@ -9,6 +9,7 @@ const POSTAL_CODE_OPTION = 'postal';
 
 export default class NewCertificationCandidateModal extends Component {
   @service currentUser;
+  @service intl;
 
   @tracked selectedBirthGeoCodeOption = INSEE_CODE_OPTION;
   @tracked selectedCountryInseeCode = FRANCE_INSEE_CODE;
@@ -22,6 +23,11 @@ export default class NewCertificationCandidateModal extends Component {
 
   get complementaryCertifications() {
     return this.currentUser.currentAllowedCertificationCenterAccess?.habilitations;
+  }
+
+  get billingMenuPlaceholder() {
+    const labelTranslation = this.intl.t('common.actions.choose');
+    return `-- ${labelTranslation} --`;
   }
 
   @action
@@ -134,10 +140,14 @@ export default class NewCertificationCandidateModal extends Component {
   }
 
   get billingModeOptions() {
+    const freeLabel = this.intl.t('common.forms.certification-labels.billing-mode.free');
+    const paidLabel = this.intl.t('common.forms.certification-labels.billing-mode.paid');
+    const prepaidLabel = this.intl.t('common.forms.certification-labels.billing-mode.prepaid');
+
     return [
-      { label: 'Gratuite', value: 'FREE' },
-      { label: 'Payante', value: 'PAID' },
-      { label: 'Prépayée', value: 'PREPAID' },
+      { label: freeLabel, value: 'FREE' },
+      { label: paidLabel, value: 'PAID' },
+      { label: prepaidLabel, value: 'PREPAID' },
     ];
   }
 

--- a/certif/app/components/session-summary-list.hbs
+++ b/certif/app/components/session-summary-list.hbs
@@ -5,22 +5,22 @@
         <thead>
           <tr>
             <th class="table__column table__column--small" scope="col">
-              {{t "pages.sessions.list.table.header.session-number"}}
+              {{t "common.forms.session-labels.session-number"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              {{t "pages.sessions.list.table.header.center-name"}}
+              {{t "common.forms.session-labels.center-name"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              {{t "pages.sessions.list.table.header.room"}}
+              {{t "common.forms.session-labels.room"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              {{t "pages.sessions.list.table.header.date"}}
+              {{t "common.forms.session-labels.date"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              {{t "pages.sessions.list.table.header.time"}}
+              {{t "common.forms.session-labels.time"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              {{t "pages.sessions.list.table.header.supervisor"}}
+              {{t "common.forms.session-labels.invigilator"}}
             </th>
             <th class="table__column table__column" scope="col">
               {{t "pages.sessions.list.table.header.enrolled-candidates"}}
@@ -29,7 +29,7 @@
               {{t "pages.sessions.list.table.header.effective-candidates"}}
             </th>
             <th class="table__column table__column--small" scope="col">
-              {{t "pages.sessions.list.table.header.status"}}
+              {{t "common.forms.session-labels.status"}}
             </th>
             <th class="table__column table__column--small" scope="col">
               <span class="sr-only">

--- a/certif/app/components/session-supervising/candidate-in-list.hbs
+++ b/certif/app/components/session-supervising/candidate-in-list.hbs
@@ -25,7 +25,7 @@
       {{dayjs-format @candidate.birthdate "DD/MM/YYYY"}}
       {{#if @candidate.extraTimePercentage}}
         ·
-        {{t "pages.session-supervising.candidate-in-list.extra-time"}}
+        {{t "common.forms.certification-labels.extratime"}}
         :
         {{@candidate.extraTimePercentage}}%
       {{/if}}
@@ -35,17 +35,17 @@
         <span
           class="session-supervising-candidate-in-list__status session-supervising-candidate-in-list__status--authorized-to-resume"
         >
-          {{t "pages.session-supervising.candidate-in-list.authorized-to-resume"}}
+          {{t "common.forms.certification-labels.candidate-status.authorized-to-resume"}}
         </span>
       {{else}}
         <span
           class="session-supervising-candidate-in-list__status session-supervising-candidate-in-list__status--started"
         >
-          {{t "pages.session-supervising.candidate-in-list.ongoing"}}
+          {{t "common.forms.certification-labels.candidate-status.ongoing"}}
         </span>
       {{/if}}
       <span class="session-supervising-candidate-in-list__start-time">{{t
-          "pages.session-supervising.candidate-in-list.start"
+          "common.forms.certification-labels.candidate-status.start"
         }}
         :
         <time>{{this.candidateStartTime}}</time></span>
@@ -54,7 +54,7 @@
       <span
         class="session-supervising-candidate-in-list__status session-supervising-candidate-in-list__status--completed"
       >
-        {{t "pages.session-supervising.candidate-in-list.finished"}}
+        {{t "common.forms.certification-labels.candidate-status.finished"}}
       </span>
     {{/if}}
   </div>

--- a/certif/app/components/session-supervising/candidate-list.hbs
+++ b/certif/app/components/session-supervising/candidate-list.hbs
@@ -1,7 +1,7 @@
 <div class="session-supervising-candidate-list-background">
   {{#if @candidates}}
     <div class="session-supervising-candidate-list">
-      <h1 class="session-supervising-candidate-list__title">{{t "common.candidate.candidates"}}</h1>
+      <h1 class="session-supervising-candidate-list__title">{{t "common.sessions.candidates"}}</h1>
       <p class="session-supervising-candidate-list__description">{{t
           "pages.session-supervising.candidate-list.indicate-candidates-attendance"
         }}</p>

--- a/certif/app/components/session-supervising/header.hbs
+++ b/certif/app/components/session-supervising/header.hbs
@@ -22,17 +22,15 @@
 
   <div>
     <p class="session-supervising-header__line">
-      <span class="session-supervising-header__label">{{t "pages.session-supervising.header.center-name"}}</span>
+      <span class="session-supervising-header__label">{{t "common.forms.session-labels.center-name"}}</span>
       {{@session.certificationCenterName}}
     </p>
     <p class="session-supervising-header__line">
-      <span class="session-supervising-header__label">{{t "pages.session-supervising.header.room"}}</span>
+      <span class="session-supervising-header__label">{{t "common.forms.session-labels.room"}}</span>
       {{@session.room}}
     </p>
     <p class="session-supervising-header__line">
-      <span class="session-supervising-header__label">{{t
-          "pages.session-supervising.header.multiple-supervisor"
-        }}</span>
+      <span class="session-supervising-header__label">{{t "common.forms.session-labels.invigilator"}}</span>
       {{@session.examiner}}
     </p>
     <p class="session-supervising-header__line">

--- a/certif/app/controllers/authenticated/sessions/update.js
+++ b/certif/app/controllers/authenticated/sessions/update.js
@@ -10,7 +10,7 @@ export default class SessionsUpdateController extends Controller {
   @service intl;
 
   get pageTitle() {
-    return `${this.intl.t('pages.sessions.update.page-title')} | Session ${this.session.id} | Pix Certif`;
+    return `${this.intl.t('pages.sessions.update.title')} | Session ${this.session.id} | Pix Certif`;
   }
 
   @action

--- a/certif/app/models/certification-candidate.js
+++ b/certif/app/models/certification-candidate.js
@@ -41,7 +41,7 @@ export default class CertificationCandidate extends Model {
   get billingModeLabel() {
     const candidateBillingMode = this.billingMode;
     if (candidateBillingMode) {
-      return this.intl.t(`common.forms.certification-labels.billing-mode.${candidateBillingMode.toLowerCase()}`);
+      return this.intl.t(`common.labels.billing-mode.${candidateBillingMode.toLowerCase()}`);
     }
 
     return '-';

--- a/certif/app/models/certification-candidate.js
+++ b/certif/app/models/certification-candidate.js
@@ -30,10 +30,10 @@ export default class CertificationCandidate extends Model {
     const candidateGender = this.sex;
 
     if (candidateGender === 'M') {
-      return this.intl.t('pages.sessions.detail.candidates.informations.man');
+      return this.intl.t('common.forms.labels.gender.man');
     }
     if (candidateGender === 'F') {
-      return this.intl.t('pages.sessions.detail.candidates.informations.woman');
+      return this.intl.t('common.forms.labels.gender.woman');
     }
     return '-';
   }
@@ -41,9 +41,7 @@ export default class CertificationCandidate extends Model {
   get billingModeLabel() {
     const candidateBillingMode = this.billingMode;
     if (candidateBillingMode) {
-      return this.intl.t(
-        `pages.sessions.detail.candidates.informations.billing-mode.${candidateBillingMode.toLowerCase()}`
-      );
+      return this.intl.t(`common.forms.certification-labels.billing-mode.${candidateBillingMode.toLowerCase()}`);
     }
 
     return '-';

--- a/certif/app/models/certification-candidate.js
+++ b/certif/app/models/certification-candidate.js
@@ -30,10 +30,10 @@ export default class CertificationCandidate extends Model {
     const candidateGender = this.sex;
 
     if (candidateGender === 'M') {
-      return this.intl.t('common.forms.labels.gender.man');
+      return this.intl.t('common.forms.common-labels.gender.man');
     }
     if (candidateGender === 'F') {
-      return this.intl.t('common.forms.labels.gender.woman');
+      return this.intl.t('common.forms.common-labels.gender.woman');
     }
     return '-';
   }

--- a/certif/app/models/certification-candidate.js
+++ b/certif/app/models/certification-candidate.js
@@ -30,10 +30,10 @@ export default class CertificationCandidate extends Model {
     const candidateGender = this.sex;
 
     if (candidateGender === 'M') {
-      return this.intl.t('common.forms.common-labels.gender.man');
+      return this.intl.t('common.labels.candidate.gender.man');
     }
     if (candidateGender === 'F') {
-      return this.intl.t('common.forms.common-labels.gender.woman');
+      return this.intl.t('common.labels.candidate.gender.woman');
     }
     return '-';
   }

--- a/certif/app/styles/components/new-certification-candidate-modal.scss
+++ b/certif/app/styles/components/new-certification-candidate-modal.scss
@@ -21,10 +21,6 @@
       width: 100%;
     }
 
-    .required-field-indicator {
-      color: $pix-error-70;
-    }
-
     &__field {
       width: 100%;
       margin: 12px 0;

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -10,14 +10,14 @@
 
     <div class="session-details-header__datetime">
       <div class="session-details-header-datetime__date">
-        <h2 class="label-text session-details-content__label">{{t "pages.sessions.detail.date"}}</h2>
+        <h2 class="label-text session-details-content__label">{{t "common.forms.session-labels.date"}}</h2>
         <span class="content-text content-text--big session-details-header-datetime__text">
           {{dayjs-format this.session.date "dddd DD MMM YYYY" allow-empty=true}}
         </span>
       </div>
 
       <div>
-        <h2 class="label-text session-details-content__label">{{t "pages.sessions.detail.datetime"}}</h2>
+        <h2 class="label-text session-details-content__label">{{t "common.forms.session-labels.time-start"}}</h2>
         <span class="content-text content-text--big session-details-header-datetime__text">
           {{dayjs-format this.session.time "HH:mm" inputFormat="HH:mm:ss" allow-empty=true}}
         </span>
@@ -35,7 +35,7 @@
         {{t "pages.sessions.detail.tabs.details"}}
       </LinkTo>
       <LinkTo @route="authenticated.sessions.details.certification-candidates" class="navbar-item">
-        {{t "pages.sessions.detail.tabs.candidates"}}
+        {{t "common.sessions.candidates"}}
         {{this.certificationCandidatesCount}}
       </LinkTo>
     </nav>

--- a/certif/app/templates/authenticated/sessions/details/parameters.hbs
+++ b/certif/app/templates/authenticated/sessions/details/parameters.hbs
@@ -54,7 +54,7 @@
       <h3 class="label-text session-details-content__label">
         {{t "pages.sessions.detail.parameters.password.label"}}
         <div class="session-details-content__sub-label">
-          {{t "pages.sessions.detail.parameters.password.invigilator"}}
+          {{t "common.sessions.invigilator"}}
         </div>
       </h3>
       <div class="session-details-content__clipboard" {{on "mouseout" this.removeSupervisorPasswordTooltip}}>
@@ -86,19 +86,19 @@
 
     <div class="session-details-content session-details-content--multiple">
       <h3 class="label-text session-details-content__label">
-        {{t "pages.sessions.detail.parameters.location-name"}}
+        {{t "common.forms.session-labels.center-name"}}
       </h3>
       <span class="content-text session-details-content__text">{{this.session.address}}</span>
     </div>
 
     <div class="session-details-content session-details-content--multiple">
-      <h3 class="label-text session-details-content__label">{{t "pages.sessions.detail.parameters.room"}}</h3>
+      <h3 class="label-text session-details-content__label">{{t "common.forms.session-labels.room"}}</h3>
       <span class="content-text session-details-content__text">{{this.session.room}}</span>
     </div>
 
     <div class="session-details-content session-details-content--multiple">
       <h3 class="label-text session-details-content__label">
-        {{t "pages.sessions.detail.parameters.invigilators"}}
+        {{t "common.forms.session-labels.invigilator"}}
       </h3>
       <span class="content-text session-details-content__text">{{this.session.examiner}}</span>
     </div>
@@ -107,7 +107,7 @@
 
   <div class="session-details-row">
     <div class="session-details-content session-details-content--single">
-      <h3 class="label-text session-details-content__label">{{t "pages.sessions.detail.parameters.observations"}}</h3>
+      <h3 class="label-text session-details-content__label">{{t "common.forms.session-labels.observations"}}</h3>
       <p class="content-text session-details-content__text">
         {{this.session.description}}
       </p>

--- a/certif/app/templates/authenticated/sessions/new.hbs
+++ b/certif/app/templates/authenticated/sessions/new.hbs
@@ -4,13 +4,13 @@
 
   <form {{on "submit" this.createSession}} class="session-form">
     <p class="session-form__mandatory-information">
-      {{t "pages.sessions.new.required-fields" htmlSafe=true}}
+      {{t "common.forms.mandatory-fields" htmlSafe=true}}
     </p>
 
     <div class="session-form__field">
       <label for="session-address" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        {{t "pages.sessions.new.address"}}
+        {{t "common.forms.session-labels.address"}}
       </label>
       <Input
         id="session-address"
@@ -30,7 +30,7 @@
     <div class="session-form__field">
       <label for="session-room" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        {{t "pages.sessions.new.room"}}
+        {{t "common.forms.session-labels.room"}}
       </label>
       <Input
         id="session-room"
@@ -50,7 +50,7 @@
     <div class="session-form__field">
       <label for="session-date" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        {{t "pages.sessions.new.date"}}
+        {{t "common.forms.session-labels.date"}}
       </label>
       <EmberFlatpickr
         id="session-date"
@@ -74,7 +74,7 @@
     <div class="session-form__field">
       <label for="session-time" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        {{t "pages.sessions.new.time"}}
+        {{t "common.forms.session-labels.time"}}
       </label>
       <EmberFlatpickr
         id="session-time"
@@ -99,7 +99,7 @@
     <div class="session-form__field">
       <label for="session-examiner" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        {{t "pages.sessions.new.examiner"}}
+        {{t "common.forms.session-labels.examiner"}}
       </label>
       <Input
         id="session-examiner"
@@ -117,7 +117,7 @@
     </div>
 
     <div class="session-form__field">
-      <label for="session-description" class="label">{{t "pages.sessions.new.description"}}</label>
+      <label for="session-description" class="label">{{t "common.forms.session-labels.description"}}</label>
       <Textarea
         id="session-description"
         name="session-description"

--- a/certif/app/templates/authenticated/sessions/new.hbs
+++ b/certif/app/templates/authenticated/sessions/new.hbs
@@ -9,7 +9,7 @@
 
     <div class="session-form__field">
       <label for="session-address" class="label">
-        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
         {{t "common.forms.session-labels.center-name"}}
       </label>
       <Input
@@ -29,7 +29,7 @@
 
     <div class="session-form__field">
       <label for="session-room" class="label">
-        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
         {{t "common.forms.session-labels.room-name"}}
       </label>
       <Input
@@ -49,7 +49,7 @@
 
     <div class="session-form__field">
       <label for="session-date" class="label">
-        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
         {{t "common.forms.session-labels.date-start"}}
       </label>
       <EmberFlatpickr
@@ -73,7 +73,7 @@
 
     <div class="session-form__field">
       <label for="session-time" class="label">
-        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
         {{t "common.forms.session-labels.time-start"}}
       </label>
       <EmberFlatpickr
@@ -98,7 +98,7 @@
 
     <div class="session-form__field">
       <label for="session-examiner" class="label">
-        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
         {{t "common.forms.session-labels.invigilator"}}
       </label>
       <Input

--- a/certif/app/templates/authenticated/sessions/new.hbs
+++ b/certif/app/templates/authenticated/sessions/new.hbs
@@ -10,7 +10,7 @@
     <div class="session-form__field">
       <label for="session-address" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        {{t "common.forms.session-labels.address"}}
+        {{t "common.forms.session-labels.center-name"}}
       </label>
       <Input
         id="session-address"
@@ -30,7 +30,7 @@
     <div class="session-form__field">
       <label for="session-room" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        {{t "common.forms.session-labels.room"}}
+        {{t "common.forms.session-labels.room-name"}}
       </label>
       <Input
         id="session-room"
@@ -50,7 +50,7 @@
     <div class="session-form__field">
       <label for="session-date" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        {{t "common.forms.session-labels.date"}}
+        {{t "common.forms.session-labels.date-start"}}
       </label>
       <EmberFlatpickr
         id="session-date"
@@ -74,7 +74,7 @@
     <div class="session-form__field">
       <label for="session-time" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        {{t "common.forms.session-labels.time"}}
+        {{t "common.forms.session-labels.time-start"}}
       </label>
       <EmberFlatpickr
         id="session-time"
@@ -99,7 +99,7 @@
     <div class="session-form__field">
       <label for="session-examiner" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        {{t "common.forms.session-labels.examiner"}}
+        {{t "common.forms.session-labels.invigilator"}}
       </label>
       <Input
         id="session-examiner"
@@ -117,7 +117,7 @@
     </div>
 
     <div class="session-form__field">
-      <label for="session-description" class="label">{{t "common.forms.session-labels.description"}}</label>
+      <label for="session-description" class="label">{{t "common.forms.session-labels.observations"}}</label>
       <Textarea
         id="session-description"
         name="session-description"

--- a/certif/app/templates/authenticated/sessions/update.hbs
+++ b/certif/app/templates/authenticated/sessions/update.hbs
@@ -4,13 +4,13 @@
 
   <form {{on "submit" this.updateSession}} class="session-form">
     <p class="session-form__mandatory-information">
-      {{t "pages.sessions.new.required-fields" htmlSafe=true}}
+      {{t "common.forms.mandatory-fields" htmlSafe=true}}
     </p>
 
     <div class="session-form__field">
       <label for="session-address" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        {{t "pages.sessions.update.address"}}
+        {{t "common.forms.session-labels.center-name"}}
       </label>
       <Input
         id="session-address"
@@ -30,7 +30,7 @@
     <div class="session-form__field">
       <label for="session-room" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        {{t "pages.sessions.update.room"}}
+        {{t "common.forms.session-labels.room-name"}}
       </label>
       <Input
         id="session-room"
@@ -50,7 +50,7 @@
     <div class="session-form__field">
       <label for="session-date" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        {{t "pages.sessions.update.date"}}
+        {{t "common.forms.session-labels.date-start"}}
       </label>
       <EmberFlatpickr
         id="session-date"
@@ -73,7 +73,7 @@
     <div class="session-form__field">
       <label for="session-time" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        {{t "pages.sessions.update.time"}}
+        {{t "common.forms.session-labels.time-start"}}
       </label>
       <EmberFlatpickr
         id="session-time"
@@ -98,7 +98,7 @@
     <div class="session-form__field">
       <label for="session-examiner" class="label">
         <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
-        {{t "pages.sessions.update.examiner"}}
+        {{t "common.forms.session-labels.invigilator"}}
       </label>
       <Input
         id="session-examiner"
@@ -116,7 +116,7 @@
     </div>
 
     <div class="session-form__field">
-      <label for="session-description" class="label">{{t "pages.sessions.update.description"}}</label>
+      <label for="session-description" class="label">{{t "common.forms.session-labels.observations"}}</label>
       <Textarea
         id="session-description"
         name="session-description"

--- a/certif/app/templates/authenticated/sessions/update.hbs
+++ b/certif/app/templates/authenticated/sessions/update.hbs
@@ -9,7 +9,7 @@
 
     <div class="session-form__field">
       <label for="session-address" class="label">
-        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
         {{t "common.forms.session-labels.center-name"}}
       </label>
       <Input
@@ -29,7 +29,7 @@
 
     <div class="session-form__field">
       <label for="session-room" class="label">
-        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
         {{t "common.forms.session-labels.room-name"}}
       </label>
       <Input
@@ -49,7 +49,7 @@
 
     <div class="session-form__field">
       <label for="session-date" class="label">
-        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
         {{t "common.forms.session-labels.date-start"}}
       </label>
       <EmberFlatpickr
@@ -72,7 +72,7 @@
 
     <div class="session-form__field">
       <label for="session-time" class="label">
-        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
         {{t "common.forms.session-labels.time-start"}}
       </label>
       <EmberFlatpickr
@@ -97,7 +97,7 @@
 
     <div class="session-form__field">
       <label for="session-examiner" class="label">
-        <abbr title="obligatoire" class="mandatory-mark" aria-hidden="true">*</abbr>
+        <abbr title={{t "common.forms.required"}} class="mandatory-mark" aria-hidden="true">*</abbr>
         {{t "common.forms.session-labels.invigilator"}}
       </label>
       <Input

--- a/certif/tests/acceptance/join_test.js
+++ b/certif/tests/acceptance/join_test.js
@@ -22,8 +22,8 @@ module('Acceptance | join ', function (hooks) {
     let loginFormButton;
 
     hooks.beforeEach(function () {
-      emailInputLabel = this.intl.t('pages.login-or-register.login-form.fields.email.label');
-      passwordInputLabel = this.intl.t('pages.login-or-register.login-form.fields.password.label');
+      emailInputLabel = this.intl.t('common.forms.login-labels.email.label');
+      passwordInputLabel = this.intl.t('common.forms.login-labels.password.label');
       loginFormButton = this.intl.t('pages.login-or-register.login-form.login');
       toogleloginFormButton = this.intl.t('pages.login-or-register.login-form.button');
     });

--- a/certif/tests/acceptance/join_test.js
+++ b/certif/tests/acceptance/join_test.js
@@ -22,8 +22,8 @@ module('Acceptance | join ', function (hooks) {
     let loginFormButton;
 
     hooks.beforeEach(function () {
-      emailInputLabel = this.intl.t('common.forms.login-labels.email.label');
-      passwordInputLabel = this.intl.t('common.forms.login-labels.password.label');
+      emailInputLabel = this.intl.t('common.forms.login.email');
+      passwordInputLabel = this.intl.t('common.forms.login.password');
       loginFormButton = this.intl.t('pages.login-or-register.login-form.login');
       toogleloginFormButton = this.intl.t('pages.login-or-register.login-form.button');
     });

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -292,8 +292,10 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           });
           const screen = await visit(`/sessions/${sessionWithoutCandidates.id}/candidats`);
 
+          this.pauseTest();
+
           await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
-          await fillIn(screen.getByLabelText('* Nom de famille'), 'BackStreet');
+          await fillIn(screen.getByLabelText('* Nom de naissance'), 'BackStreet');
           await fillIn(screen.getByLabelText('* Prénom'), 'Boys');
           await click(screen.getByLabelText('Homme'));
           await fillIn(screen.getByLabelText('* Date de naissance'), '01/01/2000');
@@ -321,7 +323,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
 
           // then
-          assert.strictEqual(screen.getByLabelText('* Nom de famille').value, '');
+          assert.strictEqual(screen.getByLabelText('* Nom de naissance').value, '');
           assert.strictEqual(screen.getByLabelText('* Prénom').value, '');
           assert.false(screen.getByLabelText('Homme').checked);
           assert.strictEqual(screen.getByLabelText('* Date de naissance').value, '');
@@ -403,7 +405,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
               const screen = await visit(`/sessions/${session.id}/candidats`);
               await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
               await fillIn(screen.getByLabelText('* Prénom'), 'Guybrush');
-              await fillIn(screen.getByLabelText('* Nom de famille'), 'Threepwood');
+              await fillIn(screen.getByLabelText('* Nom de naissance'), 'Threepwood');
               await fillIn(screen.getByLabelText('* Date de naissance'), '28/04/2019');
               await click(screen.getByLabelText('Homme'));
               await fillIn(screen.getByLabelText('* Pays de naissance'), '99100');
@@ -434,7 +436,7 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
 
   async function _fillFormWithCorrectData(screen) {
     await fillIn(screen.getByLabelText('* Prénom'), 'Guybrush');
-    await fillIn(screen.getByLabelText('* Nom de famille'), 'Threepwood');
+    await fillIn(screen.getByLabelText('* Nom de naissance'), 'Threepwood');
     await fillIn(screen.getByLabelText('* Date de naissance'), '28/04/2019');
     await click(screen.getByLabelText('Homme'));
     await fillIn(screen.getByLabelText('* Pays de naissance'), '99100');

--- a/certif/tests/acceptance/session-new_test.js
+++ b/certif/tests/acceptance/session-new_test.js
@@ -62,16 +62,19 @@ module('Acceptance | Session creation', function (hooks) {
       const screen = await visit('/sessions/creation');
       assert.dom(screen.getByRole('heading', { name: t('pages.sessions.new.title') })).exists();
       assert
-        .dom(screen.getByRole('textbox', { name: t('pages.sessions.new.description') }))
+        .dom(screen.getByRole('textbox', { name: t('common.forms.session-labels.description') }))
         .hasAttribute('maxLength', '350');
       assert
         .dom(screen.getByRole('button', { name: t('pages.sessions.new.actions.cancel-extra-information') }))
         .exists();
 
-      await fillIn(screen.getByRole('textbox', { name: t('pages.sessions.new.address') }), 'My address');
-      await fillIn(screen.getByRole('textbox', { name: t('pages.sessions.new.room') }), 'My room');
-      await fillIn(screen.getByRole('textbox', { name: t('pages.sessions.new.examiner') }), 'My examiner');
-      await fillIn(screen.getByRole('textbox', { name: t('pages.sessions.new.description') }), 'My description');
+      await fillIn(screen.getByRole('textbox', { name: t('common.forms.session-labels.address') }), 'My address');
+      await fillIn(screen.getByRole('textbox', { name: t('common.forms.session-labels.room') }), 'My room');
+      await fillIn(screen.getByRole('textbox', { name: t('common.forms.session-labels.examiner') }), 'My examiner');
+      await fillIn(
+        screen.getByRole('textbox', { name: t('common.forms.session-labels.description') }),
+        'My description'
+      );
       await setFlatpickrDate('#session-date', sessionDate);
       await setFlatpickrDate('#session-time', sessionTime);
       await click(screen.getByRole('button', { name: t('pages.sessions.new.actions.create-session') }));

--- a/certif/tests/acceptance/session-new_test.js
+++ b/certif/tests/acceptance/session-new_test.js
@@ -62,17 +62,17 @@ module('Acceptance | Session creation', function (hooks) {
       const screen = await visit('/sessions/creation');
       assert.dom(screen.getByRole('heading', { name: t('pages.sessions.new.title') })).exists();
       assert
-        .dom(screen.getByRole('textbox', { name: t('common.forms.session-labels.description') }))
+        .dom(screen.getByRole('textbox', { name: t('common.forms.session-labels.observations') }))
         .hasAttribute('maxLength', '350');
       assert
         .dom(screen.getByRole('button', { name: t('pages.sessions.new.actions.cancel-extra-information') }))
         .exists();
 
-      await fillIn(screen.getByRole('textbox', { name: t('common.forms.session-labels.address') }), 'My address');
-      await fillIn(screen.getByRole('textbox', { name: t('common.forms.session-labels.room') }), 'My room');
-      await fillIn(screen.getByRole('textbox', { name: t('common.forms.session-labels.examiner') }), 'My examiner');
+      await fillIn(screen.getByRole('textbox', { name: t('common.forms.session-labels.center-name') }), 'My address');
+      await fillIn(screen.getByRole('textbox', { name: t('common.forms.session-labels.room-name') }), 'My room');
+      await fillIn(screen.getByRole('textbox', { name: t('common.forms.session-labels.invigilator') }), 'My examiner');
       await fillIn(
-        screen.getByRole('textbox', { name: t('common.forms.session-labels.description') }),
+        screen.getByRole('textbox', { name: t('common.forms.session-labels.observations') }),
         'My description'
       );
       await setFlatpickrDate('#session-date', sessionDate);

--- a/certif/tests/integration/components/auth/login-or-register_test.js
+++ b/certif/tests/integration/components/auth/login-or-register_test.js
@@ -39,10 +39,8 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
 
   test('it toggle the register form by default', async function (assert) {
     // given
-    const registerButton = this.intl.t('pages.login-or-register.register-form.button');
-    const firstNameInputLabelFromRegisterForm = this.intl.t(
-      'pages.login-or-register.register-form.fields.first-name.label'
-    );
+    const registerButton = this.intl.t('pages.login-or-register.register-form.actions.login');
+    const firstNameInputLabelFromRegisterForm = this.intl.t('common.forms.common-labels.firstname.label');
 
     // when
     const screen = await render(hbs`<Auth::LoginOrRegister/>`);
@@ -55,7 +53,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
 
   test('it toggle the login form on click on login button', async function (assert) {
     // given
-    const emailInputLabelFromLoginForm = this.intl.t('pages.login-or-register.login-form.fields.email.label');
+    const emailInputLabelFromLoginForm = this.intl.t('common.forms.login-labels.email.label');
     const screen = await render(hbs`<Auth::LoginOrRegister/>`);
 
     // when
@@ -67,8 +65,8 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
 
   test('it toggle the register form on click on register button', async function (assert) {
     // given
-    const emailInputLabelFromRegisterForm = this.intl.t('pages.login-or-register.register-form.fields.email.label');
-    const registerButtonLabel = this.intl.t('pages.login-or-register.register-form.button');
+    const emailInputLabelFromRegisterForm = this.intl.t('common.forms.login-labels.email.label');
+    const registerButtonLabel = this.intl.t('pages.login-or-register.register-form.actions.login');
 
     const screen = await render(hbs`<Auth::LoginOrRegister/>`);
 

--- a/certif/tests/integration/components/auth/login-or-register_test.js
+++ b/certif/tests/integration/components/auth/login-or-register_test.js
@@ -40,7 +40,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
   test('it toggle the register form by default', async function (assert) {
     // given
     const registerButton = this.intl.t('pages.login-or-register.register-form.actions.login');
-    const firstNameInputLabelFromRegisterForm = this.intl.t('common.forms.common-labels.firstname.label');
+    const firstNameInputLabelFromRegisterForm = this.intl.t('common.labels.candidate.firstname');
 
     // when
     const screen = await render(hbs`<Auth::LoginOrRegister/>`);
@@ -53,7 +53,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
 
   test('it toggle the login form on click on login button', async function (assert) {
     // given
-    const emailInputLabelFromLoginForm = this.intl.t('common.forms.login-labels.email.label');
+    const emailInputLabelFromLoginForm = this.intl.t('common.forms.login.email');
     const screen = await render(hbs`<Auth::LoginOrRegister/>`);
 
     // when
@@ -65,7 +65,7 @@ module('Integration | Component | Auth::LoginOrRegister', function (hooks) {
 
   test('it toggle the register form on click on register button', async function (assert) {
     // given
-    const emailInputLabelFromRegisterForm = this.intl.t('common.forms.login-labels.email.label');
+    const emailInputLabelFromRegisterForm = this.intl.t('common.forms.login.email');
     const registerButtonLabel = this.intl.t('pages.login-or-register.register-form.actions.login');
 
     const screen = await render(hbs`<Auth::LoginOrRegister/>`);

--- a/certif/tests/integration/components/auth/register-form_test.js
+++ b/certif/tests/integration/components/auth/register-form_test.js
@@ -5,10 +5,10 @@ import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
-const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'pages.login-or-register.register-form.fields.first-name.error';
-const EMPTY_LASTNAME_ERROR_MESSAGE = 'pages.login-or-register.register-form.fields.last-name.error';
-const EMPTY_EMAIL_ERROR_MESSAGE = 'pages.login-or-register.register-form.fields.email.error';
-const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE = 'pages.login-or-register.register-form.fields.password.error';
+const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'common.forms.common-labels.firstname.error-mandatory';
+const EMPTY_LASTNAME_ERROR_MESSAGE = 'common.forms.common-labels.lastname.error-mandatory';
+const EMPTY_EMAIL_ERROR_MESSAGE = 'common.forms.login-labels.email.error-format';
+const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE = 'common.forms.login-labels.password.error-format';
 const CGU_ERROR_MESSAGE = 'pages.login-or-register.register-form.fields.cgu.error';
 
 module('Integration | Component | Auth::RegisterForm', function (hooks) {
@@ -21,10 +21,10 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
   let cguAriaLabel;
 
   hooks.beforeEach(function () {
-    firstNameInputLabel = this.intl.t('pages.login-or-register.register-form.fields.first-name.label');
-    lastNameInputLabel = this.intl.t('pages.login-or-register.register-form.fields.last-name.label');
-    emailInputLabel = this.intl.t('pages.login-or-register.register-form.fields.email.label');
-    passwordInputLabel = this.intl.t('pages.login-or-register.register-form.fields.password.label');
+    firstNameInputLabel = this.intl.t('common.forms.common-labels.firstname.label');
+    lastNameInputLabel = this.intl.t('common.forms.common-labels.lastname.label');
+    emailInputLabel = this.intl.t('common.forms.login-labels.email.label');
+    passwordInputLabel = this.intl.t('common.forms.login-labels.password.label');
     cguAriaLabel = this.intl.t('pages.login-or-register.register-form.fields.cgu.aria-label');
   });
 

--- a/certif/tests/integration/components/auth/register-form_test.js
+++ b/certif/tests/integration/components/auth/register-form_test.js
@@ -5,10 +5,10 @@ import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
-const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'common.forms.common-labels.firstname.error-mandatory';
-const EMPTY_LASTNAME_ERROR_MESSAGE = 'common.forms.common-labels.lastname.error-mandatory';
-const EMPTY_EMAIL_ERROR_MESSAGE = 'common.forms.login-labels.email.error-format';
-const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE = 'common.forms.login-labels.password.error-format';
+const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'common.form-errors.firstname.mandatory';
+const EMPTY_LASTNAME_ERROR_MESSAGE = 'common.form-errors.lastname.mandatory';
+const EMPTY_EMAIL_ERROR_MESSAGE = 'common.form-errors.email.format';
+const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE = 'common.form-errors.password.format';
 const CGU_ERROR_MESSAGE = 'pages.login-or-register.register-form.fields.cgu.error';
 
 module('Integration | Component | Auth::RegisterForm', function (hooks) {
@@ -21,10 +21,10 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
   let cguAriaLabel;
 
   hooks.beforeEach(function () {
-    firstNameInputLabel = this.intl.t('common.forms.common-labels.firstname.label');
-    lastNameInputLabel = this.intl.t('common.forms.common-labels.lastname.label');
-    emailInputLabel = this.intl.t('common.forms.login-labels.email.label');
-    passwordInputLabel = this.intl.t('common.forms.login-labels.password.label');
+    firstNameInputLabel = this.intl.t('common.labels.candidate.firstname');
+    lastNameInputLabel = this.intl.t('common.labels.candidate.lastname');
+    emailInputLabel = this.intl.t('common.forms.login.email');
+    passwordInputLabel = this.intl.t('common.forms.login.password');
     cguAriaLabel = this.intl.t('pages.login-or-register.register-form.fields.cgu.aria-label');
   });
 

--- a/certif/tests/integration/components/auth/toggable-login-form_test.js
+++ b/certif/tests/integration/components/auth/toggable-login-form_test.js
@@ -20,8 +20,8 @@ module('Integration | Component | Auth::ToggableLoginForm', function (hooks) {
   hooks.beforeEach(function () {
     this.owner.register('service:session', SessionStub);
 
-    emailInputLabel = this.intl.t('pages.login-or-register.login-form.fields.email.label');
-    passwordInputLabel = this.intl.t('pages.login-or-register.login-form.fields.password.label');
+    emailInputLabel = this.intl.t('common.forms.login-labels.email.label');
+    passwordInputLabel = this.intl.t('common.forms.login-labels.password.label');
     loginLabel = this.intl.t('pages.login-or-register.login-form.login');
   });
 
@@ -57,7 +57,7 @@ module('Integration | Component | Auth::ToggableLoginForm', function (hooks) {
         await triggerEvent(emailInput, 'focusout');
 
         // then
-        assert.dom(screen.getByText(this.intl.t('pages.login-or-register.login-form.fields.email.error'))).exists();
+        assert.dom(screen.getByText(this.intl.t('common.forms.login-labels.email.error-format'))).exists();
       });
 
       test('should display an empty password error message when focus-out', async function (assert) {
@@ -70,7 +70,7 @@ module('Integration | Component | Auth::ToggableLoginForm', function (hooks) {
         await triggerEvent(passwordInput, 'focusout');
 
         // then
-        assert.dom(screen.getByText(this.intl.t('pages.login-or-register.login-form.fields.password.error'))).exists();
+        assert.dom(screen.getByText(this.intl.t('common.forms.login-labels.password.error-mandatory'))).exists();
       });
     });
   });

--- a/certif/tests/integration/components/auth/toggable-login-form_test.js
+++ b/certif/tests/integration/components/auth/toggable-login-form_test.js
@@ -20,8 +20,8 @@ module('Integration | Component | Auth::ToggableLoginForm', function (hooks) {
   hooks.beforeEach(function () {
     this.owner.register('service:session', SessionStub);
 
-    emailInputLabel = this.intl.t('common.forms.login-labels.email.label');
-    passwordInputLabel = this.intl.t('common.forms.login-labels.password.label');
+    emailInputLabel = this.intl.t('common.forms.login.email');
+    passwordInputLabel = this.intl.t('common.forms.login.password');
     loginLabel = this.intl.t('pages.login-or-register.login-form.login');
   });
 
@@ -57,7 +57,7 @@ module('Integration | Component | Auth::ToggableLoginForm', function (hooks) {
         await triggerEvent(emailInput, 'focusout');
 
         // then
-        assert.dom(screen.getByText(this.intl.t('common.forms.login-labels.email.error-format'))).exists();
+        assert.dom(screen.getByText(this.intl.t('common.form-errors.email.format'))).exists();
       });
 
       test('should display an empty password error message when focus-out', async function (assert) {
@@ -70,7 +70,7 @@ module('Integration | Component | Auth::ToggableLoginForm', function (hooks) {
         await triggerEvent(passwordInput, 'focusout');
 
         // then
-        assert.dom(screen.getByText(this.intl.t('common.forms.login-labels.password.error-mandatory'))).exists();
+        assert.dom(screen.getByText(this.intl.t('common.form-errors.password.mandatory'))).exists();
       });
     });
   });

--- a/certif/tests/integration/components/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-modal_test.js
@@ -200,7 +200,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
     `);
 
     // then
-    assert.dom(screen.getByRole('button', { name: '* Pays de naissance' })).includesText('France');
+    assert.dom(screen.getByRole('button', { name: 'Pays de naissance' })).includesText('France');
   });
 
   module('when close button cross icon is clicked', () => {

--- a/certif/tests/integration/components/new-certification-candidate-modal_test.js
+++ b/certif/tests/integration/components/new-certification-candidate-modal_test.js
@@ -4,7 +4,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import Service from '@ember/service';
-import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 module('Integration | Component | new-certification-candidate-modal', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -59,7 +59,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
     `);
 
     // then
-    assert.dom(screen.getByLabelText('* Nom de famille')).exists();
+    assert.dom(screen.getByLabelText('* Nom de naissance')).exists();
     assert.dom(screen.getByLabelText('* Prénom')).exists();
     assert.dom(screen.getByLabelText('Homme')).exists();
     assert.dom(screen.getByLabelText('Femme')).exists();
@@ -130,7 +130,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
       `);
 
       // then
-      assert.dom(screen.getByLabelText('* Nom de famille')).exists();
+      assert.dom(screen.getByLabelText('* Nom de naissance')).exists();
       assert.dom(screen.getByLabelText('* Prénom')).exists();
       assert.dom(screen.getByLabelText('Homme')).exists();
       assert.dom(screen.getByLabelText('Femme')).exists();
@@ -471,7 +471,7 @@ module('Integration | Component | new-certification-candidate-modal', function (
           />
       `);
       await fillIn(screen.getByLabelText('* Prénom'), 'Guybrush');
-      await fillIn(screen.getByLabelText('* Nom de famille'), 'Threepwood');
+      await fillIn(screen.getByLabelText('* Nom de naissance'), 'Threepwood');
       await fillIn(screen.getByLabelText('* Date de naissance'), '28/04/2019');
       await click(screen.getByRole('radio', { name: 'Homme' }));
       await click(screen.getByLabelText('* Pays de naissance'));

--- a/certif/tests/unit/components/auth/register-form_test.js
+++ b/certif/tests/unit/components/auth/register-form_test.js
@@ -93,7 +93,7 @@ module('Unit | Component | register-form', (hooks) => {
         await component.register(eventStub);
 
         // then
-        assert.strictEqual(component.errorMessage, this.intl.t('common.forms.error-default'));
+        assert.strictEqual(component.errorMessage, this.intl.t('common.form-errors.default'));
         sinon.assert.calledOnce(deleteRecord);
       });
 
@@ -117,10 +117,7 @@ module('Unit | Component | register-form', (hooks) => {
           await component.register(eventStub);
 
           // then
-          assert.strictEqual(
-            component.errorMessage,
-            this.intl.t('common.forms.login-labels.email.error-already-exists')
-          );
+          assert.strictEqual(component.errorMessage, this.intl.t('common.form-errors.email.already-exists'));
           sinon.assert.calledOnce(deleteRecord);
         });
       });

--- a/certif/tests/unit/components/auth/register-form_test.js
+++ b/certif/tests/unit/components/auth/register-form_test.js
@@ -93,7 +93,7 @@ module('Unit | Component | register-form', (hooks) => {
         await component.register(eventStub);
 
         // then
-        assert.strictEqual(component.errorMessage, this.intl.t('pages.login-or-register.register-form.errors.default'));
+        assert.strictEqual(component.errorMessage, this.intl.t('common.forms.error-default'));
         sinon.assert.calledOnce(deleteRecord);
       });
 
@@ -119,7 +119,7 @@ module('Unit | Component | register-form', (hooks) => {
           // then
           assert.strictEqual(
             component.errorMessage,
-            this.intl.t('pages.login-or-register.register-form.errors.email-already-exists')
+            this.intl.t('common.forms.login-labels.email.error-already-exists')
           );
           sinon.assert.calledOnce(deleteRecord);
         });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -24,11 +24,6 @@
     "forms": {
       "certification-labels": {
         "additional-certification": "Additional certification",
-        "billing-mode": {
-          "free": "Free",
-          "paid": "Payable",
-          "prepaid": "Prepaid"
-        },
         "candidate-status": {
           "authorized-to-resume": "Allowed to resume",
           "finished": "Finished",
@@ -83,6 +78,11 @@
       "mandatory-all-fields": "All fields are required."
     },
     "labels": {
+      "billing-mode": {
+        "free": "Free",
+        "paid": "Payable",
+        "prepaid": "Prepaid"
+      },
       "candidate": {
         "birth-city": "Birth city",
         "birth-city-insee-code": "Birth city INSEE code (only for France)",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -22,6 +22,9 @@
       "internal-error": "An error occurred"
     },
     "forms": {
+      "error-default": "The service is temporarily unavailable. Please try again later.",
+      "mandatory-fields": "The fields marked by <abbr title=\"required\" class=\"mandatory-mark\">*</abbr> are required.",
+      "mandatory-all-fields": "All fields are required.",
       "certification-labels": {
         "additional-certification": "Additional certification",
         "billing-mode": {
@@ -37,7 +40,7 @@
         "prepayment-code": "Prepayment code",
         "pricing": "Pricing of Pix’s share"
       },
-      "labels": {
+      "common-labels": {
         "birth-city": "Birth city",
         "birth-city-insee-code": "Birth city INSEE code (only for France)",
         "birth-city-postcode": "Birth city postcode",
@@ -45,16 +48,35 @@
         "birth-country": "Birth country",
         "birth-date": "Date of birth",
         "birth-name": "Birth name",
-        "email": "Email address",
-        "firstname": "First name",
+        "firstname": {
+          "label": "First name",
+          "error-mandatory": "Please enter a first name."
+        },
         "gender": {
           "title": "Gender",
           "man": "Man",
           "woman": "Woman"
         },
         "insee-code": "INSEE code",
+        "lastname": {
+          "label": "Lastname",
+          "error": "Please enter a last name."
+        },
         "none": "None",
         "postcode": "City postcode"
+      },
+      "login-labels": {
+        "email": {
+          "label": "Email address",
+          "error-already-exists": "This email address is already registered, please login.",
+          "error-format": "Your email address is invalid."
+        },
+        "password": {
+          "label": "Password",
+          "error-format": "Your password must contain at least 8 characters and include at least one uppercase letter, one lowercase letter and one number.",
+          "error-mandatory": "Your password can't be empty.",
+          "forgot-password": "Forgot your password?"
+        }
       },
       "session-labels": {
         "address": "Location name",
@@ -63,9 +85,7 @@
         "examiner": "Invigilator(s)",
         "room": "Room name",
         "time": "Starting time (local time)"
-      },
-      "mandatory-fields": "The fields marked by <abbr title=\"required\" class=\"mandatory-mark\">*</abbr> are required.",
-      "mandatory-all-fields": "All fields are required."
+      }
     },
     "candidate": {
       "candidates": "Candidates"
@@ -92,19 +112,17 @@
   "pages": {
     "login": {
       "title": "Login",
+      "actions": {
+        "login": {
+          "label": "Log in"
+        }
+      },
       "errors": {
         "should-change-password": "You currently have a temporary password. <a href=\"{url}\">Reset your password here</a>.",
         "invitation-was-cancelled": "This invitation is no longer valid.<br/>Please contact the administrator of your Pix Certif space.",
         "invitation-already-accepted": "This invitation has already been accepted.<br/>Please log in or contact the administrator of your Pix Certif space."
       },
-      "login": "Log in",
-      "accessible-to": "Pix Certif is only accessible to Pix certification centres.",
-      "form": {
-        "mandatory-fields": "All fields are required.",
-        "button": "Log in",
-        "forgotten-password": "Forgot your password?",
-        "password": "Password"
-      }
+      "accessible-to": "Pix Certif is only accessible to Pix certification centres."
     },
     "login-or-register": {
       "title": "You have been invited to join the certification center {certificationCenterName}",
@@ -118,27 +136,16 @@
           }
         },
         "title": "Already have an account?",
-        "fields": {
-          "email": {
-            "label": "Email address",
-            "error": "Your email address is invalid."
-          },
-          "password": {
-            "label": "Password",
-            "error": "Your password can't be empty.",
-            "forgot-password": "Forgot your password?"
-          }
-        },
         "login": "Log in",
         "button": "Log in"
       },
       "register-form": {
         "title": "Sign up",
-        "button": "Sign up",
+        "actions": {
+          "login": "Sign up",
+          "login-button": "Sign up"
+        },
         "fields": {
-          "button": {
-            "label": "Sign up"
-          },
           "cgu": {
             "accept": "I agree to the",
             "and": "and",
@@ -146,27 +153,7 @@
             "data-protection-policy": "personal data protection policy",
             "error": "You must agree to the Pix terms of use and personal data protection policy to create an account.",
             "terms-of-use": "Pix terms of use"
-          },
-          "email": {
-            "error": "Please enter a valid email address.",
-            "label": "Email address"
-          },
-          "first-name": {
-            "error": "Please enter a first name.",
-            "label": "First name"
-          },
-          "last-name": {
-            "error": "Please enter a last name.",
-            "label": "Last name"
-          },
-          "password": {
-            "error": "Your password must contain at least 8 characters and include at least one uppercase letter, one lowercase letter and one number.",
-            "label": "Password"
           }
-        },
-        "errors": {
-          "default": "The service is temporarily unavailable. Please try again later.",
-          "email-already-exists": "This email address is already registered, please login."
         }
       }
     },

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -32,6 +32,12 @@
           "paid": "Payable",
           "prepaid": "Prepaid"
         },
+        "candidate-status": {
+          "authorized-to-resume": "Allowed to resume",
+          "finished": "Finished",
+          "ongoing": "In progress",
+          "start": "Start"
+        },
         "email-convocation": "Email for the convocation",
         "email-results": "Email of the results' recipient (instructor, teacher...)",
         "external-id": "External user ID",
@@ -59,8 +65,8 @@
         },
         "insee-code": "INSEE code",
         "lastname": {
-          "label": "Lastname",
-          "error": "Please enter a last name."
+          "label": "Last name",
+          "error-mandatory": "Please enter a last name."
         },
         "none": "None",
         "postcode": "City postcode"
@@ -79,16 +85,22 @@
         }
       },
       "session-labels": {
-        "address": "Location name",
-        "date": "Starting date",
-        "description": "Observations",
-        "examiner": "Invigilator(s)",
-        "room": "Room name",
-        "time": "Starting time (local time)"
+        "center-name": "Location name",
+        "date": "Date",
+        "date-start": "Starting date",
+        "invigilator": "Invigilator(s)",
+        "observations": "Observations",
+        "room": "Room",
+        "room-name": "Room name",
+        "session-number": "Session No.",
+        "status": "Status",
+        "time": "Time",
+        "time-start": "Starting time (local time)"
       }
     },
-    "candidate": {
-      "candidates": "Candidates"
+    "sessions": {
+      "candidates": "Candidates",
+      "invigilator": "Invigilator"
     }
   },
   "current-lang": "en",
@@ -312,15 +324,8 @@
           "empty": "No session found",
           "header": {
             "actions": "Actions",
-            "center-name": "Location name",
-            "date": "Date",
             "effective-candidates": "Certifications taken",
-            "enrolled-candidates": "Signed up candidates",
-            "room": "Room",
-            "session-number": "Session No.",
-            "status": "Status",
-            "supervisor": "Invigilator(s)",
-            "time": "Time"
+            "enrolled-candidates": "Signed up candidates"
           },
           "row": {
             "label": "Certification session",
@@ -341,7 +346,7 @@
             "prepayment-tooltip": "Required in particular when purchasing combined credits)<br />It must be comprised of the organisation’s SIRET and of the invoice’s number. Ex : 12345678912345/FACT12345.<br />If you don’t have an invoice, a prepayment code must be set with Pix.",
             "notifications": {
               "add-success": "The candidate has been successfully enrolled.",
-              "remove-success": "The candidate has been successfully deleted./The candidates have been successfully deleted."
+              "remove-success": "The candidate has been successfully deleted."
             }
           },
           "detail-modal": {
@@ -349,32 +354,6 @@
             "actions": {
               "close-extra-information": "Close candidate's detail window modal"
             }
-          },
-          "informations": {
-            "additional-certification": "Additional certification",
-            "billing-mode": {
-              "free": "Free",
-              "paid": "Payable",
-              "prepaid": "Prepaid"
-            },
-            "birth-city": "Birth city",
-            "birth-city-insee-code": "Birth city INSEE code (only for France)",
-            "birth-city-postcode": "Birth city postcode",
-            "birth-country": "Birth country",
-            "birth-date": "Date of birth",
-            "birth-name": "Birth name",
-            "email-convocation": "Email for the convocation",
-            "email-results": "Email of the results' recipient (instructor, teacher…)",
-            "external-id": "External user ID",
-            "extratime": "Extra time",
-            "extratime-percentage": "Extra time (%)",
-            "firstname": "First name",
-            "gender": "Gender",
-            "lastname": "Last name",
-            "man": "Man",
-            "prepayment-code": "Prepayment code",
-            "pricing": "Pricing of Pix’s share",
-            "woman": "Woman"
           },
           "list": {
             "title": "Candidates' list",
@@ -416,8 +395,6 @@
           },
           "page-title": "Candidates"
         },
-        "date": "Date",
-        "datetime": "Starting time (local time)",
         "downloads": {
           "label": "Downloads:",
           "attendance-sheet": {
@@ -435,8 +412,7 @@
         },
         "page-title": "Details",
         "tabs": {
-          "details": "Details",
-          "candidates": "Candidates"
+          "details": "Details"
         },
         "title": "Session {sessionId}",
         "panel-clea": {
@@ -452,8 +428,6 @@
             "update": "Edit the details for session {sessionId}"
           },
           "finalization-info": "The finalisation information for the session has already been transmitted to Pix.",
-          "invigilators": "Invigilator(s)",
-          "location-name": "Location name",
           "session": {
             "copy-number": "Copy the session number",
             "label": "Session number"
@@ -463,12 +437,9 @@
             "candidate": "Candidate",
             "copy-code": "Copy the session’s access code"
           },
-          "room": "Room",
-          "observations": "Observations",
           "password": {
             "copy-password": "Copy the invigilator’s session password",
-            "label": "Session password",
-            "invigilator": "Invigilator"
+            "label": "Session password"
           }
         }
       },
@@ -478,29 +449,14 @@
           "cancel-extra-information": "Cancel the session creation and return to the previous page",
           "create-session": "Create the session"
         },
-        "address": "Location name",
-        "date": "Starting date",
-        "description": "Observations",
-        "examiner": "Invigilator(s)",
-        "extra-information": "Session scheduling | Pix Certif",
-        "required-fields": "The fields marked by <abbr title=\"required\" class=\"mandatory-mark\">*</abbr> are required.",
-        "room": "Room name",
-        "time": "Starting time (local time)"
+        "extra-information": "Session scheduling | Pix Certif"
       },
       "update": {
         "title": "Certification session change",
         "actions": {
           "cancel-extra-information": "Cancel the session change and return to the previous page",
           "edit-session": "Edit the session"
-        },
-        "address": "Location name",
-        "date": "Starting date",
-        "description": "Observations",
-        "examiner": "Invigilator(s)",
-        "page-title": "Certification session change",
-        "required-fields": "The fields marked by <abbr title=\"required\" class=\"mandatory-mark\">*</abbr> are required.",
-        "room": "Room name",
-        "time": "Starting time (local time)"
+        }
       }
     },
     "session-supervising": {
@@ -532,16 +488,7 @@
           "exit-extra-information": "Exit the invigilation of session {sessionId}"
         },
         "access-code": "Access code (candidates)",
-        "center-name": "Location",
-        "multiple-supervisor": "Invigilator(s)",
-        "room": "Room",
-        "session-id": "Session {sessionId}",
-        "center-name": "Center name",
-        "center-name-full": "Center name",
-        "room": "Room",
-        "supervisor": "Supervisor",
-        "multiple-supervisor": "Supervisor(s)",
-        "access-code": "Access code (candidates)"
+        "session-id": "Session {sessionId}"
       },
       "candidate-list": {
         "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidate} other {candidates}} selected",
@@ -551,13 +498,8 @@
         "search-candidate": "Search for a candidate"
       },
       "candidate-in-list": {
-        "extra-time": "Extra time",
-        "ongoing": "In progress",
-        "finished": "Finished",
-        "authorized-to-resume": "Allowed to resume",
         "display-candidate-options": "Display the candidate's options",
         "candidate-options": "Candidate's options",
-        "start": "Start",
         "test-end-modal": {
           "description": "Attention : cette action entraîne la fin de son test de certification et est irréversible.",
           "instruction-with-name": "Finish the test of {firstName} {lastName}?",
@@ -585,8 +527,6 @@
     },
     "team": {
       "title": "Team",
-      "last-name": "Last name",
-      "first-name": "First name",
       "referer": "Référent",
       "pix-referer": "Référent Pix",
       "update-referer-button": "Changer de référent",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -3,6 +3,7 @@
     "actions": {
       "back": "Retour",
       "cancel": "Cancel",
+      "choose": "Choose",
       "close": "Close",
       "continue": "Continue",
       "add": "Add",
@@ -20,7 +21,50 @@
       "gateway-timeout-error": "The service is being slow. Please try again later.",
       "internal-error": "An error occurred"
     },
-    "form": {
+    "forms": {
+      "certification-labels": {
+        "additional-certification": "Additional certification",
+        "billing-mode": {
+          "free": "Free",
+          "paid": "Payable",
+          "prepaid": "Prepaid"
+        },
+        "email-convocation": "Email for the convocation",
+        "email-results": "Email of the results' recipient (instructor, teacher...)",
+        "external-id": "External user ID",
+        "extratime": "Extra time",
+        "extratime-percentage": "Extra time (%)",
+        "prepayment-code": "Prepayment code",
+        "pricing": "Pricing of Pix’s share"
+      },
+      "labels": {
+        "birth-city": "Birth city",
+        "birth-city-insee-code": "Birth city INSEE code (only for France)",
+        "birth-city-postcode": "Birth city postcode",
+        "birth-geographical-code": "Geographical birth code",
+        "birth-country": "Birth country",
+        "birth-date": "Date of birth",
+        "birth-name": "Birth name",
+        "email": "Email address",
+        "firstname": "First name",
+        "gender": {
+          "title": "Gender",
+          "man": "Man",
+          "woman": "Woman"
+        },
+        "insee-code": "INSEE code",
+        "none": "None",
+        "postcode": "City postcode"
+      },
+      "session-labels": {
+        "address": "Location name",
+        "date": "Starting date",
+        "description": "Observations",
+        "examiner": "Invigilator(s)",
+        "room": "Room name",
+        "time": "Starting time (local time)"
+      },
+      "mandatory-fields": "The fields marked by <abbr title=\"required\" class=\"mandatory-mark\">*</abbr> are required.",
       "mandatory-all-fields": "All fields are required."
     },
     "candidate": {
@@ -57,10 +101,9 @@
       "accessible-to": "Pix Certif is only accessible to Pix certification centres.",
       "form": {
         "mandatory-fields": "All fields are required.",
-        "email-address": "Email address",
-        "password": "Password",
         "button": "Log in",
-        "forgotten-password": "Forgot your password?"
+        "forgotten-password": "Forgot your password?",
+        "password": "Password"
       }
     },
     "login-or-register": {
@@ -302,7 +345,16 @@
         "candidates": {
           "add-modal": {
             "actions": {
-              "close-extra-information": "Close add candidate window modal"
+              "close-extra-information": "Close add candidate window modal",
+              "enrol-the-candidate": "Enrol the candidate"
+            },
+            "title": "Inscrire un candidat",
+            "info-panel": "If this field isn’t filled in, the results won't be transmitted by email for the affected candidate(s).<br />The candidate will see their results displayed directly on their Pix account.",
+            "prepayment-information": "Prepayment code information",
+            "prepayment-tooltip": "Required in particular when purchasing combined credits)<br />It must be comprised of the organisation’s SIRET and of the invoice’s number. Ex : 12345678912345/FACT12345.<br />If you don’t have an invoice, a prepayment code must be set with Pix.",
+            "notifications": {
+              "add-success": "The candidate has been successfully enrolled.",
+              "remove-success": "The candidate has been successfully deleted./The candidates have been successfully deleted."
             }
           },
           "detail-modal": {
@@ -497,7 +549,12 @@
         "multiple-supervisor": "Invigilator(s)",
         "room": "Room",
         "session-id": "Session {sessionId}",
-        "supervisor": "Supervisor"
+        "center-name": "Center name",
+        "center-name-full": "Center name",
+        "room": "Room",
+        "supervisor": "Supervisor",
+        "multiple-supervisor": "Supervisor(s)",
+        "access-code": "Access code (candidates)"
       },
       "candidate-list": {
         "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidate} other {candidates}} selected",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -22,10 +22,6 @@
       "internal-error": "An error occurred"
     },
     "forms": {
-      "error-default": "The service is temporarily unavailable. Please try again later.",
-      "mandatory-fields": "The fields marked by <abbr title=\"required\" class=\"mandatory-mark\">*</abbr> are required.",
-      "mandatory-all-fields": "All fields are required.",
-      "required": "Required",
       "certification-labels": {
         "additional-certification": "Additional certification",
         "billing-mode": {
@@ -47,44 +43,13 @@
         "prepayment-code": "Prepayment code",
         "pricing": "Pricing of Pix’s share"
       },
-      "common-labels": {
-        "birth-city": "Birth city",
-        "birth-city-insee-code": "Birth city INSEE code (only for France)",
-        "birth-city-postcode": "Birth city postcode",
-        "birth-geographical-code": "Geographical birth code",
-        "birth-country": "Birth country",
-        "birth-date": "Date of birth",
-        "birth-name": "Birth name",
-        "firstname": {
-          "label": "First name",
-          "error-mandatory": "Please enter a first name."
-        },
-        "gender": {
-          "title": "Gender",
-          "man": "Man",
-          "woman": "Woman"
-        },
-        "insee-code": "INSEE code",
-        "lastname": {
-          "label": "Last name",
-          "error-mandatory": "Please enter a last name."
-        },
-        "none": "None",
-        "postcode": "City postcode"
+      "login": {
+        "email": "Email address",
+        "password": "Password",
+        "forgot-password": "Forgot your password?"
       },
-      "login-labels": {
-        "email": {
-          "label": "Email address",
-          "error-already-exists": "This email address is already registered, please login.",
-          "error-format": "Your email address is invalid."
-        },
-        "password": {
-          "label": "Password",
-          "error-format": "Your password must contain at least 8 characters and include at least one uppercase letter, one lowercase letter and one number.",
-          "error-mandatory": "Your password can't be empty.",
-          "forgot-password": "Forgot your password?"
-        }
-      },
+      "mandatory-fields": "The fields marked by <abbr title=\"required\" class=\"mandatory-mark\">*</abbr> are required.",
+      "required": "Required",
       "session-labels": {
         "center-name": "Location name",
         "date": "Date",
@@ -97,6 +62,45 @@
         "status": "Status",
         "time": "Time",
         "time-start": "Starting time (local time)"
+      }
+    },
+    "form-errors": {
+      "default": "The service is temporarily unavailable. Please try again later.",
+      "email": {
+        "already-exists": "This email address is already registered, please login.",
+        "format": "Your email address is invalid."
+      },
+      "firstname": {
+        "mandatory": "Please enter a first name."
+      },
+      "lastname": {
+        "mandatory": "Please enter a last name."
+      },
+      "password": {
+        "format": "Your password must contain at least 8 characters and include at least one uppercase letter, one lowercase letter and one number.",
+        "mandatory": "Your password can't be empty."
+      },
+      "mandatory-all-fields": "All fields are required."
+    },
+    "labels": {
+      "candidate": {
+        "birth-city": "Birth city",
+        "birth-city-insee-code": "Birth city INSEE code (only for France)",
+        "birth-city-postcode": "Birth city postcode",
+        "birth-geographical-code": "Geographical birth code",
+        "birth-country": "Birth country",
+        "birth-date": "Date of birth",
+        "birth-name": "Birth name",
+        "firstname": "First name",
+        "gender": {
+          "title": "Gender",
+          "man": "Man",
+          "woman": "Woman"
+        },
+        "insee-code": "INSEE code",
+        "lastname": "Last name",
+        "none": "None",
+        "postcode": "City postcode"
       }
     },
     "sessions": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -25,6 +25,7 @@
       "error-default": "The service is temporarily unavailable. Please try again later.",
       "mandatory-fields": "The fields marked by <abbr title=\"required\" class=\"mandatory-mark\">*</abbr> are required.",
       "mandatory-all-fields": "All fields are required.",
+      "required": "Required",
       "certification-labels": {
         "additional-certification": "Additional certification",
         "billing-mode": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -24,11 +24,6 @@
     "forms": {
       "certification-labels": {
         "additional-certification": "Certification complémentaire",
-        "billing-mode": {
-          "free": "Gratuite",
-          "paid": "Payante",
-          "prepaid": "Prépayée"
-        },
         "candidate-status": {
           "authorized-to-resume": "Autorisé à reprendre",
           "finished": "Terminé",
@@ -83,6 +78,11 @@
       "mandatory-all-fields": "Tous les champs sont obligatoires."
     },
     "labels": {
+      "billing-mode": {
+        "free": "Gratuite",
+        "paid": "Payante",
+        "prepaid": "Prépayée"
+      },
       "candidate": {
         "birth-city": "Commune de naissance",
         "birth-city-insee-code": "Code INSEE de naissance",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -23,7 +23,7 @@
     },
     "forms": {
       "error-default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
-      "mandatory-fields": "Les champs marqués de <abbr title=\"required\" class=\"mandatory-mark\">*</abbr>sont obligatoires.",
+      "mandatory-fields": "Les champs marqués de <abbr title=\"obligatoire\" class=\"mandatory-mark\">*</abbr>sont obligatoires.",
       "mandatory-all-fields": "Tous les champs sont obligatoires.",
       "certification-labels": {
         "additional-certification": "Certification complémentaire",
@@ -31,6 +31,12 @@
           "free": "Gratuite",
           "paid": "Payante",
           "prepaid": "Prépayée"
+        },
+        "candidate-status": {
+          "authorized-to-resume": "Autorisé à reprendre",
+          "finished": "Terminé",
+          "ongoing": "En cours",
+          "start": "Début"
         },
         "email-convocation": "E-mail de convocation",
         "email-results": "E-mail du destinataire des résultats (formateur, enseignant...)",
@@ -59,7 +65,7 @@
         },
         "lastname": {
           "label": "Nom",
-          "error": "Le champ nom est obligatoire."
+          "error-mandatory": "Le champ nom est obligatoire."
         },
         "insee-code": "Code INSEE",
         "none": "Aucune",
@@ -79,16 +85,22 @@
         }
       },
       "session-labels": {
-        "address": "Nom du site",
-        "date": "Date de début",
-        "description": "Observations",
-        "examiner": "Surveillant(s)",
-        "room": "Nom de la salle",
-        "time": "Heure de début (heure locale)"
+        "center-name": "Nom du site",
+        "date": "Date",
+        "date-start": "Date de début",
+        "invigilator": "Surveillant(s)",
+        "observations": "Observations",
+        "room": "Salle",
+        "room-name": "Nom de la salle",
+        "session-number": "N° de session",
+        "status": "Statut",
+        "time": "Heure",
+        "time-start": "Heure de début (heure locale)"
       }
     },
-    "candidate": {
-      "candidates": "Candidats"
+    "sessions": {
+      "candidates": "Candidats",
+      "invigilator": "Surveillant"
     }
   },
   "current-lang": "fr",
@@ -190,6 +202,7 @@
             "download": "Une erreur s'est produite pendant le téléchargement"
           },
           "instructions": {
+            "title": "Comment ça marche ?",
             "creation": {
               "title": "Pour créer des sessions ?",
               "list": "Vous pouvez créer des sessions :",
@@ -201,8 +214,7 @@
               "replace": "<strong>Pour remplacer</strong> une liste pré-existante dans le fichier modèle,",
               "subscription": "<strong>Pour inscrire</strong> des candidats dans une session vide.",
               "warning": "Attention à renseigner le numéro de session sans les autres informations de sessions (ex: date, heure, etc.) pour éviter les doublons lors de la création."
-            },
-            "title": "Comment ça marche ?"
+            }
           }
         },
         "step-two": {
@@ -311,15 +323,8 @@
           "empty": "Aucune session trouvée",
           "header": {
             "actions": "Actions",
-            "center-name": "Nom du site",
-            "date": "Date",
             "effective-candidates": "Certifications passées",
-            "enrolled-candidates": "Candidats inscrits",
-            "room": "Salle",
-            "session-number": "N° de session",
-            "status": "Statut",
-            "supervisor": "Surveillant(s)",
-            "time": "Heure"
+            "enrolled-candidates": "Candidats inscrits"
           },
           "row": {
             "label": "Session de certification",
@@ -390,8 +395,6 @@
           },
           "page-title": "Candidats"
         },
-        "date": "Date",
-        "datetime": "Heure de début (heure locale)",
         "downloads": {
           "label": "Téléchargements :",
           "attendance-sheet": {
@@ -421,8 +424,6 @@
             "update": "Modifier les informations de la session {sessionId}"
           },
           "finalization-info": "Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix.",
-          "invigilators": "Surveillant(s)",
-          "location-name": "Nom du site",
           "session": {
             "copy-number": "Copier le numéro de session",
             "label": "Numéro de session"
@@ -432,17 +433,13 @@
             "candidate": "Candidat",
             "copy-code": "Copier le code d’accès à la session"
           },
-          "room": "Salle",
-          "observations": "Observations",
           "password": {
             "copy-password": "Copier le mot de passe de session pour le surveillant",
-            "label": "Mot de passe de session",
-            "invigilator": "Surveillant"
+            "label": "Mot de passe de session"
           }
         },
         "tabs": {
-          "details": "Détails",
-          "candidates": "Candidats"
+          "details": "Détails"
         }
       },
       "new": {
@@ -451,29 +448,14 @@
           "cancel-extra-information": "Annuler la création de session et retourner vers la page précédente",
           "create-session": "Créer la session"
         },
-        "address": "Nom du site",
-        "date": "Date de début",
-        "description": "Observations",
-        "examiner": "Surveillant(s)",
-        "extra-information": "Planification d’une session | Pix Certif",
-        "required-fields": "Les champs marqués de <abbr title=\"obligatoire\" class=\"mandatory-mark\">*</abbr> sont obligatoires.",
-        "room": "Nom de la salle",
-        "time": "Heure de début (heure locale)"
+        "extra-information": "Planification d’une session | Pix Certif"
       },
       "update": {
         "title": "Modification d'une session de certification",
         "actions": {
           "cancel-extra-information": "Annuler la modification de la session et retourner vers la page précédente",
           "edit-session": "Modifier la session"
-        },
-        "address": "Nom du site",
-        "date": "Date de début",
-        "description": "Observations",
-        "examiner": "Surveillant(s)",
-        "page-title": "Modification d'une session de certification",
-        "required-fields": "Les champs marqués de <abbr title=\"obligatoire\" class=\"mandatory-mark\">*</abbr> sont obligatoires.",
-        "room": "Nom de la salle",
-        "time": "Heure de début (heure locale)"
+        }
       }
     },
     "session-supervising": {
@@ -505,11 +487,7 @@
           "exit-extra-information": "Quitter la surveillance de la session {sessionId}"
         },
         "access-code": "Code d'accès (candidats)",
-        "center-name": "Site",
-        "multiple-supervisor": "Surveillant(s)",
-        "room": "Salle",
-        "session-id": "Session {sessionId}",
-        "supervisor": "Surveillant"
+        "session-id": "Session {sessionId}"
       },
       "candidate-list": {
         "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidat sélectionné} other {candidats sélectionnés}}",
@@ -519,13 +497,8 @@
         "search-candidate": "Rechercher un candidat"
       },
       "candidate-in-list": {
-        "extra-time": "Temps majoré",
-        "ongoing": "En cours",
-        "authorized-to-resume": "Autorisé à reprendre",
-        "finished": "Terminé",
         "display-candidate-options": "Afficher les options du candidat",
         "candidate-options": "Options du candidat",
-        "start": "Début",
         "test-end-modal": {
           "description": "Attention : cette action entraîne la fin de son test de certification et est irréversible.",
           "instruction-with-name": "Terminer le test de {firstName} {lastName} ?",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -25,6 +25,7 @@
       "error-default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
       "mandatory-fields": "Les champs marqués de <abbr title=\"obligatoire\" class=\"mandatory-mark\">*</abbr>sont obligatoires.",
       "mandatory-all-fields": "Tous les champs sont obligatoires.",
+      "required": "Obligatoire",
       "certification-labels": {
         "additional-certification": "Certification complémentaire",
         "billing-mode": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -4,6 +4,7 @@
       "add": "Ajouter",
       "back": "Retour",
       "cancel": "Annuler",
+      "choose": "Choisissez",
       "close": "Fermer",
       "continue": "Continuer",
       "delete": "Supprimer",
@@ -20,7 +21,51 @@
       "gateway-timeout-error": "Le service subit des ralentissements. Veuillez réessayer ultérieurement.",
       "internal-error": "Une erreur est survenue"
     },
-    "form": {
+    "forms": {
+      "certification-labels": {
+        "additional-certification": "Certification complémentaire",
+        "billing-mode": {
+          "free": "Gratuite",
+          "paid": "Payante",
+          "prepaid": "Prépayée"
+        },
+        "email-convocation": "E-mail de convocation",
+        "email-results": "E-mail du destinataire des résultats (formateur, enseignant...)",
+        "external-id": "Identifiant externe",
+        "extratime": "Temps majoré",
+        "extratime-percentage": "Temps majoré (%)",
+        "prepayment-code": "Code de prépaiement",
+        "pricing": "Tarification part Pix"
+      },
+      "labels": {
+        "birth-city": "Commune de naissance",
+        "birth-city-insee-code": "Code INSEE de naissance",
+        "birth-city-postcode": "Code postal de naissance",
+        "birth-geographical-code": "Code géographique de naissance",
+        "birth-country": "Pays de naissance",
+        "birth-date": "Date de naissance",
+        "birth-name": "Nom de naissance",
+        "firstname": "Prénom",
+        "email": "Adresse e-mail",
+        "gender": {
+          "title": "Sexe",
+          "man": "Homme",
+          "woman": "Femme"
+        },
+        "lastname": "Nom",
+        "insee-code": "Code INSEE",
+        "none": "Aucune",
+        "postcode": "Code postal"
+      },
+      "session-labels": {
+        "address": "Nom du site",
+        "date": "Date de début",
+        "description": "Observations",
+        "examiner": "Surveillant(s)",
+        "room": "Nom de la salle",
+        "time": "Heure de début (heure locale)"
+      },
+      "mandatory-fields": "Les champs marqués de <abbr title=\"required\" class=\"mandatory-mark\">*</abbr>sont obligatoires.",
       "mandatory-all-fields": "Tous les champs sont obligatoires."
     },
     "candidate": {
@@ -56,8 +101,6 @@
       "login": "Connectez-vous",
       "accessible-to": "L'accès à Pix Certif est limité aux centres de certification Pix.",
       "form": {
-        "mandatory-fields": "Tous les champs sont obligatoires.",
-        "email-address": "Adresse e-mail",
         "password": "Mot de passe",
         "button": "Je me connecte",
         "forgotten-password": "Mot de passe oublié ?"
@@ -301,8 +344,17 @@
         "title": "Session {sessionId}",
         "candidates": {
           "add-modal": {
+            "title": "Inscrire un candidat",
             "actions": {
-              "close-extra-information": "Fermer la modale d'ajout de candidat"
+              "close-extra-information": "Fermer la modale d'ajout de candidat",
+              "enrol-the-candidate": "Inscrire le candidat"
+            },
+            "info-panel": "Si le champ n’est pas renseigné, les résultats ne seront pas transmis par mail pour le/les candidats concernés.<br />Le candidat verra ses résultats affichés directement sur son compte Pix.",
+            "prepayment-information": "Information du code de prépaiement",
+            "prepayment-tooltip": "(Requis notamment dans le cas d'un achat de crédits combinés)<br />Doit être composé du SIRET de l’organisation et du numéro de facture. Ex : 12345678912345/FACT12345'.<br/>Si vous ne possédez pas de facture, un code de prépaiement doit être établi avec Pix.",
+            "notifications": {
+              "add-success": "Le candidat a été inscrit avec succès.",
+              "remove-success": "Le candidat a été supprimé avec succès."
             }
           },
           "detail-modal": {
@@ -310,32 +362,6 @@
             "actions": {
               "close-extra-information": "Fermer la fenêtre de détail du candidat"
             }
-          },
-          "informations": {
-            "additional-certification": "Certification complémentaire",
-            "billing-mode": {
-              "free": "Gratuite",
-              "paid": "Payante",
-              "prepaid": "Prépayée"
-            },
-            "birth-city": "Commune de naissance",
-            "birth-city-insee-code": "Code INSEE de naissance",
-            "birth-city-postcode": "Code postal de naissance",
-            "birth-country": "Pays de naissance",
-            "birth-date": "Date de naissance",
-            "birth-name": "Nom de naissance",
-            "email-convocation": "E-mail de convocation",
-            "email-results": "E-mail du destinataire des résultats (formateur, enseignant...)",
-            "external-id": "Identifiant externe",
-            "extratime": "Temps majoré",
-            "extratime-percentage": "Temps majoré (%)",
-            "firstname": "Prénom",
-            "gender": "Sexe",
-            "lastname": "Nom",
-            "man": "Homme",
-            "prepayment-code": "Code de prépaiement",
-            "pricing": "Tarification part Pix",
-            "woman": "Femme"
           },
           "list": {
             "title": "Liste des candidats",
@@ -540,8 +566,6 @@
     },
     "team": {
       "title": "Équipe",
-      "last-name": "Nom",
-      "first-name": "Prénom",
       "referer": "Référent",
       "pix-referer": "Référent Pix",
       "update-referer-button": "Changer de référent",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -22,6 +22,9 @@
       "internal-error": "Une erreur est survenue"
     },
     "forms": {
+      "error-default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
+      "mandatory-fields": "Les champs marqués de <abbr title=\"required\" class=\"mandatory-mark\">*</abbr>sont obligatoires.",
+      "mandatory-all-fields": "Tous les champs sont obligatoires.",
       "certification-labels": {
         "additional-certification": "Certification complémentaire",
         "billing-mode": {
@@ -37,7 +40,7 @@
         "prepayment-code": "Code de prépaiement",
         "pricing": "Tarification part Pix"
       },
-      "labels": {
+      "common-labels": {
         "birth-city": "Commune de naissance",
         "birth-city-insee-code": "Code INSEE de naissance",
         "birth-city-postcode": "Code postal de naissance",
@@ -45,17 +48,35 @@
         "birth-country": "Pays de naissance",
         "birth-date": "Date de naissance",
         "birth-name": "Nom de naissance",
-        "firstname": "Prénom",
-        "email": "Adresse e-mail",
+        "firstname": {
+          "label": "Prénom",
+          "error-mandatory": "Le champ prénom est obligatoire."
+        },
         "gender": {
           "title": "Sexe",
           "man": "Homme",
           "woman": "Femme"
         },
-        "lastname": "Nom",
+        "lastname": {
+          "label": "Nom",
+          "error": "Le champ nom est obligatoire."
+        },
         "insee-code": "Code INSEE",
         "none": "Aucune",
         "postcode": "Code postal"
+      },
+      "login-labels": {
+        "email": {
+          "label": "Adresse e-mail",
+          "error-already-exists": "Cette adresse e-mail est déjà enregistrée, connectez-vous.",
+          "error-format": "Le champ adresse e-mail n’est pas valide."
+        },
+        "password": {
+          "label": "Mot de passe",
+          "error-format": "Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.",
+          "error-mandatory": "Le champ mot de passe est obligatoire.",
+          "forgot-password": "Mot de passe oublié ?"
+        }
       },
       "session-labels": {
         "address": "Nom du site",
@@ -64,9 +85,7 @@
         "examiner": "Surveillant(s)",
         "room": "Nom de la salle",
         "time": "Heure de début (heure locale)"
-      },
-      "mandatory-fields": "Les champs marqués de <abbr title=\"required\" class=\"mandatory-mark\">*</abbr>sont obligatoires.",
-      "mandatory-all-fields": "Tous les champs sont obligatoires."
+      }
     },
     "candidate": {
       "candidates": "Candidats"
@@ -93,18 +112,17 @@
   "pages": {
     "login": {
       "title": "Connectez-vous",
+      "actions": {
+        "login": {
+          "label": "Je me connecte"
+        }
+      },
       "errors": {
         "should-change-password": "Vous avez actuellement un mot de passe temporaire. Cliquez sur <a href=\"{url}\">mot de passe oublié</a> pour le réinitialiser.",
         "invitation-was-cancelled": "Cette invitation n’est plus valide.<br/>Contactez l’administrateur de votre espace Pix Certif.",
         "invitation-already-accepted": "Cette invitation a déjà été acceptée.<br/>Connectez-vous ou contactez l’administrateur de votre espace Pix Certif."
       },
-      "login": "Connectez-vous",
-      "accessible-to": "L'accès à Pix Certif est limité aux centres de certification Pix.",
-      "form": {
-        "password": "Mot de passe",
-        "button": "Je me connecte",
-        "forgotten-password": "Mot de passe oublié ?"
-      }
+      "accessible-to": "L'accès à Pix Certif est limité aux centres de certification Pix."
     },
     "login-or-register": {
       "title": "Vous êtes invité(e) à rejoindre le centre de certification {certificationCenterName}",
@@ -118,27 +136,16 @@
           }
         },
         "title": "J'ai déjà un compte",
-        "fields": {
-          "email": {
-            "label": "Adresse e-mail",
-            "error": "Le champ adresse e-mail n’est pas valide."
-          },
-          "password": {
-            "label": "Mot de passe",
-            "error": "Le champ mot de passe est obligatoire.",
-            "forgot-password": "Mot de passe oublié ?"
-          }
-        },
         "login": "Je me connecte",
         "button": "Se connecter"
       },
       "register-form": {
         "title": "Je m’inscris",
-        "button": "S'inscrire",
+        "actions": {
+          "login": "S'inscrire",
+          "login-button": "Je m'inscris"
+        },
         "fields": {
-          "button": {
-            "label": "Je m'inscris"
-          },
           "cgu": {
             "accept": "J'accepte les",
             "and": "et la",
@@ -146,27 +153,7 @@
             "data-protection-policy": "politique de confidentialité",
             "error": "Vous devez accepter les conditions d’utilisation de Pix et la politique de confidentialité pour créer un compte.",
             "terms-of-use": "conditions d'utilisation de Pix"
-          },
-          "email": {
-            "error": "Le champ adresse e-mail n’est pas valide.",
-            "label": "Adresse e-mail"
-          },
-          "first-name": {
-            "error": "Le champ prénom est obligatoire.",
-            "label": "Prénom"
-          },
-          "last-name": {
-            "error": "Le champ nom est obligatoire.",
-            "label": "Nom"
-          },
-          "password": {
-            "error": "Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.",
-            "label": "Mot de passe"
           }
-        },
-        "errors": {
-          "default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
-          "email-already-exists": "Cette adresse e-mail est déjà enregistrée, connectez-vous."
         }
       }
     },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -22,10 +22,6 @@
       "internal-error": "Une erreur est survenue"
     },
     "forms": {
-      "error-default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
-      "mandatory-fields": "Les champs marqués de <abbr title=\"obligatoire\" class=\"mandatory-mark\">*</abbr>sont obligatoires.",
-      "mandatory-all-fields": "Tous les champs sont obligatoires.",
-      "required": "Obligatoire",
       "certification-labels": {
         "additional-certification": "Certification complémentaire",
         "billing-mode": {
@@ -47,44 +43,13 @@
         "prepayment-code": "Code de prépaiement",
         "pricing": "Tarification part Pix"
       },
-      "common-labels": {
-        "birth-city": "Commune de naissance",
-        "birth-city-insee-code": "Code INSEE de naissance",
-        "birth-city-postcode": "Code postal de naissance",
-        "birth-geographical-code": "Code géographique de naissance",
-        "birth-country": "Pays de naissance",
-        "birth-date": "Date de naissance",
-        "birth-name": "Nom de naissance",
-        "firstname": {
-          "label": "Prénom",
-          "error-mandatory": "Le champ prénom est obligatoire."
-        },
-        "gender": {
-          "title": "Sexe",
-          "man": "Homme",
-          "woman": "Femme"
-        },
-        "lastname": {
-          "label": "Nom",
-          "error-mandatory": "Le champ nom est obligatoire."
-        },
-        "insee-code": "Code INSEE",
-        "none": "Aucune",
-        "postcode": "Code postal"
+      "login": {
+        "email": "Adresse e-mail",
+        "password":"Mot de passe",
+        "forgot-password": "Mot de passe oublié ?"
       },
-      "login-labels": {
-        "email": {
-          "label": "Adresse e-mail",
-          "error-already-exists": "Cette adresse e-mail est déjà enregistrée, connectez-vous.",
-          "error-format": "Le champ adresse e-mail n’est pas valide."
-        },
-        "password": {
-          "label": "Mot de passe",
-          "error-format": "Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.",
-          "error-mandatory": "Le champ mot de passe est obligatoire.",
-          "forgot-password": "Mot de passe oublié ?"
-        }
-      },
+      "mandatory-fields": "Les champs marqués de <abbr title=\"obligatoire\" class=\"mandatory-mark\">*</abbr>sont obligatoires.",
+      "required": "Obligatoire",
       "session-labels": {
         "center-name": "Nom du site",
         "date": "Date",
@@ -97,6 +62,45 @@
         "status": "Statut",
         "time": "Heure",
         "time-start": "Heure de début (heure locale)"
+      }
+    },
+    "form-errors": {
+      "default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
+      "email": {
+        "already-exists": "Cette adresse e-mail est déjà enregistrée, connectez-vous.",
+        "format": "Le champ adresse e-mail n’est pas valide."
+      },
+      "firstname": {
+        "mandatory": "Le champ prénom est obligatoire."
+      },
+      "lastname": {
+        "mandatory": "Le champ nom est obligatoire."
+      },
+      "password": {
+        "format": "Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.",
+        "mandatory": "Le champ mot de passe est obligatoire."
+      },
+      "mandatory-all-fields": "Tous les champs sont obligatoires."
+    },
+    "labels": {
+      "candidate": {
+        "birth-city": "Commune de naissance",
+        "birth-city-insee-code": "Code INSEE de naissance",
+        "birth-city-postcode": "Code postal de naissance",
+        "birth-geographical-code": "Code géographique de naissance",
+        "birth-country": "Pays de naissance",
+        "birth-date": "Date de naissance",
+        "birth-name": "Nom de naissance",
+        "firstname": "Prénom",
+        "gender": {
+          "title": "Sexe",
+          "man": "Homme",
+          "woman": "Femme"
+        },
+        "insee-code": "Code INSEE",
+        "lastname":  "Nom",
+        "none": "Aucune",
+        "postcode": "Code postal"
       }
     },
     "sessions": {


### PR DESCRIPTION
## :unicorn: Problème
Les fichiers `json` des traductions EN et FR contiennent des doublons. Par ex : les formulaires d'ajout et de modifications d'un candidat ont des champs identiques, en doublon dans la traduction, comme `firstName` ou `email`.

## :robot: Proposition
Passer les traductions liées aux formulaires dans `common` plutôt que de les laisser dans `pages`.

Ce qui nous donnera : 
```json
{
  "common": {
    "forms": {
      "mandatory-all-fields": "All fields are required.",
      "certification-labels": {
        "email-convocation": "Email for the convocation",
      },
      "common-labels": {
        "birth-city": "Birth city",
        "firstname": {
          "label": "First name",
          "error-mandatory": "Please enter a first name."
        },
      },
  },
}
```

## :rainbow: Remarques
Pour certains labels, il y a des messages d'erreurs associées (formulaire de login, par ex)
Dans ce cas, ils sont indiqués comme ceci : 
```json
"firstname": {
    "label": "First name",
    "error-mandatory": "Please enter a first name."
},
```

## :100: Pour tester
Se connecter sur Pix Certif avec [certifsup@example.net](mailto:certifsup@example.net)
Passer ?lang=en dans l'url
Vérifier que la page de login est toujours correctement traduite
Cliquer sur une session, puis sur l'onglet "Candidates", puis "Créer un candidat"
Constater que tous les éléments sont traduits
Idem pour la modification d'un candidat
