### PR TITLE
[FEATURE] Ajout d'un role "alert" quand le code campagne est erroné (PIX-7262)

### DIFF
--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -34,7 +34,7 @@
         </div>
 
         {{#if this.errorMessage}}
-          <div class="fill-in-campaign-code__error" aria-live="polite">
+          <div role="alert" class="fill-in-campaign-code__error">
             {{this.errorMessage}}
           </div>
         {{/if}}


### PR DESCRIPTION
## :unicorn: Problème
Sur la page “J’ai un code”, lorsque le code renseigné est erroné, l'erreur n’est pas mise en avant pour les utilisateurs de lecteurs d'écran.

## :robot: Proposition
Ajouter un role="alert" au message d’erreur pour les utilisateurs de lecteurs d'écran.

voir le critère 7.5 du RGAA.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
(Avec un lecteur d'écran)
Aller sur Mon Pix sur la page "J'ai un code".
Rentrer un code erroné.
Vérifier que le message d'erreur est bien restitué des le clic sur le bouton de validation.