### PR TITLE
[FEATURE] Retirer l'alternative textuelle aux logos des organisations sur la page fin de parcours (PIX-7266)

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -184,7 +184,7 @@
     <PixBlock class="skill-review__organization-message">
       {{#if @model.campaign.organizationLogoUrl}}
         <div class="skill-review-organization-message__logo">
-          <img class="logo" src={{@model.campaign.organizationLogoUrl}} alt="{{@model.campaign.organizationName}}" />
+          <img class="logo" src={{@model.campaign.organizationLogoUrl}} alt="" role="presentation" />
         </div>
       {{/if}}
       <div class="skill-review-organization-message__content">


### PR DESCRIPTION

## :unicorn: Problème
Lors de la fin de parcours on affiche les logos des organisations à l’origine des campagnes. L’alternative textuelle correspondant à ce logo est redondante par rapport au nom de l’organisation qui est précisée juste à côté. Expliciter cette image aux lecteurs d'écran n’ajoute donc aucune plusvalue.

## :robot: Proposition
Mettre un alt vide au logo organisation.

## :rainbow: Remarques
Bonsoir

## :100: Pour tester
- Se connecter à mon-pix
- Se rendre sur la page "j'ai un code"
- lancer la campagne PROCOMP51
- **Essayez d'avoir le meilleur résultat possible**
- Et vérifier la page de fin de parcours avec le lecteur d'écran
- tada 🎉 