### PR TITLE
[FEATURE] Enregistrer la locale à l'inscription d'un utilisateur via un SSO OIDC  (PIX-7517)

### DIFF
--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -81,11 +81,13 @@ module.exports = {
 
   async createUser(request, h) {
     const { identityProvider, authenticationKey } = request.deserializedPayload;
+    const localeFromCookie = request.state?.locale;
 
     const oidcAuthenticationService = await authenticationServiceRegistry.lookupAuthenticationService(identityProvider);
     const { accessToken, logoutUrlUUID } = await usecases.createOidcUser({
       authenticationKey,
       identityProvider,
+      localeFromCookie,
       oidcAuthenticationService,
     });
 

--- a/api/lib/domain/models/UserToCreate.js
+++ b/api/lib/domain/models/UserToCreate.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const localeService = require('../services/locale-service');
 
 class UserToCreate {
   constructor({
@@ -19,6 +20,10 @@ class UserToCreate {
     createdAt,
     updatedAt,
   } = {}) {
+    if (locale) {
+      locale = localeService.getCanonicalLocale(locale);
+    }
+
     this.firstName = firstName;
     this.lastName = lastName;
     this.email = email;

--- a/api/lib/domain/services/locale-service.js
+++ b/api/lib/domain/services/locale-service.js
@@ -3,24 +3,24 @@ const { SUPPORTED_LOCALES } = require('../constants');
 
 module.exports = {
   getCanonicalLocale(locale) {
-    let formattedLocale;
+    let canonicalLocale;
 
     try {
-      formattedLocale = Intl.getCanonicalLocales(locale)[0];
+      canonicalLocale = Intl.getCanonicalLocales(locale)[0];
     } catch (error) {
       throw new LocaleFormatError(locale);
     }
 
     // Pix site uses en-GB as international English locale instead of en
     // TODO remove this code after handling en as international English locale on Pix site
-    if (formattedLocale === 'en-GB') {
-      formattedLocale = 'en';
+    if (canonicalLocale === 'en-GB') {
+      canonicalLocale = 'en';
     }
 
-    if (!SUPPORTED_LOCALES.includes(formattedLocale)) {
-      throw new LocaleNotSupportedError(formattedLocale);
+    if (!SUPPORTED_LOCALES.includes(canonicalLocale)) {
+      throw new LocaleNotSupportedError(canonicalLocale);
     }
 
-    return formattedLocale;
+    return canonicalLocale;
   },
 };

--- a/api/lib/domain/usecases/authenticate-user.js
+++ b/api/lib/domain/usecases/authenticate-user.js
@@ -26,8 +26,8 @@ async function _checkUserAccessScope(scope, user, adminMemberRepository) {
 async function _updateUserLocaleIfNotAlreadySet({ user, locale, localeService, userRepository }) {
   if (user.locale) return;
   if (!locale) return;
-  const formattedLocale = localeService.getCanonicalLocale(locale);
-  return userRepository.updateLocale({ userId: user.id, locale: formattedLocale });
+  const canonicalLocale = localeService.getCanonicalLocale(locale);
+  return userRepository.updateLocale({ userId: user.id, locale: canonicalLocale });
 }
 
 module.exports = async function authenticateUser({

--- a/api/lib/domain/usecases/create-oidc-user.js
+++ b/api/lib/domain/usecases/create-oidc-user.js
@@ -4,6 +4,7 @@ const { AuthenticationKeyExpired, UserAlreadyExistsWithAuthenticationMethodError
 module.exports = async function createOidcUser({
   identityProvider,
   authenticationKey,
+  localeFromCookie,
   authenticationSessionService,
   oidcAuthenticationService,
   authenticationMethodRepository,
@@ -31,6 +32,7 @@ module.exports = async function createOidcUser({
   const user = UserToCreate.createWithTermsOfServiceAccepted({
     firstName: userInfo.firstName,
     lastName: userInfo.lastName,
+    locale: localeFromCookie,
   });
 
   const { userId, idToken } = await oidcAuthenticationService.createUserAccount({

--- a/api/tests/acceptance/application/authentication/oidc/users-route-post_test.js
+++ b/api/tests/acceptance/application/authentication/oidc/users-route-post_test.js
@@ -49,6 +49,9 @@ describe('Acceptance | Route | oidc users', function () {
       const request = {
         method: 'POST',
         url: '/api/oidc/users',
+        headers: {
+          cookie: 'locale=fr-FR',
+        },
         payload: {
           data: {
             attributes: {
@@ -69,6 +72,7 @@ describe('Acceptance | Route | oidc users', function () {
       const createdUser = await knex('users').first();
       expect(createdUser.firstName).to.equal('Brice');
       expect(createdUser.lastName).to.equal('Glace');
+      expect(createdUser.locale).to.equal('fr-FR');
 
       const createdAuthenticationMethod = await knex('authentication-methods').first();
       expect(createdAuthenticationMethod.externalIdentifier).to.equal('sub');

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -184,6 +184,9 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       // given
       const request = {
         deserializedPayload: { identityProvider, authenticationKey: 'abcde' },
+        state: {
+          locale: 'fr-FR',
+        },
       };
       const accessToken = 'access.token';
       const oidcAuthenticationService = {};
@@ -193,7 +196,12 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
         .returns(oidcAuthenticationService);
       sinon
         .stub(usecases, 'createOidcUser')
-        .withArgs({ authenticationKey: 'abcde', identityProvider, oidcAuthenticationService })
+        .withArgs({
+          authenticationKey: 'abcde',
+          identityProvider,
+          oidcAuthenticationService,
+          localeFromCookie: 'fr-FR',
+        })
         .resolves({ accessToken, logoutUrlUUID: 'logoutUrlUUID' });
 
       // when

--- a/api/tests/unit/domain/models/UserToCreate_test.js
+++ b/api/tests/unit/domain/models/UserToCreate_test.js
@@ -1,9 +1,34 @@
 const { expect, sinon } = require('../../../test-helper');
-
+const localeService = require('../../../../lib/domain/services/locale-service');
 const UserToCreate = require('../../../../lib/domain/models/UserToCreate');
 
 describe('Unit | Domain | Models | UserToCreate', function () {
   describe('constructor', function () {
+    it('accepts no locale', function () {
+      // given
+      const users = [
+        new UserToCreate({ locale: '' }),
+        new UserToCreate({ locale: null }),
+        new UserToCreate({ locale: undefined }),
+      ];
+
+      // then
+      expect(users.length).to.equal(3);
+    });
+
+    it('validates and canonicalizes the locale', function () {
+      // given
+      const getCanonicalLocaleStub = sinon.stub(localeService, 'getCanonicalLocale');
+      getCanonicalLocaleStub.returns('fr-BE');
+
+      // when
+      const userToCreate = new UserToCreate({ locale: 'fr-be' });
+
+      // then
+      expect(getCanonicalLocaleStub).to.have.been.calledWith('fr-be');
+      expect(userToCreate.locale).to.equal('fr-BE');
+    });
+
     it('should build a default user', function () {
       // given / when
       const user = new UserToCreate();

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -1,5 +1,6 @@
-const { expect, domainBuilder } = require('../../../test-helper');
+const { sinon, expect, domainBuilder } = require('../../../test-helper');
 const config = require('../../../../lib/config');
+const localeService = require('../../../../lib/domain/services/locale-service');
 const User = require('../../../../lib/domain/models/User');
 
 describe('Unit | Domain | Models | User', function () {
@@ -10,6 +11,19 @@ describe('Unit | Domain | Models | User', function () {
 
       //then
       expect(users.length).to.equal(3);
+    });
+
+    it('validates and canonicalizes the locale', function () {
+      // given
+      const getCanonicalLocaleStub = sinon.stub(localeService, 'getCanonicalLocale');
+      getCanonicalLocaleStub.returns('fr-BE');
+
+      // when
+      const user = new User({ locale: 'fr-be' });
+
+      // then
+      expect(getCanonicalLocaleStub).to.have.been.calledWith('fr-be');
+      expect(user.locale).to.equal('fr-BE');
     });
   });
 

--- a/api/tests/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-user_test.js
@@ -395,7 +395,7 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
 
         pixAuthenticationService.getUserByUsernameAndPassword.resolves(user);
         refreshTokenService.createAccessTokenFromRefreshToken.resolves({ accessToken, expirationDelaySeconds });
-        localeService.getCanonicalLocale.returns('formattedLocale');
+        localeService.getCanonicalLocale.returns('canonicalLocale');
 
         // when
         await authenticateUser({
@@ -413,7 +413,7 @@ describe('Unit | Application | UseCase | authenticate-user', function () {
         expect(localeService.getCanonicalLocale).to.have.been.calledWithExactly('localeFromCookie');
         expect(userRepository.updateLocale).to.have.been.calledWithExactly({
           userId: user.id,
-          locale: 'formattedLocale',
+          locale: 'canonicalLocale',
         });
       });
 

--- a/api/tests/unit/domain/usecases/create-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/create-oidc-user_test.js
@@ -103,6 +103,7 @@ describe('Unit | UseCase | create-oidc-user', function () {
     const result = await createOidcUser({
       identityProvider: 'SOME_IDP',
       authenticationKey: 'AUTHENTICATION_KEY',
+      localeFromCookie: 'fr-FR',
       oidcAuthenticationService,
       authenticationSessionService,
       authenticationMethodRepository,
@@ -115,6 +116,7 @@ describe('Unit | UseCase | create-oidc-user', function () {
       user: {
         firstName: 'Jean',
         lastName: 'Heymar',
+        locale: 'fr-FR',
         cgu: true,
         lastTermsOfServiceValidatedAt: now,
       },

--- a/api/tests/unit/domain/usecases/create-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/create-oidc-user_test.js
@@ -88,12 +88,6 @@ describe('Unit | UseCase | create-oidc-user', function () {
   it('should create user account and return an access token, the logout url uuid and update the last logged date with the existing external user id', async function () {
     // given
     const idToken = 'idToken';
-    const expectedUser = {
-      firstName: 'Jean',
-      lastName: 'Heymar',
-      cgu: true,
-      lastTermsOfServiceValidatedAt: now,
-    };
     authenticationSessionService.getByKey.withArgs('AUTHENTICATION_KEY').resolves({
       sessionContent: { idToken, accessToken: 'accessToken' },
       userInfo: { firstName: 'Jean', lastName: 'Heymar', externalIdentityId: 'externalId' },
@@ -118,7 +112,12 @@ describe('Unit | UseCase | create-oidc-user', function () {
 
     // then
     expect(oidcAuthenticationService.createUserAccount).to.have.been.calledWithMatch({
-      user: expectedUser,
+      user: {
+        firstName: 'Jean',
+        lastName: 'Heymar',
+        cgu: true,
+        lastTermsOfServiceValidatedAt: now,
+      },
       sessionContent: { idToken, accessToken: 'accessToken' },
       externalIdentityId: 'externalId',
       userToCreateRepository,

--- a/mon-pix/app/components/authentication/login-or-register-oidc.js
+++ b/mon-pix/app/components/authentication/login-or-register-oidc.js
@@ -73,15 +73,27 @@ export default class LoginOrRegisterOidcComponent extends Component {
           identityProviderSlug: this.args.identityProviderSlug,
           hostSlug: 'users',
         });
-      } catch (error) {
+      } catch (responseError) {
+        const error = get(responseError, 'errors[0]');
         this.registerError = true;
-        const status = get(error, 'errors[0].status');
-        if (status === '401') {
+        switch (error?.code) {
+          case 'INVALID_LOCALE_FORMAT':
+            this.registerErrorMessage = this.intl.t('pages.sign-up.errors.invalid-locale-format', {
+              invalidLocale: error.meta.locale,
+            });
+            return;
+          case 'LOCALE_NOT_SUPPORTED':
+            this.registerErrorMessage = this.intl.t('pages.sign-up.errors.locale-not-supported', {
+              localeNotSupported: error.meta.locale,
+            });
+            return;
+        }
+
+        if (error.status === '401') {
           this.registerErrorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['expiredAuthenticationKey']);
         } else {
-          const errorDetail = get(error, 'errors[0].detail');
           this.registerErrorMessage =
-            this.intl.t(ERROR_INPUT_MESSAGE_MAP['unknownError']) + (errorDetail ? ` (${errorDetail})` : '');
+            this.intl.t(ERROR_INPUT_MESSAGE_MAP['unknownError']) + (error.detail ? ` (${error.detail})` : '');
         }
       }
     } else {

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -183,14 +183,14 @@ export default class SignupForm extends Component {
     }
 
     switch (firstError?.code) {
-      case 'LOCALE_NOT_SUPPORTED':
-        this.errorMessage = this.intl.t('pages.sign-up.errors.locale-not-supported', {
-          localeNotSupported: firstError.meta.locale,
-        });
-        return;
       case 'INVALID_LOCALE_FORMAT':
         this.errorMessage = this.intl.t('pages.sign-up.errors.invalid-locale-format', {
           invalidLocale: firstError.meta.locale,
+        });
+        return;
+      case 'LOCALE_NOT_SUPPORTED':
+        this.errorMessage = this.intl.t('pages.sign-up.errors.locale-not-supported', {
+          localeNotSupported: firstError.meta.locale,
         });
         return;
     }

--- a/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
@@ -76,6 +76,60 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
       });
     });
 
+    module('locale errors', function () {
+      module('when invalid locale', function () {
+        test('it displays the invalid locale error message', async function (assert) {
+          // given
+          const component = createGlimmerComponent('component:authentication/login-or-register-oidc');
+          const authenticateStub = sinon
+            .stub()
+            .rejects({ errors: [{ status: '400', code: 'INVALID_LOCALE_FORMAT', meta: { locale: 'zzzz' } }] });
+          class SessionStub extends Service {
+            authenticate = authenticateStub;
+          }
+          this.owner.register('service:session', SessionStub);
+          component.args.identityProviderSlug = 'super-idp';
+          component.args.authenticationKey = 'super-key';
+          component.isTermsOfServiceValidated = true;
+
+          // when
+          await component.register();
+
+          // then
+          assert.strictEqual(
+            component.registerErrorMessage,
+            `${this.intl.t('pages.sign-up.errors.invalid-locale-format', { invalidLocale: 'zzzz' })}`
+          );
+        });
+      });
+
+      module('when locale is not supported', function () {
+        test('it displays the unsupported locale error message', async function (assert) {
+          // given
+          const component = createGlimmerComponent('component:authentication/login-or-register-oidc');
+          const authenticateStub = sinon
+            .stub()
+            .rejects({ errors: [{ status: '400', code: 'LOCALE_NOT_SUPPORTED', meta: { locale: 'jp' } }] });
+          class SessionStub extends Service {
+            authenticate = authenticateStub;
+          }
+          this.owner.register('service:session', SessionStub);
+          component.args.identityProviderSlug = 'super-idp';
+          component.args.authenticationKey = 'super-key';
+          component.isTermsOfServiceValidated = true;
+
+          // when
+          await component.register();
+
+          // then
+          assert.strictEqual(
+            component.registerErrorMessage,
+            `${this.intl.t('pages.sign-up.errors.locale-not-supported', { localeNotSupported: 'jp' })}`
+          );
+        });
+      });
+    });
+
     test('it should display detailed error', async function (assert) {
       // given
       const component = createGlimmerComponent('component:authentication/login-or-register-oidc');


### PR DESCRIPTION
## :unicorn: Problème

La locale de l'utilisateur n'est pas enregistrée à l'inscription depuis un SSO OIDC.

## :robot: Proposition

1. À la connexion depuis un SSO, enregistrer la locale (lue dans le cookie `locale`) lors de la création de l'utilisateur.
2. Ajouter la gestion des deux nouvelles erreurs au niveau du formulaire d'inscription

## :rainbow: Remarques

RAS

## :100: Pour tester

Cette PR ne peut pas être testée par le biais des RA car aucun SSO n'est configuré pour fonctionner avec les RA.

De plus de manière à pouvoir facilement recréer plusieurs comptes il est préférable de gérer ses propres comptes en local.

→ Donc il faut tester en **local**.

**1. Domaine .fr**

1. Aller sur Pix App version .fr (par exemple http://app.dev.pix.fr/)
3. Se connecter via un SSO au choix (par exemple http://app.dev.pix.fr/connexion/pole-emploi)
4. Choisir un utilisateur de son choix et se connecter selon les modalités de chaque SSO
5. Une fois l'authentification réussie, sur la page « Créez votre compte Pix », aller dans le panneau de gauche « Je n'ai pas de compte Pix » de la double mire et cocher « J'accepte les conditions d'utilisation », puis cliquer sur « Je crée mon compte »
6. Tester ensuite dans Pix Admin que l'utilisateur **n'a pas de locale**

**2. Domaine .org et sans cookie**

1. Aller sur Pix App version .org (par exemple http://app.dev.pix.org/)
2. Effacer le cookie `locale` si il est présent
3. Se connecter via un SSO au choix (par exemple http://app.dev.pix.org/connexion/fwb)
4. Choisir un utilisateur de son choix et se connecter selon les modalités de chaque SSO
5. Une fois l'authentification réussie, sur la page « Créez votre compte Pix », aller dans le panneau de gauche « Je n'ai pas de compte Pix » de la double mire et cocher « J'accepte les conditions d'utilisation », puis cliquer sur « Je crée mon compte »
7. Tester ensuite dans Pix Admin que l'utilisateur **n'a pas de locale**

**3. Domaine .org et avec cookie**

1. Se connecter sur un site vitrine et choisir une locale sur la page d'accueil pour positionner le cookie (par exemple https://pix.org/)
2. . Revenir sur Pix App version .org (par exemple http://app.dev.pix.org/)
3. Se connecter via un SSO au choix (par exemple http://app.dev.pix.org/connexion/fwb)
4. Choisir un utilisateur de son choix et se connecter selon les modalités de chaque SSO
5. Une fois l'authentification réussie, sur la page « Créez votre compte Pix », aller dans le panneau de gauche « Je n'ai pas de compte Pix » de la double mire et cocher « J'accepte les conditions d'utilisation », puis cliquer sur « Je crée mon compte »
6. Tester ensuite dans Pix Admin que l'utilisateur **a bien la locale choisie lors de la visite du site vitrine**