### PR TITLE
[FEATURE] Améliorer le label de la page "J'ai un code" (PIX-7263).

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
@@ -8,7 +8,7 @@ Fonctionnalité: Campagne d'évaluation
     Étant donné que je vais sur Pix
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Lorsque je vais sur la page d'accès à une campagne
-    Et je saisis "NERA" dans le champ "Ce code est transmis par votre établissement/organisation et permet de démarrer un parcours ou d’envoyer votre profil."
+    Et je saisis le code "NERA"
     Lorsque je clique sur "Accéder au parcours"
     Alors je vois la page de "presentation" de la campagne
     Et la page "Presentation campagne evaluation" est correctement affichée
@@ -45,7 +45,7 @@ Fonctionnalité: Campagne d'évaluation
     Étant donné que je vais sur Pix
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Et je vais sur la page d'accès à une campagne
-    Lorsque je saisis "WINTER" dans le champ "Ce code est transmis par votre établissement/organisation et permet de démarrer un parcours ou d’envoyer votre profil."
+    Lorsque je saisis le code "WINTER"
     Et je clique sur "Accéder au parcours"
     Alors je vois la page de "presentation" de la campagne
     Lorsque je clique sur "Je commence"
@@ -59,7 +59,7 @@ Fonctionnalité: Campagne d'évaluation
 
   Scénario: Je rejoins un parcours prescrit restreint en étant connecté via un organisme externe
     Étant donné que je me connecte à Pix via le GAR
-    Lorsque je saisis "WINTER" dans le champ "Ce code est transmis par votre établissement/organisation et permet de démarrer un parcours ou d’envoyer votre profil."
+    Lorsque je saisis le code "WINTER"
     Et je clique sur "Accéder au parcours"
     Alors je vois la page de "presentation" de la campagne
     Lorsque je clique sur "Je commence"

--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-collect-profiles.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-collect-profiles.feature
@@ -8,7 +8,7 @@ Fonctionnalité: Campagne de collecte de profils
     Étant donné que je vais sur Pix
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Lorsque je vais sur la page d'accès à une campagne
-    Et je saisis "LION" dans le champ "Ce code est transmis par votre établissement/organisation et permet de démarrer un parcours ou d’envoyer votre profil."
+    Et je saisis le code "LION"
     Lorsque je clique sur "Accéder au parcours"
     Alors je vois la page de "presentation" de la campagne
     Et la page "Presentation campagne collecte profils" est correctement affichée
@@ -34,7 +34,7 @@ Fonctionnalité: Campagne de collecte de profils
     Étant donné que je vais sur Pix
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Et je vais sur la page d'accès à une campagne
-    Lorsque je saisis "WOLF" dans le champ "Ce code est transmis par votre établissement/organisation et permet de démarrer un parcours ou d’envoyer votre profil."
+    Lorsque je saisis le code "WOLF"
     Et je clique sur "Accéder au parcours"
     Alors je vois la page de "presentation" de la campagne
     Lorsque je clique sur "C'est parti !"
@@ -50,7 +50,7 @@ Fonctionnalité: Campagne de collecte de profils
 
   Scénario: Je partage mon profil de manière restreinte en étant connecté via un organisme externe
     Étant donné que je me connecte à Pix via le GAR
-    Lorsque je saisis "WOLF" dans le champ "Ce code est transmis par votre établissement/organisation et permet de démarrer un parcours ou d’envoyer votre profil."
+    Lorsque je saisis le code "WOLF"
     Et je clique sur "Accéder au parcours"
     Alors je vois la page de "presentation" de la campagne
     Lorsque je clique sur "C'est parti !"

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -69,6 +69,10 @@ When(`je saisis {string} dans le champ {string}`, (value, label) => {
   cy.contains(label).type(value);
 });
 
+When(`je saisis le code {string}`, (value) => {
+  cy.get('input[id="campaign-code"]').type(value);
+});
+
 When(`je sélectionne {string} dans le champ {string}`, (value, label) => {
   cy.contains(label)
     .parent()

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -15,15 +15,17 @@
       <h1 class="fill-in-campaign-code__title rounded-panel-title">
         {{this.firstTitle}}
       </h1>
-
-      <label for="campaign-code" class="fill-in-campaign-code__instruction">{{{t
+      <p id="campaign-code-description" class="fill-in-campaign-code__instruction">{{{t
           "pages.fill-in-campaign-code.description"
-        }}}</label>
+        }}}</p>
+
+      <label for="campaign-code" class="screen-reader-only">{{{t "pages.fill-in-campaign-code.label"}}}</label>
       <form class="fill-in-campaign-code__form" autocomplete="off">
 
         <div class="fill-in-campaign-code__form-field">
           <Input
             required
+            aria-describedby="campaign-code-description"
             id="campaign-code"
             class="input-code"
             @type="text"

--- a/mon-pix/tests/acceptance/fill-in-campaign-code_test.js
+++ b/mon-pix/tests/acceptance/fill-in-campaign-code_test.js
@@ -65,13 +65,11 @@ module('Acceptance | Fill in campaign code page', function (hooks) {
 
         // when
         const screen = await visit(`/campagnes`);
-        await fillIn(screen.getByLabelText(this.intl.t('pages.fill-in-campaign-code.description')), campaign.code);
+        await fillIn(screen.getByLabelText(this.intl.t('pages.fill-in-campaign-code.label')), campaign.code);
         await click(screen.getByRole('button', { name: 'Accéder au parcours' }));
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/campagnes');
+        assert.strictEqual(currentURL(), '/campagnes');
         assert.ok(screen.getByText(this.intl.t('pages.fill-in-campaign-code.mediacentre-start-campaign-modal.title')));
       });
 
@@ -86,15 +84,13 @@ module('Acceptance | Fill in campaign code page', function (hooks) {
 
           // when
           const screen = await visit(`/campagnes`);
-          await fillIn(screen.getByLabelText(this.intl.t('pages.fill-in-campaign-code.description')), campaign.code);
+          await fillIn(screen.getByLabelText(this.intl.t('pages.fill-in-campaign-code.label')), campaign.code);
           await click(screen.getByRole('button', { name: 'Accéder au parcours' }));
           await waitForDialog();
           await click(screen.getByRole('link', { name: 'Continuer' }));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
         });
       });
 
@@ -109,15 +105,13 @@ module('Acceptance | Fill in campaign code page', function (hooks) {
 
           // when
           const screen = await visit(`/campagnes`);
-          await fillIn(screen.getByLabelText(this.intl.t('pages.fill-in-campaign-code.description')), campaign.code);
+          await fillIn(screen.getByLabelText(this.intl.t('pages.fill-in-campaign-code.label')), campaign.code);
           await click(screen.getByRole('button', { name: 'Accéder au parcours' }));
           await waitForDialog();
           await click(screen.getByRole('button', { name: 'Quitter' }));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), '/campagnes');
+          assert.strictEqual(currentURL(), '/campagnes');
         });
       });
     });
@@ -129,13 +123,11 @@ module('Acceptance | Fill in campaign code page', function (hooks) {
 
         // when
         const screen = await visit(`/campagnes`);
-        await fillIn(screen.getByLabelText(this.intl.t('pages.fill-in-campaign-code.description')), campaign.code);
+        await fillIn(screen.getByLabelText(this.intl.t('pages.fill-in-campaign-code.label')), campaign.code);
         await click(screen.getByRole('button', { name: 'Accéder au parcours' }));
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+        assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
       });
     });
   });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -767,7 +767,8 @@
     },
     "fill-in-campaign-code": {
       "title": "I have a code",
-      "description": "This code is given by your school/organisation and can be used to start a customised test or to submit your profile",
+      "description": "This code contains 9 letters and/or numbers. It is given by your school/organisation and can be used to start a customised test or to submit your profile",
+      "label": "Enter your code to start",
       "errors": {
         "forbidden": "Oops! We can’t find you. Check your details to continue or contact the organiser.",
         "missing-code": "Please enter a code.",
@@ -777,7 +778,7 @@
       "explanation-link": "https://support.pix.org/en/support/solutions/articles/15000029147-what-is-a-customised-test-code-and-how-do-i-use-it-",
       "first-title-connected": "{ firstName }, enter your code",
       "first-title-not-connected": "Enter your code",
-      "start": "Start the customised test",
+      "start": "Start",
       "warning-message": "If you are not { firstName } { lastName },",
       "warning-message-logout": "please log out",
       "mediacentre-start-campaign-modal": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -767,7 +767,8 @@
     },
     "fill-in-campaign-code": {
       "title": "J'ai un code",
-      "description": "Ce code est transmis par votre établissement/organisation et permet de démarrer un parcours ou d’envoyer votre profil.",
+      "description": "Ce code est composé de 9 chiffres et/ou lettres. Il est transmis par votre établissement/organisation et permet de démarrer un parcours ou d’envoyer votre profil.",
+      "label": "Saisir votre code pour commencer.",
       "errors": {
         "forbidden": "Oups ! nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez l’organisateur.",
         "missing-code": "Veuillez saisir un code.",


### PR DESCRIPTION
## :unicorn: Problème
Pertinence Label - Le label lest très long et peut prêter à confusion, il ressemble plus à une explication qu'une étiquette. 

## :robot: Proposition
Placer ce texte dans un élément <p> et l'associer au champ avec un attribut aria-describedby. Rajouter une étiquette (visible ou non) avec un label plus concis et pertinent (Ex : Code de 9 caractères alphanumériques)

## :rainbow: Remarques
Wording du bouton modifié pour la version en

## :100: Pour tester
(Avec un lecteur d'écran)
Aller sur Mon Pix sur la page "J'ai un code".
Vérifier que la description et le label sont bien restitués.
