### PR TITLE
[FEATURE] Modale autorisation à reprendre dans l'ES en anglais (PIX-6680)

### DIFF
--- a/certif/app/components/session-supervising/candidate-in-list.js
+++ b/certif/app/components/session-supervising/candidate-in-list.js
@@ -46,7 +46,9 @@ export default class CandidateInList extends Component {
       'pages.session-supervising.candidate-in-list.resume-test-modal.description'
     );
     this.modalCancelText = this.intl.t('common.actions.close');
-    this.modalConfirmationText = this.intl.t('pages.session-supervising.candidate-in-list.resume-test-modal.confirm');
+    this.modalConfirmationText = this.intl.t(
+      'pages.session-supervising.candidate-in-list.resume-test-modal.actions.confirm'
+    );
     this.modalInstructionText = this.intl.t(
       'pages.session-supervising.candidate-in-list.resume-test-modal.instruction-with-name',
       {

--- a/certif/app/templates/session-supervising.hbs
+++ b/certif/app/templates/session-supervising.hbs
@@ -1,4 +1,4 @@
-{{page-title "Surveiller la session n° " @model.id}}
+{{page-title (t "pages.session-supervising.title" sessionId=@model.id)}}
 
 <div class="app">
   <div class="session-supervising-page">

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -522,13 +522,15 @@
           "error": "An error occured, {firstName} {lastName}'s test could not be finished."
         },
         "resume-test-modal": {
-          "allow-test-resume": "Autoriser la reprise du test",
-          "description": "Si le candidat a fermé la fenêtre de son test de certification (par erreur, ou à cause d'un problème technique) et est toujours présent dans la salle de test, vous pouvez lui permettre de reprendre son test à l'endroit où il l'avait quitté.",
-          "instruction-with-name": "Autoriser {firstName} {lastName} à reprendre son test ?`",
-          "confirm": "Je confirme l'autorisation",
-          "cancel-label": "Annuler et fermer la fenêtre de confirmation",
-          "success": "Succès ! {firstName} {lastName} peut reprendre son test de certification.",
-          "error": "Une erreur est survenue, {firstName} {lastName} n'a a pu être autorisé à reprendre son test."
+          "actions": {
+            "confirm": "I confirm permission"
+          },
+          "allow-test-resume": "Allow to resume the test",
+          "cancel-label": "Cancel and close the confirmation window",
+          "description": "If the candidate has closed their Pix Certification exam window (by mistake, or because of a technical problem) and is still present in the exam room, you can allow them to resume their test where they left it.",
+          "error": " An error has occurred, {firstName} {lastName} couldn't be allowed to resume his/her Pix certification exam.",
+          "instruction-with-name": "Allow {firstName} {lastName} to resume their test ?",
+          "success": "Success ! {firstName} {lastName} can resume his/her Pix certification exam."
         }
       }
     },

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -465,6 +465,7 @@
       }
     },
     "session-supervising": {
+      "title": "Inviligate session n° {sessionId}",
       "login": {
         "title": "Log into the invigilator's portal",
         "form": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -521,13 +521,15 @@
           "error": "Une erreur est survenue, le test de {firstName} {lastName} n'a pas pu être terminé."
         },
         "resume-test-modal": {
+          "actions": {
+            "confirm": "Je confirme l'autorisation"
+          },
           "allow-test-resume": "Autoriser la reprise du test",
-          "description": "Si le candidat a fermé la fenêtre de son test de certification (par erreur, ou à cause d'un problème technique) et est toujours présent dans la salle de test, vous pouvez lui permettre de reprendre son test à l'endroit où il l'avait quitté.",
-          "instruction-with-name": "Autoriser {firstName} {lastName} à reprendre son test ?",
-          "confirm": "Je confirme l'autorisation",
           "cancel-label": "Annuler et fermer la fenêtre de confirmation",
-          "success": "Succès ! {firstName} {lastName} peut reprendre son test de certification.",
-          "error": "Une erreur est survenue, {firstName} {lastName} n'a a pu être autorisé à reprendre son test."
+          "description": "Si le candidat a fermé la fenêtre de son test de certification (par erreur, ou à cause d'un problème technique) et est toujours présent dans la salle de test, vous pouvez lui permettre de reprendre son test à l'endroit où il l'avait quitté.",
+          "error": "Une erreur est survenue, {firstName} {lastName} n'a a pu être autorisé à reprendre son test.",
+          "instruction-with-name": "Autoriser {firstName} {lastName} à reprendre son test ?",
+          "success": "Succès ! {firstName} {lastName} peut reprendre son test de certification."
         }
       }
     },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -464,6 +464,7 @@
       }
     },
     "session-supervising": {
+      "title": "Surveiller la session n° {sessionId}",
       "login": {
         "title": "Connexion à l'espace surveillant",
         "form": {


### PR DESCRIPTION
## :unicorn: Problème
Afin d'élargir le champ de prospection et de développement de Pix, et plus précisément de sa certification, à l’international, il nous faut permettre une utilisation de Pix Certif par un utilisateur anglophone.

Une fois connecté sur l’Espace Surveillant de Pix Certif, un utilisateur anglophone dispose d’une page pour l’aider dans sa surveillance de session de certification.

Lorsqu’un candidat a commencé sa session de certification, un menu peut-être ouvert au bout de sa ligne afin que le surveillant puisse effectuer une action pour ce candidat : autoriser à reprendre s’il a été déconnecté, ou bien terminer son test avant qu’il n’en soit parvenu au bout.

S’il sélectionne “Autoriser à reprendre”, une modale s’ouvre mais toutes les informations sont en français.

## :robot: Proposition
Traduire cette modale

## :100: Pour tester
![image](https://user-images.githubusercontent.com/37305474/227264584-b612463a-df9e-489a-9bd5-f74865e271f6.png)

