### PR TITLE
[FEATURE] Ajouter un exemple de format de code attendu dans l'erreur de la page "J'ai un code" (PIX-7264)

### DIFF
--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -408,7 +408,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
           assert.strictEqual(currentURL(), '/campagnes');
           assert.ok(
             find('.fill-in-campaign-code__error').textContent.includes(
-              'Votre code est erroné, veuillez vérifier ou contacter l’organisateur.'
+              t('pages.fill-in-campaign-code.errors.not-found')
             )
           );
         });

--- a/mon-pix/tests/unit/controllers/fill-in-campaign-code_test.js
+++ b/mon-pix/tests/unit/controllers/fill-in-campaign-code_test.js
@@ -152,10 +152,7 @@ module('Unit | Controller | Fill in Campaign Code', function (hooks) {
       // then
       // TODO: Fix this the next time the file is edited.
       // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(
-        controller.get('errorMessage'),
-        'Votre code est erroné, veuillez vérifier ou contacter l’organisateur.'
-      );
+      assert.equal(controller.get('errorMessage'), controller.intl.t('pages.fill-in-campaign-code.errors.not-found'));
     });
 
     test('should set error when student is not authorized in campaign', async function (assert) {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -772,7 +772,7 @@
       "errors": {
         "forbidden": "Oops! We can’t find you. Check your details to continue or contact the organiser.",
         "missing-code": "Please enter a code.",
-        "not-found": "Your code is incorrect. Please check it or contact the organiser."
+        "not-found": "Your code is incorrect. Please check its format (ex: ABCDEF234) or contact the organiser."
       },
       "explanation-message": "What is a customised test code and how do I use it?",
       "explanation-link": "https://support.pix.org/en/support/solutions/articles/15000029147-what-is-a-customised-test-code-and-how-do-i-use-it-",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -772,7 +772,7 @@
       "errors": {
         "forbidden": "Oups ! nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez l’organisateur.",
         "missing-code": "Veuillez saisir un code.",
-        "not-found": "Votre code est erroné, veuillez vérifier ou contacter l’organisateur."
+        "not-found": "Votre code est erroné, veuillez vérifier son format (ex: ABCDEF234) ou contacter l’organisateur."
       },
       "explanation-message": "Qu’est-ce qu’un code parcours et comment l’utiliser ?",
       "explanation-link": "https://support.pix.org/fr/support/solutions/articles/15000029147-qu-est-ce-qu-un-code-parcours-et-comment-l-utiliser-",


### PR DESCRIPTION
## :unicorn: Problème
Il n'a pas d'exemple de format attendu pour le code ni de rappel dans son erreur.

## :robot: Proposition
Ajouter un exemple de format dans l'erreur quand le code est erroné

## :rainbow: Remarques
Jambon

## :100: Pour tester
- Aller sur la page j'ai un code
- Renseigner un code erroné
- Vérifier l'erreur
- Peut être testé en étant connecté et non connecté
- Tada 🎉 