### PR TITLE
[FEATURE] Montée de version de Pix UI en v29.0.0 sur Pix App (PIX-7550)

### DIFF
--- a/mon-pix/app/components/skill-review-improve.hbs
+++ b/mon-pix/app/components/skill-review-improve.hbs
@@ -1,6 +1,6 @@
 <div class="skill-review__begin-improvement">
   <div>
-    <h2 class="skill-review__subtitle">
+    <h2>
       {{t "pages.skill-review.improve.title"}}
     </h2>
     <p class="skill-review__explain-text">

--- a/mon-pix/app/styles/components/_assessment-banner.scss
+++ b/mon-pix/app/styles/components/_assessment-banner.scss
@@ -21,7 +21,6 @@
 
 .assessment-banner__title {
   margin: 0;
-  font-weight: $font-light;
   font-size: 1.094rem;
 
   @include device-is('mobile') {

--- a/mon-pix/app/styles/components/_badge-card-certifiable.scss
+++ b/mon-pix/app/styles/components/_badge-card-certifiable.scss
@@ -22,7 +22,7 @@
   }
 
   &__header {
-    margin-bottom: $spacing-s;
+    margin-bottom: $pix-spacing-s;
     text-align: center;
   }
 

--- a/mon-pix/app/styles/components/_certification-joiner.scss
+++ b/mon-pix/app/styles/components/_certification-joiner.scss
@@ -48,13 +48,13 @@
     }
 
     &.certification-joiner__input--invalid:not(:hover) {
-      outline: 1px solid $error;
-      box-shadow: 0 0 0 2px $error;
+      outline: 1px solid $pix-error-50;
+      box-shadow: 0 0 0 2px $pix-error-50;
     }
 
     &.certification-joiner__input--invalid:focus {
-      outline: 1px solid $error;
-      box-shadow: 0 0 0 2px $error;
+      outline: 1px solid $pix-error-50;
+      box-shadow: 0 0 0 2px $pix-error-50;
     }
   }
 

--- a/mon-pix/app/styles/components/_certification-joiner.scss
+++ b/mon-pix/app/styles/components/_certification-joiner.scss
@@ -5,7 +5,6 @@
   &__title {
     margin-bottom: 32px;
     color: $pix-neutral-90;
-    font-weight: $font-light;
     font-size: 2rem;
     font-family: $font-open-sans;
     text-align: center;
@@ -112,7 +111,6 @@
   }
 
   .certification-course-page {
-
     &__errors {
       margin: 5px;
       color: $pix-warning-60;
@@ -120,7 +118,6 @@
       text-align: start;
 
       &__list {
-
         li {
           margin: 8px 0 0 16px;
           text-align: start;

--- a/mon-pix/app/styles/components/_certification-not-certifiable.scss
+++ b/mon-pix/app/styles/components/_certification-not-certifiable.scss
@@ -19,7 +19,6 @@
 }
 
 .certification-not-certifiable__title {
-  font-weight: $font-light;
   font-size: 2rem;
   font-family: $font-open-sans;
   text-align: center;

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -104,7 +104,7 @@
       display: flex;
       align-items: center;
       padding: 10px 16px;
-      color: $yellow-alert-dark;
+      color: $pix-warning-70;
       background-color: $yellow-alert-light;
     }
 

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -9,7 +9,6 @@
 }
 
 .certification-start-page {
-
   &__block {
     max-width: 980px;
     margin-bottom: 32px;
@@ -27,7 +26,6 @@
     text-align: start;
 
     &__list {
-
       li {
         margin: 8px 0 0 16px;
         text-align: start;
@@ -62,7 +60,6 @@
   &__title {
     margin-bottom: 20px;
     color: $pix-neutral-100;
-    font-weight: $font-light;
     font-size: 2.625rem;
     font-family: $font-open-sans;
     text-align: center;
@@ -122,7 +119,6 @@
   margin-top: 5px;
   margin-bottom: 5px;
   color: $pix-neutral-80;
-  font-weight: $font-light;
   font-size: 1.25rem;
   font-family: $font-open-sans;
   line-height: 28px;
@@ -160,11 +156,14 @@
   font-family: $font-roboto-mono;
   letter-spacing: $space-between-dashes;
   text-transform: uppercase;
-  background: repeating-linear-gradient(90deg,
-    $pix-neutral-22 0,
-    $pix-neutral-22 1ch,
-    transparent 0,
-    transparent 1ch + $space-between-dashes) 0 100% / #{$total-width - $space-between-dashes} 2px no-repeat;
+  background: repeating-linear-gradient(
+      90deg,
+      $pix-neutral-22 0,
+      $pix-neutral-22 1ch,
+      transparent 0,
+      transparent 1ch + $space-between-dashes
+    )
+    0 100% / #{$total-width - $space-between-dashes} 2px no-repeat;
   background-position-x: 0.5ch;
   background-position-y: 2.5ch;
   border: solid 2px $pix-neutral-20;
@@ -182,11 +181,14 @@
     // display differently for IE because 1 character (ch) is equal to 1.162
     line-height: 0.7;
     letter-spacing: $space-between-dashes;
-    background: repeating-linear-gradient(90deg,
-      $pix-neutral-22 0,
-      $pix-neutral-22 1.3ch,
-      transparent 0,
-      transparent 1.3ch + $space-between-dashes) 0 100% / #{$total-width - $space-between-dashes} 2px no-repeat;
+    background: repeating-linear-gradient(
+        90deg,
+        $pix-neutral-22 0,
+        $pix-neutral-22 1.3ch,
+        transparent 0,
+        transparent 1.3ch + $space-between-dashes
+      )
+      0 100% / #{$total-width - $space-between-dashes} 2px no-repeat;
     background-position-x: 0.1ch * $ie11-modifier;
     background-position-y: 2.8ch * $ie11-modifier;
     background-origin: content-box;

--- a/mon-pix/app/styles/components/_certification-starter.scss
+++ b/mon-pix/app/styles/components/_certification-starter.scss
@@ -105,7 +105,7 @@
       align-items: center;
       padding: 10px 16px;
       color: $pix-warning-70;
-      background-color: $yellow-alert-light;
+      background-color: $pix-warning-5;
     }
 
     &__info-icon {

--- a/mon-pix/app/styles/components/_challenge-actions.scss
+++ b/mon-pix/app/styles/components/_challenge-actions.scss
@@ -57,7 +57,7 @@
   &__already-answered {
     margin-right: 20px;
     color: $pix-neutral-70;
-    font-weight: $font-semi-bold;
+    font-weight: $font-medium;
     font-size: 1rem;
     font-family: $font-roboto;
     letter-spacing: 0.031rem;
@@ -82,7 +82,6 @@
 }
 
 .challenge-actions-alert-message {
-
   &__icon {
     margin-right: 20px;
     margin-left: 0;

--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -107,7 +107,7 @@ form .challenge-response {
   .qroc-proposal {
     display: flex;
     flex-wrap: wrap;
-    gap: $spacing-xs;
+    gap: $pix-spacing-xs;
     align-items: center;
 
     .qroc_input-label {

--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -188,7 +188,7 @@
 .challenge-statement__action-link {
   width: 156px;
   height: 46px;
-  margin-bottom: $spacing-m;
+  margin-bottom: $pix-spacing-m;
   color: $pix-neutral-0;
   text-align: center;
   background-color: $pix-primary;

--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -211,7 +211,7 @@
     &:active,
     &:focus,
     &:hover {
-      color: $dark-blue-pro;
+      color: $pix-primary-60;
     }
 
     &:visited {

--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -48,7 +48,7 @@
     }
 
     strong {
-      font-weight: $font-heavy;
+      font-weight: $font-bold;
     }
 
     a {
@@ -230,7 +230,7 @@
 
 .challenge-statement__action-label {
   width: 76px;
-  font-weight: $font-heavy;
+  font-weight: $font-bold;
   font-size: 1rem;
   line-height: 46px;
   text-transform: uppercase;

--- a/mon-pix/app/styles/components/_checkpoint.scss
+++ b/mon-pix/app/styles/components/_checkpoint.scss
@@ -79,7 +79,6 @@
   &:hover,
   &:focus,
   &:active {
-
     & > svg {
       left: 12px;
     }
@@ -93,7 +92,6 @@
   text-align: center;
 
   &__header {
-    font-weight: $font-light;
     font-size: 2.625rem;
     line-height: 3rem;
   }
@@ -103,7 +101,6 @@
     margin-top: 0;
     margin-bottom: 40px;
     color: $pix-neutral-60;
-    font-weight: $font-light;
     font-size: 1.5rem;
     line-height: 2.063rem;
     white-space: pre-line;

--- a/mon-pix/app/styles/components/_comparison-window.scss
+++ b/mon-pix/app/styles/components/_comparison-window.scss
@@ -84,5 +84,5 @@
 }
 
 .comparison-window .feedback-panel {
-  margin-bottom: $spacing-xs;
+  margin-bottom: $pix-spacing-xs;
 }

--- a/mon-pix/app/styles/components/_comparison-window.scss
+++ b/mon-pix/app/styles/components/_comparison-window.scss
@@ -46,7 +46,7 @@
   &__default-message-title {
     margin: 10px 25px 40px;
     color: $pix-neutral-110;
-    font-weight: $font-semi-bold;
+    font-weight: $font-medium;
     font-size: 1.063rem;
     font-family: $font-open-sans;
     text-align: center;

--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -1,6 +1,6 @@
 .feedback-panel {
   z-index: 1;
-  padding: 0 $spacing-s;
+  padding: 0 $pix-spacing-s;
   color: $pix-neutral-60;
   font-size: 0.938rem;
   background-color: white;
@@ -24,7 +24,7 @@
   cursor: pointer;
 
   svg {
-    margin-right: $spacing-xxs;
+    margin-right: $pix-spacing-xxs;
   }
 
   &[aria-expanded='true'] {
@@ -46,7 +46,7 @@
 }
 
 .feedback-panel__view--form {
-  padding: $spacing-xs 0;
+  padding: $pix-spacing-xs 0;
 }
 
 .feedback-panel__form-description {
@@ -63,7 +63,7 @@
 
 .feedback-panel__form-wrapper {
   display: flex;
-  margin-top: $spacing-s;
+  margin-top: $pix-spacing-s;
 }
 
 .feedback-panel__form {
@@ -71,7 +71,7 @@
 }
 
 .feedback-panel__group {
-  margin-bottom: $spacing-xs;
+  margin-bottom: $pix-spacing-xs;
 }
 
 .feedback-panel__field {
@@ -85,14 +85,14 @@
 }
 
 .feedback-panel__field-notice {
-  margin: $spacing-s 0 $spacing-xxs;
+  margin: $pix-spacing-s 0 $pix-spacing-xxs;
   font-size: 0.75rem;
 }
 
 .feedback-panel__category-selection {
   display: flex;
   flex-direction: column;
-  gap: $spacing-s;
+  gap: $pix-spacing-s;
 }
 
 .feedback-panel__dropdown {
@@ -156,8 +156,8 @@
 }
 
 .feedback-panel__form-legal-notice {
-  margin-top: $spacing-s;
-  padding-top: $spacing-s;
+  margin-top: $pix-spacing-s;
+  padding-top: $pix-spacing-s;
   color: $pix-neutral-50;
   font-size: 0.75rem;
   line-height: 1.5;
@@ -172,12 +172,12 @@
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 
 .feedback-panel__view--mercix {
-  padding: $spacing-s 0 $spacing-m;
+  padding: $pix-spacing-s 0 $pix-spacing-m;
   font-size: 1rem;
   text-align: center;
 
   p + p {
-    margin-top: $spacing-xs;
+    margin-top: $pix-spacing-xs;
   }
 }
 

--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -53,10 +53,10 @@
   font-size: 1.25rem;
 
   & .link {
-    color: $dark-blue-pro;
+    color: $pix-primary-60;
 
     &:hover {
-      color: $dark-blue-pro;
+      color: $pix-primary-60;
     }
   }
 }

--- a/mon-pix/app/styles/components/_focused-certification-challenge-instructions.scss
+++ b/mon-pix/app/styles/components/_focused-certification-challenge-instructions.scss
@@ -10,7 +10,6 @@
   justify-content: center;
 
   &__image {
-
     img {
       width: 158px;
       height: 158px;
@@ -20,7 +19,6 @@
   &__title {
     margin-top: 22px;
     color: $pix-neutral-80;
-    font-weight: $font-light;
     font-size: 3rem;
     font-family: $font-open-sans;
     font-style: normal;
@@ -48,7 +46,6 @@
 }
 
 .focused-challenge-instructions-action {
-
   &__confirmation-button {
     font-size: 0.875rem;
     text-transform: uppercase;

--- a/mon-pix/app/styles/components/_footer.scss
+++ b/mon-pix/app/styles/components/_footer.scss
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   max-width: 1280px;
-  padding: $spacing-m 20px;
+  padding: $pix-spacing-m 20px;
 
   @include device-is('desktop') {
     flex-direction: row;

--- a/mon-pix/app/styles/components/_login-or-register.scss
+++ b/mon-pix/app/styles/components/_login-or-register.scss
@@ -29,7 +29,6 @@
 }
 
 .login-or-register-panel {
-
   &__logo {
     display: flex;
     width: 159px;
@@ -80,7 +79,6 @@
 }
 
 .login-or-register-panel-form {
-
   &__expandable {
     display: flex;
     flex-direction: column;
@@ -97,7 +95,6 @@
 .form-title {
   margin-bottom: 20px;
   color: $pix-neutral-100;
-  font-weight: $font-light;
   font-size: 1.875rem;
   font-family: $font-open-sans;
 }

--- a/mon-pix/app/styles/components/_navbar-burger-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-burger-menu.scss
@@ -9,7 +9,6 @@
 }
 
 .navbar-burger__menu .navbar-burger-menu {
-
   &__header {
     display: flex;
     align-items: center;
@@ -36,7 +35,6 @@
 }
 
 .navbar-burger-menu-list-item {
-
   &__link {
     display: inline-block;
     width: 100%;
@@ -64,7 +62,6 @@
 }
 
 .navbar-burger-menu-footer {
-
   &__list {
     margin: 0;
     padding-left: 0;
@@ -72,7 +69,6 @@
 }
 
 .navbar-burger-menu-footer-item {
-
   &__link {
     display: inline-block;
     width: 100%;
@@ -95,7 +91,7 @@
     }
 
     &--logout {
-      margin-top: $spacing-xs;
+      margin-top: $pix-spacing-xs;
     }
   }
 }

--- a/mon-pix/app/styles/components/_new-information.scss
+++ b/mon-pix/app/styles/components/_new-information.scss
@@ -72,7 +72,6 @@
 }
 
 .new-information-content {
-
   &__img {
     display: block;
     margin: 12px 48px 12px 30px;
@@ -81,7 +80,6 @@
   &__text {
     display: inline-block;
     padding: 0 10px 14px;
-    font-weight: $font-light;
     font-size: 1.5rem;
     line-height: 2rem;
 
@@ -118,7 +116,6 @@
 }
 
 .new-information-content-text {
-
   &__button {
     display: inline-table;
     margin-top: 20px;

--- a/mon-pix/app/styles/components/_new-information.scss
+++ b/mon-pix/app/styles/components/_new-information.scss
@@ -93,7 +93,7 @@
 
     h2 {
       margin-bottom: 14px;
-      font-weight: $font-semi-bold;
+      font-weight: $font-medium;
       font-size: 1.125rem;
       font-family: $font-open-sans;
       line-height: 1.875rem;

--- a/mon-pix/app/styles/components/_password-reset-demand-form.scss
+++ b/mon-pix/app/styles/components/_password-reset-demand-form.scss
@@ -1,5 +1,4 @@
 .password-reset-demand-form {
-
   &__container {
     display: flex;
     flex-direction: column;
@@ -24,7 +23,6 @@
     flex-direction: column;
     gap: 20px;
     align-items: center;
-    font-weight: $font-light;
     text-align: center;
   }
 
@@ -50,7 +48,7 @@
     &--forgotten-password {
       color: $pix-neutral-80;
       font-size: 1.563rem;
-  
+
       @include device-is('desktop') {
         font-size: 2rem;
       }

--- a/mon-pix/app/styles/components/_qcm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qcm-solution-panel.scss
@@ -35,7 +35,7 @@
   &__answer-details[data-goodness='good'] {
     display: inline;
     color: $pix-success-70;
-    font-weight: $font-heavy;
+    font-weight: $font-bold;
   }
 
   &__answer-details[data-goodness='bad'][data-checked='yes'] {

--- a/mon-pix/app/styles/components/_qcu-panel.scss
+++ b/mon-pix/app/styles/components/_qcu-panel.scss
@@ -1,5 +1,4 @@
 .qcu-panel {
-
   a {
     color: $pix-primary;
     text-decoration: underline;
@@ -29,7 +28,6 @@
   }
 
   &-solution {
-
     &__proposal-item {
       position: relative;
       display: flex;
@@ -49,7 +47,7 @@
 
       &[data-goodness='good'] {
         color: $pix-success-70;
-        font-weight: $font-heavy;
+        font-weight: $font-bold;
       }
 
       &[data-goodness='bad'][data-checked='yes'] {

--- a/mon-pix/app/styles/components/_qcu-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qcu-solution-panel.scss
@@ -5,7 +5,6 @@
 /* See https://stylelint.io/user-guide/rules/list/no-descending-specificity/#dom-limitations for further detail */
 
 .qcu-solution-panel {
-
   a {
     color: $pix-primary;
     text-decoration: underline;
@@ -46,7 +45,7 @@
 
     &[data-goodness='good'] {
       color: $pix-success-70;
-      font-weight: $font-heavy;
+      font-weight: $font-bold;
     }
 
     &[data-goodness='bad'][data-checked='yes'] {
@@ -64,7 +63,6 @@
 }
 
 .qcu-solution-answer-feedback {
-
   &__expected-answer {
     font-weight: $font-medium;
   }

--- a/mon-pix/app/styles/components/_reached-stage.scss
+++ b/mon-pix/app/styles/components/_reached-stage.scss
@@ -23,7 +23,7 @@
     justify-content: center;
     min-width: 200px;
     max-width: 250px;
-    margin-bottom: $spacing-m;
+    margin-bottom: $pix-spacing-m;
   }
 
   &__percentage-text {

--- a/mon-pix/app/styles/components/_reset-password-form.scss
+++ b/mon-pix/app/styles/components/_reset-password-form.scss
@@ -41,7 +41,6 @@
 
 .reset-password-form-title {
   color: $pix-neutral-80;
-  font-weight: $font-light;
   font-size: 1.563rem;
   font-family: $font-open-sans;
 
@@ -54,7 +53,6 @@
   width: 100%;
   margin-top: 10px;
   color: $pix-neutral-80;
-  font-weight: $font-light;
   font-size: 0.938rem;
   font-family: $font-open-sans;
   line-height: 28px;

--- a/mon-pix/app/styles/components/_result-item.scss
+++ b/mon-pix/app/styles/components/_result-item.scss
@@ -76,7 +76,7 @@
   }
 
   &--red {
-    color: $error;
+    color: $pix-error-50;
   }
 
   &--grey {

--- a/mon-pix/app/styles/components/_result-item.scss
+++ b/mon-pix/app/styles/components/_result-item.scss
@@ -53,7 +53,7 @@
   &:hover,
   &:focus,
   &:active {
-    color: $dark-blue-pro;
+    color: $pix-primary-60;
     text-decoration: underline;
     cursor: pointer;
   }

--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -64,7 +64,6 @@
 }
 
 .rounded-panel-header {
-
   &__left-wrapper {
     margin-left: 8px;
   }
@@ -117,14 +116,12 @@
 }
 
 .rounded-panel-header-text {
-
   &__content {
     margin: 10px 0;
   }
 
   &__content--first-title {
     color: $pix-neutral-90;
-    font-weight: $font-light;
     font-size: 1.625rem;
     font-family: $font-open-sans;
     line-height: 2.75rem;

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -10,7 +10,6 @@
 .tutorials-header {
   &__title {
     margin-bottom: $spacing-s;
-    font-weight: $font-light;
     font-size: 2rem;
     font-family: $font-open-sans;
   }
@@ -162,7 +161,6 @@
 
   &__name {
     margin: 15px 0;
-    font-weight: $font-light;
     font-size: 2rem;
     font-family: $font-open-sans;
   }
@@ -222,7 +220,6 @@
   &__warning {
     padding-bottom: 10px;
     color: $pix-neutral-80;
-    font-weight: $font-light;
     font-size: 1rem;
     font-family: $font-roboto;
 

--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -9,7 +9,7 @@
 
 .tutorials-header {
   &__title {
-    margin-bottom: $spacing-s;
+    margin-bottom: $pix-spacing-s;
     font-size: 2rem;
     font-family: $font-open-sans;
   }
@@ -70,12 +70,12 @@
 
   &__resume-or-start-button,
   &__improve-button {
-    margin-top: $spacing-m;
+    margin-top: $pix-spacing-m;
   }
 
   &__reset-button {
     width: 180px;
-    margin-top: $spacing-m;
+    margin-top: $pix-spacing-m;
   }
 
   &__reset-modal {
@@ -210,7 +210,7 @@
 
 .scorecard-details-reset-modal {
   &__important-message {
-    margin-bottom: $spacing-s;
+    margin-bottom: $pix-spacing-s;
     color: $pix-neutral-110;
     font-weight: $font-medium;
     font-size: 1.375rem;
@@ -228,7 +228,7 @@
     }
 
     .scorecard-details-reset-modal__list {
-      padding-left: $spacing-l;
+      padding-left: $pix-spacing-l;
     }
 
     .scorecard-details-reset-modal-list__item {

--- a/mon-pix/app/styles/components/_training-card.scss
+++ b/mon-pix/app/styles/components/_training-card.scss
@@ -24,7 +24,7 @@
 }
 
 .training-card-content__infos {
-  padding: 0 $spacing-s $spacing-xxl;
+  padding: 0 $pix-spacing-s $pix-spacing-xxl;
 }
 
 .training-card-content-infos__tag {
@@ -56,13 +56,12 @@
   height: 155px;
 
   .training-card-content-illustration {
-
     &__logo {
       position: absolute;
-      left: $spacing-s;
+      left: $pix-spacing-s;
       z-index: 1;
       width: 64px;
-      padding: $spacing-xxs;
+      padding: $pix-spacing-xxs;
       background-color: $pix-neutral-0;
       border-radius: 0 0 4px 4px;
     }

--- a/mon-pix/app/styles/components/_tutorial-card.scss
+++ b/mon-pix/app/styles/components/_tutorial-card.scss
@@ -19,7 +19,7 @@
     display: -webkit-box;
     margin-bottom: 4px;
     overflow: hidden;
-    font-weight: $font-semi-bold;
+    font-weight: $font-medium;
     font-size: 1.25rem;
     font-family: $font-open-sans;
     line-height: 1.25;

--- a/mon-pix/app/styles/components/_user-certification-hexagon-score.scss
+++ b/mon-pix/app/styles/components/_user-certification-hexagon-score.scss
@@ -9,7 +9,9 @@
   background: url('/images/macaron-certif.svg') no-repeat center center;
   background-size: 100% 100%;
 
-  p { margin: 0; }
+  p {
+    margin: 0;
+  }
 
   &__content {
     padding-bottom: 7%;
@@ -26,7 +28,7 @@
 
     &-pix-score {
       color: $pix-neutral-70;
-      font-weight: $font-semi-bold;
+      font-weight: $font-medium;
       font-size: 2.3rem;
       font-family: $font-open-sans;
     }

--- a/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
@@ -80,13 +80,11 @@
 }
 
 @mixin coloriseElements($color) {
-
   .user-certifications-detail-competence__title {
     color: $color;
   }
 
   .user-certifications-detail-competence__competence {
-
     &--level {
       color: $color;
     }
@@ -98,7 +96,7 @@
 }
 
 .user-certifications-detail-competence--jaffa {
-  @include coloriseElements($information-light);
+  @include coloriseElements($pix-information-light);
 }
 
 .user-certifications-detail-competence--emerald {
@@ -118,9 +116,7 @@
 }
 
 @include device-is('mobile') {
-
   .user-certifications-detail-competence {
-
     &__title {
       font-weight: $font-normal;
       font-size: 0.875rem;
@@ -131,13 +127,11 @@
     }
 
     &__competence {
-
       &--level {
         padding-right: 0;
       }
 
       &--disabled {
-
         span {
           display: block;
           opacity: 0;

--- a/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
@@ -108,7 +108,7 @@
 }
 
 .user-certifications-detail-competence--wild-strawberry {
-  @include coloriseElements($security-light);
+  @include coloriseElements($pix-security-light);
 }
 
 .user-certifications-detail-competence--butterfly-bush {

--- a/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
@@ -112,7 +112,7 @@
 }
 
 .user-certifications-detail-competence--butterfly-bush {
-  @include coloriseElements($environment-light);
+  @include coloriseElements($pix-environment-light);
 }
 
 @include device-is('mobile') {

--- a/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
@@ -100,7 +100,7 @@
 }
 
 .user-certifications-detail-competence--emerald {
-  @include coloriseElements($content-light);
+  @include coloriseElements($pix-content-light);
 }
 
 .user-certifications-detail-competence--cerulean {

--- a/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-competence.scss
@@ -104,7 +104,7 @@
 }
 
 .user-certifications-detail-competence--cerulean {
-  @include coloriseElements($communication-light);
+  @include coloriseElements($pix-communication-light);
 }
 
 .user-certifications-detail-competence--wild-strawberry {

--- a/mon-pix/app/styles/components/_user-certifications-detail-header.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-header.scss
@@ -4,7 +4,6 @@
   padding: 14px 24px;
 
   @include device-is('mobile') {
-
     .pix-block {
       padding: 16px;
     }
@@ -90,7 +89,7 @@
     &__error-message {
       max-width: 250px;
       margin-top: 15px;
-      color: $error;
+      color: $pix-error-50;
     }
   }
 
@@ -140,7 +139,9 @@
         border: none;
         cursor: pointer;
 
-        &:hover { color: darken($pix-primary, 20%); }
+        &:hover {
+          color: darken($pix-primary, 20%);
+        }
       }
     }
 

--- a/mon-pix/app/styles/components/authentication/_oidc-reconciliation.scss
+++ b/mon-pix/app/styles/components/authentication/_oidc-reconciliation.scss
@@ -14,7 +14,7 @@
   }
 
   &__subtitle {
-    @include h4;
+    @extend %pix-title-xs;
 
     display: block;
     margin: 0;
@@ -51,7 +51,7 @@
     }
 
     p {
-      @include h4;
+      @extend %pix-title-xs;
 
       margin: 0;
       padding-top: $spacing-xs;

--- a/mon-pix/app/styles/components/authentication/_oidc-reconciliation.scss
+++ b/mon-pix/app/styles/components/authentication/_oidc-reconciliation.scss
@@ -22,7 +22,7 @@
   }
 
   &__information {
-    @include subheading;
+    @extend %pix-title-xs;
 
     margin-bottom: $spacing-xxl;
     font-weight: 400;
@@ -64,7 +64,7 @@
     padding: $spacing-l;
 
     p {
-      @include subheading;
+      @extend %pix-title-xs;
 
       font-weight: 400;
     }
@@ -75,7 +75,7 @@
     padding-top: $spacing-s;
 
     p {
-      @include subheading;
+      @extend %pix-title-xs;
 
       color: $pix-neutral-90;
       font-weight: 400;

--- a/mon-pix/app/styles/components/authentication/_oidc-reconciliation.scss
+++ b/mon-pix/app/styles/components/authentication/_oidc-reconciliation.scss
@@ -92,7 +92,7 @@
       display: inline;
       color: $pix-neutral-90;
 
-      @include text-large;
+      @extend %pix-body-l;
     }
 
     dt {
@@ -124,7 +124,7 @@
       margin: 0;
       padding: $spacing-l $spacing-xl;
 
-      @include text-large;
+      @extend %pix-body-l;
 
       color: $pix-neutral-90;
     }

--- a/mon-pix/app/styles/components/authentication/_oidc-reconciliation.scss
+++ b/mon-pix/app/styles/components/authentication/_oidc-reconciliation.scss
@@ -9,7 +9,7 @@
   &__title {
     @extend %pix-title-m;
 
-    padding-top: $spacing-l;
+    padding-top: $pix-spacing-l;
     text-align: center;
   }
 
@@ -18,13 +18,13 @@
 
     display: block;
     margin: 0;
-    padding: $spacing-s 0 $spacing-xxs 0;
+    padding: $pix-spacing-s 0 $pix-spacing-xxs 0;
   }
 
   &__information {
     @extend %pix-title-xs;
 
-    margin-bottom: $spacing-xxl;
+    margin-bottom: $pix-spacing-xxl;
     font-weight: 400;
   }
 
@@ -40,9 +40,9 @@
     flex-direction: column;
     align-items: center;
     width: 570px;
-    padding-top: $spacing-l;
+    padding-top: $pix-spacing-l;
     background-color: $pix-neutral-10;
-    border-radius: $spacing-xs;
+    border-radius: $pix-spacing-xs;
 
     svg {
       min-width: 120px;
@@ -54,14 +54,14 @@
       @extend %pix-title-xs;
 
       margin: 0;
-      padding-top: $spacing-xs;
+      padding-top: $pix-spacing-xs;
       color: $pix-neutral-90;
     }
   }
 
   &__user-authentication-methods {
     width: 100%;
-    padding: $spacing-l;
+    padding: $pix-spacing-l;
 
     p {
       @extend %pix-title-xs;
@@ -72,7 +72,7 @@
 
   &__new-authentication-method {
     width: 506px;
-    padding-top: $spacing-s;
+    padding-top: $pix-spacing-s;
 
     p {
       @extend %pix-title-xs;
@@ -83,9 +83,9 @@
   }
 
   &__user-authentication-methods-list {
-    padding: $spacing-l $spacing-xl;
+    padding: $pix-spacing-l $pix-spacing-xl;
     background-color: $pix-neutral-0;
-    border-radius: $spacing-xs;
+    border-radius: $pix-spacing-xs;
 
     dd,
     dt {
@@ -98,7 +98,7 @@
     dt {
       display: inline-block;
       width: 38%;
-      padding: $spacing-xxs 0;
+      padding: $pix-spacing-xxs 0;
       font-weight: 500;
     }
   }
@@ -107,7 +107,7 @@
     display: flex;
     justify-content: right;
     width: 570px;
-    margin-top: $spacing-xs;
+    margin-top: $pix-spacing-xs;
   }
 
   &__arrow {
@@ -122,7 +122,7 @@
 
     dl {
       margin: 0;
-      padding: $spacing-l $spacing-xl;
+      padding: $pix-spacing-l $pix-spacing-xl;
 
       @extend %pix-body-l;
 
@@ -141,9 +141,9 @@
 
   &__action-buttons {
     display: flex;
-    gap: $spacing-m;
+    gap: $pix-spacing-m;
     justify-content: center;
     width: 100%;
-    padding-top: $spacing-l;
+    padding-top: $pix-spacing-l;
   }
 }

--- a/mon-pix/app/styles/components/authentication/_oidc-reconciliation.scss
+++ b/mon-pix/app/styles/components/authentication/_oidc-reconciliation.scss
@@ -1,5 +1,4 @@
 .oidc-reconciliation {
-
   &__title,
   &__subtitle,
   &__information {
@@ -8,7 +7,7 @@
   }
 
   &__title {
-    @include h2;
+    @extend %pix-title-m;
 
     padding-top: $spacing-l;
     text-align: center;

--- a/mon-pix/app/styles/components/campaign-participation-overview/_card.scss
+++ b/mon-pix/app/styles/components/campaign-participation-overview/_card.scss
@@ -62,7 +62,6 @@
 }
 
 .campaign-participation-overview-card-header {
-
   &__tag {
     margin-bottom: 16px;
     border-radius: 11px;
@@ -88,7 +87,6 @@
 
   &__date {
     color: $pix-neutral-50;
-    font-weight: $font-light;
     font-size: 0.8125rem;
   }
 }

--- a/mon-pix/app/styles/components/dashboard/_content.scss
+++ b/mon-pix/app/styles/components/dashboard/_content.scss
@@ -122,7 +122,6 @@
 }
 
 .dashboard-content-score {
-
   &__wrapper {
     display: flex;
     flex-direction: column;
@@ -140,7 +139,6 @@
 }
 
 .dashboard-content-score-wrapper {
-
   &__button {
     padding-top: 10px;
     color: $pix-primary;
@@ -158,10 +156,9 @@
 }
 
 .dashboard-section {
-
   &__title {
     color: $pix-neutral-80;
-    font-weight: $font-semi-bold;
+    font-weight: $font-medium;
     font-size: 1.125rem;
     font-family: $font-open-sans;
     line-height: 1.562rem;
@@ -177,7 +174,6 @@
   }
 
   &__header {
-
     &--with-button {
       display: flex;
       align-items: baseline;

--- a/mon-pix/app/styles/globals/_text.scss
+++ b/mon-pix/app/styles/globals/_text.scss
@@ -17,7 +17,7 @@
   z-index: 1;
   margin-bottom: 20px;
   color: $pix-neutral-80;
-  font-weight: $font-semi-bold;
+  font-weight: $font-medium;
   font-size: 1.375rem;
 
   // XXX Inspired from https://codepen.io/ericrasch/pen/Irlpm

--- a/mon-pix/app/styles/pages/_assessment-results.scss
+++ b/mon-pix/app/styles/pages/_assessment-results.scss
@@ -55,7 +55,7 @@
 
 .assessment-results__link-back {
   color: $pix-neutral-0;
-  font-weight: $font-semi-bold;
+  font-weight: $font-medium;
   font-size: 1rem;
   font-family: $font-open-sans;
   text-align: center;

--- a/mon-pix/app/styles/pages/_campaign-landing-page.scss
+++ b/mon-pix/app/styles/pages/_campaign-landing-page.scss
@@ -44,7 +44,6 @@
   }
 
   &__title {
-    font-weight: $font-light;
     font-size: 1.875rem;
 
     @include device-is('tablet') {
@@ -58,7 +57,6 @@
 
   &__announcement {
     margin-top: 16px;
-    font-weight: $font-light;
     font-size: 1.125rem;
   }
 
@@ -124,7 +122,6 @@
   font-family: $font-open-sans;
 
   .title {
-    font-weight: $font-light;
     font-size: 1.375rem;
     text-align: center;
 
@@ -195,7 +192,6 @@
   font-family: $font-open-sans;
 
   .title {
-    font-weight: $font-light;
     font-size: 1.375rem;
     text-align: center;
   }

--- a/mon-pix/app/styles/pages/_campaign-landing-page.scss
+++ b/mon-pix/app/styles/pages/_campaign-landing-page.scss
@@ -51,7 +51,7 @@
     }
 
     span {
-      font-weight: $font-semi-bold;
+      font-weight: $font-medium;
     }
   }
 
@@ -76,7 +76,7 @@
   border-top: 1px dashed $pix-neutral-22;
 
   strong {
-    font-weight: $font-semi-bold;
+    font-weight: $font-medium;
   }
 
   h1 {
@@ -137,7 +137,7 @@
 
   .article-title {
     color: $pix-neutral-100;
-    font-weight: $font-semi-bold;
+    font-weight: $font-medium;
     font-size: 1.5rem;
     line-height: 30px;
   }

--- a/mon-pix/app/styles/pages/_challenge.scss
+++ b/mon-pix/app/styles/pages/_challenge.scss
@@ -121,7 +121,6 @@
 
   &__subtitle {
     margin: 0;
-    font-weight: $font-light;
     font-size: 0.875rem;
     line-height: 1.375rem;
     letter-spacing: 0.009rem;

--- a/mon-pix/app/styles/pages/_challenge.scss
+++ b/mon-pix/app/styles/pages/_challenge.scss
@@ -61,7 +61,7 @@
     z-index: 1;
     width: 100%;
     max-width: 990px;
-    margin: $spacing-s 0;
+    margin: $pix-spacing-s 0;
     padding: 0 20px;
     text-align: left;
 

--- a/mon-pix/app/styles/pages/_connection-methods.scss
+++ b/mon-pix/app/styles/pages/_connection-methods.scss
@@ -1,7 +1,7 @@
 .user-account-panel__item {
   display: flex;
   flex-wrap: wrap;
-  gap: $spacing-m;
+  gap: $pix-spacing-m;
   justify-content: space-between;
   padding-top: 16px;
   padding-bottom: 16px;
@@ -28,7 +28,7 @@
 .user-account-panel-item__text {
   display: flex;
   flex-wrap: wrap;
-  gap: $spacing-xs;
+  gap: $pix-spacing-xs;
 }
 
 .user-account-panel-item__label {

--- a/mon-pix/app/styles/pages/_course-preview.scss
+++ b/mon-pix/app/styles/pages/_course-preview.scss
@@ -1,4 +1,4 @@
 #course-preview strong {
   color: $pix-primary;
-  font-weight: $font-semi-bold;
+  font-weight: $font-medium;
 }

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -5,22 +5,22 @@
     align-items: center;
     width: 100%;
     margin-bottom: 32px;
-    padding: 16px 16px $spacing-s;
+    padding: 16px 16px $pix-spacing-s;
 
     @include device-is('tablet') {
-      padding: $spacing-xl;
+      padding: $pix-spacing-xl;
     }
   }
 
   &__title {
-    margin-bottom: $spacing-l;
+    margin-bottom: $pix-spacing-l;
     font-size: 2rem;
     text-align: center;
   }
 
   &__instruction {
     max-width: 600px;
-    margin-bottom: $spacing-s;
+    margin-bottom: $pix-spacing-s;
     color: $pix-neutral-100;
     font-size: 1.219rem;
     font-family: $font-open-sans;
@@ -37,7 +37,7 @@
 
   &__form-field {
     display: inline-block;
-    margin-bottom: $spacing-s;
+    margin-bottom: $pix-spacing-s;
     text-align: left;
 
     input {
@@ -56,19 +56,19 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin-bottom: $spacing-s;
+    margin-bottom: $pix-spacing-s;
   }
 
   &__error {
-    margin-bottom: $spacing-s;
+    margin-bottom: $pix-spacing-s;
     color: $pix-warning-60;
     font-size: 0.875rem;
     text-align: center;
   }
 
   &__warning {
-    margin-top: $spacing-s;
-    margin-bottom: $spacing-s;
+    margin-top: $pix-spacing-s;
+    margin-bottom: $pix-spacing-s;
     color: $pix-neutral-90;
     font-size: 0.875rem;
     text-align: center;

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -96,3 +96,9 @@
   align-items: center;
   justify-content: flex-end;
 }
+
+.mediacentre-start-campaign-modal-action-buttons__continue-action {
+  @extend %pix-body-s;
+
+  color: $pix-primary;
+}

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -1,5 +1,4 @@
 .fill-in-campaign-code {
-
   &__container {
     display: flex;
     flex-direction: column;
@@ -15,7 +14,6 @@
 
   &__title {
     margin-bottom: $spacing-l;
-    font-weight: $font-light;
     font-size: 2rem;
     text-align: center;
   }
@@ -24,7 +22,6 @@
     max-width: 600px;
     margin-bottom: $spacing-s;
     color: $pix-neutral-100;
-    font-weight: $font-light;
     font-size: 1.219rem;
     font-family: $font-open-sans;
     text-align: center;

--- a/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
@@ -17,7 +17,6 @@
     .form__title {
       margin-bottom: 16px;
       color: $pix-neutral-80;
-      font-weight: $font-light;
       font-size: 2rem;
       font-family: $font-open-sans;
     }
@@ -26,7 +25,6 @@
       max-width: 500px;
       margin-bottom: 32px;
       color: $pix-neutral-60;
-      font-weight: $font-light;
       line-height: 22px;
     }
 
@@ -49,7 +47,6 @@
       }
 
       @media all and (-ms-high-contrast: none) {
-
         input {
           width: 17.4ch;
         }

--- a/mon-pix/app/styles/pages/_fill-in-participant-external-id.scss
+++ b/mon-pix/app/styles/pages/_fill-in-participant-external-id.scss
@@ -59,7 +59,7 @@
 .fill-in-participant-external-id__form-field input {
   width: 232px;
   height: 43px;
-  margin-right: $spacing-xs;
+  margin-right: $pix-spacing-xs;
   padding: 4px 8px;
   border: solid 2px $pix-neutral-20;
   border-radius: 3px;

--- a/mon-pix/app/styles/pages/_join-restricted-campaign.scss
+++ b/mon-pix/app/styles/pages/_join-restricted-campaign.scss
@@ -1,5 +1,4 @@
 .join-restricted-campaign {
-
   form {
     display: flex;
     flex-direction: column;
@@ -34,7 +33,6 @@
   &__title,
   &__sco-title {
     color: $pix-neutral-100;
-    font-weight: $font-light;
     font-family: $font-open-sans;
     text-align: center;
   }
@@ -57,7 +55,6 @@
   &__subtitle {
     margin-bottom: 30px;
     color: $pix-neutral-100;
-    font-weight: $font-light;
     font-size: 1.125rem;
     font-family: $font-open-sans;
     text-align: center;
@@ -159,7 +156,6 @@
 }
 
 .join-error-modal-header {
-
   &__title {
     display: flex;
     align-items: center;
@@ -167,7 +163,6 @@
 }
 
 .join-error-modal-header-title {
-
   &__text {
     margin-left: 8px;
     color: $pix-neutral-90;
@@ -179,7 +174,6 @@
 }
 
 .join-error-modal-header-close {
-
   &__icon {
     width: 32px;
     height: 32px;
@@ -191,7 +185,6 @@
 }
 
 .join-error-modal-body {
-
   &__message {
     color: $pix-neutral-110;
     font-weight: $font-normal;

--- a/mon-pix/app/styles/pages/_not-connected.scss
+++ b/mon-pix/app/styles/pages/_not-connected.scss
@@ -21,7 +21,6 @@
   &__text-block {
     padding-top: 30px;
     color: $pix-neutral-80;
-    font-weight: $font-light;
     font-size: 1.875rem;
     line-height: 46px;
     text-align: center;

--- a/mon-pix/app/styles/pages/_profile-already-shared.scss
+++ b/mon-pix/app/styles/pages/_profile-already-shared.scss
@@ -8,7 +8,6 @@
   border-top: 1px dashed $pix-neutral-22;
 
   &__message {
-    font-weight: $font-light;
     font-size: 1.5rem;
     font-family: $font-open-sans;
     text-align: center;

--- a/mon-pix/app/styles/pages/_send-profile.scss
+++ b/mon-pix/app/styles/pages/_send-profile.scss
@@ -20,7 +20,6 @@
 
   &__title {
     color: $pix-neutral-90;
-    font-weight: $font-light;
     font-size: 2rem;
     font-family: $font-open-sans;
     text-align: center;
@@ -29,7 +28,6 @@
   &__instruction {
     margin: 30px;
     color: $pix-neutral-90;
-    font-weight: $font-light;
     font-size: 1.25rem;
     font-family: $font-open-sans;
     line-height: 2.5rem;
@@ -79,7 +77,6 @@
     max-width: 640px;
     margin: 30px auto 60px;
     color: $pix-neutral-35;
-    font-weight: $font-light;
     font-size: 1.375rem;
     font-family: $font-open-sans;
     text-align: center;

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -171,7 +171,7 @@
     &:focus,
     &:hover,
     &:focus-within {
-      border: 2px solid $white;
+      border: 2px solid $pix-neutral-0;
       box-shadow: 0 0 0 2px $pole-emploi;
     }
 

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -21,7 +21,7 @@
   &__container {
     display: flex;
     flex-direction: column;
-    gap: $spacing-m;
+    gap: $pix-spacing-m;
     align-items: center;
     width: 95%;
     max-width: 609px;
@@ -39,7 +39,7 @@
   &__header {
     display: flex;
     flex-direction: column;
-    gap: $spacing-s;
+    gap: $pix-spacing-s;
     align-items: center;
   }
 
@@ -107,7 +107,7 @@
   &__inputs {
     display: flex;
     flex-direction: column;
-    gap: $spacing-s;
+    gap: $pix-spacing-s;
     align-items: center;
   }
 

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -69,11 +69,9 @@
 }
 
 .sign-form-header {
-
   &__title {
     margin: 0;
     color: $pix-neutral-80;
-    font-weight: $font-light;
     font-size: 1.563rem;
     font-family: $font-open-sans;
 
@@ -98,7 +96,6 @@
 .sign-form-header-subtitle {
   margin-right: 3px;
   color: $pix-neutral-80;
-  font-weight: $font-light;
 }
 
 .sign-form-body {

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -439,7 +439,7 @@
     margin-bottom: 16px;
     padding: 16px;
     color: $pix-success-70;
-    font-weight: $font-semi-bold;
+    font-weight: $font-medium;
     font-size: 1rem;
     font-family: $font-open-sans;
     line-height: 2rem;

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -35,7 +35,7 @@
   }
 
   &__trainings {
-    margin-top: $spacing-xl;
+    margin-top: $pix-spacing-xl;
     padding: 2.5rem 2rem 3rem;
     background-color: $pix-neutral-10;
     border-radius: 10px;

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -22,7 +22,6 @@
 
   &__retry {
     color: $pix-neutral-100;
-    font-weight: $font-light;
     font-size: 1.125rem;
     font-family: $font-open-sans;
     text-align: center;
@@ -77,10 +76,6 @@
     }
   }
 
-  &__subtitle {
-    font-weight: $font-light;
-  }
-
   &__begin-improvement {
     display: flex;
     flex-direction: row;
@@ -93,7 +88,6 @@
 
   &__explain-text {
     color: $pix-neutral-60;
-    font-weight: $font-light;
     font-size: 1.5rem;
     line-height: 33px;
   }
@@ -323,7 +317,6 @@
   &__text {
     margin: 16px 0;
     color: $pix-neutral-90;
-    font-weight: $font-light;
     font-size: 1.625rem;
     font-family: $font-open-sans;
     line-height: 2.75rem;
@@ -545,7 +538,6 @@
     max-width: 640px;
     margin: 30px auto 60px;
     color: $pix-neutral-35;
-    font-weight: $font-light;
     font-size: 1.375rem;
     font-family: $font-open-sans;
     line-height: 30px;

--- a/mon-pix/app/styles/pages/_terms-of-service.scss
+++ b/mon-pix/app/styles/pages/_terms-of-service.scss
@@ -52,16 +52,14 @@
 }
 
 .terms-of-service-form-conditions {
-
   &__validation-error {
     margin-top: 16px;
-    color: $error;
+    color: $pix-error-50;
     font-weight: normal;
   }
 }
 
 .terms-of-service-form-actions {
-
   &__submit {
     margin-left: 10px;
   }

--- a/mon-pix/app/styles/pages/_update-expired-password-form.scss
+++ b/mon-pix/app/styles/pages/_update-expired-password-form.scss
@@ -14,7 +14,6 @@
 }
 
 .update-expired-password-form {
-
   &__container {
     display: flex;
     flex-direction: column;
@@ -67,7 +66,6 @@
 }
 
 .update-expired-password-form-body {
-
   &__input {
     width: 100%;
     max-width: 449px;
@@ -92,7 +90,6 @@
 .update-expired-password-form-title {
   margin: 0;
   color: $pix-neutral-80;
-  font-weight: $font-light;
   font-size: 1.563rem;
   font-family: $font-open-sans;
   text-align: center;

--- a/mon-pix/app/styles/pages/_user-tests.scss
+++ b/mon-pix/app/styles/pages/_user-tests.scss
@@ -13,7 +13,6 @@
   margin: auto;
   margin-bottom: 16px;
   padding: 0 20px;
-  font-weight: $font-light;
   font-family: $font-roboto;
   text-align: center;
 
@@ -54,7 +53,6 @@
   max-width: 980px;
   margin: auto;
   padding: 0 20px;
-  font-weight: $font-light;
   font-family: $font-roboto;
 
   @include device-is('desktop') {

--- a/mon-pix/app/styles/pages/_user-trainings.scss
+++ b/mon-pix/app/styles/pages/_user-trainings.scss
@@ -1,7 +1,6 @@
 .user-trainings-banner {
   margin: 0 24px;
   padding-bottom: 16px;
-  font-weight: $font-light;
   font-family: $font-roboto;
 
   @include device-is('desktop') {

--- a/mon-pix/app/styles/pages/_user-tutorials.scss
+++ b/mon-pix/app/styles/pages/_user-tutorials.scss
@@ -1,7 +1,6 @@
 .user-tutorials-banner {
   margin: 0 24px;
   padding-bottom: 16px;
-  font-weight: $font-light;
   font-family: $font-roboto;
 
   @include device-is('desktop') {
@@ -98,7 +97,6 @@
 
 .user-tutorials-saved-empty,
 .user-tutorials-recommended-empty {
-
   &__title,
   &__description {
     color: $pix-neutral-90;
@@ -151,8 +149,6 @@
   }
 
   &__instructions {
-    font-weight: $font-light;
-
     svg {
       margin: 0 3px;
     }

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -85,12 +85,12 @@
   <:content>
     <p>
       {{t "pages.fill-in-campaign-code.mediacentre-start-campaign-modal.message"}}
-      <p class="pix-text--small">
-        <div class="pix-text--small"><b>{{this.campaign.targetProfileName}}</b></div>
+      <p class="pix-body-s">
+        <div><b>{{this.campaign.targetProfileName}}</b></div>
         {{t "pages.fill-in-campaign-code.mediacentre-start-campaign-modal.organised-by"}}
         <b>{{this.campaign.organizationName}}</b>
       </p>
-      <p class="pix-text--small">
+      <p class="pix-body-s">
         <b>{{t "pages.fill-in-campaign-code.mediacentre-start-campaign-modal.message-footer"}}</b>
       </p>
     </p>
@@ -98,7 +98,11 @@
 
   <:footer>
     <div class="mediacentre-start-campaign-modal__action-buttons">
-      <LinkTo class="pix-text--link pix-text--small" @route="campaigns.entry-point" @model={{this.campaign.code}}>
+      <LinkTo
+        class="mediacentre-start-campaign-modal-action-buttons__continue-action"
+        @route="campaigns.entry-point"
+        @model={{this.campaign.code}}
+      >
         {{t "pages.fill-in-campaign-code.mediacentre-start-campaign-modal.actions.continue"}}
       </LinkTo>
       <PixButton @triggerAction={{this.closeModal}}>

--- a/mon-pix/ember-cli-build.js
+++ b/mon-pix/ember-cli-build.js
@@ -34,12 +34,6 @@ module.exports = function (defaults) {
   // modules that you would like to import into your application
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
-  app.import('node_modules/@1024pix/pix-ui/public/fonts/OpenSans/OpenSans-Light.ttf');
-  app.import('node_modules/@1024pix/pix-ui/public/fonts/OpenSans/OpenSans-Regular.ttf');
-  app.import('node_modules/@1024pix/pix-ui/public/fonts/OpenSans/OpenSans-SemiBold.ttf');
-  app.import('node_modules/@1024pix/pix-ui/public/fonts/Roboto/Roboto-Light.ttf');
-  app.import('node_modules/@1024pix/pix-ui/public/fonts/Roboto/Roboto-Medium.ttf');
-  app.import('node_modules/@1024pix/pix-ui/public/fonts/Roboto/Roboto-Regular.ttf');
 
   return app.toTree();
 };

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.0",
-        "@1024pix/pix-ui": "^28.1.1",
+        "@1024pix/pix-ui": "^29.0.0",
         "@1024pix/stylelint-config": "^2.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
@@ -1153,9 +1153,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-28.1.1.tgz",
-      "integrity": "sha512-z3d/wncer6b7TIvet/Hx39vfSSAJZ+zKhb/+JmtVeQoTLb0KCpee6NabDKBFUcmaMb+FVMWqsYFKxaFTHECJGA==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-29.0.0.tgz",
+      "integrity": "sha512-0/2zjNg+bPSFdHx9mdNyuwRPPp0tSHQU6GnsRJ3WcZgoXLGrAcOwYS5NNorgAA5XHXuEBD5eaYzutqU5oDBRbg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -42351,9 +42351,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-28.1.1.tgz",
-      "integrity": "sha512-z3d/wncer6b7TIvet/Hx39vfSSAJZ+zKhb/+JmtVeQoTLb0KCpee6NabDKBFUcmaMb+FVMWqsYFKxaFTHECJGA==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-29.0.0.tgz",
+      "integrity": "sha512-0/2zjNg+bPSFdHx9mdNyuwRPPp0tSHQU6GnsRJ3WcZgoXLGrAcOwYS5NNorgAA5XHXuEBD5eaYzutqU5oDBRbg==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.0",
-    "@1024pix/pix-ui": "^28.1.1",
+    "@1024pix/pix-ui": "^29.0.0",
     "@1024pix/stylelint-config": "^2.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",


### PR DESCRIPTION
## :unicorn: Problème
Nous ne sommes pas à jour sur la version de Pix UI.

## :robot: Proposition
Monter de version de Pix UI en v29.0.0.


L'idée est de pouvoir bénéficier des nouveaux Design Tokens en particulier concernant les typographies. 

Voilà comment j'ai procédé : 
1. Reprise des variables, classes et mixins de typographies
2. Reprise des variables d'espacement (pas d'impact, juste des changements de nommage)
3. Reprise des variables de couleurs

La typo par défaut est maintenant du Roboto 400 (regular) contre Roboto 500 (medium) précédemment. Les polices sont aussi affinées sur les navigateurs récents pour mieux coller aux maquettes Figma. Pour le détail sur ce sujet, voir https://github.com/1024pix/pix-ui/pull/367.

On pourra petit à petit revoir les textes de chaque écran pour les réaligner avec la vision du pôle UX/UI.

Quelques couleurs dépréciées ont été réalignées avec les attentes du même pôle.

Il y a un commit pour chaque changement pour faciliter la reproduction sur les autres applis. Je me chargerai des autres migrations suite aux retours et à la validation de cette PR.

## :rainbow: Remarques
J'ai aussi fait un nettoyage des imports de fonts inutiles pour Ember.

## :100: Pour tester
Vérifier que les tests passent toujours et que Pix App est tout pimpant.
