### PR TITLE
[TECH] Introduit la notion d'ApplicationTransaction (PIX-11205)

### DIFF
--- a/api/src/prescription/campaign-participation/application/learner-participation-controller.js
+++ b/api/src/prescription/campaign-participation/application/learner-participation-controller.js
@@ -3,6 +3,7 @@ import { usecases } from '../domain/usecases/index.js';
 import * as events from '../../../../lib/domain/events/index.js';
 import * as campaignParticipationSerializer from '../infrastructure/serializers/jsonapi/campaign-participation-serializer.js';
 import { DomainTransaction } from '../../../../lib/infrastructure/DomainTransaction.js';
+import { ApplicationTransaction } from '../../shared/infrastructure/ApplicationTransaction.js';
 
 const save = async function (request, h, dependencies = { campaignParticipationSerializer, monitoringTools }) {
   const userId = request.auth.credentials.userId;
@@ -25,12 +26,12 @@ const shareCampaignResult = async function (request) {
   const userId = request.auth.credentials.userId;
   const campaignParticipationId = request.params.campaignParticipationId;
 
-  await DomainTransaction.execute(async (domainTransaction) => {
+  await ApplicationTransaction.execute(async () => {
     const event = await usecases.shareCampaignResult({
       userId,
       campaignParticipationId,
-      domainTransaction,
     });
+    const domainTransaction = ApplicationTransaction.getTransactionAsDomainTransaction();
     await events.eventBus.publish(event, domainTransaction);
     return event;
   });

--- a/api/src/prescription/campaign-participation/domain/usecases/share-campaign-result.js
+++ b/api/src/prescription/campaign-participation/domain/usecases/share-campaign-result.js
@@ -1,18 +1,13 @@
 import { UserNotAuthorizedToAccessEntityError } from '../../../../../lib/domain/errors.js';
 import { CampaignParticipationResultsShared } from '../../../../../lib/domain/events/CampaignParticipationResultsShared.js';
 
-const shareCampaignResult = async function ({
-  userId,
-  campaignParticipationId,
-  campaignParticipationRepository,
-  domainTransaction,
-}) {
-  const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId, domainTransaction);
+const shareCampaignResult = async function ({ userId, campaignParticipationId, campaignParticipationRepository }) {
+  const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
 
   _checkUserIsOwnerOfCampaignParticipation(campaignParticipation, userId);
 
   campaignParticipation.share();
-  await campaignParticipationRepository.updateWithSnapshot(campaignParticipation, domainTransaction);
+  await campaignParticipationRepository.updateWithSnapshot(campaignParticipation);
 
   return new CampaignParticipationResultsShared({
     campaignParticipationId: campaignParticipation.id,

--- a/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js
@@ -4,9 +4,11 @@ import { Campaign } from '../../../../../lib/domain/models/Campaign.js';
 
 import { CampaignParticipation } from '../../domain/models/CampaignParticipation.js';
 import { Assessment } from '../../../../shared/domain/models/Assessment.js';
+import { ApplicationTransaction } from '../../../shared/infrastructure/ApplicationTransaction.js';
 
-const updateWithSnapshot = async function (campaignParticipation, domainTransaction) {
-  await this.update(campaignParticipation, domainTransaction);
+const updateWithSnapshot = async function (campaignParticipation) {
+  const domainTransaction = ApplicationTransaction.getTransactionAsDomainTransaction();
+  await this.update(campaignParticipation);
 
   const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({
     userId: campaignParticipation.userId,
@@ -22,7 +24,7 @@ const updateWithSnapshot = async function (campaignParticipation, domainTransact
 };
 
 const update = async function (campaignParticipation, domainTransaction) {
-  const knexConn = domainTransaction.knexTransaction;
+  const knexConn = ApplicationTransaction.getConnection(domainTransaction);
 
   const attributes = {
     participantExternalId: campaignParticipation.participantExternalId,
@@ -37,7 +39,7 @@ const update = async function (campaignParticipation, domainTransaction) {
 };
 
 const get = async function (id, domainTransaction) {
-  const knexConn = domainTransaction.knexTransaction;
+  const knexConn = ApplicationTransaction.getConnection(domainTransaction);
 
   const campaignParticipation = await knexConn.from('campaign-participations').where({ id }).first();
   const campaign = await knexConn.from('campaigns').where({ id: campaignParticipation.campaignId }).first();

--- a/api/src/prescription/shared/infrastructure/ApplicationTransaction.js
+++ b/api/src/prescription/shared/infrastructure/ApplicationTransaction.js
@@ -1,0 +1,41 @@
+import { knex } from '../../../../db/knex-database-connection.js';
+import { asyncLocalStorage } from './utils/async-local-storage.js';
+import { DomainTransaction } from '../../../shared/domain/DomainTransaction.js';
+
+class ApplicationTransaction {
+  static getConnection(domainTransaction = DomainTransaction.emptyTransaction()) {
+    const store = asyncLocalStorage.getStore();
+
+    if (domainTransaction.knexTransaction) {
+      return domainTransaction.knexTransaction;
+    } else if (store?.transaction) {
+      return store.transaction;
+    }
+    return knex;
+  }
+
+  static getTransactionAsDomainTransaction() {
+    const store = asyncLocalStorage.getStore();
+
+    if (!store?.transaction) throw new Error('No transaction');
+
+    return new DomainTransaction(store.transaction);
+  }
+
+  static async execute(func) {
+    const trx = await knex.transaction();
+    let result;
+
+    try {
+      result = await asyncLocalStorage.run({ transaction: trx }, func);
+    } catch (e) {
+      await trx.rollback();
+      throw e;
+    }
+
+    await trx.commit();
+    return result;
+  }
+}
+
+export { ApplicationTransaction };

--- a/api/src/prescription/shared/infrastructure/utils/async-local-storage.js
+++ b/api/src/prescription/shared/infrastructure/utils/async-local-storage.js
@@ -1,0 +1,5 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const asyncLocalStorage = new AsyncLocalStorage();
+
+export { asyncLocalStorage };

--- a/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/prescription/campaign-participation/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -2,6 +2,7 @@ import { sinon, expect, knex, databaseBuilder, catchErr } from '../../../../../t
 import { CampaignParticipationStatuses } from '../../../../../../src/prescription/shared/domain/constants.js';
 import * as campaignParticipationRepository from '../../../../../../src/prescription/campaign-participation/infrastructure/repositories/campaign-participation-repository.js';
 import { DomainTransaction } from '../../../../../../lib/infrastructure/DomainTransaction.js';
+import { ApplicationTransaction } from '../../../../../../src/prescription/shared/infrastructure/ApplicationTransaction.js';
 
 const { STARTED, SHARED } = CampaignParticipationStatuses;
 
@@ -42,8 +43,8 @@ describe('Integration | Repository | Campaign Participation', function () {
       campaignParticipation.participantExternalId = 'Laura';
 
       // when
-      await DomainTransaction.execute((domainTransaction) => {
-        return campaignParticipationRepository.updateWithSnapshot(campaignParticipation, domainTransaction);
+      await ApplicationTransaction.execute(async () => {
+        await campaignParticipationRepository.updateWithSnapshot(campaignParticipation);
       });
 
       const updatedCampaignParticipation = await knex('campaign-participations')
@@ -59,9 +60,10 @@ describe('Integration | Repository | Campaign Participation', function () {
       campaignParticipation.sharedAt = new Date();
 
       // when
-      await DomainTransaction.execute(async (domainTransaction) => {
-        await campaignParticipationRepository.updateWithSnapshot(campaignParticipation, domainTransaction);
+      await ApplicationTransaction.execute(async () => {
+        await campaignParticipationRepository.updateWithSnapshot(campaignParticipation);
       });
+
       // then
       const snapshotInDB = await knex.select('id').from('knowledge-element-snapshots');
       expect(snapshotInDB).to.have.length(1);
@@ -71,8 +73,8 @@ describe('Integration | Repository | Campaign Participation', function () {
       it('should save a snapshot using a transaction', async function () {
         campaignParticipation.sharedAt = new Date();
 
-        await DomainTransaction.execute((domainTransaction) => {
-          return campaignParticipationRepository.updateWithSnapshot(campaignParticipation, domainTransaction);
+        await ApplicationTransaction.execute(async () => {
+          await campaignParticipationRepository.updateWithSnapshot(campaignParticipation);
         });
 
         const snapshotInDB = await knex.select('id').from('knowledge-element-snapshots');
@@ -83,8 +85,8 @@ describe('Integration | Repository | Campaign Participation', function () {
         campaignParticipation.sharedAt = new Date();
 
         try {
-          await DomainTransaction.execute(async (domainTransaction) => {
-            await campaignParticipationRepository.updateWithSnapshot(campaignParticipation, domainTransaction);
+          await ApplicationTransaction.execute(async () => {
+            await campaignParticipationRepository.updateWithSnapshot(campaignParticipation);
             throw new Error();
           });
           // eslint-disable-next-line no-empty

--- a/api/tests/prescription/campaign-participation/unit/application/learner-participation-controller_test.js
+++ b/api/tests/prescription/campaign-participation/unit/application/learner-participation-controller_test.js
@@ -5,10 +5,10 @@ import { usecases } from '../../../../../src/prescription/campaign-participation
 import { CampaignParticipationResultsShared } from '../../../../../lib/domain/events/CampaignParticipationResultsShared.js';
 import { CampaignParticipationStarted } from '../../../../../lib/domain/events/CampaignParticipationStarted.js';
 import { DomainTransaction } from '../../../../../lib/infrastructure/DomainTransaction.js';
+import { ApplicationTransaction } from '../../../../../src/prescription/shared/infrastructure/ApplicationTransaction.js';
 
 describe('Unit | Application | Controller | Campaign-Participation', function () {
   describe('#shareCampaignResult', function () {
-    let domainTransaction;
     let dependencies;
     const userId = 1;
     const request = {
@@ -37,12 +37,10 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       const monitoringToolsStub = {
         logErrorWithCorrelationIds: sinon.stub(),
       };
-      domainTransaction = {
-        knexTransaction: Symbol('transaction'),
-      };
-      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
-        return callback(domainTransaction);
+      sinon.stub(ApplicationTransaction, 'execute').callsFake((callback) => {
+        return callback();
       });
+      sinon.stub(ApplicationTransaction, 'getTransactionAsDomainTransaction');
 
       dependencies = {
         requestResponseUtils: requestResponseUtilsStub,
@@ -68,6 +66,8 @@ describe('Unit | Application | Controller | Campaign-Participation', function ()
       // given
       const campaignParticipationResultsSharedEvent = new CampaignParticipationResultsShared();
       usecases.shareCampaignResult.resolves(campaignParticipationResultsSharedEvent);
+      const domainTransaction = Symbol('domainTransaction');
+      ApplicationTransaction.getTransactionAsDomainTransaction.returns(domainTransaction);
 
       // when
       await learnerParticipationController.shareCampaignResult(request, hFake, dependencies);

--- a/api/tests/prescription/campaign-participation/unit/domain/usecases/share-campaign-result_test.js
+++ b/api/tests/prescription/campaign-participation/unit/domain/usecases/share-campaign-result_test.js
@@ -20,7 +20,6 @@ describe('Unit | UseCase | share-campaign-result', function () {
   context('when user is not the owner of the campaign participation', function () {
     it('throws a UserNotAuthorizedToAccessEntityError error ', async function () {
       // given
-      const domainTransaction = Symbol('transaction');
       campaignParticipationRepository.get.resolves({ userId: userId + 1 });
 
       // when
@@ -28,7 +27,6 @@ describe('Unit | UseCase | share-campaign-result', function () {
         userId,
         campaignParticipationId,
         campaignParticipationRepository,
-        domainTransaction,
       });
 
       // then
@@ -39,35 +37,27 @@ describe('Unit | UseCase | share-campaign-result', function () {
   context('when user is the owner of the campaign participation', function () {
     it('updates the campaign participation', async function () {
       // given
-      const domainTransaction = Symbol('transaction');
       const campaignParticipation = domainBuilder.prescription.campaignParticipation.buildCampaignParticipation({
         id: campaignParticipationId,
         userId,
       });
       sinon.stub(campaignParticipation, 'share');
-      campaignParticipationRepository.get
-        .withArgs(campaignParticipationId, domainTransaction)
-        .resolves(campaignParticipation);
+      campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
 
       // when
       await usecases.shareCampaignResult({
         userId,
         campaignParticipationId,
         campaignParticipationRepository,
-        domainTransaction,
       });
 
       // then
       expect(campaignParticipation.share).to.have.been.called;
-      expect(campaignParticipationRepository.updateWithSnapshot).to.have.been.calledWithExactly(
-        campaignParticipation,
-        domainTransaction,
-      );
+      expect(campaignParticipationRepository.updateWithSnapshot).to.have.been.calledWithExactly(campaignParticipation);
     });
 
     it('returns the CampaignParticipationResultsShared event', async function () {
       // given
-      const domainTransaction = Symbol('transaction');
       const campaignParticipation = domainBuilder.prescription.campaignParticipation.buildCampaignParticipation({
         id: campaignParticipationId,
         userId,
@@ -81,7 +71,6 @@ describe('Unit | UseCase | share-campaign-result', function () {
         userId,
         campaignParticipationId,
         campaignParticipationRepository,
-        domainTransaction,
       });
 
       // then

--- a/api/tests/prescription/shared/unit/infrastructure/application-transaction_test.js
+++ b/api/tests/prescription/shared/unit/infrastructure/application-transaction_test.js
@@ -1,0 +1,121 @@
+import { expect, sinon, knex, catchErr } from '../../../../test-helper.js';
+import { asyncLocalStorage } from '../../../../../src/prescription/shared/infrastructure/utils/async-local-storage.js';
+import { ApplicationTransaction } from '../../../../../src/prescription/shared/infrastructure/ApplicationTransaction.js';
+import { DomainTransaction } from '../../../../../src/shared/domain/DomainTransaction.js';
+
+describe('Unit | Infrastructure | application-transaction', function () {
+  describe('#getTransactionAsDomainTransaction', function () {
+    it('should return transaction as a DomainTransaction', function () {
+      const transaction = Symbol('transaction');
+      const storeStub = { transaction };
+      sinon.stub(asyncLocalStorage, 'getStore');
+      asyncLocalStorage.getStore.returns(storeStub);
+
+      const domainTransaction = ApplicationTransaction.getTransactionAsDomainTransaction();
+
+      expect(domainTransaction).to.be.instanceof(DomainTransaction);
+      expect(domainTransaction.knexTransaction).to.equal(transaction);
+    });
+
+    it('should throw an error if there is no transaction', async function () {
+      sinon.stub(asyncLocalStorage, 'getStore');
+      asyncLocalStorage.getStore.returns();
+
+      const err = await catchErr(ApplicationTransaction.getTransactionAsDomainTransaction)();
+
+      expect(err.message).to.equal('No transaction');
+    });
+  });
+
+  describe('#getConnection', function () {
+    it('should return connection from store', function () {
+      const transaction = Symbol('transaction');
+      const storeStub = { transaction };
+      sinon.stub(asyncLocalStorage, 'getStore');
+      asyncLocalStorage.getStore.returns(storeStub);
+
+      const connection = ApplicationTransaction.getConnection();
+
+      expect(connection).to.equal(transaction);
+    });
+
+    it('should return connection from domainTransaction if provided', function () {
+      const transaction = Symbol('transaction');
+      const domainTransaction = { knexTransaction: transaction };
+      sinon.stub(asyncLocalStorage, 'getStore');
+
+      const connection = ApplicationTransaction.getConnection(domainTransaction);
+
+      expect(connection).to.equal(transaction);
+    });
+
+    it('should return knex connection by default', function () {
+      sinon.stub(asyncLocalStorage, 'getStore');
+
+      const connection = ApplicationTransaction.getConnection();
+
+      expect(connection).to.equal(knex);
+    });
+  });
+
+  describe('#execute', function () {
+    it('should commit transaction', async function () {
+      const transactionStub = {
+        commit: sinon.stub(),
+      };
+      sinon.stub(asyncLocalStorage, 'run');
+      sinon.stub(knex, 'transaction');
+      knex.transaction.resolves(transactionStub);
+
+      await ApplicationTransaction.execute(function () {
+        // Something
+      });
+
+      expect(transactionStub.commit).to.have.been.called;
+    });
+
+    it('should rollback and throw error if something went wrong', async function () {
+      const transactionStub = {
+        rollback: sinon.stub(),
+      };
+      sinon.stub(asyncLocalStorage, 'run').callsFake((_, cb) => cb());
+      sinon.stub(knex, 'transaction');
+      knex.transaction.resolves(transactionStub);
+
+      await catchErr(ApplicationTransaction.execute)(function () {
+        throw new Error();
+      });
+
+      expect(transactionStub.rollback).to.have.been.called;
+    });
+
+    it('should store transaction', async function () {
+      const transactionStub = {
+        commit: sinon.stub(),
+      };
+      sinon.stub(asyncLocalStorage, 'run');
+      sinon.stub(knex, 'transaction');
+      knex.transaction.resolves(transactionStub);
+
+      await ApplicationTransaction.execute(function () {
+        // Something
+      });
+
+      expect(asyncLocalStorage.run).to.have.been.calledWith({ transaction: transactionStub });
+    });
+
+    it('should return function result', async function () {
+      const expectedResult = Symbol('return');
+      const transactionStub = {
+        commit: sinon.stub(),
+      };
+      sinon.stub(asyncLocalStorage, 'run').resolves(expectedResult);
+      sinon.stub(knex, 'transaction');
+      knex.transaction.resolves(transactionStub);
+
+      const result = await ApplicationTransaction.execute();
+
+      expect(result).to.equal(expectedResult);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on utilise des transactions, elles sont démarrées dans la couche application puis passées à la couche domain pour finalement être passées à la couche infrastructure. 

Dns l'appoche DDD, la couche domain ne devrait pas avoir conscience que les requêtes SQL sont executées dans le cadre d'une transaction.

Pour plus de détails, voir l'argumentaire [ici](https://github.com/1024pix/pix/pull/5867#issuecomment-1598572904)

## :robot: Proposition
~On souhaite faire un POC d'une implémentation utilisant knex.transactionProvider~

On souhaite faire un POC d'une implémentation utilisant AsyncLocalStorage

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
