### PR TITLE
[FEATURE] Ajout d'un fil d'ariane sur la page de détail d'un prescrit (PIX-7301)

### DIFF
--- a/orga/app/controllers/authenticated/organization-participants/organization-participant.js
+++ b/orga/app/controllers/authenticated/organization-participants/organization-participant.js
@@ -1,0 +1,22 @@
+import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
+
+export default class OrganizationParticipant extends Controller {
+  @service intl;
+
+  get breadcrumbLinks() {
+    return [
+      {
+        route: 'authenticated.organization-participants',
+        label: this.intl.t('navigation.main.organization-participants'),
+      },
+      {
+        route: 'authenticated.organization-participants.organization-participant',
+        label: this.intl.t('common.fullname', {
+          firstName: this.model.firstName,
+          lastName: this.model.lastName,
+        }),
+      },
+    ];
+  }
+}

--- a/orga/app/controllers/authenticated/sco-organization-participants/sco-organization-participant.js
+++ b/orga/app/controllers/authenticated/sco-organization-participants/sco-organization-participant.js
@@ -1,0 +1,22 @@
+import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
+
+export default class ScoOrganizationParticipant extends Controller {
+  @service intl;
+
+  get breadcrumbLinks() {
+    return [
+      {
+        route: 'authenticated.sco-organization-participants',
+        label: this.intl.t('navigation.main.sco-organization-participants'),
+      },
+      {
+        route: 'authenticated.sco-organization-participants.sco-organization-participant',
+        label: this.intl.t('common.fullname', {
+          firstName: this.model.organizationLearner.firstName,
+          lastName: this.model.organizationLearner.lastName,
+        }),
+      },
+    ];
+  }
+}

--- a/orga/app/controllers/authenticated/sup-organization-participants/sup-organization-participant.js
+++ b/orga/app/controllers/authenticated/sup-organization-participants/sup-organization-participant.js
@@ -1,0 +1,22 @@
+import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
+
+export default class SupOrganizationParticipant extends Controller {
+  @service intl;
+
+  get breadcrumbLinks() {
+    return [
+      {
+        route: 'authenticated.sup-organization-participants',
+        label: this.intl.t('navigation.main.sup-organization-participants'),
+      },
+      {
+        route: 'authenticated.sup-organization-participants.sup-organization-participant',
+        label: this.intl.t('common.fullname', {
+          firstName: this.model.firstName,
+          lastName: this.model.lastName,
+        }),
+      },
+    ];
+  }
+}

--- a/orga/app/styles/components/ui/information.scss
+++ b/orga/app/styles/components/ui/information.scss
@@ -1,5 +1,6 @@
 .information-wrapper {
   display: flex;
+  margin: 0;
 }
 
 .information {

--- a/orga/app/styles/pages/authenticated/organization-participants/organization-participant.scss
+++ b/orga/app/styles/pages/authenticated/organization-participants/organization-participant.scss
@@ -1,9 +1,19 @@
 .learner-header {
-  display: flex;
-  margin: $spacing-m 0;
-  justify-content: flex-start;
+  margin: $spacing-l 0;
 
-  &-title {
+  &__breadcrumb {
+    text-transform: capitalize;
+  }
+
+  &__info {
+    display: flex;
+    align-items: center;
+    margin-top: $spacing-m;
+  }
+
+  &-info__title {
+    @include h2;
+
     text-transform: capitalize;
   }
 }

--- a/orga/app/styles/pages/authenticated/sco-organization-participants/sco-organization-participant.scss
+++ b/orga/app/styles/pages/authenticated/sco-organization-participants/sco-organization-participant.scss
@@ -1,8 +1,19 @@
 .learner-header {
-  display: flex;
-  margin: $spacing-m 0;
+  margin: $spacing-l 0;
 
-  &-title {
+  &__breadcrumb {
+    text-transform: capitalize;
+  }
+
+  &__info {
+    display: flex;
+    align-items: center;
+    margin-top: $spacing-m;
+  }
+
+  &-info__title {
+    @include h2;
+
     text-transform: capitalize;
   }
 }

--- a/orga/app/styles/pages/authenticated/sup-organization-participants/sup-organization-participant.scss
+++ b/orga/app/styles/pages/authenticated/sup-organization-participants/sup-organization-participant.scss
@@ -1,7 +1,19 @@
 .learner-header {
-  margin-bottom: $spacing-m;
+  margin: $spacing-l 0;
 
-  &-title {
+  &__breadcrumb {
+    text-transform: capitalize;
+  }
+
+  &__info {
+    display: flex;
+    align-items: center;
+    margin-top: $spacing-m;
+  }
+
+  &-info__title {
+    @include h2;
+
     text-transform: capitalize;
   }
 }

--- a/orga/app/templates/authenticated/organization-participants/organization-participant.hbs
+++ b/orga/app/templates/authenticated/organization-participants/organization-participant.hbs
@@ -1,18 +1,15 @@
 <article>
   <header class="learner-header">
-    <Ui::PreviousPageButton
-      @route="authenticated.organization-participants"
-      @backButtonAriaLabel={{t "common.actions.back"}}
-      aria-label={{t
-        "pages.organization-learner.header.aria-labe-title"
-        firstName=@model.firstName
-        lastName=@model.lastName
-      }}
-      class="learner-header-title"
-    >
-      {{t "common.fullname" firstName=@model.firstName lastName=@model.lastName}}
-    </Ui::PreviousPageButton>
-    <Ui::LearnerHeaderInfo @isCertifiable={{@model.isCertifiable}} @certifiableAt={{@model.certifiableAt}} />
+    <Ui::Breadcrumb class="learner-header__breadcrumb" @links={{this.breadcrumbLinks}} />
+    <div class="learner-header__info">
+
+      <h1 class="learner-header-info__title">{{t
+          "common.fullname"
+          firstName=@model.firstName
+          lastName=@model.lastName
+        }}</h1>
+      <Ui::LearnerHeaderInfo @isCertifiable={{@model.isCertifiable}} @certifiableAt={{@model.certifiableAt}} />
+    </div>
   </header>
   {{outlet}}
 </article>

--- a/orga/app/templates/authenticated/sco-organization-participants/sco-organization-participant.hbs
+++ b/orga/app/templates/authenticated/sco-organization-participants/sco-organization-participant.hbs
@@ -1,28 +1,21 @@
 <article>
   <header class="learner-header">
-    <Ui::PreviousPageButton
-      @route="authenticated.sco-organization-participants"
-      @backButtonAriaLabel={{t "common.actions.back"}}
-      aria-label={{t
-        "pages.organization-learner.header.aria-label-title"
-        firstName=@model.organizationLearner.firstName
-        lastName=@model.organizationLearner.lastName
-      }}
-      class="learner-header-title"
-    >
-      {{t
-        "common.fullname"
-        firstName=@model.organizationLearner.firstName
-        lastName=@model.organizationLearner.lastName
-      }}
-    </Ui::PreviousPageButton>
-    <Ui::LearnerHeaderInfo
-      @groupName={{t "components.group.SCO"}}
-      @group={{@model.organizationLearner.division}}
-      @authenticationMethods={{@model.organizationLearner.authenticationMethodsList}}
-      @isCertifiable={{@model.organizationLearner.isCertifiable}}
-      @certifiableAt={{@model.organizationLearner.certifiableAt}}
-    />
+    <Ui::Breadcrumb class="learner-header__breadcrumb" @links={{this.breadcrumbLinks}} />
+    <div class="learner-header__info">
+
+      <h1 class="learner-header-info__title">{{t
+          "common.fullname"
+          firstName=@model.organizationLearner.firstName
+          lastName=@model.organizationLearner.lastName
+        }}</h1>
+      <Ui::LearnerHeaderInfo
+        @groupName={{t "components.group.SCO"}}
+        @group={{@model.organizationLearner.division}}
+        @authenticationMethods={{@model.organizationLearner.authenticationMethodsList}}
+        @isCertifiable={{@model.organizationLearner.isCertifiable}}
+        @certifiableAt={{@model.organizationLearner.certifiableAt}}
+      />
+    </div>
   </header>
   {{outlet}}
 </article>

--- a/orga/app/templates/authenticated/sup-organization-participants/sup-organization-participant.hbs
+++ b/orga/app/templates/authenticated/sup-organization-participants/sup-organization-participant.hbs
@@ -1,23 +1,19 @@
 <article>
   <header class="learner-header">
-    <Ui::PreviousPageButton
-      @route="authenticated.sup-organization-participants"
-      @backButtonAriaLabel={{t "common.actions.back"}}
-      aria-label={{t
-        "pages.organization-learner.header.aria-label-title"
-        firstName=@model.firstName
-        lastName=@model.lastName
-      }}
-      class="learner-header-title"
-    >
-      {{t "common.fullname" firstName=@model.firstName lastName=@model.lastName}}
-    </Ui::PreviousPageButton>
-    <Ui::LearnerHeaderInfo
-      @groupName={{t "components.group.SUP"}}
-      @group={{@model.group}}
-      @isCertifiable={{@model.isCertifiable}}
-      @certifiableAt={{@model.certifiableAt}}
-    />
+    <Ui::Breadcrumb class="learner-header__breadcrumb" @links={{this.breadcrumbLinks}} />
+    <div class="learner-header__info">
+      <h1 class="learner-header-info__title">{{t
+          "common.fullname"
+          firstName=@model.firstName
+          lastName=@model.lastName
+        }}</h1>
+      <Ui::LearnerHeaderInfo
+        @groupName={{t "components.group.SUP"}}
+        @group={{@model.group}}
+        @isCertifiable={{@model.isCertifiable}}
+        @certifiableAt={{@model.certifiableAt}}
+      />
+    </div>
   </header>
   {{outlet}}
 </article>


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la consolidation de l’activité d’un prescrit, [nous avons commencé à revoir la navigation dans Pix Orga](https://1024pix.atlassian.net/browse/PIX-7294) : mise en place d’un vrai titre de page et remplacement de la flèche de retour arrière par un fil d’Ariane.

Nous allons poursuivre cette évolution, en harmonisant toutes les pages Pix Orga pour qu’elles aient le même principe fil d’Ariane+titre.

## :robot: Proposition
Sur la page d’activité d’un prescrit ([https://orga.pix.fr/participants/](https://orga.recette.pix.fr/campagnes/10000693)organizationLearnerId), afficher un fil d’Ariane (Participants > OrganizationLearnerName) + titre de page (OrganizationLearnerName).

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
**Se connecter à Pix Orga (Avec les 3 types d'orga)
Aller sur la page Eleves/Etudiants/Participants
Aller sur le détail d'un eleve/etudiant/participant**

- Le bouton de retour sur la liste des eleves/etudiants/participants, et son nom, ne sont plus affichés.
- Le fil d'Ariane est affiché en haut à gauche de la page. Il indique : Eleves/Etudiants/Participants > <Prénom Nom>.
- Le titre de la page est le prénom et nom.
- Le lien permet bien d'accéder à la page eleves/etudiants/participants.
