### PR TITLE
[FEATURE] Enregistrer la locale de l'utilisateur à la connexion sur app.pix.fr (PIX-7549)

### DIFF
--- a/mon-pix/app/services/locale.js
+++ b/mon-pix/app/services/locale.js
@@ -7,6 +7,10 @@ export default class LocaleService extends Service {
   @service cookies;
   @service currentDomain;
 
+  hasLocaleCookie() {
+    return this.cookies.exists('locale');
+  }
+
   setLocaleCookie(locale) {
     this.cookies.write('locale', locale, {
       domain: `pix.${this.currentDomain.getExtension()}`,

--- a/mon-pix/app/services/locale.js
+++ b/mon-pix/app/services/locale.js
@@ -1,0 +1,18 @@
+import Service, { inject as service } from '@ember/service';
+import config from 'mon-pix/config/environment';
+
+const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
+
+export default class LocaleService extends Service {
+  @service cookies;
+  @service currentDomain;
+
+  setLocaleCookie(locale) {
+    this.cookies.write('locale', locale, {
+      domain: `pix.${this.currentDomain.getExtension()}`,
+      maxAge: COOKIE_LOCALE_LIFESPAN_IN_SECONDS,
+      path: '/',
+      sameSite: 'Strict',
+    });
+  }
+}

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -92,7 +92,10 @@ export default class CurrentSessionService extends SessionService {
 
     if (domain === 'fr') {
       await this._setLocale(defaultLocale);
-      this.locale.setLocaleCookie(FRENCH_LOCALE);
+
+      if (!this.locale.hasLocaleCookie()) {
+        this.locale.setLocaleCookie(FRENCH_LOCALE);
+      }
       return;
     }
 

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -2,6 +2,8 @@ import { inject as service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
 import get from 'lodash/get';
 
+const FRENCH_LOCALE = 'fr-FR';
+
 export default class CurrentSessionService extends SessionService {
   @service currentUser;
   @service currentDomain;
@@ -10,6 +12,7 @@ export default class CurrentSessionService extends SessionService {
   @service url;
   @service router;
   @service oidcIdentityProviders;
+  @service locale;
 
   routeAfterAuthentication = 'authenticated.user-dashboard';
 
@@ -89,6 +92,7 @@ export default class CurrentSessionService extends SessionService {
 
     if (domain === 'fr') {
       await this._setLocale(defaultLocale);
+      this.locale.setLocaleCookie(FRENCH_LOCALE);
       return;
     }
 

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -62,7 +62,6 @@ module.exports = function (environment) {
       EMBED_ALLOWED_ORIGINS: (
         process.env.EMBED_ALLOWED_ORIGINS || 'https://epreuves.pix.fr,https://1024pix.github.io'
       ).split(','),
-
       API_ERROR_MESSAGES: {
         BAD_REQUEST: {
           CODE: '400',
@@ -99,6 +98,7 @@ module.exports = function (environment) {
         defaultValue: 48,
         minValue: 1,
       }),
+      COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
     },
 
     fontawesome: {

--- a/mon-pix/tests/unit/services/locale_test.js
+++ b/mon-pix/tests/unit/services/locale_test.js
@@ -13,6 +13,7 @@ module('Unit | Services | locale', function (hooks) {
     localeService = this.owner.lookup('service:locale');
     cookiesService = this.owner.lookup('service:cookies');
     sinon.stub(cookiesService, 'write');
+    sinon.stub(cookiesService, 'exists');
     currentDomainService = this.owner.lookup('service:currentDomain');
     sinon.stub(currentDomainService, 'getExtension');
   });
@@ -33,6 +34,36 @@ module('Unit | Services | locale', function (hooks) {
         sameSite: 'Strict',
       });
       assert.ok(true);
+    });
+  });
+
+  module('#hasLocaleCookie', function () {
+    module('when there is no cookie locale', function () {
+      test('returns "false"', function (assert) {
+        // given
+        cookiesService.exists.returns(false);
+
+        // when
+        const hasNoCookieLocale = localeService.hasLocaleCookie();
+
+        // then
+        sinon.assert.calledWith(cookiesService.exists, 'locale');
+        assert.notOk(hasNoCookieLocale);
+      });
+    });
+
+    module('when there is a cookie locale', function () {
+      test('returns "true"', function (assert) {
+        // given
+        cookiesService.exists.returns(true);
+
+        // when
+        const hasCookieLocale = localeService.hasLocaleCookie();
+
+        // then
+        sinon.assert.calledWith(cookiesService.exists, 'locale');
+        assert.ok(hasCookieLocale);
+      });
     });
   });
 });

--- a/mon-pix/tests/unit/services/locale_test.js
+++ b/mon-pix/tests/unit/services/locale_test.js
@@ -1,0 +1,38 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Services | locale', function (hooks) {
+  setupTest(hooks);
+
+  let localeService;
+  let cookiesService;
+  let currentDomainService;
+
+  hooks.beforeEach(function () {
+    localeService = this.owner.lookup('service:locale');
+    cookiesService = this.owner.lookup('service:cookies');
+    sinon.stub(cookiesService, 'write');
+    currentDomainService = this.owner.lookup('service:currentDomain');
+    sinon.stub(currentDomainService, 'getExtension');
+  });
+
+  module('#setLocaleCookie', function () {
+    test('saves the locale in cookie locale', function (assert) {
+      // given
+      currentDomainService.getExtension.returns('fr');
+
+      // when
+      localeService.setLocaleCookie('fr-CA');
+
+      // then
+      sinon.assert.calledWith(cookiesService.write, 'locale', 'fr-CA', {
+        domain: 'pix.fr',
+        maxAge: 31536000,
+        path: '/',
+        sameSite: 'Strict',
+      });
+      assert.ok(true);
+    });
+  });
+});

--- a/mon-pix/tests/unit/services/session_test.js
+++ b/mon-pix/tests/unit/services/session_test.js
@@ -16,7 +16,7 @@ module('Unit | Services | session', function (hooks) {
     sessionService.currentDomain = { getExtension: sinon.stub() };
     sessionService.intl = { setLocale: sinon.stub() };
     sessionService.dayjs = { setLocale: sinon.stub(), self: { locale: sinon.stub() } };
-    sessionService.locale = { setLocaleCookie: sinon.stub() };
+    sessionService.locale = { setLocaleCookie: sinon.stub(), hasLocaleCookie: sinon.stub() };
     sessionService._getRouteAfterInvalidation = sinon.stub();
     sessionService._logoutUser = sinon.stub();
 
@@ -283,9 +283,10 @@ module('Unit | Services | session', function (hooks) {
       });
 
       module('when the current domain  is "fr"', function () {
-        module('when there is no cookie', function () {
+        module('when there is no cookie locale', function () {
           test('add a cookie locale with "fr-FR" as value', async function (assert) {
             // given
+            sessionService.locale.hasLocaleCookie.returns(false);
             sessionService.currentDomain.getExtension.returns('fr');
 
             // when
@@ -293,6 +294,21 @@ module('Unit | Services | session', function (hooks) {
 
             // then
             sinon.assert.calledWith(sessionService.locale.setLocaleCookie, 'fr-FR');
+            assert.ok(true);
+          });
+        });
+
+        module('when there is a cookie locale', function () {
+          test('does not update cookie locale', async function (assert) {
+            // given
+            sessionService.locale.hasLocaleCookie.returns(true);
+            sessionService.currentDomain.getExtension.returns('fr');
+
+            // when
+            await sessionService.handleUserLanguageAndLocale();
+
+            // then
+            sinon.assert.notCalled(sessionService.locale.setLocaleCookie);
             assert.ok(true);
           });
         });

--- a/mon-pix/tests/unit/services/session_test.js
+++ b/mon-pix/tests/unit/services/session_test.js
@@ -16,6 +16,7 @@ module('Unit | Services | session', function (hooks) {
     sessionService.currentDomain = { getExtension: sinon.stub() };
     sessionService.intl = { setLocale: sinon.stub() };
     sessionService.dayjs = { setLocale: sinon.stub(), self: { locale: sinon.stub() } };
+    sessionService.locale = { setLocaleCookie: sinon.stub() };
     sessionService._getRouteAfterInvalidation = sinon.stub();
     sessionService._logoutUser = sinon.stub();
 
@@ -276,6 +277,22 @@ module('Unit | Services | session', function (hooks) {
             // then
             sinon.assert.calledWith(sessionService.intl.setLocale, ['ru', 'fr']);
             sinon.assert.calledWith(sessionService.dayjs.setLocale, 'ru');
+            assert.ok(true);
+          });
+        });
+      });
+
+      module('when the current domain  is "fr"', function () {
+        module('when there is no cookie', function () {
+          test('add a cookie locale with "fr-FR" as value', async function (assert) {
+            // given
+            sessionService.currentDomain.getExtension.returns('fr');
+
+            // when
+            await sessionService.handleUserLanguageAndLocale();
+
+            // then
+            sinon.assert.calledWith(sessionService.locale.setLocaleCookie, 'fr-FR');
             assert.ok(true);
           });
         });


### PR DESCRIPTION
## :unicorn: Problème

Nous avons géré l'ajout de la locale sur un compte utilisateur n'ayant pas de locale à la connexion de ce dernier sur le domaine **.org** de Pix App.

Il manque la gestion de la locale lorsqu'un utilisateur se trouve sur le domaine **.fr**.

## :robot: Proposition

Lorsqu'un utilisateur arrive sur le domaine **.fr** de Pix App, et que ce dernier n'a pas de cookie **locale**, ajouter la valeur `fr-FR` dans le cookie locale. Si un cookie est déjà présent, ne pas le modifier.

## :rainbow: Remarques

RAS

## :100: Pour tester

### Sans cookie

- Ouvrir un nouvel onglet avec https://app-pr5877.review.pix.fr/
- Ouvrir la console développeur
- Supprimer les cookies qui peuvent être présent
- Rafraichir la page
- Constater que le cookie `locale` est présent avec comme valeur `fr-FR`
- Trouver un compte en base de données n'ayant pas encore de locale
- Se connecter avec ce compte
- Constater en base de données que l'utilisateur a bien la valeur du cookie locale

### Avec cookie

- Ouvrir un nouvel onglet avec https://app-pr5877.review.pix.fr/
- Ouvrir la console développeur
- Modifier le cookie locale en `fr-CA`
- Rafraichir la page
- Constater que le cookie `locale` a toujours la valeur `fr-CA`
- Utiliser le compte du précédent scénario
- Se connecter avec ce compte
- Constater en base de données que l'utilisateur a bien l'ancienne valeur et non la nouvelle