### PR TITLE
[TECH] Change les imports de ember-cli-mirage à miragejs

### DIFF
--- a/admin/mirage/factories/badge.js
+++ b/admin/mirage/factories/badge.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 
 export default Factory.extend({
   key() {

--- a/admin/mirage/factories/certification-center-invitation.js
+++ b/admin/mirage/factories/certification-center-invitation.js
@@ -1,4 +1,4 @@
-import { Factory, association } from 'ember-cli-mirage';
+import { Factory, association } from 'miragejs';
 import faker from 'faker';
 
 export default Factory.extend({

--- a/admin/mirage/factories/certification-center.js
+++ b/admin/mirage/factories/certification-center.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 import faker from 'faker';
 
 export default Factory.extend({

--- a/admin/mirage/factories/feature-toggle.js
+++ b/admin/mirage/factories/feature-toggle.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 
 export default Factory.extend({
   id: 0,

--- a/admin/mirage/factories/organization-invitation.js
+++ b/admin/mirage/factories/organization-invitation.js
@@ -1,4 +1,4 @@
-import { Factory, association } from 'ember-cli-mirage';
+import { Factory, association } from 'miragejs';
 import faker from 'faker';
 
 export default Factory.extend({

--- a/admin/mirage/factories/organization.js
+++ b/admin/mirage/factories/organization.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 
 export default Factory.extend({
   isManagingStudents() {

--- a/admin/mirage/factories/session.js
+++ b/admin/mirage/factories/session.js
@@ -1,4 +1,4 @@
-import { Factory, trait } from 'ember-cli-mirage';
+import { Factory, trait } from 'miragejs';
 import faker from 'faker';
 import dayjs from 'dayjs';
 import { CREATED, FINALIZED, IN_PROCESS, PROCESSED } from 'pix-admin/models/session';

--- a/admin/mirage/factories/target-profile.js
+++ b/admin/mirage/factories/target-profile.js
@@ -1,4 +1,4 @@
-import { Factory, trait } from 'ember-cli-mirage';
+import { Factory, trait } from 'miragejs';
 import { createLearningContent } from '../helpers/create-learning-content';
 
 export default Factory.extend({

--- a/admin/mirage/factories/training.js
+++ b/admin/mirage/factories/training.js
@@ -1,4 +1,4 @@
-import { Factory, trait } from 'ember-cli-mirage';
+import { Factory, trait } from 'miragejs';
 import faker from 'faker';
 import { createLearningContent } from '../helpers/create-learning-content';
 

--- a/admin/mirage/factories/user.js
+++ b/admin/mirage/factories/user.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 import faker from 'faker';
 
 export default Factory.extend({

--- a/admin/mirage/serializers/application.js
+++ b/admin/mirage/serializers/application.js
@@ -1,4 +1,4 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import { JSONAPISerializer } from 'miragejs';
 import Inflector from 'ember-inflector';
 
 export default JSONAPISerializer.extend({

--- a/admin/mirage/serializers/certification-center-membership.js
+++ b/admin/mirage/serializers/certification-center-membership.js
@@ -1,4 +1,4 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import { JSONAPISerializer } from 'miragejs';
 
 const relationshipsToInclude = ['certificationCenter', 'user'];
 

--- a/admin/mirage/serializers/certification-center.js
+++ b/admin/mirage/serializers/certification-center.js
@@ -1,4 +1,4 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import { JSONAPISerializer } from 'miragejs';
 
 const include = ['habilitations'];
 

--- a/admin/mirage/serializers/jury-certification-summary.js
+++ b/admin/mirage/serializers/jury-certification-summary.js
@@ -1,3 +1,3 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import { JSONAPISerializer } from 'miragejs';
 
 export default JSONAPISerializer.extend({});

--- a/certif/mirage/factories/certification-candidate.js
+++ b/certif/mirage/factories/certification-candidate.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 import faker from 'faker';
 import dayjs from 'dayjs';
 

--- a/certif/mirage/factories/certification-issue-report.js
+++ b/certif/mirage/factories/certification-issue-report.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 
 export default Factory.extend({
   category() {

--- a/certif/mirage/factories/certification-point-of-contact.js
+++ b/certif/mirage/factories/certification-point-of-contact.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 
 export default Factory.extend({
   firstName() {

--- a/certif/mirage/factories/certification-report.js
+++ b/certif/mirage/factories/certification-report.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 import faker from 'faker';
 
 export default Factory.extend({

--- a/certif/mirage/factories/country.js
+++ b/certif/mirage/factories/country.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 import faker from 'faker';
 
 export default Factory.extend({

--- a/certif/mirage/factories/division.js
+++ b/certif/mirage/factories/division.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 import faker from 'faker';
 
 export default Factory.extend({

--- a/certif/mirage/factories/feature-toggle.js
+++ b/certif/mirage/factories/feature-toggle.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 
 export default Factory.extend({
   id: 0,

--- a/certif/mirage/factories/session.js
+++ b/certif/mirage/factories/session.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 import faker from 'faker';
 import dayjs from 'dayjs';
 import { CREATED } from 'pix-certif/models/session';

--- a/certif/mirage/factories/student.js
+++ b/certif/mirage/factories/student.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 import faker from 'faker';
 import dayjs from 'dayjs';
 

--- a/certif/mirage/serializers/application.js
+++ b/certif/mirage/serializers/application.js
@@ -1,3 +1,3 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import { JSONAPISerializer } from 'miragejs';
 
 export default JSONAPISerializer.extend({});

--- a/certif/mirage/serializers/session-summary.js
+++ b/certif/mirage/serializers/session-summary.js
@@ -1,3 +1,3 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
-export default JSONAPISerializer.extend({});
+export default ApplicationSerializer.extend({});

--- a/certif/mirage/serializers/student.js
+++ b/certif/mirage/serializers/student.js
@@ -1,3 +1,3 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
-export default JSONAPISerializer.extend({});
+export default ApplicationSerializer.extend({});

--- a/orga/mirage/factories/campaign-analysis.js
+++ b/orga/mirage/factories/campaign-analysis.js
@@ -1,4 +1,4 @@
-import { Factory, trait } from 'ember-cli-mirage';
+import { Factory, trait } from 'miragejs';
 
 export default Factory.extend({
   withTubeRecommendations: trait({

--- a/orga/mirage/factories/campaign-assessment-participation-result.js
+++ b/orga/mirage/factories/campaign-assessment-participation-result.js
@@ -1,4 +1,4 @@
-import { Factory, trait } from 'ember-cli-mirage';
+import { Factory, trait } from 'miragejs';
 
 export default Factory.extend({
   withCompetenceResults: trait({

--- a/orga/mirage/factories/campaign-collective-result.js
+++ b/orga/mirage/factories/campaign-collective-result.js
@@ -1,4 +1,4 @@
-import { Factory, trait } from 'ember-cli-mirage';
+import { Factory, trait } from 'miragejs';
 
 export default Factory.extend({
   withCompetenceCollectiveResults: trait({

--- a/orga/mirage/factories/campaign-participation.js
+++ b/orga/mirage/factories/campaign-participation.js
@@ -1,4 +1,4 @@
-import { Factory, association } from 'ember-cli-mirage';
+import { Factory, association } from 'miragejs';
 import faker from 'faker';
 
 export default Factory.extend({

--- a/orga/mirage/factories/campaign-profile.js
+++ b/orga/mirage/factories/campaign-profile.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 import faker from 'faker';
 
 export default Factory.extend({

--- a/orga/mirage/factories/campaign.js
+++ b/orga/mirage/factories/campaign.js
@@ -1,4 +1,4 @@
-import { Factory, trait } from 'ember-cli-mirage';
+import { Factory, trait } from 'miragejs';
 import faker from 'faker';
 
 export default Factory.extend({

--- a/orga/mirage/factories/division.js
+++ b/orga/mirage/factories/division.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 import faker from 'faker';
 
 export default Factory.extend({

--- a/orga/mirage/factories/feature-toggle.js
+++ b/orga/mirage/factories/feature-toggle.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 
 export default Factory.extend({
   id: 0,

--- a/orga/mirage/factories/organization-invitation.js
+++ b/orga/mirage/factories/organization-invitation.js
@@ -1,4 +1,4 @@
-import { Factory, association } from 'ember-cli-mirage';
+import { Factory, association } from 'miragejs';
 import faker from 'faker';
 
 export default Factory.extend({

--- a/orga/mirage/factories/organization-participant.js
+++ b/orga/mirage/factories/organization-participant.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 import faker from 'faker';
 
 export default Factory.extend({

--- a/orga/mirage/factories/target-profile.js
+++ b/orga/mirage/factories/target-profile.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 import faker from 'faker';
 
 export default Factory.extend({

--- a/orga/mirage/factories/user.js
+++ b/orga/mirage/factories/user.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 import faker from 'faker';
 
 export default Factory.extend({

--- a/orga/mirage/serializers/application.js
+++ b/orga/mirage/serializers/application.js
@@ -1,3 +1,3 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import { JSONAPISerializer } from 'miragejs';
 
 export default JSONAPISerializer.extend({});

--- a/orga/mirage/serializers/area.js
+++ b/orga/mirage/serializers/area.js
@@ -1,7 +1,7 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
 const _include = ['competences'];
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   include: _include,
 });

--- a/orga/mirage/serializers/campaign-analysis.js
+++ b/orga/mirage/serializers/campaign-analysis.js
@@ -1,7 +1,7 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
 const relationshipsToInclude = ['campaignTubeRecommendations'];
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   include: relationshipsToInclude,
 });

--- a/orga/mirage/serializers/campaign-assessment-participation-result.js
+++ b/orga/mirage/serializers/campaign-assessment-participation-result.js
@@ -1,7 +1,7 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
 const relationshipsToInclude = ['competenceResults'];
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   include: relationshipsToInclude,
 });

--- a/orga/mirage/serializers/campaign-assessment-participation.js
+++ b/orga/mirage/serializers/campaign-assessment-participation.js
@@ -1,6 +1,6 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   links(campaignAssessmentParticipation) {
     return {
       campaignAssessmentParticipationResult: {

--- a/orga/mirage/serializers/campaign-collective-result.js
+++ b/orga/mirage/serializers/campaign-collective-result.js
@@ -1,7 +1,7 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
 const relationshipsToInclude = ['campaignCompetenceCollectiveResults'];
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   include: relationshipsToInclude,
 });

--- a/orga/mirage/serializers/campaign.js
+++ b/orga/mirage/serializers/campaign.js
@@ -1,6 +1,6 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   links(campaign) {
     return {
       campaignCollectiveResult: {

--- a/orga/mirage/serializers/competence.js
+++ b/orga/mirage/serializers/competence.js
@@ -1,7 +1,7 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
 const _include = ['thematics'];
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   include: _include,
 });

--- a/orga/mirage/serializers/framework.js
+++ b/orga/mirage/serializers/framework.js
@@ -1,7 +1,7 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
 const _include = ['areas'];
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   include: _include,
 });

--- a/orga/mirage/serializers/membership.js
+++ b/orga/mirage/serializers/membership.js
@@ -1,7 +1,7 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
 const relationshipsToInclude = ['organization', 'user'];
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   include: relationshipsToInclude,
 });

--- a/orga/mirage/serializers/organization-participant.js
+++ b/orga/mirage/serializers/organization-participant.js
@@ -1,3 +1,3 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
-export default JSONAPISerializer.extend({});
+export default ApplicationSerializer.extend({});

--- a/orga/mirage/serializers/organization.js
+++ b/orga/mirage/serializers/organization.js
@@ -1,6 +1,6 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   links(organization) {
     return {
       campaigns: {

--- a/orga/mirage/serializers/prescriber.js
+++ b/orga/mirage/serializers/prescriber.js
@@ -1,7 +1,7 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
 const relationshipsToInclude = ['memberships', 'userOrgaSettings'];
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   include: relationshipsToInclude,
 });

--- a/orga/mirage/serializers/sco-organization-participant.js
+++ b/orga/mirage/serializers/sco-organization-participant.js
@@ -1,3 +1,3 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
-export default JSONAPISerializer.extend({});
+export default ApplicationSerializer.extend({});

--- a/orga/mirage/serializers/sup-organization-participant.js
+++ b/orga/mirage/serializers/sup-organization-participant.js
@@ -1,3 +1,3 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
-export default JSONAPISerializer.extend({});
+export default ApplicationSerializer.extend({});

--- a/orga/mirage/serializers/thematic.js
+++ b/orga/mirage/serializers/thematic.js
@@ -1,7 +1,7 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
 const _include = ['tubes'];
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   include: _include,
 });

--- a/orga/mirage/serializers/user-orga-setting.js
+++ b/orga/mirage/serializers/user-orga-setting.js
@@ -1,7 +1,7 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
 const relationshipsToInclude = ['organization'];
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   include: relationshipsToInclude,
 });

--- a/orga/mirage/serializers/user.js
+++ b/orga/mirage/serializers/user.js
@@ -1,7 +1,7 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import ApplicationSerializer from './application';
 
 const relationshipsToInclude = ['userOrgaSettings'];
 
-export default JSONAPISerializer.extend({
+export default ApplicationSerializer.extend({
   include: relationshipsToInclude,
 });


### PR DESCRIPTION
## :unicorn: Problème
Les imports des classes et autres de `miragejs` via `ember-cli-mirage` sont dépréciés.

## :robot: Proposition
Importer directement depuis `miragejs`.

## :100: Pour tester
:green_circle:  tests
