### PR TITLE
[FEATURE] Afficher un message d'erreur correct pour les erreurs liées à la locale lors de la connexion à Pix App (PIX-7434)

### DIFF
--- a/mon-pix/app/components/signin-form.js
+++ b/mon-pix/app/components/signin-form.js
@@ -53,6 +53,16 @@ export default class SigninForm extends Component {
     const errors = get(responseError, 'responseJSON.errors');
     const error = Array.isArray(errors) && errors.length > 0 && errors[0];
     switch (error?.code) {
+      case 'INVALID_LOCALE_FORMAT':
+        this.errorMessage = this.intl.t('pages.sign-up.errors.invalid-locale-format', {
+          invalidLocale: error.meta.locale,
+        });
+        break;
+      case 'LOCALE_NOT_SUPPORTED':
+        this.errorMessage = this.intl.t('pages.sign-up.errors.locale-not-supported', {
+          localeNotSupported: error.meta.locale,
+        });
+        break;
       case 'SHOULD_CHANGE_PASSWORD': {
         const passwordResetToken = error.meta;
         await this._updateExpiredPassword(passwordResetToken);


### PR DESCRIPTION
## :unicorn: Problème

Lors de la connexion à Pix App, la requête peut contenir un cookie **locale** contenant la valeur de la locale de l’utilisateur. Cette valeur est ajoutée comme information du compte de l’utilisateur si ce dernier n’a pas de locale défini. Lors de la réception du cookie, un formatage et une vérification sont faites et peuvent entrainer des erreurs comme **LocaleNotSupportedError** ou **LocaleFormatError**. Ces erreurs ne sont pas gérées au niveau de Pix App et un message générique est affiché.

## :robot: Proposition

Afficher un message d’erreur précis pour chacune des erreurs suivantes : **LocaleNotSupportedError** et **LocaleFormatError**.

## :rainbow: Remarques

RAS

## :100: Pour tester

### Domaine .fr

#### Locale invalide

- Ouvrir https://app-pr5882.review.pix.fr/ dans un nouvel onglet
- Ouvrir la console développeur
- Ajouter `zzzz` comme valeur pour le cookie **locale**
- Se connecter avec `userpix1@example.net`
- Constater l'affichage d'un message d'erreur concernant la locale qui n'est pas dans le bon format

#### Locale non supportée

- Ouvrir https://app-pr5882.review.pix.fr/ dans un nouvel onglet
- Ouvrir la console développeur
- Ajouter `fr-CA` comme valeur pour le cookie **locale**
- Se connecter avec `userpix1@example.net`
- Constater l'affichage d'un message d'erreur concernant la locale qui n'est pas supportée

### Domaine .org

#### Locale invalide

- Ouvrir https://app-pr5882.review.pix.org/ dans un nouvel onglet
- Ouvrir la console développeur
- Ajouter `zzzz` comme valeur pour le cookie **locale**
- Se connecter avec `userpix1@example.net`
- Constater l'affichage d'un message d'erreur concernant la locale qui n'est pas dans le bon format

#### Locale non supportée

- Ouvrir https://app-pr5882.review.pix.org/ dans un nouvel onglet
- Ouvrir la console développeur
- Ajouter `fr-CA` comme valeur pour le cookie **locale**
- Se connecter avec `userpix1@example.net`
- Constater l'affichage d'un message d'erreur concernant la locale qui n'est pas supportée