### PR TITLE
[BUGFIX] Ajouter les traductions pour les champs en erreur dans les formulaires de création et modification de session (PIX-7157).

### DIFF
--- a/certif/app/controllers/authenticated/sessions/new.js
+++ b/certif/app/controllers/authenticated/sessions/new.js
@@ -9,9 +9,13 @@ export default class SessionsNewController extends Controller {
   @alias('model') session;
   @service router;
   @service intl;
+  @service notifications;
 
+  @tracked isSessionAddressMissing;
+  @tracked isSessionRoomMissing;
   @tracked isSessionDateMissing;
   @tracked isSessionTimeMissing;
+  @tracked isSessionExaminerMissing;
 
   get pageTitle() {
     return this.intl.t('pages.sessions.new.extra-information');
@@ -20,20 +24,42 @@ export default class SessionsNewController extends Controller {
   @action
   async createSession(event) {
     event.preventDefault();
-    if (!this.session.date) {
-      this.isSessionDateMissing = true;
+    if (this.checkMissingSessionFields()) return;
+    try {
+      await this.session.save();
+    } catch (error) {
+      if (error.errors) {
+        switch (error.errors[0].status) {
+          case '400':
+            this.notifications.error(this.intl.t('common.api-error-messages.bad-request-error'));
+            break;
+          case '500':
+            this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
+            break;
+          default:
+            this.notifications.error(this.intl.t('common.api-error-messages.internal-error'));
+            break;
+        }
+      }
     }
-    if (!this.session.time) {
-      this.isSessionTimeMissing = true;
-    }
-    if (this.isSessionDateMissing || this.isSessionTimeMissing) return;
-    await this.session.save();
     this.router.transitionTo('authenticated.sessions.details', this.session.id);
   }
 
   @action
   cancel() {
     this.router.transitionTo('authenticated.sessions.list');
+  }
+
+  @action
+  onChangeAddress(event) {
+    this.session.address = event.target.value;
+    this.isSessionAddressMissing = false;
+  }
+
+  @action
+  onChangeRoom(event) {
+    this.session.room = event.target.value;
+    this.isSessionRoomMissing = false;
   }
 
   @action
@@ -46,5 +72,27 @@ export default class SessionsNewController extends Controller {
   onTimePicked(selectedTimes, lastSelectedTimeFormatted) {
     this.session.time = lastSelectedTimeFormatted;
     this.isSessionTimeMissing = false;
+  }
+
+  @action
+  onChangeExaminer(event) {
+    this.session.examiner = event.target.value;
+    this.isSessionExaminerMissing = false;
+  }
+
+  checkMissingSessionFields() {
+    this.isSessionAddressMissing = !this.session.address;
+    this.isSessionRoomMissing = !this.session.room;
+    this.isSessionDateMissing = !this.session.date;
+    this.isSessionTimeMissing = !this.session.time;
+    this.isSessionExaminerMissing = !this.session.examiner;
+
+    return (
+      this.isSessionAddressMissing ||
+      this.isSessionRoomMissing ||
+      this.isSessionDateMissing ||
+      this.isSessionTimeMissing ||
+      this.isSessionExaminerMissing
+    );
   }
 }

--- a/certif/app/controllers/authenticated/sessions/new.js
+++ b/certif/app/controllers/authenticated/sessions/new.js
@@ -3,11 +3,15 @@ import { action } from '@ember/object';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class SessionsNewController extends Controller {
   @alias('model') session;
   @service router;
   @service intl;
+
+  @tracked isSessionDateMissing;
+  @tracked isSessionTimeMissing;
 
   get pageTitle() {
     return this.intl.t('pages.sessions.new.extra-information');
@@ -16,6 +20,13 @@ export default class SessionsNewController extends Controller {
   @action
   async createSession(event) {
     event.preventDefault();
+    if (!this.session.date) {
+      this.isSessionDateMissing = true;
+    }
+    if (!this.session.time) {
+      this.isSessionTimeMissing = true;
+    }
+    if (this.isSessionDateMissing || this.isSessionTimeMissing) return;
     await this.session.save();
     this.router.transitionTo('authenticated.sessions.details', this.session.id);
   }
@@ -28,10 +39,12 @@ export default class SessionsNewController extends Controller {
   @action
   onDatePicked(selectedDates, lastSelectedDateFormatted) {
     this.session.date = lastSelectedDateFormatted;
+    this.isSessionDateMissing = false;
   }
 
   @action
   onTimePicked(selectedTimes, lastSelectedTimeFormatted) {
     this.session.time = lastSelectedTimeFormatted;
+    this.isSessionTimeMissing = false;
   }
 }

--- a/certif/app/controllers/authenticated/sessions/update.js
+++ b/certif/app/controllers/authenticated/sessions/update.js
@@ -3,11 +3,19 @@ import { action } from '@ember/object';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 export default class SessionsUpdateController extends Controller {
   @alias('model') session;
   @service router;
   @service intl;
+  @service notifications;
+
+  @tracked isSessionAddressMissing;
+  @tracked isSessionRoomMissing;
+  @tracked isSessionDateMissing;
+  @tracked isSessionTimeMissing;
+  @tracked isSessionExaminerMissing;
 
   get pageTitle() {
     return `${this.intl.t('pages.sessions.update.title')} | Session ${this.session.id} | Pix Certif`;
@@ -16,7 +24,24 @@ export default class SessionsUpdateController extends Controller {
   @action
   async updateSession(event) {
     event.preventDefault();
-    await this.session.save();
+    if (this.checkMissingSessionFields()) return;
+    try {
+      await this.session.save();
+    } catch (error) {
+      if (error.errors) {
+        switch (error.errors[0].status) {
+          case '400':
+            this.notifications.error(this.intl.t('common.api-error-messages.bad-request-error'));
+            break;
+          case '500':
+            this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
+            break;
+          default:
+            this.notifications.error(this.intl.t('common.api-error-messages.internal-error'));
+            break;
+        }
+      }
+    }
     this.router.transitionTo('authenticated.sessions.details', this.session.id);
   }
 
@@ -26,12 +51,48 @@ export default class SessionsUpdateController extends Controller {
   }
 
   @action
+  onChangeAddress(event) {
+    this.session.address = event.target.value;
+    this.isSessionAddressMissing = false;
+  }
+
+  @action
+  onChangeRoom(event) {
+    this.session.room = event.target.value;
+    this.isSessionRoomMissing = false;
+  }
+
+  @action
   onDatePicked(selectedDates, lastSelectedDateFormatted) {
     this.session.date = lastSelectedDateFormatted;
+    this.isSessionDateMissing = false;
   }
 
   @action
   onTimePicked(selectedTimes, lastSelectedTimeFormatted) {
     this.session.time = lastSelectedTimeFormatted;
+    this.isSessionTimeMissing = false;
+  }
+
+  @action
+  onChangeExaminer(event) {
+    this.session.examiner = event.target.value;
+    this.isSessionExaminerMissing = false;
+  }
+
+  checkMissingSessionFields() {
+    this.isSessionAddressMissing = !this.session.address;
+    this.isSessionRoomMissing = !this.session.room;
+    this.isSessionDateMissing = !this.session.date;
+    this.isSessionTimeMissing = !this.session.time;
+    this.isSessionExaminerMissing = !this.session.examiner;
+
+    return (
+      this.isSessionAddressMissing ||
+      this.isSessionRoomMissing ||
+      this.isSessionDateMissing ||
+      this.isSessionTimeMissing ||
+      this.isSessionExaminerMissing
+    );
   }
 }

--- a/certif/app/templates/authenticated/sessions/new.hbs
+++ b/certif/app/templates/authenticated/sessions/new.hbs
@@ -23,11 +23,13 @@
         aria-describedby="address-error"
         aria-required="true"
       />
-      {{#if this.isSessionAddressMissing}}
-        <div id="address-error" class="session-form__error error-message">
+
+      <p id="address-error" class="session-form__error error-message">
+        {{#if this.isSessionAddressMissing}}
           {{t "pages.sessions.new.errors.SESSION_ADDRESS_REQUIRED"}}
-        </div>
-      {{/if}}
+        {{/if}}
+      </p>
+
     </div>
 
     <div class="session-form__field">
@@ -46,11 +48,12 @@
         aria-describedby="room-error"
         aria-required="true"
       />
-      {{#if this.isSessionRoomMissing}}
-        <div id="room-error" class="session-form__error error-message">
+
+      <p id="room-error" class="session-form__error error-message">
+        {{#if this.isSessionRoomMissing}}
           {{t "pages.sessions.new.errors.SESSION_ROOM_REQUIRED"}}
-        </div>
-      {{/if}}
+        {{/if}}
+      </p>
     </div>
 
     <div class="session-form__field">
@@ -72,11 +75,12 @@
         aria-describedby="date-error"
         aria-required="true"
       />
-      {{#if this.isSessionDateMissing}}
-        <div id="date-error" class="session-form__error error-message">
+
+      <p id="date-error" class="session-form__error error-message">
+        {{#if this.isSessionDateMissing}}
           {{t "pages.sessions.new.errors.SESSION_DATE_REQUIRED"}}
-        </div>
-      {{/if}}
+        {{/if}}
+      </p>
     </div>
 
     <div class="session-form__field">
@@ -99,11 +103,11 @@
         aria-describedby="time-error"
         aria-required="true"
       />
-      {{#if this.isSessionTimeMissing}}
-        <div id="time-error" class="session-form__error error-message">
+      <p id="time-error" class="session-form__error error-message">
+        {{#if this.isSessionTimeMissing}}
           {{t "pages.sessions.new.errors.SESSION_TIME_REQUIRED"}}
-        </div>
-      {{/if}}
+        {{/if}}
+      </p>
     </div>
 
     <div class="session-form__field">
@@ -122,11 +126,11 @@
         aria-describedby="examiner-error"
         aria-required="true"
       />
-      {{#if this.isSessionExaminerMissing}}
-        <div id="examiner-error" class="session-form__error error-message">
+      <p id="examiner-error" class="session-form__error error-message">
+        {{#if this.isSessionExaminerMissing}}
           {{t "pages.sessions.new.errors.SESSION_EXAMINER_REQUIRED"}}
-        </div>
-      {{/if}}
+        {{/if}}
+      </p>
     </div>
 
     <div class="session-form__field">

--- a/certif/app/templates/authenticated/sessions/new.hbs
+++ b/certif/app/templates/authenticated/sessions/new.hbs
@@ -19,13 +19,14 @@
         maxlength="255"
         class="input"
         @value={{this.session.address}}
-        required
+        aria-describedby="address-error"
+        aria-required="true"
       />
-      {{#each this.session.errors.address as |error|}}
-        <div class="session-form__error error-message">
-          {{error.message}}
+      {{#if this.isSessionAddressMissing}}
+        <div id="address-error" class="session-form__error error-message">
+          {{t "pages.sessions.new.errors.SESSION_ADDRESS_REQUIRED"}}
         </div>
-      {{/each}}
+      {{/if}}
     </div>
 
     <div class="session-form__field">
@@ -40,13 +41,14 @@
         maxlength="255"
         class="input"
         @value={{this.session.room}}
-        required
+        aria-describedby="room-error"
+        aria-required="true"
       />
-      {{#each this.session.errors.room as |error|}}
-        <div class="session-form__error error-message">
-          {{error.message}}
+      {{#if this.isSessionRoomMissing}}
+        <div id="room-error" class="session-form__error error-message">
+          {{t "pages.sessions.new.errors.SESSION_ROOM_REQUIRED"}}
         </div>
-      {{/each}}
+      {{/if}}
     </div>
 
     <div class="session-form__field">
@@ -65,9 +67,11 @@
         @minDate="today"
         @name="session-date"
         class="input input--small"
+        aria-describedby="date-error"
+        aria-required="true"
       />
       {{#if this.isSessionDateMissing}}
-        <div class="session-form__error error-message">
+        <div id="date-error" class="session-form__error error-message">
           {{t "pages.sessions.new.errors.SESSION_DATE_REQUIRED"}}
         </div>
       {{/if}}
@@ -90,9 +94,11 @@
         @enableSeconds={{false}}
         @name="session-time"
         class="input input--small"
+        aria-describedby="time-error"
+        aria-required="true"
       />
       {{#if this.isSessionTimeMissing}}
-        <div class="session-form__error error-message">
+        <div id="time-error" class="session-form__error error-message">
           {{t "pages.sessions.new.errors.SESSION_TIME_REQUIRED"}}
         </div>
       {{/if}}
@@ -110,13 +116,14 @@
         maxlength="255"
         class="input"
         @value={{this.session.examiner}}
-        required
+        aria-describedby="examiner-error"
+        aria-required="true"
       />
-      {{#each this.session.errors.examiner as |error|}}
-        <div class="session-form__error error-message">
-          {{error.message}}
+      {{#if this.isSessionExaminerMissing}}
+        <div id="examiner-error" class="session-form__error error-message">
+          {{t "pages.sessions.new.errors.SESSION_EXAMINER_REQUIRED"}}
         </div>
-      {{/each}}
+      {{/if}}
     </div>
 
     <div class="session-form__field">

--- a/certif/app/templates/authenticated/sessions/new.hbs
+++ b/certif/app/templates/authenticated/sessions/new.hbs
@@ -19,6 +19,7 @@
         maxlength="255"
         class="input"
         @value={{this.session.address}}
+        required
       />
       {{#each this.session.errors.address as |error|}}
         <div class="session-form__error error-message">
@@ -39,6 +40,7 @@
         maxlength="255"
         class="input"
         @value={{this.session.room}}
+        required
       />
       {{#each this.session.errors.room as |error|}}
         <div class="session-form__error error-message">
@@ -64,11 +66,11 @@
         @name="session-date"
         class="input input--small"
       />
-      {{#each this.session.errors.date as |error|}}
+      {{#if this.isSessionDateMissing}}
         <div class="session-form__error error-message">
-          {{error.message}}
+          {{t "pages.sessions.new.errors.SESSION_DATE_REQUIRED"}}
         </div>
-      {{/each}}
+      {{/if}}
     </div>
 
     <div class="session-form__field">
@@ -89,11 +91,11 @@
         @name="session-time"
         class="input input--small"
       />
-      {{#each this.session.errors.time as |error|}}
+      {{#if this.isSessionTimeMissing}}
         <div class="session-form__error error-message">
-          {{error.message}}
+          {{t "pages.sessions.new.errors.SESSION_TIME_REQUIRED"}}
         </div>
-      {{/each}}
+      {{/if}}
     </div>
 
     <div class="session-form__field">
@@ -108,6 +110,7 @@
         maxlength="255"
         class="input"
         @value={{this.session.examiner}}
+        required
       />
       {{#each this.session.errors.examiner as |error|}}
         <div class="session-form__error error-message">

--- a/certif/app/templates/authenticated/sessions/new.hbs
+++ b/certif/app/templates/authenticated/sessions/new.hbs
@@ -19,6 +19,7 @@
         maxlength="255"
         class="input"
         @value={{this.session.address}}
+        {{on "change" this.onChangeAddress}}
         aria-describedby="address-error"
         aria-required="true"
       />
@@ -41,6 +42,7 @@
         maxlength="255"
         class="input"
         @value={{this.session.room}}
+        {{on "change" this.onChangeRoom}}
         aria-describedby="room-error"
         aria-required="true"
       />
@@ -116,6 +118,7 @@
         maxlength="255"
         class="input"
         @value={{this.session.examiner}}
+        {{on "change" this.onChangeExaminer}}
         aria-describedby="examiner-error"
         aria-required="true"
       />

--- a/certif/app/templates/authenticated/sessions/update.hbs
+++ b/certif/app/templates/authenticated/sessions/update.hbs
@@ -23,11 +23,11 @@
         aria-describedby="address-error"
         aria-required="true"
       />
-      {{#if this.isSessionAddressMissing}}
-        <div id="address-error" class="session-form__error error-message">
+      <p id="address-error" class="session-form__error error-message">
+        {{#if this.isSessionAddressMissing}}
           {{t "pages.sessions.new.errors.SESSION_ADDRESS_REQUIRED"}}
-        </div>
-      {{/if}}
+        {{/if}}
+      </p>
     </div>
 
     <div class="session-form__field">
@@ -46,11 +46,11 @@
         aria-describedby="room-error"
         aria-required="true"
       />
-      {{#if this.isSessionRoomMissing}}
-        <div id="room-error" class="session-form__error error-message">
+      <p id="room-error" class="session-form__error error-message">
+        {{#if this.isSessionRoomMissing}}
           {{t "pages.sessions.new.errors.SESSION_ROOM_REQUIRED"}}
-        </div>
-      {{/if}}
+        {{/if}}
+      </p>
     </div>
 
     <div class="session-form__field">
@@ -71,11 +71,11 @@
         aria-describedby="date-error"
         aria-required="true"
       />
-      {{#if this.isSessionDateMissing}}
-        <div id="date-error" class="session-form__error error-message">
+      <p id="date-error" class="session-form__error error-message">
+        {{#if this.isSessionDateMissing}}
           {{t "pages.sessions.new.errors.SESSION_DATE_REQUIRED"}}
-        </div>
-      {{/if}}
+        {{/if}}
+      </p>
     </div>
 
     <div class="session-form__field">
@@ -98,11 +98,11 @@
         aria-describedby="time-error"
         aria-required="true"
       />
-      {{#if this.isSessionTimeMissing}}
-        <div id="time-error" class="session-form__error error-message">
+      <p id="time-error" class="session-form__error error-message">
+        {{#if this.isSessionTimeMissing}}
           {{t "pages.sessions.new.errors.SESSION_TIME_REQUIRED"}}
-        </div>
-      {{/if}}
+        {{/if}}
+      </p>
     </div>
 
     <div class="session-form__field">
@@ -121,11 +121,11 @@
         aria-describedby="examiner-error"
         aria-required="true"
       />
-      {{#if this.isSessionExaminerMissing}}
-        <div id="examiner-error" class="session-form__error error-message">
+      <p id="examiner-error" class="session-form__error error-message">
+        {{#if this.isSessionExaminerMissing}}
           {{t "pages.sessions.new.errors.SESSION_EXAMINER_REQUIRED"}}
-        </div>
-      {{/if}}
+        {{/if}}
+      </p>
     </div>
 
     <div class="session-form__field">

--- a/certif/app/templates/authenticated/sessions/update.hbs
+++ b/certif/app/templates/authenticated/sessions/update.hbs
@@ -19,6 +19,7 @@
         maxlength="255"
         class="input"
         @value={{this.session.address}}
+        {{on "change" this.onChangeAddress}}
         aria-describedby="address-error"
         aria-required="true"
       />
@@ -41,6 +42,7 @@
         maxlength="255"
         class="input"
         @value={{this.session.room}}
+        {{on "change" this.onChangeRoom}}
         aria-describedby="room-error"
         aria-required="true"
       />
@@ -115,6 +117,7 @@
         maxlength="255"
         class="input"
         @value={{this.session.examiner}}
+        {{on "change" this.onChangeExaminer}}
         aria-describedby="examiner-error"
         aria-required="true"
       />

--- a/certif/app/templates/authenticated/sessions/update.hbs
+++ b/certif/app/templates/authenticated/sessions/update.hbs
@@ -19,12 +19,14 @@
         maxlength="255"
         class="input"
         @value={{this.session.address}}
+        aria-describedby="address-error"
+        aria-required="true"
       />
-      {{#each this.session.errors.address as |error|}}
-        <div class="session-form__error error-message">
-          {{error.message}}
+      {{#if this.isSessionAddressMissing}}
+        <div id="address-error" class="session-form__error error-message">
+          {{t "pages.sessions.new.errors.SESSION_ADDRESS_REQUIRED"}}
         </div>
-      {{/each}}
+      {{/if}}
     </div>
 
     <div class="session-form__field">
@@ -39,12 +41,14 @@
         maxlength="255"
         class="input"
         @value={{this.session.room}}
+        aria-describedby="room-error"
+        aria-required="true"
       />
-      {{#each this.session.errors.room as |error|}}
-        <div class="session-form__error error-message">
-          {{error.message}}
+      {{#if this.isSessionRoomMissing}}
+        <div id="room-error" class="session-form__error error-message">
+          {{t "pages.sessions.new.errors.SESSION_ROOM_REQUIRED"}}
         </div>
-      {{/each}}
+      {{/if}}
     </div>
 
     <div class="session-form__field">
@@ -62,12 +66,14 @@
         @name="session-date"
         class="input input--small"
         @date={{readonly this.session.date}}
+        aria-describedby="date-error"
+        aria-required="true"
       />
-      {{#each this.session.errors.date as |error|}}
-        <div class="session-form__error error-message">
-          {{error.message}}
+      {{#if this.isSessionDateMissing}}
+        <div id="date-error" class="session-form__error error-message">
+          {{t "pages.sessions.new.errors.SESSION_DATE_REQUIRED"}}
         </div>
-      {{/each}}
+      {{/if}}
     </div>
 
     <div class="session-form__field">
@@ -87,12 +93,14 @@
         @name="session-time"
         class="input input--small"
         @date={{readonly this.session.time}}
+        aria-describedby="time-error"
+        aria-required="true"
       />
-      {{#each this.session.errors.time as |error|}}
-        <div class="session-form__error error-message">
-          {{error.message}}
+      {{#if this.isSessionTimeMissing}}
+        <div id="time-error" class="session-form__error error-message">
+          {{t "pages.sessions.new.errors.SESSION_TIME_REQUIRED"}}
         </div>
-      {{/each}}
+      {{/if}}
     </div>
 
     <div class="session-form__field">
@@ -107,12 +115,14 @@
         maxlength="255"
         class="input"
         @value={{this.session.examiner}}
+        aria-describedby="examiner-error"
+        aria-required="true"
       />
-      {{#each this.session.errors.examiner as |error|}}
-        <div class="session-form__error error-message">
-          {{error.message}}
+      {{#if this.isSessionExaminerMissing}}
+        <div id="examiner-error" class="session-form__error error-message">
+          {{t "pages.sessions.new.errors.SESSION_EXAMINER_REQUIRED"}}
         </div>
-      {{/each}}
+      {{/if}}
     </div>
 
     <div class="session-form__field">

--- a/certif/tests/unit/controllers/authenticated/sessions/new_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/new_test.js
@@ -15,6 +15,7 @@ module('Unit | Controller | authenticated/sessions/new', function (hooks) {
       controller = this.owner.lookup('controller:authenticated/sessions/new');
       event = { preventDefault: sinon.stub() };
       sinon.stub(controller.router, 'transitionTo');
+      sinon.stub(controller, 'checkMissingSessionFields');
       session.save = sinon.stub().resolves();
       controller.model = session;
     });

--- a/certif/tests/unit/controllers/authenticated/sessions/update_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/update_test.js
@@ -15,6 +15,7 @@ module('Unit | Controller | authenticated/sessions/update', function (hooks) {
       controller = this.owner.lookup('controller:authenticated/sessions/update');
       event = { preventDefault: sinon.stub() };
       sinon.stub(controller.router, 'transitionTo');
+      sinon.stub(controller, 'checkMissingSessionFields');
       session.save = sinon.stub().resolves();
       controller.model = session;
     });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -477,7 +477,21 @@
           "cancel-extra-information": "Cancel the session creation and return to the previous page",
           "create-session": "Create the session"
         },
-        "extra-information": "Session scheduling | Pix Certif"
+        "address": "Location name",
+        "date": "Starting date",
+        "description": "Observations",
+        "errors": {
+          "SESSION_ADDRESS_REQUIRED": "Please indicate a location name.",
+          "SESSION_ROOM_REQUIRED": "Please indicate a room name.",
+          "SESSION_DATE_REQUIRED": "Please indicate a starting date.",
+          "SESSION_TIME_REQUIRED": "Please indicate a starting time in local time.",
+          "SESSION_EXAMINER_REQUIRED": "Please indicate the invigilator(s)."
+        },
+        "examiner": "Invigilator(s)",
+        "extra-information": "Session scheduling | Pix Certif",
+        "required-fields": "The fields marked by <abbr title=\"required\" class=\"mandatory-mark\">*</abbr> are required.",
+        "room": "Room name",
+        "time": "Starting time (local time)"
       },
       "update": {
         "title": "Certification session change",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -557,7 +557,7 @@
       }
     },
     "session-supervising": {
-      "title": "Inviligate session n° {sessionId}",
+      "title": "Invigilate session n° {sessionId}",
       "login": {
         "title": "Log into the invigilator's portal",
         "form": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -56,7 +56,7 @@
         "session-number": "Session No.",
         "status": "Status",
         "time": "Time",
-        "time-start": "Starting time (local time)"
+        "time-start": "Starting time (local time in 24-hour format)"
       }
     },
     "form-errors": {
@@ -485,7 +485,7 @@
           "SESSION_ROOM_REQUIRED": "Please indicate a room name.",
           "SESSION_DATE_REQUIRED": "Please indicate a starting date.",
           "SESSION_TIME_REQUIRED": "Please indicate a starting time in local time.",
-          "SESSION_EXAMINER_REQUIRED": "Please indicate the invigilator(s)."
+          "SESSION_EXAMINER_REQUIRED": "Please indicate the last name and first name of the invigilator(s)."
         },
         "examiner": "Invigilator(s)",
         "extra-information": "Session scheduling | Pix Certif",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -484,7 +484,7 @@
           "SESSION_ROOM_REQUIRED": "Veuillez indiquer un nom de salle.",
           "SESSION_DATE_REQUIRED": "Veuillez indiquer une date de début.",
           "SESSION_TIME_REQUIRED": "Veuillez indiquer une heure de début en heure locale.",
-          "SESSION_EXAMINER_REQUIRED": "Veuillez indiquer une surveillante ou un surveillant."
+          "SESSION_EXAMINER_REQUIRED": "Veuillez indiquer le nom et prénom du ou des surveillants."
         },
         "examiner": "Surveillant(s)",
         "extra-information": "Planification d’une session | Pix Certif",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -476,7 +476,21 @@
           "cancel-extra-information": "Annuler la création de session et retourner vers la page précédente",
           "create-session": "Créer la session"
         },
-        "extra-information": "Planification d’une session | Pix Certif"
+        "address": "Nom du site",
+        "date": "Date de début",
+        "description": "Observations",
+        "errors": {
+          "SESSION_ADDRESS_REQUIRED": "Veuillez indiquer un nom de site.",
+          "SESSION_ROOM_REQUIRED": "Veuillez indiquer un nom de salle.",
+          "SESSION_DATE_REQUIRED": "Veuillez indiquer une date de début.",
+          "SESSION_TIME_REQUIRED": "Veuillez indiquer une heure de début en heure locale.",
+          "SESSION_EXAMINER_REQUIRED": "Veuillez indiquer une surveillante ou un surveillant."
+        },
+        "examiner": "Surveillant(s)",
+        "extra-information": "Planification d’une session | Pix Certif",
+        "required-fields": "Les champs marqués de <abbr title=\"obligatoire\" class=\"mandatory-mark\">*</abbr> sont obligatoires.",
+        "room": "Nom de la salle",
+        "time": "Heure de début (heure locale)"
       },
       "update": {
         "title": "Modification d'une session de certification",


### PR DESCRIPTION
## :unicorn: Problème
Suite au ticket PIX-6667: Page de création d'une session en anglais, la page de création de session a été traduite.

L’utilisateur anglophone peut donc créer une nouvelle session en renseignant les différents champs requis. S’il manque un des champs obligatoires, une erreur doit s’afficher.

## :robot: Proposition
Traduire les messages d'erreur pour les formulaires de création et de modification de session de certification. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Lancer Pix Certif
- Aller sur la page de création de session, ne pas remplir les champs et tenter de créer la session.
- Passer l'application en anglais puis réessayer de créer la session avec des champs obligatoires vides.
- Réaliser la même opération sur la page de modification de session.
