### PR TITLE
[FEATURE] Utiliser le paquet NPM openid-client (PIX-7546)

### DIFF
--- a/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
+++ b/api/lib/domain/services/authentication/pole-emploi-oidc-authentication-service.js
@@ -32,6 +32,7 @@ class PoleEmploiOidcAuthenticationService extends OidcAuthenticationService {
       authenticationUrl: settings.poleEmploi.authenticationUrl,
       authenticationUrlParameters,
       userInfoUrl: settings.poleEmploi.userInfoUrl,
+      wellknownUrl: 'https://authentification-candidat-r.pe-qvr.fr/connexion/oauth2/.well-known/openid-configuration?realm=%2Findividu'
     });
 
     this.logoutUrl = settings.poleEmploi.logoutUrl;

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -53,6 +53,7 @@
         "ms": "^2.1.3",
         "node-cache": "^5.1.2",
         "node-stream-zip": "^1.15.0",
+        "openid-client": "^5.4.0",
         "oppsy": "https://github.com/1024pix/oppsy#main",
         "papaparse": "^5.3.2",
         "pdf-lib": "^1.17.1",
@@ -9685,6 +9686,14 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
+    "node_modules/jose": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.13.1.tgz",
+      "integrity": "sha512-MSJQC5vXco5Br38mzaQKiq9mwt7lwj2eXpgpRyQYNHYt2lq1PjkWa7DLXX0WVcQLE9HhMh3jPiufS7fhJf+CLQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -11660,7 +11669,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
       "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -11698,6 +11706,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/oidc-token-hash": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
+      "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
       }
     },
     "node_modules/on-exit-leak-free": {
@@ -11741,6 +11757,20 @@
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
       "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw==",
       "peer": true
+    },
+    "node_modules/openid-client": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.4.0.tgz",
+      "integrity": "sha512-hgJa2aQKcM2hn3eyVtN12tEA45ECjTJPXCgUh5YzTzy9qwapCvmDTVPWOcWVL0d34zeQoQ/hbG9lJhl3AYxJlQ==",
+      "dependencies": {
+        "jose": "^4.10.0",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.0.1",
+        "oidc-token-hash": "^5.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/oppsy": {
       "version": "3.0.0",
@@ -22901,6 +22931,11 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
+    "jose": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.13.1.tgz",
+      "integrity": "sha512-MSJQC5vXco5Br38mzaQKiq9mwt7lwj2eXpgpRyQYNHYt2lq1PjkWa7DLXX0WVcQLE9HhMh3jPiufS7fhJf+CLQ=="
+    },
     "joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -24421,8 +24456,7 @@
     "object-hash": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "dev": true
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
     },
     "object-inspect": {
       "version": "1.11.0",
@@ -24446,6 +24480,11 @@
         "has-symbols": "^1.0.1",
         "object-keys": "^1.1.1"
       }
+    },
+    "oidc-token-hash": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
+      "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ=="
     },
     "on-exit-leak-free": {
       "version": "2.1.0",
@@ -24482,6 +24521,17 @@
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
       "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw==",
       "peer": true
+    },
+    "openid-client": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.4.0.tgz",
+      "integrity": "sha512-hgJa2aQKcM2hn3eyVtN12tEA45ECjTJPXCgUh5YzTzy9qwapCvmDTVPWOcWVL0d34zeQoQ/hbG9lJhl3AYxJlQ==",
+      "requires": {
+        "jose": "^4.10.0",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.0.1",
+        "oidc-token-hash": "^5.0.1"
+      }
     },
     "oppsy": {
       "version": "git+ssh://git@github.com/1024pix/oppsy.git#ca8c3f37989eee9089dd7127e1c5d1c57f827de0",

--- a/api/package.json
+++ b/api/package.json
@@ -25,6 +25,7 @@
     "@hapi/vision": "^6.1.0",
     "@joi/date": "^2.1.0",
     "@pdf-lib/fontkit": "^1.1.1",
+    "@xmldom/xmldom": "^0.7.5",
     "axios": "^0.27.2",
     "bcrypt": "^5.0.1",
     "bluebird": "^3.7.2",
@@ -58,6 +59,7 @@
     "ms": "^2.1.3",
     "node-cache": "^5.1.2",
     "node-stream-zip": "^1.15.0",
+    "openid-client": "^5.4.0",
     "oppsy": "https://github.com/1024pix/oppsy#main",
     "papaparse": "^5.3.2",
     "pdf-lib": "^1.17.1",
@@ -83,7 +85,6 @@
     "xml-buffer-tostring": "^0.2.0",
     "xml2js": "^0.4.23",
     "xmlbuilder2": "^3.0.2",
-    "@xmldom/xmldom": "^0.7.5",
     "xregexp": "^5.1.1",
     "yargs": "^17.5.1"
   },


### PR DESCRIPTION
## :unicorn: Problème

Actuellement tous les appels OIDC sont gérés avec du code « maison ».

## :robot: Proposition

On souhaite utiliser la bibliothèque https://github.com/panva/node-openid-client pour bénéficier d'une brique développée par les experts du domaine et très bien maintenue.

Décision : Après des essais réussis 👌 qui nous ont permis d'instancier des objets `Client`  👌 et de récupérer les informations de discovery des OIDC Providers 👌, nous ne sommes malheureusement pas arrivé à intégrer facilement _openid-client_ dans le code actuel de pix. La structure et la logique de certains fichiers implémentant la gestion OIDC du code de pix ne sont pas bonnes et nous avions déjà identifié ce problème. Aussi, le code de Pix allant continuer d'évoluer cette PR n'a pas de valeur ajoutée à rester ouverte. Nous reviendrons donc sur cette tâche d'utiliser _openid-client_ qui reste pertinente.

## :100: Pour tester

Non testable.