### PR TITLE
[TECH]Ajout d'un test sur la validation joi de la route GET authentication-url(PIX-7117)

### DIFF
--- a/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication/oidc-authentication-service_test.js
@@ -231,6 +231,28 @@ describe('Unit | Domain | Services | oidc-authentication-service', function () {
       expect(queryParams.get('scope')).to.equal('openid profile');
       expect(queryParams.get('realm')).to.equal('/individu');
     });
+
+    describe('when config is missing', function () {
+      it('should throw an error', async function () {
+        // given
+        const redirectUri = 'https://example.org/please-redirect-to-me';
+
+        const oidcAuthenticationService = new OidcAuthenticationService({});
+
+        // when
+        let errorResponse;
+        try {
+          await oidcAuthenticationService.getAuthenticationUrl({
+            redirectUri,
+          });
+        } catch (error) {
+          errorResponse = error;
+        }
+
+        // then
+        expect(errorResponse.code).to.be.equal('ERR_INVALID_URL');
+      });
+    });
   });
 
   describe('#getUserInfo', function () {


### PR DESCRIPTION
## :unicorn: Problème
L'appel à la route authentication-url renvoyait une 500 et cela a été corrigé dans la [PR](https://github.com/1024pix/pix/pull/5610). Une investigation a été faite pour comprendre d'où venait cette erreur 

## :robot: Proposition
- ~~un test a été ajouté pour reproduire les conditions~~ Test supprimé après la code review
- il s'avère que c'est la méthode getAuthenticationUrl qui renvoie une 500 quand les var d'env de configuration d'un identity provider ne sont pas renseignés
- cette route n'est plus appelée depuis le front quand ces vars d'env ne sont pas renseignés car la route GET identityProivers ne renvoie que les idp renseignés.
- Dans le TU de #getAuthenticationUrl on teste en renseignant des valeurs, un test reproduisant l'erreur a été ajouté pour visualiser

## :rainbow: Remarques
- Nous n'avons pas de moyen de vérifier de manière automatisée qu'un var d'env de configuration d'idp est manquante. Si nous passions à une gestion de ces variables en base de données, cela sera possible en test d'intégration peut-être.

## :100: Pour tester
Lancer le test
Un ticket tech va être créé pour réflechir en mob à une façon de s'assurer que la configuration d'un identity provider a été correctement renseigné.
Peut-être pourrait-on ajouter un modèle dans le domaine, actuellement, cette configuration est généré quand on instancie la classe d'un IDP, ex FwbOidcAuthenticationService
