### PR TITLE
[BUGFIX] Eviter les erreurs 500 en cas de mauvais format d'heure et/ou date de session lors de l'import en masse (PIX-7575)

### DIFF
--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -162,11 +162,12 @@ function _getDataFromColumnNames({ csvLineKeys, headers, line }) {
   csvLineKeys.forEach((key) => {
     const headerKeyInCurrentLine = line[headers[key]];
     if (key === 'birthdate' || key === 'date') {
-      data[key] = convertDateValue({
-        dateString: headerKeyInCurrentLine,
-        inputFormat: 'DD/MM/YYYY',
-        outputFormat: 'YYYY-MM-DD',
-      });
+      data[key] =
+        convertDateValue({
+          dateString: headerKeyInCurrentLine,
+          inputFormat: 'DD/MM/YYYY',
+          outputFormat: 'YYYY-MM-DD',
+        }) ?? headerKeyInCurrentLine;
     } else if (key === 'extraTimePercentage') {
       data[key] = headerKeyInCurrentLine !== '' ? headerKeyInCurrentLine : null;
     } else if (key === 'prepaymentCode') {

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -243,7 +243,7 @@ function _createSession({ sessionId, address, room, date, time, examiner, descri
     address,
     room,
     date,
-    time,
+    time: time ? time : null,
     examiner: examiner ? [examiner] : [],
     description,
     line,

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -195,6 +195,58 @@ describe('Unit | Service | sessions import validation Service', function () {
       });
     });
 
+    describe('when session date is not valid', function () {
+      it('should return an sessionErrors that contains a session invalid date format error', async function () {
+        // given
+        const session = _buildValidSessionWithoutId();
+        session.date = 'toto';
+
+        // when
+        const sessionErrors = await sessionsImportValidationService.validateSession({
+          session,
+          line: 1,
+          sessionRepository,
+          certificationCourseRepository,
+        });
+
+        // then
+        expect(sessionRepository.isSessionExisting).to.not.have.been.called;
+        expect(sessionErrors).to.deep.equal([
+          {
+            line: 1,
+            code: 'SESSION_DATE_NOT_VALID',
+            blocking: true,
+          },
+        ]);
+      });
+    });
+
+    describe('when session time is not valid', function () {
+      it('should return an sessionErrors that contains a invalid time format error', async function () {
+        // given
+        const session = _buildValidSessionWithoutId();
+        session.time = 'toto';
+
+        // when
+        const sessionErrors = await sessionsImportValidationService.validateSession({
+          session,
+          line: 1,
+          sessionRepository,
+          certificationCourseRepository,
+        });
+
+        // then
+        expect(sessionRepository.isSessionExisting).to.not.have.been.called;
+        expect(sessionErrors).to.deep.equal([
+          {
+            line: 1,
+            code: 'SESSION_TIME_NOT_VALID',
+            blocking: true,
+          },
+        ]);
+      });
+    });
+
     context('when session has certification candidates', function () {
       context('when at least one candidate is duplicated', function () {
         it('should return an sessionErrors that contains a duplicate candidate error', async function () {

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -168,6 +168,43 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
         });
       });
 
+      describe('when session date format is incorrect', function () {
+        it('should return original date', function () {
+          // given
+          const sessionLine = _line({
+            sessionId: '',
+            address: `Site 1`,
+            room: `Salle 1`,
+            date: 'wrong format',
+            time: '',
+            examiner: 'Paul',
+            description: '',
+          });
+
+          const parsedCsvData = [sessionLine];
+
+          const expectedResult = [
+            {
+              sessionId: undefined,
+              address: 'Site 1',
+              room: 'Salle 1',
+              date: 'wrong format',
+              time: null,
+              examiner: 'Paul',
+              description: '',
+              certificationCandidates: [],
+              line: 2,
+            },
+          ];
+
+          // when
+          const result = csvSerializer.deserializeForSessionsImport(parsedCsvData);
+
+          // then
+          expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+        });
+      });
+
       describe('when session information is identical on consecutive lines', function () {
         it('should return a full session object per line', function () {
           // given

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -131,6 +131,43 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
     });
 
     describe('when there is session information', function () {
+      describe('when session time is empty', function () {
+        it('should return null for time', function () {
+          // given
+          const sessionLine = _line({
+            sessionId: '',
+            address: `Site 1`,
+            room: `Salle 1`,
+            date: '12/05/2023',
+            time: '',
+            examiner: 'Paul',
+            description: '',
+          });
+
+          const parsedCsvData = [sessionLine];
+
+          const expectedResult = [
+            {
+              sessionId: undefined,
+              address: 'Site 1',
+              room: 'Salle 1',
+              date: '2023-05-12',
+              time: null,
+              examiner: 'Paul',
+              description: '',
+              certificationCandidates: [],
+              line: 2,
+            },
+          ];
+
+          // when
+          const result = csvSerializer.deserializeForSessionsImport(parsedCsvData);
+
+          // then
+          expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
+        });
+      });
+
       describe('when session information is identical on consecutive lines', function () {
         it('should return a full session object per line', function () {
           // given


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'import en masse, si l'heure et/ou la date de session ne sont pas renseignée(s) ou dans un mauvais format, l'api crash et renvoie une erreur 500

## :robot: Proposition
Eviter les erreurs 500 :sweat_smile: 

## :100: Pour tester
- Tenter l'import en masse avec une date ou heure vide et constater l'affichage suivant 

![image](https://user-images.githubusercontent.com/37305474/228287607-4011d458-b466-464b-8e22-04bbaa9319b7.png)

- Tenter l'import en masse avec une date ou heure au mauvais format et constater l'affichage suivant 

![image](https://user-images.githubusercontent.com/37305474/228288048-52c3b0de-c112-4a65-abf2-c690881b102a.png)

