### PR TITLE
[TECH] Nettoyer les tests des erreurs de lint sur les applications front (PIX-7577).

### DIFF
--- a/admin/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
+++ b/admin/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
@@ -9,6 +9,6 @@ module('Acceptance | <%= dasherizedModuleName %>', function(hooks) {
   test('visiting /<%= dasherizedModuleName %>', async function(assert) {
     await visit('/<%= dasherizedModuleName %>');
 
-    assert.equal(currentURL(), '/<%= dasherizedModuleName %>');
+    assert.strictEqual(currentURL(), '/<%= dasherizedModuleName %>');
   });
 });

--- a/admin/tests/unit/adapters/application_test.js
+++ b/admin/tests/unit/adapters/application_test.js
@@ -6,28 +6,24 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
   setupTest(hooks);
 
   test('should specify /api as the root url', function (assert) {
-    // Given
+    // given
     const applicationAdapter = this.owner.lookup('adapter:application');
 
-    // Then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(applicationAdapter.namespace, 'api');
+    // then
+    assert.strictEqual(applicationAdapter.namespace, 'api');
   });
 
   module('get headers()', function () {
     test('should add header with authentication token when the session is authenticated', function (assert) {
-      // Given
+      // given
       const access_token = '23456789';
       const applicationAdapter = this.owner.lookup('adapter:application');
 
-      // When
+      // when
       applicationAdapter.set('session', { isAuthenticated: true, data: { authenticated: { access_token } } });
 
-      // Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(applicationAdapter.headers['Authorization'], `Bearer ${access_token}`);
+      // then
+      assert.strictEqual(applicationAdapter.headers['Authorization'], `Bearer ${access_token}`);
     });
 
     test('should not add header authentication token when the session is not authenticated', function (assert) {

--- a/admin/tests/unit/adapters/campaign-test.js
+++ b/admin/tests/unit/adapters/campaign-test.js
@@ -17,9 +17,7 @@ module('Unit | Adapter | Campaign', function (hooks) {
 
       // then
       assert.ok(url.endsWith('/admin/organizations/10/campaigns'));
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(query.organizationId, undefined);
+      assert.strictEqual(query.organizationId, undefined);
     });
   });
 });

--- a/admin/tests/unit/components/certifications/details-competence_test.js
+++ b/admin/tests/unit/components/certifications/details-competence_test.js
@@ -1,6 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { htmlSafe } from '@ember/template';
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 
 module('Unit | Component | certifications/details-competence', function (hooks) {
@@ -60,12 +59,8 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.level, 3);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.score, 25);
+      assert.strictEqual(actual.level, 3);
+      assert.strictEqual(actual.score, 25);
     });
 
     test('it should not give jury values when a jury rate is set and score does not differ', async function (assert) {
@@ -95,12 +90,8 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.level, 3);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.score, 25);
+      assert.strictEqual(actual.level, 3);
+      assert.strictEqual(actual.score, 25);
     });
 
     test('it should give level n and positioned score when jury rate is set to 81 and 2 ok and 1 ko', async function (assert) {
@@ -115,12 +106,8 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.level, 3);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.score, 25);
+      assert.strictEqual(actual.level, 3);
+      assert.strictEqual(actual.score, 25);
     });
 
     test('it should give level n and positioned score when jury rate is set to 81 and 2 ok and 1 aband', async function (assert) {
@@ -135,12 +122,8 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.level, 3);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.score, 25);
+      assert.strictEqual(actual.level, 3);
+      assert.strictEqual(actual.score, 25);
     });
 
     test('it should give level n and positioned score when jury rate is set to 81 and 2 ok and 1 partially', async function (assert) {
@@ -155,12 +138,8 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.level, 3);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.score, 25);
+      assert.strictEqual(actual.level, 3);
+      assert.strictEqual(actual.score, 25);
     });
 
     test('it should give level n and positioned score when jury rate is set to 81 and 2 ok and 1 timedout', async function (assert) {
@@ -175,12 +154,8 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.level, 3);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.score, 25);
+      assert.strictEqual(actual.level, 3);
+      assert.strictEqual(actual.score, 25);
     });
 
     test('it should give level n-1 and score positionedScore-8 when jury rate is set to 65 and 2 ok and 1 ko', async function (assert) {
@@ -195,12 +170,8 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.level, 2);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.score, 17);
+      assert.strictEqual(actual.level, 2);
+      assert.strictEqual(actual.score, 17);
     });
 
     test('it should give level n-1 and score positionedScore-8 when jury rate is set to 65 and 2 ok and 1 aband', async function (assert) {
@@ -215,12 +186,8 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.level, 2);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.score, 17);
+      assert.strictEqual(actual.level, 2);
+      assert.strictEqual(actual.score, 17);
     });
 
     test('it should give level n-1 and score positionedScore-8 when jury rate is set to 65 and 2 ok and 1 partiallyx  x', async function (assert) {
@@ -235,12 +202,8 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.level, 2);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.score, 17);
+      assert.strictEqual(actual.level, 2);
+      assert.strictEqual(actual.score, 17);
     });
 
     test('it should give level n-1 and score positionedScore-8 when jury rate is set to 65 and 2 ok and 1 timedout', async function (assert) {
@@ -255,12 +218,8 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.level, 2);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.score, 17);
+      assert.strictEqual(actual.level, 2);
+      assert.strictEqual(actual.score, 17);
     });
 
     test('it should give level -1 and score 0 when jury rate is set and 1 ok', async function (assert) {
@@ -275,12 +234,8 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.level, -1);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.score, 0);
+      assert.strictEqual(actual.level, -1);
+      assert.strictEqual(actual.score, 0);
     });
 
     test('it should give level -1 and score 0 when jury rate is set to 49', async function (assert) {
@@ -295,12 +250,8 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.level, -1);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.score, 0);
+      assert.strictEqual(actual.level, -1);
+      assert.strictEqual(actual.score, 0);
     });
 
     test('it should give level n and positioned score when jury rate is set to 81 and 2 ok and 1 skip', async function (assert) {
@@ -315,12 +266,8 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.level, 3);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.score, 25);
+      assert.strictEqual(actual.level, 3);
+      assert.strictEqual(actual.score, 25);
     });
 
     test('it should give level n and positioned score when jury rate is set to 65 and 2 ok and 1 skip', async function (assert) {
@@ -335,12 +282,8 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.level, 3);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.score, 25);
+      assert.strictEqual(actual.level, 3);
+      assert.strictEqual(actual.score, 25);
     });
 
     test('it should give level n when jury rate is set to 90, 1 ok, 1 partially, 1 skip', async function (assert) {
@@ -355,12 +298,8 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.level, 3);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.score, 25);
+      assert.strictEqual(actual.level, 3);
+      assert.strictEqual(actual.score, 25);
     });
 
     test('it should give level n-1 when jury rate is set to 65, 1 ok, 1 partially, 1 skip', async function (assert) {
@@ -375,12 +314,8 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.level, 2);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.score, 17);
+      assert.strictEqual(actual.level, 2);
+      assert.strictEqual(actual.score, 17);
     });
 
     test('it should give level -1 when jury rate is set, 1 ok, 1 ko, 1 skip', async function (assert) {
@@ -395,12 +330,8 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
       const actual = component.competenceJury;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.level, -1);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actual.score, 0);
+      assert.strictEqual(actual.level, -1);
+      assert.strictEqual(actual.score, 0);
     });
   });
 
@@ -413,15 +344,9 @@ module('Unit | Component | certifications/details-competence', function (hooks) 
     };
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(component.positionedWidth.toString(), htmlSafe('width:' + Math.round((3 / 8) * 100) + '%'));
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(component.certifiedWidth.toString(), htmlSafe('width:' + Math.round((2 / 8) * 100) + '%'));
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(component.competenceJury.width.toString(), htmlSafe('width:' + Math.round((3 / 8) * 100) + '%'));
+    assert.strictEqual(component.positionedWidth.toString(), 'width:' + Math.round((3 / 8) * 100) + '%');
+    assert.strictEqual(component.certifiedWidth.toString(), 'width:' + Math.round((2 / 8) * 100) + '%');
+    assert.strictEqual(component.competenceJury.width.toString(), 'width:' + Math.round((3 / 8) * 100) + '%');
   });
 
   test('it should retrieve answers from competence', async function (assert) {

--- a/admin/tests/unit/components/target-profiles/organizations_test.js
+++ b/admin/tests/unit/components/target-profiles/organizations_test.js
@@ -16,6 +16,7 @@ module('Unit | Component | Target Profiles | Organizations', function (hooks) {
 
     module('when attaching organization works correctly', () => {
       test('it displays a success message notifications', async function (assert) {
+        // given
         const component = createComponent('component:target-profiles/organizations');
         component.notifications = { success: sinon.stub() };
         component.args = {
@@ -33,12 +34,12 @@ module('Unit | Component | Target Profiles | Organizations', function (hooks) {
         component.organizationsToAttach = '1,2';
         component.router = { replaceWith: sinon.stub() };
 
+        // when
         await component.attachOrganizations(event);
 
+        // then
         assert.ok(component.args.targetProfile.attachOrganizations.calledWith({ 'organization-ids': [1, 2] }));
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.organizationsToAttach, '');
+        assert.strictEqual(component.organizationsToAttach, '');
         assert.ok(
           component.notifications.success.calledWith('Organisation(s) rattaché(es) avec succès.', { htmlContent: true })
         );
@@ -48,6 +49,7 @@ module('Unit | Component | Target Profiles | Organizations', function (hooks) {
       });
 
       test('it displays duplicate message notifications', async function (assert) {
+        // given
         const component = createComponent('component:target-profiles/organizations');
         component.notifications = { success: sinon.stub() };
         component.args = {
@@ -60,12 +62,12 @@ module('Unit | Component | Target Profiles | Organizations', function (hooks) {
         component.organizationsToAttach = '1';
         component.router = { replaceWith: sinon.stub() };
 
+        // when
         await component.attachOrganizations(event);
 
+        // then
         assert.ok(component.args.targetProfile.attachOrganizations.calledWith({ 'organization-ids': [1] }));
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.organizationsToAttach, '');
+        assert.strictEqual(component.organizationsToAttach, '');
         assert.ok(
           component.notifications.success.calledWith(
             'Le(s) organisation(s) suivantes étai(en)t déjà rattachée(s) à ce profil cible : 1',
@@ -78,6 +80,7 @@ module('Unit | Component | Target Profiles | Organizations', function (hooks) {
       });
 
       test('it displays a duplicate and success messages notifications', async function (assert) {
+        // given
         const component = createComponent('component:target-profiles/organizations');
         component.notifications = { success: sinon.stub() };
         component.args = {
@@ -90,12 +93,12 @@ module('Unit | Component | Target Profiles | Organizations', function (hooks) {
         component.organizationsToAttach = '1,2';
         component.router = { replaceWith: sinon.stub() };
 
+        // when
         await component.attachOrganizations(event);
 
+        // then
         assert.ok(component.args.targetProfile.attachOrganizations.calledWith({ 'organization-ids': [1, 2] }));
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.organizationsToAttach, '');
+        assert.strictEqual(component.organizationsToAttach, '');
         assert.ok(
           component.notifications.success.calledWith(
             'Organisation(s) rattaché(es) avec succès.<br/>Le(s) organisation(s) suivantes étai(en)t déjà rattachée(s) à ce profil cible : 1',
@@ -110,6 +113,7 @@ module('Unit | Component | Target Profiles | Organizations', function (hooks) {
 
     module('when an organization is present several times', () => {
       test('it remove duplicate ids', async function (assert) {
+        // given
         const component = createComponent('component:target-profiles/organizations');
         component.notifications = { success: sinon.stub() };
         component.args = {
@@ -122,12 +126,12 @@ module('Unit | Component | Target Profiles | Organizations', function (hooks) {
         component.organizationsToAttach = '1,1,2,3,3';
         component.router = { replaceWith: sinon.stub() };
 
+        // when
         await component.attachOrganizations(event);
 
+        // then
         assert.ok(component.args.targetProfile.attachOrganizations.calledWith({ 'organization-ids': [1, 2, 3] }));
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.organizationsToAttach, '');
+        assert.strictEqual(component.organizationsToAttach, '');
         assert.ok(
           component.router.replaceWith.calledWith('authenticated.target-profiles.target-profile.organizations')
         );
@@ -137,6 +141,7 @@ module('Unit | Component | Target Profiles | Organizations', function (hooks) {
     module('when there is an error', () => {
       module('when the error is correctly formed', () => {
         test('it displays a notification for each 404 error found', async function (assert) {
+          // given
           const component = createComponent('component:target-profiles/organizations');
           const errors = {
             errors: [
@@ -148,16 +153,17 @@ module('Unit | Component | Target Profiles | Organizations', function (hooks) {
           component.args = { targetProfile: { attachOrganizations: sinon.stub().rejects(errors) } };
           component.organizationsToAttach = '1,1,2,3,3';
 
+          // when
           await component.attachOrganizations(event);
 
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.organizationsToAttach, '1,1,2,3,3');
+          // then
+          assert.strictEqual(component.organizationsToAttach, '1,1,2,3,3');
           assert.ok(component.notifications.error.calledWith('I am displayed 1'));
           assert.ok(component.notifications.error.calledWith('I am displayed 2'));
         });
 
         test('it displays a notification for each 412 error found', async function (assert) {
+          // given
           const component = createComponent('component:target-profiles/organizations');
           const errors = {
             errors: [
@@ -169,16 +175,17 @@ module('Unit | Component | Target Profiles | Organizations', function (hooks) {
           component.args = { targetProfile: { attachOrganizations: sinon.stub().rejects(errors) } };
           component.organizationsToAttach = '1,1,5,3,3';
 
+          // when
           await component.attachOrganizations(event);
 
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.organizationsToAttach, '1,1,5,3,3');
+          // then
+          assert.strictEqual(component.organizationsToAttach, '1,1,5,3,3');
           assert.ok(component.notifications.error.calledWith('I am displayed too 1'));
           assert.ok(component.notifications.error.calledWith('I am displayed too 2'));
         });
 
         test('it display default notification for all other error found', async function (assert) {
+          // given
           const component = createComponent('component:target-profiles/organizations');
           const errors = {
             errors: [
@@ -190,30 +197,29 @@ module('Unit | Component | Target Profiles | Organizations', function (hooks) {
           component.args = { targetProfile: { attachOrganizations: sinon.stub().rejects(errors) } };
           component.organizationsToAttach = '1,1,2,3,3';
 
+          // when
           await component.attachOrganizations(event);
 
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.organizationsToAttach, '1,1,2,3,3');
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.notifications.error.withArgs('Une erreur est survenue.').callCount, 2);
+          // then
+          assert.strictEqual(component.organizationsToAttach, '1,1,2,3,3');
+          assert.strictEqual(component.notifications.error.withArgs('Une erreur est survenue.').callCount, 2);
         });
       });
 
       module('when the error is not correctly formed', () => {
         test('it displays a default notification', async function (assert) {
+          // given
           const component = createComponent('component:target-profiles/organizations');
           const errors = {};
           component.notifications = { error: sinon.stub() };
           component.args = { targetProfile: { attachOrganizations: sinon.stub().rejects(errors) } };
           component.organizationsToAttach = '1,1,2,3,3';
 
+          // when
           await component.attachOrganizations(event);
 
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.organizationsToAttach, '1,1,2,3,3');
+          // then
+          assert.strictEqual(component.organizationsToAttach, '1,1,2,3,3');
           assert.ok(component.notifications.error.calledWith('Une erreur est survenue.'));
         });
       });
@@ -229,22 +235,23 @@ module('Unit | Component | Target Profiles | Organizations', function (hooks) {
 
     module('when attaching organization works correctly', () => {
       test('it shows a success notifications', async function (assert) {
+        // given
         const component = createComponent('component:target-profiles/organizations');
         component.notifications = { success: sinon.stub() };
         component.args = { targetProfile: { attachOrganizationsFromExistingTargetProfile: sinon.stub().resolves() } };
         component.existingTargetProfile = 1;
         component.router = { replaceWith: sinon.stub() };
 
+        // when
         await component.attachOrganizationsFromExistingTargetProfile(event);
 
+        // then
         assert.ok(
           component.args.targetProfile.attachOrganizationsFromExistingTargetProfile.calledWith({
             'target-profile-id': 1,
           })
         );
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.existingTargetProfile, '');
+        assert.strictEqual(component.existingTargetProfile, '');
         assert.ok(component.notifications.success.calledWith('Organisation(s) rattaché(es) avec succès.'));
         assert.ok(
           component.router.replaceWith.calledWith('authenticated.target-profiles.target-profile.organizations')
@@ -295,6 +302,7 @@ module('Unit | Component | Target Profiles | Organizations', function (hooks) {
         });
 
         test('it shows default notification for all other error found', async function (assert) {
+          // given
           const component = createComponent('component:target-profiles/organizations');
           const errors = {
             errors: [
@@ -308,11 +316,11 @@ module('Unit | Component | Target Profiles | Organizations', function (hooks) {
           };
           component.existingTargetProfile = 1;
 
+          // when
           await component.attachOrganizationsFromExistingTargetProfile(event);
 
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.notifications.error.withArgs('Une erreur est survenue.').callCount, 2);
+          // then
+          assert.strictEqual(component.notifications.error.withArgs('Une erreur est survenue.').callCount, 2);
         });
       });
 

--- a/admin/tests/unit/components/update-target-profile_test.js
+++ b/admin/tests/unit/components/update-target-profile_test.js
@@ -64,9 +64,7 @@ module('Unit | Component | update-target-profile', function (hooks) {
 
       // then
       assert.ok(event.preventDefault.called);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.args.model.name, 'Edited name');
+      assert.strictEqual(component.args.model.name, 'Edited name');
     });
 
     test('it should update the description of the target profile', async function (assert) {
@@ -95,10 +93,9 @@ module('Unit | Component | update-target-profile', function (hooks) {
 
       // when
       await component.updateProfile(event);
+
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.args.model.description, 'Edited description');
+      assert.strictEqual(component.args.model.description, 'Edited description');
     });
 
     test('it should update the comment of the target profile', async function (assert) {
@@ -128,9 +125,7 @@ module('Unit | Component | update-target-profile', function (hooks) {
       // when
       await component.updateProfile(event);
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.args.model.comment, 'Edited comment');
+      assert.strictEqual(component.args.model.comment, 'Edited comment');
     });
 
     test('it should do nothing when form is not valid', async function (assert) {

--- a/admin/tests/unit/controllers/authenticated/certification-centers/list_test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-centers/list_test.js
@@ -20,9 +20,7 @@ module('Unit | Controller | authenticated/certification-centers/list', function 
         await controller.triggerFiltering.perform('id', { target: { value: expectedValue } });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.id, expectedValue);
+        assert.strictEqual(controller.id, expectedValue);
       });
     });
 
@@ -36,9 +34,7 @@ module('Unit | Controller | authenticated/certification-centers/list', function 
         await controller.triggerFiltering.perform('name', { target: { value: expectedValue } });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.name, expectedValue);
+        assert.strictEqual(controller.name, expectedValue);
       });
     });
 
@@ -52,9 +48,7 @@ module('Unit | Controller | authenticated/certification-centers/list', function 
         await controller.triggerFiltering.perform('type', { target: { value: expectedValue } });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.type, expectedValue);
+        assert.strictEqual(controller.type, expectedValue);
       });
     });
 
@@ -68,9 +62,7 @@ module('Unit | Controller | authenticated/certification-centers/list', function 
         await controller.triggerFiltering.perform('externalId', { target: { value: expectedValue } });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.externalId, expectedValue);
+        assert.strictEqual(controller.externalId, expectedValue);
       });
     });
   });

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/details_test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/details_test.js
@@ -51,9 +51,7 @@ module('Unit | Controller | authenticated/certifications/certification/details',
     });
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(controller.get('juryRate'), 78.57);
+    assert.strictEqual(controller.get('juryRate'), 78.57);
   });
 
   test('it computes jury score correctly', function (assert) {
@@ -79,9 +77,7 @@ module('Unit | Controller | authenticated/certifications/certification/details',
 
     // then
     // 3 jury scores + 2 obtained scores
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(controller.get('juryScore'), 12 * 3 + 26 * 2);
+    assert.strictEqual(controller.get('juryScore'), 12 * 3 + 26 * 2);
   });
 
   module('#shouldDisplayJuryScore', function () {

--- a/admin/tests/unit/controllers/authenticated/organizations/list_test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/list_test.js
@@ -20,9 +20,7 @@ module('Unit | Controller | authenticated/organizations/list', function (hooks) 
         await controller.updateFilters({ name: expectedValue });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.name, expectedValue);
+        assert.strictEqual(controller.name, expectedValue);
       });
     });
 
@@ -36,9 +34,7 @@ module('Unit | Controller | authenticated/organizations/list', function (hooks) 
         await controller.updateFilters({ type: expectedValue });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.type, expectedValue);
+        assert.strictEqual(controller.type, expectedValue);
       });
     });
 
@@ -52,9 +48,7 @@ module('Unit | Controller | authenticated/organizations/list', function (hooks) 
         await controller.updateFilters({ externalId: expectedValue });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.externalId, expectedValue);
+        assert.strictEqual(controller.externalId, expectedValue);
       });
     });
   });

--- a/admin/tests/unit/controllers/authenticated/sessions/list/all_test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/list/all_test.js
@@ -20,9 +20,7 @@ module('Unit | Controller | authenticated/sessions/list/all', function (hooks) {
         await controller.triggerFiltering.perform('id', { target: { value: expectedValue } });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.id, expectedValue);
+        assert.strictEqual(controller.id, expectedValue);
       });
     });
 
@@ -36,9 +34,7 @@ module('Unit | Controller | authenticated/sessions/list/all', function (hooks) {
         await controller.triggerFiltering.perform('certificationCenterName', { target: { value: expectedValue } });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.certificationCenterName, expectedValue);
+        assert.strictEqual(controller.certificationCenterName, expectedValue);
       });
     });
 
@@ -52,9 +48,7 @@ module('Unit | Controller | authenticated/sessions/list/all', function (hooks) {
         await controller.triggerFiltering.perform('status', expectedValue);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.status, expectedValue);
+        assert.strictEqual(controller.status, expectedValue);
       });
     });
 
@@ -68,9 +62,7 @@ module('Unit | Controller | authenticated/sessions/list/all', function (hooks) {
         await controller.triggerFiltering.perform('resultsSentToPrescriberAt', expectedValue);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.resultsSentToPrescriberAt, expectedValue);
+        assert.strictEqual(controller.resultsSentToPrescriberAt, expectedValue);
       });
     });
 
@@ -84,9 +76,7 @@ module('Unit | Controller | authenticated/sessions/list/all', function (hooks) {
         await controller.triggerFiltering.perform('certificationCenterType', expectedValue);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.certificationCenterType, expectedValue);
+        assert.strictEqual(controller.certificationCenterType, expectedValue);
       });
     });
   });

--- a/admin/tests/unit/controllers/authenticated/sessions/session/informations_test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/session/informations_test.js
@@ -140,9 +140,7 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
 
       // then
       assert.ok(writeTextStub.calledWithExactly('www.jeremypluquet.com'));
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.copyButtonText, 'Copié');
+      assert.strictEqual(controller.copyButtonText, 'Copié');
       assert.ok(controller.isCopyButtonClicked);
       assert.ok(window.setTimeout);
     });
@@ -159,9 +157,7 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
       await controller.actions.copyResultsDownloadLink.call(controller);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.copyButtonText, 'Erreur !');
+      assert.strictEqual(controller.copyButtonText, 'Erreur !');
       assert.ok(controller.isCopyButtonClicked);
       assert.ok(window.setTimeout);
     });

--- a/admin/tests/unit/controllers/authenticated/target-profiles/list_test.js
+++ b/admin/tests/unit/controllers/authenticated/target-profiles/list_test.js
@@ -20,9 +20,7 @@ module('Unit | Controller | authenticated/target-profiles/list', function (hooks
         await controller.triggerFiltering.perform('name', { target: { value: expectedValue } });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.name, expectedValue);
+        assert.strictEqual(controller.name, expectedValue);
       });
     });
 
@@ -36,9 +34,7 @@ module('Unit | Controller | authenticated/target-profiles/list', function (hooks
         await controller.triggerFiltering.perform('id', { target: { value: expectedValue } });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.id, expectedValue);
+        assert.strictEqual(controller.id, expectedValue);
       });
     });
   });

--- a/admin/tests/unit/controllers/authenticated/target-profiles/target-profile/organizations_test.js
+++ b/admin/tests/unit/controllers/authenticated/target-profiles/target-profile/organizations_test.js
@@ -20,9 +20,7 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
         await controller.updateFilters({ name: expectedValue });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.name, expectedValue);
+        assert.strictEqual(controller.name, expectedValue);
       });
     });
 
@@ -36,9 +34,7 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
         await controller.updateFilters({ type: expectedValue });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.type, expectedValue);
+        assert.strictEqual(controller.type, expectedValue);
       });
     });
 
@@ -52,9 +48,7 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
         await controller.updateFilters({ externalId: expectedValue });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.externalId, expectedValue);
+        assert.strictEqual(controller.externalId, expectedValue);
       });
     });
   });

--- a/admin/tests/unit/controllers/campaigns/campaign_test.js
+++ b/admin/tests/unit/controllers/campaigns/campaign_test.js
@@ -10,13 +10,12 @@ module('Unit | Controller | authenticated/campaigns/campaign', function (hooks) 
       const controller = this.owner.lookup('controller:authenticated.campaigns.campaign');
       controller.isEditMode = false;
       const expectedValue = true;
+
       //when
       await controller.toggleEditMode();
 
       //then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.isEditMode, expectedValue);
+      assert.strictEqual(controller.isEditMode, expectedValue);
     });
   });
 });

--- a/admin/tests/unit/helpers/format-date_test.js
+++ b/admin/tests/unit/helpers/format-date_test.js
@@ -10,9 +10,7 @@ module('Unit | Helpers | formatDate', function () {
     const value = formatDate([date]);
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(value, null);
+    assert.strictEqual(value, null);
   });
 
   test('it should return formatted date', function (assert) {
@@ -23,8 +21,6 @@ module('Unit | Helpers | formatDate', function () {
     const value = formatDate([date]);
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(value, '14/08/2020');
+    assert.strictEqual(value, '14/08/2020');
   });
 });

--- a/admin/tests/unit/models/to-be-published-session_test.js
+++ b/admin/tests/unit/models/to-be-published-session_test.js
@@ -17,9 +17,7 @@ module('Unit | Model | to be published session', function (hooks) {
       const printableDateAndTime = toBePublishedSession.printableDateAndTime;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(printableDateAndTime, '01/02/2020 à 14:30');
+      assert.strictEqual(printableDateAndTime, '01/02/2020 à 14:30');
     });
   });
 
@@ -35,9 +33,7 @@ module('Unit | Model | to be published session', function (hooks) {
       const printableFinalizationDate = toBePublishedSession.printableFinalizationDate;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(printableFinalizationDate, '01/02/2020');
+      assert.strictEqual(printableFinalizationDate, '01/02/2020');
     });
   });
 });

--- a/admin/tests/unit/models/with-required-action-session_test.js
+++ b/admin/tests/unit/models/with-required-action-session_test.js
@@ -17,9 +17,7 @@ module('Unit | Model | with required action session', function (hooks) {
       const printableDateAndTime = sessionWithRequiredAction.printableDateAndTime;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(printableDateAndTime, '01/02/2020 à 14:30');
+      assert.strictEqual(printableDateAndTime, '01/02/2020 à 14:30');
     });
   });
 
@@ -35,9 +33,7 @@ module('Unit | Model | with required action session', function (hooks) {
       const printableFinalizationDate = sessionWithRequiredAction.printableFinalizationDate;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(printableFinalizationDate, '01/02/2020');
+      assert.strictEqual(printableFinalizationDate, '01/02/2020');
     });
   });
 });

--- a/admin/tests/unit/routes/authenticated/certification-centers/list_test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/list_test.js
@@ -85,24 +85,12 @@ module('Unit | Route | authenticated/certification-centers/list', function (hook
         route.resetController(controller, true);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageNumber, 1);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageSize, 10);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.id, null);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.name, null);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.type, null);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.externalId, null);
+        assert.strictEqual(controller.pageNumber, 1);
+        assert.strictEqual(controller.pageSize, 10);
+        assert.strictEqual(controller.id, null);
+        assert.strictEqual(controller.name, null);
+        assert.strictEqual(controller.type, null);
+        assert.strictEqual(controller.externalId, null);
       });
     });
 
@@ -112,24 +100,12 @@ module('Unit | Route | authenticated/certification-centers/list', function (hook
         route.resetController(controller, false);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageNumber, 'somePageNumber');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageSize, 'somePageSize');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.id, 'someId');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.name, 'someName');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.type, 'someType');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.externalId, 'someExternalId');
+        assert.strictEqual(controller.pageNumber, 'somePageNumber');
+        assert.strictEqual(controller.pageSize, 'somePageSize');
+        assert.strictEqual(controller.id, 'someId');
+        assert.strictEqual(controller.name, 'someName');
+        assert.strictEqual(controller.type, 'someType');
+        assert.strictEqual(controller.externalId, 'someExternalId');
       });
     });
   });

--- a/admin/tests/unit/routes/authenticated/organizations/list_test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/list_test.js
@@ -85,24 +85,12 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
         route.resetController(controller, true);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageNumber, 1);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageSize, 10);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.id, null);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.name, null);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.type, null);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.externalId, null);
+        assert.strictEqual(controller.pageNumber, 1);
+        assert.strictEqual(controller.pageSize, 10);
+        assert.strictEqual(controller.id, null);
+        assert.strictEqual(controller.name, null);
+        assert.strictEqual(controller.type, null);
+        assert.strictEqual(controller.externalId, null);
       });
     });
 
@@ -112,24 +100,12 @@ module('Unit | Route | authenticated/organizations/list', function (hooks) {
         route.resetController(controller, false);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageNumber, 'somePageNumber');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.pageSize, 'somePageSize');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.id, 'someId');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.name, 'someName');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.type, 'someType');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(controller.externalId, 'someExternalId');
+        assert.strictEqual(controller.pageNumber, 'somePageNumber');
+        assert.strictEqual(controller.pageSize, 'somePageSize');
+        assert.strictEqual(controller.id, 'someId');
+        assert.strictEqual(controller.name, 'someName');
+        assert.strictEqual(controller.type, 'someType');
+        assert.strictEqual(controller.externalId, 'someExternalId');
       });
     });
   });

--- a/admin/tests/unit/validators/absolute-url-test.js
+++ b/admin/tests/unit/validators/absolute-url-test.js
@@ -21,9 +21,7 @@ module('Unit | Validator | absolute-url', function (hooks) {
 
     const message = await validator.validate(badUrl, options);
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(message, options.message);
+    assert.strictEqual(message, options.message);
   });
 
   test('it does not return an error message when url starts with http://', async function (assert) {
@@ -50,8 +48,6 @@ module('Unit | Validator | absolute-url', function (hooks) {
 
     const message = await validator.validate(badUrl, options);
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(message, options.message);
+    assert.strictEqual(message, options.message);
   });
 });

--- a/certif/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
+++ b/certif/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
@@ -9,6 +9,6 @@ module('Acceptance | <%= dasherizedModuleName %>', function(hooks) {
   test('visiting /<%= dasherizedModuleName %>', async function(assert) {
     await visitScreen('/<%= dasherizedModuleName %>');
 
-    assert.equal(currentURL(), '/<%= dasherizedModuleName %>');
+    assert.strictEqual(currentURL(), '/<%= dasherizedModuleName %>');
   });
 });

--- a/certif/tests/acceptance/authentication_test.js
+++ b/certif/tests/acceptance/authentication_test.js
@@ -25,9 +25,7 @@ module('Acceptance | authentication', function (hooks) {
       await visit('/');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/connexion');
+      assert.strictEqual(currentURL(), '/connexion');
       assert.notOk(
         currentSession(this.application).get('isAuthenticated'),
         'The certificationPointOfContact is still unauthenticated'
@@ -49,9 +47,7 @@ module('Acceptance | authentication', function (hooks) {
       await click('button[type=submit]');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/cgu');
+      assert.strictEqual(currentURL(), '/cgu');
       assert.ok(
         currentSession(this.application).get('isAuthenticated'),
         'The certificationPointOfContact is authenticated'
@@ -95,9 +91,8 @@ module('Acceptance | authentication', function (hooks) {
       await click('button[type=submit]');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/sessions/liste');
+
+      assert.strictEqual(currentURL(), '/sessions/liste');
       assert.ok(
         currentSession(this.application).get('isAuthenticated'),
         'The certificationPointOfContact is authenticated'
@@ -135,9 +130,7 @@ module('Acceptance | authentication', function (hooks) {
       await visit('/sessions/liste');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/sessions/liste');
+      assert.strictEqual(currentURL(), '/sessions/liste');
       assert.ok(
         currentSession(this.application).get('isAuthenticated'),
         'The certificationPointOfContact is authenticated'
@@ -165,9 +158,7 @@ module('Acceptance | authentication', function (hooks) {
       await visit('/');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/sessions/liste');
+      assert.strictEqual(currentURL(), '/sessions/liste');
     });
   });
 });

--- a/certif/tests/acceptance/session-details_test.js
+++ b/certif/tests/acceptance/session-details_test.js
@@ -26,9 +26,7 @@ module('Acceptance | Session Details', function (hooks) {
       await visit(`/sessions/${session.id}`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/connexion');
+      assert.strictEqual(currentURL(), '/connexion');
     });
   });
 
@@ -63,9 +61,7 @@ module('Acceptance | Session Details', function (hooks) {
         await visit(`/sessions/${session.id}`);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/espace-ferme');
+        assert.strictEqual(currentURL(), '/espace-ferme');
       });
     });
 

--- a/certif/tests/acceptance/terms-of-service_test.js
+++ b/certif/tests/acceptance/terms-of-service_test.js
@@ -22,9 +22,7 @@ module('Acceptance | terms-of-service', function (hooks) {
     await visit('/cgu');
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/connexion');
+    assert.strictEqual(currentURL(), '/connexion');
     assert.notOk(
       currentSession(this.application).get('isAuthenticated'),
       'The certificationPointOfContact is still unauthenticated'
@@ -63,9 +61,7 @@ module('Acceptance | terms-of-service', function (hooks) {
         await click(screen.getByRole('button', { name: 'J’accepte les conditions d’utilisation' }));
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/sessions/liste');
+        assert.strictEqual(currentURL(), '/sessions/liste');
       });
 
       test('it should not be possible to visit another page if cgu are not accepted', async function (assert) {
@@ -76,9 +72,7 @@ module('Acceptance | terms-of-service', function (hooks) {
         await visit('/campagnes');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/cgu');
+        assert.strictEqual(currentURL(), '/cgu');
       });
     }
   );
@@ -95,9 +89,7 @@ module('Acceptance | terms-of-service', function (hooks) {
       await visit('/cgu');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/sessions/liste');
+      assert.strictEqual(currentURL(), '/sessions/liste');
     });
   });
 });

--- a/certif/tests/unit/components/add-student-list_test.js
+++ b/certif/tests/unit/components/add-student-list_test.js
@@ -86,9 +86,8 @@ module('Unit | Component | add-student-list', function (hooks) {
       component.toggleItem(student);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(student.isSelected, !initialValue);
+
+      assert.strictEqual(student.isSelected, !initialValue);
     });
   });
 

--- a/certif/tests/unit/components/enrolled-candidates_test.js
+++ b/certif/tests/unit/components/enrolled-candidates_test.js
@@ -71,9 +71,7 @@ module('Unit | Component | enrolled-candidates', function (hooks) {
       // then
       sinon.assert.notCalled(savableCandidate.save);
       sinon.assert.calledOnce(savableCandidate.deleteRecord);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.args.certificationCandidates.length, 1);
+      assert.strictEqual(component.args.certificationCandidates.length, 1);
     });
   });
 
@@ -173,9 +171,7 @@ module('Unit | Component | enrolled-candidates', function (hooks) {
 
       // then
       assert.true(component.shouldDisplayCertificationCandidateModal);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.certificationCandidateInDetailsModal, candidate);
+      assert.strictEqual(component.certificationCandidateInDetailsModal, candidate);
     });
   });
 
@@ -196,9 +192,7 @@ module('Unit | Component | enrolled-candidates', function (hooks) {
 
       // then
       assert.false(component.shouldDisplayCertificationCandidateModal);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.certificationCandidateInDetailsModal, null);
+      assert.strictEqual(component.certificationCandidateInDetailsModal, null);
     });
   });
 

--- a/certif/tests/unit/components/new-certification-candidate-modal_test.js
+++ b/certif/tests/unit/components/new-certification-candidate-modal_test.js
@@ -26,9 +26,7 @@ module('Unit | Component | new-certification-candidate-modal', function (hooks) 
         await modal.selectBirthGeoCodeOption('insee');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(modal.selectedBirthGeoCodeOption, 'insee');
+        assert.strictEqual(modal.selectedBirthGeoCodeOption, 'insee');
       });
 
       test('should reset the birth city', async function (assert) {
@@ -76,9 +74,7 @@ module('Unit | Component | new-certification-candidate-modal', function (hooks) 
         await modal.selectBirthGeoCodeOption('postal');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(modal.selectedBirthGeoCodeOption, 'postal');
+        assert.strictEqual(modal.selectedBirthGeoCodeOption, 'postal');
       });
 
       test('should reset the birth insee code', async function (assert) {

--- a/certif/tests/unit/controllers/authenticated/sessions/new_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/new_test.js
@@ -79,9 +79,7 @@ module('Unit | Controller | authenticated/sessions/new', function (hooks) {
       controller.send('onDatePicked', 'ignoredParam', lastSelectedDateFormatted);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(session.date, lastSelectedDateFormatted);
+      assert.strictEqual(session.date, lastSelectedDateFormatted);
     });
   });
 
@@ -100,9 +98,7 @@ module('Unit | Controller | authenticated/sessions/new', function (hooks) {
       controller.send('onTimePicked', 'ignoredParam', lastSelectedTimeFormatted);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(session.time, lastSelectedTimeFormatted);
+      assert.strictEqual(session.time, lastSelectedTimeFormatted);
     });
   });
 });

--- a/certif/tests/unit/controllers/authenticated/sessions/update_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/update_test.js
@@ -79,9 +79,7 @@ module('Unit | Controller | authenticated/sessions/update', function (hooks) {
       controller.send('onDatePicked', 'ignoredParam', lastSelectedDateFormatted);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(session.date, lastSelectedDateFormatted);
+      assert.strictEqual(session.date, lastSelectedDateFormatted);
     });
   });
 
@@ -100,9 +98,7 @@ module('Unit | Controller | authenticated/sessions/update', function (hooks) {
       controller.send('onTimePicked', 'ignoredParam', lastSelectedTimeFormatted);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(session.time, lastSelectedTimeFormatted);
+      assert.strictEqual(session.time, lastSelectedTimeFormatted);
     });
   });
 });

--- a/certif/tests/unit/controllers/authenticated_test.js
+++ b/certif/tests/unit/controllers/authenticated_test.js
@@ -27,9 +27,7 @@ module('Unit | Controller | authenticated', function (hooks) {
       const documentationLink = controller.documentationLink;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(documentationLink, 'http://cloud.pix.fr/s/fLSG4mYCcX7GDRF');
+      assert.strictEqual(documentationLink, 'http://cloud.pix.fr/s/fLSG4mYCcX7GDRF');
     });
 
     test('should return the dedicated link for SCO isManagingStudents certification center', function (assert) {
@@ -53,9 +51,7 @@ module('Unit | Controller | authenticated', function (hooks) {
       const documentationLink = controller.documentationLink;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(documentationLink, 'http://cloud.pix.fr/s/GqwW6dFDDrHezfS');
+      assert.strictEqual(documentationLink, 'http://cloud.pix.fr/s/GqwW6dFDDrHezfS');
     });
   });
 

--- a/certif/tests/unit/routes/not-found_test.js
+++ b/certif/tests/unit/routes/not-found_test.js
@@ -10,9 +10,11 @@ module('Unit | Route | not-found', function (hooks) {
     const expectedRedirection = 'application';
 
     route.transitionTo = (redirection) => {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(redirection, expectedRedirection, `expect transition to ${expectedRedirection}, got ${redirection}`);
+      assert.strictEqual(
+        redirection,
+        expectedRedirection,
+        `expect transition to ${expectedRedirection}, got ${redirection}`
+      );
     };
 
     route.afterModel();

--- a/certif/tests/unit/services/current-user_test.js
+++ b/certif/tests/unit/services/current-user_test.js
@@ -34,12 +34,8 @@ module('Unit | Service | current-user', function (hooks) {
       await currentUser.load();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentUser.certificationPointOfContact, certificationPointOfContact);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentUser.currentAllowedCertificationCenterAccess, allowedCertificationCenterAccesseA);
+      assert.strictEqual(currentUser.certificationPointOfContact, certificationPointOfContact);
+      assert.strictEqual(currentUser.currentAllowedCertificationCenterAccess, allowedCertificationCenterAccesseA);
     });
   });
 
@@ -56,9 +52,7 @@ module('Unit | Service | current-user', function (hooks) {
       await currentUser.load();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentUser.certificationPointOfContact, null);
+      assert.strictEqual(currentUser.certificationPointOfContact, undefined);
     });
   });
 
@@ -81,9 +75,8 @@ module('Unit | Service | current-user', function (hooks) {
       const result = await currentUser.load();
 
       // Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, 'invalidate');
+
+      assert.strictEqual(result, 'invalidate');
     });
   });
 
@@ -170,9 +163,8 @@ module('Unit | Service | current-user', function (hooks) {
       currentUser.updateCurrentCertificationCenter(222);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentUser.currentAllowedCertificationCenterAccess, newAllowedCertificationCenterAccess);
+
+      assert.strictEqual(currentUser.currentAllowedCertificationCenterAccess, newAllowedCertificationCenterAccess);
     });
   });
 });

--- a/mon-pix/tests/acceptance/account-recovery/find-sco-record_test.js
+++ b/mon-pix/tests/acceptance/account-recovery/find-sco-record_test.js
@@ -62,9 +62,7 @@ module('Acceptance | account-recovery | FindScoRecordRoute', function (hooks) {
     const screen = await visit('/recuperer-mon-compte');
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/recuperer-mon-compte');
+    assert.strictEqual(currentURL(), '/recuperer-mon-compte');
     assert.ok(
       screen.getByRole('heading', {
         name: this.intl.t('pages.account-recovery.find-sco-record.student-information.title'),

--- a/mon-pix/tests/acceptance/account-recovery/update-sco-record_test.js
+++ b/mon-pix/tests/acceptance/account-recovery/update-sco-record_test.js
@@ -22,9 +22,7 @@ module('Acceptance | account-recovery | UpdateScoRecordRoute', function (hooks) 
       const screen = await visit(`/recuperer-mon-compte/${temporaryKey}`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), `/recuperer-mon-compte/${temporaryKey}`);
+      assert.strictEqual(currentURL(), `/recuperer-mon-compte/${temporaryKey}`);
 
       assert.ok(
         screen.getByRole('heading', {
@@ -174,9 +172,7 @@ module('Acceptance | account-recovery | UpdateScoRecordRoute', function (hooks) 
       await clickByLabel(this.intl.t('pages.account-recovery.update-sco-record.form.login-button'));
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/accueil');
+      assert.strictEqual(currentURL(), '/accueil');
     });
 
     test('should display an error message when account with email already exists', async function (assert) {

--- a/mon-pix/tests/acceptance/certification-course_test.js
+++ b/mon-pix/tests/acceptance/certification-course_test.js
@@ -38,9 +38,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
         });
 
         test('should render the not certifiable template', function (assert) {
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(
+          assert.strictEqual(
             find('.certification-not-certifiable__title').textContent.trim(),
             "Votre profil n'est pas encore certifiable."
           );
@@ -155,9 +153,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
 
           test('should redirect to certification start route', function (assert) {
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), '/certifications/candidat/1');
+            assert.strictEqual(currentURL(), '/certifications/candidat/1');
           });
         });
 
@@ -185,9 +181,7 @@ module('Acceptance | Certification | Certification Course', function (hooks) {
 
           test('should redirect to certification start route', function (assert) {
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), '/certifications/candidat/2');
+            assert.strictEqual(currentURL(), '/certifications/candidat/2');
           });
         });
 

--- a/mon-pix/tests/acceptance/challenge-attachment_test.js
+++ b/mon-pix/tests/acceptance/challenge-attachment_test.js
@@ -27,12 +27,8 @@ module('Acceptance | Download an attachment from a challenge', function (hooks) 
 
     test('should expose the correct attachment link', function (assert) {
       assert.ok(find('.challenge-statement__action-link').textContent.includes('Télécharger'));
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(challengeWithAttachment.attachments.length, 1);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(
+      assert.strictEqual(challengeWithAttachment.attachments.length, 1);
+      assert.strictEqual(
         find('.challenge-statement__action-link').getAttribute('href'),
         challengeWithAttachment.attachments[0]
       );

--- a/mon-pix/tests/acceptance/challenge-commons_test.js
+++ b/mon-pix/tests/acceptance/challenge-commons_test.js
@@ -53,34 +53,24 @@ module('Acceptance | Common behavior to all challenges', function (hooks) {
 
     test('should display the challenge to answered instead of challenge asked', async function (assert) {
       await visit(`/assessments/${assessment.id}/challenges/${challengeBis.id}`);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.challenge-statement-instruction__text').textContent.trim(), 'Instruction lien');
+      assert.strictEqual(find('.challenge-statement-instruction__text').textContent.trim(), 'Instruction lien');
     });
 
     test('should display the challenge instruction', function (assert) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.challenge-statement-instruction__text').textContent.trim(), 'Instruction lien');
+      assert.strictEqual(find('.challenge-statement-instruction__text').textContent.trim(), 'Instruction lien');
     });
 
     test('should format content written as [foo](bar) as clickable link', function (assert) {
       assert.dom('.challenge-statement-instruction__text a').exists();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.challenge-statement-instruction__text a').textContent, 'lien');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(
+      assert.strictEqual(find('.challenge-statement-instruction__text a').textContent, 'lien');
+      assert.strictEqual(
         find('.challenge-statement-instruction__text a').getAttribute('href'),
         'http://www.a.link.example.url'
       );
     });
 
     test('should open links in a new tab', function (assert) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.challenge-statement-instruction__text a').getAttribute('target'), '_blank');
+      assert.strictEqual(find('.challenge-statement-instruction__text a').getAttribute('target'), '_blank');
     });
 
     test('should display the skip button', function (assert) {
@@ -96,9 +86,7 @@ module('Acceptance | Common behavior to all challenges', function (hooks) {
     });
 
     test('should come back to the home route when the back button is clicked', async function (assert) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.assessment-banner__home-link').getAttribute('href'), '/');
+      assert.strictEqual(find('.assessment-banner__home-link').getAttribute('href'), '/');
     });
 
     test('should be able to send a feedback about the current challenge', function (assert) {

--- a/mon-pix/tests/acceptance/challenge-feedback_test.js
+++ b/mon-pix/tests/acceptance/challenge-feedback_test.js
@@ -60,9 +60,8 @@ module('Acceptance | Giving feedback about a challenge', function (hooks) {
           test('should always reset the feedback form between two consecutive challenges', async function (assert) {
             await click('.feedback-panel__open-button');
             await fillIn(DROPDOWN, 'accessibility');
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(find(TEXTAREA).value, '');
+
+            assert.strictEqual(find(TEXTAREA).value, '');
           });
         });
       });

--- a/mon-pix/tests/acceptance/challenge-flash-in-campaign_test.js
+++ b/mon-pix/tests/acceptance/challenge-flash-in-campaign_test.js
@@ -30,9 +30,8 @@ module('Acceptance | Flash', function (hooks) {
 
       const progressValue = find('.assessment-progress__value').textContent.replace(/\s+/g, '');
       const maxNbOfQuestions = environment.APP.NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD;
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(progressValue, `1/${maxNbOfQuestions}`);
+
+      assert.strictEqual(progressValue, `1/${maxNbOfQuestions}`);
     });
   });
 });

--- a/mon-pix/tests/acceptance/challenge-item-qcm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcm_test.js
@@ -22,38 +22,24 @@ module('Acceptance | Displaying a QCM challenge', function (hooks) {
 
     test('should render challenge information and question', function (assert) {
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.challenge-statement-instruction__text').textContent.trim(), qcmChallenge.instruction);
+      assert.strictEqual(find('.challenge-statement-instruction__text').textContent.trim(), qcmChallenge.instruction);
 
       assert.dom('input[type="checkbox"]').exists({ count: 4 });
 
       const proposalsText = findAll('.proposal-text');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(proposalsText[0].innerHTML.trim(), '<p><em>possibilite</em> 1, et/ou</p>');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(proposalsText[1].textContent.trim(), 'possibilite 2, et/ou');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(
+
+      assert.strictEqual(proposalsText[0].innerHTML.trim(), '<p><em>possibilite</em> 1, et/ou</p>');
+      assert.strictEqual(proposalsText[1].textContent.trim(), 'possibilite 2, et/ou');
+      assert.strictEqual(
         proposalsText[1].innerHTML.trim(),
         '<p><a href="/test" rel="noopener noreferrer" target="_blank">possibilite 2</a>, et/ou</p>'
       );
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(proposalsText[2].textContent.trim(), ', et/ou');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(
+      assert.strictEqual(proposalsText[2].textContent.trim(), ', et/ou');
+      assert.strictEqual(
         proposalsText[2].innerHTML.trim(),
         '<p><img src="/images/pix-logo-blanc.svg" alt="possibilite 3">, et/ou</p>'
       );
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(proposalsText[3].textContent.trim(), 'possibilite 4');
-
+      assert.strictEqual(proposalsText[3].textContent.trim(), 'possibilite 4');
       assert.dom('.challenge-response__alert').doesNotExist();
     });
 
@@ -63,9 +49,7 @@ module('Acceptance | Displaying a QCM challenge', function (hooks) {
 
       // then
       assert.dom('.challenge-response__alert').exists();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(
+      assert.strictEqual(
         find('.challenge-response__alert').textContent.trim(),
         'Pour valider, sélectionnez au moins une réponse. Sinon, passez.'
       );
@@ -151,15 +135,12 @@ module('Acceptance | Displaying a QCM challenge', function (hooks) {
 
     test('should show the result of previous challenge in checkpoint', async function (assert) {
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.result-item__icon').title, 'Réponse incorrecte');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.result-item__instruction').textContent.trim(), qcmChallenge.instruction);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.result-item__correction-button').textContent.trim(), 'Réponses et tutos');
+
+      assert.strictEqual(find('.result-item__icon').title, 'Réponse incorrecte');
+
+      assert.strictEqual(find('.result-item__instruction').textContent.trim(), qcmChallenge.instruction);
+
+      assert.strictEqual(find('.result-item__correction-button').textContent.trim(), 'Réponses et tutos');
     });
 
     test('should show details of challenge result in pop-in, with tutorials and feedbacks', async function (assert) {
@@ -167,25 +148,15 @@ module('Acceptance | Displaying a QCM challenge', function (hooks) {
       await click('.result-item__correction-button');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.challenge-statement-instruction__text').textContent.trim(), qcmChallenge.instruction);
+      assert.strictEqual(find('.challenge-statement-instruction__text').textContent.trim(), qcmChallenge.instruction);
 
       const goodAnswer = findAll('.qcm-proposal-label__answer-details')[0];
       const badAnswerFromUserResult = findAll('.qcm-proposal-label__answer-details')[1];
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(goodAnswer.getAttribute('data-goodness'), 'good');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(goodAnswer.getAttribute('data-checked'), 'no');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(badAnswerFromUserResult.getAttribute('data-goodness'), 'bad');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(badAnswerFromUserResult.getAttribute('data-checked'), 'yes');
 
+      assert.strictEqual(goodAnswer.getAttribute('data-goodness'), 'good');
+      assert.strictEqual(goodAnswer.getAttribute('data-checked'), 'no');
+      assert.strictEqual(badAnswerFromUserResult.getAttribute('data-goodness'), 'bad');
+      assert.strictEqual(badAnswerFromUserResult.getAttribute('data-checked'), 'yes');
       assert.ok(find('.tutorial-panel__hint-container').textContent.includes(correction.hint));
 
       const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card')[0];

--- a/mon-pix/tests/acceptance/challenge-item-qcu_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qcu_test.js
@@ -22,39 +22,22 @@ module('Acceptance | Displaying a QCU challenge', function (hooks) {
 
     test('should render challenge information and question', function (assert) {
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.challenge-statement-instruction__text').textContent.trim(), qcuChallenge.instruction);
 
+      assert.strictEqual(find('.challenge-statement-instruction__text').textContent.trim(), qcuChallenge.instruction);
       assert.dom('input[type=radio][name="radio"]').exists({ count: 4 });
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.proposal-text')[0].textContent.trim(), '1ere possibilite');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.proposal-text')[0].innerHTML.trim(), '<p>1ere <em>possibilite</em></p>');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.proposal-text')[1].textContent.trim(), '2eme possibilite');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(
+      assert.strictEqual(findAll('.proposal-text')[0].textContent.trim(), '1ere possibilite');
+      assert.strictEqual(findAll('.proposal-text')[0].innerHTML.trim(), '<p>1ere <em>possibilite</em></p>');
+      assert.strictEqual(findAll('.proposal-text')[1].textContent.trim(), '2eme possibilite');
+      assert.strictEqual(
         findAll('.proposal-text')[1].innerHTML.trim(),
         '<p>2eme <a href="/test" rel="noopener noreferrer" target="_blank">possibilite</a></p>'
       );
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.proposal-text')[2].textContent.trim(), '');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(
+      assert.strictEqual(findAll('.proposal-text')[2].textContent.trim(), '');
+      assert.strictEqual(
         findAll('.proposal-text')[2].innerHTML.trim(),
         '<p><img src="/images/pix-logo-blanc.svg" alt="3eme possibilite"></p>'
       );
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.proposal-text')[3].textContent.trim(), '4eme possibilite');
-
+      assert.strictEqual(findAll('.proposal-text')[3].textContent.trim(), '4eme possibilite');
       assert.dom('.challenge-reponse__alert').doesNotExist();
     });
 
@@ -64,9 +47,7 @@ module('Acceptance | Displaying a QCU challenge', function (hooks) {
 
       // then
       assert.dom('.challenge-response__alert').exists();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(
+      assert.strictEqual(
         find('.challenge-response__alert').textContent.trim(),
         'Pour valider, sélectionnez une réponse. Sinon, passez.'
       );
@@ -151,15 +132,9 @@ module('Acceptance | Displaying a QCU challenge', function (hooks) {
 
     test('should show the result of previous challenge in checkpoint', async function (assert) {
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.result-item__icon').title, 'Réponse incorrecte');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.result-item__instruction').textContent.trim(), qcuChallenge.instruction);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.result-item__correction-button').textContent.trim(), 'Réponses et tutos');
+      assert.strictEqual(find('.result-item__icon').title, 'Réponse incorrecte');
+      assert.strictEqual(find('.result-item__instruction').textContent.trim(), qcuChallenge.instruction);
+      assert.strictEqual(find('.result-item__correction-button').textContent.trim(), 'Réponses et tutos');
     });
 
     test('should show details of challenge result in pop-in, with tutorials and feedbacks', async function (assert) {
@@ -167,24 +142,15 @@ module('Acceptance | Displaying a QCU challenge', function (hooks) {
       await click('.result-item__correction-button');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.challenge-statement-instruction__text').textContent.trim(), qcuChallenge.instruction);
+      assert.strictEqual(find('.challenge-statement-instruction__text').textContent.trim(), qcuChallenge.instruction);
 
       const goodAnswer = findAll('.qcu-solution-panel__proposition')[0];
       const badAnswerFromUserResult = findAll('.qcu-solution-panel__proposition')[1];
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(goodAnswer.getAttribute('data-goodness'), 'good');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(goodAnswer.getAttribute('data-checked'), 'no');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(badAnswerFromUserResult.getAttribute('data-goodness'), 'bad');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(badAnswerFromUserResult.getAttribute('data-checked'), 'yes');
+
+      assert.strictEqual(goodAnswer.getAttribute('data-goodness'), 'good');
+      assert.strictEqual(goodAnswer.getAttribute('data-checked'), 'no');
+      assert.strictEqual(badAnswerFromUserResult.getAttribute('data-goodness'), 'bad');
+      assert.strictEqual(badAnswerFromUserResult.getAttribute('data-checked'), 'yes');
 
       assert.ok(find('.qcu-solution-answer-feedback__expected-answer').textContent.includes(1));
       assert.ok(find('.qcu-solution-answer-feedback__expected-answer').innerHTML.includes('1ere <em>possibilite</em>'));

--- a/mon-pix/tests/acceptance/challenge-item-qroc_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qroc_test.js
@@ -39,9 +39,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
         // then
         assert.dom('.challenge-response__alert').exists();
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+        assert.strictEqual(
           find('.challenge-response__alert').textContent.trim(),
           '“Vous pouvez valider” s‘affiche quand l‘épreuve est réussie. Essayez encore ou passez.'
         );
@@ -81,9 +79,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
         // then
         await click('.challenge-actions__action-validate');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+        assert.strictEqual(
           find('.challenge-response__alert').textContent.trim(),
           'Pour valider, veuillez remplir le champ texte. Sinon, passez.'
         );
@@ -98,16 +94,12 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
       test('should render challenge information and question', function (assert) {
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.challenge-statement-instruction__text').textContent.trim(), qrocChallenge.instruction);
-
+        assert.strictEqual(
+          find('.challenge-statement-instruction__text').textContent.trim(),
+          qrocChallenge.instruction
+        );
         assert.dom('.challenge-response__proposal').exists({ count: 1 });
-        // TODO : est-ce que cette ligne sert à quelque chose ?
-        // assert.false(find('.challenge-response__proposal').disabled);
-
         assert.ok(findAll('.qroc_input-label')[0].innerHTML.includes('Entrez le <em>prénom</em> de B. Gates :'));
-
         assert.dom('.challenge-response__alert').doesNotExist();
       });
 
@@ -119,9 +111,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
         // then
         assert.dom('.challenge-response__alert').exists();
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+        assert.strictEqual(
           find('.challenge-response__alert').textContent.trim(),
           'Pour valider, veuillez remplir le champ texte. Sinon, passez.'
         );
@@ -165,12 +155,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
       test('should set the input value with the current answer and propose to continue', async function (assert) {
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.challenge-response__proposal').value, 'Reponse');
-        // TODO : est-ce que cette ligne sert à quelque chose ?
-        // assert.true(find('.challenge-response__proposal').disabled);
-
+        assert.strictEqual(find('.challenge-response__proposal').value, 'Reponse');
         assert.dom('.challenge-actions__action-continue').exists();
         assert.dom('.challenge-actions__action-validate').doesNotExist();
         assert.dom('.challenge-actions__action-skip-text').doesNotExist();
@@ -203,15 +188,9 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
       test('should show the result of previous challenge in checkpoint', async function (assert) {
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.result-item__icon').title, 'Réponse incorrecte');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.result-item__instruction').textContent.trim(), qrocChallenge.instruction);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.result-item__correction-button').textContent.trim(), 'Réponses et tutos');
+        assert.strictEqual(find('.result-item__icon').title, 'Réponse incorrecte');
+        assert.strictEqual(find('.result-item__instruction').textContent.trim(), qrocChallenge.instruction);
+        assert.strictEqual(find('.result-item__correction-button').textContent.trim(), 'Réponses et tutos');
       });
 
       test('should show details of challenge result in pop-in, with tutorials and feedbacks', async function (assert) {
@@ -219,20 +198,16 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
         await click('.result-item__correction-button');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.challenge-statement-instruction__text').textContent.trim(), qrocChallenge.instruction);
+        assert.strictEqual(
+          find('.challenge-statement-instruction__text').textContent.trim(),
+          qrocChallenge.instruction
+        );
 
         const goodAnswer = find('.comparison-window-solution__text');
         const badAnswerFromUserResult = find('.correction-qroc-box-answer');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(goodAnswer.textContent.trim(), 'Mangue');
+        assert.strictEqual(goodAnswer.textContent.trim(), 'Mangue');
         assert.ok(badAnswerFromUserResult.className.includes('correction-qroc-box-answer--wrong'));
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(badAnswerFromUserResult.value, 'Banane');
-
+        assert.strictEqual(badAnswerFromUserResult.value, 'Banane');
         assert.ok(find('.tutorial-panel__hint-container').textContent.includes(correction.hint));
 
         const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card')[0];
@@ -240,7 +215,6 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
         assert.ok(tutorialToSuccess.textContent.includes(tutorial.title));
         assert.ok(tutorialToLearnMore.textContent.includes(learningMoreTutorial.title));
-
         assert.dom('.feedback-panel').exists();
       });
     });
@@ -257,9 +231,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
       });
 
       test('should display the correct challenge for first one', async function (assert) {
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+        assert.strictEqual(
           find('.challenge-statement-instruction__text').textContent.trim(),
           qrocWithFile1Challenge.instruction
         );
@@ -272,12 +244,8 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
       test('should display the error alert if the users tries to validate an empty answer', async function (assert) {
         await click(find('.challenge-actions__action-skip'));
 
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), `/assessments/${assessment.id}/challenges/1`);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+        assert.strictEqual(currentURL(), `/assessments/${assessment.id}/challenges/1`);
+        assert.strictEqual(
           find('.challenge-statement-instruction__text').textContent.trim(),
           qrocWithFile2Challenge.instruction
         );
@@ -303,15 +271,12 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
       test('should render challenge information and question', function (assert) {
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.challenge-statement-instruction__text').textContent.trim(), qrocChallenge.instruction);
-
+        assert.strictEqual(
+          find('.challenge-statement-instruction__text').textContent.trim(),
+          qrocChallenge.instruction
+        );
         assert.dom('.challenge-response__proposal').exists({ count: 1 });
-        // TODO : est-ce que cette ligne sert à quelque chose ?
-        // assert.false(find('.challenge-response__proposal').disabled);
         assert.ok(findAll('.qroc_input-label')[0].innerHTML.includes('Entrez le <em>prénom</em> de B. Gates :'));
-
         assert.dom('.challenge-response__alert').doesNotExist();
       });
 
@@ -323,9 +288,7 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
         // then
         assert.dom('.challenge-response__alert').exists();
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+        assert.strictEqual(
           find('.challenge-response__alert').textContent.trim(),
           'Pour valider, veuillez remplir le champ texte. Sinon, passez.'
         );
@@ -379,15 +342,9 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
       test('should show the result of previous challenge in checkpoint', async function (assert) {
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.result-item__icon').title, 'Réponse incorrecte');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.result-item__instruction').textContent.trim(), qrocChallenge.instruction);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.result-item__correction-button').textContent.trim(), 'Réponses et tutos');
+        assert.strictEqual(find('.result-item__icon').title, 'Réponse incorrecte');
+        assert.strictEqual(find('.result-item__instruction').textContent.trim(), qrocChallenge.instruction);
+        assert.strictEqual(find('.result-item__correction-button').textContent.trim(), 'Réponses et tutos');
       });
 
       test('should show details of challenge result in pop-in, with tutorials and feedbacks', async function (assert) {
@@ -395,20 +352,16 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
         await click('.result-item__correction-button');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.challenge-statement-instruction__text').textContent.trim(), qrocChallenge.instruction);
+        assert.strictEqual(
+          find('.challenge-statement-instruction__text').textContent.trim(),
+          qrocChallenge.instruction
+        );
 
         const goodAnswer = find('.comparison-window-solution__text');
         const badAnswerFromUserResult = find('.correction-qroc-box-answer');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(goodAnswer.textContent.trim(), 'Mangue');
+        assert.strictEqual(goodAnswer.textContent.trim(), 'Mangue');
         assert.ok(badAnswerFromUserResult.className.includes('correction-qroc-box-answer--wrong'));
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(badAnswerFromUserResult.value, 'Banane');
-
+        assert.strictEqual(badAnswerFromUserResult.value, 'Banane');
         assert.ok(find('.tutorial-panel__hint-container').textContent.includes(correction.hint));
 
         const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card')[0];
@@ -416,7 +369,6 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
         assert.ok(tutorialToSuccess.textContent.includes(tutorial.title));
         assert.ok(tutorialToLearnMore.textContent.includes(learningMoreTutorial.title));
-
         assert.dom('.feedback-panel').exists();
       });
     });
@@ -439,8 +391,6 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
           qrocChallenge.instruction
         );
         assert.dom('.challenge-response__proposal').exists({ count: 1 });
-        // TODO : est-ce que cette ligne sert à quelque chose ?
-        // assert.false(find('[data-test="challenge-response-proposal-selector"]').disabled);
         assert.ok(findAll('.qroc_input-label')[0].innerHTML.includes('Select: '));
         assert.dom('.challenge-response__alert').doesNotExist();
       });
@@ -502,15 +452,9 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
 
       test('should show the result of previous challenge in checkpoint', async function (assert) {
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.result-item__icon').title, 'Réponse incorrecte');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.result-item__instruction').textContent.trim(), qrocChallenge.instruction);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.result-item__correction-button').textContent.trim(), 'Réponses et tutos');
+        assert.strictEqual(find('.result-item__icon').title, 'Réponse incorrecte');
+        assert.strictEqual(find('.result-item__instruction').textContent.trim(), qrocChallenge.instruction);
+        assert.strictEqual(find('.result-item__correction-button').textContent.trim(), 'Réponses et tutos');
       });
 
       test('should show details of challenge result in pop-in, with tutorials and feedbacks', async function (assert) {
@@ -518,20 +462,16 @@ module('Acceptance | Displaying a QROC challenge', function (hooks) {
         await click('.result-item__correction-button');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.challenge-statement-instruction__text').textContent.trim(), qrocChallenge.instruction);
+        assert.strictEqual(
+          find('.challenge-statement-instruction__text').textContent.trim(),
+          qrocChallenge.instruction
+        );
 
         const goodAnswer = find('.comparison-window-solution__text');
         const badAnswerFromUserResult = find('.correction-qroc-box-answer');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(goodAnswer.textContent.trim(), 'Mangue');
+        assert.strictEqual(goodAnswer.textContent.trim(), 'Mangue');
         assert.ok(badAnswerFromUserResult.className.includes('correction-qroc-box-answer--wrong'));
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(badAnswerFromUserResult.value, 'Banane');
-
+        assert.strictEqual(badAnswerFromUserResult.value, 'Banane');
         assert.ok(find('.tutorial-panel__hint-container').textContent.includes(correction.hint));
 
         const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-card')[0];

--- a/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
+++ b/mon-pix/tests/acceptance/challenge-item-qrocm_test.js
@@ -24,9 +24,10 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
 
       test('should render challenge information and question', function (assert) {
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.challenge-statement-instruction__text').textContent.trim(), qrocmDepChallenge.instruction);
+        assert.strictEqual(
+          find('.challenge-statement-instruction__text').textContent.trim(),
+          qrocmDepChallenge.instruction
+        );
 
         assert.dom('.challenge-response__proposal').exists({ count: 2 });
         assert.false(findAll('.challenge-response__proposal')[0].disabled);
@@ -45,9 +46,7 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
         await click(find('.challenge-actions__action-validate'));
 
         assert.dom('.challenge-response__alert').exists();
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+        assert.strictEqual(
           find('.challenge-response__alert').textContent.trim(),
           'Pour valider, veuillez remplir tous les champs réponse. Sinon, passez.'
         );
@@ -143,13 +142,9 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
         // then
         assert.ok(find('div[data-test="qrocm-label-0"]').innerHTML.includes('Station <strong>1</strong> :'));
         assert.ok(find('div[data-test="qrocm-label-1"]').innerHTML.includes('Station <em>2</em> :'));
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(findAll('.challenge-response__proposal')[0].value, 'Republique');
+        assert.strictEqual(findAll('.challenge-response__proposal')[0].value, 'Republique');
         assert.true(findAll('.challenge-response__proposal')[0].disabled);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(findAll('.challenge-response__proposal')[1].value, 'Chatelet');
+        assert.strictEqual(findAll('.challenge-response__proposal')[1].value, 'Chatelet');
         assert.true(findAll('.challenge-response__proposal')[1].disabled);
 
         assert.dom('.challenge-actions__action-continue').exists();
@@ -246,38 +241,21 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
 
     test('should show the result of previous challenges in checkpoint', async function (assert) {
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.result-item__icon')[0].title, 'Réponse incorrecte');
+      assert.strictEqual(findAll('.result-item__icon')[0].title, 'Réponse incorrecte');
       const instructionStripped = qrocmDepChallenge.instruction.slice(0, 102);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.result-item__instruction')[0].textContent.trim(), `${instructionStripped}...`);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.result-item__correction-button')[0].textContent.trim(), 'Réponses et tutos');
-
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.result-item__icon')[1].title, 'Réponse incorrecte');
+      assert.strictEqual(findAll('.result-item__instruction')[0].textContent.trim(), `${instructionStripped}...`);
+      assert.strictEqual(findAll('.result-item__correction-button')[0].textContent.trim(), 'Réponses et tutos');
+      assert.strictEqual(findAll('.result-item__icon')[1].title, 'Réponse incorrecte');
       const instructionStrippedInd = qrocmIndChallenge.instruction.slice(0, 104);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.result-item__instruction')[1].textContent.trim(), `${instructionStrippedInd}....`);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.result-item__correction-button')[1].textContent.trim(), 'Réponses et tutos');
-
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.result-item__icon')[2].title, 'Réponse incorrecte');
+      assert.strictEqual(findAll('.result-item__instruction')[1].textContent.trim(), `${instructionStrippedInd}....`);
+      assert.strictEqual(findAll('.result-item__correction-button')[1].textContent.trim(), 'Réponses et tutos');
+      assert.strictEqual(findAll('.result-item__icon')[2].title, 'Réponse incorrecte');
       const instructionStrippedSelect = qrocmIndSelectChallenge.instruction.slice(0, 104);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.result-item__instruction')[2].textContent.trim(), `${instructionStrippedSelect}....`);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.result-item__correction-button')[2].textContent.trim(), 'Réponses et tutos');
+      assert.strictEqual(
+        findAll('.result-item__instruction')[2].textContent.trim(),
+        `${instructionStrippedSelect}....`
+      );
+      assert.strictEqual(findAll('.result-item__correction-button')[2].textContent.trim(), 'Réponses et tutos');
     });
 
     test('should show details of QROCM-dep challenge result in pop-in, with tutorials and feedbacks', async function (assert) {
@@ -285,22 +263,17 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
       await click(findAll('.result-item__correction-button')[0]);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.challenge-statement-instruction__text').textContent.trim(), qrocmDepChallenge.instruction);
+      assert.strictEqual(
+        find('.challenge-statement-instruction__text').textContent.trim(),
+        qrocmDepChallenge.instruction
+      );
 
       const goodAnswers = find('.correction-qrocm__solution-text');
       const badAnswersFromUserResult = findAll('.correction-qrocm__answer');
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(goodAnswers.textContent.trim(), 'Versailles-Chantiers et Poissy');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(badAnswersFromUserResult[0].value, 'Republique');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(badAnswersFromUserResult[1].value, 'Chatelet');
+      assert.strictEqual(goodAnswers.textContent.trim(), 'Versailles-Chantiers et Poissy');
+      assert.strictEqual(badAnswersFromUserResult[0].value, 'Republique');
+      assert.strictEqual(badAnswersFromUserResult[1].value, 'Chatelet');
 
       assert.ok(find('.tutorial-panel__hint-container').textContent.includes(correctionDep.hint));
 
@@ -318,25 +291,18 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
       await click(findAll('.result-item__correction-button')[1]);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.challenge-statement-instruction__text').textContent.trim(), qrocmIndChallenge.instruction);
+      assert.strictEqual(
+        find('.challenge-statement-instruction__text').textContent.trim(),
+        qrocmIndChallenge.instruction
+      );
 
       const goodAnswers = findAll('.correction-qrocm__solution-text');
       const badAnswersFromUserResult = findAll('.correction-qrocm__answer');
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(goodAnswers[0].textContent.trim(), 'Le petit prince');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(goodAnswers[1].textContent.trim(), 'Saint-Exupéry');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(badAnswersFromUserResult[0].value, 'Le rouge et le noir');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(badAnswersFromUserResult[1].value, 'Stendhal');
+      assert.strictEqual(goodAnswers[0].textContent.trim(), 'Le petit prince');
+      assert.strictEqual(goodAnswers[1].textContent.trim(), 'Saint-Exupéry');
+      assert.strictEqual(badAnswersFromUserResult[0].value, 'Le rouge et le noir');
+      assert.strictEqual(badAnswersFromUserResult[1].value, 'Stendhal');
 
       assert.ok(find('.tutorial-panel__hint-container').textContent.includes(correctionDep.hint));
 
@@ -354,9 +320,7 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
       await click(findAll('.result-item__correction-button')[2]);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(
+      assert.strictEqual(
         find('.challenge-statement-instruction__text').textContent.trim(),
         qrocmIndSelectChallenge.instruction
       );
@@ -364,12 +328,8 @@ module('Acceptance | Displaying a QROCM challenge', function (hooks) {
       const goodAnswers = findAll('.correction-qrocm__solution-text');
       const badAnswersFromUserResult = findAll('.correction-qrocm__answer');
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(goodAnswers[0].textContent.trim(), 'mango');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(badAnswersFromUserResult[0].value, 'potato');
+      assert.strictEqual(goodAnswers[0].textContent.trim(), 'mango');
+      assert.strictEqual(badAnswersFromUserResult[0].value, 'potato');
 
       assert.ok(find('.tutorial-panel__hint-container').textContent.includes(correctionIndSelect.hint));
 

--- a/mon-pix/tests/acceptance/challenge-page-banner_test.js
+++ b/mon-pix/tests/acceptance/challenge-page-banner_test.js
@@ -42,9 +42,7 @@ module('Acceptance | Challenge page banner', function (hooks) {
       const a11yText = title.firstChild.textContent;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(a11yText, "Épreuve pour l'évaluation : ");
+      assert.strictEqual(a11yText, "Épreuve pour l'évaluation : ");
     });
 
     test('should display the campaign name in the banner', async function (assert) {
@@ -58,9 +56,7 @@ module('Acceptance | Challenge page banner', function (hooks) {
       const campaignName = title.lastChild.textContent;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(campaignName, campaign.title);
+      assert.strictEqual(campaignName, campaign.title);
     });
   });
 });

--- a/mon-pix/tests/acceptance/course-ending-screen_test.js
+++ b/mon-pix/tests/acceptance/course-ending-screen_test.js
@@ -30,9 +30,7 @@ module('Acceptance | Course ending screen', function (hooks) {
   });
 
   test('should be available directly from the url', function (assert) {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), `/assessments/${assessment.id}/results`);
+    assert.strictEqual(currentURL(), `/assessments/${assessment.id}/results`);
   });
 
   test('should display a summary of all the answers', function (assert) {
@@ -62,9 +60,10 @@ module('Acceptance | Course ending screen', function (hooks) {
 
   test('should display a button that redirects to inscription page', async function (assert) {
     assert.dom('.assessment-results__index-link__element').exists();
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.assessment-results__index-a-link').attributes.href.value, 'https://app.pix.fr/inscription');
+    assert.strictEqual(
+      find('.assessment-results__index-a-link').attributes.href.value,
+      'https://app.pix.fr/inscription'
+    );
     assert.ok(find('.assessment-results__link-back').textContent.includes('Continuer mon expérience Pix'));
   });
 });

--- a/mon-pix/tests/acceptance/error-redirection_test.js
+++ b/mon-pix/tests/acceptance/error-redirection_test.js
@@ -22,9 +22,7 @@ module('Acceptance | Error page', function (hooks) {
     await visit('/mes-certifications');
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/mes-certifications');
+    assert.strictEqual(currentURL(), '/mes-certifications');
     assert.dom('.error-page').exists();
   });
 });

--- a/mon-pix/tests/acceptance/fill-in-certificate-verification-code_test.js
+++ b/mon-pix/tests/acceptance/fill-in-certificate-verification-code_test.js
@@ -20,9 +20,7 @@ module('Acceptance | Certificate verification', function (hooks) {
       await clickByLabel(this.intl.t('pages.fill-in-certificate-verification-code.verify'));
 
       // Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/partage-certificat/200');
+      assert.strictEqual(currentURL(), '/partage-certificat/200');
     });
   });
 
@@ -36,9 +34,7 @@ module('Acceptance | Certificate verification', function (hooks) {
       await clickByLabel(this.intl.t('pages.fill-in-certificate-verification-code.verify'));
 
       // Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/verification-certificat');
+      assert.strictEqual(currentURL(), '/verification-certificat');
     });
 
     test('shows error message', async function (assert) {
@@ -60,9 +56,7 @@ module('Acceptance | Certificate verification', function (hooks) {
       await visit('/partage-certificat/200');
 
       // Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/verification-certificat');
+      assert.strictEqual(currentURL(), '/verification-certificat');
     });
   });
 });

--- a/mon-pix/tests/acceptance/logout-anonymous-user-when-access-to-not-allowed-pages_test.js
+++ b/mon-pix/tests/acceptance/logout-anonymous-user-when-access-to-not-allowed-pages_test.js
@@ -25,9 +25,7 @@ module('Acceptance | Campaigns | Simplified access | Anonymous user access to no
         await visit('/competences');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), EXPECTED_ROUTE_CAMPAIGN);
+        assert.strictEqual(currentURL(), EXPECTED_ROUTE_CAMPAIGN);
         assert.false(currentSession(this.application).get('isAuthenticated'));
       });
     });
@@ -38,37 +36,32 @@ module('Acceptance | Campaigns | Simplified access | Anonymous user access to no
         // when
         const CAMPAIGN_RESULT_ROUTE = `/campagnes/${SIMPLIFIED_CODE_CAMPAIGN}/evaluation/resultats`;
         await visit(CAMPAIGN_RESULT_ROUTE);
+
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), CAMPAIGN_RESULT_ROUTE);
+        assert.strictEqual(currentURL(), CAMPAIGN_RESULT_ROUTE);
         assert.true(currentSession(this.application).get('isAuthenticated'));
 
         // when
         const CHALLENGE_ROUTE = `/assessments/${ID_ASSESSMENT}/challenges/0`;
         await visit(`${CHALLENGE_ROUTE}`);
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), CHALLENGE_ROUTE);
+        assert.strictEqual(currentURL(), CHALLENGE_ROUTE);
         assert.true(currentSession(this.application).get('isAuthenticated'));
 
         // when
         const CAMPAIGN_DIDACTICIEL_ROUTE = `/campagnes/${SIMPLIFIED_CODE_CAMPAIGN}/evaluation/didacticiel`;
         await visit(CAMPAIGN_DIDACTICIEL_ROUTE);
+
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), CAMPAIGN_DIDACTICIEL_ROUTE);
+        assert.strictEqual(currentURL(), CAMPAIGN_DIDACTICIEL_ROUTE);
         assert.true(currentSession(this.application).get('isAuthenticated'));
 
         // when
         const CAMPAIGN_ROUTE = `/campagnes/${SIMPLIFIED_CODE_CAMPAIGN}`;
         await visit(CAMPAIGN_ROUTE);
+
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), CAMPAIGN_ROUTE);
+        assert.strictEqual(currentURL(), CAMPAIGN_ROUTE);
         assert.true(currentSession(this.application).get('isAuthenticated'));
       });
     });

--- a/mon-pix/tests/acceptance/navigation_test.js
+++ b/mon-pix/tests/acceptance/navigation_test.js
@@ -52,9 +52,7 @@ module('Acceptance | Navbar', function (hooks) {
         );
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), userNavigation.expectedRoute);
+        assert.strictEqual(currentURL(), userNavigation.expectedRoute);
         assert.ok(
           find('.navbar-desktop-header-container__menu')
             .children[0].children[userNavigation.targetedNavigationItem].children[0].getAttribute('class')

--- a/mon-pix/tests/acceptance/not-found-redirect-to-index_test.js
+++ b/mon-pix/tests/acceptance/not-found-redirect-to-index_test.js
@@ -10,8 +10,6 @@ module('Acceptance | Page | Not Found Redirection', function (hooks) {
   test('should redirect to home page when URL is a nonexistant page', async function (assert) {
     await visit('/plop');
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/connexion');
+    assert.strictEqual(currentURL(), '/connexion');
   });
 });

--- a/mon-pix/tests/acceptance/oidc/oidc-authentication-flow_test.js
+++ b/mon-pix/tests/acceptance/oidc/oidc-authentication-flow_test.js
@@ -25,9 +25,7 @@ module('Acceptance | OIDC | authentication flow', function (hooks) {
         await click(screen.getByRole('link', { name: 'Se déconnecter' }));
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/deconnexion');
+        assert.strictEqual(currentURL(), '/deconnexion');
       });
     });
 

--- a/mon-pix/tests/acceptance/personal-information_test.js
+++ b/mon-pix/tests/acceptance/personal-information_test.js
@@ -26,9 +26,7 @@ module('Acceptance | personal-information', function (hooks) {
 
       // then
       const userNames = screen.getAllByText(user.firstName).length;
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(userNames, 2);
+      assert.strictEqual(userNames, 2);
       assert.ok(screen.getByText(user.lastName));
     });
   });

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-assessment_test.js
@@ -47,12 +47,8 @@ module('Acceptance | Campaigns | Resume Campaigns with type Assessment', functio
     });
   });
 
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line qunit/no-async-module-callbacks
-  module('When user is logged', async function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('When there is no more questions', async function () {
+  module('When user is logged', function () {
+    module('When there is no more questions', function () {
       test('should redirect to last checkpoint page', async function (assert) {
         // when
         await visit(`/campagnes/${campaign.code}`);
@@ -62,9 +58,7 @@ module('Acceptance | Campaigns | Resume Campaigns with type Assessment', functio
       });
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('When user has completed his campaign participation', async function () {
+    module('When user has completed his campaign participation', function () {
       test('should redirect directly to results', async function (assert) {
         // given
         await visit(`/campagnes/${campaign.code}`);
@@ -78,9 +72,7 @@ module('Acceptance | Campaigns | Resume Campaigns with type Assessment', functio
       });
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('When user has already send his results', async function () {
+    module('When user has already send his results', function () {
       test('should redirect directly to shared results', async function (assert) {
         // given
         await visit(`/campagnes/${campaign.code}`);

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection_test.js
@@ -51,12 +51,8 @@ module('Acceptance | Campaigns | Resume Campaigns with type Profiles Collection'
     });
   });
 
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line qunit/no-async-module-callbacks
-  module('When user is logged', async function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('When user has seen profile page but has not send it', async function () {
+  module('When user is logged', function () {
+    module('When user has seen profile page but has not send it', function () {
       test('should redirect directly to send profile page', async function (assert) {
         // when
         await visit(`/campagnes/${campaign.code}`);
@@ -66,9 +62,7 @@ module('Acceptance | Campaigns | Resume Campaigns with type Profiles Collection'
       });
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('When user has already send his profile', async function () {
+    module('When user has already send his profile', function () {
       test('should redirect directly to send already sent page', async function (assert) {
         // given
         await completeCampaignOfTypeProfilesCollectionByCode(campaign.code);
@@ -90,9 +84,8 @@ module('Acceptance | Campaigns | Resume Campaigns with type Profiles Collection'
         // then
         assert.ok(screen.getByText('156'));
         const area1Titles = screen.getAllByText('Area_1_title').length;
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(area1Titles, 2);
+
+        assert.strictEqual(area1Titles, 2);
         assert.ok(screen.getByText('Area_1_Competence_1_name'));
       });
     });

--- a/mon-pix/tests/acceptance/resume-competence-evaluations_test.js
+++ b/mon-pix/tests/acceptance/resume-competence-evaluations_test.js
@@ -23,9 +23,7 @@ module('Acceptance | Competence Evaluations | Resume Competence Evaluations', f
       });
 
       test('should redirect to signin page', async function (assert) {
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/connexion');
+        assert.strictEqual(currentURL(), '/connexion');
       });
 
       test('should redirect to assessment after signin', async function (assert) {

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment_test.js
@@ -91,9 +91,8 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
                 type: ASSESSMENT,
               });
               await visit(`/campagnes/${campaign.code}?participantExternalId=a73at01r3`);
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line qunit/no-assert-equal
-              assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+
+              assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
               await clickByLabel('Je commence');
 
               // when
@@ -180,12 +179,9 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
           // when
           campaign = server.create('campaign', { type: ASSESSMENT });
           await visit(`/campagnes/${campaign.code}`);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('.campaign-landing-page__start-button').textContent.trim(), 'Je commence');
+
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
+          assert.strictEqual(find('.campaign-landing-page__start-button').textContent.trim(), 'Je commence');
         });
       });
 
@@ -217,9 +213,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
             await clickByLabel(this.intl.t('pages.fill-in-participant-external-id.buttons.continue'));
 
             //then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
           });
         });
       });
@@ -237,9 +231,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Assessment', function
             await clickByLabel(this.intl.t('pages.fill-in-participant-external-id.buttons.continue'));
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
           });
 
           test('should start the assessment when the user has seen tutorial', async function (assert) {

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection_test.js
@@ -44,15 +44,14 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
             await clickByLabel(this.intl.t('pages.fill-in-participant-external-id.buttons.continue'));
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
           });
         });
 
         module('When participant external id is set in the url', function () {
-          module('When campaign is not restricted', function (hooks) {
-            hooks.beforeEach(async function () {
+          module('When campaign is not restricted', function () {
+            test('should redirect to send profile page', async function (assert) {
+              // given & when
               campaign = server.create('campaign', {
                 type: PROFILES_COLLECTION,
                 isRestricted: false,
@@ -65,13 +64,9 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
               await fillIn('#password', campaignParticipant.password);
               await click(screen.getByRole('checkbox', { name: this.intl.t('common.cgu.label') }));
               await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
-            });
 
-            test('should redirect to send profile page', async function (assert) {
               // then
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line qunit/no-assert-equal
-              assert.equal(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
+              assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
             });
           });
 
@@ -85,9 +80,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
                 organizationType: 'SCO',
               });
               await visit(`/campagnes/${campaign.code}?participantExternalId=a73at01r3`);
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line qunit/no-assert-equal
-              assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
+              assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
               await clickByLabel("C'est parti !");
 
               // when
@@ -106,16 +99,15 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
               await clickByLabel(this.intl.t('pages.join.sco.associate'));
 
               // then
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line qunit/no-assert-equal
-              assert.equal(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
+              assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
             });
           });
         });
       });
 
-      module('When campaign does not have external id', function (hooks) {
-        hooks.beforeEach(async function () {
+      module('When campaign does not have external id', function () {
+        test('should redirect to send profile page after signup', async function (assert) {
+          // given & when
           campaign = server.create('campaign', { type: PROFILES_COLLECTION, idPixLabel: null });
           const screen = await startCampaignByCode(campaign.code);
           await fillIn('#firstName', campaignParticipant.firstName);
@@ -124,38 +116,30 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
           await fillIn('#password', campaignParticipant.password);
           await click(screen.getByRole('checkbox', { name: this.intl.t('common.cgu.label') }));
           await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
-        });
 
-        test('should redirect to send profile page after signup', async function (assert) {
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
         });
       });
 
-      module(
-        'When campaign does not have external id but a participant external id is set in the url',
-        function (hooks) {
-          hooks.beforeEach(async function () {
-            campaign = server.create('campaign', { type: PROFILES_COLLECTION });
-            const screen = await startCampaignByCodeAndExternalId(campaign.code);
-            await fillIn('#firstName', campaignParticipant.firstName);
-            await fillIn('#lastName', campaignParticipant.lastName);
-            await fillIn('#email', campaignParticipant.email);
-            await fillIn('#password', campaignParticipant.password);
-            await click(screen.getByRole('checkbox', { name: this.intl.t('common.cgu.label') }));
-            await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
-          });
+      module('When campaign does not have external id but a participant external id is set in the url', function () {
+        test('should redirect to send profile page after signup', async function (assert) {
+          // given
+          campaign = server.create('campaign', { type: PROFILES_COLLECTION });
+          const screen = await startCampaignByCodeAndExternalId(campaign.code);
+          await fillIn('#firstName', campaignParticipant.firstName);
+          await fillIn('#lastName', campaignParticipant.lastName);
+          await fillIn('#email', campaignParticipant.email);
+          await fillIn('#password', campaignParticipant.password);
+          await click(screen.getByRole('checkbox', { name: this.intl.t('common.cgu.label') }));
 
-          test('should redirect to send profile page after signup', async function (assert) {
-            // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
-          });
-        }
-      );
+          // when
+          await clickByLabel(this.intl.t('pages.sign-up.actions.submit'));
+
+          // then
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
+        });
+      });
     });
 
     module('When user is logged in', function (hooks) {
@@ -168,12 +152,8 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
           // when
           campaign = server.create('campaign', { type: PROFILES_COLLECTION });
           await visit(`/campagnes/${campaign.code}`);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/campagnes/${campaign.code}/presentation`);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('.campaign-landing-page__start-button').textContent.trim(), "C'est parti !");
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
+          assert.strictEqual(find('.campaign-landing-page__start-button').textContent.trim(), "C'est parti !");
         });
       });
 
@@ -205,9 +185,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
             await clickByLabel(this.intl.t('pages.fill-in-participant-external-id.buttons.continue'));
 
             //then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
           });
 
           module('When user has already a reconciled account', function (hooks) {
@@ -249,9 +227,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
               await clickByLabel(this.intl.t('pages.join.sco.continue-with-pix'));
 
               //then
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line qunit/no-assert-equal
-              assert.equal(currentURL(), `/campagnes/${campaign.code}/rejoindre/identification`);
+              assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/rejoindre/identification`);
               assert.ok(screen.getByRole('button', { name: 'Se connecter' }));
             });
           });
@@ -259,41 +235,35 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
       });
 
       module('When campaign has external id', function () {
-        module('When participant external id is not set in the url', function (hooks) {
-          hooks.beforeEach(async function () {
+        module('When participant external id is not set in the url', function () {
+          test('should redirect to send profile page when the user fill in his id', async function (assert) {
+            // given
             campaign = server.create('campaign', {
               type: PROFILES_COLLECTION,
               idPixLabel: 'nom de naissance de maman',
             });
             await startCampaignByCode(campaign.code);
-          });
 
-          test('should redirect to send profile page when the user fill in his id', async function (assert) {
             // when
             await fillIn('#id-pix-label', 'monmail@truc.fr');
             await clickByLabel(this.intl.t('pages.fill-in-participant-external-id.buttons.continue'));
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
           });
         });
 
-        module('When participant external id is set in the url', function (hooks) {
-          hooks.beforeEach(async function () {
+        module('When participant external id is set in the url', function () {
+          test('should redirect to send profile page', async function (assert) {
+            // given & when
             campaign = server.create('campaign', {
               type: PROFILES_COLLECTION,
               idPixLabel: 'nom de naissance de maman',
             });
             await startCampaignByCodeAndExternalId(campaign.code);
-          });
 
-          test('should redirect to send profile page', async function (assert) {
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
           });
         });
       });
@@ -309,9 +279,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
           await click('.campaign-landing-page__start-button');
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
         });
       });
 
@@ -328,9 +296,7 @@ module('Acceptance | Campaigns | Start Campaigns with type Profiles Collection',
             await click('.campaign-landing-page__start-button');
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
+            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/collecte/envoi-profil`);
           });
         }
       );

--- a/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow_test.js
@@ -168,8 +168,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             });
           });
 
-          // eslint-disable-next-line qunit/no-async-module-callbacks
-          module('When user must accept Pix last terms of service', async function () {
+          module('When user must accept Pix last terms of service', function () {
             test('should redirect to invited sco student page after accept terms of service', async function (assert) {
               // given
               await visit('/campagnes');
@@ -428,13 +427,12 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
         });
       });
 
-      module('When the user has already seen the landing page', function (hooks) {
-        hooks.beforeEach(async function () {
+      module('When the user has already seen the landing page', function () {
+        test('should redirect to signin page', async function (assert) {
+          // given & when
           const campaign = server.create('campaign');
           await startCampaignByCode(campaign.code);
-        });
 
-        test('should redirect to signin page', async function (assert) {
           // then
           assert.strictEqual(currentURL(), '/inscription');
         });
@@ -648,53 +646,50 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
       });
 
       module('When campaign has external id', function () {
-        module('When participant external id is not set in the url', function (hooks) {
-          hooks.beforeEach(async function () {
+        module('When participant external id is not set in the url', function () {
+          test('should show the identifiant page after clicking on start button in landing page', async function (assert) {
+            // given & when
             campaign = server.create('campaign', { idPixLabel: 'nom de naissance de maman' });
             await startCampaignByCode(campaign.code);
-          });
 
-          test('should show the identifiant page after clicking on start button in landing page', function (assert) {
+            // then
             assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/prescrit/identifiant`);
           });
         });
 
-        module('When participant external id is set in the url', function (hooks) {
-          hooks.beforeEach(async function () {
+        module('When participant external id is set in the url', function () {
+          test('should begin campaign participation', async function (assert) {
+            // given & when
             campaign = server.create('campaign', { idPixLabel: 'nom de naissance de maman' });
             await startCampaignByCodeAndExternalId(campaign.code);
-          });
 
-          test('should begin campaign participation', function (assert) {
+            // then
             assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
           });
         });
       });
 
-      module('When campaign does not have external id', function (hooks) {
-        hooks.beforeEach(async function () {
+      module('When campaign does not have external id', function () {
+        test('should begin campaign participation', async function (assert) {
+          // given & when
           campaign = server.create('campaign', { idPixLabel: null });
           await startCampaignByCode(campaign.code);
-        });
 
-        test('should begin campaign participation', function (assert) {
+          // then
           assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
         });
       });
 
-      module(
-        'When campaign does not have external id but a participant external id is set in the url',
-        function (hooks) {
-          hooks.beforeEach(async function () {
-            campaign = server.create('campaign', { idPixLabel: null });
-            await startCampaignByCodeAndExternalId(campaign.code);
-          });
+      module('When campaign does not have external id but a participant external id is set in the url', function () {
+        test('should begin campaign participation', async function (assert) {
+          // given & when
+          campaign = server.create('campaign', { idPixLabel: null });
+          await startCampaignByCodeAndExternalId(campaign.code);
 
-          test('should begin campaign participation', function (assert) {
-            assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
-          });
-        }
-      );
+          // then
+          assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/evaluation/didacticiel`);
+        });
+      });
 
       module('When the campaign is restricted and organization learner is disabled', function (hooks) {
         hooks.beforeEach(function () {
@@ -757,14 +752,11 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
       });
     });
 
-    module('When user is logged as anonymous and campaign is simplified access', function (hooks) {
-      hooks.beforeEach(async function () {
-        campaign = server.create('campaign', { isSimplifiedAccess: true, idPixLabel: 'Les anonymes' });
-        await currentSession().authenticate('authenticator:anonymous', { campaignCode: campaign.code });
-      });
-
+    module('When user is logged as anonymous and campaign is simplified access', function () {
       test('should replace previous connected anonymous user', async function (assert) {
         // given
+        campaign = server.create('campaign', { isSimplifiedAccess: true, idPixLabel: 'Les anonymes' });
+        await currentSession().authenticate('authenticator:anonymous', { campaignCode: campaign.code });
         const session = currentSession();
         const previousUserId = session.data.authenticated['user_id'];
 
@@ -865,8 +857,7 @@ module('Acceptance | Campaigns | Start Campaigns workflow', function (hooks) {
             assert.strictEqual(currentURL(), `/campagnes/${campaign.code}/presentation`);
           });
 
-          // eslint-disable-next-line qunit/no-async-module-callbacks
-          module('When user is already reconciled in another organization', async function () {
+          module('When user is already reconciled in another organization', function () {
             test('should reconcile and redirect to landing-page', async function (assert) {
               // given
               server.get('sco-organization-learners', () => {

--- a/mon-pix/tests/acceptance/terms-of-service_test.js
+++ b/mon-pix/tests/acceptance/terms-of-service_test.js
@@ -11,9 +11,7 @@ module('Acceptance | terms-of-service', function (hooks) {
   setupMirage(hooks);
   setupIntl(hooks);
 
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line qunit/no-async-module-callbacks
-  module('When user log in and must validate Pix latest terms of service', async function () {
+  module('When user log in and must validate Pix latest terms of service', function () {
     test('should be redirected to terms-of-services page', async function (assert) {
       // given
       const user = server.create('user', {
@@ -28,15 +26,11 @@ module('Acceptance | terms-of-service', function (hooks) {
       await authenticateByEmail(user);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/cgu');
+      assert.strictEqual(currentURL(), '/cgu');
     });
   });
 
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line qunit/no-async-module-callbacks
-  module('when the user has validated terms of service', async function () {
+  module('when the user has validated terms of service', function () {
     test('should redirect to default page when user validate the terms of service', async function (assert) {
       // given
       const user = server.create('user', {
@@ -53,9 +47,7 @@ module('Acceptance | terms-of-service', function (hooks) {
       await clickByLabel(this.intl.t('pages.terms-of-service.form.button'));
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/accueil');
+      assert.strictEqual(currentURL(), '/accueil');
     });
   });
 });

--- a/mon-pix/tests/acceptance/update-expired-password_test.js
+++ b/mon-pix/tests/acceptance/update-expired-password_test.js
@@ -28,9 +28,7 @@ module('Acceptance | Update Expired Password', function (hooks) {
     await clickByLabel(this.intl.t('pages.update-expired-password.button'));
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/accueil');
+    assert.strictEqual(currentURL(), '/accueil');
   });
 
   test('should display validation error message when update password fails with http 400 error', async function (assert) {
@@ -53,13 +51,10 @@ module('Acceptance | Update Expired Password', function (hooks) {
     await fillIn('#password', 'newPass12345!');
 
     // when
-
     await clickByLabel(this.intl.t('pages.update-expired-password.button'));
-    // then
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(currentURL(), '/mise-a-jour-mot-de-passe-expire');
+    // then
+    assert.strictEqual(currentURL(), '/mise-a-jour-mot-de-passe-expire');
     const expectedValidationErrorMessage = this.intl.t('pages.update-expired-password.fields.error');
     assert.ok(screen.getByText(expectedValidationErrorMessage));
   });

--- a/mon-pix/tests/acceptance/user-account_test.js
+++ b/mon-pix/tests/acceptance/user-account_test.js
@@ -18,9 +18,7 @@ module('Acceptance | User account page', function (hooks) {
       await visit('/mon-compte');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/connexion');
+      assert.strictEqual(currentURL(), '/connexion');
     });
   });
 
@@ -38,9 +36,7 @@ module('Acceptance | User account page', function (hooks) {
       await visit('/mon-compte');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/mon-compte/informations-personnelles');
+      assert.strictEqual(currentURL(), '/mon-compte/informations-personnelles');
     });
 
     module('My account menu', function () {
@@ -62,9 +58,7 @@ module('Acceptance | User account page', function (hooks) {
         await clickByLabel(this.intl.t('pages.user-account.personal-information.menu-link-title'));
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/mon-compte/informations-personnelles');
+        assert.strictEqual(currentURL(), '/mon-compte/informations-personnelles');
       });
 
       test('should display connection methods on click on "Méthodes de connexion"', async function (assert) {
@@ -75,9 +69,7 @@ module('Acceptance | User account page', function (hooks) {
         await clickByLabel(this.intl.t('pages.user-account.connexion-methods.menu-link-title'));
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/mon-compte/methodes-de-connexion');
+        assert.strictEqual(currentURL(), '/mon-compte/methodes-de-connexion');
       });
 
       test('should display language on click on "Choisir ma langue"', async function (assert) {
@@ -88,9 +80,7 @@ module('Acceptance | User account page', function (hooks) {
         await clickByLabel(this.intl.t('pages.user-account.language.menu-link-title'));
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(currentURL(), '/mon-compte/langue');
+        assert.strictEqual(currentURL(), '/mon-compte/langue');
       });
     });
   });

--- a/mon-pix/tests/acceptance/user-certifications_test.js
+++ b/mon-pix/tests/acceptance/user-certifications_test.js
@@ -19,9 +19,7 @@ module('Acceptance | User certifications page', function (hooks) {
       await visit('/mes-certifications');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/connexion');
+      assert.strictEqual(currentURL(), '/connexion');
     });
 
     test('should be accessible when user is connected', async function (assert) {
@@ -32,9 +30,7 @@ module('Acceptance | User certifications page', function (hooks) {
       await visit('/mes-certifications');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/mes-certifications');
+      assert.strictEqual(currentURL(), '/mes-certifications');
     });
   });
 
@@ -87,9 +83,7 @@ module('Acceptance | User certifications page', function (hooks) {
         await visit('/mes-certifications');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+        assert.strictEqual(
           findAll('.certifications-list__table-body .certifications-list-item').length,
           userWithSomeCertificates.certifications.length
         );

--- a/mon-pix/tests/acceptance/user-dashboard_test.js
+++ b/mon-pix/tests/acceptance/user-dashboard_test.js
@@ -27,9 +27,7 @@ module('Acceptance | User dashboard page', function (hooks) {
       await visit('/accueil');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/connexion');
+      assert.strictEqual(currentURL(), '/connexion');
     });
 
     test('is possible when user is connected', async function (assert) {
@@ -40,9 +38,7 @@ module('Acceptance | User dashboard page', function (hooks) {
       await visit('/accueil');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/accueil');
+      assert.strictEqual(currentURL(), '/accueil');
     });
   });
 
@@ -98,12 +94,11 @@ module('Acceptance | User dashboard page', function (hooks) {
         test('should display a card with a resume button', async function (assert) {
           // when
           await visit('/accueil');
+
           // then
           const resumeButton = find('.campaign-participation-overview-card-content__action');
           assert.ok(resumeButton);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(resumeButton.textContent.trim(), 'Reprendre');
+          assert.strictEqual(resumeButton.textContent.trim(), 'Reprendre');
         });
       });
 
@@ -140,9 +135,7 @@ module('Acceptance | User dashboard page', function (hooks) {
           // then
           const shareButton = find('.campaign-participation-overview-card-content__action');
           assert.ok(shareButton);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(shareButton.textContent.trim(), 'Envoyer mes résultats');
+          assert.strictEqual(shareButton.textContent.trim(), 'Envoyer mes résultats');
         });
       });
     });
@@ -174,9 +167,8 @@ module('Acceptance | User dashboard page', function (hooks) {
       const competencesButtons = screen.getAllByText(
         this.intl.t('pages.dashboard.recommended-competences.profile-link')
       ).length;
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(competencesButtons, 2);
+
+      assert.strictEqual(competencesButtons, 2);
     });
   });
 
@@ -211,9 +203,7 @@ module('Acceptance | User dashboard page', function (hooks) {
 
       // then
       const scorecard = user.scorecards.models[0];
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), `/competences/${scorecard.competenceId}/details`);
+      assert.strictEqual(currentURL(), `/competences/${scorecard.competenceId}/details`);
     });
   });
 

--- a/mon-pix/tests/acceptance/user-tests_test.js
+++ b/mon-pix/tests/acceptance/user-tests_test.js
@@ -33,9 +33,7 @@ module('Acceptance | User tests', function (hooks) {
       await visit('/mes-parcours');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/mes-parcours');
+      assert.strictEqual(currentURL(), '/mes-parcours');
     });
 
     test('should display user participation cards', async function (assert) {
@@ -68,9 +66,9 @@ module('Acceptance | User tests', function (hooks) {
     test('should redirect to home, when user is not authenticated', async function (assert) {
       // when
       await visit('/mes-parcours');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/connexion');
+
+      // then
+      assert.strictEqual(currentURL(), '/connexion');
     });
   });
 });

--- a/mon-pix/tests/acceptance/user-tutorials_test.js
+++ b/mon-pix/tests/acceptance/user-tutorials_test.js
@@ -16,17 +16,19 @@ module('Acceptance | mes-tutos', function (hooks) {
     });
 
     test('user is redirected to /mes-tutos/recommandes when visiting /mes-tutos', async function (assert) {
+      // given & when
       await visit('/mes-tutos');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/mes-tutos/recommandes');
+
+      // then
+      assert.strictEqual(currentURL(), '/mes-tutos/recommandes');
     });
 
     test('user is redirected to /mes-tutos/enregistres when visiting /mes-tutos/enregistres', async function (assert) {
+      // given & when
       await visit('/mes-tutos/enregistres');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentURL(), '/mes-tutos/enregistres');
+
+      // then
+      assert.strictEqual(currentURL(), '/mes-tutos/enregistres');
     });
   });
 });

--- a/mon-pix/tests/integration/components/account-recovery/backup-email-confirmation-form-test.js
+++ b/mon-pix/tests/integration/components/account-recovery/backup-email-confirmation-form-test.js
@@ -68,9 +68,7 @@ module('Integration | Component | account-recovery::backup-email-confirmation-fo
     });
   });
 
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line qunit/no-async-module-callbacks
-  module('when the user does not have an email associated with his account', async function () {
+  module('when the user does not have an email associated with his account', function () {
     test('should render recover account backup email confirmation form', async function (assert) {
       // given
       const resetErrors = sinon.stub();

--- a/mon-pix/tests/integration/components/assessment-banner_test.js
+++ b/mon-pix/tests/integration/components/assessment-banner_test.js
@@ -32,25 +32,17 @@ module('Integration | Component | assessment-banner', function (hooks) {
     test('should render the banner with accessible title information', function (assert) {
       const title = find('.assessment-banner__title');
       assert.ok(title);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(title.childNodes.length, 2);
+      assert.strictEqual(title.childNodes.length, 2);
       const a11yText = title.firstChild.textContent;
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(a11yText, "Épreuve pour l'évaluation : ");
+      assert.strictEqual(a11yText, "Épreuve pour l'évaluation : ");
     });
 
     test('should render the banner with a title', function (assert) {
       const title = find('.assessment-banner__title');
       assert.ok(title);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(title.childNodes.length, 2);
+      assert.strictEqual(title.childNodes.length, 2);
       const assessmentName = title.lastChild.textContent;
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(assessmentName, 'My assessment');
+      assert.strictEqual(assessmentName, 'My assessment');
     });
 
     test('should render the banner with a splitter', function (assert) {

--- a/mon-pix/tests/integration/components/badge-card_test.js
+++ b/mon-pix/tests/integration/components/badge-card_test.js
@@ -21,11 +21,7 @@ module('Integration | Component | Badge Card', function (hooks) {
 
     // then
     assert.dom('.badge-card').exists();
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.badge-card-text__title').textContent.trim(), 'Badge de winner');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.badge-card-text__message').textContent.trim(), 'Bravo ! Tu as ton badge !');
+    assert.strictEqual(find('.badge-card-text__title').textContent.trim(), 'Badge de winner');
+    assert.strictEqual(find('.badge-card-text__message').textContent.trim(), 'Bravo ! Tu as ton badge !');
   });
 });

--- a/mon-pix/tests/integration/components/campaign-participation-overview/grid_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/grid_test.js
@@ -39,15 +39,11 @@ module('Integration | Component | CampaignParticipationOverview | Grid', functio
     await render(hbs`<CampaignParticipationOverview::Grid @model={{this.campaignParticipationOverviews}} />}`);
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(findAll('.campaign-participation-overview-grid__item').length, 2);
+    assert.strictEqual(findAll('.campaign-participation-overview-grid__item').length, 2);
+
     const participationCardSubtitles = findAll('.campaign-participation-overview-card-header__subtitle');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(participationCardSubtitles[0].textContent, 'My campaign 1');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(participationCardSubtitles[1].textContent, 'My campaign 2');
+
+    assert.strictEqual(participationCardSubtitles[0].textContent, 'My campaign 1');
+    assert.strictEqual(participationCardSubtitles[1].textContent, 'My campaign 2');
   });
 });

--- a/mon-pix/tests/integration/components/certification-banner_test.js
+++ b/mon-pix/tests/integration/components/certification-banner_test.js
@@ -29,9 +29,7 @@ module('Integration | Component | Certification Banner', function (hooks) {
       await render(hbs`<CertificationBanner @certification={{this.certification}} />`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.assessment-banner__title').textContent.trim(), fullName);
+      assert.strictEqual(find('.assessment-banner__title').textContent.trim(), fullName);
     });
 
     test('should render component with certificationNumber', async function (assert) {
@@ -39,9 +37,7 @@ module('Integration | Component | Certification Banner', function (hooks) {
       await render(hbs`<CertificationBanner @certificationNumber={{this.certificationNumber}} />`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.certification-number__value').textContent.trim(), `${certificationNumber}`);
+      assert.strictEqual(find('.certification-number__value').textContent.trim(), `${certificationNumber}`);
     });
   });
 });

--- a/mon-pix/tests/integration/components/certification-not-certifiable_test.js
+++ b/mon-pix/tests/integration/components/certification-not-certifiable_test.js
@@ -9,15 +9,11 @@ module('Integration | Component | certification-not-certifiable', function (hook
   test('renders', async function (assert) {
     await render(hbs`{{certification-not-certifiable}}`);
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(
+    assert.strictEqual(
       find('.certification-not-certifiable__title').textContent.trim(),
       "Votre profil n'est pas encore certifiable."
     );
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(
+    assert.strictEqual(
       find('.certification-not-certifiable__text').textContent.trim(),
       'Pour faire certifier votre profil, vous devez avoir obtenu un niveau supérieur à 0 dans 5 compétences minimum.'
     );

--- a/mon-pix/tests/integration/components/certifications-list_test.js
+++ b/mon-pix/tests/integration/components/certifications-list_test.js
@@ -38,9 +38,7 @@ module('Integration | Component | certifications list', function (hooks) {
       await render(hbs`<CertificationsList @certifications={{this.certifications}}/>`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.certifications-list__table-body .certifications-list-item').length, 2);
+      assert.strictEqual(findAll('.certifications-list__table-body .certifications-list-item').length, 2);
     });
   });
 });

--- a/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
+++ b/mon-pix/tests/integration/components/challenge-embed-simulator_test.js
@@ -45,9 +45,7 @@ module('Integration | Component | Challenge Embed Simulator', function (hooks) {
       await render(hbs`<ChallengeEmbedSimulator />`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.embed__reboot').textContent.trim(), 'Réinitialiser');
+      assert.strictEqual(find('.embed__reboot').textContent.trim(), 'Réinitialiser');
     });
   });
 
@@ -88,21 +86,15 @@ module('Integration | Component | Challenge Embed Simulator', function (hooks) {
     });
 
     test('should have an height that is the one defined in the referential', function (assert) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.challenge-embed-simulator').style.cssText, 'height: 200px;');
+      assert.strictEqual(find('.challenge-embed-simulator').style.cssText, 'height: 200px;');
     });
 
     test('should define a title attribute on the iframe element that is the one defined in the referential for field "Embed title"', function (assert) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.embed__iframe').title, 'Embed simulator');
+      assert.strictEqual(find('.embed__iframe').title, 'Embed simulator');
     });
 
     test('should define a src attribute on the iframe element that is the one defined in the referential for field "Embed URL"', function (assert) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.embed__iframe').src, 'http://embed-simulator.url/');
+      assert.strictEqual(find('.embed__iframe').src, 'http://embed-simulator.url/');
     });
   });
 });

--- a/mon-pix/tests/integration/components/challenge-illustration_test.js
+++ b/mon-pix/tests/integration/components/challenge-illustration_test.js
@@ -37,12 +37,8 @@ module('Integration | Component | challenge-illustration', function (hooks) {
     // then
     assert.ok(findImageElement());
     assert.ok(findImageElement().className.includes(HIDDEN_CLASS_NAME));
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(findImageElement().getAttribute('alt'), IMG_ALT);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(findImageElement().getAttribute('src'), IMG_SRC);
+    assert.strictEqual(findImageElement().getAttribute('alt'), IMG_ALT);
+    assert.strictEqual(findImageElement().getAttribute('src'), IMG_SRC);
     assert.ok(findImagePlaceholderElement());
 
     await triggerEvent(findImageElement(), 'load');

--- a/mon-pix/tests/integration/components/challenge-item-qroc_test.js
+++ b/mon-pix/tests/integration/components/challenge-item-qroc_test.js
@@ -41,9 +41,7 @@ module('Integration | Component | Challenge item QROC', function (hooks) {
       );
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.challenge-response__proposal--paragraph').tagName, 'TEXTAREA');
+      assert.strictEqual(find('.challenge-response__proposal--paragraph').tagName, 'TEXTAREA');
     });
   });
 
@@ -63,9 +61,7 @@ module('Integration | Component | Challenge item QROC', function (hooks) {
       );
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.challenge-response__proposal--sentence').tagName, 'INPUT');
+      assert.strictEqual(find('.challenge-response__proposal--sentence').tagName, 'INPUT');
     });
   });
 
@@ -85,9 +81,7 @@ module('Integration | Component | Challenge item QROC', function (hooks) {
       );
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('[id="qroc_input"]').getAttribute('type'), 'number');
+      assert.strictEqual(find('[id="qroc_input"]').getAttribute('type'), 'number');
     });
   });
 
@@ -114,12 +108,8 @@ module('Integration | Component | Challenge item QROC', function (hooks) {
         // then
         assert.dom('.challenge-response__proposal--paragraph').doesNotExist();
         assert.dom('.challenge-response__proposal--sentence').doesNotExist();
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.challenge-response__proposal').tagName, 'INPUT');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.challenge-response__proposal').getAttribute('size'), data.expectedSize);
+        assert.strictEqual(find('.challenge-response__proposal').tagName, 'INPUT');
+        assert.strictEqual(find('.challenge-response__proposal').getAttribute('size'), data.expectedSize);
       });
     });
   });
@@ -147,9 +137,7 @@ module('Integration | Component | Challenge item QROC', function (hooks) {
           );
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find(data.cssClass).getAttribute('autocomplete'), 'nope');
+          assert.strictEqual(find(data.cssClass).getAttribute('autocomplete'), 'nope');
         });
       });
 
@@ -169,9 +157,7 @@ module('Integration | Component | Challenge item QROC', function (hooks) {
           );
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find(data.cssClass).value, 'myValue');
+          assert.strictEqual(find(data.cssClass).value, 'myValue');
         });
       });
 
@@ -201,9 +187,7 @@ module('Integration | Component | Challenge item QROC', function (hooks) {
             );
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(find(data.cssClass).value, output);
+            assert.strictEqual(find(data.cssClass).value, output);
           });
         });
       });

--- a/mon-pix/tests/integration/components/challenge-statement_test.js
+++ b/mon-pix/tests/integration/components/challenge-statement_test.js
@@ -52,9 +52,7 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
       await renderChallengeStatement(this);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.challenge-statement-instruction__text').textContent.trim(), 'La consigne de mon test');
+      assert.strictEqual(find('.challenge-statement-instruction__text').textContent.trim(), 'La consigne de mon test');
     });
 
     test('should render a tag for focused challenge with tooltip', async function (assert) {
@@ -295,9 +293,7 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
 
       // then
       assert.ok(find('.challenge-illustration__loaded-image').src.includes(challenge.illustrationUrl));
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.challenge-illustration__loaded-image').alt, challenge.illustrationAlt);
+      assert.strictEqual(find('.challenge-illustration__loaded-image').alt, challenge.illustrationAlt);
     });
 
     test('should not display challenge illustration if it does not exist', async function (assert) {
@@ -353,9 +349,7 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
 
         // then
         assert.dom('.challenge-statement__action-link').exists();
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.challenge-statement__action-link').href, 'http://challenge.file.url/');
+        assert.strictEqual(find('.challenge-statement__action-link').href, 'http://challenge.file.url/');
       });
     });
 
@@ -404,12 +398,8 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
         await renderChallengeStatement(this);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(findAll('.challenge-statement__file-option-label')[0].textContent.trim(), 'fichier .docx');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(findAll('.challenge-statement__file-option-label')[1].textContent.trim(), 'fichier .odt');
+        assert.strictEqual(findAll('.challenge-statement__file-option-label')[0].textContent.trim(), 'fichier .docx');
+        assert.strictEqual(findAll('.challenge-statement__file-option-label')[1].textContent.trim(), 'fichier .odt');
       });
 
       test('should select first attachment as default selected radio button', async function (assert) {
@@ -447,9 +437,7 @@ module('Integration | Component | ChallengeStatement', function (hooks) {
         await renderChallengeStatement(this);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+        assert.strictEqual(
           find('span[data-test-id="challenge-statement__text-content"]').textContent.trim(),
           'Choisissez le type de fichier que vous voulez utiliser'
         );

--- a/mon-pix/tests/integration/components/circle-chart_test.js
+++ b/mon-pix/tests/integration/components/circle-chart_test.js
@@ -24,9 +24,10 @@ module('Integration | Component | circle-chart', function (hooks) {
       await render(hbs`<CircleChart @value={{this.value}}/>`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(this.element.querySelector('.circle--slice').getAttribute('stroke-dasharray'), `${value}, 100`);
+      assert.strictEqual(
+        this.element.querySelector('.circle--slice').getAttribute('stroke-dasharray'),
+        `${value}, 100`
+      );
     });
 
     test('should display the circle with given color', async function (assert) {

--- a/mon-pix/tests/integration/components/comparison-window_test.js
+++ b/mon-pix/tests/integration/components/comparison-window_test.js
@@ -43,9 +43,7 @@ module('Integration | Component | comparison-window', function (hooks) {
 
       // then
       assert.ok(find('.challenge-illustration__loaded-image').src.includes(challenge.illustrationUrl));
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.challenge-illustration__loaded-image').alt, challenge.illustrationAlt);
+      assert.strictEqual(find('.challenge-illustration__loaded-image').alt, challenge.illustrationAlt);
     });
 
     test('should render challenge instruction', async function (assert) {
@@ -166,9 +164,7 @@ module('Integration | Component | comparison-window', function (hooks) {
       });
 
       module('when challenge type is QROC', function () {
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-async-module-callbacks
-        module('and challenge is not autoReply', async function () {
+        module('and challenge is not autoReply', function () {
           test('should display answers', async function (assert) {
             // given
             challenge = EmberObject.create({ type: 'QROC', autoReply: false });
@@ -184,9 +180,7 @@ module('Integration | Component | comparison-window', function (hooks) {
           });
         });
 
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-async-module-callbacks
-        module('and challenge is autoReply', async function () {
+        module('and challenge is autoReply', function () {
           test('should hide answers when correction has no solutionToDisplay', async function (assert) {
             // given
             challenge = EmberObject.create({ type: 'QROC', autoReply: true });

--- a/mon-pix/tests/integration/components/competence-card-default_test.js
+++ b/mon-pix/tests/integration/components/competence-card-default_test.js
@@ -50,9 +50,7 @@ module('Integration | Component | competence-card-default', function (hooks) {
       await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.competence-card__area-name').textContent, scorecard.area.title);
+      assert.strictEqual(find('.competence-card__area-name').textContent, scorecard.area.title);
     });
 
     test('should display the competence name', async function (assert) {
@@ -64,9 +62,7 @@ module('Integration | Component | competence-card-default', function (hooks) {
       await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.competence-card__competence-name').textContent, scorecard.name);
+      assert.strictEqual(find('.competence-card__competence-name').textContent, scorecard.name);
     });
 
     test('should display the level', async function (assert) {
@@ -78,17 +74,11 @@ module('Integration | Component | competence-card-default', function (hooks) {
       await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.score-label').textContent, 'niveau');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.score-value').textContent, scorecard.level.toString());
+      assert.strictEqual(find('.score-label').textContent, 'niveau');
+      assert.strictEqual(find('.score-value').textContent, scorecard.level.toString());
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('when user can start the competence', async function () {
+    module('when user can start the competence', function () {
       test('should show the button "Commencer"', async function (assert) {
         // given
         const scorecard = { area, level: 3, isFinished: false, isStarted: false };
@@ -102,9 +92,7 @@ module('Integration | Component | competence-card-default', function (hooks) {
       });
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('when user can continue the competence', async function () {
+    module('when user can continue the competence', function () {
       test('should show the button "Reprendre"', async function (assert) {
         // given
         const scorecard = { area, level: 3, isFinished: false, isStarted: true };
@@ -139,9 +127,7 @@ module('Integration | Component | competence-card-default', function (hooks) {
       });
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('when user has finished the competence', async function () {
+    module('when user has finished the competence', function () {
       test('should show the improving button when there is no remaining days before improving', async function (assert) {
         // given
         const scorecard = { area, level: 3, isFinished: true, isStarted: false, remainingDaysBeforeImproving: 0 };

--- a/mon-pix/tests/integration/components/competence-card-mobile_test.js
+++ b/mon-pix/tests/integration/components/competence-card-mobile_test.js
@@ -50,9 +50,7 @@ module('Integration | Component | competence-card-mobile', function (hooks) {
       await render(hbs`{{competence-card-mobile scorecard=this.scorecard}}`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.competence-card__area-name').textContent, scorecard.area.title);
+      assert.strictEqual(find('.competence-card__area-name').textContent, scorecard.area.title);
     });
 
     test('should display the competence name', async function (assert) {
@@ -64,9 +62,7 @@ module('Integration | Component | competence-card-mobile', function (hooks) {
       await render(hbs`{{competence-card-mobile scorecard=this.scorecard}}`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.competence-card__competence-name').textContent, scorecard.name);
+      assert.strictEqual(find('.competence-card__competence-name').textContent, scorecard.name);
     });
 
     test('should display the level', async function (assert) {
@@ -78,14 +74,10 @@ module('Integration | Component | competence-card-mobile', function (hooks) {
       await render(hbs`{{competence-card-mobile scorecard=this.scorecard}}`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.score-value').textContent, scorecard.level.toString());
+      assert.strictEqual(find('.score-value').textContent, scorecard.level.toString());
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('when user can continue the competence', async function () {
+    module('when user can continue the competence', function () {
       module('and the user has reached the maximum level', function (hooks) {
         hooks.beforeEach(async function () {
           // given
@@ -103,9 +95,7 @@ module('Integration | Component | competence-card-mobile', function (hooks) {
       });
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('when user has finished the competence', async function () {
+    module('when user has finished the competence', function () {
       module('and the user has reached the maximum level', function (hooks) {
         hooks.beforeEach(async function () {
           // given

--- a/mon-pix/tests/integration/components/feedback-panel_test.js
+++ b/mon-pix/tests/integration/components/feedback-panel_test.js
@@ -81,9 +81,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_NESTED_LEVEL);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(findAll(DROPDOWN).length, 2);
+        assert.strictEqual(findAll(DROPDOWN).length, 2);
         assert.dom(TEXTAREA).doesNotExist();
         assert.dom(BUTTON_SEND).doesNotExist();
       });
@@ -94,9 +92,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(findAll(DROPDOWN).length, 1);
+        assert.strictEqual(findAll(DROPDOWN).length, 1);
         assert.dom(TEXTAREA).exists();
         assert.ok(contains(this.intl.t('pages.challenge.feedback-panel.form.actions.submit')));
       });
@@ -107,9 +103,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TUTORIAL);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(findAll(DROPDOWN).length, 2);
+        assert.strictEqual(findAll(DROPDOWN).length, 2);
         assert.dom(BUTTON_SEND).doesNotExist();
         assert.dom(TEXTAREA).doesNotExist();
       });
@@ -121,9 +115,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(findAll(DROPDOWN).length, 1);
+        assert.strictEqual(findAll(DROPDOWN).length, 1);
         assert.dom(TUTORIAL_AREA).doesNotExist();
         assert.ok(contains(this.intl.t('pages.challenge.feedback-panel.form.actions.submit')));
         assert.dom(TEXTAREA).exists();
@@ -136,9 +128,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(findAll(DROPDOWN).length, 1);
+        assert.strictEqual(findAll(DROPDOWN).length, 1);
         assert.dom(TUTORIAL_AREA).doesNotExist();
         assert.ok(contains(this.intl.t('pages.challenge.feedback-panel.form.actions.submit')));
         assert.dom(TEXTAREA).exists();
@@ -151,9 +141,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
         await fillIn(SUBCATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA_AND_TUTORIAL);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(findAll(DROPDOWN).length, 2);
+        assert.strictEqual(findAll(DROPDOWN).length, 2);
         assert.dom(TUTORIAL_AREA).exists();
         assert.dom(TEXTAREA).exists();
         assert.ok(contains(this.intl.t('pages.challenge.feedback-panel.form.actions.submit')));
@@ -220,9 +208,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
 
     test('should display the "form" view', async function (assert) {
       assert.dom('.feedback-panel__view--form').exists();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll(DROPDOWN).length, 1);
+      assert.strictEqual(findAll(DROPDOWN).length, 1);
     });
 
     test('should not be able to hide the form view', async function (assert) {
@@ -246,9 +232,7 @@ module('Integration | Component | feedback-panel', function (hooks) {
 
     test('should display the "form" view', async function (assert) {
       assert.dom('.feedback-panel__view--form').exists();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll(DROPDOWN).length, 1);
+      assert.strictEqual(findAll(DROPDOWN).length, 1);
     });
 
     test('should be able to hide the form view', async function (assert) {

--- a/mon-pix/tests/integration/components/form-textfield-date_test.js
+++ b/mon-pix/tests/integration/components/form-textfield-date_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { fillIn, find, render, settled, triggerEvent } from '@ember/test-helpers';
+import { fillIn, find, render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | form textfield date', function (hooks) {
@@ -58,9 +58,7 @@ module('Integration | Component | form textfield date', function (hooks) {
       test(`Should render a ${expectedRendering}`, function (assert) {
         // Then
         assert.dom(item).exists({ count: expectedLength });
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find(item).nodeName, expectedRendering.toUpperCase());
+        assert.strictEqual(find(item).nodeName, expectedRendering.toUpperCase());
       });
     });
 
@@ -218,14 +216,10 @@ module('Integration | Component | form textfield date', function (hooks) {
         />`);
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
       test('return true if any img does exist', function (assert) {
         // then
-        return settled().then(() => {
-          assert.dom('img').exists({ count: 3 });
-          assert.ok(find('img').getAttribute('class').includes('form-textfield-icon__state--error'));
-        });
+        assert.dom('img').exists({ count: 3 });
+        assert.ok(find('img').getAttribute('class').includes('form-textfield-icon__state--error'));
       });
 
       [

--- a/mon-pix/tests/integration/components/form-textfield_test.js
+++ b/mon-pix/tests/integration/components/form-textfield_test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { click, fillIn, find, render, settled, triggerEvent } from '@ember/test-helpers';
+import { click, fillIn, find, render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | form textfield', function (hooks) {
@@ -40,9 +40,7 @@ module('Integration | Component | form textfield', function (hooks) {
       test(`should render a ${expectedRendering}`, function (assert) {
         // Then
         assert.dom(item).exists({ count: expectedLength });
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find(item).nodeName, expectedRendering.toUpperCase());
+        assert.strictEqual(find(item).nodeName, expectedRendering.toUpperCase());
       });
     });
 
@@ -58,8 +56,6 @@ module('Integration | Component | form textfield', function (hooks) {
   });
 
   module('#Component Interactions', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/require-expect
     test('should handle action <validate> when input lost focus', async function (assert) {
       // given
       let isActionValidateHandled = false;
@@ -83,11 +79,10 @@ module('Integration | Component | form textfield', function (hooks) {
       // when
       await fillIn(INPUT, 'pix');
       await triggerEvent(INPUT, 'focusout');
+
       // then
-      return settled().then(() => {
-        assert.true(isActionValidateHandled);
-        assert.deepEqual(inputValueToValidate, expectedInputValue);
-      });
+      assert.true(isActionValidateHandled);
+      assert.deepEqual(inputValueToValidate, expectedInputValue);
     });
 
     module('#When validationStatus gets "default", Component should ', function (hooks) {
@@ -129,14 +124,10 @@ module('Integration | Component | form textfield', function (hooks) {
         );
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
       test('return true if any img does exist', function (assert) {
         // then
-        return settled().then(() => {
-          assert.dom('img').exists({ count: 1 });
-          assert.ok(find('img').getAttribute('class').includes('form-textfield-icon__state--error'));
-        });
+        assert.dom('img').exists({ count: 1 });
+        assert.ok(find('img').getAttribute('class').includes('form-textfield-icon__state--error'));
       });
 
       [
@@ -198,9 +189,7 @@ module('Integration | Component | form textfield', function (hooks) {
         await click('.form-textfield-icon__button');
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('input').getAttribute('type'), 'text');
+        assert.strictEqual(find('input').getAttribute('type'), 'text');
       });
 
       test('should change icon when user click on it', async function (assert) {

--- a/mon-pix/tests/integration/components/levelup-notif_test.js
+++ b/mon-pix/tests/integration/components/levelup-notif_test.js
@@ -9,6 +9,7 @@ module('Integration | Component | levelup-notif', function (hooks) {
   test('renders', async function (assert) {
     //when
     await render(hbs`<LevelupNotif />`);
+
     //then
     assert.dom('.levelup__competence').exists();
   });
@@ -19,17 +20,15 @@ module('Integration | Component | levelup-notif', function (hooks) {
     this.set('model', {
       title: "Mener une recherche et une veille d'information",
     });
+
     // when
     await render(hbs`<LevelupNotif @level={{this.newLevel}} @competenceName={{this.model.title}}/>`);
+
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(
+    assert.strictEqual(
       find('.levelup-competence__level').innerHTML,
       this.intl.t('pages.levelup-notif.obtained-level', { level: this.newLevel })
     );
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.levelup-competence__name').innerHTML, "Mener une recherche et une veille d'information");
+    assert.strictEqual(find('.levelup-competence__name').innerHTML, "Mener une recherche et une veille d'information");
   });
 });

--- a/mon-pix/tests/integration/components/pix-toggle-deprecated_test.js
+++ b/mon-pix/tests/integration/components/pix-toggle-deprecated_test.js
@@ -29,38 +29,21 @@ module('Integration | Component | pix-toggle-deprecated', function (hooks) {
   });
 
   test('should display the toggle with on/off span with the correct values', function (assert) {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.pix-toggle-deprecated__on').nodeName, 'SPAN');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.pix-toggle-deprecated__off').nodeName, 'SPAN');
-
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.pix-toggle-deprecated__on').textContent, 'valueFirstLabel');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.pix-toggle-deprecated__off').textContent, 'valueSecondLabel');
+    assert.strictEqual(find('.pix-toggle-deprecated__on').nodeName, 'SPAN');
+    assert.strictEqual(find('.pix-toggle-deprecated__off').nodeName, 'SPAN');
+    assert.strictEqual(find('.pix-toggle-deprecated__on').textContent, 'valueFirstLabel');
+    assert.strictEqual(find('.pix-toggle-deprecated__off').textContent, 'valueSecondLabel');
   });
 
   test('should change the value of toggleOn when toggle off', async function (assert) {
     await click('.pix-toggle-deprecated__off');
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.pix-toggle-deprecated__on').textContent, 'valueSecondLabel');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.pix-toggle-deprecated__off').textContent, 'valueFirstLabel');
+    assert.strictEqual(find('.pix-toggle-deprecated__on').textContent, 'valueSecondLabel');
+    assert.strictEqual(find('.pix-toggle-deprecated__off').textContent, 'valueFirstLabel');
 
     await click('.pix-toggle-deprecated__off');
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.pix-toggle-deprecated__on').textContent, 'valueFirstLabel');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('.pix-toggle-deprecated__off').textContent, 'valueSecondLabel');
+    assert.strictEqual(find('.pix-toggle-deprecated__on').textContent, 'valueFirstLabel');
+    assert.strictEqual(find('.pix-toggle-deprecated__off').textContent, 'valueSecondLabel');
   });
 });

--- a/mon-pix/tests/integration/components/qcm-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qcm-solution-panel_test.js
@@ -129,18 +129,10 @@ module('Integration | Component | qcm-solution-panel.js', function (hooks) {
 
         // Then
         const labels = findAll('.qcm-proposal-label__answer-details');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(labels[1].getAttribute('data-checked'), 'yes');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(findAll('input[type=checkbox]')[1].getAttribute('disabled'), 'disabled');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(labels[1].getAttribute('data-goodness'), 'good');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+        assert.strictEqual(labels[1].getAttribute('data-checked'), 'yes');
+        assert.strictEqual(findAll('input[type=checkbox]')[1].getAttribute('disabled'), 'disabled');
+        assert.strictEqual(labels[1].getAttribute('data-goodness'), 'good');
+        assert.strictEqual(
           labels[1].innerHTML.trim(),
           '<p><a href="/test" rel="noopener noreferrer" target="_blank">possibilite 2</a></p>'
         );
@@ -160,15 +152,9 @@ module('Integration | Component | qcm-solution-panel.js', function (hooks) {
         // Then
         const labels = findAll('.qcm-proposal-label__answer-details');
 
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(labels[0].getAttribute('data-checked'), 'no');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(labels[0].getAttribute('data-goodness'), 'bad');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(labels[0].innerHTML.trim(), '<p><em>possibilite</em> 1</p>');
+        assert.strictEqual(labels[0].getAttribute('data-checked'), 'no');
+        assert.strictEqual(labels[0].getAttribute('data-goodness'), 'bad');
+        assert.strictEqual(labels[0].innerHTML.trim(), '<p><em>possibilite</em> 1</p>');
       });
 
       test('should display at least one of the correct answers as not ticked', async function (assert) {
@@ -187,15 +173,12 @@ module('Integration | Component | qcm-solution-panel.js', function (hooks) {
         // Then
         const labels = findAll('.qcm-proposal-label__answer-details');
 
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(labels[2].getAttribute('data-checked'), 'no');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(labels[2].getAttribute('data-goodness'), 'good');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(labels[2].innerHTML.trim(), '<p><img src="/images/pix-logo-blanc.svg" alt="possibilite 3"></p>');
+        assert.strictEqual(labels[2].getAttribute('data-checked'), 'no');
+        assert.strictEqual(labels[2].getAttribute('data-goodness'), 'good');
+        assert.strictEqual(
+          labels[2].innerHTML.trim(),
+          '<p><img src="/images/pix-logo-blanc.svg" alt="possibilite 3"></p>'
+        );
       });
 
       test('should display at least one of the incorrect answers as ticked', async function (assert) {
@@ -214,12 +197,8 @@ module('Integration | Component | qcm-solution-panel.js', function (hooks) {
         // Then
         const labels = findAll('.qcm-proposal-label__answer-details');
 
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(labels[0].getAttribute('data-checked'), 'yes');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(labels[0].getAttribute('data-goodness'), 'bad');
+        assert.strictEqual(labels[0].getAttribute('data-checked'), 'yes');
+        assert.strictEqual(labels[0].getAttribute('data-goodness'), 'bad');
       });
 
       test('should display no clickable input', async function (assert) {
@@ -234,18 +213,10 @@ module('Integration | Component | qcm-solution-panel.js', function (hooks) {
         );
 
         // Then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(findAll('.qcm-panel__proposal-checkbox')[0].getAttribute('disabled'), 'disabled');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(findAll('.qcm-panel__proposal-checkbox')[1].getAttribute('disabled'), 'disabled');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(findAll('.qcm-panel__proposal-checkbox')[2].getAttribute('disabled'), 'disabled');
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(findAll('.qcm-panel__proposal-checkbox')[3].getAttribute('disabled'), 'disabled');
+        assert.strictEqual(findAll('.qcm-panel__proposal-checkbox')[0].getAttribute('disabled'), 'disabled');
+        assert.strictEqual(findAll('.qcm-panel__proposal-checkbox')[1].getAttribute('disabled'), 'disabled');
+        assert.strictEqual(findAll('.qcm-panel__proposal-checkbox')[2].getAttribute('disabled'), 'disabled');
+        assert.strictEqual(findAll('.qcm-panel__proposal-checkbox')[3].getAttribute('disabled'), 'disabled');
       });
     });
   });

--- a/mon-pix/tests/integration/components/qcu-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qcu-solution-panel_test.js
@@ -68,9 +68,7 @@ module('Integration | Component | qcu-solution-panel.js', function (hooks) {
       );
 
       // Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('[data-goodness=good]').length, 1);
+      assert.strictEqual(findAll('[data-goodness=good]').length, 1);
     });
   });
 
@@ -145,9 +143,7 @@ module('Integration | Component | qcu-solution-panel.js', function (hooks) {
       // Then
       const correctAnswer = find('.qcu-solution-answer-feedback__expected-answer');
       assert.ok(correctAnswer);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(correctAnswer.innerText, 'Réponse incorrecte.\nLa bonne réponse est : ' + solutionAsText);
+      assert.strictEqual(correctAnswer.innerText, 'Réponse incorrecte.\nLa bonne réponse est : ' + solutionAsText);
     });
 
     test('should inform the user of the correct answer with solution to display when it is not null', async function (assert) {
@@ -165,9 +161,7 @@ module('Integration | Component | qcu-solution-panel.js', function (hooks) {
       // Then
       const correctAnswer = find('.qcu-solution-answer-feedback__expected-answer');
       assert.ok(correctAnswer);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(correctAnswer.innerText, 'Réponse incorrecte.\nLa bonne réponse est : ' + solutionToDisplay);
+      assert.strictEqual(correctAnswer.innerText, 'Réponse incorrecte.\nLa bonne réponse est : ' + solutionToDisplay);
     });
   });
 
@@ -196,12 +190,8 @@ module('Integration | Component | qcu-solution-panel.js', function (hooks) {
       );
 
       // Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.qcu-solution-panel__proposition')[1].getAttribute('data-checked'), 'yes');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.qcu-solution-panel__proposition')[1].getAttribute('data-goodness'), 'good');
+      assert.strictEqual(findAll('.qcu-solution-panel__proposition')[1].getAttribute('data-checked'), 'yes');
+      assert.strictEqual(findAll('.qcu-solution-panel__proposition')[1].getAttribute('data-goodness'), 'good');
       assert.ok(findAll('.qcu-solution-panel__radio-button')[1].innerHTML.includes('Votre réponse'));
     });
 
@@ -220,12 +210,8 @@ module('Integration | Component | qcu-solution-panel.js', function (hooks) {
       );
 
       // Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.qcu-solution-panel__proposition')[1].getAttribute('data-checked'), 'no');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.qcu-solution-panel__proposition')[1].getAttribute('data-goodness'), 'good');
+      assert.strictEqual(findAll('.qcu-solution-panel__proposition')[1].getAttribute('data-checked'), 'no');
+      assert.strictEqual(findAll('.qcu-solution-panel__proposition')[1].getAttribute('data-goodness'), 'good');
       assert.ok(findAll('.qcu-solution-panel__radio-button')[1].innerHTML.includes('Autre proposition'));
     });
 
@@ -242,12 +228,8 @@ module('Integration | Component | qcu-solution-panel.js', function (hooks) {
       );
 
       // Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.qcu-solution-panel__proposition')[0].getAttribute('data-checked'), 'no');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.qcu-solution-panel__proposition')[0].getAttribute('data-goodness'), 'bad');
+      assert.strictEqual(findAll('.qcu-solution-panel__proposition')[0].getAttribute('data-checked'), 'no');
+      assert.strictEqual(findAll('.qcu-solution-panel__proposition')[0].getAttribute('data-goodness'), 'bad');
       assert.ok(findAll('.qcu-solution-panel__radio-button')[0].innerHTML.includes('Autre proposition'));
     });
 
@@ -266,12 +248,8 @@ module('Integration | Component | qcu-solution-panel.js', function (hooks) {
       );
 
       // Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.qcu-solution-panel__proposition')[2].getAttribute('data-checked'), 'yes');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(findAll('.qcu-solution-panel__proposition')[2].getAttribute('data-goodness'), 'bad');
+      assert.strictEqual(findAll('.qcu-solution-panel__proposition')[2].getAttribute('data-checked'), 'yes');
+      assert.strictEqual(findAll('.qcu-solution-panel__proposition')[2].getAttribute('data-goodness'), 'bad');
       assert.ok(findAll('.qcu-solution-panel__radio-button')[2].innerHTML.includes('Votre réponse'));
     });
   });

--- a/mon-pix/tests/integration/components/qroc-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qroc-solution-panel_test.js
@@ -22,9 +22,7 @@ module('Integration | Component | QROC solution panel', function (hooks) {
       // then
       assert.dom('input').doesNotExist();
       assert.dom('textarea.correction-qroc-box-answer--paragraph').hasAttribute('disabled');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.correction-qroc-box-answer').getAttribute('rows'), '5');
+      assert.strictEqual(find('.correction-qroc-box-answer').getAttribute('rows'), '5');
     });
   });
 
@@ -61,9 +59,7 @@ module('Integration | Component | QROC solution panel', function (hooks) {
       assert.dom('textarea.correction-qroc-box-answer--paragraph').doesNotExist();
       assert.dom('textarea.correction-qroc-box-answer--sentence').doesNotExist();
       assert.dom('input.correction-qroc-box-answer').hasAttribute('disabled');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('input.correction-qroc-box-answer').getAttribute('size'), answer.value.length.toString());
+      assert.strictEqual(find('input.correction-qroc-box-answer').getAttribute('size'), answer.value.length.toString());
     });
   });
 
@@ -156,9 +152,7 @@ module('Integration | Component | QROC solution panel', function (hooks) {
             const answerBlock = find('.correction-qroc-box-answer');
 
             assert.ok(answerBlock);
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(answerBlock.value, EMPTY_DEFAULT_MESSAGE);
+            assert.strictEqual(answerBlock.value, EMPTY_DEFAULT_MESSAGE);
             assert.dom('.correction-qroc-box-answer--aband').exists();
           });
         });

--- a/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-dep-solution-panel_test.js
@@ -65,9 +65,8 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
           test('should not have solution block', function (assert) {
             // then
             const solutionBlockList = findAll(SOLUTION_BLOCK);
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(solutionBlockList.length, 0);
+
+            assert.strictEqual(solutionBlockList.length, 0);
           });
         });
 
@@ -94,18 +93,15 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
           test('should display one solution in bold green', async function (assert) {
             // then
             const noAnswerSolutionBlockList = findAll(SOLUTION_BLOCK);
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(noAnswerSolutionBlockList.length, 1);
+
+            assert.strictEqual(noAnswerSolutionBlockList.length, 1);
           });
 
           test('should display the empty answer with the default message "Pas de réponse" in italic', async function (assert) {
             // then
             const firstAnswerInput = findAll(ANSWER)[0];
             assert.ok(firstAnswerInput);
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(firstAnswerInput.value, EMPTY_DEFAULT_MESSAGE);
+            assert.strictEqual(firstAnswerInput.value, EMPTY_DEFAULT_MESSAGE);
             assert.true(firstAnswerInput.classList.contains('correction-qroc-box-answer--aband'));
           });
         });
@@ -192,12 +188,8 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
       //then
       assert.dom(PARAGRAPH).doesNotExist();
       assert.dom(SENTENCE).doesNotExist();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find(INPUT).tagName, 'INPUT');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find(INPUT).getAttribute('size'), answerSize.toString());
+      assert.strictEqual(find(INPUT).tagName, 'INPUT');
+      assert.strictEqual(find(INPUT).getAttribute('size'), answerSize.toString());
       assert.true(find(INPUT).hasAttribute('disabled'));
     });
   });
@@ -226,9 +218,7 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
       // then
       assert.dom(INPUT).doesNotExist();
       assert.dom(SENTENCE).doesNotExist();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find(PARAGRAPH).tagName, 'TEXTAREA');
+      assert.strictEqual(find(PARAGRAPH).tagName, 'TEXTAREA');
       assert.true(find(PARAGRAPH).hasAttribute('disabled'));
     });
   });
@@ -257,9 +247,7 @@ module('Integration | Component | QROCm dep solution panel', function (hooks) {
       // then
       assert.dom(INPUT).doesNotExist();
       assert.dom(PARAGRAPH).doesNotExist();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find(SENTENCE).tagName, 'INPUT');
+      assert.strictEqual(find(SENTENCE).tagName, 'INPUT');
       assert.true(find(SENTENCE).hasAttribute('disabled'));
     });
   });

--- a/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
+++ b/mon-pix/tests/integration/components/qrocm-ind-solution-panel_test.js
@@ -52,9 +52,8 @@ module('Integration | Component | QROCm ind solution panel', function (hooks) {
 
         test('should dqrocm-ind-solution-panel-test.jsisplay the labels', function (assert) {
           const labels = findAll('.correction-qrocm-text__label');
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(labels.length, 3);
+
+          assert.strictEqual(labels.length, 3);
         });
 
         module('When the answer is correct', function () {
@@ -70,9 +69,7 @@ module('Integration | Component | QROCm ind solution panel', function (hooks) {
             const correctSolutionBlock = solutionBlockList[CORRECT_ANSWER_POSITION];
 
             assert.notOk(correctSolutionBlock);
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(solutionBlockList.length, 2);
+            assert.strictEqual(solutionBlockList.length, 2);
           });
         });
 
@@ -93,9 +90,7 @@ module('Integration | Component | QROCm ind solution panel', function (hooks) {
             const answerInput = findAll(ANSWER)[NO_ANSWER_POSITION];
 
             assert.ok(answerInput);
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(answerInput.value, EMPTY_DEFAULT_MESSAGE);
+            assert.strictEqual(answerInput.value, EMPTY_DEFAULT_MESSAGE);
             assert.true(answerInput.classList.contains('correction-qroc-box-answer--aband'));
           });
         });
@@ -152,15 +147,9 @@ module('Integration | Component | QROCm ind solution panel', function (hooks) {
       //then
 
       assert.dom(PARAGRAPH).doesNotExist();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find(INPUT).tagName, 'INPUT');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find(INPUT).value, EMPTY_DEFAULT_MESSAGE);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find(INPUT).getAttribute('size'), EMPTY_DEFAULT_MESSAGE.length.toString());
+      assert.strictEqual(find(INPUT).tagName, 'INPUT');
+      assert.strictEqual(find(INPUT).value, EMPTY_DEFAULT_MESSAGE);
+      assert.strictEqual(find(INPUT).getAttribute('size'), EMPTY_DEFAULT_MESSAGE.length.toString());
       assert.true(find(INPUT).hasAttribute('disabled'));
     });
   });
@@ -182,9 +171,7 @@ module('Integration | Component | QROCm ind solution panel', function (hooks) {
       // then
       assert.dom(INPUT).doesNotExist();
       assert.dom(SENTENCE).doesNotExist();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find(PARAGRAPH).tagName, 'TEXTAREA');
+      assert.strictEqual(find(PARAGRAPH).tagName, 'TEXTAREA');
       assert.true(find(PARAGRAPH).hasAttribute('disabled'));
     });
   });
@@ -206,9 +193,7 @@ module('Integration | Component | QROCm ind solution panel', function (hooks) {
       // then
       assert.dom(INPUT).doesNotExist();
       assert.dom(PARAGRAPH).doesNotExist();
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find(SENTENCE).tagName, 'INPUT');
+      assert.strictEqual(find(SENTENCE).tagName, 'INPUT');
       assert.true(find(SENTENCE).hasAttribute('disabled'));
     });
   });

--- a/mon-pix/tests/integration/components/qrocm-proposal_test.js
+++ b/mon-pix/tests/integration/components/qrocm-proposal_test.js
@@ -50,9 +50,7 @@ module('Integration | Component | QROCm proposal', function (hooks) {
         await render(hbs`<QrocmProposal @proposals={{this.proposals}} @format={{this.format}} />`);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.challenge-response__proposal--paragraph').tagName, 'TEXTAREA');
+        assert.strictEqual(find('.challenge-response__proposal--paragraph').tagName, 'TEXTAREA');
       });
     });
 
@@ -66,9 +64,7 @@ module('Integration | Component | QROCm proposal', function (hooks) {
         await render(hbs`<QrocmProposal @proposals={{this.proposals}} @format={{this.format}} />`);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.challenge-response__proposal--sentence').tagName, 'INPUT');
+        assert.strictEqual(find('.challenge-response__proposal--sentence').tagName, 'INPUT');
       });
     });
 
@@ -88,12 +84,8 @@ module('Integration | Component | QROCm proposal', function (hooks) {
 
           // then
           assert.dom('.challenge-response__proposal--paragraph').doesNotExist();
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('.challenge-response__proposal').tagName, 'INPUT');
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('.challenge-response__proposal').getAttribute('size'), data.expectedSize);
+          assert.strictEqual(find('.challenge-response__proposal').tagName, 'INPUT');
+          assert.strictEqual(find('.challenge-response__proposal').getAttribute('size'), data.expectedSize);
         });
       });
     });
@@ -119,9 +111,7 @@ module('Integration | Component | QROCm proposal', function (hooks) {
             );
 
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(find(`${data.cssClass}`).getAttribute('autocomplete'), 'nope');
+            assert.strictEqual(find(`${data.cssClass}`).getAttribute('autocomplete'), 'nope');
           });
         });
       });
@@ -152,9 +142,7 @@ module('Integration | Component | QROCm proposal', function (hooks) {
           // eslint-disable-next-line qunit/require-expect
           test('should have an aria-label', async function (assert) {
             // then
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(allInputElements.length, data.expectedAriaLabel.length);
+            assert.strictEqual(allInputElements.length, data.expectedAriaLabel.length);
             allInputElements.forEach((element, index) => {
               assert.ok(element.getAttribute('aria-label').includes(data.expectedAriaLabel[index]));
             });
@@ -192,16 +180,10 @@ module('Integration | Component | QROCm proposal', function (hooks) {
             // eslint-disable-next-line qunit/require-expect
             test('should have a label', async function (assert) {
               // then
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line qunit/no-assert-equal
-              assert.equal(allLabelElements.length, allInputElements.length);
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line qunit/no-assert-equal
-              assert.equal(allLabelElements.length, data.expectedLabel.length);
+              assert.strictEqual(allLabelElements.length, allInputElements.length);
+              assert.strictEqual(allLabelElements.length, data.expectedLabel.length);
               allLabelElements.forEach((element, index) => {
-                // TODO: Fix this the next time the file is edited.
-                // eslint-disable-next-line qunit/no-assert-equal
-                assert.equal(element.textContent.trim(), data.expectedLabel[index]);
+                assert.strictEqual(element.textContent.trim(), data.expectedLabel[index]);
               });
             });
 
@@ -212,9 +194,7 @@ module('Integration | Component | QROCm proposal', function (hooks) {
 
             test('should connect the label with the input', async function (assert) {
               // then
-              // TODO: Fix this the next time the file is edited.
-              // eslint-disable-next-line qunit/no-assert-equal
-              assert.equal(allInputElements.length, allLabelElements.length);
+              assert.strictEqual(allInputElements.length, allLabelElements.length);
               const allInputElementsId = allInputElements.map((inputElement) => inputElement.getAttribute('id'));
               const allLabelElementsFor = allLabelElements.map((labelElement) => labelElement.getAttribute('for'));
               assert.deepEqual(allInputElementsId, allLabelElementsFor);

--- a/mon-pix/tests/integration/components/result-item-campaign_test.js
+++ b/mon-pix/tests/integration/components/result-item-campaign_test.js
@@ -56,9 +56,8 @@ module('Integration | Component | result-item', function (hooks) {
 
       // then
       const expectedChallengeInstruction = "Un QCM propose plusieurs choix, l'utilisateur peut en choisir plusieurs";
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('.result-item__instruction').textContent.trim(), expectedChallengeInstruction);
+
+      assert.strictEqual(find('.result-item__instruction').textContent.trim(), expectedChallengeInstruction);
     });
 
     test('should render a button when QCM', async function (assert) {

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -446,9 +446,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
           const url = component.customButtonUrl;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(url, 'http://www.my-url.net/resultats?stage=6');
+          assert.strictEqual(url, 'http://www.my-url.net/resultats?stage=6');
         });
       });
 
@@ -462,9 +460,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
           const url = component.customButtonUrl;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(url, 'http://www.my-url.net/resultats?masteryPercentage=56');
+          assert.strictEqual(url, 'http://www.my-url.net/resultats?masteryPercentage=56');
         });
       });
 
@@ -478,9 +474,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
           const url = component.customButtonUrl;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(url, 'http://www.my-url.net/resultats?masteryPercentage=0');
+          assert.strictEqual(url, 'http://www.my-url.net/resultats?masteryPercentage=0');
         });
       });
 
@@ -494,9 +488,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
           const url = component.customButtonUrl;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(url, 'http://www.my-url.net/resultats?externalId=1234F56');
+          assert.strictEqual(url, 'http://www.my-url.net/resultats?externalId=1234F56');
         });
       });
 
@@ -514,9 +506,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
           const url = component.customButtonUrl;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(url, 'http://www.my-url.net/resultats?masteryPercentage=56&externalId=1234F56&stage=6');
+          assert.strictEqual(url, 'http://www.my-url.net/resultats?masteryPercentage=56&externalId=1234F56&stage=6');
         });
       });
 
@@ -534,9 +524,10 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
           const url = component.customButtonUrl;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(url, 'http://www.my-url.net/resultats?foo=bar&masteryPercentage=56&externalId=1234F56&stage=6');
+          assert.strictEqual(
+            url,
+            'http://www.my-url.net/resultats?foo=bar&masteryPercentage=56&externalId=1234F56&stage=6'
+          );
         });
       });
 
@@ -554,9 +545,8 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
           const url = component.customButtonUrl;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(url, 'http://www.my-url.net/?masteryPercentage=56&externalId=1234F56&stage=6#page1');
+
+          assert.strictEqual(url, 'http://www.my-url.net/?masteryPercentage=56&externalId=1234F56&stage=6#page1');
         });
       });
 
@@ -570,9 +560,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
           const url = component.customButtonUrl;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(url, 'http://www.my-url.net/');
+          assert.strictEqual(url, 'http://www.my-url.net/');
         });
       });
     });
@@ -587,9 +575,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
         const url = component.customButtonUrl;
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(url, null);
+        assert.strictEqual(url, null);
       });
     });
   });
@@ -603,9 +589,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
       const result = component.customButtonText;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, 'Next step');
+      assert.strictEqual(result, 'Next step');
     });
   });
 

--- a/mon-pix/tests/integration/components/routes/login-form_test.js
+++ b/mon-pix/tests/integration/components/routes/login-form_test.js
@@ -60,9 +60,7 @@ module('Integration | Component | routes/login-form', function (hooks) {
     await click('.form-textfield-icon__button');
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find('#password').getAttribute('type'), 'text');
+    assert.strictEqual(find('#password').getAttribute('type'), 'text');
   });
 
   test('should change icon when user click on it', async function (assert) {
@@ -229,9 +227,7 @@ module('Integration | Component | routes/login-form', function (hooks) {
       await clickByLabel(this.intl.t('pages.login-or-register.login-form.button'));
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('#update-form-error-message').textContent, expectedErrorMessage);
+      assert.strictEqual(find('#update-form-error-message').textContent, expectedErrorMessage);
     });
 
     test('should display the default error message if update fails with other http error', async function (assert) {
@@ -261,9 +257,7 @@ module('Integration | Component | routes/login-form', function (hooks) {
       await clickByLabel(this.intl.t('pages.login-or-register.login-form.button'));
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('#update-form-error-message').textContent, expectedErrorMessage);
+      assert.strictEqual(find('#update-form-error-message').textContent, expectedErrorMessage);
     });
 
     test('should display the specific error message if update fails with http error 409 and code UNEXPECTED_USER_ACCOUNT', async function (assert) {
@@ -297,9 +291,7 @@ module('Integration | Component | routes/login-form', function (hooks) {
       await clickByLabel(this.intl.t('pages.login-or-register.login-form.button'));
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('#update-form-error-message').textContent, expectedErrorMessage);
+      assert.strictEqual(find('#update-form-error-message').textContent, expectedErrorMessage);
     });
   });
 });

--- a/mon-pix/tests/integration/components/routes/register-form_test.js
+++ b/mon-pix/tests/integration/components/routes/register-form_test.js
@@ -135,9 +135,7 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await triggerEvent('#firstName', 'focusout');
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(
+          assert.strictEqual(
             find('#register-firstName-container #validationMessage-firstName').textContent,
             EMPTY_FIRSTNAME_ERROR_MESSAGE
           );
@@ -155,9 +153,7 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await triggerEvent('#lastName', 'focusout');
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(
+          assert.strictEqual(
             find('#register-lastName-container #validationMessage-lastName').textContent,
             EMPTY_LASTNAME_ERROR_MESSAGE
           );
@@ -177,9 +173,7 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await triggerEvent('#dayOfBirth', 'focusout');
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(
+          assert.strictEqual(
             find('#register-birthdate-container #dayValidationMessage').textContent,
             INVALID_DAY_OF_BIRTH_ERROR_MESSAGE
           );
@@ -199,9 +193,7 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await triggerEvent('#monthOfBirth', 'focusout');
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(
+          assert.strictEqual(
             find('#register-birthdate-container #monthValidationMessage').textContent,
             INVALID_MONTH_OF_BIRTH_ERROR_MESSAGE
           );
@@ -221,9 +213,7 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await triggerEvent('#yearOfBirth', 'focusout');
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(
+          assert.strictEqual(
             find('#register-birthdate-container #yearValidationMessage').textContent,
             INVALID_YEAR_OF_BIRTH_ERROR_MESSAGE
           );
@@ -247,9 +237,7 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await triggerEvent('#email', 'focusout');
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(
+          assert.strictEqual(
             find('#register-email-container #validationMessage-email').textContent,
             EMPTY_EMAIL_ERROR_MESSAGE
           );
@@ -276,9 +264,7 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await triggerEvent('#password', 'focusout');
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(
+          assert.strictEqual(
             find('#register-password-container #validationMessage-password').textContent,
             INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE
           );
@@ -301,17 +287,16 @@ module('Integration | Component | routes/register-form', function (hooks) {
       await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('#register-email-container #validationMessage-email').textContent, EMPTY_EMAIL_ERROR_MESSAGE);
+      assert.strictEqual(
+        find('#register-email-container #validationMessage-email').textContent,
+        EMPTY_EMAIL_ERROR_MESSAGE
+      );
       assert.dom('#register-email-container .form-textfield__input-container--error').exists();
       sinon.assert.notCalled(saveDependentUserStub);
       assert.ok(true);
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('When create and reconcile service fails', async function () {
+    module('When create and reconcile service fails', function () {
       test('Should display registerErrorMessage when authentication service fails with error', async function (assert) {
         // given
         const expectedRegisterErrorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY);
@@ -405,18 +390,12 @@ module('Integration | Component | routes/register-form', function (hooks) {
         await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('div[id="register-error-message"').innerHTML, errorMessage);
+        assert.strictEqual(find('div[id="register-error-message"').innerHTML, errorMessage);
       });
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('When student is already reconciled in the same organization', async function () {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-async-module-callbacks
-      module('When student account is authenticated by email only', async function () {
+    module('When student is already reconciled in the same organization', function () {
+      module('When student account is authenticated by email only', function () {
         test('should display the error message related to the short code S61)', async function (assert) {
           // given
           const meta = { shortCode: 'S61', value: 'j***@example.net' };
@@ -439,15 +418,11 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
         });
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-async-module-callbacks
-      module('When student account is authenticated by username only', async function () {
+      module('When student account is authenticated by username only', function () {
         test('should display the error message related to the short code S62)', async function (assert) {
           // given
           const meta = { shortCode: 'S62', value: 'j***.h***2' };
@@ -470,15 +445,11 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
         });
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-async-module-callbacks
-      module('When student account is authenticated by SamlId only', async function () {
+      module('When student account is authenticated by SamlId only', function () {
         test('should display the error message related to the short code S63)', async function (assert) {
           // given
           const meta = { shortCode: 'S63', value: undefined };
@@ -501,15 +472,11 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
         });
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-async-module-callbacks
-      module('When student account is authenticated by SamlId and username', async function () {
+      module('When student account is authenticated by SamlId and username', function () {
         test('should display the error message related to the short code S63)', async function (assert) {
           // given
           const meta = { shortCode: 'S63', value: undefined };
@@ -532,15 +499,11 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
         });
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-async-module-callbacks
-      module('When student account is authenticated by SamlId and email', async function () {
+      module('When student account is authenticated by SamlId and email', function () {
         test('should display the error message related to the short code S63)', async function (assert) {
           // given
           const meta = { shortCode: 'S63', value: undefined };
@@ -563,15 +526,11 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
         });
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-async-module-callbacks
-      module('When student account is authenticated by SamlId, email and username', async function () {
+      module('When student account is authenticated by SamlId, email and username', function () {
         test('should display the error message related to the short code S63)', async function (assert) {
           // given
           const meta = { shortCode: 'S63', value: undefined };
@@ -594,15 +553,11 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
         });
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-async-module-callbacks
-      module('When student account is authenticated by email and username', async function () {
+      module('When student account is authenticated by email and username', function () {
         test('should display the error message related to the short code S62)', async function (assert) {
           // given
           const meta = { shortCode: 'S62', value: 'j***.h***2' };
@@ -625,19 +580,13 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
         });
       });
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('When student is already reconciled in others organization', async function () {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-async-module-callbacks
-      module('When student account is authenticated by email only', async function () {
+    module('When student is already reconciled in others organization', function () {
+      module('When student account is authenticated by email only', function () {
         test('should display the error message related to the short code S51)', async function (assert) {
           // given
           const meta = { shortCode: 'S51', value: 'j***@example.net' };
@@ -660,15 +609,11 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
         });
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-async-module-callbacks
-      module('When student account is authenticated by username only', async function () {
+      module('When student account is authenticated by username only', function () {
         test('should display the error message related to the short code S52)', async function (assert) {
           // given
           const meta = { shortCode: 'S52', value: 'j***.h***2' };
@@ -691,15 +636,11 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
         });
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-async-module-callbacks
-      module('When student account is authenticated by SamlId only', async function () {
+      module('When student account is authenticated by SamlId only', function () {
         test('should display the error message related to the short code S53)', async function (assert) {
           // given
           const meta = { shortCode: 'S53', value: undefined };
@@ -722,15 +663,11 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
         });
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-async-module-callbacks
-      module('When student account is authenticated by SamlId and username', async function () {
+      module('When student account is authenticated by SamlId and username', function () {
         test('should display the error message related to the short code S53)', async function (assert) {
           // given
           const meta = { shortCode: 'S53', value: undefined };
@@ -753,15 +690,11 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
         });
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-async-module-callbacks
-      module('When student account is authenticated by SamlId and email', async function () {
+      module('When student account is authenticated by SamlId and email', function () {
         test('should display the error message related to the short code S53)', async function (assert) {
           // given
           const meta = { shortCode: 'S53', value: undefined };
@@ -784,15 +717,11 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
         });
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-async-module-callbacks
-      module('When student account is authenticated by SamlId, username and email', async function () {
+      module('When student account is authenticated by SamlId, username and email', function () {
         test('should display the error message related to the short code S53)', async function (assert) {
           // given
           const meta = { shortCode: 'S53', value: undefined };
@@ -815,15 +744,11 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
         });
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-async-module-callbacks
-      module('When student account is authenticated by username and email', async function () {
+      module('When student account is authenticated by username and email', function () {
         test('should display the error message related to the short code S52)', async function (assert) {
           // given
           const meta = { shortCode: 'S52', value: 'j***.h***2' };
@@ -844,10 +769,9 @@ module('Integration | Component | routes/register-form', function (hooks) {
 
           // when
           await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
         });
       });
     });

--- a/mon-pix/tests/integration/components/timeout-gauge_test.js
+++ b/mon-pix/tests/integration/components/timeout-gauge_test.js
@@ -26,9 +26,7 @@ module('Integration | Component | TimeoutGauge', function (hooks) {
       await render(hbs`<TimeoutGauge @allottedTime={{this.allottedTime}} />`);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(find('[data-test="timeout-gauge-remaining"]').textContent.trim(), '1:00');
+      assert.strictEqual(find('[data-test="timeout-gauge-remaining"]').textContent.trim(), '1:00');
     });
 
     test('renders a red clock if time is over', async function (assert) {

--- a/mon-pix/tests/integration/components/tutorial-panel_test.js
+++ b/mon-pix/tests/integration/components/tutorial-panel_test.js
@@ -25,9 +25,7 @@ module('Integration | Component | Tutorial Panel', function (hooks) {
         assert.dom('.tutorial-panel__hint-picto-container').exists();
         assert.dom('.tutorial-panel__hint-picto').exists();
         assert.dom('.tutorial-panel__hint-content').exists();
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find('.tutorial-panel__hint-content').textContent.trim(), 'Ceci est un indice.');
+        assert.strictEqual(find('.tutorial-panel__hint-content').textContent.trim(), 'Ceci est un indice.');
       });
     });
 

--- a/mon-pix/tests/integration/components/tutorials/cards_test.js
+++ b/mon-pix/tests/integration/components/tutorials/cards_test.js
@@ -16,9 +16,7 @@ module('Integration | Component | Tutorials | Cards', function (hooks) {
 
     // then
     assert.dom('.user-tutorials-content__cards').exists();
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(findAll('.tutorial-card').length, 0);
+    assert.strictEqual(findAll('.tutorial-card').length, 0);
   });
 
   test('renders a list of cards if there are tutorials', async function (assert) {
@@ -50,8 +48,6 @@ module('Integration | Component | Tutorials | Cards', function (hooks) {
 
     // then
     assert.dom('.user-tutorials-content__cards').exists();
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(findAll('.tutorial-card').length, 2);
+    assert.strictEqual(findAll('.tutorial-card').length, 2);
   });
 });

--- a/mon-pix/tests/integration/components/user-certifications-detail-competence_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-competence_test.js
@@ -71,9 +71,7 @@ module('Integration | Component | user-certifications-detail-competence', functi
   module('on a specific line of competence', function () {
     module('when competence level is -1', function () {
       test('should be grayed out (almost transparent) and not show the level', function (assert) {
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+        assert.strictEqual(
           find(`${COMPETENCE_SELECTOR}:nth-child(3) span`).textContent,
           area.resultCompetences[1].level.toString()
         );
@@ -83,18 +81,14 @@ module('Integration | Component | user-certifications-detail-competence', functi
 
     module('when competence level is 0', function () {
       test('should show "-" for the level (not 0)', function (assert) {
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find(`${COMPETENCE_SELECTOR}:nth-child(4) span`).textContent, '-');
+        assert.strictEqual(find(`${COMPETENCE_SELECTOR}:nth-child(4) span`).textContent, '-');
         assert.notOk(find(`${COMPETENCE_SELECTOR}:nth-child(4) p`).classList.toString().includes(DISABLED_CLASS));
       });
     });
 
     module('when competence level is greater or equal than 1', function () {
       test('should show the level', function (assert) {
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(find(`${COMPETENCE_SELECTOR}:nth-child(5) span`).textContent, '3');
+        assert.strictEqual(find(`${COMPETENCE_SELECTOR}:nth-child(5) span`).textContent, '3');
         assert.notOk(find(`${COMPETENCE_SELECTOR}:nth-child(5) p`).classList.toString().includes(DISABLED_CLASS));
       });
     });

--- a/mon-pix/tests/integration/components/user-certifications-detail-competences-list_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-competences-list_test.js
@@ -55,9 +55,7 @@ module('Integration | Component | user-certifications-detail-competences-list', 
 
   test('should have "Compétences certifiées (niveaux sur 5)" as a title', async function (assert) {
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(find(`${PARENT_SELECTOR} h2`).innerText, 'Compétences certifiées (niveaux sur 5)');
+    assert.strictEqual(find(`${PARENT_SELECTOR} h2`).innerText, 'Compétences certifiées (niveaux sur 5)');
   });
 
   module('when area has a list of competences', function () {

--- a/mon-pix/tests/unit/adapters/user-tutorial_test.js
+++ b/mon-pix/tests/unit/adapters/user-tutorial_test.js
@@ -61,9 +61,7 @@ module('Unit | Adapters | user-saved-tutorial', function (hooks) {
       const url = adapter.urlForDeleteRecord(null, 'user-saved-tutorial', snapshot);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(url, 'http://localhost:3000/api/users/tutorials/tutorialId');
+      assert.strictEqual(url, 'http://localhost:3000/api/users/tutorials/tutorialId');
     });
   });
 });

--- a/mon-pix/tests/unit/authenticators/oauth2_test.js
+++ b/mon-pix/tests/unit/authenticators/oauth2_test.js
@@ -15,11 +15,7 @@ module('Unit | Authenticator | oauth2', function (hooks) {
     const authenticator = this.owner.lookup('authenticator:oauth2');
 
     // Then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(authenticator.serverTokenEndpoint, serverTokenEndpoint);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(authenticator.serverTokenRevocationEndpoint, serverTokenRevocationEndpoint);
+    assert.strictEqual(authenticator.serverTokenEndpoint, serverTokenEndpoint);
+    assert.strictEqual(authenticator.serverTokenRevocationEndpoint, serverTokenRevocationEndpoint);
   });
 });

--- a/mon-pix/tests/unit/authenticators/oidc_test.js
+++ b/mon-pix/tests/unit/authenticators/oidc_test.js
@@ -185,9 +185,7 @@ module('Unit | Authenticator | oidc', function (hooks) {
         });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(authenticator.session.alternativeRootURL, redirectLogoutUrl);
+        assert.strictEqual(authenticator.session.alternativeRootURL, redirectLogoutUrl);
         sinon.restore();
       });
     });

--- a/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/unit/components/authentication/login-or-register-oidc_test.js
@@ -51,9 +51,7 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
         await component.register();
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+        assert.strictEqual(
           component.registerErrorMessage,
           this.intl.t('pages.login-or-register-oidc.error.expired-authentication-key')
         );
@@ -70,9 +68,11 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
         component.register();
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.registerErrorMessage, this.intl.t('pages.login-or-register-oidc.error.error-message'));
+
+        assert.strictEqual(
+          component.registerErrorMessage,
+          this.intl.t('pages.login-or-register-oidc.error.error-message')
+        );
       });
     });
 
@@ -146,9 +146,7 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
       await component.register();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.registerErrorMessage, `${this.intl.t('common.error')} (some detail)`);
+      assert.strictEqual(component.registerErrorMessage, `${this.intl.t('common.error')} (some detail)`);
     });
 
     test('it should display generic error', async function (assert) {
@@ -167,9 +165,7 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
       await component.register();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.registerErrorMessage, this.intl.t('common.error'));
+      assert.strictEqual(component.registerErrorMessage, this.intl.t('common.error'));
     });
   });
 
@@ -183,9 +179,7 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
       component.validateEmail({ target: { value: emailWithSpaces } });
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.email, emailWithSpaces.trim());
+      assert.strictEqual(component.email, emailWithSpaces.trim());
     });
 
     module('when email is invalid', function () {
@@ -198,9 +192,10 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
         component.validateEmail({ target: { value: invalidEmail } });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.emailValidationMessage, this.intl.t('pages.login-or-register-oidc.error.invalid-email'));
+        assert.strictEqual(
+          component.emailValidationMessage,
+          this.intl.t('pages.login-or-register-oidc.error.invalid-email')
+        );
       });
     });
   });
@@ -272,9 +267,7 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
         await component.login(eventStub);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+        assert.strictEqual(
           component.loginErrorMessage,
           this.intl.t('pages.login-or-register-oidc.error.expired-authentication-key')
         );
@@ -294,9 +287,7 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
         await component.login(eventStub);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(
+        assert.strictEqual(
           component.loginErrorMessage,
           this.intl.t('pages.login-or-register-oidc.error.login-unauthorized-error')
         );
@@ -316,9 +307,10 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
         await component.login(eventStub);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.loginErrorMessage, this.intl.t('pages.login-or-register-oidc.error.account-conflict'));
+        assert.strictEqual(
+          component.loginErrorMessage,
+          this.intl.t('pages.login-or-register-oidc.error.account-conflict')
+        );
       });
     });
 
@@ -334,9 +326,7 @@ module('Unit | Component | authentication | login-or-register-oidc', function (h
       await component.login(eventStub);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.loginErrorMessage, this.intl.t('common.error'));
+      assert.strictEqual(component.loginErrorMessage, this.intl.t('common.error'));
     });
   });
 });

--- a/mon-pix/tests/unit/components/authentication/oidc-reconciliation_test.js
+++ b/mon-pix/tests/unit/components/authentication/oidc-reconciliation_test.js
@@ -82,9 +82,7 @@ module('Unit | Component | authentication | oidc-reconciliation', function (hook
       component.args.identityProviderSlug = 'oidc-partner';
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.identityProviderOrganizationName, 'Partenaire OIDC');
+      assert.strictEqual(component.identityProviderOrganizationName, 'Partenaire OIDC');
     });
   });
 
@@ -153,9 +151,7 @@ module('Unit | Component | authentication | oidc-reconciliation', function (hook
       await component.reconcile();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(
+      assert.strictEqual(
         component.reconcileErrorMessage,
         this.intl.t('pages.login-or-register-oidc.error.expired-authentication-key')
       );
@@ -179,9 +175,7 @@ module('Unit | Component | authentication | oidc-reconciliation', function (hook
       await component.reconcile();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.reconcileErrorMessage, this.intl.t('common.error'));
+      assert.strictEqual(component.reconcileErrorMessage, this.intl.t('common.error'));
     });
   });
 });

--- a/mon-pix/tests/unit/components/challenge-statement_test.js
+++ b/mon-pix/tests/unit/components/challenge-statement_test.js
@@ -56,9 +56,7 @@ module('Unit | Component | challenge statement', function (hooks) {
       const orderedAttachments = component.orderedAttachments;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(orderedAttachments.length, 0);
+      assert.strictEqual(orderedAttachments.length, 0);
     });
 
     test('should return files using the preferred formats first, then the others', function (assert) {
@@ -71,9 +69,7 @@ module('Unit | Component | challenge statement', function (hooks) {
       const orderedAttachments = component.orderedAttachments;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(orderedAttachments.length, attachments.length);
+      assert.strictEqual(orderedAttachments.length, attachments.length);
       assert.ok(orderedAttachments[0].includes('docx'));
       assert.ok(orderedAttachments[1].includes('odp'));
     });
@@ -93,9 +89,7 @@ module('Unit | Component | challenge statement', function (hooks) {
       const orderedAttachments = component.orderedAttachments;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(orderedAttachments.length, attachments.length);
+      assert.strictEqual(orderedAttachments.length, attachments.length);
       assert.ok(orderedAttachments[0].includes('docx'));
       assert.ok(orderedAttachments[1].includes('pptx'));
       assert.ok(orderedAttachments[2].includes('odp'));

--- a/mon-pix/tests/unit/components/comparison-window_test.js
+++ b/mon-pix/tests/unit/components/comparison-window_test.js
@@ -168,12 +168,8 @@ module('Unit | Component | comparison-window', function (hooks) {
         resultItem = component.resultItem;
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(this.intl.t(resultItem.title), `${data.expectedTitle}`);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(this.intl.t(resultItem.tooltip), `${data.expectedTooltip}`);
+        assert.strictEqual(this.intl.t(resultItem.title), `${data.expectedTitle}`);
+        assert.strictEqual(this.intl.t(resultItem.tooltip), `${data.expectedTooltip}`);
       });
     });
 
@@ -191,12 +187,8 @@ module('Unit | Component | comparison-window', function (hooks) {
         resultItem = component.resultItem;
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(this.intl.t(resultItem.title), `${data.expectedTitle}`);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(this.intl.t(resultItem.tooltip), `${data.expectedTooltip}`);
+        assert.strictEqual(this.intl.t(resultItem.title), `${data.expectedTitle}`);
+        assert.strictEqual(this.intl.t(resultItem.tooltip), `${data.expectedTooltip}`);
       });
     });
   });
@@ -223,9 +215,7 @@ module('Unit | Component | comparison-window', function (hooks) {
       const solution = component.solution;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(solution, 'solution');
+      assert.strictEqual(solution, 'solution');
     });
   });
 });

--- a/mon-pix/tests/unit/components/competence-card-mobile_test.js
+++ b/mon-pix/tests/unit/components/competence-card-mobile_test.js
@@ -21,9 +21,7 @@ module('Unit | Component | competence-card-mobile', function (hooks) {
         const displayedLevel = component.displayedLevel;
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(displayedLevel, data.expectedLevel);
+        assert.strictEqual(displayedLevel, data.expectedLevel);
       });
     });
   });

--- a/mon-pix/tests/unit/components/dashboard/content_test.js
+++ b/mon-pix/tests/unit/components/dashboard/content_test.js
@@ -248,9 +248,7 @@ module('Unit | Component | Dashboard | Content', function (hooks) {
       const result = component.userFirstname;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, userFirstName);
+      assert.strictEqual(result, userFirstName);
     });
   });
 
@@ -343,9 +341,7 @@ module('Unit | Component | Dashboard | Content', function (hooks) {
       const result = component.userScore;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, pixScore);
+      assert.strictEqual(result, pixScore);
     });
   });
 });

--- a/mon-pix/tests/unit/components/form-textfield-date_test.js
+++ b/mon-pix/tests/unit/components/form-textfield-date_test.js
@@ -26,9 +26,7 @@ module('Unit | Component | form-textfield-date', function (hooks) {
           const propertyValue = component[property];
 
           // Then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(propertyValue, expectedValue);
+          assert.strictEqual(propertyValue, expectedValue);
         });
       });
     });
@@ -49,9 +47,7 @@ module('Unit | Component | form-textfield-date', function (hooks) {
           const propertyValue = component[property];
 
           // Then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(propertyValue, expectedValue);
+          assert.strictEqual(propertyValue, expectedValue);
         });
       });
     });
@@ -72,9 +68,7 @@ module('Unit | Component | form-textfield-date', function (hooks) {
           const propertyValue = component[property];
 
           // Then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(propertyValue, expectedValue);
+          assert.strictEqual(propertyValue, expectedValue);
         });
       });
     });

--- a/mon-pix/tests/unit/components/form-textfield_test.js
+++ b/mon-pix/tests/unit/components/form-textfield_test.js
@@ -23,9 +23,7 @@ module('Unit | Component | form-textfield', function (hooks) {
         // when
         const inputType = component.textfieldType;
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(inputType, data.type);
+        assert.strictEqual(inputType, data.type);
       });
     });
   });
@@ -37,18 +35,10 @@ module('Unit | Component | form-textfield', function (hooks) {
 
       // Then
       assert.false(component.hasIcon);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.iconType, '');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.inputValidationStatus, 'form-textfield__input--default');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.inputContainerStatusClass, 'form-textfield__input-container--default');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.validationMessageClass, 'form-textfield__message--default');
+      assert.strictEqual(component.iconType, '');
+      assert.strictEqual(component.inputValidationStatus, 'form-textfield__input--default');
+      assert.strictEqual(component.inputContainerStatusClass, 'form-textfield__input-container--default');
+      assert.strictEqual(component.validationMessageClass, 'form-textfield__message--default');
     });
 
     test('should return error values when validationStatus is "error"', function (assert) {
@@ -57,18 +47,10 @@ module('Unit | Component | form-textfield', function (hooks) {
 
       // Then
       assert.true(component.hasIcon);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.iconType, 'error');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.inputValidationStatus, 'form-textfield__input--error');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.inputContainerStatusClass, 'form-textfield__input-container--error');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.validationMessageClass, 'form-textfield__message--error');
+      assert.strictEqual(component.iconType, 'error');
+      assert.strictEqual(component.inputValidationStatus, 'form-textfield__input--error');
+      assert.strictEqual(component.inputContainerStatusClass, 'form-textfield__input-container--error');
+      assert.strictEqual(component.validationMessageClass, 'form-textfield__message--error');
     });
 
     test('should return success values when validationStatus is "success"', function (assert) {
@@ -77,18 +59,10 @@ module('Unit | Component | form-textfield', function (hooks) {
 
       // Then
       assert.true(component.hasIcon);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.iconType, 'success');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.inputValidationStatus, 'form-textfield__input--success');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.inputContainerStatusClass, 'form-textfield__input-container--success');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.validationMessageClass, 'form-textfield__message--success');
+      assert.strictEqual(component.iconType, 'success');
+      assert.strictEqual(component.inputValidationStatus, 'form-textfield__input--success');
+      assert.strictEqual(component.inputContainerStatusClass, 'form-textfield__input-container--success');
+      assert.strictEqual(component.validationMessageClass, 'form-textfield__message--success');
     });
   });
 });

--- a/mon-pix/tests/unit/components/markdown-to-html-unsafe_test.js
+++ b/mon-pix/tests/unit/components/markdown-to-html-unsafe_test.js
@@ -19,9 +19,7 @@ module('Unit | Component | markdown-to-html-unsafe', function (hooks) {
         component = createGlimmerComponent('component:markdown-to-html-unsafe', { markdown });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.html.string, expectedValue);
+        assert.strictEqual(component.html.string, expectedValue);
       });
     });
   });
@@ -42,9 +40,7 @@ module('Unit | Component | markdown-to-html-unsafe', function (hooks) {
         component = createGlimmerComponent('component:markdown-to-html-unsafe', { markdown });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.html.string, expectedValue);
+        assert.strictEqual(component.html.string, expectedValue);
       });
     });
   });
@@ -58,9 +54,7 @@ module('Unit | Component | markdown-to-html-unsafe', function (hooks) {
 
     // then
     const expectedHtml = `<p>${html}</p>`;
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(component.html.string, expectedHtml);
+    assert.strictEqual(component.html.string, expectedHtml);
   });
 
   module('when extensions are passed in arguments', function () {
@@ -74,9 +68,7 @@ module('Unit | Component | markdown-to-html-unsafe', function (hooks) {
 
       // then
       const expectedHtml = '<h1 id="title1">Title 1</h1>\nCeci est un paragraphe.\n<img src="/images.png" alt="img" />';
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.html.string, expectedHtml);
+      assert.strictEqual(component.html.string, expectedHtml);
     });
   });
 });

--- a/mon-pix/tests/unit/components/markdown-to-html_test.js
+++ b/mon-pix/tests/unit/components/markdown-to-html_test.js
@@ -19,9 +19,7 @@ module('Unit | Component | markdown-to-html', function (hooks) {
         component = createGlimmerComponent('component:markdown-to-html', { markdown });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.html.string, expectedValue);
+        assert.strictEqual(component.html.string, expectedValue);
       });
     });
   });
@@ -43,9 +41,7 @@ module('Unit | Component | markdown-to-html', function (hooks) {
         component = createGlimmerComponent('component:markdown-to-html', { markdown });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.html.string, expectedValue);
+        assert.strictEqual(component.html.string, expectedValue);
       });
     });
   });
@@ -59,9 +55,7 @@ module('Unit | Component | markdown-to-html', function (hooks) {
 
     // then
     const expectedHtml = `<p>${html}</p>`;
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(component.html.string, expectedHtml);
+    assert.strictEqual(component.html.string, expectedHtml);
   });
 
   module('when extensions are passed in arguments', function () {
@@ -75,9 +69,7 @@ module('Unit | Component | markdown-to-html', function (hooks) {
 
       // then
       const expectedHtml = '<h1>Title 1</h1>\nCeci est un paragraphe.\n<img src="/images.png" alt="img" />';
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.html.string, expectedHtml);
+      assert.strictEqual(component.html.string, expectedHtml);
     });
   });
 
@@ -91,9 +83,7 @@ module('Unit | Component | markdown-to-html', function (hooks) {
 
       // then
       const expectedHtml = '<h1>Test</h1>';
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.html.string, expectedHtml);
+      assert.strictEqual(component.html.string, expectedHtml);
     });
   });
 
@@ -107,9 +97,7 @@ module('Unit | Component | markdown-to-html', function (hooks) {
 
       // then
       const expectedHtml = '<h1 class="sr-only">Test</h1>';
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.html.string, expectedHtml);
+      assert.strictEqual(component.html.string, expectedHtml);
     });
   });
 });

--- a/mon-pix/tests/unit/components/navbar-desktop-header_test.js
+++ b/mon-pix/tests/unit/components/navbar-desktop-header_test.js
@@ -73,15 +73,9 @@ module('Unit | Component | Navbar Desktop Header Component', function (hooks) {
         const expectedMenu = [{ link: 'authentication.login' }, { link: 'inscription' }];
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.menu.length, expectedMenu.length);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.menu[0].link, expectedMenu[0].link);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.menu[1].link, expectedMenu[1].link);
+        assert.strictEqual(component.menu.length, expectedMenu.length);
+        assert.strictEqual(component.menu[0].link, expectedMenu[0].link);
+        assert.strictEqual(component.menu[1].link, expectedMenu[1].link);
       });
     });
 

--- a/mon-pix/tests/unit/components/qcu-proposals_test.js
+++ b/mon-pix/tests/unit/components/qcu-proposals_test.js
@@ -47,9 +47,7 @@ module('Unit | Component | QCU proposals', function (hooks) {
       const labeledRadios = component.labeledRadios;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(labeledRadios.length, 5);
+      assert.strictEqual(labeledRadios.length, 5);
     });
 
     test('should not select a radio when given answer is null', function (assert) {

--- a/mon-pix/tests/unit/components/qroc-solution-panel_test.js
+++ b/mon-pix/tests/unit/components/qroc-solution-panel_test.js
@@ -38,10 +38,9 @@ module('Unit | Component | qroc-solution-panel', function (hooks) {
       const component = createGlimmerComponent('component:qroc-solution-panel', { answer });
       // when
       const answerToDisplay = component.answerToDisplay;
+
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(answerToDisplay, 'Pas de réponse');
+      assert.strictEqual(answerToDisplay, 'Pas de réponse');
     });
 
     test('should return the answer if the answer is not #ABAND#', function (assert) {
@@ -52,10 +51,9 @@ module('Unit | Component | qroc-solution-panel', function (hooks) {
       const component = createGlimmerComponent('component:qroc-solution-panel', { answer });
       // when
       const answerToDisplay = component.answerToDisplay;
+
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(answerToDisplay, 'La Reponse B');
+      assert.strictEqual(answerToDisplay, 'La Reponse B');
     });
   });
 
@@ -66,10 +64,9 @@ module('Unit | Component | qroc-solution-panel', function (hooks) {
       const component = createGlimmerComponent('component:qroc-solution-panel', { solution });
       // when
       const solutionToDisplay = component.understandableSolution;
+
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(solutionToDisplay, 'Reponse');
+      assert.strictEqual(solutionToDisplay, 'Reponse');
     });
 
     test('should return the solution', function (assert) {
@@ -78,10 +75,9 @@ module('Unit | Component | qroc-solution-panel', function (hooks) {
       const component = createGlimmerComponent('component:qroc-solution-panel', { solution });
       // when
       const solutionToDisplay = component.understandableSolution;
+
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(solutionToDisplay, 'Reponse');
+      assert.strictEqual(solutionToDisplay, 'Reponse');
     });
 
     test('should return an empty string if the solution is null', function (assert) {
@@ -90,10 +86,9 @@ module('Unit | Component | qroc-solution-panel', function (hooks) {
       const component = createGlimmerComponent('component:qroc-solution-panel', { solution: emptySolution });
       // when
       const solutionToDisplay = component.understandableSolution;
+
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(solutionToDisplay, '');
+      assert.strictEqual(solutionToDisplay, '');
     });
 
     test('should return an empty string if the solution is an empty String', function (assert) {
@@ -102,10 +97,9 @@ module('Unit | Component | qroc-solution-panel', function (hooks) {
       const component = createGlimmerComponent('component:qroc-solution-panel', { solution: solutionNull });
       // when
       const solutionToDisplay = component.understandableSolution;
+
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(solutionToDisplay, '');
+      assert.strictEqual(solutionToDisplay, '');
     });
   });
 });

--- a/mon-pix/tests/unit/components/qrocm-dep-solution-panel_test.js
+++ b/mon-pix/tests/unit/components/qrocm-dep-solution-panel_test.js
@@ -87,9 +87,7 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
       const understandableSolution = component.understandableSolution;
 
       //Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(understandableSolution, 'horizontalité et cadre');
+      assert.strictEqual(understandableSolution, 'horizontalité et cadre');
     });
 
     test('should return examples of good answers', function (assert) {
@@ -105,9 +103,7 @@ module('Unit | Component | qrocm-dep-solution-panel', function (hooks) {
       const understandableSolution = component.understandableSolution;
 
       //Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(understandableSolution, 'tag ou marche ou ...');
+      assert.strictEqual(understandableSolution, 'tag ou marche ou ...');
     });
   });
 });

--- a/mon-pix/tests/unit/components/recover-account-student-information_test.js
+++ b/mon-pix/tests/unit/components/recover-account-student-information_test.js
@@ -256,9 +256,7 @@ module('Unit | Component | account-recovery/student-information-form', function 
       const result = component._formatBirthdate;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, '2004-05-02');
+      assert.strictEqual(result, '2004-05-02');
     });
   });
 });

--- a/mon-pix/tests/unit/components/reset-password-form_test.js
+++ b/mon-pix/tests/unit/components/reset-password-form_test.js
@@ -12,9 +12,8 @@ module('Unit | Component | reset password form', function (hooks) {
   module('#validatePassword', function () {
     test('should set validation status to default, when component is rendered', function (assert) {
       const component = createGlimmerComponent('component:reset-password-form');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.validation.status, 'default');
+
+      assert.strictEqual(component.validation.status, 'default');
     });
 
     test('should set validation status to error, when there is an validation error on password field', async function (assert) {

--- a/mon-pix/tests/unit/components/result-item_test.js
+++ b/mon-pix/tests/unit/components/result-item_test.js
@@ -57,12 +57,8 @@ module('Unit | Component | result-item-component', function (hooks) {
         component = createGlimmerComponent('component:result-item', { answer: answerWithOkResult });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.resultItem.color, `${data.expectedColor}`);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.resultItem.icon, `${data.expectedIcon}`);
+        assert.strictEqual(component.resultItem.color, `${data.expectedColor}`);
+        assert.strictEqual(component.resultItem.icon, `${data.expectedIcon}`);
       });
     });
   });
@@ -84,9 +80,7 @@ module('Unit | Component | result-item-component', function (hooks) {
         const tooltipText = component.resultTooltip;
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(tooltipText, `${data.expectedTooltip}`);
+        assert.strictEqual(tooltipText, `${data.expectedTooltip}`);
       });
     });
   });
@@ -97,9 +91,7 @@ module('Unit | Component | result-item-component', function (hooks) {
       window.innerWidth = 600;
 
       //then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.textLength, 60);
+      assert.strictEqual(component.textLength, 60);
     });
 
     test('should be 110 when it a tablet/desktop', function (assert) {
@@ -107,9 +99,7 @@ module('Unit | Component | result-item-component', function (hooks) {
       window.innerWidth = 1200;
 
       //then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.textLength, 110);
+      assert.strictEqual(component.textLength, 110);
     });
   });
 
@@ -131,9 +121,7 @@ module('Unit | Component | result-item-component', function (hooks) {
         component = createGlimmerComponent('component:result-item', { answer });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.validationImplementedForChallengeType, data.expected);
+        assert.strictEqual(component.validationImplementedForChallengeType, data.expected);
       });
     });
   });

--- a/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
@@ -447,9 +447,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
           const url = component.customButtonUrl;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(url, 'http://www.my-url.net/resultats?stage=6');
+          assert.strictEqual(url, 'http://www.my-url.net/resultats?stage=6');
         });
       });
 
@@ -463,9 +461,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
           const url = component.customButtonUrl;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(url, 'http://www.my-url.net/resultats?masteryPercentage=56');
+          assert.strictEqual(url, 'http://www.my-url.net/resultats?masteryPercentage=56');
         });
       });
 
@@ -479,9 +475,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
           const url = component.customButtonUrl;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(url, 'http://www.my-url.net/resultats?masteryPercentage=0');
+          assert.strictEqual(url, 'http://www.my-url.net/resultats?masteryPercentage=0');
         });
       });
 
@@ -495,9 +489,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
           const url = component.customButtonUrl;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(url, 'http://www.my-url.net/resultats?externalId=1234F56');
+          assert.strictEqual(url, 'http://www.my-url.net/resultats?externalId=1234F56');
         });
       });
 
@@ -515,9 +507,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
           const url = component.customButtonUrl;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(url, 'http://www.my-url.net/resultats?masteryPercentage=56&externalId=1234F56&stage=6');
+          assert.strictEqual(url, 'http://www.my-url.net/resultats?masteryPercentage=56&externalId=1234F56&stage=6');
         });
       });
 
@@ -535,9 +525,10 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
           const url = component.customButtonUrl;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(url, 'http://www.my-url.net/resultats?foo=bar&masteryPercentage=56&externalId=1234F56&stage=6');
+          assert.strictEqual(
+            url,
+            'http://www.my-url.net/resultats?foo=bar&masteryPercentage=56&externalId=1234F56&stage=6'
+          );
         });
       });
 
@@ -555,9 +546,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
           const url = component.customButtonUrl;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(url, 'http://www.my-url.net/?masteryPercentage=56&externalId=1234F56&stage=6#page1');
+          assert.strictEqual(url, 'http://www.my-url.net/?masteryPercentage=56&externalId=1234F56&stage=6#page1');
         });
       });
 
@@ -571,9 +560,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
           const url = component.customButtonUrl;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(url, 'http://www.my-url.net/');
+          assert.strictEqual(url, 'http://www.my-url.net/');
         });
       });
     });
@@ -588,9 +575,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
         const url = component.customButtonUrl;
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(url, null);
+        assert.strictEqual(url, null);
       });
     });
   });
@@ -604,9 +589,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
       const result = component.customButtonText;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, 'Next step');
+      assert.strictEqual(result, 'Next step');
     });
   });
 

--- a/mon-pix/tests/unit/components/routes/campaigns/invited/associate-sco-student-form_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/invited/associate-sco-student-form_test.js
@@ -150,9 +150,7 @@ module('Unit | Component | routes/campaigns/invited/associate-sco-student-form',
 
         // then
         sinon.assert.calledOnce(record.unloadRecord);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.errorMessage.string, expectedErrorMessage);
+        assert.strictEqual(component.errorMessage.string, expectedErrorMessage);
         assert.ok(true);
       });
 
@@ -169,16 +167,12 @@ module('Unit | Component | routes/campaigns/invited/associate-sco-student-form',
           // then
           sinon.assert.calledOnce(record.unloadRecord);
           assert.true(component.displayInformationModal);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.reconciliationError, error);
+          assert.strictEqual(component.reconciliationError, error);
           assert.ok(true);
         });
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-async-module-callbacks
-      module('When another student is already reconciled on the same organization', async function () {
+      module('When another student is already reconciled on the same organization', function () {
         test('should return a conflict error and display the error message related to the short code R70)', async function (assert) {
           // given
           const meta = { shortCode: 'R70' };
@@ -198,9 +192,7 @@ module('Unit | Component | routes/campaigns/invited/associate-sco-student-form',
           await component.actions.submit.call(component, attributes);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.errorMessage, expectedErrorMessage);
+          assert.strictEqual(component.errorMessage, expectedErrorMessage);
         });
       });
 
@@ -237,9 +229,7 @@ module('Unit | Component | routes/campaigns/invited/associate-sco-student-form',
           await component.actions.submit.call(component, attributes);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.errorMessage.string, expectedErrorMessage);
+          assert.strictEqual(component.errorMessage.string, expectedErrorMessage);
         });
       });
 
@@ -255,9 +245,7 @@ module('Unit | Component | routes/campaigns/invited/associate-sco-student-form',
 
           // then
           assert.true(component.displayInformationModal);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.reconciliationError, error);
+          assert.strictEqual(component.reconciliationError, error);
         });
       });
     });

--- a/mon-pix/tests/unit/components/routes/campaigns/invited/associate-sup-student-form_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/invited/associate-sup-student-form_test.js
@@ -64,9 +64,7 @@ module('Unit | Component | routes/campaigns/invited/associate-sup-student-form',
         await component.actions.submit.call(component, eventStub);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.errors.studentNumber, 'Votre numéro étudiant n’est pas renseigné.');
+        assert.strictEqual(component.errors.studentNumber, 'Votre numéro étudiant n’est pas renseigné.');
       });
 
       test('should display an error when first name is not correct', async function (assert) {
@@ -77,9 +75,7 @@ module('Unit | Component | routes/campaigns/invited/associate-sup-student-form',
         await component.actions.submit.call(component, eventStub);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.errors.firstName, 'Votre prénom n’est pas renseigné.');
+        assert.strictEqual(component.errors.firstName, 'Votre prénom n’est pas renseigné.');
       });
 
       test('should display an error when last name is not correct', async function (assert) {
@@ -90,9 +86,7 @@ module('Unit | Component | routes/campaigns/invited/associate-sup-student-form',
         await component.actions.submit.call(component, eventStub);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.errors.lastName, 'Votre nom n’est pas renseigné.');
+        assert.strictEqual(component.errors.lastName, 'Votre nom n’est pas renseigné.');
       });
 
       test('should display an error when day of birth is not correct', async function (assert) {
@@ -103,9 +97,7 @@ module('Unit | Component | routes/campaigns/invited/associate-sup-student-form',
         await component.actions.submit.call(component, eventStub);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.errors.dayOfBirth, 'Votre jour de naissance n’est pas valide.');
+        assert.strictEqual(component.errors.dayOfBirth, 'Votre jour de naissance n’est pas valide.');
       });
 
       test('should display an error when month of birth is not correct', async function (assert) {
@@ -116,9 +108,7 @@ module('Unit | Component | routes/campaigns/invited/associate-sup-student-form',
         await component.actions.submit.call(component, eventStub);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.errors.monthOfBirth, 'Votre mois de naissance n’est pas valide.');
+        assert.strictEqual(component.errors.monthOfBirth, 'Votre mois de naissance n’est pas valide.');
       });
 
       test('should display an error when year of birth is not correct', async function (assert) {
@@ -129,9 +119,7 @@ module('Unit | Component | routes/campaigns/invited/associate-sup-student-form',
         await component.actions.submit.call(component, eventStub);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.errors.yearOfBirth, 'Votre année de naissance n’est pas valide.');
+        assert.strictEqual(component.errors.yearOfBirth, 'Votre année de naissance n’est pas valide.');
       });
     });
   });

--- a/mon-pix/tests/unit/components/routes/campaigns/invited/fill-in-participant-external-id_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/invited/fill-in-participant-external-id_test.js
@@ -51,9 +51,7 @@ module('Unit | Component | routes/campaigns/invited/fill-in-participant-external
       await component.actions.submit.call(component, eventStub);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.errorMessage, `Merci de renseigner votre ${component.args.campaign.idPixLabel}.`);
+      assert.strictEqual(component.errorMessage, `Merci de renseigner votre ${component.args.campaign.idPixLabel}.`);
     });
 
     test('should display error when participant external id exceed 255 characters', async function (assert) {
@@ -65,9 +63,7 @@ module('Unit | Component | routes/campaigns/invited/fill-in-participant-external
       await component.actions.submit.call(component, eventStub);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(
+      assert.strictEqual(
         component.errorMessage,
         `Votre ${component.args.campaign.idPixLabel} ne doit pas dépasser les 255 caractères.`
       );

--- a/mon-pix/tests/unit/components/routes/campaigns/join/associate-sco-student-with-mediacentre-form_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/join/associate-sco-student-with-mediacentre-form_test.js
@@ -79,9 +79,7 @@ module('Unit | Component | routes/campaigns/join/associate-sco-student-with-medi
       await component.actions.submit.call(component, attributes);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.errorMessage, null);
+      assert.strictEqual(component.errorMessage, null);
     });
 
     module('Errors', function () {
@@ -103,9 +101,7 @@ module('Unit | Component | routes/campaigns/join/associate-sco-student-with-medi
 
         // then
         sinon.assert.calledOnce(record.unloadRecord);
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.errorMessage.string, expectedErrorMessage);
+        assert.strictEqual(component.errorMessage.string, expectedErrorMessage);
         assert.ok(true);
       });
 
@@ -122,17 +118,13 @@ module('Unit | Component | routes/campaigns/join/associate-sco-student-with-medi
           // then
           sinon.assert.calledOnce(record.unloadRecord);
           assert.true(component.displayInformationModal);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.reconciliationError, error);
+          assert.strictEqual(component.reconciliationError, error);
           sinon.assert.calledWith(sessionStub.set, 'data.expectedUserId', error.meta.userId);
           assert.ok(true);
         });
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-async-module-callbacks
-      module('When another student is already reconciled on the same organization', async function () {
+      module('When another student is already reconciled on the same organization', function () {
         test('should return a conflict error and display the error message related to the short code R70)', async function (assert) {
           // given
           const meta = { shortCode: 'R70' };
@@ -152,9 +144,7 @@ module('Unit | Component | routes/campaigns/join/associate-sco-student-with-medi
           await component.actions.submit.call(component, attributes);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.errorMessage, expectedErrorMessage);
+          assert.strictEqual(component.errorMessage, expectedErrorMessage);
         });
       });
 
@@ -190,9 +180,7 @@ module('Unit | Component | routes/campaigns/join/associate-sco-student-with-medi
           await component.actions.submit.call(component, attributes);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.errorMessage.string, expectedErrorMessage);
+          assert.strictEqual(component.errorMessage.string, expectedErrorMessage);
         });
       });
     });

--- a/mon-pix/tests/unit/components/routes/campaigns/sco-form_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/sco-form_test.js
@@ -31,9 +31,7 @@ module('Unit | Component | routes/campaigns/sco-form', function (hooks) {
           await component.actions.triggerInputDayValidation.call(component, 'dayOfBirth', wrongDayOfBirth);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.validation.dayOfBirth, 'Votre jour de naissance n’est pas valide.');
+          assert.strictEqual(component.validation.dayOfBirth, 'Votre jour de naissance n’est pas valide.');
         });
       });
     });
@@ -45,9 +43,7 @@ module('Unit | Component | routes/campaigns/sco-form', function (hooks) {
           await component.actions.triggerInputDayValidation.call(component, 'dayOfBirth', validDayOfBirth);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.validation.dayOfBirth, null);
+          assert.strictEqual(component.validation.dayOfBirth, null);
         });
       });
     });
@@ -61,9 +57,7 @@ module('Unit | Component | routes/campaigns/sco-form', function (hooks) {
           await component.actions.triggerInputMonthValidation.call(component, 'monthOfBirth', wrongMonthOfBirth);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.validation.monthOfBirth, 'Votre mois de naissance n’est pas valide.');
+          assert.strictEqual(component.validation.monthOfBirth, 'Votre mois de naissance n’est pas valide.');
         });
       });
     });
@@ -75,9 +69,7 @@ module('Unit | Component | routes/campaigns/sco-form', function (hooks) {
           await component.actions.triggerInputMonthValidation.call(component, 'monthOfBirth', validMonthOfBirth);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.validation.monthOfBirth, null);
+          assert.strictEqual(component.validation.monthOfBirth, null);
         });
       });
     });
@@ -91,9 +83,7 @@ module('Unit | Component | routes/campaigns/sco-form', function (hooks) {
           await component.actions.triggerInputYearValidation.call(component, 'yearOfBirth', wrongYearOfBirth);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.validation.yearOfBirth, 'Votre année de naissance n’est pas valide.');
+          assert.strictEqual(component.validation.yearOfBirth, 'Votre année de naissance n’est pas valide.');
         });
       });
     });
@@ -105,9 +95,7 @@ module('Unit | Component | routes/campaigns/sco-form', function (hooks) {
           await component.actions.triggerInputYearValidation.call(component, 'yearOfBirth', validYearOfBirth);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.validation.yearOfBirth, null);
+          assert.strictEqual(component.validation.yearOfBirth, null);
         });
       });
     });
@@ -121,9 +109,7 @@ module('Unit | Component | routes/campaigns/sco-form', function (hooks) {
           await component.actions.triggerInputStringValidation.call(component, 'firstName', wrongString);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.validation.firstName, 'Votre prénom n’est pas renseigné.');
+          assert.strictEqual(component.validation.firstName, 'Votre prénom n’est pas renseigné.');
         });
 
         test(`should display an error when lastName is "${wrongString}"`, async function (assert) {
@@ -131,9 +117,7 @@ module('Unit | Component | routes/campaigns/sco-form', function (hooks) {
           await component.actions.triggerInputStringValidation.call(component, 'lastName', wrongString);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.validation.lastName, 'Votre nom n’est pas renseigné.');
+          assert.strictEqual(component.validation.lastName, 'Votre nom n’est pas renseigné.');
         });
       });
     });
@@ -145,9 +129,7 @@ module('Unit | Component | routes/campaigns/sco-form', function (hooks) {
           await component.actions.triggerInputStringValidation.call(component, 'firstName', validString);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.validation.firstName, null);
+          assert.strictEqual(component.validation.firstName, null);
         });
 
         test(`should not display an error when lastName is ${validString}`, async function (assert) {
@@ -155,9 +137,7 @@ module('Unit | Component | routes/campaigns/sco-form', function (hooks) {
           await component.actions.triggerInputStringValidation.call(component, 'lastName', validString);
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(component.validation.lastName, null);
+          assert.strictEqual(component.validation.lastName, null);
         });
       });
     });
@@ -293,9 +273,7 @@ module('Unit | Component | routes/campaigns/sco-form', function (hooks) {
         await component.actions.validateForm.call(component, eventStub);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.validation.firstName, 'Votre prénom n’est pas renseigné.');
+        assert.strictEqual(component.validation.firstName, 'Votre prénom n’est pas renseigné.');
       });
 
       test('should display an error on lastName', async function (assert) {
@@ -306,9 +284,7 @@ module('Unit | Component | routes/campaigns/sco-form', function (hooks) {
         await component.actions.validateForm.call(component, eventStub);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.validation.lastName, 'Votre nom n’est pas renseigné.');
+        assert.strictEqual(component.validation.lastName, 'Votre nom n’est pas renseigné.');
       });
 
       test('should display an error on dayOfBirth', async function (assert) {
@@ -319,9 +295,7 @@ module('Unit | Component | routes/campaigns/sco-form', function (hooks) {
         await component.actions.validateForm.call(component, eventStub);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.validation.dayOfBirth, 'Votre jour de naissance n’est pas valide.');
+        assert.strictEqual(component.validation.dayOfBirth, 'Votre jour de naissance n’est pas valide.');
       });
 
       test('should display an error on monthOfBirth', async function (assert) {
@@ -332,9 +306,7 @@ module('Unit | Component | routes/campaigns/sco-form', function (hooks) {
         await component.actions.validateForm.call(component, eventStub);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.validation.monthOfBirth, 'Votre mois de naissance n’est pas valide.');
+        assert.strictEqual(component.validation.monthOfBirth, 'Votre mois de naissance n’est pas valide.');
       });
 
       test('should display an error on yearOfBirth', async function (assert) {
@@ -345,9 +317,7 @@ module('Unit | Component | routes/campaigns/sco-form', function (hooks) {
         await component.actions.validateForm.call(component, eventStub);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.validation.yearOfBirth, 'Votre année de naissance n’est pas valide.');
+        assert.strictEqual(component.validation.yearOfBirth, 'Votre année de naissance n’est pas valide.');
       });
     });
   });

--- a/mon-pix/tests/unit/components/scorecard-details_test.js
+++ b/mon-pix/tests/unit/components/scorecard-details_test.js
@@ -58,17 +58,13 @@ module('Unit | Component | scorecard-details ', function (hooks) {
       // then
       assert.deepEqual(result[0].name, expectedResult[0].name);
       assert.deepEqual(result[0].practicalTitle, expectedResult[0].practicalTitle);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result[0].tutorials.length, 2);
+      assert.strictEqual(result[0].tutorials.length, 2);
       assert.deepEqual(result[0].tutorials[0].id, expectedResult[0].tutorials[0].id);
       assert.deepEqual(result[0].tutorials[1].id, expectedResult[0].tutorials[1].id);
 
       assert.deepEqual(result[1].name, expectedResult[1].name);
       assert.deepEqual(result[1].practicalTitle, expectedResult[1].practicalTitle);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result[1].tutorials.length, 1);
+      assert.strictEqual(result[1].tutorials.length, 1);
       assert.deepEqual(result[1].tutorials[0].id, expectedResult[1].tutorials[0].id);
     });
 
@@ -85,9 +81,7 @@ module('Unit | Component | scorecard-details ', function (hooks) {
 
       // then
       assert.deepEqual(result, expectedResult);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result.length, 0);
+      assert.strictEqual(result.length, 0);
     });
   });
 

--- a/mon-pix/tests/unit/components/timed-challenge-instructions_test.js
+++ b/mon-pix/tests/unit/components/timed-challenge-instructions_test.js
@@ -37,9 +37,7 @@ module('Unit | Component | timed-challenge-instructions', function (hooks) {
           const allocatedTime = component.allocatedTime;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(allocatedTime, data.expected);
+          assert.strictEqual(allocatedTime, data.expected);
         });
       });
     });

--- a/mon-pix/tests/unit/components/timeout-gauge_test.js
+++ b/mon-pix/tests/unit/components/timeout-gauge_test.js
@@ -22,12 +22,12 @@ module('Unit | Component | timeout-gauge-component ', function (hooks) {
         test(`should return "${data.expected}" when remainingSeconds is ${data.remainingSeconds}s`, function (assert) {
           // given
           component.remainingSeconds = data.remainingSeconds;
+
           // when
           const formattedRemainingTime = component.formattedRemainingTime;
+
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(formattedRemainingTime, data.expected);
+          assert.strictEqual(formattedRemainingTime, data.expected);
         });
       });
     });
@@ -47,12 +47,12 @@ module('Unit | Component | timeout-gauge-component ', function (hooks) {
           // given
           component.args.allottedTime = data.allottedTime;
           component.remainingSeconds = data.remainingSeconds;
+
           // when
           const percentageOfTimeout = component.percentageOfTimeout;
+
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(percentageOfTimeout, data.expected);
+          assert.strictEqual(percentageOfTimeout, data.expected);
         });
       });
     });

--- a/mon-pix/tests/unit/components/training/card_test.js
+++ b/mon-pix/tests/unit/components/training/card_test.js
@@ -70,9 +70,7 @@ module('Unit | Component | Training | card', function (hooks) {
         const result = component.durationFormatted;
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(result, expectedResult);
+        assert.strictEqual(result, expectedResult);
       });
     });
   });
@@ -117,9 +115,7 @@ module('Unit | Component | Training | card', function (hooks) {
       const result = component.tagColor;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, 'purple-light');
+      assert.strictEqual(result, 'purple-light');
     });
 
     test('should return appropriate tag color for given type autoformation', function (assert) {
@@ -131,9 +127,7 @@ module('Unit | Component | Training | card', function (hooks) {
       const result = component.tagColor;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, 'blue-light');
+      assert.strictEqual(result, 'blue-light');
     });
   });
 });

--- a/mon-pix/tests/unit/components/tutorial-panel_test.js
+++ b/mon-pix/tests/unit/components/tutorial-panel_test.js
@@ -179,9 +179,7 @@ module('Unit | Component | tutorial panel', function (hooks) {
       const result = component.limitedTutorials;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result.length, 3);
+      assert.strictEqual(result.length, 3);
       assert.deepEqual(result, expectedTutorials);
     });
   });

--- a/mon-pix/tests/unit/components/tutorials/card_test.js
+++ b/mon-pix/tests/unit/components/tutorials/card_test.js
@@ -144,9 +144,7 @@ module('Unit | Component | Tutorial | card item', function (hooks) {
         await component.toggleSaveTutorial();
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.savingStatus, 'recorded');
+        assert.strictEqual(component.savingStatus, 'recorded');
       });
     });
 
@@ -177,9 +175,7 @@ module('Unit | Component | Tutorial | card item', function (hooks) {
         await component.toggleSaveTutorial();
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(component.savingStatus, 'unrecorded');
+        assert.strictEqual(component.savingStatus, 'unrecorded');
       });
     });
   });

--- a/mon-pix/tests/unit/components/user-account/email-verification-code-test.js
+++ b/mon-pix/tests/unit/components/user-account/email-verification-code-test.js
@@ -44,9 +44,7 @@ module('Unit | Component | user-account | email-verification-code', function (ho
       await component.onSubmitCode(code);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.currentUser.user.email, newEmail);
+      assert.strictEqual(component.currentUser.user.email, newEmail);
     });
   });
 

--- a/mon-pix/tests/unit/components/user-account/email-with-validation-form-test.js
+++ b/mon-pix/tests/unit/components/user-account/email-with-validation-form-test.js
@@ -16,9 +16,7 @@ module('Unit | Component | user-account | email-with-validation-form', function 
       component.validateNewEmail({ target: { value: emailWithSpaces } });
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.newEmail, emailWithSpaces.trim());
+      assert.strictEqual(component.newEmail, emailWithSpaces.trim());
     });
   });
 

--- a/mon-pix/tests/unit/components/user-account/update-email-with-validation-test.js
+++ b/mon-pix/tests/unit/components/user-account/update-email-with-validation-test.js
@@ -29,9 +29,7 @@ module('Unit | Component | user-account | update-email-with-validation', functio
       component.showVerificationCode({ newEmail, password });
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.newEmail, 'Toto@Example.net');
+      assert.strictEqual(component.newEmail, 'Toto@Example.net');
     });
 
     test('should save password on sendVerificationCode', async function (assert) {
@@ -44,9 +42,7 @@ module('Unit | Component | user-account | update-email-with-validation', functio
       component.showVerificationCode({ newEmail, password });
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.password, 'pix123');
+      assert.strictEqual(component.password, 'pix123');
     });
   });
 });

--- a/mon-pix/tests/unit/components/user-logged-menu_test.js
+++ b/mon-pix/tests/unit/components/user-logged-menu_test.js
@@ -45,9 +45,7 @@ module('Unit | Component | User logged Menu', function (hooks) {
       });
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.displayedIdentifier, 'email@example.net');
+      assert.strictEqual(component.displayedIdentifier, 'email@example.net');
     });
 
     test("should return user's username if not undefined and no email defined", function (assert) {
@@ -59,9 +57,7 @@ module('Unit | Component | User logged Menu', function (hooks) {
       });
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.displayedIdentifier, 'my username');
+      assert.strictEqual(component.displayedIdentifier, 'my username');
     });
 
     test("should return user's email if email and username are defined", function (assert) {
@@ -74,9 +70,7 @@ module('Unit | Component | User logged Menu', function (hooks) {
       });
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.displayedIdentifier, 'email@example.net');
+      assert.strictEqual(component.displayedIdentifier, 'email@example.net');
     });
 
     test('should return undefined if no email or username are defined', function (assert) {
@@ -86,9 +80,7 @@ module('Unit | Component | User logged Menu', function (hooks) {
       });
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.displayedIdentifier, undefined);
+      assert.strictEqual(component.displayedIdentifier, undefined);
     });
   });
 });

--- a/mon-pix/tests/unit/components/user-tutorials/filters/sidebar_test.js
+++ b/mon-pix/tests/unit/components/user-tutorials/filters/sidebar_test.js
@@ -49,9 +49,7 @@ module('Unit | Component | User-Tutorials | Filters | Sidebar', function (hooks)
 
       // then
       assert.ok(component.filters.competences);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(component.filters.competences.length, 0);
+      assert.strictEqual(component.filters.competences.length, 0);
     });
   });
 });

--- a/mon-pix/tests/unit/controllers/assessments/challenge_test.js
+++ b/mon-pix/tests/unit/controllers/assessments/challenge_test.js
@@ -159,9 +159,7 @@ module('Unit | Controller | Assessments | Challenge', function (hooks) {
           const result = controller.displayChallenge;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(result, data.expectedResult);
+          assert.strictEqual(result, data.expectedResult);
         });
       });
     });
@@ -194,9 +192,7 @@ module('Unit | Controller | Assessments | Challenge', function (hooks) {
           const result = controller.displayChallenge;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(result, data.expectedResult);
+          assert.strictEqual(result, data.expectedResult);
         });
       });
     });
@@ -229,9 +225,7 @@ module('Unit | Controller | Assessments | Challenge', function (hooks) {
           const result = controller.displayChallenge;
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(result, data.expectedResult);
+          assert.strictEqual(result, data.expectedResult);
         });
       });
     });

--- a/mon-pix/tests/unit/controllers/assessments/checkpoint_test.js
+++ b/mon-pix/tests/unit/controllers/assessments/checkpoint_test.js
@@ -20,9 +20,7 @@ module('Unit | Controller | Assessments | Checkpoint', function (hooks) {
       controller.set('finalCheckpoint', false);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.nextPageButtonText, 'Continuer');
+      assert.strictEqual(controller.nextPageButtonText, 'Continuer');
     });
 
     test('should propose to see the results of the assessment if it is the final checkpoint', function (assert) {
@@ -30,9 +28,7 @@ module('Unit | Controller | Assessments | Checkpoint', function (hooks) {
       controller.set('finalCheckpoint', true);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.nextPageButtonText, 'Voir mes résultats');
+      assert.strictEqual(controller.nextPageButtonText, 'Voir mes résultats');
     });
   });
 
@@ -49,9 +45,7 @@ module('Unit | Controller | Assessments | Checkpoint', function (hooks) {
       controller.set('finalCheckpoint', true);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.completionPercentage, 100);
+      assert.strictEqual(controller.completionPercentage, 100);
     });
 
     test('should equal the progression completionPercentage', function (assert) {
@@ -64,9 +58,7 @@ module('Unit | Controller | Assessments | Checkpoint', function (hooks) {
       controller.set('model', model);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.completionPercentage, 73);
+      assert.strictEqual(controller.completionPercentage, 73);
     });
   });
 

--- a/mon-pix/tests/unit/controllers/authentication/login-or-register-oidc_test.js
+++ b/mon-pix/tests/unit/controllers/authentication/login-or-register-oidc_test.js
@@ -50,18 +50,10 @@ module('Unit | Controller | authentication | login-or-register-oidc', function (
         identityProvider,
       });
       sinon.assert.calledOnce(login);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.email, 'glace.alo@example.net');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.username, 'glace.alo345');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.fullNameFromExternalIdentityProvider, 'Glace Idp');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.fullNameFromPix, 'Glace Alo');
+      assert.strictEqual(controller.email, 'glace.alo@example.net');
+      assert.strictEqual(controller.username, 'glace.alo345');
+      assert.strictEqual(controller.fullNameFromExternalIdentityProvider, 'Glace Idp');
+      assert.strictEqual(controller.fullNameFromPix, 'Glace Alo');
       assert.deepEqual(controller.authenticationMethods, [{ identityProvider: 'OIDC_PARTNER' }]);
       assert.ok(true);
     });

--- a/mon-pix/tests/unit/controllers/fill-in-campaign-code_test.js
+++ b/mon-pix/tests/unit/controllers/fill-in-campaign-code_test.js
@@ -129,9 +129,7 @@ module('Unit | Controller | Fill in Campaign Code', function (hooks) {
       await controller.actions.startCampaign.call(controller, eventStub);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.get('errorMessage'), 'Veuillez saisir un code.');
+      assert.strictEqual(controller.get('errorMessage'), 'Veuillez saisir un code.');
     });
 
     test('should set error when no campaign found with code', async function (assert) {
@@ -150,9 +148,10 @@ module('Unit | Controller | Fill in Campaign Code', function (hooks) {
       await controller.actions.startCampaign.call(controller, eventStub);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.get('errorMessage'), controller.intl.t('pages.fill-in-campaign-code.errors.not-found'));
+      assert.strictEqual(
+        controller.get('errorMessage'),
+        controller.intl.t('pages.fill-in-campaign-code.errors.not-found')
+      );
     });
 
     test('should set error when student is not authorized in campaign', async function (assert) {
@@ -171,9 +170,7 @@ module('Unit | Controller | Fill in Campaign Code', function (hooks) {
       await controller.actions.startCampaign.call(controller, eventStub);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(
+      assert.strictEqual(
         controller.get('errorMessage'),
         'Oups ! nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez l’organisateur.'
       );
@@ -191,9 +188,7 @@ module('Unit | Controller | Fill in Campaign Code', function (hooks) {
         const firstTitle = controller.firstTitle;
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(firstTitle, expectedFirstTitle);
+        assert.strictEqual(firstTitle, expectedFirstTitle);
       });
     });
 
@@ -209,9 +204,7 @@ module('Unit | Controller | Fill in Campaign Code', function (hooks) {
         const firstTitle = controller.firstTitle;
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(firstTitle, expectedFirstTitle);
+        assert.strictEqual(firstTitle, expectedFirstTitle);
       });
     });
 
@@ -226,9 +219,7 @@ module('Unit | Controller | Fill in Campaign Code', function (hooks) {
         const firstTitle = controller.firstTitle;
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(firstTitle, expectedFirstTitle);
+        assert.strictEqual(firstTitle, expectedFirstTitle);
       });
     });
   });
@@ -242,9 +233,7 @@ module('Unit | Controller | Fill in Campaign Code', function (hooks) {
       const isUserAuthenticatedByPix = controller.isUserAuthenticatedByPix;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(isUserAuthenticatedByPix, sessionStub.isAuthenticated);
+      assert.strictEqual(isUserAuthenticatedByPix, sessionStub.isAuthenticated);
     });
   });
 

--- a/mon-pix/tests/unit/controllers/fill-in-certificate-verification-code_test.js
+++ b/mon-pix/tests/unit/controllers/fill-in-certificate-verification-code_test.js
@@ -28,9 +28,7 @@ module('Unit | Controller | Fill in certificate verification Code', function (ho
       await controller.actions.checkCertificate.call(controller, event);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.get('errorMessage'), 'Merci de renseigner le code de vérification.');
+      assert.strictEqual(controller.get('errorMessage'), 'Merci de renseigner le code de vérification.');
     });
 
     test('should set error when certificateVerificationCode code is not matching the right format', async function (assert) {
@@ -42,9 +40,7 @@ module('Unit | Controller | Fill in certificate verification Code', function (ho
       await controller.actions.checkCertificate.call(controller, event);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(controller.get('errorMessage'), 'Veuillez vérifier le format de votre code (P-XXXXXXXX).');
+      assert.strictEqual(controller.get('errorMessage'), 'Veuillez vérifier le format de votre code (P-XXXXXXXX).');
     });
 
     test('should set showNotFoundCertificationErrorMessage to true when no certificate is found', async function (assert) {

--- a/mon-pix/tests/unit/helpers/contains_test.js
+++ b/mon-pix/tests/unit/helpers/contains_test.js
@@ -21,9 +21,8 @@ module('Unit | Helpers | contains', function (hooks) {
 
     test('should find only one element', async function (assert) {
       await render(hbs`<div><span id="first">Hello</span><span>Hello</span></div>`);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(contains('Hello').tagName, 'DIV');
+
+      assert.strictEqual(contains('Hello').tagName, 'DIV');
     });
 
     test('should not find any element deeply', async function (assert) {

--- a/mon-pix/tests/unit/helpers/convert-to-html_test.js
+++ b/mon-pix/tests/unit/helpers/convert-to-html_test.js
@@ -12,33 +12,29 @@ module('Unit | Helper | ConvertToHtml', function () {
     test('should return html formatted result', function (assert) {
       const boldSentence = new Array(['**a bold sentence**']);
       const result = helper.compute(boldSentence);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, '<p><strong>a bold sentence</strong></p>');
+
+      assert.strictEqual(result, '<p><strong>a bold sentence</strong></p>');
     });
 
     test('should return a string without html/css artifacts', function (assert) {
       const input = new Array(['**a bold sentence**<style>width:10px</style>']);
       const result = helper.compute(input);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, '<p><strong>a bold sentence</strong></p>');
+
+      assert.strictEqual(result, '<p><strong>a bold sentence</strong></p>');
     });
 
     test('should return an empty string when called with an argument that is not an array', function (assert) {
       const badArgument = 'bad argument';
       const result = helper.compute(badArgument);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, '');
+
+      assert.strictEqual(result, '');
     });
 
     test('should return an empty string when called with an empty argument', function (assert) {
       const emptyArgument = new Array(['']);
       const result = helper.compute(emptyArgument);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, '');
+
+      assert.strictEqual(result, '');
     });
   });
 });

--- a/mon-pix/tests/unit/helpers/extract-extension_test.js
+++ b/mon-pix/tests/unit/helpers/extract-extension_test.js
@@ -3,14 +3,8 @@ import { extractExtension } from 'mon-pix/helpers/extract-extension';
 
 module('Unit | Helpers | ExtractExtension', function () {
   test('works', function (assert) {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(extractExtension(['file.url.ext.docx']), 'docx');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(extractExtension(['file_url_without_extension']), 'file_url_without_extension');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(extractExtension(['']), '');
+    assert.strictEqual(extractExtension(['file.url.ext.docx']), 'docx');
+    assert.strictEqual(extractExtension(['file_url_without_extension']), 'file_url_without_extension');
+    assert.strictEqual(extractExtension(['']), '');
   });
 });

--- a/mon-pix/tests/unit/helpers/get-challenge-component-class_test.js
+++ b/mon-pix/tests/unit/helpers/get-challenge-component-class_test.js
@@ -22,9 +22,7 @@ module('Unit | Helper | get challenge component class', function () {
       const componentClass = getChallengeComponentClass(params);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(componentClass, useCase.expectedClass);
+      assert.strictEqual(componentClass, useCase.expectedClass);
     });
   });
 });

--- a/mon-pix/tests/unit/helpers/get-qroc-input-size_test.js
+++ b/mon-pix/tests/unit/helpers/get-qroc-input-size_test.js
@@ -8,9 +8,7 @@ module('Unit | Helper | get qroc input size', function () {
     { format: 'unreferenced_format', size: '20' },
   ].forEach((expected) => {
     test(`should return correct size ${expected.size} for a given format ${expected.format}`, function (assert) {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(getQrocInputSize(expected.format), expected.size);
+      assert.strictEqual(getQrocInputSize(expected.format), expected.size);
     });
   });
 });

--- a/mon-pix/tests/unit/helpers/jwt_test.js
+++ b/mon-pix/tests/unit/helpers/jwt_test.js
@@ -53,12 +53,8 @@ module('Unit | Helpers | decodeToken', function (hooks) {
       const dataFromToken = decodeToken(token);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(dataFromToken.user_id, user_id);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(dataFromToken.source, source);
+      assert.strictEqual(dataFromToken.user_id, user_id);
+      assert.strictEqual(dataFromToken.source, source);
     });
   });
 });

--- a/mon-pix/tests/unit/helpers/replace-zero-by-dash_test.js
+++ b/mon-pix/tests/unit/helpers/replace-zero-by-dash_test.js
@@ -4,30 +4,23 @@ import { replaceZeroByDash } from 'mon-pix/helpers/replace-zero-by-dash';
 module('Unit | Helpers | replaceZeroByDash', function () {
   test('does not change null values', function (assert) {
     const value = replaceZeroByDash([null]);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(value, null);
+
+    assert.strictEqual(value, null);
   });
 
   test('does not change number non-zero values', function (assert) {
     const value1 = replaceZeroByDash([1]);
     const value2 = replaceZeroByDash([111]);
     const value3 = replaceZeroByDash([0.0001]);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(value1, 1);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(value2, 111);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(value3, 0.0001);
+
+    assert.strictEqual(value1, 1);
+    assert.strictEqual(value2, 111);
+    assert.strictEqual(value3, 0.0001);
   });
 
   test('replaces zero by dash', function (assert) {
     const value = replaceZeroByDash([0]);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(value, '–');
+
+    assert.strictEqual(value, '–');
   });
 });

--- a/mon-pix/tests/unit/helpers/strip-instruction_test.js
+++ b/mon-pix/tests/unit/helpers/strip-instruction_test.js
@@ -5,9 +5,8 @@ module('Unit | Helpers | StripInstructionHelper', function () {
   module('when sentence is short enough', function () {
     test('should be the same sentence', function (assert) {
       const result = stripInstruction(['<div class="paragraph"><strong>a bold sentence</strong></div>']);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, 'a bold sentence');
+
+      assert.strictEqual(result, 'a bold sentence');
     });
   });
 
@@ -18,9 +17,8 @@ module('Unit | Helpers | StripInstructionHelper', function () {
           '<strong>a bold sentence a bold sentence a bold sentence a bold sentence a bold sentence</strong>' +
           '</div>',
       ]);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, 'a bold sentence a bold sentence a bold sentence a bold sentence a...');
+
+      assert.strictEqual(result, 'a bold sentence a bold sentence a bold sentence a bold sentence a...');
     });
 
     test('should be the sentence shorten at a space', function (assert) {
@@ -29,18 +27,16 @@ module('Unit | Helpers | StripInstructionHelper', function () {
           '<strong>bold sentence a bold sentence a bold sentence a bold sentence a bold sentence</strong>' +
           '</div>',
       ]);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, 'bold sentence a bold sentence a bold sentence a bold sentence a...');
+
+      assert.strictEqual(result, 'bold sentence a bold sentence a bold sentence a bold sentence a...');
     });
   });
 
   module('when the length is specified', function () {
     test('should be the sentence shorten by the specified parameter', function (assert) {
       const result = stripInstruction(['<div class="paragraph"><strong>a bold sentence</strong></div>', 10]);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, 'a bold...');
+
+      assert.strictEqual(result, 'a bold...');
     });
   });
 });

--- a/mon-pix/tests/unit/helpers/text-with-multiple-lang_test.js
+++ b/mon-pix/tests/unit/helpers/text-with-multiple-lang_test.js
@@ -27,9 +27,10 @@ module('Unit | Helper | text with multiple lang', function (hooks) {
     test(`should return the text "${expected.outputText}" if the text is "${expected.text}" in lang ${expected.lang}`, function (assert) {
       textWithMultipleLangHelper.intl.t = () => expected.lang;
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(textWithMultipleLangHelper.compute([expected.text, expected.lang]).toString(), expected.outputText);
+      assert.strictEqual(
+        textWithMultipleLangHelper.compute([expected.text, expected.lang]).toString(),
+        expected.outputText
+      );
     });
   });
 });

--- a/mon-pix/tests/unit/mixins/progression-tracker_test.js
+++ b/mon-pix/tests/unit/mixins/progression-tracker_test.js
@@ -26,9 +26,7 @@ module('Unit | Mixin | progression-tracker', function () {
     const s = ProgressionTrackerObject.create({ steps });
     s.next();
     assert.deepEqual(s.progression, testProgression);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(s.activeStep, 'two');
+    assert.strictEqual(s.activeStep, 'two');
   });
 
   test('it should move backward to other step and update the state', function (assert) {
@@ -38,9 +36,7 @@ module('Unit | Mixin | progression-tracker', function () {
     s.next();
     s.prev();
     assert.deepEqual(s.progression, testProgression);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(s.activeStep, 'two');
+    assert.strictEqual(s.activeStep, 'two');
   });
 
   test('it should not mutate the steps passed in', function (assert) {

--- a/mon-pix/tests/unit/models/campaign-participation-badge_test.js
+++ b/mon-pix/tests/unit/models/campaign-participation-badge_test.js
@@ -32,9 +32,7 @@ module('Unit | Model | CampaignParticipationBadge', function (hooks) {
       const maxTotalSkillsCountInSkillSets = model.maxTotalSkillsCountInSkillSets;
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(maxTotalSkillsCountInSkillSets, 10);
+      assert.strictEqual(maxTotalSkillsCountInSkillSets, 10);
     });
   });
 });

--- a/mon-pix/tests/unit/models/campaign-participation-overview_test.js
+++ b/mon-pix/tests/unit/models/campaign-participation-overview_test.js
@@ -18,10 +18,9 @@ module('Unit | Model | Campaign-Participation-Overview', function (hooks) {
           const model = store.createRecord('campaign-participation-overview', {
             status: 'STARTED',
           });
+
           // when / then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(model.cardStatus, 'ONGOING');
+          assert.strictEqual(model.cardStatus, 'ONGOING');
         });
       });
 
@@ -33,10 +32,9 @@ module('Unit | Model | Campaign-Participation-Overview', function (hooks) {
             isShared: false,
             disabledAt: null,
           });
+
           // when / then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(model.cardStatus, 'TO_SHARE');
+          assert.strictEqual(model.cardStatus, 'TO_SHARE');
         });
       });
 
@@ -48,10 +46,9 @@ module('Unit | Model | Campaign-Participation-Overview', function (hooks) {
             disabledAt: null,
             isShared: true,
           });
+
           // when / then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(model.cardStatus, 'ENDED');
+          assert.strictEqual(model.cardStatus, 'ENDED');
         });
       });
     });
@@ -64,10 +61,9 @@ module('Unit | Model | Campaign-Participation-Overview', function (hooks) {
           isShared: true,
           disabledAt: new Date('2021-01-01'),
         });
+
         // when / then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(model.cardStatus, 'DISABLED');
+        assert.strictEqual(model.cardStatus, 'DISABLED');
       });
     });
   });

--- a/mon-pix/tests/unit/models/challenge_test.js
+++ b/mon-pix/tests/unit/models/challenge_test.js
@@ -1,4 +1,3 @@
-import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
@@ -17,113 +16,85 @@ module('Unit | Model | Challenge', function (hooks) {
   });
 
   module('Computed property #hasAttachment', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/require-expect
     test('Should be true when challenge has at least one attachment file', function (assert) {
-      run(() => {
-        // given
-        const challenge = store.createRecord('challenge', { attachments: ['file.url'] });
+      // given
+      const challenge = store.createRecord('challenge', { attachments: ['file.url'] });
 
-        // when
-        const hasAttachment = challenge.hasAttachment;
+      // when
+      const hasAttachment = challenge.hasAttachment;
 
-        // then
-        assert.true(hasAttachment);
-      });
+      // then
+      assert.true(hasAttachment);
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/require-expect
     test('Should be false when challenge has multiple attachment files', function (assert) {
-      run(() => {
-        // given
-        const challenge = store.createRecord('challenge', { attachments: [] });
+      // given
+      const challenge = store.createRecord('challenge', { attachments: [] });
 
-        // when
-        const hasAttachment = challenge.hasAttachment;
+      // when
+      const hasAttachment = challenge.hasAttachment;
 
-        // then
-        assert.false(hasAttachment);
-      });
+      // then
+      assert.false(hasAttachment);
     });
   });
 
   module('Computed property #hasSingleAttachment', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/require-expect
     test('Should be true when challenge has only one attachment file', function (assert) {
-      run(() => {
-        // given
-        const challenge = store.createRecord('challenge', { attachments: ['file.url'] });
+      // given
+      const challenge = store.createRecord('challenge', { attachments: ['file.url'] });
 
-        // when
-        const hasSingleAttachment = challenge.hasSingleAttachment;
+      // when
+      const hasSingleAttachment = challenge.hasSingleAttachment;
 
-        // then
-        assert.true(hasSingleAttachment);
-      });
+      // then
+      assert.true(hasSingleAttachment);
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/require-expect
     test('Should be false when challenge has multiple attachment files', function (assert) {
-      run(() => {
-        // given
-        const challenge = store.createRecord('challenge', { attachments: ['file.url', 'file.1.url', 'file.2.url'] });
+      // given
+      const challenge = store.createRecord('challenge', { attachments: ['file.url', 'file.1.url', 'file.2.url'] });
 
-        // when
-        const hasSingleAttachment = challenge.hasSingleAttachment;
+      // when
+      const hasSingleAttachment = challenge.hasSingleAttachment;
 
-        // then
-        assert.false(hasSingleAttachment);
-      });
+      // then
+      assert.false(hasSingleAttachment);
     });
   });
 
   module('Computed property #hasMultipleAttachments', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/require-expect
     test('Should be false when challenge has no attachment file', function (assert) {
-      run(() => {
-        // given
-        const challenge = store.createRecord('challenge', { attachments: [] });
+      // given
+      const challenge = store.createRecord('challenge', { attachments: [] });
 
-        // when
-        const hasMultipleAttachments = challenge.hasMultipleAttachments;
+      // when
+      const hasMultipleAttachments = challenge.hasMultipleAttachments;
 
-        // then
-        assert.false(hasMultipleAttachments);
-      });
+      // then
+      assert.false(hasMultipleAttachments);
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/require-expect
     test('Should be false when challenge has only one attachment file', function (assert) {
-      run(() => {
-        // given
-        const challenge = store.createRecord('challenge', { attachments: ['file.url'] });
+      // given
+      const challenge = store.createRecord('challenge', { attachments: ['file.url'] });
 
-        // when
-        const hasMultipleAttachments = challenge.hasMultipleAttachments;
+      // when
+      const hasMultipleAttachments = challenge.hasMultipleAttachments;
 
-        // then
-        assert.false(hasMultipleAttachments);
-      });
+      // then
+      assert.false(hasMultipleAttachments);
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/require-expect
     test('Should be true when challenge has multiple attachments files', function (assert) {
-      run(() => {
-        // given
-        const challenge = store.createRecord('challenge', { attachments: ['file.url', 'file.1.url', 'file.2.url'] });
+      // given
+      const challenge = store.createRecord('challenge', { attachments: ['file.url', 'file.1.url', 'file.2.url'] });
 
-        // when
-        const hasMultipleAttachments = challenge.hasMultipleAttachments;
+      // when
+      const hasMultipleAttachments = challenge.hasMultipleAttachments;
 
-        // then
-        assert.true(hasMultipleAttachments);
-      });
+      // then
+      assert.true(hasMultipleAttachments);
     });
   });
 

--- a/mon-pix/tests/unit/models/profile_test.js
+++ b/mon-pix/tests/unit/models/profile_test.js
@@ -1,4 +1,3 @@
-import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
@@ -17,30 +16,26 @@ module('Unit | Model | Profile model', function (hooks) {
   });
 
   module('@areas', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/require-expect
     test('should return an array of unique areas code', function (assert) {
-      return run(() => {
-        // given
-        const area1 = store.createRecord('area', { code: 1 });
-        const area2 = store.createRecord('area', { code: 2 });
+      // given
+      const area1 = store.createRecord('area', { code: 1 });
+      const area2 = store.createRecord('area', { code: 2 });
 
-        const scorecard1 = store.createRecord('scorecard', { area: area1 });
-        const scorecard2 = store.createRecord('scorecard', { area: area1 });
-        const scorecard3 = store.createRecord('scorecard', { area: area2 });
+      const scorecard1 = store.createRecord('scorecard', { area: area1 });
+      const scorecard2 = store.createRecord('scorecard', { area: area1 });
+      const scorecard3 = store.createRecord('scorecard', { area: area2 });
 
-        const model = store.createRecord('profile');
-        model.scorecards = [scorecard1, scorecard2, scorecard3];
+      const model = store.createRecord('profile');
+      model.scorecards = [scorecard1, scorecard2, scorecard3];
 
-        // when
-        const areas = model.areas;
+      // when
+      const areas = model.areas;
 
-        // then
-        assert.deepEqual(
-          areas.map((area) => area.get('code')),
-          [1, 2]
-        );
-      });
+      // then
+      assert.deepEqual(
+        areas.map((area) => area.get('code')),
+        [1, 2]
+      );
     });
   });
 });

--- a/mon-pix/tests/unit/models/progression_test.js
+++ b/mon-pix/tests/unit/models/progression_test.js
@@ -1,4 +1,3 @@
-import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
@@ -17,21 +16,15 @@ module('Unit | Model | Progression', function (hooks) {
   });
 
   module('Computed property #completionPercentage', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/require-expect
     test('should compute a completionRate property in %', function (assert) {
-      run(() => {
-        // given
-        const progression = store.createRecord('progression', { completionRate: 0.06815 });
+      // given
+      const progression = store.createRecord('progression', { completionRate: 0.06815 });
 
-        // when
-        const completionPercentage = progression.completionPercentage;
+      // when
+      const completionPercentage = progression.completionPercentage;
 
-        // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(completionPercentage, 7);
-      });
+      // then
+      assert.strictEqual(completionPercentage, 7);
     });
   });
 });

--- a/mon-pix/tests/unit/models/reset-expired-password-demand_test.js
+++ b/mon-pix/tests/unit/models/reset-expired-password-demand_test.js
@@ -42,9 +42,7 @@ module('Unit | Model | Reset-expired-password-demand', function (hooks) {
         },
       };
       sinon.assert.calledWith(adapter.ajax, url, 'POST', payload);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, 'oui.oui0912');
+      assert.strictEqual(result, 'oui.oui0912');
       assert.ok(true);
     });
   });

--- a/mon-pix/tests/unit/models/result-competence_test.js
+++ b/mon-pix/tests/unit/models/result-competence_test.js
@@ -24,12 +24,8 @@ module('Unit | Model | result-competence model', function (hooks) {
       const relationship = competence.relationshipsByName.get('area');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(relationship.key, 'area');
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(relationship.kind, 'belongsTo');
+      assert.strictEqual(relationship.key, 'area');
+      assert.strictEqual(relationship.kind, 'belongsTo');
     });
   });
 });

--- a/mon-pix/tests/unit/models/tutorial-evaluation_test.js
+++ b/mon-pix/tests/unit/models/tutorial-evaluation_test.js
@@ -17,9 +17,7 @@ module('Unit | Model | tutorial-evaluation model', function (hooks) {
       model.status = 'LIKED';
 
       // when & then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.nextStatus, 'NEUTRAL');
+      assert.strictEqual(model.nextStatus, 'NEUTRAL');
     });
 
     test('should return "LIKED" when current status is different from "LIKED"', function (assert) {
@@ -28,9 +26,7 @@ module('Unit | Model | tutorial-evaluation model', function (hooks) {
       model.status = 'NEUTRAL';
 
       // when & then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.nextStatus, 'LIKED');
+      assert.strictEqual(model.nextStatus, 'LIKED');
     });
   });
 

--- a/mon-pix/tests/unit/routes/account-recovery/update-sco-record-test.js
+++ b/mon-pix/tests/unit/routes/account-recovery/update-sco-record-test.js
@@ -32,37 +32,28 @@ module('Unit | Route | account-recovery | update sco record', function (hooks) {
       assert.ok(route);
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/require-expect
-    test('should get valid account recovery', function (assert) {
+    test('should get valid account recovery', async function (assert) {
       // given
       queryRecordStub.resolves({});
       const route = this.owner.lookup('route:account-recovery/update-sco-record');
       route.set('store', storeStub);
 
       // when
-      const promise = route.model(params);
+      await route.model(params);
 
       // then
-      return promise.then(() => {
-        sinon.assert.calledOnce(queryRecordStub);
-        sinon.assert.calledWith(queryRecordStub, 'account-recovery-demand', {
-          temporaryKey: params.temporary_key,
-        });
-        assert.ok(true);
+
+      sinon.assert.calledOnce(queryRecordStub);
+      sinon.assert.calledWith(queryRecordStub, 'account-recovery-demand', {
+        temporaryKey: params.temporary_key,
       });
+      assert.ok(true);
     });
 
     module('when account recovery demand is valid', function () {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
-      test('should create account recovery demand with fetched data', function (assert) {
+      test('should create account recovery demand with fetched data', async function (assert) {
         // given
         const stubbedAccountRecoveryDetails = {
-          email: 'philipe@example.net',
-          firstName: 'philippe',
-        };
-        const expectedAccountRecoveryDetails = {
           email: 'philipe@example.net',
           firstName: 'philippe',
         };
@@ -72,21 +63,18 @@ module('Unit | Route | account-recovery | update sco record', function (hooks) {
         route.set('store', storeStub);
 
         // when
-        const promise = route.model(params);
+        const result = await route.model(params);
 
         // then
-        return promise.then(({ temporaryKey, ...accountRecoveryDetails }) => {
-          assert.deepEqual(accountRecoveryDetails, expectedAccountRecoveryDetails);
-          assert.deepEqual(temporaryKey, params.temporary_key);
-        });
+        assert.strictEqual(result.email, 'philipe@example.net');
+        assert.strictEqual(result.firstName, 'philippe');
+        assert.strictEqual(result.temporaryKey, params.temporary_key);
       });
     });
 
     module('when account recovery demand is invalid ', function () {
       ['400', '404'].forEach((statusCode) => {
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/require-expect
-        test(`should return error message when account recovery fails with ${statusCode}`, function (assert) {
+        test(`should return error message when account recovery fails with ${statusCode}`, async function (assert) {
           // given
           queryRecordStub.rejects({ errors: [{ status: statusCode }] });
 
@@ -94,21 +82,15 @@ module('Unit | Route | account-recovery | update sco record', function (hooks) {
           route.set('store', storeStub);
 
           // when
-          const promise = route.model(params);
+          const result = await route.model(params);
 
           // then
-          return promise.then((result) => {
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/no-assert-equal
-            assert.equal(result.errorMessage, this.intl.t('pages.account-recovery.errors.key-invalid'));
-            assert.true(result.showBackToHomeButton);
-          });
+          assert.strictEqual(result.errorMessage, this.intl.t('pages.account-recovery.errors.key-invalid'));
+          assert.true(result.showBackToHomeButton);
         });
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
-      test('should return error message when account recovery fails with 401', function (assert) {
+      test('should return error message when account recovery fails with 401', async function (assert) {
         // given
         queryRecordStub.rejects({ errors: [{ status: 401 }] });
 
@@ -116,20 +98,14 @@ module('Unit | Route | account-recovery | update sco record', function (hooks) {
         route.set('store', storeStub);
 
         // when
-        const promise = route.model(params);
+        const result = await route.model(params);
 
         // then
-        return promise.then((result) => {
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(result.errorMessage, this.intl.t('pages.account-recovery.errors.key-expired'));
-          assert.true(result.showRenewLink);
-        });
+        assert.strictEqual(result.errorMessage, this.intl.t('pages.account-recovery.errors.key-expired'));
+        assert.true(result.showRenewLink);
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
-      test('should return error message when account recovery fails with 400 and ACCOUNT_WITH_EMAIL_ALREADY_EXISTS', function (assert) {
+      test('should return error message when account recovery fails with 400 and ACCOUNT_WITH_EMAIL_ALREADY_EXISTS', async function (assert) {
         // given
         queryRecordStub.rejects({ errors: [{ status: 400, code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXISTS' }] });
 
@@ -137,20 +113,14 @@ module('Unit | Route | account-recovery | update sco record', function (hooks) {
         route.set('store', storeStub);
 
         // when
-        const promise = route.model(params);
+        const result = await route.model(params);
 
         // then
-        return promise.then((result) => {
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(result.errorMessage, this.intl.t('pages.account-recovery.errors.account-exists'));
-          assert.true(result.showBackToHomeButton);
-        });
+        assert.strictEqual(result.errorMessage, this.intl.t('pages.account-recovery.errors.account-exists'));
+        assert.true(result.showBackToHomeButton);
       });
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
-      test('should return error message when account recovery fails with 403', function (assert) {
+      test('should return error message when account recovery fails with 403', async function (assert) {
         // given
         queryRecordStub.rejects({ errors: [{ status: 403 }] });
 
@@ -158,21 +128,15 @@ module('Unit | Route | account-recovery | update sco record', function (hooks) {
         route.set('store', storeStub);
 
         // when
-        const promise = route.model(params);
+        const result = await route.model(params);
 
         // then
-        return promise.then((result) => {
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(result.errorMessage, this.intl.t('pages.account-recovery.errors.key-used'));
-          assert.true(result.showBackToHomeButton);
-        });
+        assert.strictEqual(result.errorMessage, this.intl.t('pages.account-recovery.errors.key-used'));
+        assert.true(result.showBackToHomeButton);
       });
 
       ['500', '502', '504'].forEach((statusCode) => {
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/require-expect
-        test(`should return error message when account recovery fails with ${statusCode}`, function (assert) {
+        test(`should return error message when account recovery fails with ${statusCode}`, async function (assert) {
           // given
           queryRecordStub.rejects({ errors: [{ status: statusCode }] });
 
@@ -180,13 +144,11 @@ module('Unit | Route | account-recovery | update sco record', function (hooks) {
           route.set('store', storeStub);
 
           // when
-          const promise = route.model(params);
+          const result = await route.model(params);
 
           // then
-          return promise.then((result) => {
-            assert.strictEqual(result.errorMessage, this.intl.t('common.api-error-messages.internal-server-error'));
-            assert.true(result.showBackToHomeButton);
-          });
+          assert.strictEqual(result.errorMessage, this.intl.t('common.api-error-messages.internal-server-error'));
+          assert.true(result.showBackToHomeButton);
         });
       });
     });

--- a/mon-pix/tests/unit/routes/application_test.js
+++ b/mon-pix/tests/unit/routes/application_test.js
@@ -22,9 +22,7 @@ module('Unit | Route | application', function (hooks) {
     route.activate();
 
     // Then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(SplashServiceStub.hideCount, 1);
+    assert.strictEqual(SplashServiceStub.hideCount, 1);
   });
 
   module('#beforeModel', function (hooks) {
@@ -57,9 +55,7 @@ module('Unit | Route | application', function (hooks) {
       await route.beforeModel();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(this.intl.primaryLocale, 'fr');
+      assert.strictEqual(this.intl.primaryLocale, 'fr');
     });
 
     test('should set the head description', async function (assert) {
@@ -73,9 +69,7 @@ module('Unit | Route | application', function (hooks) {
       await route.beforeModel();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(route.headData.description, this.intl.t('application.description'));
+      assert.strictEqual(route.headData.description, this.intl.t('application.description'));
     });
 
     test('should get feature toogles', async function (assert) {

--- a/mon-pix/tests/unit/routes/assessments/challenge_test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge_test.js
@@ -74,9 +74,8 @@ module('Unit | Route | Assessments | Challenge', function (hooks) {
       });
       assert.ok(true);
     });
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('when the assessment is a Preview', async function (hooks) {
+
+    module('when the assessment is a Preview', function (hooks) {
       hooks.beforeEach(function () {
         const assessmentForPreview = {
           answers: [],
@@ -118,9 +117,7 @@ module('Unit | Route | Assessments | Challenge', function (hooks) {
       });
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('when the asked challenges is already answered', async function (hooks) {
+    module('when the asked challenges is already answered', function (hooks) {
       hooks.beforeEach(function () {
         const assessmentWithAnswers = {
           answers: [

--- a/mon-pix/tests/unit/routes/assessments_test.js
+++ b/mon-pix/tests/unit/routes/assessments_test.js
@@ -22,9 +22,7 @@ module('Unit | Route | Assessments', function (hooks) {
       const model = route.afterModel(assessment);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.title, 'Programmer');
+      assert.strictEqual(model.title, 'Programmer');
     });
 
     test('should update the title when the assessment is a certification ', function (assert) {
@@ -35,9 +33,7 @@ module('Unit | Route | Assessments', function (hooks) {
       const model = route.afterModel(assessment);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.title, 'Certification 1223');
+      assert.strictEqual(model.title, 'Certification 1223');
     });
   });
 });

--- a/mon-pix/tests/unit/routes/authenticated/competences/results_test.js
+++ b/mon-pix/tests/unit/routes/authenticated/competences/results_test.js
@@ -59,12 +59,8 @@ module('Unit | Route | Competences | Results', function (hooks) {
       });
 
       // Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.competenceEvaluation.id, 2);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model.scorecard.id, 1);
+      assert.strictEqual(model.competenceEvaluation.id, 2);
+      assert.strictEqual(model.scorecard.id, 1);
     });
   });
 });

--- a/mon-pix/tests/unit/routes/authenticated/competences/resume_test.js
+++ b/mon-pix/tests/unit/routes/authenticated/competences/resume_test.js
@@ -39,9 +39,7 @@ module('Unit | Route | Competence | Resume', function (hooks) {
       const model = await route.model(null, transition);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(model, competenceEvaluation);
+      assert.strictEqual(model, competenceEvaluation);
     });
   });
 

--- a/mon-pix/tests/unit/routes/authenticated/user-certifications/get_test.js
+++ b/mon-pix/tests/unit/routes/authenticated/user-certifications/get_test.js
@@ -29,28 +29,23 @@ module('Unit | Route | user certifications/get', function (hooks) {
   });
 
   module('#model', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/require-expect
-    test('should get the certification', function (assert) {
+    test('should get the certification', async function (assert) {
       // given
       const params = { id: certificationId };
       const retreivedCertification = [EmberObject.create({ id: certificationId })];
       findRecordStub.resolves(retreivedCertification);
 
       // when
-      const promise = route.model(params);
+      await route.model(params);
 
       // then
-      return promise.then(() => {
-        sinon.assert.calledOnce(findRecordStub);
-        sinon.assert.calledWith(findRecordStub, 'certification', certificationId);
-        assert.ok(true);
-      });
+
+      sinon.assert.calledOnce(findRecordStub);
+      sinon.assert.calledWith(findRecordStub, 'certification', certificationId);
+      assert.ok(true);
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/require-expect
-    test('should not return to /mes-certifications when the certification is published and validated', function (assert) {
+    test('should not return to /mes-certifications when the certification is published and validated', async function (assert) {
       // given
       const params = { id: certificationId };
       const retrievedCertification = EmberObject.create({
@@ -64,17 +59,13 @@ module('Unit | Route | user certifications/get', function (hooks) {
       findRecordStub.resolves(retrievedCertification);
 
       // when
-      const promise = route.model(params);
+      await route.model(params);
 
       // then
-      return promise.then(() => {
-        assert.true(route.router.replaceWith.notCalled);
-      });
+      assert.true(route.router.replaceWith.notCalled);
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/require-expect
-    test('should return to /mes-certifications when the certification is not published', function (assert) {
+    test('should return to /mes-certifications when the certification is not published', async function (assert) {
       // given
       const params = { id: certificationId };
       const retreivedCertification = EmberObject.create({
@@ -88,19 +79,15 @@ module('Unit | Route | user certifications/get', function (hooks) {
       findRecordStub.resolves(retreivedCertification);
 
       // when
-      const promise = route.model(params);
+      await route.model(params);
 
       // then
-      return promise.then(() => {
-        sinon.assert.calledOnce(route.router.replaceWith);
-        sinon.assert.calledWith(route.router.replaceWith, '/mes-certifications');
-        assert.ok(true);
-      });
+      sinon.assert.calledOnce(route.router.replaceWith);
+      sinon.assert.calledWith(route.router.replaceWith, '/mes-certifications');
+      assert.ok(true);
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/require-expect
-    test('should return to /mes-certifications when the certification is not validated', function (assert) {
+    test('should return to /mes-certifications when the certification is not validated', async function (assert) {
       // given
       const params = { id: certificationId };
       const retreivedCertification = EmberObject.create({
@@ -114,14 +101,12 @@ module('Unit | Route | user certifications/get', function (hooks) {
       findRecordStub.resolves(retreivedCertification);
 
       // when
-      const promise = route.model(params);
+      await route.model(params);
 
       // then
-      return promise.then(() => {
-        sinon.assert.calledOnce(route.router.replaceWith);
-        sinon.assert.calledWith(route.router.replaceWith, '/mes-certifications');
-        assert.ok(true);
-      });
+      sinon.assert.calledOnce(route.router.replaceWith);
+      sinon.assert.calledWith(route.router.replaceWith, '/mes-certifications');
+      assert.ok(true);
     });
   });
 });

--- a/mon-pix/tests/unit/routes/authenticated/user-certifications/index_test.js
+++ b/mon-pix/tests/unit/routes/authenticated/user-certifications/index_test.js
@@ -26,21 +26,15 @@ module('Unit | Route | user certifications/index', function (hooks) {
     assert.ok(route);
   });
 
-  // TODO: Fix this the next time the file is edited.
-  // eslint-disable-next-line qunit/require-expect
-  test('should return connected user certifications', function (assert) {
+  test('should return connected user certifications', async function (assert) {
     // given
     const certifications = [EmberObject.create({ id: 1 })];
     findAll.resolves(certifications);
 
     // when
-    const result = route.model();
+    const result = await route.model();
 
     // then
-    return result.then((certifications) => {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(certifications[0].id, 1);
-    });
+    assert.strictEqual(result[0].id, 1);
   });
 });

--- a/mon-pix/tests/unit/routes/authentication/login-oidc_test.js
+++ b/mon-pix/tests/unit/routes/authentication/login-oidc_test.js
@@ -92,9 +92,7 @@ module('Unit | Route | login-oidc', function (hooks) {
           await route.beforeModel({ to: { queryParams: {}, params: { identity_provider_slug: 'oidc-partner' } } });
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(sessionStub.data.nextURL, '/campagnes/PIXOIDC01/acces');
+          assert.strictEqual(sessionStub.data.nextURL, '/campagnes/PIXOIDC01/acces');
         });
 
         test('should build the url from the intent name and contexts in session data nextUrl', async function (assert) {

--- a/mon-pix/tests/unit/routes/campaigns/access_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/access_test.js
@@ -54,9 +54,8 @@ module('Unit | Route | Access', function (hooks) {
       await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(route.authenticationRoute, 'inscription');
+
+      assert.strictEqual(route.authenticationRoute, 'inscription');
     });
 
     test('should call parent’s beforeModel and transition to authenticationRoute', async function (assert) {
@@ -132,9 +131,7 @@ module('Unit | Route | Access', function (hooks) {
           await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(route.authenticationRoute, 'campaigns.join.student-sco');
+          assert.strictEqual(route.authenticationRoute, 'campaigns.join.student-sco');
         });
       }
     );
@@ -152,9 +149,7 @@ module('Unit | Route | Access', function (hooks) {
         await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(route.authenticationRoute, 'campaigns.join.student-sco');
+        assert.strictEqual(route.authenticationRoute, 'campaigns.join.student-sco');
       });
     });
 
@@ -168,9 +163,7 @@ module('Unit | Route | Access', function (hooks) {
         await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(route.authenticationRoute, 'campaigns.join.sco-mediacentre');
+        assert.strictEqual(route.authenticationRoute, 'campaigns.join.sco-mediacentre');
       });
     });
 
@@ -184,9 +177,7 @@ module('Unit | Route | Access', function (hooks) {
         await route.beforeModel({ from: 'campaigns.campaign-landing-page' });
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(route.authenticationRoute, 'campaigns.join.anonymous');
+        assert.strictEqual(route.authenticationRoute, 'campaigns.join.anonymous');
       });
     });
   });

--- a/mon-pix/tests/unit/routes/campaigns/assessment/tutorial_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/assessment/tutorial_test.js
@@ -25,13 +25,9 @@ module('Unit | Route | campaigns | evaluation | tutorial', function (hooks) {
       const tutorialPage = route.model();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(tutorialPage.title, this.intl.t('pages.tutorial.pages.page0.title'));
+      assert.strictEqual(tutorialPage.title, this.intl.t('pages.tutorial.pages.page0.title'));
       assert.true(tutorialPage.showNextButton);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(tutorialPage.paging[0], 'dot__active');
+      assert.strictEqual(tutorialPage.paging[0], 'dot__active');
     });
   });
 
@@ -45,9 +41,7 @@ module('Unit | Route | campaigns | evaluation | tutorial', function (hooks) {
       route.send('next');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(route.get('tutorialPageId'), 1);
+      assert.strictEqual(route.get('tutorialPageId'), 1);
       sinon.assert.calledWith(route.refresh);
       assert.ok(true);
     });
@@ -61,9 +55,7 @@ module('Unit | Route | campaigns | evaluation | tutorial', function (hooks) {
       route.send('next');
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(route.get('tutorialPageId'), 4);
+      assert.strictEqual(route.get('tutorialPageId'), 4);
       sinon.assert.notCalled(route.refresh);
       assert.ok(true);
     });

--- a/mon-pix/tests/unit/routes/campaigns/join_test.js
+++ b/mon-pix/tests/unit/routes/campaigns/join_test.js
@@ -39,9 +39,7 @@ module('Unit | Route | Join', function (hooks) {
       await route.beforeModel({ from: 'campaigns.entry-point' });
 
       //then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(route.routeIfAlreadyAuthenticated, 'campaigns.access');
+      assert.strictEqual(route.routeIfAlreadyAuthenticated, 'campaigns.access');
     });
   });
 

--- a/mon-pix/tests/unit/routes/fill-in-campaign-code_test.js
+++ b/mon-pix/tests/unit/routes/fill-in-campaign-code_test.js
@@ -22,9 +22,7 @@ module('Unit | Route | fill-in-campaign-code', function (hooks) {
       route.beforeModel(transition);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(sessionStub.data.externalUser, externalUser);
+      assert.strictEqual(sessionStub.data.externalUser, externalUser);
     });
   });
 });

--- a/mon-pix/tests/unit/routes/logout_test.js
+++ b/mon-pix/tests/unit/routes/logout_test.js
@@ -90,9 +90,7 @@ module('Unit | Route | logout', function (hooks) {
       route.beforeModel();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(route.session.alternativeRootURL, null);
+      assert.strictEqual(route.session.alternativeRootURL, null);
     });
 
     test('should redirect to disconnected page when source of connexion is external', function (assert) {
@@ -118,9 +116,7 @@ module('Unit | Route | logout', function (hooks) {
       route.beforeModel();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(route.session.alternativeRootURL, '/nonconnecte');
+      assert.strictEqual(route.session.alternativeRootURL, '/nonconnecte');
     });
   });
 

--- a/mon-pix/tests/unit/routes/reset-password-demand_test.js
+++ b/mon-pix/tests/unit/routes/reset-password-demand_test.js
@@ -29,31 +29,25 @@ module('Unit | Route | changer mot de passe', function (hooks) {
       assert.ok(route);
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/require-expect
-    test('should ask password reset demand validity', function (assert) {
+    test('should ask password reset demand validity', async function (assert) {
       // given
       queryRecordStub.resolves();
       const route = this.owner.lookup('route:reset-password');
       route.set('store', storeStub);
 
       // when
-      const promise = route.model(params);
+      await route.model(params);
 
       // then
-      return promise.then(() => {
-        sinon.assert.calledOnce(queryRecordStub);
-        sinon.assert.calledWith(queryRecordStub, 'user', {
-          passwordResetTemporaryKey: params.temporary_key,
-        });
-        assert.ok(true);
+      sinon.assert.calledOnce(queryRecordStub);
+      sinon.assert.calledWith(queryRecordStub, 'user', {
+        passwordResetTemporaryKey: params.temporary_key,
       });
+      assert.ok(true);
     });
 
     module('when password reset demand is valid', function () {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/require-expect
-      test('should create a new ember user model with fetched data', function (assert) {
+      test('should create a new ember user model with fetched data', async function (assert) {
         // given
         const fetchedOwnerDetails = {
           data: {
@@ -77,13 +71,11 @@ module('Unit | Route | changer mot de passe', function (hooks) {
         route.set('store', storeStub);
 
         // when
-        const promise = route.model(params);
+        const result = await route.model(params);
 
         // then
-        return promise.then(({ user, temporaryKey }) => {
-          assert.deepEqual(user, expectedUser);
-          assert.deepEqual(temporaryKey, params.temporary_key);
-        });
+        assert.deepEqual(result.user, expectedUser);
+        assert.deepEqual(result.temporaryKey, params.temporary_key);
       });
     });
   });

--- a/mon-pix/tests/unit/routes/update-expired-password_test.js
+++ b/mon-pix/tests/unit/routes/update-expired-password_test.js
@@ -25,8 +25,6 @@ module('Unit | Route | update-expired-password', function (hooks) {
     const model = await route.model();
 
     // then
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(model, resetExpiredPasswordDemand);
+    assert.strictEqual(model, resetExpiredPasswordDemand);
   });
 });

--- a/mon-pix/tests/unit/serializers/assessment_test.js
+++ b/mon-pix/tests/unit/serializers/assessment_test.js
@@ -16,15 +16,9 @@ module('Unit | Serializer | assessment', function (hooks) {
 
     const json = serializer.serialize(snapshot);
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(json.data.type, 'assessments');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(json.data.attributes['certification-number'], 'cert123');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-assert-equal
-    assert.equal(json.data.attributes['code-campaign'], 'campaign123');
+    assert.strictEqual(json.data.type, 'assessments');
+    assert.strictEqual(json.data.attributes['certification-number'], 'cert123');
+    assert.strictEqual(json.data.attributes['code-campaign'], 'campaign123');
   });
 
   module('when adapter options are given', function () {
@@ -39,9 +33,7 @@ module('Unit | Serializer | assessment', function (hooks) {
 
       const json = serializer.serialize(snapshot);
 
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(json.data.attributes['challenge-id'], 'challenge1');
+      assert.strictEqual(json.data.attributes['challenge-id'], 'challenge1');
     });
   });
 });

--- a/mon-pix/tests/unit/services/ajax-queue_test.js
+++ b/mon-pix/tests/unit/services/ajax-queue_test.js
@@ -26,9 +26,7 @@ module('Unit | Service | ajax-queue', function (hooks) {
       });
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(actualValue, expectedValue);
+      assert.strictEqual(actualValue, expectedValue);
     });
 
     test('should execute concurrently as many jobs as indicated in settings file', async function (assert) {
@@ -51,9 +49,7 @@ module('Unit | Service | ajax-queue', function (hooks) {
       await ajaxQueueService.add(job);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(maxCounter, maxJobsInQueue);
+      assert.strictEqual(maxCounter, maxJobsInQueue);
     });
   });
 });

--- a/mon-pix/tests/unit/services/competence-evaluation_test.js
+++ b/mon-pix/tests/unit/services/competence-evaluation_test.js
@@ -50,9 +50,7 @@ module('Unit | Service | competence-evaluation', function (hooks) {
       });
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('when improving fails with ImproveCompetenceEvaluationForbidden error', async function (hooks) {
+    module('when improving fails with ImproveCompetenceEvaluationForbidden error', function (hooks) {
       hooks.beforeEach(async function () {
         // given
         competenceEvaluationService = this.owner.lookup('service:competence-evaluation');
@@ -75,9 +73,7 @@ module('Unit | Service | competence-evaluation', function (hooks) {
       });
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('when improving fails with another error', async function (hooks) {
+    module('when improving fails with another error', function (hooks) {
       const error = new Error();
 
       hooks.beforeEach(async function () {
@@ -99,9 +95,7 @@ module('Unit | Service | competence-evaluation', function (hooks) {
           await competenceEvaluationService.improve({ userId, competenceId });
         } catch (err) {
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(err, err);
+          assert.strictEqual(err, err);
           // eslint-disable-next-line qunit/no-early-return
           return;
         }

--- a/mon-pix/tests/unit/services/current-user_test.js
+++ b/mon-pix/tests/unit/services/current-user_test.js
@@ -28,9 +28,7 @@ module('Unit | Service | current-user', function (hooks) {
       await currentUser.load();
 
       // Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentUser.user, user);
+      assert.strictEqual(currentUser.user, user);
     });
   });
 
@@ -72,9 +70,7 @@ module('Unit | Service | current-user', function (hooks) {
       const result = await currentUser.load();
 
       // Then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, 'invalidate');
+      assert.strictEqual(result, 'invalidate');
     });
   });
 });

--- a/mon-pix/tests/unit/services/errors_test.js
+++ b/mon-pix/tests/unit/services/errors_test.js
@@ -14,9 +14,7 @@ module('Unit | Service | errors', function (hooks) {
       service.push(error);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(service.errors[0], error);
+      assert.strictEqual(service.errors[0], error);
     });
   });
 
@@ -33,12 +31,8 @@ module('Unit | Service | errors', function (hooks) {
       const result = service.shift();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(result, error1);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(service.errors.length, 1);
+      assert.strictEqual(result, error1);
+      assert.strictEqual(service.errors.length, 1);
     });
   });
 

--- a/mon-pix/tests/unit/services/file-saver_test.js
+++ b/mon-pix/tests/unit/services/file-saver_test.js
@@ -102,9 +102,7 @@ module('Unit | Service | file-saver', function (hooks) {
             downloadFileForModernBrowsers: downloadFileForModernBrowsersStub,
           });
         } catch (error) {
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(error.message, 'the error message');
+          assert.strictEqual(error.message, 'the error message');
         }
       });
     });

--- a/mon-pix/tests/unit/services/oidc-identity-providers_test.js
+++ b/mon-pix/tests/unit/services/oidc-identity-providers_test.js
@@ -30,30 +30,15 @@ module('Unit | Service | oidc-identity-providers', function (hooks) {
       await oidcIdentityProvidersService.load();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(oidcIdentityProvidersService['oidc-partner'].code, oidcPartner.code);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(oidcIdentityProvidersService['oidc-partner'].organizationName, oidcPartner.organizationName);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(oidcIdentityProvidersService['oidc-partner'].hasLogoutUrl, oidcPartner.hasLogoutUrl);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(oidcIdentityProvidersService['oidc-partner'].source, oidcPartner.source);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(oidcIdentityProvidersService.list[0].code, oidcPartner.code);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(oidcIdentityProvidersService.list[0].organizationName, oidcPartner.organizationName);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(oidcIdentityProvidersService.list[0].hasLogoutUrl, oidcPartner.hasLogoutUrl);
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(oidcIdentityProvidersService.list[0].source, oidcPartner.source);
+
+      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].code, oidcPartner.code);
+      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].organizationName, oidcPartner.organizationName);
+      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].hasLogoutUrl, oidcPartner.hasLogoutUrl);
+      assert.strictEqual(oidcIdentityProvidersService['oidc-partner'].source, oidcPartner.source);
+      assert.strictEqual(oidcIdentityProvidersService.list[0].code, oidcPartner.code);
+      assert.strictEqual(oidcIdentityProvidersService.list[0].organizationName, oidcPartner.organizationName);
+      assert.strictEqual(oidcIdentityProvidersService.list[0].hasLogoutUrl, oidcPartner.hasLogoutUrl);
+      assert.strictEqual(oidcIdentityProvidersService.list[0].source, oidcPartner.source);
     });
   });
 

--- a/mon-pix/tests/unit/services/session_test.js
+++ b/mon-pix/tests/unit/services/session_test.js
@@ -107,9 +107,7 @@ module('Unit | Services | session', function (hooks) {
       });
     });
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line qunit/no-async-module-callbacks
-    module('when current URL domain extension is .org', async function () {
+    module('when current URL domain extension is .org', function () {
       test('should load current user and set locale to fr', async function (assert) {
         // given
         sessionService.currentDomain.getExtension.returns('org');

--- a/mon-pix/tests/unit/utils/labeled-checkboxes_test.js
+++ b/mon-pix/tests/unit/utils/labeled-checkboxes_test.js
@@ -100,9 +100,7 @@ module('Unit | Utility | labeled checkboxes', function () {
           ' when ' +
           testCase.when,
         function (assert) {
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(
+          assert.strictEqual(
             JSON.stringify(labeledCheckboxes(testCase.proposals, testCase.answers)),
             JSON.stringify(testCase.output)
           );

--- a/mon-pix/tests/unit/utils/pix-window_test.js
+++ b/mon-pix/tests/unit/utils/pix-window_test.js
@@ -19,9 +19,7 @@ module('Unit | Utilities | pix-window', function (hooks) {
       const url = PixWindow.getLocationHref();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(url, 'http://domain.com/timely#hash');
+      assert.strictEqual(url, 'http://domain.com/timely#hash');
     });
   });
 
@@ -34,9 +32,7 @@ module('Unit | Utilities | pix-window', function (hooks) {
       const hash = PixWindow.getLocationHash();
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(hash, '#hash');
+      assert.strictEqual(hash, '#hash');
     });
   });
 });

--- a/mon-pix/tests/unit/utils/progress-in-assessment_test.js
+++ b/mon-pix/tests/unit/utils/progress-in-assessment_test.js
@@ -21,9 +21,7 @@ module('Unit | Utility | progress-in-assessment', function () {
       const currentStepIndex = progressInAssessment.getCurrentStepIndex(assessment, currentChallengeNumber);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentStepIndex, 1);
+      assert.strictEqual(currentStepIndex, 1);
     });
 
     test('should return 0 when the assessment is a preview', function (assert) {
@@ -35,9 +33,7 @@ module('Unit | Utility | progress-in-assessment', function () {
       const currentStepIndex = progressInAssessment.getCurrentStepIndex(assessment, currentChallengeNumber);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentStepIndex, 0);
+      assert.strictEqual(currentStepIndex, 0);
     });
   });
 
@@ -50,9 +46,7 @@ module('Unit | Utility | progress-in-assessment', function () {
       const maxStepNumber = progressInAssessment.getMaxStepsNumber(assessment);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(maxStepNumber, ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS);
+      assert.strictEqual(maxStepNumber, ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS);
     });
 
     module('when assessment has flash method', function () {
@@ -64,9 +58,7 @@ module('Unit | Utility | progress-in-assessment', function () {
         const maxStepNumber = progressInAssessment.getMaxStepsNumber(assessment);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(maxStepNumber, ENV.APP.NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD);
+        assert.strictEqual(maxStepNumber, ENV.APP.NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD);
       });
 
       test('when assessment is certification, should return the maximum number of challenges', function (assert) {
@@ -77,9 +69,7 @@ module('Unit | Utility | progress-in-assessment', function () {
         const maxStepNumber = progressInAssessment.getMaxStepsNumber(assessment);
 
         // then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(maxStepNumber, ENV.APP.NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD);
+        assert.strictEqual(maxStepNumber, ENV.APP.NUMBER_OF_CHALLENGES_FOR_FLASH_METHOD);
       });
     });
 
@@ -95,9 +85,7 @@ module('Unit | Utility | progress-in-assessment', function () {
       const maxStepNumber = progressInAssessment.getMaxStepsNumber(assessment);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(maxStepNumber, nbChallenges);
+      assert.strictEqual(maxStepNumber, nbChallenges);
     });
 
     test('should return the number of challenge in course', function (assert) {
@@ -109,9 +97,7 @@ module('Unit | Utility | progress-in-assessment', function () {
       const maxStepNumber = progressInAssessment.getMaxStepsNumber(assessment);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(maxStepNumber, nbChallenges);
+      assert.strictEqual(maxStepNumber, nbChallenges);
     });
 
     test('should return 1 when the assessment is a preview', function (assert) {
@@ -122,9 +108,7 @@ module('Unit | Utility | progress-in-assessment', function () {
       const maxStepNumber = progressInAssessment.getMaxStepsNumber(assessment);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(maxStepNumber, 1);
+      assert.strictEqual(maxStepNumber, 1);
     });
   });
 
@@ -145,9 +129,7 @@ module('Unit | Utility | progress-in-assessment', function () {
       const currentStepIndex = progressInAssessment.getCurrentStepNumber(assessment, currentChallengeNumber);
 
       // then
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line qunit/no-assert-equal
-      assert.equal(currentStepIndex, 4);
+      assert.strictEqual(currentStepIndex, 4);
     });
   });
 });

--- a/mon-pix/tests/unit/utils/proposals-parser/select-block_test.js
+++ b/mon-pix/tests/unit/utils/proposals-parser/select-block_test.js
@@ -149,22 +149,12 @@ module('Unit | Utils | Proposals Parser | Select Block', function () {
           const result = new SelectBlock({ input, inputIndex: 123 });
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(result.input, data.expected.input);
+          assert.strictEqual(result.input, data.expected.input);
           assert.deepEqual(result.options, data.expected.options);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(result.autoAriaLabel, data.expected.autoAriaLabel);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(result.ariaLabel, data.expected.ariaLabel);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(result.placeholder, data.expected.placeholder);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(result.type, 'select');
+          assert.strictEqual(result.autoAriaLabel, data.expected.autoAriaLabel);
+          assert.strictEqual(result.ariaLabel, data.expected.ariaLabel);
+          assert.strictEqual(result.placeholder, data.expected.placeholder);
+          assert.strictEqual(result.type, 'select');
         });
       });
     });
@@ -256,22 +246,12 @@ module('Unit | Utils | Proposals Parser | Select Block', function () {
           const result = new SelectBlock({ input, inputIndex: 123 });
 
           // then
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(result.input, data.expected.input);
+          assert.strictEqual(result.input, data.expected.input);
           assert.deepEqual(result.options, data.expected.options);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(result.autoAriaLabel, data.expected.autoAriaLabel);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(result.ariaLabel, data.expected.ariaLabel);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(result.placeholder, data.expected.placeholder);
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/no-assert-equal
-          assert.equal(result.type, 'select');
+          assert.strictEqual(result.autoAriaLabel, data.expected.autoAriaLabel);
+          assert.strictEqual(result.ariaLabel, data.expected.ariaLabel);
+          assert.strictEqual(result.placeholder, data.expected.placeholder);
+          assert.strictEqual(result.type, 'select');
         });
       });
     });

--- a/mon-pix/tests/unit/utils/proposals-parser/text-block_test.js
+++ b/mon-pix/tests/unit/utils/proposals-parser/text-block_test.js
@@ -20,9 +20,7 @@ module('Unit | Utils | Proposals Parser | Text Block', function () {
         const block = new TextBlock({ text: inputData });
 
         //then
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(block.text, expectedText);
+        assert.strictEqual(block.text, expectedText);
       });
     });
   });

--- a/mon-pix/tests/unit/utils/standardize-number_test.js
+++ b/mon-pix/tests/unit/utils/standardize-number_test.js
@@ -14,9 +14,7 @@ module('Unit | Utility | standardizeNumber', function () {
 
     testData.forEach(({ number, size, expected }) => {
       test(`When number is ${number} with size ${size} it should return ${expected}`, function (assert) {
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(standardizeNumber(number, size), expected);
+        assert.strictEqual(standardizeNumber(number, size), expected);
       });
     });
   });
@@ -31,9 +29,7 @@ module('Unit | Utility | standardizeNumber', function () {
 
     testData.forEach(({ number, expected }) => {
       test(`When number is ${number} it should return ${expected}`, function (assert) {
-        // TODO: Fix this the next time the file is edited.
-        // eslint-disable-next-line qunit/no-assert-equal
-        assert.equal(standardizeNumberInTwoDigitFormat(number), expected);
+        assert.strictEqual(standardizeNumberInTwoDigitFormat(number), expected);
       });
     });
   });

--- a/orga/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
+++ b/orga/blueprints/acceptance-test/files/tests/acceptance/__name___test.js
@@ -9,6 +9,6 @@ module('Acceptance | <%= dasherizedModuleName %>', function (hooks) {
   test('visiting /<%= dasherizedModuleName %>', async function (assert) {
     await visitScreen('/<%= dasherizedModuleName %>');
 
-    assert.equal(currentURL(), '/<%= dasherizedModuleName %>');
+    assert.strictEqual(currentURL(), '/<%= dasherizedModuleName %>');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Plusieurs règles eslint liés à qunit ont étés ajoutés dans nos applis. De nombreux tests ne suivent pas tout à fait ces règles et ont donc été disabled en vu d'être corrigé plus tard. 

## :robot: Proposition
Corriger les tests de ces erreurs qunit. (il en reste encore quelque unes, mais le plus gros à été fait)

## :rainbow: Remarques

Pourquoi ces erreurs existent-elles ? Comment les corrige-t-on ?

`// eslint-disable-next-line qunit/no-assert-equal`

> The assert.equal assertion method in QUnit uses loose equality comparison. In a project which favors strict equality comparison, it is better to use `assert.strictEqual` for scalar values and either `assert.deepEqual` or `assert.propEqual` for more complex objects.
https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/no-assert-equal.md


`// eslint-disable-next-line qunit/require-expect`

> QUnit's assert.expect(...) helps developers create tests that correctly fail when their expected number of assertions are not called.
https://github.com/platinumazure/eslint-plugin-qunit/blob/master/docs/rules/require-expect.md

## :100: Pour tester
Bonne journée 🌸
