### PR TITLE
[TECH] Remplacer l'utilisation de bookshelf dans certains repositories

### DIFF
--- a/api/lib/infrastructure/repositories/badge-repository.js
+++ b/api/lib/infrastructure/repositories/badge-repository.js
@@ -3,7 +3,7 @@ const Badge = require('../../domain/models/Badge.js');
 const SkillSet = require('../../domain/models/SkillSet.js');
 const BadgeCriterion = require('../../domain/models/BadgeCriterion.js');
 const omit = require('lodash/omit');
-const bookshelfUtils = require('../utils/knex-utils.js');
+const knexUtils = require('../utils/knex-utils.js');
 const { AlreadyExistingEntityError } = require('../../domain/errors.js');
 const DomainTransaction = require('../../infrastructure/DomainTransaction.js');
 
@@ -54,7 +54,7 @@ module.exports = {
       const [savedBadge] = await (knexTransaction ?? knex)(TABLE_NAME).insert(_adaptModelToDb(badge)).returning('*');
       return new Badge(savedBadge);
     } catch (err) {
-      if (bookshelfUtils.isUniqConstraintViolated(err)) {
+      if (knexUtils.isUniqConstraintViolated(err)) {
         throw new AlreadyExistingEntityError(`The badge key ${badge.key} already exists`);
       }
       throw err;

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -12,6 +12,8 @@ const DomainTransaction = require('../../infrastructure/DomainTransaction.js');
 
 const { SHARED } = CampaignParticipationStatuses;
 
+const tableName = 'knowledge-elements';
+
 function _getUniqMostRecents(knowledgeElements) {
   return _(knowledgeElements).orderBy('createdAt', 'desc').uniqBy('skillId').value();
 }
@@ -31,7 +33,7 @@ function _findByUserIdAndLimitDateQuery({
   domainTransaction = DomainTransaction.emptyTransaction(),
 }) {
   const knexConn = domainTransaction.knexTransaction || knex;
-  return knexConn('knowledge-elements').where((qb) => {
+  return knexConn(tableName).where((qb) => {
     qb.where({ userId });
     if (limitDate) {
       qb.where('createdAt', '<', limitDate);
@@ -199,7 +201,7 @@ module.exports = {
   },
 
   async findInvalidatedAndDirectByUserId(userId) {
-    const invalidatedKnowledgeElements = await knex('knowledge-elements')
+    const invalidatedKnowledgeElements = await knex(tableName)
       .where({
         userId,
         status: KnowledgeElement.StatusType.INVALIDATED,

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -4,8 +4,6 @@ const constants = require('../constants.js');
 const { knex } = require('../../../db/knex-database-connection.js');
 const KnowledgeElement = require('../../domain/models/KnowledgeElement.js');
 const CampaignParticipationStatuses = require('../../domain/models/CampaignParticipationStatuses.js');
-const BookshelfKnowledgeElement = require('../orm-models/KnowledgeElement.js');
-const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter.js');
 const knowledgeElementSnapshotRepository = require('./knowledge-element-snapshot-repository.js');
 const campaignRepository = require('./campaign-repository.js');
 const DomainTransaction = require('../../infrastructure/DomainTransaction.js');
@@ -91,9 +89,8 @@ async function _countValidatedByCompetencesForUsersWithinCampaign(userIdsAndDate
 module.exports = {
   async save(knowledgeElement) {
     const knowledgeElementToSave = _.omit(knowledgeElement, ['id', 'createdAt']);
-    const savedKnowledgeElement = await new BookshelfKnowledgeElement(knowledgeElementToSave).save();
-
-    return bookshelfToDomainConverter.buildDomainObject(BookshelfKnowledgeElement, savedKnowledgeElement);
+    const [savedKnowledgeElement] = await knex(tableName).insert(knowledgeElementToSave).returning('*');
+    return new KnowledgeElement(savedKnowledgeElement);
   },
 
   findUniqByUserId({ userId, limitDate, domainTransaction }) {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, un ADR existe concernant la suppression de l'ORM bookshelf de l'api. Cependant, il y a encore beaucoup trop de repository qui l'utilisent.

## :robot: Proposition
Remplacer l'utilisation de bookshelf par knex

## :rainbow: Remarques
même si on a supprimé l'utilisation des modèles bookshelfs dans les repository, leur utilisation est encore présente dans d'autres modèles bookshelf. Il faudra donc attendre encore un peu pour pouvoir les supprimer.

## :100: Pour tester
La CI est ✅ 