### PR TITLE
[FEATURE] Traduire la modale de fin de test dans l'espace surveillant sur Pix Certif (PIX-6681).

### DIFF
--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -520,12 +520,12 @@
         "display-candidate-options": "Display the candidate's options",
         "candidate-options": "Candidate's options",
         "test-end-modal": {
-          "description": "Attention : cette action entraîne la fin de son test de certification et est irréversible.",
-          "instruction-with-name": "Finish the test of {firstName} {lastName}?",
-          "end-assessment": "Finish the test",
+          "description": "Warning, this action triggers the end of their Pix certification exam and is irreversible.",
+          "instruction-with-name": "End the exam of {firstName} {lastName}?",
+          "end-assessment": "End the exam",
           "cancel-label": "Annuler et fermer la fenêtre de confirmation",
-          "success": "Success! {firstName} {lastName}'s test has been finished.",
-          "error": "An error occured, {firstName} {lastName}'s test could not be finished."
+          "success": "Success! {firstName} {lastName}'s test has been ended.",
+          "error": "An error occured, {firstName} {lastName}'s test could not be ended."
         },
         "resume-test-modal": {
           "actions": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -523,7 +523,6 @@
           "description": "Warning, this action triggers the end of their Pix certification exam and is irreversible.",
           "instruction-with-name": "End the exam of {firstName} {lastName}?",
           "end-assessment": "End the exam",
-          "cancel-label": "Annuler et fermer la fenêtre de confirmation",
           "success": "Success! {firstName} {lastName}'s test has been ended.",
           "error": "An error occured, {firstName} {lastName}'s test could not be ended."
         },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -522,7 +522,6 @@
           "description": "Attention : cette action entraîne la fin de son test de certification et est irréversible.",
           "instruction-with-name": "Terminer le test de {firstName} {lastName} ?",
           "end-assessment": "Terminer le test",
-          "cancel-label": "Annuler et fermer la fenêtre de confirmation",
           "success": "Succès ! Le test de {firstName} {lastName} est terminé.",
           "error": "Une erreur est survenue, le test de {firstName} {lastName} n'a pas pu être terminé."
         },


### PR DESCRIPTION
## :unicorn: Problème
Pix Certif doit être disponible en anglais pour les utilisateurs anglophones. Or toutes les pages ne sont pas encore traduites en anglais.

## :robot: Proposition
Traduire la modale de fin de test dans l'espace surveillant


Attention : cette action entraîne la fin de son test de certification et est irréversible. -> `Warning, this action triggers the end of their Pix certification exam and is irreversible.`
Terminer le test -> `End the exam`
Annuler -> `Cancel`

Toaster de succès : 
Success! {firstName} {lastName}'s test has been finished. -> `Success! {firstName} {lastName}'s test has been ended.`

Toaster d'erreur : 
An error occured, {firstName} {lastName}'s test could not be finished. -> `An error occured, {firstName} {lastName}'s test could not be ended.`

## :rainbow: Remarques
Suppression d'un label qui n'était pas utilisé.

## :100: Pour tester

- Se connecter a Certif avec certifsco@example.net en **.org** + `?lang=en`
- Choisir une session avec des candidats, prendre son numéro de session et le mot de passe surveillant.
- Accéder à l'espace surveillant et remplir les 2 champs
- Avoir un élève qui a commencé le test ou en "Autorisé à reprendre"
- Cliquer sur les trois points et cliquer sur terminer le test
- Constater que la modale est correctement traduite.
- Couper le network pour avoir le toaster d'erreur et constater que le message a été modifié
- Puis valider la modale pour le cas passant et constater que le message a été modifié
