### PR TITLE
[BUGFIX] Gérer le mauvais format d'id de session lors de l'import en masse (PIX-7576)

### DIFF
--- a/api/lib/domain/constants/sessions-errors.js
+++ b/api/lib/domain/constants/sessions-errors.js
@@ -15,6 +15,10 @@ module.exports.CERTIFICATION_SESSIONS_ERRORS = {
     code: 'SESSION_SCHEDULED_IN_THE_PAST',
     getMessage: () => `Une session ne peut pas être programmée dans le passé`,
   },
+  SESSION_ID_NOT_VALID: {
+    code: 'SESSION_ID_NOT_VALID',
+    getMessage: () => '',
+  },
   DUPLICATE_CANDIDATE_NOT_ALLOWED_IN_SESSION: {
     code: 'DUPLICATE_CANDIDATE_NOT_ALLOWED_IN_SESSION',
     getMessage: () => `Une session contient au moins un élève en double.`,

--- a/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
+++ b/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
@@ -17,11 +17,19 @@ module.exports = {
         });
       }
 
-      if (await _isSessionStarted({ certificationCourseRepository, sessionId })) {
+      if (_isSessionIdFormatValid(sessionId)) {
+        if (await _isSessionStarted({ certificationCourseRepository, sessionId })) {
+          _addToErrorList({
+            errorList: sessionErrors,
+            line,
+            codes: [CERTIFICATION_SESSIONS_ERRORS.CANDIDATE_NOT_ALLOWED_FOR_STARTED_SESSION.code],
+          });
+        }
+      } else {
         _addToErrorList({
           errorList: sessionErrors,
           line,
-          codes: [CERTIFICATION_SESSIONS_ERRORS.CANDIDATE_NOT_ALLOWED_FOR_STARTED_SESSION.code],
+          codes: [CERTIFICATION_SESSIONS_ERRORS.SESSION_ID_NOT_VALID.code],
         });
       }
     } else {
@@ -115,6 +123,10 @@ module.exports = {
 
 function _isDateAndTimeValid(session) {
   return dayjs(`${session.date} ${session.time}`, 'YYYY-MM-DD HH:mm', true).isValid();
+}
+
+function _isSessionIdFormatValid(sessionId) {
+  return !isNaN(sessionId);
 }
 
 function _isErrorNotDuplicated({ certificationCandidateErrors, errorCode }) {

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -48,22 +48,50 @@ describe('Unit | Service | sessions import validation Service', function () {
         });
 
         context('when there is a sessionId', function () {
-          it('should return an empty sessionErrors array', async function () {
-            // given
-            const sessionId = 1;
-            const session = _buildValidSessionWithId(sessionId);
-            certificationCourseRepository.findCertificationCoursesBySessionId.resolves([]);
+          describe('when sessionId is not valid', function () {
+            it('should return a sessionErrors array that contains a sessionId invalid format error', async function () {
+              // given
+              const session = _buildValidSessionWithId();
+              session.id = 'toto123$';
 
-            // when
-            const sessionErrors = await sessionsImportValidationService.validateSession({
-              session,
-              line: 1,
-              sessionRepository,
-              certificationCourseRepository,
+              // when
+              const sessionErrors = await sessionsImportValidationService.validateSession({
+                session,
+                line: 1,
+                sessionRepository,
+                certificationCourseRepository,
+              });
+
+              // then
+              expect(certificationCourseRepository.findCertificationCoursesBySessionId).to.not.have.been.called;
+              expect(sessionErrors).to.deep.equal([
+                {
+                  line: 1,
+                  code: 'SESSION_ID_NOT_VALID',
+                  blocking: true,
+                },
+              ]);
             });
+          });
 
-            // then
-            expect(sessionErrors).to.be.empty;
+          describe('when sessionId is valid', function () {
+            it('should return an empty sessionErrors array', async function () {
+              // given
+              const sessionId = 1;
+              const session = _buildValidSessionWithId(sessionId);
+              certificationCourseRepository.findCertificationCoursesBySessionId.resolves([]);
+
+              // when
+              const sessionErrors = await sessionsImportValidationService.validateSession({
+                session,
+                line: 1,
+                sessionRepository,
+                certificationCourseRepository,
+              });
+
+              // then
+              expect(sessionErrors).to.be.empty;
+            });
           });
         });
       });
@@ -97,7 +125,7 @@ describe('Unit | Service | sessions import validation Service', function () {
 
     context('date validation', function () {
       context('when at least one session is scheduled in the past', function () {
-        it('should return an sessionErrors that contains a no session scheduled in the past error', async function () {
+        it('should return a sessionErrors array that contains a no session scheduled in the past error', async function () {
           // given
           const session = _buildValidSessionWithoutId();
           session.date = '2020-03-12';
@@ -124,7 +152,7 @@ describe('Unit | Service | sessions import validation Service', function () {
 
     context('conflicting session information validation', function () {
       context('when there is a sessionId and session information', function () {
-        it('should return an sessionErrors that contains an already given ID error', async function () {
+        it('should return a sessionErrors array that contains an already given ID error', async function () {
           // given
           const session = _buildValidSessionWithoutId();
           session.id = 1234;
@@ -171,7 +199,7 @@ describe('Unit | Service | sessions import validation Service', function () {
     });
 
     context('when there already is an existing session with the same data as a newly imported one', function () {
-      it('should return an sessionErrors that contains a session already existing error', async function () {
+      it('should return a sessionErrors array that contains a session already existing error', async function () {
         // given
         const session = _buildValidSessionWithoutId();
         sessionRepository.isSessionExisting.withArgs({ ...session }).resolves(true);
@@ -196,7 +224,7 @@ describe('Unit | Service | sessions import validation Service', function () {
     });
 
     describe('when session date is not valid', function () {
-      it('should return an sessionErrors that contains a session invalid date format error', async function () {
+      it('should return a sessionErrors array that contains a session invalid date format error', async function () {
         // given
         const session = _buildValidSessionWithoutId();
         session.date = 'toto';
@@ -222,7 +250,7 @@ describe('Unit | Service | sessions import validation Service', function () {
     });
 
     describe('when session time is not valid', function () {
-      it('should return an sessionErrors that contains a invalid time format error', async function () {
+      it('should return a sessionErrors array that contains a invalid time format error', async function () {
         // given
         const session = _buildValidSessionWithoutId();
         session.time = 'toto';
@@ -249,7 +277,7 @@ describe('Unit | Service | sessions import validation Service', function () {
 
     context('when session has certification candidates', function () {
       context('when at least one candidate is duplicated', function () {
-        it('should return an sessionErrors that contains a duplicate candidate error', async function () {
+        it('should return a sessionErrors array that contains a duplicate candidate error', async function () {
           // given
           const validCandidateData = _buildValidCandidateData(1);
           const validCandidateDataDuplicate = _buildValidCandidateData(1);
@@ -277,7 +305,7 @@ describe('Unit | Service | sessions import validation Service', function () {
     });
 
     context('when session has one invalid field', function () {
-      it('should return an sessionErrors that contains a session invalid field error', async function () {
+      it('should return a sessionErrors array that contains a session invalid field error', async function () {
         // given
         const session = _buildValidSessionWithoutId();
         session.room = null;
@@ -302,7 +330,7 @@ describe('Unit | Service | sessions import validation Service', function () {
     });
 
     context('when session has more than one invalid fields', function () {
-      it('should return an sessionErrors that contains all session errors', async function () {
+      it('should return a sessionErrors array that contains all session errors', async function () {
         // given
         const session = _buildValidSessionWithoutId();
         session.room = null;

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -268,9 +268,10 @@
               "SESSION_TIME_REQUIRED": "Champ obligatoire \"Heure de début\" manquant",
               "SESSION_TIME_NOT_VALID": "Format d'heure invalide, champ \"Heure de début\", format accepté HH:MM",
               "SESSION_EXAMINER_REQUIRED": "Champ obligatoire \"Surveillant(s)\" manquant",
-              "SESSION_WITH_DATE_AND_TIME_ALREADY_EXISTS": "Une session a déjà été créée avec ces informations. Pour ajouter des candidats à une session, indiquer uniquement le numéro (N°) de session sans les informations de session",
-              "SESSION_SCHEDULED_IN_THE_PAST": "Date et/ou heure indiquées antérieures à la date du jour",
-              "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées"
+              "SESSION_WITH_DATE_AND_TIME_ALREADY_EXISTS": "Session déjà créée avec ces critères, pour ajouter des candidats n’indiquer que le N°, pas les informations de session.",
+              "SESSION_SCHEDULED_IN_THE_PAST": "Date et/ou heure indiquées antérieures à la date du jour.",
+              "SESSION_ID_NOT_VALID": "N° de session invalide.",
+              "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées."
             }
           },
           "non-blocking-errors": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -270,6 +270,7 @@
               "SESSION_EXAMINER_REQUIRED": "Champ obligatoire \"Surveillant(s)\" manquant",
               "SESSION_WITH_DATE_AND_TIME_ALREADY_EXISTS": "Une session a déjà été créée avec ces informations. Pour ajouter des candidats à une session, indiquer uniquement le numéro (N°) de session sans les informations de session",
               "SESSION_SCHEDULED_IN_THE_PAST": "Date et/ou heure indiquées antérieures à la date du jour",
+              "SESSION_ID_NOT_VALID": "N° de session invalide.",
               "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées"
             }
           },


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'import en masse, si l'id de session est dans un mauvais format, l'api crash et renvoie une erreur 500

## :robot: Proposition
Eviter les erreurs 500 :sweat_smile: 

## :100: Pour tester
- Tenter l'import en masse avec un numéro de session invalid (ex: QSD123$)
```
N° de session,* Nom du site,* Nom de la salle,* Date de début,* Heure de début (heure locale),* Surveillant(s),Observations (optionnel),* Nom de naissance,* Prénom,* Date de naissance (format: jj/mm/aaaa),* Sexe (M ou F),Code Insee,Code postal,Nom de la commune,* Pays,"E-mail du destinataire des résultats (formateur, enseignant…)",E-mail de convocation,Identifiant local,Temps majoré ?,Tarification part Pix,Code de prépaiement,CléA Numérique ('oui' ou laisser vide),Pix+ Droit ('oui' ou laisser vide)
QSD$,,,,,,,toto1,tata,01/01/2000,M,75115,,,FRANCE,,,,,Gratuite,,,
```


- Constater l'erreur suivante 

![image](https://user-images.githubusercontent.com/37305474/228558385-c4e1c52b-0e3c-47da-b50e-6df3ac764182.png)



