### PR TITLE
[TECH] Supprime les imports de librairie externe dans ember-cli-build

### DIFF
--- a/orga/ember-cli-build.js
+++ b/orga/ember-cli-build.js
@@ -36,17 +36,6 @@ module.exports = function (defaults) {
   // modules that you would like to import into your application
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
-  app.import('node_modules/chart.js/dist/chart.js', {
-    using: [{ transformation: 'amd', as: 'chart.js' }],
-  });
-
-  app.import('node_modules/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.js', {
-    using: [{ transformation: 'amd', as: 'chartjs-adapter-date-fns.js' }],
-  });
-
-  app.import('node_modules/patternomaly/dist/patternomaly.js', {
-    using: [{ transformation: 'amd', as: 'patternomaly.js' }],
-  });
 
   return app.toTree();
 };


### PR DESCRIPTION
## :unicorn: Problème
On importe des librairies dans le ember-cli alors que ce n'est pas nécessaire, merci ember-auto-import.

## :robot: Proposition
Supprimer les imports.

## :rainbow: Remarques
Je me demande si ce n'a pas été nécessaire a un moment. Est-ce que ember-auto-import a été amélioré pour gérer ça ?

## :100: Pour tester
Ces librairies sont utilisés dans les graphs. Se connecter sur une campagne et voir les graphs avec les différents patterns et checker les traductions.
