### PR TITLE
[FEATURE] Préparation de la recommandation de contenu formatif - partie 5 (PIX-7591).

### DIFF
--- a/api/lib/domain/models/TrainingTrigger.js
+++ b/api/lib/domain/models/TrainingTrigger.js
@@ -4,7 +4,7 @@ const types = {
 };
 
 class TrainingTrigger {
-  constructor({ id, trainingId, triggerTubes, type, threshold, areas = [], competences = [], thematics = [] } = {}) {
+  constructor({ id, trainingId, triggerTubes, type, threshold } = {}) {
     this.id = id;
     this.trainingId = trainingId;
     if (!Object.values(types).includes(type)) {
@@ -12,46 +12,10 @@ class TrainingTrigger {
     }
     this.type = type;
     this.threshold = threshold;
-    this.tubesCount = triggerTubes.length;
-    this.areas = areas.map((area) => new _Area({ ...area, competences, thematics, triggerTubes }));
+    this.triggerTubes = triggerTubes;
   }
 }
 
 TrainingTrigger.types = types;
-
-class _Area {
-  constructor({ id, title, code, color, competences = [], thematics = [], triggerTubes = [] } = {}) {
-    this.id = id;
-    this.title = title;
-    this.code = code;
-    this.color = color;
-
-    this.competences = competences
-      .filter((competence) => competence.areaId === id)
-      .map((competence) => new _Competence({ ...competence, thematics, triggerTubes }));
-  }
-}
-
-class _Competence {
-  constructor({ id, name, index, thematics = [], triggerTubes = [] } = {}) {
-    this.id = id;
-    this.name = name;
-    this.index = index;
-
-    this.thematics = thematics
-      .filter((thematic) => thematic.competenceId === id)
-      .map((thematic) => new _Thematic({ ...thematic, triggerTubes }));
-  }
-}
-
-class _Thematic {
-  constructor({ id, name, index, triggerTubes = [] } = {}) {
-    this.id = id;
-    this.name = name;
-    this.index = index;
-
-    this.triggerTubes = triggerTubes.filter((trainingTriggerTube) => trainingTriggerTube.tube.thematicId === id);
-  }
-}
 
 module.exports = TrainingTrigger;

--- a/api/lib/domain/usecases/handle-training-recommendation.js
+++ b/api/lib/domain/usecases/handle-training-recommendation.js
@@ -9,7 +9,7 @@ module.exports = async function handleTrainingRecommendation({
     return;
   }
   const { campaignParticipationId } = assessment;
-  const trainings = await trainingRepository.findByCampaignParticipationIdAndLocale({
+  const trainings = await trainingRepository.findWithTriggersByCampaignParticipationIdAndLocale({
     campaignParticipationId,
     locale,
     domainTransaction,

--- a/api/lib/infrastructure/repositories/training-repository.js
+++ b/api/lib/infrastructure/repositories/training-repository.js
@@ -31,7 +31,7 @@ async function getWithTriggersForAdmin({ trainingId, domainTransaction = DomainT
 
   const targetProfileTrainings = await knexConn('target-profile-trainings').where('trainingId', trainingDTO.id);
 
-  const trainingTriggers = await trainingTriggerRepository.findByTrainingId({ trainingId, domainTransaction });
+  const trainingTriggers = await trainingTriggerRepository.findByTrainingIdForAdmin({ trainingId, domainTransaction });
 
   return _toDomainForAdmin({ training: trainingDTO, targetProfileTrainings, trainingTriggers });
 }

--- a/api/lib/infrastructure/repositories/training-repository.js
+++ b/api/lib/infrastructure/repositories/training-repository.js
@@ -65,7 +65,16 @@ async function findByCampaignParticipationIdAndLocale({
     trainingsDTO.map(({ id }) => id)
   );
 
-  return trainingsDTO.map((training) => _toDomain(training, targetProfileTrainings));
+  return Promise.all(
+    trainingsDTO.map(async (training) => {
+      const trainingTriggers = await trainingTriggerRepository.findByTrainingId({
+        trainingId: training.id,
+        domainTransaction,
+      });
+      training.trainingTriggers = trainingTriggers;
+      return _toDomain(training, targetProfileTrainings);
+    })
+  );
 }
 
 async function create({ training, domainTransaction = DomainTransaction.emptyTransaction() }) {

--- a/api/lib/infrastructure/repositories/training-repository.js
+++ b/api/lib/infrastructure/repositories/training-repository.js
@@ -45,7 +45,7 @@ async function findPaginatedSummaries({ page, domainTransaction = DomainTransact
   return { trainings, pagination };
 }
 
-async function findByCampaignParticipationIdAndLocale({
+async function findWithTriggersByCampaignParticipationIdAndLocale({
   campaignParticipationId,
   locale,
   domainTransaction = DomainTransaction.emptyTransaction(),
@@ -129,7 +129,7 @@ module.exports = {
   get,
   getWithTriggersForAdmin,
   findPaginatedSummaries,
-  findByCampaignParticipationIdAndLocale,
+  findWithTriggersByCampaignParticipationIdAndLocale,
   create,
   update,
   findPaginatedByUserId,

--- a/api/lib/infrastructure/repositories/training-trigger-repository.js
+++ b/api/lib/infrastructure/repositories/training-trigger-repository.js
@@ -71,7 +71,7 @@ async function _toDomainForAdmin({ trainingTrigger, triggerTubes }) {
   const tubes = await tubeRepository.findByRecordIds(triggerTubeIds);
 
   const tubeIds = tubes.map(({ id }) => id);
-  const notFoundTubeIds = triggerTubes.filter(({ tubeId }) => {
+  const notFoundTubeIds = triggerTubeIds.filter((tubeId) => {
     return !tubeIds.includes(tubeId);
   });
 

--- a/api/lib/infrastructure/repositories/training-trigger-repository.js
+++ b/api/lib/infrastructure/repositories/training-trigger-repository.js
@@ -40,10 +40,10 @@ module.exports = {
       .insert(trainingTriggerTubesToCreate)
       .returning('*');
 
-    return _toDomain({ trainingTrigger, triggerTubes: createdTrainingTriggerTubes });
+    return _toDomainForAdmin({ trainingTrigger, triggerTubes: createdTrainingTriggerTubes });
   },
 
-  async findByTrainingId({ trainingId, domainTransaction = DomainTransaction.emptyTransaction() }) {
+  async findByTrainingIdForAdmin({ trainingId, domainTransaction = DomainTransaction.emptyTransaction() }) {
     const knexConn = domainTransaction?.knexTransaction || knex;
     const trainingTriggers = await knexConn(TABLE_NAME).select('*').where({ trainingId }).orderBy('id', 'asc');
     if (!trainingTriggers) {
@@ -59,13 +59,13 @@ module.exports = {
         const triggerTubes = trainingTriggerTubes.filter(
           ({ trainingTriggerId }) => trainingTriggerId === trainingTrigger.id
         );
-        return await _toDomain({ trainingTrigger, triggerTubes });
+        return await _toDomainForAdmin({ trainingTrigger, triggerTubes });
       })
     );
   },
 };
 
-async function _toDomain({ trainingTrigger, triggerTubes }) {
+async function _toDomainForAdmin({ trainingTrigger, triggerTubes }) {
   const triggerTubeIds = triggerTubes.map(({ tubeId }) => tubeId);
 
   const tubes = await tubeRepository.findByRecordIds(triggerTubeIds);

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -200,7 +200,7 @@ describe('Integration | Repository | training-repository', function () {
     });
   });
 
-  describe('#findByCampaignParticipationIdAndLocale', function () {
+  describe('#findWithTriggersByCampaignParticipationIdAndLocale', function () {
     let area1;
     let competence1;
     let thematic1;
@@ -324,7 +324,7 @@ describe('Integration | Repository | training-repository', function () {
       await databaseBuilder.commit();
 
       // when
-      const trainings = await trainingRepository.findByCampaignParticipationIdAndLocale({
+      const trainings = await trainingRepository.findWithTriggersByCampaignParticipationIdAndLocale({
         campaignParticipationId: campaignParticipation.id,
         locale: 'fr-fr',
       });
@@ -368,7 +368,7 @@ describe('Integration | Repository | training-repository', function () {
       await databaseBuilder.commit();
 
       // when
-      const trainings = await trainingRepository.findByCampaignParticipationIdAndLocale({
+      const trainings = await trainingRepository.findWithTriggersByCampaignParticipationIdAndLocale({
         campaignParticipationId: campaignParticipation.id,
         locale: 'fr-fr',
       });
@@ -424,7 +424,7 @@ describe('Integration | Repository | training-repository', function () {
       await databaseBuilder.commit();
 
       // when
-      const trainings = await trainingRepository.findByCampaignParticipationIdAndLocale({
+      const trainings = await trainingRepository.findWithTriggersByCampaignParticipationIdAndLocale({
         campaignParticipationId: campaignParticipation.id,
         locale: 'fr-fr',
       });

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -6,6 +6,9 @@ const Training = require('../../../../lib/domain/models/Training');
 const UserRecommendedTraining = require('../../../../lib/domain/read-models/UserRecommendedTraining');
 const TrainingTriggerForAdmin = require('../../../../lib/domain/read-models/TrainingTriggerForAdmin');
 const TrainingForAdmin = require('../../../../lib/domain/read-models/TrainingForAdmin');
+const TrainingTrigger = require('../../../../lib/domain/models/TrainingTrigger');
+const TrainingTriggerTube = require('../../../../lib/domain/models/TrainingTriggerTube');
+const _ = require('lodash');
 
 describe('Integration | Repository | training-repository', function () {
   describe('#get', function () {
@@ -198,6 +201,62 @@ describe('Integration | Repository | training-repository', function () {
   });
 
   describe('#findByCampaignParticipationIdAndLocale', function () {
+    let area1;
+    let competence1;
+    let thematic1;
+    let tube;
+
+    beforeEach(async function () {
+      area1 = domainBuilder.buildArea({ id: 'recAreaA' });
+      competence1 = domainBuilder.buildCompetence({ id: 'recCompA', areaId: 'recAreaA' });
+      const competenceInAnotherArea = domainBuilder.buildCompetence({ id: 'recCompB', areaId: 'recAreaB' });
+      thematic1 = domainBuilder.buildThematic({
+        id: 'recThemA',
+        name: 'thematic1_name',
+        competenceId: 'recCompA',
+      });
+      const thematicInAnotherCompetence = domainBuilder.buildThematic({
+        id: 'recThemB',
+        name: 'thematic2_name',
+        competenceId: 'anotherCompetence',
+      });
+      tube = domainBuilder.buildTube({
+        id: 'recTube0',
+        name: 'tubeName',
+        title: 'tubeTitle',
+        description: 'tubeDescription',
+        practicalTitle: 'translatedPracticalTitle',
+        practicalDescription: 'translatedPracticalDescription',
+        isMobileCompliant: true,
+        isTabletCompliant: true,
+        competenceId: 'recCompetence0',
+        thematicId: 'recThemA',
+        skillIds: ['skillSuper', 'skillGenial'],
+        skills: [],
+      });
+      const learningContent = {
+        areas: [area1],
+        competences: [competence1, competenceInAnotherArea],
+        thematics: [
+          { id: thematic1.id, name_i18n: { fr: thematic1.name }, competenceId: thematic1.competenceId },
+          {
+            id: thematicInAnotherCompetence.id,
+            name_i18n: { fr: thematicInAnotherCompetence.name },
+            competenceId: thematicInAnotherCompetence.competenceId,
+          },
+        ],
+        tubes: [
+          {
+            id: tube.id,
+            name: tube.name,
+            thematicId: 'recThemA',
+            skillIds: ['skillSuper', 'skillGenial'],
+          },
+        ],
+      };
+      mockLearningContent(learningContent);
+    });
+
     it('should find trainings by campaignParticipationId and locale', async function () {
       // given
       const targetProfile1 = databaseBuilder.factory.buildTargetProfile();
@@ -213,24 +272,28 @@ describe('Integration | Repository | training-repository', function () {
         title: 'training 1',
         targetProfileIds: [targetProfile1.id],
         locale: 'fr-fr',
+        trainingTriggers: [],
       });
       const training2 = domainBuilder.buildTraining({
         id: 2,
         title: 'training 2',
         targetProfileIds: [targetProfile1.id],
         locale: 'fr-fr',
+        trainingTriggers: [],
       });
       const trainingWithDifferentLocale = domainBuilder.buildTraining({
         id: 3,
         title: 'training 3',
         targetProfileIds: [targetProfile1.id],
         locale: 'en-gb',
+        trainingTriggers: [],
       });
       const trainingWithDifferentTargetProfile = domainBuilder.buildTraining({
         id: 4,
         title: 'training 4',
         targetProfileIds: [targetProfile2.id],
         locale: 'fr-fr',
+        trainingTriggers: [],
       });
 
       databaseBuilder.factory.buildTraining({ ...training1, duration: '5h' });
@@ -270,6 +333,68 @@ describe('Integration | Repository | training-repository', function () {
       expect(trainings).to.have.lengthOf(2);
       expect(trainings[0]).to.be.instanceOf(Training);
       expect(trainings[0]).to.deep.equal(training1);
+    });
+
+    it('should return trainings with trainingTriggers', async function () {
+      // given
+      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+      const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id });
+      const training = domainBuilder.buildTraining({
+        id: 1,
+        title: 'training 1',
+        targetProfileIds: [targetProfile.id],
+        locale: 'fr-fr',
+      });
+
+      const goalTrainingTrigger = {
+        trainingId: training.id,
+        type: TrainingTrigger.types.GOAL,
+        threshold: 80,
+      };
+
+      databaseBuilder.factory.buildTraining({ ...training, duration: '5h' });
+      databaseBuilder.factory.buildTargetProfileTraining({
+        trainingId: training.id,
+        targetProfileId: training.targetProfileIds[0],
+      });
+
+      const expectedGoalTrainingTrigger = databaseBuilder.factory.buildTrainingTrigger(goalTrainingTrigger);
+      const expectedGoalTube = databaseBuilder.factory.buildTrainingTriggerTube({
+        trainingTriggerId: expectedGoalTrainingTrigger.id,
+        tubeId: tube.id,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const trainings = await trainingRepository.findByCampaignParticipationIdAndLocale({
+        campaignParticipationId: campaignParticipation.id,
+        locale: 'fr-fr',
+      });
+
+      // then
+      expect(trainings).to.have.lengthOf(1);
+      expect(trainings[0]).to.be.instanceOf(Training);
+      expect(_.omit(trainings[0], 'trainingTriggers')).to.deep.equal(_.omit(training, 'trainingTriggers'));
+
+      expect(trainings[0].trainingTriggers).to.have.lengthOf(1);
+
+      const trainingTrigger0 = trainings[0].trainingTriggers[0];
+      expect(trainingTrigger0).to.be.instanceOf(TrainingTrigger);
+      expect(_.omit(trainingTrigger0, 'triggerTubes')).to.deep.equal(
+        _.omit(
+          new TrainingTrigger({
+            ...expectedGoalTrainingTrigger,
+          }),
+          'triggerTubes'
+        )
+      );
+      expect(trainingTrigger0.triggerTubes).to.have.lengthOf(1);
+      expect(trainingTrigger0.triggerTubes[0]).to.be.instanceOf(TrainingTriggerTube);
+      expect(trainingTrigger0.triggerTubes[0].id).to.equal(expectedGoalTube.id);
+      expect(trainingTrigger0.triggerTubes[0].tube.id).to.equal(expectedGoalTube.tubeId);
+      expect(trainingTrigger0.triggerTubes[0].level).to.equal(expectedGoalTube.level);
     });
 
     it('should return an empty array when campaign has target-profile not linked to training', async function () {

--- a/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
@@ -287,7 +287,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
     });
   });
 
-  describe('#findByTrainingId', function () {
+  describe('#findByTrainingIdForAdmin', function () {
     it('should return the training trigger', async function () {
       // given
       const trainingId = databaseBuilder.factory.buildTraining().id;
@@ -307,7 +307,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
       await databaseBuilder.commit();
 
       // when
-      const result = await trainingTriggerRepository.findByTrainingId({ trainingId });
+      const result = await trainingTriggerRepository.findByTrainingIdForAdmin({ trainingId });
 
       // then
       expect(result).to.have.lengthOf(2);
@@ -368,7 +368,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
         await databaseBuilder.commit();
 
         // when
-        const error = await catchErr(trainingTriggerRepository.findByTrainingId)({ trainingId });
+        const error = await catchErr(trainingTriggerRepository.findByTrainingIdForAdmin)({ trainingId });
 
         // then
         expect(error).to.be.instanceOf(NotFoundError);
@@ -380,7 +380,7 @@ describe('Integration | Repository | training-trigger-repository', function () {
       const trainingId = 123;
 
       // when
-      const result = await trainingTriggerRepository.findByTrainingId({ trainingId });
+      const result = await trainingTriggerRepository.findByTrainingIdForAdmin({ trainingId });
 
       // then
       expect(result).to.be.empty;

--- a/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-trigger-repository_test.js
@@ -372,6 +372,9 @@ describe('Integration | Repository | training-trigger-repository', function () {
 
         // then
         expect(error).to.be.instanceOf(NotFoundError);
+        expect(error.message).to.be.equal(
+          `Les sujets [notExistTubeId] du déclencheur ${trainingTrigger.id} n'existent pas dans le référentiel.`
+        );
       });
     });
 

--- a/api/tests/unit/domain/models/TrainingTrigger_test.js
+++ b/api/tests/unit/domain/models/TrainingTrigger_test.js
@@ -25,7 +25,6 @@ describe('Unit | Domain | Models | TrainingTrigger', function () {
         type: TrainingTrigger.types.GOAL,
         trainingId: 100,
         threshold: 10,
-        areas: [],
       });
 
       // then
@@ -33,81 +32,6 @@ describe('Unit | Domain | Models | TrainingTrigger', function () {
       expect(trainingTrigger.type).to.equal('goal');
       expect(trainingTrigger.trainingId).to.equal(100);
       expect(trainingTrigger.threshold).to.equal(10);
-      expect(trainingTrigger.areas).to.deep.equal([]);
-      expect(trainingTrigger.tubesCount).to.equal(1);
-    });
-
-    it('should build learning content tree from parameters', function () {
-      // given
-      const area1 = domainBuilder.buildArea({ id: 'recArea1' });
-      const competence1 = domainBuilder.buildCompetence({ id: 'recCompetence1', areaId: 'recArea1' });
-      const competence2InAnotherArea = domainBuilder.buildCompetence({ id: 'recCompetence2', areaId: 'recArea2' });
-      const thematic1 = domainBuilder.buildThematic({ id: 'recThematic1', competenceId: 'recCompetence1' });
-      const thematic2 = domainBuilder.buildThematic({ id: 'recThematic2', competenceId: 'recCompetence1' });
-      const thematic3InAnotherCompetence = domainBuilder.buildThematic({
-        id: 'recThematic3',
-        competenceId: 'recCompetence2',
-      });
-      const tube1 = domainBuilder.buildTube({
-        id: 'recTube1',
-        thematicId: thematic1.id,
-      });
-      const tube2 = domainBuilder.buildTube({
-        id: 'recTube2',
-        thematicId: thematic2.id,
-      });
-      const tube3InAnotherThematic = domainBuilder.buildTube({
-        id: 'recTube3',
-        thematicId: thematic3InAnotherCompetence.id,
-      });
-      const trainingTriggerTube1 = domainBuilder.buildTrainingTriggerTube({
-        id: 'recTrainingTriggerTube1',
-        tube: tube1,
-      });
-      const trainingTriggerTube2 = domainBuilder.buildTrainingTriggerTube({
-        id: 'recTrainingTriggerTube2',
-        tube: tube2,
-      });
-      const trainingTriggerTube3 = domainBuilder.buildTrainingTriggerTube({
-        id: 'recTrainingTriggerTube3',
-        tube: tube3InAnotherThematic,
-      });
-
-      const trainingTrigger = domainBuilder.buildTrainingTrigger({
-        type: TrainingTrigger.types.PREREQUISITE,
-        areas: [area1],
-        competences: [competence1, competence2InAnotherArea],
-        thematics: [thematic1, thematic2, thematic3InAnotherCompetence],
-        triggerTubes: [trainingTriggerTube1, trainingTriggerTube2, trainingTriggerTube3],
-      });
-
-      // then
-      expect(trainingTrigger.areas).to.have.length(1);
-      expect(trainingTrigger.areas[0]).to.have.property('id', area1.id);
-      expect(trainingTrigger.areas[0]).to.have.property('title', area1.title);
-      expect(trainingTrigger.areas[0]).to.have.property('code', area1.code);
-      expect(trainingTrigger.areas[0]).to.have.property('color', area1.color);
-      expect(trainingTrigger.areas[0].competences).to.have.length(1);
-      expect(trainingTrigger.areas[0].competences[0]).to.have.property('id', competence1.id);
-      expect(trainingTrigger.areas[0].competences[0]).to.have.property('name', competence1.name);
-      expect(trainingTrigger.areas[0].competences[0]).to.have.property('index', competence1.index);
-      expect(trainingTrigger.areas[0].competences[0].thematics).to.have.length(2);
-      expect(trainingTrigger.areas[0].competences[0].thematics[0]).to.have.property('id', thematic1.id);
-      expect(trainingTrigger.areas[0].competences[0].thematics[0]).to.have.property('name', thematic1.name);
-      expect(trainingTrigger.areas[0].competences[0].thematics[0]).to.have.property('index', thematic1.index);
-      expect(trainingTrigger.areas[0].competences[0].thematics[0].triggerTubes).to.have.length(1);
-      expect(trainingTrigger.areas[0].competences[0].thematics[0].triggerTubes[0]).to.have.property(
-        'id',
-        trainingTriggerTube1.id
-      );
-      expect(trainingTrigger.areas[0].competences[0].thematics[1]).to.have.property('id', thematic2.id);
-      expect(trainingTrigger.areas[0].competences[0].thematics[1]).to.have.property('name', thematic2.name);
-      expect(trainingTrigger.areas[0].competences[0].thematics[1]).to.have.property('index', thematic2.index);
-      expect(trainingTrigger.areas[0].competences[0].thematics[1].triggerTubes).to.have.length(1);
-      expect(trainingTrigger.areas[0].competences[0].thematics[1].triggerTubes[0]).to.have.property(
-        'id',
-        trainingTriggerTube2.id
-      );
     });
   });
 });

--- a/api/tests/unit/domain/usecases/handle-training-recommendation_test.js
+++ b/api/tests/unit/domain/usecases/handle-training-recommendation_test.js
@@ -4,13 +4,13 @@ const userRecommendedTrainingRepository = require('../../../../lib/infrastructur
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 
 describe('Unit | UseCase | handle-training-recommendation', function () {
-  let findByCampaignParticipationIdAndLocaleStub;
+  let findWithTriggersByCampaignParticipationIdAndLocaleStub;
   let saveStub;
 
   beforeEach(function () {
-    findByCampaignParticipationIdAndLocaleStub = sinon.stub(
+    findWithTriggersByCampaignParticipationIdAndLocaleStub = sinon.stub(
       trainingRepository,
-      'findByCampaignParticipationIdAndLocale'
+      'findWithTriggersByCampaignParticipationIdAndLocale'
     );
     saveStub = sinon.stub(userRecommendedTrainingRepository, 'save').resolves();
   });
@@ -24,7 +24,7 @@ describe('Unit | UseCase | handle-training-recommendation', function () {
         const domainTransaction = Symbol('domain-transaction');
         const assessment = domainBuilder.buildAssessment.ofTypeCampaign({ campaignParticipationId });
         const trainings = [domainBuilder.buildTraining(), domainBuilder.buildTraining()];
-        findByCampaignParticipationIdAndLocaleStub.resolves(trainings);
+        findWithTriggersByCampaignParticipationIdAndLocaleStub.resolves(trainings);
 
         // when
         await handleTrainingRecommendation({
@@ -36,7 +36,7 @@ describe('Unit | UseCase | handle-training-recommendation', function () {
         });
 
         // then
-        expect(findByCampaignParticipationIdAndLocaleStub).to.have.been.calledWith({
+        expect(findWithTriggersByCampaignParticipationIdAndLocaleStub).to.have.been.calledWith({
           campaignParticipationId,
           locale,
           domainTransaction,
@@ -66,7 +66,7 @@ describe('Unit | UseCase | handle-training-recommendation', function () {
         const assessment = domainBuilder.buildAssessment.ofTypeCampaign({ campaignParticipationId });
         const trainings = [];
 
-        findByCampaignParticipationIdAndLocaleStub.resolves(trainings);
+        findWithTriggersByCampaignParticipationIdAndLocaleStub.resolves(trainings);
 
         // when
         await handleTrainingRecommendation({
@@ -78,7 +78,7 @@ describe('Unit | UseCase | handle-training-recommendation', function () {
         });
 
         // then
-        expect(findByCampaignParticipationIdAndLocaleStub).to.have.been.calledWith({
+        expect(findWithTriggersByCampaignParticipationIdAndLocaleStub).to.have.been.calledWith({
           campaignParticipationId,
           locale,
           domainTransaction,
@@ -99,7 +99,7 @@ describe('Unit | UseCase | handle-training-recommendation', function () {
       });
 
       // then
-      expect(findByCampaignParticipationIdAndLocaleStub).to.have.not.been.called;
+      expect(findWithTriggersByCampaignParticipationIdAndLocaleStub).to.have.not.been.called;
       expect(saveStub).to.have.not.been.called;
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, la recommandation de contenu formatif n'est pour l'instant pas intelligente. En effet, nous recommandons juste les CF liés au profil cible de la campagne, ce qui n'apporte pas de valeurs à l'utilisateur car il ne sait pas ce qui est pertinent pour lui.

## :robot: Proposition
Faire un algorithme de recommandation basé sur les déclencheurs que nous avons déjà implémenté. 

**Cette PR a pour but de retourner les déclencheurs lorsqu'on récupère les CF.**

## :rainbow: Remarques
Cette PR n'est pas testable manuellement. Il s'agit d'une première brique technique pour l'algo

- Nous en avons profité pour corriger le message d'erreur lorsqu'un tube présent dans un déclencheur n'est plus dans le référentiel.

- Nous avons ajouté uniquement un `log.warn()` dans le cas de la recommandation contrairement au cas où on cherche les triggers pour Pix Admin.


## :100: Pour tester
CI OK