### PR TITLE
[FEATURE] Utiliser le cookie locale pour transmettre la locale lors de l'inscription (PIX-7564)

### DIFF
--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -23,11 +23,14 @@ const queryParamsUtils = require('../../infrastructure/utils/query-params-utils.
 const requestResponseUtils = require('../../infrastructure/utils/request-response-utils.js');
 
 const usecases = require('../../domain/usecases/index.js');
+const localeService = require('../../domain/services/locale-service.js');
 
 module.exports = {
   async save(request, h) {
+    const localeFromCookie = request.state?.locale;
+    const canonicalLocaleFromCookie = localeFromCookie ? localeService.getCanonicalLocale(localeFromCookie) : undefined;
     const campaignCode = request.payload.meta ? request.payload.meta['campaign-code'] : null;
-    const user = userSerializer.deserialize(request.payload);
+    const user = { ...userSerializer.deserialize(request.payload), locale: canonicalLocaleFromCookie };
     const localeFromHeader = requestResponseUtils.extractLocaleFromRequest(request);
 
     const password = request.payload.data.attributes.password;

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -102,6 +102,43 @@ describe('Acceptance | Controller | users-controller', function () {
       });
     });
 
+    context('when a "locale" cookie is present', function () {
+      it('creates a user with a locale in database', async function () {
+        // given
+        const localeFromCookie = 'fr';
+        const userAttributes = {
+          'first-name': 'John',
+          'last-name': 'DoDoe',
+          email: 'john.dodoe@example.net',
+          cgu: true,
+          password: 'Password123',
+        };
+
+        const options = {
+          method: 'POST',
+          url: '/api/users',
+          headers: {
+            cookie: `locale=${localeFromCookie}`,
+          },
+          payload: {
+            data: {
+              type: 'users',
+              attributes: userAttributes,
+              relationships: {},
+            },
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        const createdUser = await userRepository.getByUsernameOrEmailWithRolesAndPassword(userAttributes.email);
+        expect(createdUser.locale).to.equal(localeFromCookie);
+        expect(response.statusCode).to.equal(201);
+      });
+    });
+
     context('user is invalid', function () {
       const validUserAttributes = {
         'first-name': 'John',

--- a/api/tests/integration/application/users/user-controller_test.js
+++ b/api/tests/integration/application/users/user-controller_test.js
@@ -32,11 +32,10 @@ describe('Integration | Application | Users | user-controller', function () {
     const auth = { credentials: {}, strategy: {} };
 
     context('Success cases', function () {
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      const campaignParticipation = domainBuilder.buildCampaignParticipation();
+      let campaignParticipation;
 
       beforeEach(function () {
+        campaignParticipation = domainBuilder.buildCampaignParticipation();
         securityPreHandlers.checkRequestedUserIsAuthenticatedUser.returns(true);
         auth.credentials.userId = '1234';
       });

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -37,6 +37,7 @@ describe('Unit | Controller | user-controller', function () {
     const deserializedUser = new User();
     const savedUser = new User({ email });
     const localeFromHeader = 'fr-fr';
+    let createUserUsecaseStub;
 
     beforeEach(function () {
       sinon.stub(userSerializer, 'deserialize').returns(deserializedUser);
@@ -44,68 +45,86 @@ describe('Unit | Controller | user-controller', function () {
       sinon.stub(validationErrorSerializer, 'serialize');
       sinon.stub(encryptionService, 'hashPassword');
       sinon.stub(mailService, 'sendAccountCreationEmail');
-      sinon.stub(usecases, 'createUser').resolves(savedUser);
+      createUserUsecaseStub = sinon.stub(usecases, 'createUser');
+      createUserUsecaseStub.resolves(savedUser);
     });
 
     describe('when request is valid', function () {
-      it('should return a serialized user and a 201 status code', async function () {
-        // given
-        const expectedSerializedUser = { message: 'serialized user' };
-        userSerializer.serialize.returns(expectedSerializedUser);
+      describe('when there is no locale cookie', function () {
+        it('should return a serialized user and a 201 status code', async function () {
+          // given
+          const expectedSerializedUser = { message: 'serialized user' };
+          userSerializer.serialize.returns(expectedSerializedUser);
 
-        // when
-        const response = await userController.save(
-          {
-            payload: {
-              data: {
-                attributes: {
-                  'first-name': 'John',
-                  'last-name': 'DoDoe',
-                  email: 'john.dodoe@example.net',
-                  cgu: true,
-                  password,
+          // when
+          const response = await userController.save(
+            {
+              payload: {
+                data: {
+                  attributes: {
+                    'first-name': 'John',
+                    'last-name': 'DoDoe',
+                    email: 'john.dodoe@example.net',
+                    cgu: true,
+                    password,
+                  },
                 },
               },
             },
-          },
-          hFake
-        );
+            hFake
+          );
 
-        // then
-        expect(userSerializer.serialize).to.have.been.calledWith(savedUser);
-        expect(response.source).to.deep.equal(expectedSerializedUser);
-        expect(response.statusCode).to.equal(201);
+          // then
+          expect(userSerializer.serialize).to.have.been.calledWith(savedUser);
+          expect(response.source).to.deep.equal(expectedSerializedUser);
+          expect(response.statusCode).to.equal(201);
+        });
       });
 
-      it('should call the user creation usecase', async function () {
-        // given
-        const useCaseParameters = {
-          user: deserializedUser,
-          password,
-          localeFromHeader,
-          campaignCode: null,
-        };
+      describe('when there is a locale cookie', function () {
+        it('should return a serialized user with "locale" attribute and a 201 status code', async function () {
+          // given
+          const localeFromCookie = 'fr-FR';
+          const expectedSerializedUser = { message: 'serialized user', locale: localeFromCookie };
+          const savedUser = new User({ email, locale: localeFromCookie });
 
-        // when
-        await userController.save(
-          {
-            payload: {
-              data: {
-                attributes: {
-                  'first-name': 'John',
-                  'last-name': 'DoDoe',
-                  email: 'john.dodoe@example.net',
-                  cgu: true,
-                  password,
+          const useCaseParameters = {
+            user: { ...deserializedUser, locale: localeFromCookie },
+            password,
+            localeFromHeader,
+            campaignCode: null,
+          };
+
+          userSerializer.serialize.returns(expectedSerializedUser);
+          createUserUsecaseStub.resolves(savedUser);
+
+          // when
+          const response = await userController.save(
+            {
+              payload: {
+                data: {
+                  attributes: {
+                    'first-name': 'John',
+                    'last-name': 'DoDoe',
+                    email: 'john.dodoe@example.net',
+                    cgu: true,
+                    password,
+                  },
                 },
               },
+              state: {
+                locale: localeFromCookie,
+              },
             },
-          },
-          hFake
-        );
+            hFake
+          );
 
-        // then
-        expect(usecases.createUser).to.have.been.calledWith(useCaseParameters);
+          // then
+          expect(usecases.createUser).to.have.been.calledWith(useCaseParameters);
+          expect(userSerializer.serialize).to.have.been.calledWith(savedUser);
+          expect(response.source).to.deep.equal(expectedSerializedUser);
+          expect(response.statusCode).to.equal(201);
+        });
       });
     });
   });

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -13,9 +13,6 @@ const ERROR_INPUT_MESSAGE_MAP = {
   email: 'pages.sign-up.fields.email.error',
   password: 'pages.sign-up.fields.password.error',
 };
-const FRENCH_DOMAIN_TLD = 'fr';
-const INTERNATIONAL_DOMAIN_TLD = 'org';
-const FRENCH_LOCALE = 'fr-FR';
 
 class LastName {
   @tracked status = 'default';
@@ -154,7 +151,6 @@ export default class SignupForm extends Component {
 
     this._trimNamesAndEmailOfUser();
     this.args.user.lang = this.intl.t('current-lang');
-    this.args.user.locale = this._getLocaleFromCookieOrDomain();
 
     const campaignCode = get(this.session, 'attemptedTransition.from.parent.params.code');
 
@@ -207,25 +203,5 @@ export default class SignupForm extends Component {
       default: ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY,
     };
     return this.intl.t(httpStatusCodeMessages[statusCode] || httpStatusCodeMessages['default']);
-  }
-
-  _getLocaleFromCookieOrDomain() {
-    const currentDomainExtension = this.currentDomain.getExtension();
-    const cookieLocale = this.cookies.read('locale');
-    const currentLocale = this.intl.get('locale')[0];
-
-    if (currentDomainExtension === INTERNATIONAL_DOMAIN_TLD) {
-      if (cookieLocale) {
-        return cookieLocale;
-      }
-
-      return currentLocale;
-    }
-
-    if (currentDomainExtension === FRENCH_DOMAIN_TLD) {
-      return FRENCH_LOCALE;
-    }
-
-    return currentLocale;
   }
 }

--- a/mon-pix/tests/unit/components/signup-form_test.js
+++ b/mon-pix/tests/unit/components/signup-form_test.js
@@ -66,69 +66,6 @@ module('Unit | Component | signup-form', function (hooks) {
       assert.deepEqual(pick(user, ['firstName', 'lastName', 'email']), expectedUser);
     });
 
-    module('on international domain', function () {
-      test('saves user locale from the pix-site cookie', function (assert) {
-        // given
-        const user = EmberObject.create({
-          firstName: 'Carry',
-          lastName: 'Bout',
-          email: 'carry.bout@example.net',
-          password: 'Pix123',
-          save: sinon.stub().resolves(),
-        });
-        component.args.user = user;
-        component.currentDomain.getExtension.returns('org');
-        component.cookies.read.returns('fr-CA');
-
-        // when
-        component.signup();
-
-        // then
-        assert.deepEqual(pick(user, ['locale']), { locale: 'fr-CA' });
-      });
-
-      test('saves user locale retrieved from the i18n service when there is no cookie', function (assert) {
-        // given
-        const user = EmberObject.create({
-          firstName: 'Carry',
-          lastName: 'Bout',
-          email: 'carry.bout@example.net',
-          password: 'Pix123',
-          save: sinon.stub().resolves(),
-        });
-        component.args.user = user;
-        component.currentDomain.getExtension.returns('org');
-        component.intl.get.returns(['de']);
-
-        // when
-        component.signup();
-
-        // then
-        assert.deepEqual(pick(user, ['locale']), { locale: 'de' });
-      });
-    });
-
-    module('on french domain', function () {
-      test('saves user locale with french locale as default', function (assert) {
-        // given
-        const user = EmberObject.create({
-          firstName: 'Carry',
-          lastName: 'Bout',
-          email: 'carry.bout@example.net',
-          password: 'Pix123',
-          save: sinon.stub().resolves(),
-        });
-        component.args.user = user;
-        component.currentDomain.getExtension.returns('fr');
-
-        // when
-        component.signup();
-
-        // then
-        assert.deepEqual(pick(user, ['locale']), { locale: 'fr-FR' });
-      });
-    });
-
     test('should authenticate user after sign up', async function (assert) {
       const userWithSpaces = EmberObject.create({
         firstName: '  Chris  ',


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, nous utilisons le cookie locale pour transmettre la locale du front au back SAUF lors de l’inscription classique (sans passer par un SSO) où la locale est transmise via le user dans le payload.

## :robot: Proposition
Pour être cohérent, utiliser le cookie locale dans tous les cas ce qui permettra aussi de simplifier le code côté front.

## :rainbow: Remarques
RAS

## :100: Pour tester
### Test domaine (.org)
#### Test avec un cookie locale
- Aller sur le site https://pix.org/
- Choisir une locale dans la liste (ex: Fédération Wallonie-Bruxelles)
- Aller sur la page d'inscription de la review-app https://app-pr5908.review.pix.org/inscription
- S'inscrire et ouvrir la console développeur -> réseau
- Cliquer sur je me connecte, vérifier dans l'appel `/api/users` que : 
   -  le body de la requête passée contient un champ locale à `null`
   - le cookie locale est bien transmis dans les headers de la requête
- Vérifier en base que l'utilisateur inscris a bien comme locale celle sélectionnée (ex: fr-BE)

#### Test sans cookie locale
- Aller sur la page d'inscription de la review-app https://app-pr5908.review.pix.org/inscription
- Supprimer le cookie locale dans la console développeur -> Appli -> cookies
- S'inscrire et aller sur l'onglet réseau de la console
- Cliquer sur je me connecte, vérifier dans l'appel` /api/users` que : 
   -  le body de la requête passée contient un champ locale à `null`
   - le cookie locale n'est pas transmis dans les headers de la requête
- Vérifier en base que l'utilisateur inscris n'a pas de locale.

### Test domaine (.fr)
- Aller sur la page d'inscription de la review-app (.fr) https://app-pr5908.review.pix.fr/
- Vérifier dans la console développeur -> Appli -> cookies, que vous avez bien un cookie locale avec une valeur` fr-FR`
- S'inscrire et aller sur l'onglet réseau de la console
- Cliquer sur je me connecte, vérifier dans l'appel` /api/users` que : 
   -  le body de la requête passée contient un champ locale à `null`
   - le cookie locale est transmis dans les headers de la requête avec une valeur `fr-FR`
- Vérifier en base que l'utilisateur inscris a une locale `fr-FR`