### PR TITLE
[TECH] Création d'un feature toggle pour la recommandation des contenus formatifs (PIX-7537)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -214,6 +214,7 @@ const configuration = (function () {
       isAlwaysOkValidateNextChallengeEndpointEnabled: isFeatureEnabled(
         process.env.FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT
       ),
+      isTrainingRecommendationEnabled: isFeatureEnabled(process.env.FT_TRAINING_RECOMMENDATION),
     },
 
     infra: {
@@ -349,6 +350,7 @@ const configuration = (function () {
 
     config.featureToggles.isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled = false;
     config.featureToggles.isMassiveSessionManagementEnabled = false;
+    config.featureToggles.isTrainingRecommendationEnabled = false;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'sendinblue';

--- a/api/lib/domain/usecases/handle-training-recommendation.js
+++ b/api/lib/domain/usecases/handle-training-recommendation.js
@@ -1,3 +1,5 @@
+const config = require('../../config');
+
 module.exports = async function handleTrainingRecommendation({
   locale,
   assessment,
@@ -14,12 +16,17 @@ module.exports = async function handleTrainingRecommendation({
     locale,
     domainTransaction,
   });
-  for (const training of trainings) {
-    await userRecommendedTrainingRepository.save({
-      userId: assessment.userId,
-      trainingId: training.id,
-      campaignParticipationId,
-      domainTransaction,
-    });
+
+  if (config.featureToggles.isTrainingRecommendationEnabled) {
+    return;
+  } else {
+    for (const training of trainings) {
+      await userRecommendedTrainingRepository.save({
+        userId: assessment.userId,
+        trainingId: training.id,
+        campaignParticipationId,
+        domainTransaction,
+      });
+    }
   }
 };

--- a/api/sample.env
+++ b/api/sample.env
@@ -819,6 +819,13 @@ TEST_REDIS_URL=redis://localhost:6379
 # default: false
 # FT_ALWAYS_OK_VALIDATE_NEXT_CHALLENGE_ENDPOINT=false
 
+# Enable the training recommendation feature
+#
+# presence: optional
+# type: boolean
+# default: false
+FT_TRAINING_RECOMMENDATION=false
+
 # =====
 # CPF
 # =====

--- a/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggles/feature-toggle-controller_tests.js
@@ -25,6 +25,7 @@ describe('Acceptance | Controller | feature-toggle-controller', function () {
             'is-always-ok-validate-next-challenge-endpoint-enabled': false,
             'is-clea-results-retrieval-by-habilitated-certification-centers-enabled': false,
             'is-massive-session-management-enabled': false,
+            'is-training-recommendation-enabled': false,
           },
         },
       };


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la mise en place de la recommandation de contenus formatifs, on souhaite effectuer une bascule entre l'ancienne logique de recommandation et la nouvelle quand les déveoppements seront terminés. Pour le moment on souhaite continuer à utiliser l'ancienne méthode, tout en avançant les développements pour la nouvelle.

## :robot: Proposition
Mettre en place un feature toggle afin de conserver l'ancienne logique, et pouvoir mettre en place la nouvelle (faire tourner les tests d'acceptance entre autres).

## :rainbow: Remarques
Il faudra créer le feature toggle sur l'environnement de prod

## :100: Pour tester
- se connecter à pix app
- passer la campagne PIXEDUINI (en .fr)
- aller jusqu'à la fin de parcours
- constater que des formations nous sont suggérées en fin de parcours