### PR TITLE
[TECH] N'avoir que le scroll du navigateur à l'affichage sur Pix Orga (PIX-7618)

### DIFF
--- a/orga/app/components/banner/communication.hbs
+++ b/orga/app/components/banner/communication.hbs
@@ -1,5 +1,5 @@
 {{#if this.isEnabled}}
-  <PixBanner @type={{this.bannerType}}>
+  <PixBanner @type={{this.bannerType}} class="sticker-banner">
     {{text-with-multiple-lang this.bannerContent}}
   </PixBanner>
 {{/if}}

--- a/orga/app/styles/components/layout/footer.scss
+++ b/orga/app/styles/components/layout/footer.scss
@@ -5,6 +5,7 @@
   justify-content: space-between;
   flex-shrink: 0;
   margin: 0 $spacing-m;
+  margin-top: 100px;
   border-top: 1px solid $pix-neutral-20;
 
   @include device-is('desktop') {

--- a/orga/app/styles/components/layout/sidebar.scss
+++ b/orga/app/styles/components/layout/sidebar.scss
@@ -1,9 +1,10 @@
 .sidebar {
-  display: flex;
-  flex-direction: column;
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
+  height: 100vh;
   width: $app-sidebar-width;
   min-width: 100px;
-  height: 100%;
   background-color: $dark-blue-orga;
 
   &__logo {
@@ -66,5 +67,7 @@
 @include device-is('mobile') {
   .sidebar {
     width: 100%;
+    height: auto;
+    position: relative;
   }
 }

--- a/orga/app/styles/pages/authenticated.scss
+++ b/orga/app/styles/pages/authenticated.scss
@@ -1,18 +1,24 @@
 .app {
   display: flex;
-  height: 100%;
+  align-items: stretch;
+  min-height: 100vh;
 }
 
 .main-content {
-  display: flex;
-  flex-direction: column;
   width: 100%;
   background-color: $pix-neutral-10;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
 
   &__body {
     flex: 1 0 auto;
   }
+}
+
+.sticker-banner {
+  position: sticky;
+  top: 0;
+  z-index: 200;
 }
 
 @include device-is('mobile') {


### PR DESCRIPTION
## :unicorn: Problème
Historiquement le scroll n'était pas posé sur le navigateur, lors d'un zoom navigateur/texte, il était possible de voir un 2nd scroll s'afficher

## :robot: Proposition
Retirer ce scroll afin de n'avoir que celui du navigateur

## :rainbow: Remarques
RAS

## :100: Pour tester
Faire un tour sur Pix Orga, zoom classique / zoom texte et vérifier que c'est vachement mieux qu'avant