### PR TITLE
[TECH] Améliorer l'accessibilité de la page des cgu sur Pix Certif (PIX-7621).

### DIFF
--- a/certif/app/components/terms-of-service/page-en.hbs
+++ b/certif/app/components/terms-of-service/page-en.hbs
@@ -1,592 +1,586 @@
-<div class="terms-of-service-form__text">
-
-  <h2 class="pix-h3">Article 1. Preamble</h2>
-
-  <p>
-    The Pix “Groupement d’Intérêt Public” (French public interest group or “GIP”) approved by the decree of 27 April
-    2017 giving approval of the agreement establishing the public interest group ‘Pix’, initially developed the Pix
-    platform within the framework of a public project in partnership with the French Ministry of Education and Ministry
-    of Higher Education, Research and Innovation, and continue its development with the GIP actual members and partners.
-  </p>
-  <p>
-    The Pix platform is an online platform for assessing and certifying digital skills. Its aim is to help raise the
-    general level of digital knowledge and skills and thus help prepare the digital transformation of society and the
-    economy. It is based on the European DigComp reference framework, which defines digital skills on eight (8) levels
-    and in five (5) competence areas:
-  </p>
-  <ul>
-    <li>Information and data;</li>
-    <li>Communication and collaboration;</li>
-    <li>Content creation;</li>
-    <li>Protection and security;</li>
-    <li>Environment and digital technology.</li>
-  </ul>
-  <p>
-    Users registered on the platform can take a certification exam of their skills at a centre approved by the GIP Pix.
-  </p>
-  <p>
-    The GIP Pix makes available to centres and their referents or authorised members (hereinafter the « users »), the
-    Pix Certif service accessible in Saas mode, for the purpose of organising certification examination sessions, in
-    particularly management of registrations and editing of the documentation necessary for their implantation.
-  </p>
-
-  <h2 class="pix-h3">Article 2. Definitions</h2>
-
-  <ul>
-    <li>
-      ‘centre’: refers to the legal person benefiting from this quality by the effect of the law or a regulation, or
-      from a valid approval under a contract with the GIP Pix as a Pix Certification Centre, and having authorised the
-      user to use the Pix Certif services;
-    </li>
-  </ul>
-  <ul>
-    <li>
-      ’certification’: refers to the certification of digital skills defined by the decree of April 27, 2017, approving
-      the constituent agreement of the public interest group Pix, as well as by the regulations in force and to come go
-      through candidates registered with the centre in part of a certification session organised by the centre;
-    </li>
-  </ul>
-  <ul>
-    <li>
-      ‘terms and conditions’: refers to these terms and conditions for the use of the Pix Certif platform;
-    </li>
-  </ul>
-  <ul>
-    <li>
-      ‘data’: all the information of any kind provided by the organisation and/or the users under their full
-      responsibility, hosted by the Pix GIP and intended to be processed with the framework of service implementation;
-    </li>
-  </ul>
-  <ul>
-    <li>
-      ‘login credentials’: login and password entered by a user in a personal and confidential way when creating a user
-      account, enabling access to the services from a secure connection to the Pix Certif platform;
-    </li>
-  </ul>
-  <ul>
-    <li>
-      ‘Pix Certif’: refers de the web application of the GIP Pix, made available by the latter to the user in Saas mode
-      and intended to allow the registration of candidates for certification, as well as the organisation and
-      implementation of certification sessions by editing the documents necessary for this purpose;
-    </li>
-  </ul>
-  <ul>
-    <li>
-      ‘Pix platform’: public platform for assessing and certifying digital skills based on an IT infrastructure made up
-      of interfaces, database(s) and server(s) that is accessible online in SAAS mode. Its source code is under the open
-      source licence GNU GPL V.3;
-    </li>
-  </ul>
-  <ul>
-    <li>
-      ‘services’: access by the user – via the Internet, in SaaS mode – to the features of the Pix Certif platform as
-      described in the Article ‘Presentation of the services’;
-    </li>
-  </ul>
-  <ul>
-    <li>
-      ‘certification session‘: session during the certification centre will welcome candidates who will pass the Pix
-      certification. The certification session is defined by a specific location (site and room), a date and a time.
-    </li>
-  </ul>
-  <ul>
-    <li>
-      ‘user’: refers to a user authorised by the Centre, accessing and implementing the functionalities of the Pix
-      Certif services, in his capacity as a referent of the Centre and/or a member of the Centre.
-    </li>
-  </ul>
-
-  <h2 class="pix-h3">Article 3. Purpose</h2>
-
-  <p>
-    The purpose of these terms and conditions is to define the conditions for using and accessing the Pix Certif
-    platform that is accessible at the aforementioned address.
-  </p>
-
-  <h2 class="pix-h3">Article 4. Acceptance and enforcement</h2>
-
-  <h3 class="pix-h4">4.1 Acceptance</h3>
-
-  <p>
-    The user may only use the Pix Certif platform and benefit from the services provided that these terms and conditions
-    are accepted.
-  </p>
-  <p>
-    Acceptance of these terms and conditions is confirmed by the user who is using the Pix Certif platform for the first
-    time clicking on the button ‘I accept the terms and conditions’, after they have read them all. This click is proof
-    that the user has acknowledged these stipulations and implies acceptance of these terms and conditions. The user has
-    the option to save and print these terms and conditions using the standard functionalities of their browser or their
-    computer.
-  </p>
-  <p>
-    The user acknowledges that access to and use of the Pix Certif platform and the services provided requires
-    observance of all the stipulations defined within these terms and conditions.
-  </p>
-
-  <h3 class="pix-h4">4.2 Enforcement</h3>
-
-  <p>
-    These terms and conditions are legally binding to the user as soon as they have accepted them when creating a user
-    account or above all when they first access the organisation space.
-  </p>
-  <p>
-    The Pix GIP reserves the right to make all the changes they deem necessary and useful to these terms and conditions.
-  </p>
-  <p>
-    These terms and conditions are enforceable throughout the duration of the use of the Pix Certif platform until new
-    terms and conditions replace them.
-  </p>
-  <p>
-    The Pix GIP undertakes to provide the user with all the new terms and conditions.
-  </p>
-  <p>
-    Any use without reservations of the user account, or acceptance by means of a checkbox, after the changes of the
-    conditions of use and information of the user or his organisation, is worth acceptance by the latter and his
-    organisation of the new conditions of use.
-  </p>
-  <p>
-    The user may at any time forego the use of the services, but remains responsible for any previous use.
-  </p>
-
-  <h2 class="pix-h3">Article 5. User account</h2>
-
-  <h3 class="pix-h4">Step 1.</h3>
-
-  <p>The user fills in a web form on the Pix platform.</p>
-  <p>
-    The form shows the required data that must be filled in to create a user account (first name, surname, email address
-    and password) with an asterisk.
-  </p>
-  <p>
-    The user must enter a valid email address that will enable a confirmation email to be sent when his user account is
-    created. Furthermore, they must choose a password that meets the following requirements:
-  </p>
-  <ul>
-    <li>minimum of 8 characters;</li>
-    <li>at least one lowercase letter;</li>
-    <li>at least one uppercase letter;</li>
-    <li>at least one digit.</li>
-  </ul>
-  <p>
-    The user must confirm, by checking the box, that they have read and accepted the Pix platform terms and conditions.
-  </p>
-
-  <h3 class="pix-h4">Step 2.</h3>
-
-  <p>
-    The user asks the centre to transfer to the GIP Pix a request to attach their user account on Pix Platform, to the
-    Pix Certif service.
-  </p>
-
-  <h3 class="pix-h4">Step 3.</h3>
-
-  <p>
-    The GIP Pix attaches the user account on the Pix platform to the Pix Certif services within the time necessary for
-    the usual security checks, which will allow the user to access the services.
-  </p>
-
-  <h3 class="pix-h4">Step 4.</h3>
-
-  <p>
-    The user logs into their user account and to Pix Certif services with their login credentials, it being recalled
-    that they are personal and confidential.
-  </p>
-  <p>The user is solely responsible for ensuring the password remains confidential, and as a result, the consequences of
-    involuntary disclosure to anyone.</p>
-  <p>Any use of the user account with the password allocated to the user is presumed to originate exclusively from the
-    user.</p>
-  <p>The user will immediately report any theft of their password or any use by an unauthorised third party that he is
-    aware of. This notification must be sent to: support@pix.fr.</p>
-  <p>They can reset the password via the user account by clicking the “Forgot your password” tab then by entering their
-    email address. An email will be sent to the user, enabling them to define a new password that must also comply with
-    the aforementioned requirements.</p>
-
-  <h2 class="pix-h3">Article 6. Description of services</h2>
-
-  <p>Pix Certif enables the user to access the following services :</p>
-  <ul>
-    <li>
-      management of certification sessions;
-    </li>
-    <li>
-      management of registration;
-    </li>
-    <li>
-      management of certification session minutes;
-    </li>
-    <li>
-      incident reporting;
-    </li>
-    <li>access to the certification kit produced by the GIP Pix in order to facilitate the organisation of sessions and
-      improve their quality (models, instructions,etc.).</li>
-  </ul>
-
-  <h2 class="pix-h3">Article 7. Access to Pix Certif</h2>
-
-  <p>The services are normally available 24 hours a day, 7 days a week.</p>
-  <p>The GIP Pix reserves the right to restrict access to the services either totally or partially, with an impact on
-    their availability, in order to maintain the Pix Certif platform within the framework of work scheduled in advance,
-    including servers and infrastructure implemented for the provision of services.</p>
-  <p>
-    The user will be responsible for monitoring the possibilities for upgrading the IT and transmission resources
-    available to them so that these resources can be adapted to upgrades to the Pix Certif platform and other services
-  </p>
-  <p>
-    If the Pix Certif platform is suspended or impossible to use, the user can always contact the Pix GIP’s support
-    service to obtain information at the following address : support@pix.fr.
-  </p>
-  <p>In the event that GIP Pix has entered into a service level agreement with the organisation, the latter prevails.</p>
-
-  <h2 class="pix-h3">Article 8. Technical features </h2>
-
-  <p>
-    The Pix GIP endeavours to provide a quality service. It enables users to use the services provided to them under the
-    best conditions possible.
-  </p>
-  <p>
-    The Pix GIP is bound, with respect to the user and in accordance with the relevant standards and usage, to an
-    obligation of means in execution of the service.
-  </p>
-  <p>
-    Due to the nature and complexity of the internet network, and in particular, its technical performance and the
-    response times in consulting, querying or transferring information data, the Pix GIP makes every effort to enable
-    access to and use of the platform, in accordance with industry standards. The Pix GIP cannot guarantee the
-    accessibility or absolute availability of the platform enabling access to the service.
-  </p>
-  <p>
-    The Pix GIP cannot be held responsible for the smooth operation of the user’s IT equipment as well as their access
-    to the internet.
-  </p>
-  <p>
-    The Pix GIP informs the user of the following technical prerequisites that are necessary to the smooth operation of
-    the Pix Certif and the services:
-  </p>
-  <ul>
-    <li>a web browser (Firefox, Internet Explorer 11 and above, Edge, Chrome, Safari or Opera) in a recent version (not
-      dating back more than 2 years);</li>
-    <li>a satisfactory internet connection.</li>
-  </ul>
-
-  <h2 class="pix-h3">Article 9. Management of certification sessions</h2>
-
-  <p>
-    It is up to the user to ensure with the centre(s) to which they are attached, at least 2 working days before the
-    certification session, that they will have the means (computer equipment and network) to access the Pix Certif
-    application to carry out all the essentials operations to allow the good proceedings of the certification sessions,
-    under the conditions provided for the approval of their centre of attachment.
-  </p>
-
-  <h2 class="pix-h3">Article 10. Use</h2>
-
-  <p>
-    The user undertakes to use the services only under the conditions defined in these conditions of use and in
-    addition:
-  </p>
-  <ul>
-    <li>not to divert the use of the services for personal purposes or contrary to the normal use of the services;</li>
-    <li>
-      to respect any agreement with the GIP Pix determining the number of end users authorised according to the number
-      of credits acquired;
-    </li>
-    <li>not to commit any act of infringement.</li>
-  </ul>
-  <p>
-    The user is responsible with their centre for the use of their user account and services. They undertake to use them
-    fairly, in compliance with these conditions of use, applicable laws and regulations, in particular laws relating to
-    intellectual and industrial property, the protection of personal data and private life.
-  </p>
-
-  <h2 class="pix-h3">Article 11. Security</h2>
-
-  <p>Any fraudulent access to the platform is prohibited and subject to criminal penalties.</p>
-  <p>
-    The GIP Pix makes its best efforts, in accordance with the industry standards, to secure the platform, given the
-    complexity of the Internet. It cannot guarantee absolute security.
-  </p>
-  <p>The user may inform the GIP Pix of any failure of their user account by sending a notification to: support@pix.fr.</p>
-  <p>
-    The user agrees to take all the appropriate measures to regularly back up their own data and to protect their data
-    and/or software and/or devices used against infection by any viruses on the internet network.
-  </p>
-
-  <h2 class="pix-h3">Article 12. Maintenance and support</h2>
-
-  <h3 class="pix-h4">12.1 Support and assistance to the user</h3>
-
-  <p>
-    The GIP Pix provides support of an exclusively technical nature to the user, who is responsible for reporting any
-    malfunctions of the services observed by themselves.
-  </p>
-  <p>The user can reach GIP Pix technical support by email at the address support@pix.fr</p>
-  <p>GIP Pix may offer different levels of assistance and support services to the user, under a separate contract.</p>
-
-  <h3 class="pix-h4">12.2 Progressive maintenance</h3>
-
-  <p>
-    The services are likely to evolve over time to take into account the technological upgrades and needs of
-    organisations who use Pix Certif and users.
-  </p>
-  <p>The services may be upgraded at any time by the Pix GIP.</p>
-  <p>
-    It is the organisation and users' responsibility to upgrade their information system (hardware and software
-    resources such as updating the operating system or browser) at their own expense, in the event of service upgrades
-    that reasonably require it, to take changes to the technological standards into account.
-  </p>
-  <p>
-    The Pix GIP is not responsible for damages of any kind that may result in the temporary unavailability of all or
-    part of the services due to maintenance operations.
-  </p>
-
-  <h2 class="pix-h3">Article 13. Liability</h2>
-
-  <h3 class="pix-h4">13.1 User’s liability</h3>
-
-  <p>
-    The user accesses and uses the services at their own risk and under their responsibility and that of the centre
-    which authorised him, in accordance with the French legislation as well as with these terms and conditions.
-  </p>
-  <p>
-    The user and the centre are solely responsible for the legality of the data they communicate in the context of
-    accessing and using the Pix Certif platform.
-  </p>
-  <p>The user is responsible along with the centre of the activity that occurs by their access to the services.</p>
-  <p>
-    The user will not disrupt other user’s access to and/or use of the Pix Certif platform or access third parties’ user
-    spaces.
-  </p>
-  <p>
-    Any operation carried out on Pix Certif with the user's login credentials is considered to have been done on behalf
-    of the latter and incurs their responsibility.
-  </p>
-  <p>
-    The user undertakes not to commit any action that could jeopardise the GIP Pix’s IT security or other users, in
-    accordance with the article “Security”.
-  </p>
-  <p>
-    The user undertakes not to interfere with or interrupt the normal operation of the user account and, more generally,
-    the Pix Certif platform.
-  </p>
-  <p>
-    The user undertakes with their centre to indemnify the GIP Pix, against complaints, action, proceedings or
-    convictions of the latter resulting from the user’s failure to observe the terms and conditions.
-  </p>
-
-  <h3 class="pix-h4">13.2 The Pix HIP’s liability</h3>
-
-  <p>
-    Given the diversity of the sources of data concerning the user, the conditions of its consultation and the time
-    scales required to transmit them, the GIP Pix will do everything it can to guarantee the general quality and
-    relevance of the information disseminated.
-  </p>
-  <p>
-    The GIP Pix will endeavour to perform all the operations incumbent on it relating to the user’s account and the
-    services, in accordance with the industry standards.
-  </p>
-  <p>
-    The GIP Pix cannot be held liable for the quality of the services, as these are provided ‘as is’, which the user
-    accepts.
-  </p>
-  <p>Furthermore, the GIP Pix cannot be held liable, unless otherwise agreed:</p>
-  <ul>
-    <li>
-      GIP Pix may be held liable, under the provisions of common law, for any direct and foreseeable damages suffered by
-      the user, excluding all indirect damages;
-    </li>
-    <li>
-      indirect damages are considered to be, the loss of data, time, profits, turnover, margins, loss of orders,
-      customers, operations, income, commercial actions or damage to the brand image, the expected results and the
-      action of third parties, even if the GIP Pix was duly informed of the risk that such damages could occur;
-    </li>
-    <li>
-      by mutual agreement with the user and irrespective of the causes, the Pix GIP’s liability shall be limited to the
-      amount (excluding VAT) of the price paid by the customer in return for the services that gave rise to the incident
-      during which the damage occurred;
-    </li>
-    <li>
-      by common agreement, the Pix GIP’s liability cannot be incurred due to the services when they are provided free of
-      charge.
-    </li>
-  </ul>
-  <p>
-    This clause remains applicable in the event all or part of this contract relationship is terminated or becomes null
-    and void.
-  </p>
-
-  <h2 class="pix-h3">Article 14. Intellectual property rights</h2>
-
-  <p>
-    The GIP Pix is, and remains, the exclusive owner of the protected elements of the Pix platform and Pix Certif
-    platform that are not under open source licence according to the terms of the French Intellectual Property Code,
-    excluding any teaching resources or questions that are the intellectual property of third parties, if applicable.
-  </p>
-  <p>
-    The GIP Pix’s property right extends, in particular and within this framework, to all the documentation and
-    databases of the Pix and Pix Certif platforms, as well as their interfaces including test questions (list non
-    exhaustive).
-  </p>
-  <p>
-    These terms and conditions contract will under no circumstances be considered to transfer or assign the intellectual
-    property rights of the Pix and Pix Certif platforms or the services to users.
-  </p>
-  <p>
-    As a result, users will refrain from any action that may directly or indirectly infringe the GIP Pix or third
-    parties’ intellectual property rights. In particular, they will refrain from editing, copying, reproducing,
-    downloading, broadcasting, transmitting, commercially exploiting and/or distributing in any way whatsoever, insofar
-    as they would respectively be subject to protection under an intellectual property right for their parts which are
-    not under an Open Source licence
-  </p>
-  <p>Elements subject to an Open Source licence must be used in accordance with their licence.</p>
-  <p>
-    Only use of the services in accordance with their intended purpose is authorised. Any non-compliant use or use not
-    explicitly authorised by the GIP Pix under these terms and conditions is illegal.
-  </p>
-
-  <h2 class="pix-h3">Article 15. Hyperlinks</h2>
-
-  <p>
-    The Pix GIP reserves the right to put in place hyperlinks on the Pix Certif giving access to web pages other than
-    those of the Pix and Pix Certif.
-  </p>
-  <p>
-    The Pix GIP declines any liability as to the content of the information provided on these websites through the
-    activation of hyperlinks.
-  </p>
-  <p>Each user accesses third-party websites under their sole and entire responsibility.</p>
-  <p>
-    Any hyperlink on a third-party website that redirects to any of the internet pages of the Pix platform requires
-    prior and written consent from the Pix GIP.
-  </p>
-
-  <h2 class="pix-h3">Article 16. Personal data</h2>
-
-  <h3 class="pix-h4">16.1 Information of use</h3>
-
-  <p>
-    As part of its relations with users, GIP Pix, as data controller, may be required to process the following personal
-    data relating to the user’s identity: surname(s), first name(s), function, qualification, professional email
-    address, telephone number, entity or centre of attachment, experience and CV, login credentials, (excluding any ID
-    listed as sensitive data within the meaning of the French data protection authority (CNIL)), usage logs.
-  </p>
-  <p>
-    These are the data processed by Pix as part of the creation of the user account on pix.fr, independently of the data
-    processed specifically by the user's centre, in that case, the centre is the sole data controller.
-  </p>
-  <p>
-    Within the framework of creating a user account, the user is informed that the information marked with an asterisk
-    on the collection form is required. Otherwise, the user's request may not be processed or its processing may be
-    delayed.
-  </p>
-  <p>
-    The data is processed for the internal needs of the GIP Pix, under the conditions of the Privacy Policy, which the
-    user has read and accepted beforehand.
-  </p>
-  <p>When creating the Pix Certif space, the user and his centre undertake to:</p>
-  <ul>
-    <li>
-      send GIP Pix the email address of the organisation's referent or Data Protection Officer and notify GIP Pix of any
-      change in these contact details, if any, via the form dedicated to the creation of this space;
-    </li>
-    <li>
-      respect the data protection regulations and the obligations of the centre as data controller, in particular
-      respect for the information of the persons concerned.
-    </li>
-  </ul>
-
-  <h3 class="pix-h4">16.2 Subcontracting</h3>
-
-  <p>
-    The user is likely to process the personal data of candidates as a subcontractor of the centre (or a second-tier
-    subcontractor of the GIP Pix), the centre itself being a subcontractor of GIP Pix.
-  </p>
-  <p>
-    The term subcontractor within the meaning of the data protection regulations and in particular of EU Regulation
-    2016/679 and of this clause, means the natural person (in this case the user as a subcontractor second-tier) or
-    legal entity (the centre as a first-tier subcontractor) which processes personal data on behalf of the data
-    controller, the GIP Pix.
-  </p>
-  <p>
-    It is up to the user to respect the contractual agreement provided between him and the centre in accordance with
-    article 28 of EU Regulation 2016/679, having at least the same level of guarantee as the contractual agreement
-    between the centre and the GIP Pix.
-  </p>
-  <p>The user can request communication of this agreement from the centre.</p>
-
-  <h2 class="pix-h3">Article 17. Cookies</h2>
-
-  <p>The user is informed that, when accessing the Pix platform, one or more cookies may be automatically installed on
-    his terminal.</p>
-  <p>
-    The cookie constitutes a block of data which is used to record information relating to the navigation of the user on
-    a website or an application.
-  </p>
-  <p>
-    The Pix platform only uses cookies for the purposes of statistical monitoring of visits to pix.fr and pix.org
-    (audience measurement) and the configuration in place benefits from the exemption from obtaining consent, to the
-    extent where it complies with the recommendations of the CNIL.
-  </p>
-
-  <h2 class="pix-h3">18. Termination</h2>
-
-  <h3 class="pix-h4">18.1 De-registration</h3>
-
-  <p>
-    Access to the services by the user is effective as long as the user logs in to the Pix Certif platform, uses its
-    services and is authorised by the centre to which he is attached to use the services. When a user has not logged in
-    or has not used their account for a period of five (5) years, the GIP Pix can archive the data concerning them and
-    reactivate their account on request.
-  </p>
-  <p>
-    Incase of withdrawal of their authorisation by the centre, to which they are attached, the user undertakes to
-    refrain from any access and any use of the services.
-  </p>
-
-  <h3 class="pix-h4">18.2 Suspension and exclusion</h3>
-
-  <p>
-    Should the user fail to meet the obligations of these terms and conditions, the GIP Pix reserves the right, without
-    compensation or reimbursement, to suspend access to the services by their centre until the cause of suspension has
-    been removed, eight (8) days after the sending the user an email requesting them to comply with these terms and
-    conditions.
-  </p>
-  <p>
-    In the event of repeated failure by the user to meet the obligations of these terms and conditions, the GIP Pix
-    reserves the right, without compensation or reimbursement, eight (8) days after sending the user an email requesting
-    them to comply with these terms and conditions that has remained without response, to terminate the user's
-    registration and to terminate access to his user account or to prohibit access to all or part of the services at his
-    centre, without prejudice to any action under common law which may be taken against them.
-  </p>
-  <p>
-    In the event of a serious failure by the user to meet obligations of these terms and conditions, the GIP Pix
-    reserves the right, without compensation or reimbursement, to terminate the user's registration and to terminate
-    access to their user account or to prohibit access to all or part of the services at its centre, without prejudice
-    to any action under common law which may be taken against them.
-  </p>
-
-  <h2 class="pix-h3">19. Agreement of proof</h2>
-
-  <p>Online acceptance of these terms and conditions electronically between the parties has the same evidential value as
-    the agreement on paper.</p>
-  <p>
-    Computer registers stored on the Pix GIP’s IT systems will be stored under reasonable security conditions and
-    considered as proof of the communications between the parties. They will be admissible until the contrary is proven.
-  </p>
-  <p>
-    The terms and conditions of the Pix Certif platform are archived on a reliable and durable medium that can be
-    produced as evidence.
-  </p>
-
-  <h2 class="pix-h3">20. Invalidity</h2>
-
-  <p>
-    If one or more stipulations of these terms and conditions are held to be invalid or declared as such pursuant to the
-    application of a law or a regulation, or following the final ruling by a court with jurisdiction, the other
-    stipulations shall retain their full force and scope.
-  </p>
-
-  <h2 class="pix-h3">21. Applicable law</h2>
-
-  <p>
-    These terms and conditions are governed by French law. This applies to the rules of substance and rules of form,
-    whatever the location in which the substantive or ancillary obligations are performed.
-  </p>
-</div>
+<h2 class="pix-h3">Article 1. Preamble</h2>
+
+<p>
+  The Pix “Groupement d’Intérêt Public” (French public interest group or “GIP”) approved by the decree of 27 April 2017
+  giving approval of the agreement establishing the public interest group ‘Pix’, initially developed the Pix platform
+  within the framework of a public project in partnership with the French Ministry of Education and Ministry of Higher
+  Education, Research and Innovation, and continue its development with the GIP actual members and partners.
+</p>
+<p>
+  The Pix platform is an online platform for assessing and certifying digital skills. Its aim is to help raise the
+  general level of digital knowledge and skills and thus help prepare the digital transformation of society and the
+  economy. It is based on the European DigComp reference framework, which defines digital skills on eight (8) levels and
+  in five (5) competence areas:
+</p>
+<ul>
+  <li>Information and data;</li>
+  <li>Communication and collaboration;</li>
+  <li>Content creation;</li>
+  <li>Protection and security;</li>
+  <li>Environment and digital technology.</li>
+</ul>
+<p>
+  Users registered on the platform can take a certification exam of their skills at a centre approved by the GIP Pix.
+</p>
+<p>
+  The GIP Pix makes available to centres and their referents or authorised members (hereinafter the « users »), the Pix
+  Certif service accessible in Saas mode, for the purpose of organising certification examination sessions, in
+  particularly management of registrations and editing of the documentation necessary for their implantation.
+</p>
+
+<h2 class="pix-h3">Article 2. Definitions</h2>
+
+<ul>
+  <li>
+    ‘centre’: refers to the legal person benefiting from this quality by the effect of the law or a regulation, or from
+    a valid approval under a contract with the GIP Pix as a Pix Certification Centre, and having authorised the user to
+    use the Pix Certif services;
+  </li>
+</ul>
+<ul>
+  <li>
+    ’certification’: refers to the certification of digital skills defined by the decree of April 27, 2017, approving
+    the constituent agreement of the public interest group Pix, as well as by the regulations in force and to come go
+    through candidates registered with the centre in part of a certification session organised by the centre;
+  </li>
+</ul>
+<ul>
+  <li>
+    ‘terms and conditions’: refers to these terms and conditions for the use of the Pix Certif platform;
+  </li>
+</ul>
+<ul>
+  <li>
+    ‘data’: all the information of any kind provided by the organisation and/or the users under their full
+    responsibility, hosted by the Pix GIP and intended to be processed with the framework of service implementation;
+  </li>
+</ul>
+<ul>
+  <li>
+    ‘login credentials’: login and password entered by a user in a personal and confidential way when creating a user
+    account, enabling access to the services from a secure connection to the Pix Certif platform;
+  </li>
+</ul>
+<ul>
+  <li>
+    ‘Pix Certif’: refers de the web application of the GIP Pix, made available by the latter to the user in Saas mode
+    and intended to allow the registration of candidates for certification, as well as the organisation and
+    implementation of certification sessions by editing the documents necessary for this purpose;
+  </li>
+</ul>
+<ul>
+  <li>
+    ‘Pix platform’: public platform for assessing and certifying digital skills based on an IT infrastructure made up of
+    interfaces, database(s) and server(s) that is accessible online in SAAS mode. Its source code is under the open
+    source licence GNU GPL V.3;
+  </li>
+</ul>
+<ul>
+  <li>
+    ‘services’: access by the user – via the Internet, in SaaS mode – to the features of the Pix Certif platform as
+    described in the Article ‘Presentation of the services’;
+  </li>
+</ul>
+<ul>
+  <li>
+    ‘certification session‘: session during the certification centre will welcome candidates who will pass the Pix
+    certification. The certification session is defined by a specific location (site and room), a date and a time.
+  </li>
+</ul>
+<ul>
+  <li>
+    ‘user’: refers to a user authorised by the Centre, accessing and implementing the functionalities of the Pix Certif
+    services, in his capacity as a referent of the Centre and/or a member of the Centre.
+  </li>
+</ul>
+
+<h2 class="pix-h3">Article 3. Purpose</h2>
+
+<p>
+  The purpose of these terms and conditions is to define the conditions for using and accessing the Pix Certif platform
+  that is accessible at the aforementioned address.
+</p>
+
+<h2 class="pix-h3">Article 4. Acceptance and enforcement</h2>
+
+<h3 class="pix-h4">4.1 Acceptance</h3>
+
+<p>
+  The user may only use the Pix Certif platform and benefit from the services provided that these terms and conditions
+  are accepted.
+</p>
+<p>
+  Acceptance of these terms and conditions is confirmed by the user who is using the Pix Certif platform for the first
+  time clicking on the button ‘I accept the terms and conditions’, after they have read them all. This click is proof
+  that the user has acknowledged these stipulations and implies acceptance of these terms and conditions. The user has
+  the option to save and print these terms and conditions using the standard functionalities of their browser or their
+  computer.
+</p>
+<p>
+  The user acknowledges that access to and use of the Pix Certif platform and the services provided requires observance
+  of all the stipulations defined within these terms and conditions.
+</p>
+
+<h3 class="pix-h4">4.2 Enforcement</h3>
+
+<p>
+  These terms and conditions are legally binding to the user as soon as they have accepted them when creating a user
+  account or above all when they first access the organisation space.
+</p>
+<p>
+  The Pix GIP reserves the right to make all the changes they deem necessary and useful to these terms and conditions.
+</p>
+<p>
+  These terms and conditions are enforceable throughout the duration of the use of the Pix Certif platform until new
+  terms and conditions replace them.
+</p>
+<p>
+  The Pix GIP undertakes to provide the user with all the new terms and conditions.
+</p>
+<p>
+  Any use without reservations of the user account, or acceptance by means of a checkbox, after the changes of the
+  conditions of use and information of the user or his organisation, is worth acceptance by the latter and his
+  organisation of the new conditions of use.
+</p>
+<p>
+  The user may at any time forego the use of the services, but remains responsible for any previous use.
+</p>
+
+<h2 class="pix-h3">Article 5. User account</h2>
+
+<h3 class="pix-h4">Step 1.</h3>
+
+<p>The user fills in a web form on the Pix platform.</p>
+<p>
+  The form shows the required data that must be filled in to create a user account (first name, surname, email address
+  and password) with an asterisk.
+</p>
+<p>
+  The user must enter a valid email address that will enable a confirmation email to be sent when his user account is
+  created. Furthermore, they must choose a password that meets the following requirements:
+</p>
+<ul>
+  <li>minimum of 8 characters;</li>
+  <li>at least one lowercase letter;</li>
+  <li>at least one uppercase letter;</li>
+  <li>at least one digit.</li>
+</ul>
+<p>
+  The user must confirm, by checking the box, that they have read and accepted the Pix platform terms and conditions.
+</p>
+
+<h3 class="pix-h4">Step 2.</h3>
+
+<p>
+  The user asks the centre to transfer to the GIP Pix a request to attach their user account on Pix Platform, to the Pix
+  Certif service.
+</p>
+
+<h3 class="pix-h4">Step 3.</h3>
+
+<p>
+  The GIP Pix attaches the user account on the Pix platform to the Pix Certif services within the time necessary for the
+  usual security checks, which will allow the user to access the services.
+</p>
+
+<h3 class="pix-h4">Step 4.</h3>
+
+<p>
+  The user logs into their user account and to Pix Certif services with their login credentials, it being recalled that
+  they are personal and confidential.
+</p>
+<p>The user is solely responsible for ensuring the password remains confidential, and as a result, the consequences of
+  involuntary disclosure to anyone.</p>
+<p>Any use of the user account with the password allocated to the user is presumed to originate exclusively from the
+  user.</p>
+<p>The user will immediately report any theft of their password or any use by an unauthorised third party that he is
+  aware of. This notification must be sent to: support@pix.fr.</p>
+<p>They can reset the password via the user account by clicking the “Forgot your password” tab then by entering their
+  email address. An email will be sent to the user, enabling them to define a new password that must also comply with
+  the aforementioned requirements.</p>
+
+<h2 class="pix-h3">Article 6. Description of services</h2>
+
+<p>Pix Certif enables the user to access the following services :</p>
+<ul>
+  <li>
+    management of certification sessions;
+  </li>
+  <li>
+    management of registration;
+  </li>
+  <li>
+    management of certification session minutes;
+  </li>
+  <li>
+    incident reporting;
+  </li>
+  <li>access to the certification kit produced by the GIP Pix in order to facilitate the organisation of sessions and
+    improve their quality (models, instructions,etc.).</li>
+</ul>
+
+<h2 class="pix-h3">Article 7. Access to Pix Certif</h2>
+
+<p>The services are normally available 24 hours a day, 7 days a week.</p>
+<p>The GIP Pix reserves the right to restrict access to the services either totally or partially, with an impact on
+  their availability, in order to maintain the Pix Certif platform within the framework of work scheduled in advance,
+  including servers and infrastructure implemented for the provision of services.</p>
+<p>
+  The user will be responsible for monitoring the possibilities for upgrading the IT and transmission resources
+  available to them so that these resources can be adapted to upgrades to the Pix Certif platform and other services
+</p>
+<p>
+  If the Pix Certif platform is suspended or impossible to use, the user can always contact the Pix GIP’s support
+  service to obtain information at the following address : support@pix.fr.
+</p>
+<p>In the event that GIP Pix has entered into a service level agreement with the organisation, the latter prevails.</p>
+
+<h2 class="pix-h3">Article 8. Technical features </h2>
+
+<p>
+  The Pix GIP endeavours to provide a quality service. It enables users to use the services provided to them under the
+  best conditions possible.
+</p>
+<p>
+  The Pix GIP is bound, with respect to the user and in accordance with the relevant standards and usage, to an
+  obligation of means in execution of the service.
+</p>
+<p>
+  Due to the nature and complexity of the internet network, and in particular, its technical performance and the
+  response times in consulting, querying or transferring information data, the Pix GIP makes every effort to enable
+  access to and use of the platform, in accordance with industry standards. The Pix GIP cannot guarantee the
+  accessibility or absolute availability of the platform enabling access to the service.
+</p>
+<p>
+  The Pix GIP cannot be held responsible for the smooth operation of the user’s IT equipment as well as their access to
+  the internet.
+</p>
+<p>
+  The Pix GIP informs the user of the following technical prerequisites that are necessary to the smooth operation of
+  the Pix Certif and the services:
+</p>
+<ul>
+  <li>a web browser (Firefox, Internet Explorer 11 and above, Edge, Chrome, Safari or Opera) in a recent version (not
+    dating back more than 2 years);</li>
+  <li>a satisfactory internet connection.</li>
+</ul>
+
+<h2 class="pix-h3">Article 9. Management of certification sessions</h2>
+
+<p>
+  It is up to the user to ensure with the centre(s) to which they are attached, at least 2 working days before the
+  certification session, that they will have the means (computer equipment and network) to access the Pix Certif
+  application to carry out all the essentials operations to allow the good proceedings of the certification sessions,
+  under the conditions provided for the approval of their centre of attachment.
+</p>
+
+<h2 class="pix-h3">Article 10. Use</h2>
+
+<p>
+  The user undertakes to use the services only under the conditions defined in these conditions of use and in addition:
+</p>
+<ul>
+  <li>not to divert the use of the services for personal purposes or contrary to the normal use of the services;</li>
+  <li>
+    to respect any agreement with the GIP Pix determining the number of end users authorised according to the number of
+    credits acquired;
+  </li>
+  <li>not to commit any act of infringement.</li>
+</ul>
+<p>
+  The user is responsible with their centre for the use of their user account and services. They undertake to use them
+  fairly, in compliance with these conditions of use, applicable laws and regulations, in particular laws relating to
+  intellectual and industrial property, the protection of personal data and private life.
+</p>
+
+<h2 class="pix-h3">Article 11. Security</h2>
+
+<p>Any fraudulent access to the platform is prohibited and subject to criminal penalties.</p>
+<p>
+  The GIP Pix makes its best efforts, in accordance with the industry standards, to secure the platform, given the
+  complexity of the Internet. It cannot guarantee absolute security.
+</p>
+<p>The user may inform the GIP Pix of any failure of their user account by sending a notification to: support@pix.fr.</p>
+<p>
+  The user agrees to take all the appropriate measures to regularly back up their own data and to protect their data
+  and/or software and/or devices used against infection by any viruses on the internet network.
+</p>
+
+<h2 class="pix-h3">Article 12. Maintenance and support</h2>
+
+<h3 class="pix-h4">12.1 Support and assistance to the user</h3>
+
+<p>
+  The GIP Pix provides support of an exclusively technical nature to the user, who is responsible for reporting any
+  malfunctions of the services observed by themselves.
+</p>
+<p>The user can reach GIP Pix technical support by email at the address support@pix.fr</p>
+<p>GIP Pix may offer different levels of assistance and support services to the user, under a separate contract.</p>
+
+<h3 class="pix-h4">12.2 Progressive maintenance</h3>
+
+<p>
+  The services are likely to evolve over time to take into account the technological upgrades and needs of organisations
+  who use Pix Certif and users.
+</p>
+<p>The services may be upgraded at any time by the Pix GIP.</p>
+<p>
+  It is the organisation and users' responsibility to upgrade their information system (hardware and software resources
+  such as updating the operating system or browser) at their own expense, in the event of service upgrades that
+  reasonably require it, to take changes to the technological standards into account.
+</p>
+<p>
+  The Pix GIP is not responsible for damages of any kind that may result in the temporary unavailability of all or part
+  of the services due to maintenance operations.
+</p>
+
+<h2 class="pix-h3">Article 13. Liability</h2>
+
+<h3 class="pix-h4">13.1 User’s liability</h3>
+
+<p>
+  The user accesses and uses the services at their own risk and under their responsibility and that of the centre which
+  authorised him, in accordance with the French legislation as well as with these terms and conditions.
+</p>
+<p>
+  The user and the centre are solely responsible for the legality of the data they communicate in the context of
+  accessing and using the Pix Certif platform.
+</p>
+<p>The user is responsible along with the centre of the activity that occurs by their access to the services.</p>
+<p>
+  The user will not disrupt other user’s access to and/or use of the Pix Certif platform or access third parties’ user
+  spaces.
+</p>
+<p>
+  Any operation carried out on Pix Certif with the user's login credentials is considered to have been done on behalf of
+  the latter and incurs their responsibility.
+</p>
+<p>
+  The user undertakes not to commit any action that could jeopardise the GIP Pix’s IT security or other users, in
+  accordance with the article “Security”.
+</p>
+<p>
+  The user undertakes not to interfere with or interrupt the normal operation of the user account and, more generally,
+  the Pix Certif platform.
+</p>
+<p>
+  The user undertakes with their centre to indemnify the GIP Pix, against complaints, action, proceedings or convictions
+  of the latter resulting from the user’s failure to observe the terms and conditions.
+</p>
+
+<h3 class="pix-h4">13.2 The Pix HIP’s liability</h3>
+
+<p>
+  Given the diversity of the sources of data concerning the user, the conditions of its consultation and the time scales
+  required to transmit them, the GIP Pix will do everything it can to guarantee the general quality and relevance of the
+  information disseminated.
+</p>
+<p>
+  The GIP Pix will endeavour to perform all the operations incumbent on it relating to the user’s account and the
+  services, in accordance with the industry standards.
+</p>
+<p>
+  The GIP Pix cannot be held liable for the quality of the services, as these are provided ‘as is’, which the user
+  accepts.
+</p>
+<p>Furthermore, the GIP Pix cannot be held liable, unless otherwise agreed:</p>
+<ul>
+  <li>
+    GIP Pix may be held liable, under the provisions of common law, for any direct and foreseeable damages suffered by
+    the user, excluding all indirect damages;
+  </li>
+  <li>
+    indirect damages are considered to be, the loss of data, time, profits, turnover, margins, loss of orders,
+    customers, operations, income, commercial actions or damage to the brand image, the expected results and the action
+    of third parties, even if the GIP Pix was duly informed of the risk that such damages could occur;
+  </li>
+  <li>
+    by mutual agreement with the user and irrespective of the causes, the Pix GIP’s liability shall be limited to the
+    amount (excluding VAT) of the price paid by the customer in return for the services that gave rise to the incident
+    during which the damage occurred;
+  </li>
+  <li>
+    by common agreement, the Pix GIP’s liability cannot be incurred due to the services when they are provided free of
+    charge.
+  </li>
+</ul>
+<p>
+  This clause remains applicable in the event all or part of this contract relationship is terminated or becomes null
+  and void.
+</p>
+
+<h2 class="pix-h3">Article 14. Intellectual property rights</h2>
+
+<p>
+  The GIP Pix is, and remains, the exclusive owner of the protected elements of the Pix platform and Pix Certif platform
+  that are not under open source licence according to the terms of the French Intellectual Property Code, excluding any
+  teaching resources or questions that are the intellectual property of third parties, if applicable.
+</p>
+<p>
+  The GIP Pix’s property right extends, in particular and within this framework, to all the documentation and databases
+  of the Pix and Pix Certif platforms, as well as their interfaces including test questions (list non exhaustive).
+</p>
+<p>
+  These terms and conditions contract will under no circumstances be considered to transfer or assign the intellectual
+  property rights of the Pix and Pix Certif platforms or the services to users.
+</p>
+<p>
+  As a result, users will refrain from any action that may directly or indirectly infringe the GIP Pix or third parties’
+  intellectual property rights. In particular, they will refrain from editing, copying, reproducing, downloading,
+  broadcasting, transmitting, commercially exploiting and/or distributing in any way whatsoever, insofar as they would
+  respectively be subject to protection under an intellectual property right for their parts which are not under an Open
+  Source licence
+</p>
+<p>Elements subject to an Open Source licence must be used in accordance with their licence.</p>
+<p>
+  Only use of the services in accordance with their intended purpose is authorised. Any non-compliant use or use not
+  explicitly authorised by the GIP Pix under these terms and conditions is illegal.
+</p>
+
+<h2 class="pix-h3">Article 15. Hyperlinks</h2>
+
+<p>
+  The Pix GIP reserves the right to put in place hyperlinks on the Pix Certif giving access to web pages other than
+  those of the Pix and Pix Certif.
+</p>
+<p>
+  The Pix GIP declines any liability as to the content of the information provided on these websites through the
+  activation of hyperlinks.
+</p>
+<p>Each user accesses third-party websites under their sole and entire responsibility.</p>
+<p>
+  Any hyperlink on a third-party website that redirects to any of the internet pages of the Pix platform requires prior
+  and written consent from the Pix GIP.
+</p>
+
+<h2 class="pix-h3">Article 16. Personal data</h2>
+
+<h3 class="pix-h4">16.1 Information of use</h3>
+
+<p>
+  As part of its relations with users, GIP Pix, as data controller, may be required to process the following personal
+  data relating to the user’s identity: surname(s), first name(s), function, qualification, professional email address,
+  telephone number, entity or centre of attachment, experience and CV, login credentials, (excluding any ID listed as
+  sensitive data within the meaning of the French data protection authority (CNIL)), usage logs.
+</p>
+<p>
+  These are the data processed by Pix as part of the creation of the user account on pix.fr, independently of the data
+  processed specifically by the user's centre, in that case, the centre is the sole data controller.
+</p>
+<p>
+  Within the framework of creating a user account, the user is informed that the information marked with an asterisk on
+  the collection form is required. Otherwise, the user's request may not be processed or its processing may be delayed.
+</p>
+<p>
+  The data is processed for the internal needs of the GIP Pix, under the conditions of the Privacy Policy, which the
+  user has read and accepted beforehand.
+</p>
+<p>When creating the Pix Certif space, the user and his centre undertake to:</p>
+<ul>
+  <li>
+    send GIP Pix the email address of the organisation's referent or Data Protection Officer and notify GIP Pix of any
+    change in these contact details, if any, via the form dedicated to the creation of this space;
+  </li>
+  <li>
+    respect the data protection regulations and the obligations of the centre as data controller, in particular respect
+    for the information of the persons concerned.
+  </li>
+</ul>
+
+<h3 class="pix-h4">16.2 Subcontracting</h3>
+
+<p>
+  The user is likely to process the personal data of candidates as a subcontractor of the centre (or a second-tier
+  subcontractor of the GIP Pix), the centre itself being a subcontractor of GIP Pix.
+</p>
+<p>
+  The term subcontractor within the meaning of the data protection regulations and in particular of EU Regulation
+  2016/679 and of this clause, means the natural person (in this case the user as a subcontractor second-tier) or legal
+  entity (the centre as a first-tier subcontractor) which processes personal data on behalf of the data controller, the
+  GIP Pix.
+</p>
+<p>
+  It is up to the user to respect the contractual agreement provided between him and the centre in accordance with
+  article 28 of EU Regulation 2016/679, having at least the same level of guarantee as the contractual agreement between
+  the centre and the GIP Pix.
+</p>
+<p>The user can request communication of this agreement from the centre.</p>
+
+<h2 class="pix-h3">Article 17. Cookies</h2>
+
+<p>The user is informed that, when accessing the Pix platform, one or more cookies may be automatically installed on his
+  terminal.</p>
+<p>
+  The cookie constitutes a block of data which is used to record information relating to the navigation of the user on a
+  website or an application.
+</p>
+<p>
+  The Pix platform only uses cookies for the purposes of statistical monitoring of visits to pix.fr and pix.org
+  (audience measurement) and the configuration in place benefits from the exemption from obtaining consent, to the
+  extent where it complies with the recommendations of the CNIL.
+</p>
+
+<h2 class="pix-h3">18. Termination</h2>
+
+<h3 class="pix-h4">18.1 De-registration</h3>
+
+<p>
+  Access to the services by the user is effective as long as the user logs in to the Pix Certif platform, uses its
+  services and is authorised by the centre to which he is attached to use the services. When a user has not logged in or
+  has not used their account for a period of five (5) years, the GIP Pix can archive the data concerning them and
+  reactivate their account on request.
+</p>
+<p>
+  Incase of withdrawal of their authorisation by the centre, to which they are attached, the user undertakes to refrain
+  from any access and any use of the services.
+</p>
+
+<h3 class="pix-h4">18.2 Suspension and exclusion</h3>
+
+<p>
+  Should the user fail to meet the obligations of these terms and conditions, the GIP Pix reserves the right, without
+  compensation or reimbursement, to suspend access to the services by their centre until the cause of suspension has
+  been removed, eight (8) days after the sending the user an email requesting them to comply with these terms and
+  conditions.
+</p>
+<p>
+  In the event of repeated failure by the user to meet the obligations of these terms and conditions, the GIP Pix
+  reserves the right, without compensation or reimbursement, eight (8) days after sending the user an email requesting
+  them to comply with these terms and conditions that has remained without response, to terminate the user's
+  registration and to terminate access to his user account or to prohibit access to all or part of the services at his
+  centre, without prejudice to any action under common law which may be taken against them.
+</p>
+<p>
+  In the event of a serious failure by the user to meet obligations of these terms and conditions, the GIP Pix reserves
+  the right, without compensation or reimbursement, to terminate the user's registration and to terminate access to
+  their user account or to prohibit access to all or part of the services at its centre, without prejudice to any action
+  under common law which may be taken against them.
+</p>
+
+<h2 class="pix-h3">19. Agreement of proof</h2>
+
+<p>Online acceptance of these terms and conditions electronically between the parties has the same evidential value as
+  the agreement on paper.</p>
+<p>
+  Computer registers stored on the Pix GIP’s IT systems will be stored under reasonable security conditions and
+  considered as proof of the communications between the parties. They will be admissible until the contrary is proven.
+</p>
+<p>
+  The terms and conditions of the Pix Certif platform are archived on a reliable and durable medium that can be produced
+  as evidence.
+</p>
+
+<h2 class="pix-h3">20. Invalidity</h2>
+
+<p>
+  If one or more stipulations of these terms and conditions are held to be invalid or declared as such pursuant to the
+  application of a law or a regulation, or following the final ruling by a court with jurisdiction, the other
+  stipulations shall retain their full force and scope.
+</p>
+
+<h2 class="pix-h3">21. Applicable law</h2>
+
+<p>
+  These terms and conditions are governed by French law. This applies to the rules of substance and rules of form,
+  whatever the location in which the substantive or ancillary obligations are performed.
+</p>

--- a/certif/app/components/terms-of-service/page-fr.hbs
+++ b/certif/app/components/terms-of-service/page-fr.hbs
@@ -1,807 +1,804 @@
-<div class="terms-of-service-form__text">
+<h2 class="pix-h3">Article 1. Préambule</h2>
 
-  <h2 class="pix-h3">Article 1. Préambule</h2>
+<p>
+  Le Groupement d’intérêt public (GIP) « Pix », approuvé par arrêté du 27 avril 2017 portant approbation de la
+  convention constitutive du groupement d'intérêt public « Pix », ayant son siège social 156, boulevard Haussmann Paris
+  (France), a développé la Plateforme Pix dans le cadre d’un projet public en partenariat avec le Ministère en charge de
+  l’Education nationale et le Ministère en charge de l’Enseignement supérieur, de la Recherche et de l’Innovation.
+</p>
+<p>
+  La plateforme Pix est une plateforme en ligne d’évaluation et de certification des compétences numériques ayant pour
+  objectif d’accompagner l’élévation du niveau général de connaissances et de compétences numériques et ainsi de
+  préparer la transformation numérique de la société et de l’économie. Elle s’appuie notamment sur le cadre de référence
+  européen DigComp, qui définit les compétences numériques sur huit (8) niveaux et cinq (5) grands domaines :
+</p>
+<ul>
+  <li>Informations et données ;</li>
+  <li>Communication et collaboration ;</li>
+  <li>Création de contenu ;</li>
+  <li>Protection et sécurité ;</li>
+  <li>Environnement et numérique.</li>
+</ul>
+<p>
+  Les utilisateurs inscrits sur cette plateforme peuvent passer un examen de certification de leurs compétences auprès
+  d’un centre agréé par le GIP Pix.
+</p>
+<p>
+  Le GIP Pix met à la disposition des centres et de leurs référents ou membres habilités (ci-après les
+  « utilisateurs »), le service Pix Certif accessible en mode Saas, aux fins d’organisation des sessions d’examen de
+  certification, en particulier de gestion des inscriptions et d’édition de la documentation nécessaire à leur mise en
+  œuvre.
+</p>
 
-  <p>
-    Le Groupement d’intérêt public (GIP) « Pix », approuvé par arrêté du 27 avril 2017 portant approbation de la
-    convention constitutive du groupement d'intérêt public « Pix », ayant son siège social 156, boulevard Haussmann
-    Paris (France), a développé la Plateforme Pix dans le cadre d’un projet public en partenariat avec le Ministère en
-    charge de l’Education nationale et le Ministère en charge de l’Enseignement supérieur, de la Recherche et de
-    l’Innovation.
-  </p>
-  <p>
-    La plateforme Pix est une plateforme en ligne d’évaluation et de certification des compétences numériques ayant pour
-    objectif d’accompagner l’élévation du niveau général de connaissances et de compétences numériques et ainsi de
-    préparer la transformation numérique de la société et de l’économie. Elle s’appuie notamment sur le cadre de
-    référence européen DigComp, qui définit les compétences numériques sur huit (8) niveaux et cinq (5) grands domaines
-    :
-  </p>
-  <ul>
-    <li>Informations et données ;</li>
-    <li>Communication et collaboration ;</li>
-    <li>Création de contenu ;</li>
-    <li>Protection et sécurité ;</li>
-    <li>Environnement et numérique.</li>
-  </ul>
-  <p>
-    Les utilisateurs inscrits sur cette plateforme peuvent passer un examen de certification de leurs compétences auprès
-    d’un centre agréé par le GIP Pix.
-  </p>
-  <p>
-    Le GIP Pix met à la disposition des centres et de leurs référents ou membres habilités (ci-après les
-    « utilisateurs »), le service Pix Certif accessible en mode Saas, aux fins d’organisation des sessions d’examen de
-    certification, en particulier de gestion des inscriptions et d’édition de la documentation nécessaire à leur mise en
-    œuvre.
-  </p>
+<h2 class="pix-h3">Article 2. Définitions</h2>
 
-  <h2 class="pix-h3">Article 2. Définitions</h2>
-
-  <ul>
-    {{! template-lint-disable no-whitespace-within-word }}
-    <li>
-      « centre » : désigne la personne morale bénéficiant de cette qualité par l’effet de la loi ou d’un règlement, ou
-      d’un agrément en cours de validité au titre d’un contrat avec le GIP Pix en tant que Centre de certification Pix,
-      et ayant habilité l’utilisateur à utiliser les services Pix Certif ;
-    </li>
-  </ul>
-  <ul>
-    {{! template-lint-disable no-whitespace-within-word }}
-    <li>
-      « certification » : désigne la certification des compétences numériques définies par l’arrêté du 27 avril 2017
-      portant approbation de la convention constitutive du groupement d'intérêt public PIX, ainsi que par la
-      réglementation en vigueur et à venir, passée par les candidats inscrits auprès du Centre dans le cadre d’une
-      session de certification organisée par le Centre ;
-    </li>
-  </ul>
-  <ul>
-    {{! template-lint-disable no-whitespace-within-word }}
-    <li>
-      « conditions d’utilisation » : désigne les présentes conditions générales d’utilisation ;
-    </li>
-  </ul>
-  <ul>
-    {{! template-lint-disable no-whitespace-within-word }}
-    <li>
-      « données » : désigne l’ensemble des informations de toutes natures communiquées par les utilisateurs sous leur
-      entière responsabilité, hébergées par le GIP Pix et destinées à être traitées dans le cadre de la mise en œuvre
-      des services ;
-    </li>
-  </ul>
-  <ul>
-    {{! template-lint-disable no-whitespace-within-word }}
-    <li>
-      « identifiants de connexion » : identifiant et mot de passe renseignés par un utilisateur de manière personnelle
-      et confidentielle lors de la connexion à son compte utilisateur, permettant l’accès aux services Pix Certif depuis
-      une connexion sécurisée ;
-    </li>
-  </ul>
-  <ul>
-    <li>
-      « Pix Certif » : désigne l’application web du GIP Pix, mise à disposition par celui-ci auprès de l’utilisateur en
-      mode Saas et ayant pour objet de permettre l’inscription des candidats à la certification, ainsi que
-      l’organisation et la mise en œuvre des sessions de certification par l’édition des documents nécessaires à cet
-      effet ;
-    </li>
-  </ul>
-  <ul>
-    {{! template-lint-disable no-whitespace-within-word }}
-    <li>
-      « plateforme Pix » : plateforme publique d’évaluation et de certification des compétences numériques reposant sur
-      une infrastructure informatique composée d’interfaces, base(s) de données, serveur(s) et accessible en ligne en
-      mode SAAS. Son code source est soumis à la licence libre GNU GPL V.3 ;
-    </li>
-  </ul>
-  <ul>
-    <li>
-      « services » : accès par internet en mode Saas aux fonctionnalités de l’application Pix Certif telles que décrites
-      à l’article « Présentation des services » par les utilisateurs ;
-    </li>
-  </ul>
-  <ul>
-    {{! template-lint-disable no-whitespace-within-word }}
-    <li>
-      « session de certification » : séance pendant laquelle le centre de certification va accueillir des candidats qui
-      vont passer la certification Pix. La session de certification est définie par un lieu précis (site et salle), une
-      date et un horaire.
-    </li>
-  </ul>
-  <ul>
-    <li>
-      « utilisateur» : désigne un utilisateur habilité par le Centre, accédant et mettant en œuvre les fonctionnalités
-      des services Pix Certif, en sa qualité de référent du Centre et/ou de membre du Centre.
-    </li>
-  </ul>
-
-  <h2 class="pix-h3">Article 3. Objet</h2>
-
-  <p>
-    Les présentes ont pour objet de définir les conditions d’accès et d’utilisation, par les utilisateurs, de Pix Certif
-    et des services.
-  </p>
-  <h2 class="pix-h3">Article 4. Entrée en vigueur - Durée</h2>
-  <p>
-    Les présentes conditions générales sont applicables pendant toute la durée de l’utilisation par l’utilisateur.
-  </p>
-  <p>
-    Elles restent applicables en cas d’utilisation non-autorisée et de cessation de l’habilitation de l’utilisateur par
-    son centre de rattachement.
-  </p>
-
-  <h2 class="pix-h3">Article 5. Acceptation et opposabilité des conditions générales</h2>
-
-  <h3 class="pix-h4">5.1 Acceptation</h3>
-  <p>
-    Les utilisateurs peuvent utiliser les services Pix Certif sous réserve de l’acceptation préalable des présentes
-    conditions générales d’utilisation et de l’engagement qu’ils respectent les prérequis suivants :
-  </p>
-  <ul>
-    <li>
-      être majeur au jour de l’inscription ;
-    </li>
-    <li>
-      être habilité par un centre ;
-    </li>
-    <li>
-      avoir créé un compte sur la plateforme Pix dans les conditions visées à l’article « Compte utilisateur » des
-      présentes ;
-    </li>
-    <li>
-      disposer de la capacité juridique leur permettant de s’engager au titre des présentes conditions générales ;
-    </li>
-    <li>
-      disposer d’un équipement informatique adapté pour accéder à Pix Certif, sur un poste informatique adéquat, selon
-      les prérequis techniques prévus aux présentes conditions d’utilisation ;
-    </li>
-    <li>
-      avoir transmis des informations personnelles valides au Centre en vue du rattachement de son compte utilisateur à
-      l’espace Pix Certif de son centre.
-    </li>
-  </ul>
-  <p>
-    L’utilisateur, en acceptant les conditions générales d’utilisation, déclare :
-  </p>
-  <ul>
-    <li>
-      avoir bien pris conscience que les services sont fournis à distance ;
-    </li>
-    <li>
-      avoir pris connaissance des conditions dans lesquelles fonctionnent les services Pix Certif ;
-    </li>
-    <li>
-      disposer de toutes les compétences techniques nécessaires pour accéder et utiliser Pix Certif dans des conditions
-      optimales ;
-    </li>
-    <li>
-      s’être assuré du respect des prérequis techniques nécessaires ;
-    </li>
-    <li>
-      avoir obtenu toutes les informations nécessaires, quant aux services Pix Certif;
-    </li>
-    <li>
-      accepter sans réserve les présentes conditions générales d’utilisation.
-    </li>
-  </ul>
-  <p>
-    L’acceptation des présentes conditions d’utilisation est formalisée par un clic sur le bouton « J’accepte les
-    conditions d’utilisation » par l’utilisateur qui utilise pour la première fois Pix Certif et ce, après qu’il ait
-    consulté l’intégralité des présentes. Ce clic constitue la preuve que l’utilisateur a pris connaissance desdites
-    stipulations et vaut acceptation des présentes.
-  </p>
-  <p>
-    L’utilisateur dispose de la faculté de sauvegarder et d’imprimer les présentes conditions d’utilisation en utilisant
-    les fonctionnalités standards de son navigateur ou de son ordinateur.
-  </p>
-  <p>
-    L’utilisateur reconnaît que l’accès et l’utilisation des services proposés nécessitent le respect de l’ensemble des
-    prescriptions définies au sein des présentes conditions d’utilisation.
-  </p>
-
-  <h3 class="pix-h4">5.2 Modification</h3>
-  <p>
-    Les conditions générales sont susceptibles d’être modifiées ou aménagées à tout moment par le GIP Pix, notamment
-    afin de faire évoluer les services.
-  </p>
-  <p>
-    En cas de modification des conditions générales d’utilisation, les nouvelles conditions générales d’utilisation
-    seront notifiées au moment de l’accès aux services par l’utilisateur et devront à nouveau être acceptées selon la
-    procédure décrite à l’article « Acceptation ».
-  </p>
-  <p>
-    Le GIP Pix se réserve le droit d’apporter aux présentes conditions d’utilisation toutes les modifications qu’il
-    jugera nécessaires et utiles.
-  </p>
-  <p>
-    Les présentes conditions d’utilisation sont opposables pendant toute la durée d’utilisation des services et jusqu’à
-    ce que de nouvelles conditions d’utilisation remplacent les présentes.
-  </p>
-  <p>
-    Tout usage du compte utilisateur par l’utilisateur après les modifications des conditions d’utilisation vaut
-    acceptation par ce dernier des nouvelles conditions d’utilisation.
-  </p>
-
-  <h3 class="pix-h4">5.3 Opposabilité</h3>
-  <p>
-    Les présentes conditions d’utilisation sont opposables à l’utilisateur dès leur acceptation par ce dernier lors de
-    la création d’un compte utilisateur ou avant tout premier accès aux services.
-  </p>
-  <p>
-    Dans tous les cas, à la date de la première utilisation des services par l’utilisateur, les conditions d’utilisation
-    sont réputées lues et applicables.
-  </p>
-  <p>
-    Les conditions d’utilisation figurant en ligne sur Pix Certif prévalent sur toute version imprimée de date
-    antérieure.
-  </p>
-  <p>
-    L’utilisateur peut à tout moment renoncer à utiliser Pix Certif et les services mais reste responsable de toute
-    utilisation antérieure.
-  </p>
-
-  <h2 class="pix-h3">Article 6. Compte utilisateur</h2>
-
-  <p>
-    La procédure de création d’un compte utilisateur comprend les étapes suivantes.
-  </p>
-  <p>
-    <b>Etape 1.</b>
-    L’utilisateur complète un formulaire internet sur la plateforme Pix.
-  </p>
-  <p>
-    L’utilisateur doit indiquer une adresse électronique valide qui permettra, notamment, l’envoi d’un courrier
-    électronique de confirmation de la création de son compte utilisateur. Par ailleurs, il doit choisir un mot de passe
-    conforme aux spécifications suivantes :
-  </p>
-  <ul>
-    <li>
-      8 caractères minimum avec au moins une lettre et un chiffre.
-    </li>
-  </ul>
-  <p>
-    L’utilisateur doit valider, en cochant une case à cet effet :
-  </p>
-  <ul>
-    <li>
-      qu’il a lu et qu’il accepte les conditions d’utilisation de la plateforme Pix.
-    </li>
-  </ul>
-  <p>
-    <b>Etape 2.</b>
-    L’utilisateur demande au Centre de transmettre au GIP Pix une demande de rattachement de son compte utilisateur sur
-    la plateforme Pix, au service Pix Certif.
-  </p>
-  <p>
-    <b>Etape 3.</b>
-    Le GIP Pix effectue le rattachement du compte utilisateur de la plateforme Pix aux services Pix Certif dans un délai
-    nécessaire aux vérifications de sécurité d’usage, qui permettra l’accès de l’utilisateur aux services.
-  </p>
-  <p>
-    <b>Etape 4.</b>
-    L’utilisateur se connecte à son compte utilisateur et aux services Pix Certif aux moyens de ses identifiants de
-    connexion. Ces derniers sont strictement personnels et confidentiels.
-  </p>
-  <p>
-    L’utilisateur est seul responsable de la préservation et de la confidentialité de son mot de passe et, par
-    conséquent, des conséquences d’une divulgation involontaire à quiconque
-  </p>
-  <p>
-    Toute utilisation du compte utilisateur à partir du mot de passe attribué à l’utilisateur est présumée comme émanant
-    exclusivement de l’utilisateur.
-  </p>
-  <p>
-    L’utilisateur s’engage à notifier sans délai tous vols de son mot de passe ou toute utilisation par un tiers dont il
-    aurait connaissance. Cette notification doit être adressée à : support@pix.fr .
-  </p>
-  <p>
-    Il est possible de réinitialiser le mot de passe via le compte utilisateur en cliquant sur l’onglet « Mot de passe
-    oublié ?» puis en saisissant son adresse email. Un email sera adressé à l’utilisateur, lui permettant de définir un
-    nouveau mot de passe qui devra lui aussi être conforme aux spécifications susvisées.
-  </p>
-
-  <h2 class="pix-h3">Article 7. Description des services</h2>
-
-  <p>
-    Pix Certif permet à l’utilisateur de bénéficier des services suivants :
-  </p>
-  <ul>
-    <li>
-      gestion de sessions de certification ;
-    </li>
-    <li>
-      gestion des inscriptions ;
-    </li>
-    <li>
-      gestion des procès-verbaux des sessions de certification ;
-    </li>
-    <li>
-      signalement des incidents ;
-    </li>
-    <li>
-      l’accès au kit de certification produit par le GIP Pix en vue de faciliter l’organisation des sessions et d’en
-      renforcer la qualité (modèles, modes d’emploi etc.).
-    </li>
-  </ul>
-
-  <h2 class="pix-h3">Article 8. Accès à Pix Certif</h2>
-
-  <p>
-    Les services sont normalement accessibles 24/24 heures, 7/7 jours.
-  </p>
-  <p>
-    Le GIP Pix se réserve le droit de restreindre, totalement ou partiellement, l’accès aux services, avec un impact sur
-    leur disponibilité, notamment afin d’assurer la maintenance des services dans le cadre d’interventions programmées à
-    l’avance, y compris des serveurs et des infrastructures mises en œuvre pour la fourniture des services.
-  </p>
-  <p>
-    Il appartiendra à l’utilisateur de veiller aux possibilités d’évolution des moyens informatiques et de transmission
-    à sa disposition pour que ces moyens puissent s’adapter aux évolutions des services.
-  </p>
-  <p>
-    En cas d’interruption ou d’impossibilité d’utiliser les services, l’utilisateur peut toujours s’adresser au service
-    support du GIP Pix pour obtenir des informations à l’adresse suivante, en transmettant le plus précisément possible
-    le problème rencontré le cas échéant sur la base de documents associés : support@pix.fr.
-  </p>
-
-  <h2 class="pix-h3">Article 9. Spécificités techniques</h2>
-
-  <p>
-    Le GIP Pix s’efforce de fournir un service de qualité. Il permet aux utilisateurs d'utiliser les services mis à leur
-    disposition dans les meilleures conditions possibles.
-  </p>
-  <p>
-    Le GIP Pix est donc tenu à l’égard de l’utilisateur et conformément aux normes et usages en la matière d’une
-    obligation de moyens dans la mise à disposition des services.
-  </p>
-  <p>
-    En raison de la nature et de la complexité du réseau internet, et en particulier, de ses performances techniques et
-    des temps de réponse pour consulter, interroger ou transférer les données d’informations, le GIP Pix fait ses
-    meilleurs efforts, conformément aux règles de l’art, pour permettre l’accès et l’utilisation des services. Le GIP
-    Pix ne saurait, en effet, assurer une accessibilité ou une disponibilité absolue de la plateforme permettant l’accès
-    au service.
-  </p>
-  <p>
-    Le GIP Pix ne saurait être responsable du bon fonctionnement de l’équipement informatique de l’utilisateur ainsi que
-    de son accès à internet.
-  </p>
-  <p>
-    Le GIP Pix informe l’utilisateur des prérequis techniques suivants nécessaires au bon fonctionnement de Pix Certif
-    et des services :
-  </p>
-  <ul>
-    <li>
-      un navigateur internet (Firefox, Internet Explorer 11 et au-delà, Edge, Chrome, Safari, Opera) dans une version
-      récente (ne datant pas de plus de 2 ans) ;
-    </li>
-    <li>
-      une connexion internet satisfaisante.
-    </li>
-  </ul>
-
-  <h2 class="pix-h3">Article 10. Gestion des sessions de certification</h2>
-
-  <p>
-    Il appartient à l’utilisateur de s’assurer avec le ou les centres au(x)quel(s) il est rattaché, au minimum 2 jours
-    ouvrés avant la session de certification, qu’il aura les moyens (matériel informatique et réseau) d’accéder à
-    l’application Pix Certif pour réaliser l’ensemble des opérations qui lui incombent pour permettre le bon déroulé des
-    sessions de certification, dans les conditions prévues à l’agrément de son centre de rattachement
-  </p>
-
-  <h2 class="pix-h3">Article 11. Utilisation</h2>
-
-  <p>
-    L’utilisateur s’engage à n’utiliser les services que dans les seules conditions définies aux présentes conditions
-    d’utilisation et en outre :
-  </p>
-  <ul>
-    <li>
-      à ne pas détourner l’utilisation des services à des fins personnelles ou contraires à l’usage normal des services
-      ;
-    </li>
-    <li>
-      à ne commettre aucun acte de contrefaçon.
-    </li>
-  </ul>
-  <p>
-    L’utilisateur est responsable de l’utilisation de son compte utilisateur et des services. Il s’engage à les utiliser
-    de façon loyale, dans le respect des présentes conditions d’utilisation, des lois et règlements applicables,
-    notamment les lois relatives à la propriété intellectuelle et industrielle, à la protection des données à caractère
-    personnel et à la vie privée.
-  </p>
-
-  <h2 class="pix-h3">Article 12. Sécurité</h2>
-
-  <p>
-    Le GIP Pix fait ses meilleurs efforts, conformément aux règles de l’art, pour sécuriser la plateforme au regard du
-    risque encouru et de la nature des données traitées. Eu égard à la complexité d’Internet, l’utilisateur reconnaît et
-    accepte qu’il ne saurait assurer une sécurité absolue.
-  </p>
+<ul>
   {{! template-lint-disable no-whitespace-within-word }}
-  <p>
-    L’utilisateur pourra informer le GIP Pix de toute défaillance de son compte utilisateur par une notification
-    adressée à : support@pix.fr.
-  </p>
-  <p>
-    L’utilisateur accepte de prendre toutes les mesures appropriées de façon, d’une part, à sauvegarder régulièrement
-    ses propres données et, d’autre part, à protéger ses données et/ou logiciels et/ou terminaux utilisés de la
-    contamination par d’éventuels virus sur le réseau internet.
-  </p>
-  <p>
-    La plateforme est un système de traitement automatisé de données.
-  </p>
-  <p>
-    Il est interdit d'accéder ou de se maintenir, frauduleusement, dans tout ou partie de Pix Certif ou des services ou
-    d’utiliser une méthode d’accès autre que l’interface mise à disposition par le GIP Pix via les services, ou de
-    permettre à un tiers d’y procéder.
-  </p>
-  <p>
-    Il est interdit d’y introduire frauduleusement des données ou même d’opérer une altération du fonctionnement des
-    services.
-  </p>
-  <p>
-    L’utilisateur veille notamment à ne pas introduire de virus, code malveillant ou toute autre technologie nuisible
-    aux services.
-  </p>
-  <p>
-    Tout accès à un espace interdit sera considéré comme un accès frauduleux au sens des dispositions du Code pénal.
-  </p>
-  <p>
-    L’utilisateur s’engage à considérer que toutes les données dont il aura eu connaissance à l’occasion d’un tel accès
-    à un espace non autorisé sont des données confidentielles et s’engage, en conséquence, à ne pas les divulguer.
-  </p>
-  <p>
-    L’utilisateur s’interdit notamment de réaliser toute opération visant à saturer une page, les opérations de rebond
-    ou toute opération ayant pour conséquence d'entraver ou de fausser le fonctionnement des services.
-  </p>
-  <p>
-    L’utilisateur s’engage à ne pas utiliser de dispositifs ou de logiciels de toutes sortes qui auraient pour
-    conséquence de perturber le bon fonctionnement des services.
-  </p>
-  <p>
-    L’utilisateur s’engage à ne pas engager d'action qui imposerait une charge disproportionnée sur les infrastructures
-    de Pix Certif.
-  </p>
+  <li>
+    « centre » : désigne la personne morale bénéficiant de cette qualité par l’effet de la loi ou d’un règlement, ou
+    d’un agrément en cours de validité au titre d’un contrat avec le GIP Pix en tant que Centre de certification Pix, et
+    ayant habilité l’utilisateur à utiliser les services Pix Certif ;
+  </li>
+</ul>
+<ul>
+  {{! template-lint-disable no-whitespace-within-word }}
+  <li>
+    « certification » : désigne la certification des compétences numériques définies par l’arrêté du 27 avril 2017
+    portant approbation de la convention constitutive du groupement d'intérêt public PIX, ainsi que par la
+    réglementation en vigueur et à venir, passée par les candidats inscrits auprès du Centre dans le cadre d’une session
+    de certification organisée par le Centre ;
+  </li>
+</ul>
+<ul>
+  {{! template-lint-disable no-whitespace-within-word }}
+  <li>
+    « conditions d’utilisation » : désigne les présentes conditions générales d’utilisation ;
+  </li>
+</ul>
+<ul>
+  {{! template-lint-disable no-whitespace-within-word }}
+  <li>
+    « données » : désigne l’ensemble des informations de toutes natures communiquées par les utilisateurs sous leur
+    entière responsabilité, hébergées par le GIP Pix et destinées à être traitées dans le cadre de la mise en œuvre des
+    services ;
+  </li>
+</ul>
+<ul>
+  {{! template-lint-disable no-whitespace-within-word }}
+  <li>
+    « identifiants de connexion » : identifiant et mot de passe renseignés par un utilisateur de manière personnelle et
+    confidentielle lors de la connexion à son compte utilisateur, permettant l’accès aux services Pix Certif depuis une
+    connexion sécurisée ;
+  </li>
+</ul>
+<ul>
+  <li>
+    « Pix Certif » : désigne l’application web du GIP Pix, mise à disposition par celui-ci auprès de l’utilisateur en
+    mode Saas et ayant pour objet de permettre l’inscription des candidats à la certification, ainsi que l’organisation
+    et la mise en œuvre des sessions de certification par l’édition des documents nécessaires à cet effet ;
+  </li>
+</ul>
+<ul>
+  {{! template-lint-disable no-whitespace-within-word }}
+  <li>
+    « plateforme Pix » : plateforme publique d’évaluation et de certification des compétences numériques reposant sur
+    une infrastructure informatique composée d’interfaces, base(s) de données, serveur(s) et accessible en ligne en mode
+    SAAS. Son code source est soumis à la licence libre GNU GPL V.3 ;
+  </li>
+</ul>
+<ul>
+  <li>
+    « services » : accès par internet en mode Saas aux fonctionnalités de l’application Pix Certif telles que décrites à
+    l’article « Présentation des services » par les utilisateurs ;
+  </li>
+</ul>
+<ul>
+  {{! template-lint-disable no-whitespace-within-word }}
+  <li>
+    « session de certification » : séance pendant laquelle le centre de certification va accueillir des candidats qui
+    vont passer la certification Pix. La session de certification est définie par un lieu précis (site et salle), une
+    date et un horaire.
+  </li>
+</ul>
+<ul>
+  <li>
+    « utilisateur» : désigne un utilisateur habilité par le Centre, accédant et mettant en œuvre les fonctionnalités des
+    services Pix Certif, en sa qualité de référent du Centre et/ou de membre du Centre.
+  </li>
+</ul>
 
-  <h2 class="pix-h3">Article 13. Maintenance et support</h2>
+<h2 class="pix-h3">Article 3. Objet</h2>
 
-  <h3 class="pix-h4">13.1 Support et assistance auprès de l’utilisateur</h3>
-  <p>
-    Le GIP Pix assure un support de nature exclusivement technique auprès de l’utilisateur qui se charge de remonter les
-    éventuels dysfonctionnements des services constatés par lui-même.
-  </p>
-  <p>
-    L’utilisateur peut joindre le support technique du GIP Pix par courrier électronique à l’adresse support@pix.fr.
-  </p>
-  <p>
-    Le GIP Pix met à disposition des utilisateurs une FAQ permettant de répondre aux besoins les plus courants.
-  </p>
+<p>
+  Les présentes ont pour objet de définir les conditions d’accès et d’utilisation, par les utilisateurs, de Pix Certif
+  et des services.
+</p>
+<h2 class="pix-h3">Article 4. Entrée en vigueur - Durée</h2>
+<p>
+  Les présentes conditions générales sont applicables pendant toute la durée de l’utilisation par l’utilisateur.
+</p>
+<p>
+  Elles restent applicables en cas d’utilisation non-autorisée et de cessation de l’habilitation de l’utilisateur par
+  son centre de rattachement.
+</p>
 
-  <h3 class="pix-h4">13.2 Maintenance évolutive</h3>
-  <p>
-    Les services sont susceptibles d’évoluer dans le temps, pour tenir compte des évolutions technologiques, des besoins
-    des centres et des utilisateurs.
-  </p>
-  <p>
-    L’évolution des services peut être effectuée à tout moment par le GIP Pix.
-  </p>
-  <p>
-    Il appartient à l’organisation et aux utilisateurs de mettre à niveau leur système d’information (moyens matériels
-    et logiciels tels que la mise à jour du système d’exploitation ou navigateur) à leurs seuls frais, en cas
-    d’évolution des services qui le nécessiterait de manière raisonnable, pour tenir compte des évolutions des standards
-    technologiques.
-  </p>
-  <p>
-    Le GIP Pix n’est pas responsable des dommages de toute nature qui peuvent résulter d’une indisponibilité temporaire
-    de tout ou partie des services due à des opérations de maintenance, ainsi que pour toute modification, suppression
-    ou interruption des services.
-  </p>
+<h2 class="pix-h3">Article 5. Acceptation et opposabilité des conditions générales</h2>
 
-  <h2 class="pix-h3">Article 14. Responsabilité</h2>
+<h3 class="pix-h4">5.1 Acceptation</h3>
+<p>
+  Les utilisateurs peuvent utiliser les services Pix Certif sous réserve de l’acceptation préalable des présentes
+  conditions générales d’utilisation et de l’engagement qu’ils respectent les prérequis suivants :
+</p>
+<ul>
+  <li>
+    être majeur au jour de l’inscription ;
+  </li>
+  <li>
+    être habilité par un centre ;
+  </li>
+  <li>
+    avoir créé un compte sur la plateforme Pix dans les conditions visées à l’article « Compte utilisateur » des
+    présentes ;
+  </li>
+  <li>
+    disposer de la capacité juridique leur permettant de s’engager au titre des présentes conditions générales ;
+  </li>
+  <li>
+    disposer d’un équipement informatique adapté pour accéder à Pix Certif, sur un poste informatique adéquat, selon les
+    prérequis techniques prévus aux présentes conditions d’utilisation ;
+  </li>
+  <li>
+    avoir transmis des informations personnelles valides au Centre en vue du rattachement de son compte utilisateur à
+    l’espace Pix Certif de son centre.
+  </li>
+</ul>
+<p>
+  L’utilisateur, en acceptant les conditions générales d’utilisation, déclare :
+</p>
+<ul>
+  <li>
+    avoir bien pris conscience que les services sont fournis à distance ;
+  </li>
+  <li>
+    avoir pris connaissance des conditions dans lesquelles fonctionnent les services Pix Certif ;
+  </li>
+  <li>
+    disposer de toutes les compétences techniques nécessaires pour accéder et utiliser Pix Certif dans des conditions
+    optimales ;
+  </li>
+  <li>
+    s’être assuré du respect des prérequis techniques nécessaires ;
+  </li>
+  <li>
+    avoir obtenu toutes les informations nécessaires, quant aux services Pix Certif ;
+  </li>
+  <li>
+    accepter sans réserve les présentes conditions générales d’utilisation.
+  </li>
+</ul>
+<p>
+  L’acceptation des présentes conditions d’utilisation est formalisée par un clic sur le bouton « J’accepte les
+  conditions d’utilisation » par l’utilisateur qui utilise pour la première fois Pix Certif et ce, après qu’il ait
+  consulté l’intégralité des présentes. Ce clic constitue la preuve que l’utilisateur a pris connaissance desdites
+  stipulations et vaut acceptation des présentes.
+</p>
+<p>
+  L’utilisateur dispose de la faculté de sauvegarder et d’imprimer les présentes conditions d’utilisation en utilisant
+  les fonctionnalités standards de son navigateur ou de son ordinateur.
+</p>
+<p>
+  L’utilisateur reconnaît que l’accès et l’utilisation des services proposés nécessitent le respect de l’ensemble des
+  prescriptions définies au sein des présentes conditions d’utilisation.
+</p>
 
-  <h3 class="pix-h4">14.1 Responsabilité de l’utilisateur</h3>
-  <p>
-    L’utilisateur accède et utilise les services à ses propres risques et sous sa responsabilité et celle du centre qui
-    l’a habilité, en accord avec la législation française en vigueur ainsi qu’avec les présentes conditions
-    d’utilisation.
-  </p>
-  <p>
-    L’utilisateur est exclusivement responsable de la licéité des données qu’il communique dans le cadre de l’accès et
-    de l’utilisation des services et dégage le GIP Pix de toute responsabilité à cet égard.
-  </p>
-  <p>
-    L’utilisateur est seul responsable de l'activité qui se produit par son accès aux services.
-  </p>
-  <p>
-    L’utilisateur s’engage à ne pas perturber l’accès et/ou l’usage que pourraient faire les autres utilisateurs des
-    services et à ne pas accéder aux espaces utilisateur ou comptes de tiers.
-  </p>
-  <p>
-    Toute opération effectuée sur Pix Certif avec les identifiants de connexion de l'utilisateur est réputée faite au
-    nom de ce dernier et engage sa responsabilité.
-  </p>
-  <p>
-    L’utilisateur s’engage à ne commettre aucun acte pouvant mettre en cause la sécurité informatique du GIP Pix ou des
-    autres utilisateurs, conformément à l’article « Sécurité ».
-  </p>
-  <p>
-    L’utilisateur s’engage à ne pas interférer ou interrompre le fonctionnement normal du compte utilisateur et, plus
-    généralement, des services.
-  </p>
-  <p>
-    L’utilisateur s’engage à indemniser le GIP Pix, son directeur, ses employés et autres agents en cas de plainte,
-    action, poursuite, condamnation de ces derniers résultant du non-respect des conditions d’utilisation par
-    l’utilisateur.
-  </p>
+<h3 class="pix-h4">5.2 Modification</h3>
+<p>
+  Les conditions générales sont susceptibles d’être modifiées ou aménagées à tout moment par le GIP Pix, notamment afin
+  de faire évoluer les services.
+</p>
+<p>
+  En cas de modification des conditions générales d’utilisation, les nouvelles conditions générales d’utilisation seront
+  notifiées au moment de l’accès aux services par l’utilisateur et devront à nouveau être acceptées selon la procédure
+  décrite à l’article « Acceptation ».
+</p>
+<p>
+  Le GIP Pix se réserve le droit d’apporter aux présentes conditions d’utilisation toutes les modifications qu’il jugera
+  nécessaires et utiles.
+</p>
+<p>
+  Les présentes conditions d’utilisation sont opposables pendant toute la durée d’utilisation des services et jusqu’à ce
+  que de nouvelles conditions d’utilisation remplacent les présentes.
+</p>
+<p>
+  Tout usage du compte utilisateur par l’utilisateur après les modifications des conditions d’utilisation vaut
+  acceptation par ce dernier des nouvelles conditions d’utilisation.
+</p>
 
-  <h3 class="pix-h4">14.2 Responsabilité du GIP Pix</h3>
-  <p>
-    Le GIP Pix s’efforcera de réaliser les opérations qui lui incombent relatives au compte utilisateur et aux services,
-    conformément aux règles de l’art.
-  </p>
-  <p>
-    Le GIP Pix ne saurait être responsable de la qualité des services, ces derniers étant proposés « en l’état », ce que
-    l’utilisateur accepte.
-  </p>
-  <p>
-    Par ailleurs, le GIP Pix ne pourra voir sa responsabilité engagée :
-  </p>
-  <ul>
-    <li>
-      en cas d’indisponibilité temporaire ou totale de tout ou partie de l’accès aux services et, d’une manière
-      générale, d’un défaut de performance quelconque ;
-    </li>
-    <li>
-      du fait de l’impossibilité d’accéder aux services, liée à des destructions de matériels, aux attaques ou au
-      piratage informatiques, à la privation, à la suppression ou à l'interdiction, temporaire ou définitive, et pour
-      quelque cause que ce soit, de l'accès au réseau Internet ;
-    </li>
-    <li>
-      dans les limites de la législation en vigueur, par tout dommage indirect et ce y compris notamment les pertes de
-      profit, de données ou tout autre perte de biens incorporels, du fait de l’utilisation des services ou, au
-      contraire, de l’impossibilité de son utilisation ;
-    </li>
-    <li>
-      du fait d'un dysfonctionnement, d'une indisponibilité d'accès, d'une mauvaise utilisation, d'une mauvaise
-      configuration de l'ordinateur ou appareils nomades (tablettes et mobiles) de l’utilisateur, ou encore de l'emploi
-      d'un navigateur ou système d’exploitation peu usité par l’utilisateur ou non conforme aux prérequis techniques ;
-    </li>
-    <li>
-      en cas d’usage frauduleux ou abusif ou dû à une divulgation volontaire ou involontaire à quiconque des codes
-      d’accès confiés à l’utilisateur ;
-    </li>
-    <li>
-      du fait d’un retrait des habilitations qui lui sont conférées à la demande d’un centre auquel il est rattaché et
-      ayant donné lieu à une coupure de l’accès aux services.
-    </li>
-  </ul>
-  <p>
-    D’un commun accord, les parties conviennent que l’utilisateur ne peut pas lui-même former une quelconque action en
-    responsabilité et renonce à recours contre le GIP Pix, dans la mesure où le préjudice subi ne peut être subi,
-    exclusivement, que par le Centre, et, en cas de préjudice propres, seul le Centre peut agir en son nom pour demander
-    réparation de son préjudice, étant précisé que :
-  </p>
-  <ul>
-    <li>
-      la responsabilité du GIP Pix pourra être engagée, dans les conditions de droit commun, à raison des dommages
-      directs et prévisibles subis par l’utilisateur, à l’exclusion de tous dommages indirects ;
-    </li>
-    <li>
-      sont considérés comme dommages indirects notamment les pertes de données, de temps, de bénéfices, de chiffre
-      d’affaires, de marges, pertes de commandes, de clients, d’exploitation, de revenus, d’actions commerciales ou
-      encore l’atteinte à l’image de marque, les résultats escomptés et l’action de tiers, et ce même si le GIP Pix
-      était dûment informé du risque de survenance de tels dommages ;
-    </li>
-    <li>
-      la responsabilité du GIP Pix est, d’un commun accord avec l’utilisateur, et tous faits générateurs confondus,
-      limitée au montant hors taxe du prix payé par le centre en contrepartie des services au cours desquels le fait à
-      l’origine du dommage a été commis ;
-    </li>
-    <li>
-      la responsabilité du GIP Pix ne peut donc, d’un commun accord, être mise en jeu à raison des services, tant que
-      les services sont fournis à titre gratuit au centre et à l’utilisateur.
-    </li>
-  </ul>
-  <p>
-    La présente clause reste applicable en cas de nullité, de résolution, de résiliation ou d’anéantissement des
-    présentes relations contractuelles.
-  </p>
+<h3 class="pix-h4">5.3 Opposabilité</h3>
+<p>
+  Les présentes conditions d’utilisation sont opposables à l’utilisateur dès leur acceptation par ce dernier lors de la
+  création d’un compte utilisateur ou avant tout premier accès aux services.
+</p>
+<p>
+  Dans tous les cas, à la date de la première utilisation des services par l’utilisateur, les conditions d’utilisation
+  sont réputées lues et applicables.
+</p>
+<p>
+  Les conditions d’utilisation figurant en ligne sur Pix Certif prévalent sur toute version imprimée de date antérieure.
+</p>
+<p>
+  L’utilisateur peut à tout moment renoncer à utiliser Pix Certif et les services mais reste responsable de toute
+  utilisation antérieure.
+</p>
 
-  <h2 class="pix-h3">Article 15. Propriété intellectuelle</h2>
+<h2 class="pix-h3">Article 6. Compte utilisateur</h2>
 
-  <p>
-    Le GIP Pix est, et reste, propriétaire exclusif des éléments protégés des services selon les termes du Code de la
-    propriété intellectuelle, à l’exclusion de toutes éventuelles ressources qui relèvent, le cas échéant, de la
-    propriété intellectuelle de tiers.
-  </p>
-  <p>
-    Le droit de propriété du GIP Pix s’étend en particulier et dans ce cadre, à toute la documentation, les bases de
-    données de Pix Certif, des services, ainsi que leurs interfaces et la documentation associée telle que définie par
-    le Code de la propriété intellectuelle, sans que cette liste ne soit exhaustive.
-  </p>
-  <p>
-    Les présentes conditions d’utilisation ne sauraient avoir pour effet de transférer ou de céder les droits de
-    propriété intellectuelle des plateformes Pix ou services, aux utilisateurs.
-  </p>
-  <p>
-    En conséquence, les utilisateurs s'interdisent tout agissement et tout acte susceptible de porter atteinte
-    directement ou non aux droits de propriété intellectuelle du GIP Pix ou des tiers. Notamment, ils s’interdisent de
-    modifier, copier, reproduire, télécharger, diffuser, transmettre, exploiter commercialement et/ou distribuer de
-    quelque façon que ce soit les services ou les pages des plateformes Pix et Pix Certif, dans la mesure où ils
-    feraient respectivement l’objet d’une protection au titre d’un droit de propriété intellectuelle pour leurs parties
-    non soumises à une licence Open Source.
-  </p>
-  <p>
-    Seule une utilisation des services conformément à leur destination est autorisée. Toute utilisation non conforme ou
-    non expressément autorisée par le GIP Pix au titre des présentes conditions d’utilisation est illicite.
-  </p>
+<p>
+  La procédure de création d’un compte utilisateur comprend les étapes suivantes.
+</p>
 
-  <h2 class="pix-h3">Article 16. Liens hypertextes</h2>
+<h3 class="pix-h4">Etape 1.</h3>
 
-  <p>
-    Le GIP Pix se réserve la possibilité de mettre en place des hyperliens sur Pix Certif donnant accès à des pages web
-    autres que celles des plateformes Pix et Pix Certif.
-  </p>
-  <p>
-    Le GIP Pix décline toute responsabilité quant au contenu des informations fournies sur ces sites au titre de
-    l’activation des hyperliens.
-  </p>
-  <p>
-    Chaque utilisateur accède aux sites tiers sous sa seule et entière responsabilité.
-  </p>
-  <p>
-    Toute mise en place d’un lien hypertexte sur un site tiers redirigeant vers l’une quelconque des pages internet de
-    la plateforme Pix requiert l’autorisation préalable et écrite du GIP Pix.
-  </p>
+<p>L’utilisateur complète un formulaire internet sur la plateforme Pix.</p>
+<p>
+  L’utilisateur doit indiquer une adresse électronique valide qui permettra, notamment, l’envoi d’un courrier
+  électronique de confirmation de la création de son compte utilisateur. Par ailleurs, il doit choisir un mot de passe
+  conforme aux spécifications suivantes :
+</p>
+<ul>
+  <li>
+    8 caractères minimum ;
+  </li>
+  <li>
+    au moins une lettre ;
+  </li>
+  <li>
+    au moins un chiffre.
+  </li>
+</ul>
+<p>
+  L’utilisateur doit valider, en cochant une case à cet effet, qu’il a lu et qu’il accepte les conditions d’utilisation
+  de la plateforme Pix.
+</p>
 
-  <h2 class="pix-h3">Article 17. Données à caractère personnel</h2>
+<h3 class="pix-h4">Etape 2.</h3>
 
-  <h3 class="pix-h4">17.1 Information de l’utilisation</h3>
-  <p>
-    Dans le cadre de ses rapports avec les utilisateurs, le GIP Pix, en qualité de responsable de traitement, peut être
-    amené à traiter les données à caractère personnel suivantes relatives à l’identité d’un utilisateur, à savoir :
-    nom(s) et prénom(s), fonction, qualification, adresse email professionnelle, numéro de téléphone, entité ou centre
-    de rattachement, expériences et CV.
-  </p>
-  <p>
-    Ces données peuvent lui être transmises par :
-  </p>
-  <ul>
-    <li>
-      l’utilisateur lors de son inscription sur la plateforme Pix ;
-    </li>
-    <li>
-      le centre, en vue :
-      <ul>
-        <li>
-          de la gestion de l’accès aux services ;
-        </li>
-        <li>
-          la gestion et le suivi du compte utilisateur Pix Certif (création, modification, suppression) ;
-        </li>
-        <li>
-          la gestion des demandes de droit d’accès, de rectification et d’opposition au traitement des données
-          personnelles des utilisateurs concernés.
-        </li>
-      </ul>
-    </li>
-  </ul>
-  <p>
-    L’utilisateur est informé et accepte que ses données soient traitées par le GIP Pix pour la finalité précitée.
-  </p>
-  <p>
-    Ce traitement est effectué sur les bases légales suivantes : votre consentement (lorsque vous acceptez les présentes
-    conditions), l'exécution des présentes conditions générales, et l'intérêt légitime du GIP Pix à mettre en œuvre des
-    traitements de gestion.
-  </p>
-  <p>
-    Ces données sont destinées au GIP Pix responsable de traitement, à son personnel habilité, et à ses éventuels
-    sous-traitants.
-  </p>
-  <p>
-    Les données seront conservées pendant une durée de 5 ans maximum à compter de la dernière utilisation ou du dernier
-    accès au compte utilisateur et/ou à Pix Certif, et archivées selon les délais de prescription légale (5 ans)
-  </p>
-  <p>
-    Toute personne concernée par le traitement dispose d’un droit d’interrogation, d’accès, de rectification,
-    d’effacement des données, d’un droit à la limitation du traitement et à la portabilité des données ; ainsi que d’un
-    droit d’opposition pour motif légitime.
-  </p>
-  <p>
-    Par ailleurs, l’utilisateur dispose d’un droit de formuler des directives spécifiques et générales concernant la
-    conservation, l’effacement et la communication de ses données post-mortem. En ce qui concerne les directives
-    générales, elles pourront être adressées à un tiers qui sera désigné par Décret.
-  </p>
-  <p>
-    La communication de directives spécifiques post-mortem et l’exercice des droits s’effectuent par courrier
-    électronique à l’adresse email suivante : dpo@pix.fr. La photocopie d’un titre d’identité signé et des informations
-    complémentaires pourront être exigées en cas de doute sur l’identité de l’utilisateur.
-  </p>
-  <p>
-    Enfin, l’utilisateur a le droit d’introduire une réclamation auprès d’une autorité de contrôle et notamment de la
-    Commission nationale Informatique et libertés (ci-après « CNIL ») et de retirer son consentement à tout moment.
-  </p>
+<p>
+  L’utilisateur demande au Centre de transmettre au GIP Pix une demande de rattachement de son compte utilisateur sur la
+  plateforme Pix, au service Pix Certif.
+</p>
 
-  <h3 class="pix-h4">17.2 Sous-traitance</h3>
-  <p>
-    L’utilisateur est susceptible de traiter les données à caractère personnel des candidats en qualité de sous-traitant
-    du centre (ou de sous-traitant de second rang du GIP Pix), le centre étant lui-même sous-traitant du GIP Pix.
-  </p>
-  <p>
-    Le terme de sous-traitant au sens de la réglementation informatique et libertés et en particulier du Règlement UE
-    2016/679 et de la présente clause, s’entend de la personne physique (en l’occurrence l’utilisateur en tant que
-    sous-traitant de second rang) ou morale (le centre en tant que sous-traitant de premier rang) qui traite des données
-    à caractère personnel pour le compte du responsable de traitement, le GIP Pix.
-  </p>
-  <p>
-    Il appartient à l’utilisateur de respecter l’accord contractuel prévu entre lui et le centre conformément à
-    l’article 28 du Règlement UE 2016/679, c’est à dire les obligations au moins équivalentes en protection à celles
-    imposées au centre, telles que figurant à la convention d’agrément entre le centre et le GIP Pix.
-  </p>
-  <p>
-    L’utilisateur peut demander communication de cette convention auprès du centre.
-  </p>
+<h3 class="pix-h4">Etape 3.</h3>
 
-  <h2 class="pix-h3">18. Résolution et résiliation</h2>
+<p>
+  Le GIP Pix effectue le rattachement du compte utilisateur de la plateforme Pix aux services Pix Certif dans un délai
+  nécessaire aux vérifications de sécurité d’usage, qui permettra l’accès de l’utilisateur aux services.
+</p>
 
-  <h3 class="pix-h4">18.1 Désinscription</h3>
-  <p>
-    L’accès aux services par l’utilisateur est effectif et valide tant que l’utilisateur :
-  </p>
-  <ul>
-    <li>
-      utilise les services ; et,
-    </li>
-    <li>
-      est habilité par le centre auquel il est rattaché à utiliser les services.
-    </li>
-  </ul>
-  <p>
-    En cas de retrait de son habilitation par le centre auquel il est rattaché, l’utilisateur s’engage à s’abstenir de
-    tout accès et de toute utilisation des services.
-  </p>
+<h3 class="pix-h4">Etape 4.</h3>
 
-  <h3 class="pix-h4">18.2 Suspension et exclusion</h3>
-  <p>
-    En cas de manquement aux obligations des présentes conditions d’utilisation par l’utilisateur, le GIP Pix se réserve
-    le droit, sans indemnité ni remboursement, huit (8) jours après l’envoi à l’utilisateur d’un courrier électronique
-    lui demandant de se conformer aux présentes conditions d’utilisation, de suspendre l’accès aux services jusqu’à ce
-    que la cause de la suspension ait disparu.
-  </p>
-  <p>
-    En cas de manquement répété aux obligations des présentes conditions par l’utilisateur, le GIP Pix se réserve le
-    droit, sans indemnité ni remboursement, huit (8) jours après l’envoi à l’utilisateur d’un courrier électronique lui
-    demandant de se conformer aux présentes conditions d’utilisation resté infructueux, de résilier l’inscription de
-    l’utilisateur et de mettre fin à l’accès à son compte utilisateur ou d’interdire l’accès de tout ou partie des
-    services, sans préjudice de toute action de droit commun qui pourrait lui être ouverte.
-  </p>
+<p>
+  L’utilisateur se connecte à son compte utilisateur et aux services Pix Certif aux moyens de ses identifiants de
+  connexion. Ces derniers sont strictement personnels et confidentiels.
+</p>
+<p>
+  L’utilisateur est seul responsable de la préservation et de la confidentialité de son mot de passe et, par conséquent,
+  des conséquences d’une divulgation involontaire à quiconque
+</p>
+<p>
+  Toute utilisation du compte utilisateur à partir du mot de passe attribué à l’utilisateur est présumée comme émanant
+  exclusivement de l’utilisateur.
+</p>
+<p>
+  L’utilisateur s’engage à notifier sans délai tous vols de son mot de passe ou toute utilisation par un tiers dont il
+  aurait connaissance. Cette notification doit être adressée à : support@pix.fr .
+</p>
+<p>
+  Il est possible de réinitialiser le mot de passe via le compte utilisateur en cliquant sur l’onglet « Mot de passe
+  oublié ?» puis en saisissant son adresse email. Un email sera adressé à l’utilisateur, lui permettant de définir un
+  nouveau mot de passe qui devra lui aussi être conforme aux spécifications susvisées.
+</p>
 
-  <h2 class="pix-h3">19. Convention de preuve</h2>
+<h2 class="pix-h3">Article 7. Description des services</h2>
 
-  <p>
-    L’acceptation en ligne des présentes conditions d’utilisation par voie électronique a entre les parties la même
-    valeur probante que l’accord sur support papier.
-  </p>
-  <p>
-    Les registres informatisés conservés dans les systèmes informatiques du GIP Pix seront conservés dans des conditions
-    raisonnables de sécurité et considérés comme les preuves des communications intervenues entre les parties. Elles
-    font foi jusqu’à preuve du contraire.
-  </p>
-  <p>
-    L’archivage des conditions d’utilisation de Pix Certif et des services est effectué sur un support fiable et durable
-    pouvant être produit à titre de preuve.
-  </p>
+<p>
+  Pix Certif permet à l’utilisateur de bénéficier des services suivants :
+</p>
+<ul>
+  <li>
+    gestion de sessions de certification ;
+  </li>
+  <li>
+    gestion des inscriptions ;
+  </li>
+  <li>
+    gestion des procès-verbaux des sessions de certification ;
+  </li>
+  <li>
+    signalement des incidents ;
+  </li>
+  <li>
+    l’accès au kit de certification produit par le GIP Pix en vue de faciliter l’organisation des sessions et d’en
+    renforcer la qualité (modèles, modes d’emploi etc.).
+  </li>
+</ul>
 
-  <h2 class="pix-h3">20. Nullité</h2>
+<h2 class="pix-h3">Article 8. Accès à Pix Certif</h2>
 
-  <p>
-    Si une ou plusieurs stipulations des présentes conditions d’utilisation sont tenues pour non valides ou déclarées
-    comme telles en application d’une loi, d’un règlement ou à la suite d’une décision passée en force de chose jugée
-    d’une juridiction compétente, les autres stipulations garderont toute leur force et leur portée.
-  </p>
+<p>
+  Les services sont normalement accessibles 24/24 heures, 7/7 jours.
+</p>
+<p>
+  Le GIP Pix se réserve le droit de restreindre, totalement ou partiellement, l’accès aux services, avec un impact sur
+  leur disponibilité, notamment afin d’assurer la maintenance des services dans le cadre d’interventions programmées à
+  l’avance, y compris des serveurs et des infrastructures mises en œuvre pour la fourniture des services.
+</p>
+<p>
+  Il appartiendra à l’utilisateur de veiller aux possibilités d’évolution des moyens informatiques et de transmission à
+  sa disposition pour que ces moyens puissent s’adapter aux évolutions des services.
+</p>
+<p>
+  En cas d’interruption ou d’impossibilité d’utiliser les services, l’utilisateur peut toujours s’adresser au service
+  support du GIP Pix pour obtenir des informations à l’adresse suivante, en transmettant le plus précisément possible le
+  problème rencontré le cas échéant sur la base de documents associés : support@pix.fr.
+</p>
 
-  <h2 class="pix-h3">21. Loi applicable</h2>
+<h2 class="pix-h3">Article 9. Spécificités techniques</h2>
 
-  <p>
-    Les présentes conditions d’utilisation sont régies par la loi française. Il en est ainsi pour les règles de fond et
-    les règles de forme et ce, nonobstant les lieux d’exécution des obligations substantielles ou accessoires.
-  </p>
+<p>
+  Le GIP Pix s’efforce de fournir un service de qualité. Il permet aux utilisateurs d'utiliser les services mis à leur
+  disposition dans les meilleures conditions possibles.
+</p>
+<p>
+  Le GIP Pix est donc tenu à l’égard de l’utilisateur et conformément aux normes et usages en la matière d’une
+  obligation de moyens dans la mise à disposition des services.
+</p>
+<p>
+  En raison de la nature et de la complexité du réseau internet, et en particulier, de ses performances techniques et
+  des temps de réponse pour consulter, interroger ou transférer les données d’informations, le GIP Pix fait ses
+  meilleurs efforts, conformément aux règles de l’art, pour permettre l’accès et l’utilisation des services. Le GIP Pix
+  ne saurait, en effet, assurer une accessibilité ou une disponibilité absolue de la plateforme permettant l’accès au
+  service.
+</p>
+<p>
+  Le GIP Pix ne saurait être responsable du bon fonctionnement de l’équipement informatique de l’utilisateur ainsi que
+  de son accès à internet.
+</p>
+<p>
+  Le GIP Pix informe l’utilisateur des prérequis techniques suivants nécessaires au bon fonctionnement de Pix Certif et
+  des services :
+</p>
+<ul>
+  <li>
+    un navigateur internet (Firefox, Internet Explorer 11 et au-delà, Edge, Chrome, Safari, Opera) dans une version
+    récente (ne datant pas de plus de 2 ans) ;
+  </li>
+  <li>
+    une connexion internet satisfaisante.
+  </li>
+</ul>
 
-</div>
+<h2 class="pix-h3">Article 10. Gestion des sessions de certification</h2>
+
+<p>
+  Il appartient à l’utilisateur de s’assurer avec le ou les centres au(x)quel(s) il est rattaché, au minimum 2 jours
+  ouvrés avant la session de certification, qu’il aura les moyens (matériel informatique et réseau) d’accéder à
+  l’application Pix Certif pour réaliser l’ensemble des opérations qui lui incombent pour permettre le bon déroulé des
+  sessions de certification, dans les conditions prévues à l’agrément de son centre de rattachement
+</p>
+
+<h2 class="pix-h3">Article 11. Utilisation</h2>
+
+<p>
+  L’utilisateur s’engage à n’utiliser les services que dans les seules conditions définies aux présentes conditions
+  d’utilisation et en outre :
+</p>
+<ul>
+  <li>
+    à ne pas détourner l’utilisation des services à des fins personnelles ou contraires à l’usage normal des services ;
+  </li>
+  <li>
+    à ne commettre aucun acte de contrefaçon.
+  </li>
+</ul>
+<p>
+  L’utilisateur est responsable de l’utilisation de son compte utilisateur et des services. Il s’engage à les utiliser
+  de façon loyale, dans le respect des présentes conditions d’utilisation, des lois et règlements applicables, notamment
+  les lois relatives à la propriété intellectuelle et industrielle, à la protection des données à caractère personnel et
+  à la vie privée.
+</p>
+
+<h2 class="pix-h3">Article 12. Sécurité</h2>
+
+<p>
+  Le GIP Pix fait ses meilleurs efforts, conformément aux règles de l’art, pour sécuriser la plateforme au regard du
+  risque encouru et de la nature des données traitées. Eu égard à la complexité d’Internet, l’utilisateur reconnaît et
+  accepte qu’il ne saurait assurer une sécurité absolue.
+</p>
+{{! template-lint-disable no-whitespace-within-word }}
+<p>
+  L’utilisateur pourra informer le GIP Pix de toute défaillance de son compte utilisateur par une notification adressée
+  à : support@pix.fr.
+</p>
+<p>
+  L’utilisateur accepte de prendre toutes les mesures appropriées de façon, d’une part, à sauvegarder régulièrement ses
+  propres données et, d’autre part, à protéger ses données et/ou logiciels et/ou terminaux utilisés de la contamination
+  par d’éventuels virus sur le réseau internet.
+</p>
+<p>
+  La plateforme est un système de traitement automatisé de données.
+</p>
+<p>
+  Il est interdit d'accéder ou de se maintenir, frauduleusement, dans tout ou partie de Pix Certif ou des services ou
+  d’utiliser une méthode d’accès autre que l’interface mise à disposition par le GIP Pix via les services, ou de
+  permettre à un tiers d’y procéder.
+</p>
+<p>
+  Il est interdit d’y introduire frauduleusement des données ou même d’opérer une altération du fonctionnement des
+  services.
+</p>
+<p>
+  L’utilisateur veille notamment à ne pas introduire de virus, code malveillant ou toute autre technologie nuisible aux
+  services.
+</p>
+<p>
+  Tout accès à un espace interdit sera considéré comme un accès frauduleux au sens des dispositions du Code pénal.
+</p>
+<p>
+  L’utilisateur s’engage à considérer que toutes les données dont il aura eu connaissance à l’occasion d’un tel accès à
+  un espace non autorisé sont des données confidentielles et s’engage, en conséquence, à ne pas les divulguer.
+</p>
+<p>
+  L’utilisateur s’interdit notamment de réaliser toute opération visant à saturer une page, les opérations de rebond ou
+  toute opération ayant pour conséquence d'entraver ou de fausser le fonctionnement des services.
+</p>
+<p>
+  L’utilisateur s’engage à ne pas utiliser de dispositifs ou de logiciels de toutes sortes qui auraient pour conséquence
+  de perturber le bon fonctionnement des services.
+</p>
+<p>
+  L’utilisateur s’engage à ne pas engager d'action qui imposerait une charge disproportionnée sur les infrastructures de
+  Pix Certif.
+</p>
+
+<h2 class="pix-h3">Article 13. Maintenance et support</h2>
+
+<h3 class="pix-h4">13.1 Support et assistance auprès de l’utilisateur</h3>
+<p>
+  Le GIP Pix assure un support de nature exclusivement technique auprès de l’utilisateur qui se charge de remonter les
+  éventuels dysfonctionnements des services constatés par lui-même.
+</p>
+<p>
+  L’utilisateur peut joindre le support technique du GIP Pix par courrier électronique à l’adresse support@pix.fr.
+</p>
+<p>
+  Le GIP Pix met à disposition des utilisateurs une FAQ permettant de répondre aux besoins les plus courants.
+</p>
+
+<h3 class="pix-h4">13.2 Maintenance évolutive</h3>
+<p>
+  Les services sont susceptibles d’évoluer dans le temps, pour tenir compte des évolutions technologiques, des besoins
+  des centres et des utilisateurs.
+</p>
+<p>
+  L’évolution des services peut être effectuée à tout moment par le GIP Pix.
+</p>
+<p>
+  Il appartient à l’organisation et aux utilisateurs de mettre à niveau leur système d’information (moyens matériels et
+  logiciels tels que la mise à jour du système d’exploitation ou navigateur) à leurs seuls frais, en cas d’évolution des
+  services qui le nécessiterait de manière raisonnable, pour tenir compte des évolutions des standards technologiques.
+</p>
+<p>
+  Le GIP Pix n’est pas responsable des dommages de toute nature qui peuvent résulter d’une indisponibilité temporaire de
+  tout ou partie des services due à des opérations de maintenance, ainsi que pour toute modification, suppression ou
+  interruption des services.
+</p>
+
+<h2 class="pix-h3">Article 14. Responsabilité</h2>
+
+<h3 class="pix-h4">14.1 Responsabilité de l’utilisateur</h3>
+<p>
+  L’utilisateur accède et utilise les services à ses propres risques et sous sa responsabilité et celle du centre qui
+  l’a habilité, en accord avec la législation française en vigueur ainsi qu’avec les présentes conditions d’utilisation.
+</p>
+<p>
+  L’utilisateur est exclusivement responsable de la licéité des données qu’il communique dans le cadre de l’accès et de
+  l’utilisation des services et dégage le GIP Pix de toute responsabilité à cet égard.
+</p>
+<p>
+  L’utilisateur est seul responsable de l'activité qui se produit par son accès aux services.
+</p>
+<p>
+  L’utilisateur s’engage à ne pas perturber l’accès et/ou l’usage que pourraient faire les autres utilisateurs des
+  services et à ne pas accéder aux espaces utilisateur ou comptes de tiers.
+</p>
+<p>
+  Toute opération effectuée sur Pix Certif avec les identifiants de connexion de l'utilisateur est réputée faite au nom
+  de ce dernier et engage sa responsabilité.
+</p>
+<p>
+  L’utilisateur s’engage à ne commettre aucun acte pouvant mettre en cause la sécurité informatique du GIP Pix ou des
+  autres utilisateurs, conformément à l’article « Sécurité ».
+</p>
+<p>
+  L’utilisateur s’engage à ne pas interférer ou interrompre le fonctionnement normal du compte utilisateur et, plus
+  généralement, des services.
+</p>
+<p>
+  L’utilisateur s’engage à indemniser le GIP Pix, son directeur, ses employés et autres agents en cas de plainte,
+  action, poursuite, condamnation de ces derniers résultant du non-respect des conditions d’utilisation par
+  l’utilisateur.
+</p>
+
+<h3 class="pix-h4">14.2 Responsabilité du GIP Pix</h3>
+<p>
+  Le GIP Pix s’efforcera de réaliser les opérations qui lui incombent relatives au compte utilisateur et aux services,
+  conformément aux règles de l’art.
+</p>
+<p>
+  Le GIP Pix ne saurait être responsable de la qualité des services, ces derniers étant proposés « en l’état », ce que
+  l’utilisateur accepte.
+</p>
+<p>
+  Par ailleurs, le GIP Pix ne pourra voir sa responsabilité engagée :
+</p>
+<ul>
+  <li>
+    en cas d’indisponibilité temporaire ou totale de tout ou partie de l’accès aux services et, d’une manière générale,
+    d’un défaut de performance quelconque ;
+  </li>
+  <li>
+    du fait de l’impossibilité d’accéder aux services, liée à des destructions de matériels, aux attaques ou au piratage
+    informatiques, à la privation, à la suppression ou à l'interdiction, temporaire ou définitive, et pour quelque cause
+    que ce soit, de l'accès au réseau Internet ;
+  </li>
+  <li>
+    dans les limites de la législation en vigueur, par tout dommage indirect et ce y compris notamment les pertes de
+    profit, de données ou tout autre perte de biens incorporels, du fait de l’utilisation des services ou, au contraire,
+    de l’impossibilité de son utilisation ;
+  </li>
+  <li>
+    du fait d'un dysfonctionnement, d'une indisponibilité d'accès, d'une mauvaise utilisation, d'une mauvaise
+    configuration de l'ordinateur ou appareils nomades (tablettes et mobiles) de l’utilisateur, ou encore de l'emploi
+    d'un navigateur ou système d’exploitation peu usité par l’utilisateur ou non conforme aux prérequis techniques ;
+  </li>
+  <li>
+    en cas d’usage frauduleux ou abusif ou dû à une divulgation volontaire ou involontaire à quiconque des codes d’accès
+    confiés à l’utilisateur ;
+  </li>
+  <li>
+    du fait d’un retrait des habilitations qui lui sont conférées à la demande d’un centre auquel il est rattaché et
+    ayant donné lieu à une coupure de l’accès aux services.
+  </li>
+</ul>
+<p>
+  D’un commun accord, les parties conviennent que l’utilisateur ne peut pas lui-même former une quelconque action en
+  responsabilité et renonce à recours contre le GIP Pix, dans la mesure où le préjudice subi ne peut être subi,
+  exclusivement, que par le Centre, et, en cas de préjudice propres, seul le Centre peut agir en son nom pour demander
+  réparation de son préjudice, étant précisé que :
+</p>
+<ul>
+  <li>
+    la responsabilité du GIP Pix pourra être engagée, dans les conditions de droit commun, à raison des dommages directs
+    et prévisibles subis par l’utilisateur, à l’exclusion de tous dommages indirects ;
+  </li>
+  <li>
+    sont considérés comme dommages indirects notamment les pertes de données, de temps, de bénéfices, de chiffre
+    d’affaires, de marges, pertes de commandes, de clients, d’exploitation, de revenus, d’actions commerciales ou encore
+    l’atteinte à l’image de marque, les résultats escomptés et l’action de tiers, et ce même si le GIP Pix était dûment
+    informé du risque de survenance de tels dommages ;
+  </li>
+  <li>
+    la responsabilité du GIP Pix est, d’un commun accord avec l’utilisateur, et tous faits générateurs confondus,
+    limitée au montant hors taxe du prix payé par le centre en contrepartie des services au cours desquels le fait à
+    l’origine du dommage a été commis ;
+  </li>
+  <li>
+    la responsabilité du GIP Pix ne peut donc, d’un commun accord, être mise en jeu à raison des services, tant que les
+    services sont fournis à titre gratuit au centre et à l’utilisateur.
+  </li>
+</ul>
+<p>
+  La présente clause reste applicable en cas de nullité, de résolution, de résiliation ou d’anéantissement des présentes
+  relations contractuelles.
+</p>
+
+<h2 class="pix-h3">Article 15. Propriété intellectuelle</h2>
+
+<p>
+  Le GIP Pix est, et reste, propriétaire exclusif des éléments protégés des services selon les termes du Code de la
+  propriété intellectuelle, à l’exclusion de toutes éventuelles ressources qui relèvent, le cas échéant, de la propriété
+  intellectuelle de tiers.
+</p>
+<p>
+  Le droit de propriété du GIP Pix s’étend en particulier et dans ce cadre, à toute la documentation, les bases de
+  données de Pix Certif, des services, ainsi que leurs interfaces et la documentation associée telle que définie par le
+  Code de la propriété intellectuelle, sans que cette liste ne soit exhaustive.
+</p>
+<p>
+  Les présentes conditions d’utilisation ne sauraient avoir pour effet de transférer ou de céder les droits de propriété
+  intellectuelle des plateformes Pix ou services, aux utilisateurs.
+</p>
+<p>
+  En conséquence, les utilisateurs s'interdisent tout agissement et tout acte susceptible de porter atteinte directement
+  ou non aux droits de propriété intellectuelle du GIP Pix ou des tiers. Notamment, ils s’interdisent de modifier,
+  copier, reproduire, télécharger, diffuser, transmettre, exploiter commercialement et/ou distribuer de quelque façon
+  que ce soit les services ou les pages des plateformes Pix et Pix Certif, dans la mesure où ils feraient respectivement
+  l’objet d’une protection au titre d’un droit de propriété intellectuelle pour leurs parties non soumises à une licence
+  Open Source.
+</p>
+<p>
+  Seule une utilisation des services conformément à leur destination est autorisée. Toute utilisation non conforme ou
+  non expressément autorisée par le GIP Pix au titre des présentes conditions d’utilisation est illicite.
+</p>
+
+<h2 class="pix-h3">Article 16. Liens hypertextes</h2>
+
+<p>
+  Le GIP Pix se réserve la possibilité de mettre en place des hyperliens sur Pix Certif donnant accès à des pages web
+  autres que celles des plateformes Pix et Pix Certif.
+</p>
+<p>
+  Le GIP Pix décline toute responsabilité quant au contenu des informations fournies sur ces sites au titre de
+  l’activation des hyperliens.
+</p>
+<p>
+  Chaque utilisateur accède aux sites tiers sous sa seule et entière responsabilité.
+</p>
+<p>
+  Toute mise en place d’un lien hypertexte sur un site tiers redirigeant vers l’une quelconque des pages internet de la
+  plateforme Pix requiert l’autorisation préalable et écrite du GIP Pix.
+</p>
+
+<h2 class="pix-h3">Article 17. Données à caractère personnel</h2>
+
+<h3 class="pix-h4">17.1 Information de l’utilisation</h3>
+<p>
+  Dans le cadre de ses rapports avec les utilisateurs, le GIP Pix, en qualité de responsable de traitement, peut être
+  amené à traiter les données à caractère personnel suivantes relatives à l’identité d’un utilisateur, à savoir : nom(s)
+  et prénom(s), fonction, qualification, adresse email professionnelle, numéro de téléphone, entité ou centre de
+  rattachement, expériences et CV.
+</p>
+<p>
+  Ces données peuvent lui être transmises par :
+</p>
+<ul>
+  <li>
+    l’utilisateur lors de son inscription sur la plateforme Pix ;
+  </li>
+  <li>
+    le centre, en vue :
+    <ul>
+      <li>
+        de la gestion de l’accès aux services ;
+      </li>
+      <li>
+        la gestion et le suivi du compte utilisateur Pix Certif (création, modification, suppression) ;
+      </li>
+      <li>
+        la gestion des demandes de droit d’accès, de rectification et d’opposition au traitement des données
+        personnelles des utilisateurs concernés.
+      </li>
+    </ul>
+  </li>
+</ul>
+<p>
+  L’utilisateur est informé et accepte que ses données soient traitées par le GIP Pix pour la finalité précitée.
+</p>
+<p>
+  Ce traitement est effectué sur les bases légales suivantes : votre consentement (lorsque vous acceptez les présentes
+  conditions), l'exécution des présentes conditions générales, et l'intérêt légitime du GIP Pix à mettre en œuvre des
+  traitements de gestion.
+</p>
+<p>
+  Ces données sont destinées au GIP Pix responsable de traitement, à son personnel habilité, et à ses éventuels
+  sous-traitants.
+</p>
+<p>
+  Les données seront conservées pendant une durée de 5 ans maximum à compter de la dernière utilisation ou du dernier
+  accès au compte utilisateur et/ou à Pix Certif, et archivées selon les délais de prescription légale (5 ans)
+</p>
+<p>
+  Toute personne concernée par le traitement dispose d’un droit d’interrogation, d’accès, de rectification, d’effacement
+  des données, d’un droit à la limitation du traitement et à la portabilité des données ; ainsi que d’un droit
+  d’opposition pour motif légitime.
+</p>
+<p>
+  Par ailleurs, l’utilisateur dispose d’un droit de formuler des directives spécifiques et générales concernant la
+  conservation, l’effacement et la communication de ses données post-mortem. En ce qui concerne les directives
+  générales, elles pourront être adressées à un tiers qui sera désigné par Décret.
+</p>
+<p>
+  La communication de directives spécifiques post-mortem et l’exercice des droits s’effectuent par courrier électronique
+  à l’adresse email suivante : dpo@pix.fr. La photocopie d’un titre d’identité signé et des informations complémentaires
+  pourront être exigées en cas de doute sur l’identité de l’utilisateur.
+</p>
+<p>
+  Enfin, l’utilisateur a le droit d’introduire une réclamation auprès d’une autorité de contrôle et notamment de la
+  Commission nationale Informatique et libertés (ci-après « CNIL ») et de retirer son consentement à tout moment.
+</p>
+
+<h3 class="pix-h4">17.2 Sous-traitance</h3>
+<p>
+  L’utilisateur est susceptible de traiter les données à caractère personnel des candidats en qualité de sous-traitant
+  du centre (ou de sous-traitant de second rang du GIP Pix), le centre étant lui-même sous-traitant du GIP Pix.
+</p>
+<p>
+  Le terme de sous-traitant au sens de la réglementation informatique et libertés et en particulier du Règlement UE
+  2016/679 et de la présente clause, s’entend de la personne physique (en l’occurrence l’utilisateur en tant que
+  sous-traitant de second rang) ou morale (le centre en tant que sous-traitant de premier rang) qui traite des données à
+  caractère personnel pour le compte du responsable de traitement, le GIP Pix.
+</p>
+<p>
+  Il appartient à l’utilisateur de respecter l’accord contractuel prévu entre lui et le centre conformément à l’article
+  28 du Règlement UE 2016/679, c’est à dire les obligations au moins équivalentes en protection à celles imposées au
+  centre, telles que figurant à la convention d’agrément entre le centre et le GIP Pix.
+</p>
+<p>
+  L’utilisateur peut demander communication de cette convention auprès du centre.
+</p>
+
+<h2 class="pix-h3">18. Résolution et résiliation</h2>
+
+<h3 class="pix-h4">18.1 Désinscription</h3>
+<p>
+  L’accès aux services par l’utilisateur est effectif et valide tant que l’utilisateur :
+</p>
+<ul>
+  <li>
+    utilise les services ; et,
+  </li>
+  <li>
+    est habilité par le centre auquel il est rattaché à utiliser les services.
+  </li>
+</ul>
+<p>
+  En cas de retrait de son habilitation par le centre auquel il est rattaché, l’utilisateur s’engage à s’abstenir de
+  tout accès et de toute utilisation des services.
+</p>
+
+<h3 class="pix-h4">18.2 Suspension et exclusion</h3>
+<p>
+  En cas de manquement aux obligations des présentes conditions d’utilisation par l’utilisateur, le GIP Pix se réserve
+  le droit, sans indemnité ni remboursement, huit (8) jours après l’envoi à l’utilisateur d’un courrier électronique lui
+  demandant de se conformer aux présentes conditions d’utilisation, de suspendre l’accès aux services jusqu’à ce que la
+  cause de la suspension ait disparu.
+</p>
+<p>
+  En cas de manquement répété aux obligations des présentes conditions par l’utilisateur, le GIP Pix se réserve le
+  droit, sans indemnité ni remboursement, huit (8) jours après l’envoi à l’utilisateur d’un courrier électronique lui
+  demandant de se conformer aux présentes conditions d’utilisation resté infructueux, de résilier l’inscription de
+  l’utilisateur et de mettre fin à l’accès à son compte utilisateur ou d’interdire l’accès de tout ou partie des
+  services, sans préjudice de toute action de droit commun qui pourrait lui être ouverte.
+</p>
+
+<h2 class="pix-h3">19. Convention de preuve</h2>
+
+<p>
+  L’acceptation en ligne des présentes conditions d’utilisation par voie électronique a entre les parties la même valeur
+  probante que l’accord sur support papier.
+</p>
+<p>
+  Les registres informatisés conservés dans les systèmes informatiques du GIP Pix seront conservés dans des conditions
+  raisonnables de sécurité et considérés comme les preuves des communications intervenues entre les parties. Elles font
+  foi jusqu’à preuve du contraire.
+</p>
+<p>
+  L’archivage des conditions d’utilisation de Pix Certif et des services est effectué sur un support fiable et durable
+  pouvant être produit à titre de preuve.
+</p>
+
+<h2 class="pix-h3">20. Nullité</h2>
+
+<p>
+  Si une ou plusieurs stipulations des présentes conditions d’utilisation sont tenues pour non valides ou déclarées
+  comme telles en application d’une loi, d’un règlement ou à la suite d’une décision passée en force de chose jugée
+  d’une juridiction compétente, les autres stipulations garderont toute leur force et leur portée.
+</p>
+
+<h2 class="pix-h3">21. Loi applicable</h2>
+
+<p>
+  Les présentes conditions d’utilisation sont régies par la loi française. Il en est ainsi pour les règles de fond et
+  les règles de forme et ce, nonobstant les lieux d’exécution des obligations substantielles ou accessoires.
+</p>

--- a/certif/app/styles/pages/terms-of-service.scss
+++ b/certif/app/styles/pages/terms-of-service.scss
@@ -16,19 +16,21 @@
   background-color: white;
   border-radius: 10px;
 
-  &__logo {
-    margin-bottom: 20px;
 
-    & img {
-      display: flex;
+  &__header {
+    display: flex;
+    flex-direction: column;
+
+    &--logo {
       margin: auto;
+      padding-bottom: 20px;
     }
-  }
 
-  &__title {
-    margin-bottom: 30px;
-    text-align: center;
-    color: $pix-neutral-80
+    &--title {
+      margin: 0 10px 30px;
+      text-align: center;
+      color: $pix-neutral-80
+    }
   }
 
   &__line {
@@ -65,9 +67,6 @@
     flex-direction: row;
     justify-content: flex-end;
     margin: 0 100px;
-  }
-
-  &__submit {
-    margin-left: 10px;
+    gap: 10px;
   }
 }

--- a/certif/app/styles/pages/terms-of-service.scss
+++ b/certif/app/styles/pages/terms-of-service.scss
@@ -64,9 +64,13 @@
 
   &__actions {
     display: flex;
-    flex-direction: row;
-    justify-content: flex-end;
+    flex-direction: column;
     margin: 0 100px;
     gap: 10px;
+
+    @include device-is('tablet') {
+      flex-direction: row;
+      justify-content: flex-end;
+    }
   }
 }

--- a/certif/app/templates/terms-of-service.hbs
+++ b/certif/app/templates/terms-of-service.hbs
@@ -3,27 +3,35 @@
 <div class="terms-of-service-page">
   <div class="terms-of-service-form">
 
-    <div class="terms-of-service-form__logo">
-      <img src="/pix-certif-logo.svg" alt="Pix Certif" />
-    </div>
+    <header class="terms-of-service-form__header">
+      <img src="/pix-certif-logo.svg" alt="Pix Certif" class="terms-of-service-form__header--logo" />
 
-    <h1 class="terms-of-service-form__title pix-h4">
-      {{t "pages.terms-of-service.title"}}
-    </h1>
+      <h1 class="terms-of-service-form__header--title pix-h4">
+        {{t "pages.terms-of-service.title"}}
+      </h1>
+    </header>
 
     <hr class="terms-of-service-form__line" />
 
-    {{#if this.isEnglishLocale}}
-      <TermsOfService::PageEn />
-    {{else}}
-      <TermsOfService::PageFr />
-    {{/if}}
+    <main class="terms-of-service-form__text" tabindex="0">
+      {{#if this.isEnglishLocale}}
+        <TermsOfService::PageEn />
+      {{else}}
+        <TermsOfService::PageFr />
+      {{/if}}
+    </main>
 
-    <div class="terms-of-service-form__actions">
-      <PixButtonLink @route="logout" @backgroundColor="transparent-light">{{t "common.actions.cancel"}}</PixButtonLink>
-      <PixButton class="terms-of-service-form__submit" @triggerAction={{this.submit}}>{{t
-          "pages.terms-of-service.actions.accept"
-        }}</PixButton>
-    </div>
+    <footer>
+      <ul class="terms-of-service-form__actions">
+        <li>
+          <PixButtonLink @route="logout" @backgroundColor="transparent-light" @isBorderVisible="true">{{t
+              "common.actions.cancel"
+            }}</PixButtonLink>
+        </li>
+        <li>
+          <PixButton @triggerAction={{this.submit}}>{{t "pages.terms-of-service.actions.accept"}}</PixButton>
+        </li>
+      </ul>
+    </footer>
   </div>
 </div>


### PR DESCRIPTION
## :unicorn: Problème
L'audit accessibilité réalisé sur l’application Pix Certif a mis en lumières plusieurs soucis sur la page des cgu qui n'ont toujours pas été corrigé.

## :robot: Proposition
Améliorer l'accessibilité de la page des cgu

## :rainbow: Remarques

Les soucis rapportés : 

- Structure incorrect : 
 - 1) Le logo et le titre principal devraient être dans un `<header>`
 - 2) Le contenu des CGU devrait être dans un `<main>`
 - 3) Le lien et le bouton devraient être dans un `<footer>`

- Les étapes de l'article 6 doivent être des titres.

- Le focus sur le lien "Annuler" n'est pas suffisamment visible

- Les deux boutons d'action doivent être dans une liste

- permettre le focus du bloc des cgu pour avoir accès à la barre de navigation interne

## :100: Pour tester

- Se connecter sur Pix Certif avec certifsup@example.net
- Dans la page des cgu, faire "Tabulation à droite" pour vérifier que le bloc des articles est désormais focusable
- Lancer Wave et vérifier qu'il n'y a pas d'autres erreurs retournées
- Passer la page en version mobile et constater que les boutons s'alignent verticalement.
