### PR TITLE
[FEATURE] Changer le lien du mot de passe oublié lorsqu'on passe en domaine ORG sur Pix Certif (PIX-7593). 

### DIFF
--- a/certif/app/components/login-form.hbs
+++ b/certif/app/components/login-form.hbs
@@ -56,7 +56,7 @@
       </PixButton>
 
       <div class="login-main-form__forgotten-password">
-        <a href="https://app.pix.fr/mot-de-passe-oublie" target="_blank" rel="noopener noreferrer">{{t
+        <a href={{this.forgottenPasswordUrl}} target="_blank" rel="noopener noreferrer">{{t
             "common.forms.login.forgot-password"
           }}</a>
       </div>

--- a/certif/app/components/login-form.js
+++ b/certif/app/components/login-form.js
@@ -12,12 +12,11 @@ export default class LoginForm extends Component {
 
   email = null;
   password = null;
-  @tracked isPasswordVisible = false;
   @tracked isErrorMessagePresent = false;
   @tracked errorMessage = null;
 
-  get passwordInputType() {
-    return this.isPasswordVisible ? 'text' : 'password';
+  get forgottenPasswordUrl() {
+    return this.url.forgottenPasswordUrl;
   }
 
   @action
@@ -42,11 +41,6 @@ export default class LoginForm extends Component {
       this.isErrorMessagePresent = true;
       this._handleApiError(responseError);
     }
-  }
-
-  @action
-  togglePasswordVisibility() {
-    this.isPasswordVisible = !this.isPasswordVisible;
   }
 
   _handleApiError(responseError) {

--- a/certif/tests/integration/components/login-form_test.js
+++ b/certif/tests/integration/components/login-form_test.js
@@ -94,6 +94,8 @@ module('Integration | Component | login-form', function (hooks) {
         errors: [{ status: '401', code: 'SHOULD_CHANGE_PASSWORD' }],
       },
     };
+    const service = this.owner.lookup('service:url');
+    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
 
     sessionStub.authenticate.callsFake(() => reject(errorResponse));
     const screen = await renderScreen(hbs`{{login-form}}`);
@@ -105,7 +107,7 @@ module('Integration | Component | login-form', function (hooks) {
 
     // then
     const expectedErrorMessage = this.intl.t('pages.login.errors.should-change-password', {
-      url: 'https://app.pix.localhost/mot-de-passe-oublie',
+      url: 'https://app.pix.fr/mot-de-passe-oublie',
       htmlSafe: true,
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix Certif, le lien du mot de passe oublié est en dur dans le code, en .fr. Or lorsqu'on passe en .org, le lien doit pouvoir passer en .org également.

## :robot: Proposition
Changer le lien selon le domaine de l'utilisateur

## :100: Pour tester

- Aller sur Certif, en fr
- Constater que le lien est : https://app.pix.fr/mot-de-passe-oublie
- passer en org, toujours en français
- Constater que le lien est : https://app.pix.org/mot-de-passe-oublie
- Passer en ?lang=en
- Constater que le lien est : https://app.pix.org/mot-de-passe-oublie?lang=en
