### PR TITLE
[FEATURE] Pour un user qui se connecte à Pix Certif (rejoindre via invitation), si le cookie de la locale est dispo, alors enregistrer cette locale (PIX-7408)

### DIFF
--- a/api/lib/application/certification-center-invitations/certification-center-invitation-controller.js
+++ b/api/lib/application/certification-center-invitations/certification-center-invitation-controller.js
@@ -5,12 +5,14 @@ module.exports = {
   async acceptCertificationCenterInvitation(request, h) {
     const certificationCenterInvitationId = request.params.id;
     const { code, email: rawEmail } = request.deserializedPayload;
+    const localeFromCookie = request.state?.locale;
     const email = rawEmail.trim().toLowerCase();
 
     await usecases.acceptCertificationCenterInvitation({
       certificationCenterInvitationId,
       code,
       email,
+      localeFromCookie,
     });
     return h.response({}).code(204);
   },

--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -89,6 +89,15 @@ class User {
     return dayjs(parsedDate).isBefore(dayjs(config.dataProtectionPolicy.updateDate)) && isNotOrganizationLearner;
   }
 
+  setLocaleIfNotAlreadySet(newLocale) {
+    this.mustBePersisted = false;
+    if (newLocale && !this.locale) {
+      const canonicalLocale = localeService.getCanonicalLocale(newLocale);
+      this.locale = canonicalLocale;
+      this.mustBePersisted = true;
+    }
+  }
+
   isLinkedToOrganizations() {
     return this.memberships.length > 0;
   }

--- a/api/lib/domain/usecases/accept-certification-center-invitation.js
+++ b/api/lib/domain/usecases/accept-certification-center-invitation.js
@@ -4,8 +4,10 @@ module.exports = async function acceptCertificationCenterInvitation({
   certificationCenterInvitationId,
   code,
   email,
+  localeFromCookie,
   certificationCenterInvitedUserRepository,
   certificationCenterMembershipRepository,
+  userRepository,
 }) {
   const certificationCenterInvitedUser = await certificationCenterInvitedUserRepository.get({
     certificationCenterInvitationId,
@@ -24,6 +26,14 @@ module.exports = async function acceptCertificationCenterInvitation({
     throw new AlreadyExistingMembershipError(
       `Certification center membership already exists for the user ID ${userId} and certification center ID ${certificationCenterId}.`
     );
+  }
+
+  if (localeFromCookie) {
+    const user = await userRepository.getById(userId);
+    user.setLocaleIfNotAlreadySet(localeFromCookie);
+    if (user.mustBePersisted) {
+      await userRepository.update({ id: user.id, locale: user.locale });
+    }
   }
 
   certificationCenterInvitedUser.acceptInvitation(code);

--- a/api/lib/domain/usecases/change-user-lang.js
+++ b/api/lib/domain/usecases/change-user-lang.js
@@ -1,3 +1,4 @@
-module.exports = function changeUserLang({ userId, lang, userRepository }) {
-  return userRepository.updateUserAttributes(userId, { lang });
+module.exports = async function changeUserLang({ userId, lang, userRepository }) {
+  await userRepository.update({ id: userId, lang });
+  return userRepository.getFullById(userId);
 };

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -407,12 +407,6 @@ module.exports = {
     await knex('users').where({ id: userId }).update({ lastLoggedAt: now });
   },
 
-  async updateLocale({ userId, locale }) {
-    const now = new Date();
-
-    await knex('users').where({ id: userId }).update({ locale, updatedAt: now });
-  },
-
   async updateLastDataProtectionPolicySeenAt({ userId }) {
     const now = new Date();
 

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -187,6 +187,12 @@ module.exports = {
     return bookshelfUser ? _toDomain(bookshelfUser) : null;
   },
 
+  async update(properties) {
+    const { id: userId, ...data } = properties;
+    data.updatedAt = new Date();
+    await knex('users').where({ id: userId }).update(data);
+  },
+
   updateWithEmailConfirmed({
     id,
     userAttributes,

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -1682,35 +1682,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
         expect(userUpdated.lastLoggedAt).to.deep.equal(now);
       });
     });
-
-    describe('#updateLocale', function () {
-      let clock;
-      const now = new Date('2020-01-02');
-
-      beforeEach(function () {
-        clock = sinon.useFakeTimers(now);
-      });
-
-      afterEach(function () {
-        clock.restore();
-      });
-
-      it('should update the user locale to the provided value', async function () {
-        // given
-        const user = databaseBuilder.factory.buildUser();
-        const userId = user.id;
-        await databaseBuilder.commit();
-        const locale = 'fr-BE';
-
-        // when
-        await userRepository.updateLocale({ userId, locale });
-
-        // then
-        const userUpdated = await knex('users').select().where({ id: userId }).first();
-        expect(userUpdated.locale).to.deep.equal(locale);
-        expect(userUpdated.updatedAt).to.deep.equal(now);
-      });
-    });
   });
 
   describe('#checkIfEmailIsAvailable', function () {

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -1282,6 +1282,34 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
   });
 
   describe('update user', function () {
+    describe('#update', function () {
+      let clock;
+      const now = new Date('2021-01-02');
+
+      beforeEach(function () {
+        clock = sinon.useFakeTimers(now);
+      });
+
+      afterEach(function () {
+        clock.restore();
+      });
+
+      it('updates the given properties', async function () {
+        // given
+        const user = databaseBuilder.factory.buildUser();
+        await databaseBuilder.commit();
+
+        // when
+        await userRepository.update({ id: user.id, email: 'chronos@example.net', locale: 'fr-BE' });
+        const fetchedUser = await knex.from('users').where({ id: user.id }).first();
+
+        // then
+        expect(fetchedUser.updatedAt).to.deep.equal(new Date('2021-01-02'));
+        expect(fetchedUser.email).to.equal('chronos@example.net');
+        expect(fetchedUser.locale).to.equal('fr-BE');
+      });
+    });
+
     describe('#updateEmail', function () {
       it('should update the user email', async function () {
         // given

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -1378,36 +1378,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', function 
       });
     });
 
-    describe('#updateUserAttributes', function () {
-      it('should update lang of the user', async function () {
-        // given
-        const userInDb = databaseBuilder.factory.buildUser(userToInsert);
-        await databaseBuilder.commit();
-
-        const userAttributes = {
-          lang: 'en',
-        };
-
-        // when
-        const updatedUser = await userRepository.updateUserAttributes(userInDb.id, userAttributes);
-
-        // then
-        expect(updatedUser).to.be.an.instanceOf(User);
-        expect(updatedUser.lang).to.equal(userAttributes.lang);
-      });
-
-      it('should throw UserNotFoundError when user id not found', async function () {
-        // given
-        const wrongUserId = 0;
-
-        // when
-        const error = await catchErr(userRepository.updateUserAttributes)(wrongUserId, { lang: 'en' });
-
-        // then
-        expect(error).to.be.instanceOf(UserNotFoundError);
-      });
-    });
-
     describe('#updateUserDetailsForAdministration', function () {
       it('should update firstName, lastName, email and username of the user', async function () {
         // given

--- a/api/tests/unit/application/certification-center-invitations/certification-center-invitation-controller_test.js
+++ b/api/tests/unit/application/certification-center-invitations/certification-center-invitation-controller_test.js
@@ -32,6 +32,7 @@ describe('Unit | Application | Certification-center-Invitations | Certification-
         certificationCenterInvitationId,
         code,
         email: notValidEmail.trim().toLowerCase(),
+        localeFromCookie: undefined,
       });
       expect(response.statusCode).to.equal(204);
     });

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -27,6 +27,56 @@ describe('Unit | Domain | Models | User', function () {
     });
   });
 
+  describe('setLocaleIfNotAlreadySet', function () {
+    it('deals with empty locale', function () {
+      // given
+      const user = new User();
+      const getCanonicalLocaleStub = sinon.stub(localeService, 'getCanonicalLocale');
+
+      // when
+      user.setLocaleIfNotAlreadySet(null);
+
+      // then
+      expect(getCanonicalLocaleStub).to.not.have.been.called;
+      expect(user.locale).to.be.undefined;
+      expect(user.mustBePersisted).to.be.false;
+    });
+
+    context('when user has no locale', function () {
+      it('validates, canonicalizes and sets the locale', function () {
+        // given
+        const user = new User();
+        const getCanonicalLocaleStub = sinon.stub(localeService, 'getCanonicalLocale');
+        getCanonicalLocaleStub.returns('fr-FR');
+
+        // when
+        user.setLocaleIfNotAlreadySet('fr-fr');
+
+        // then
+        expect(getCanonicalLocaleStub).to.have.been.calledWith('fr-fr');
+        expect(user.locale).to.equal('fr-FR');
+        expect(user.mustBePersisted).to.be.true;
+      });
+    });
+
+    context('when user has a locale', function () {
+      it('does not set a new locale', function () {
+        // given
+        const user = new User({ locale: 'en' });
+        const getCanonicalLocaleStub = sinon.stub(localeService, 'getCanonicalLocale');
+        getCanonicalLocaleStub.returns('fr-FR');
+
+        // when
+        user.setLocaleIfNotAlreadySet('fr-fr');
+
+        // then
+        expect(getCanonicalLocaleStub).to.not.have.been.called;
+        expect(user.locale).to.equal('en');
+        expect(user.mustBePersisted).to.be.false;
+      });
+    });
+  });
+
   describe('isLinkedToOrganizations', function () {
     it('should be true if user has a role in an organization', function () {
       // given

--- a/api/tests/unit/domain/usecases/accept-certification-center-invitation_test.js
+++ b/api/tests/unit/domain/usecases/accept-certification-center-invitation_test.js
@@ -5,73 +5,16 @@ const CertificationCenterInvitation = require('../../../../lib/domain/models/Cer
 const { AlreadyExistingMembershipError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | accept-certification-center-invitation', function () {
-  it('should return the user invitation', async function () {
-    // given
-    const certificationCenterInvitedUserRepository = {
-      get: sinon.stub(),
-      save: sinon.stub(),
-    };
-    const certificationCenterMembershipRepository = {
-      isMemberOfCertificationCenter: sinon.stub(),
-    };
-
-    const code = 'SDFGH123';
-    const email = 'user@example.net';
-    const certificationCenterId = domainBuilder.buildCertificationCenter().id;
-    const certificationCenterInvitation = domainBuilder.buildCertificationCenterInvitation({
-      id: 1234,
-      certificationCenterId,
-    });
-    const user = domainBuilder.buildUser({ email });
-
-    const certificationCenterInvitedUser = new CertificationCenterInvitedUser({
-      userId: user.id,
-      invitation: { code, id: certificationCenterInvitation.id },
-      status: CertificationCenterInvitation.StatusType.PENDING,
-    });
-    certificationCenterInvitedUserRepository.get.resolves(certificationCenterInvitedUser);
-    certificationCenterMembershipRepository.isMemberOfCertificationCenter.resolves(false);
-
-    // when
-    await acceptCertificationCenterInvitation({
-      certificationCenterInvitationId: certificationCenterInvitation.id,
-      code,
-      email,
+  it('should throw an error if user is already member of the certification center', async function () {
+    const {
       certificationCenterInvitedUserRepository,
       certificationCenterMembershipRepository,
-    });
+      code,
+      email,
+      certificationCenterInvitation,
+      user,
+    } = _buildInvitationContext();
 
-    // then
-    expect(certificationCenterInvitedUserRepository.get).to.have.been.calledWith({
-      certificationCenterInvitationId: 1234,
-      email: 'user@example.net',
-    });
-  });
-
-  it('should throw an error if user is already member of the certification center', async function () {
-    // given
-    const certificationCenterInvitedUserRepository = {
-      get: sinon.stub(),
-      save: sinon.stub(),
-    };
-    const certificationCenterMembershipRepository = {
-      isMemberOfCertificationCenter: sinon.stub(),
-    };
-    const code = 'SDFGH123';
-    const email = 'user@example.net';
-    const certificationCenterId = domainBuilder.buildCertificationCenter().id;
-    const certificationCenterInvitation = domainBuilder.buildCertificationCenterInvitation({
-      id: 1234,
-      certificationCenterId,
-    });
-    const user = domainBuilder.buildUser({ email });
-
-    const certificationCenterInvitedUser = new CertificationCenterInvitedUser({
-      userId: user.id,
-      invitation: { code, id: certificationCenterInvitation.id, certificationCenterId },
-      status: CertificationCenterInvitation.StatusType.PENDING,
-    });
-    certificationCenterInvitedUserRepository.get.resolves(certificationCenterInvitedUser);
     certificationCenterMembershipRepository.isMemberOfCertificationCenter.resolves(true);
 
     // when
@@ -85,49 +28,111 @@ describe('Unit | UseCase | accept-certification-center-invitation', function () 
 
     // then
     expect(error.message).to.equal(
-      `Certification center membership already exists for the user ID ${user.id} and certification center ID ${certificationCenterId}.`
+      `Certification center membership already exists for the user ID ${user.id} and certification center ID 1234.`
     );
     expect(error).to.be.an.instanceof(AlreadyExistingMembershipError);
   });
 
-  it('should update the invitation status to accepted with date and create a membership for the user', async function () {
+  it('sets the user locale if there is a localeFromCookie, updates the invitation status to accepted with date and creates a membership for the user', async function () {
     // given
-    const certificationCenterInvitedUserRepository = {
-      get: sinon.stub(),
-      save: sinon.stub(),
-    };
-    const certificationCenterMembershipRepository = {
-      isMemberOfCertificationCenter: sinon.stub(),
-    };
-    const code = 'SDFGH123';
-    const email = 'user@example.net';
-    const certificationCenterId = domainBuilder.buildCertificationCenter().id;
-    const certificationCenterInvitation = domainBuilder.buildCertificationCenterInvitation({
-      id: 1234,
-      certificationCenterId,
-    });
-    const user = domainBuilder.buildUser({ email });
-
-    const certificationCenterInvitedUser = new CertificationCenterInvitedUser({
-      userId: user.id,
-      invitation: { code, id: certificationCenterInvitation.id },
-      status: CertificationCenterInvitation.StatusType.PENDING,
-    });
-    certificationCenterInvitedUserRepository.get.resolves(certificationCenterInvitedUser);
-
-    sinon.stub(certificationCenterInvitedUser, 'acceptInvitation').resolves();
-    certificationCenterMembershipRepository.isMemberOfCertificationCenter.resolves(false);
+    const localeFromCookie = 'fr-BE';
+    const {
+      certificationCenterInvitedUserRepository,
+      certificationCenterMembershipRepository,
+      code,
+      email,
+      certificationCenterInvitation,
+      user,
+      certificationCenterInvitedUser,
+      userRepository,
+    } = _buildInvitationContext();
 
     // when
     await acceptCertificationCenterInvitation({
       certificationCenterInvitationId: certificationCenterInvitation.id,
       code,
       email,
+      localeFromCookie,
       certificationCenterInvitedUserRepository,
       certificationCenterMembershipRepository,
+      userRepository,
     });
 
     // then
     expect(certificationCenterInvitedUserRepository.save).to.have.been.calledWith(certificationCenterInvitedUser);
+    expect(userRepository.update).to.have.been.calledWith({ id: user.id, locale: 'fr-BE' });
+  });
+
+  it('does not sets the user locale if there is not a localeFromCookie, updates the invitation status to accepted with date and creates a membership for the user', async function () {
+    // given
+    const localeFromCookie = null;
+    const {
+      certificationCenterInvitedUserRepository,
+      certificationCenterMembershipRepository,
+      code,
+      email,
+      certificationCenterInvitation,
+      userRepository,
+    } = _buildInvitationContext();
+
+    // when
+    await acceptCertificationCenterInvitation({
+      certificationCenterInvitationId: certificationCenterInvitation.id,
+      code,
+      email,
+      localeFromCookie,
+      certificationCenterInvitedUserRepository,
+      certificationCenterMembershipRepository,
+      userRepository,
+    });
+
+    // then
+    expect(userRepository.update).not.to.have.been.called;
   });
 });
+
+function _buildInvitationContext() {
+  const certificationCenterInvitedUserRepository = {
+    get: sinon.stub(),
+    save: sinon.stub(),
+  };
+  const certificationCenterMembershipRepository = {
+    isMemberOfCertificationCenter: sinon.stub(),
+  };
+  const code = 'SDFGH123';
+  const email = 'user@example.net';
+  const certificationCenterId = domainBuilder.buildCertificationCenter().id;
+  const certificationCenterInvitation = domainBuilder.buildCertificationCenterInvitation({
+    id: 1234,
+    certificationCenterId,
+  });
+  const user = domainBuilder.buildUser({ email, locale: null });
+
+  const certificationCenterInvitedUser = new CertificationCenterInvitedUser({
+    userId: user.id,
+    invitation: { code, certificationCenterId: certificationCenterInvitation.id },
+    status: CertificationCenterInvitation.StatusType.PENDING,
+  });
+  certificationCenterInvitedUserRepository.get
+    .withArgs({ certificationCenterInvitationId: certificationCenterInvitation.id, email })
+    .resolves(certificationCenterInvitedUser);
+
+  sinon.stub(certificationCenterInvitedUser, 'acceptInvitation').resolves();
+  certificationCenterMembershipRepository.isMemberOfCertificationCenter.resolves(false);
+
+  const userRepository = {
+    getById: sinon.stub(),
+    update: sinon.stub(),
+  };
+  userRepository.getById.resolves(user);
+  return {
+    certificationCenterInvitedUserRepository,
+    certificationCenterMembershipRepository,
+    code,
+    email,
+    certificationCenterInvitation,
+    user,
+    certificationCenterInvitedUser,
+    userRepository,
+  };
+}

--- a/api/tests/unit/domain/usecases/change-user-lang_test.js
+++ b/api/tests/unit/domain/usecases/change-user-lang_test.js
@@ -4,7 +4,8 @@ const userRepository = require('../../../../lib/infrastructure/repositories/user
 
 describe('Unit | UseCase | change-user-lang', function () {
   beforeEach(function () {
-    sinon.stub(userRepository, 'updateUserAttributes');
+    sinon.stub(userRepository, 'update').resolves();
+    sinon.stub(userRepository, 'getFullById');
   });
 
   it('should modify user attributes to change lang', async function () {
@@ -12,13 +13,14 @@ describe('Unit | UseCase | change-user-lang', function () {
     const userId = Symbol('userId');
     const updatedUser = Symbol('updateduser');
     const lang = 'jp';
-    userRepository.updateUserAttributes.resolves(updatedUser);
+    userRepository.getFullById.resolves(updatedUser);
 
     // when
     const actualUpdatedUser = await changeUserLang({ userId, lang, userRepository });
 
     // then
-    expect(userRepository.updateUserAttributes).to.have.been.calledWith(userId, { lang });
+    expect(userRepository.update).to.have.been.calledWith({ id: userId, lang });
+    expect(userRepository.getFullById).to.have.been.calledWith(userId);
     expect(actualUpdatedUser).to.equal(updatedUser);
   });
 });

--- a/certif/app/routes/application.js
+++ b/certif/app/routes/application.js
@@ -1,12 +1,15 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
+const FRENCH_LOCALE = 'fr-FR';
+
 export default class ApplicationRoute extends Route {
   @service currentUser;
   @service featureToggles;
   @service intl;
   @service currentDomain;
   @service dayjs;
+  @service locale;
 
   async beforeModel(transition) {
     await this.featureToggles.load();
@@ -26,6 +29,11 @@ export default class ApplicationRoute extends Route {
 
     if (domain === domainFr) {
       this._setLocale(domainFr);
+
+      if (!this.locale.hasLocaleCookie()) {
+        this.locale.setLocaleCookie(FRENCH_LOCALE);
+      }
+
       return;
     }
 

--- a/certif/app/services/locale.js
+++ b/certif/app/services/locale.js
@@ -1,0 +1,22 @@
+import Service, { inject as service } from '@ember/service';
+import config from 'pix-certif/config/environment';
+
+const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
+
+export default class LocaleService extends Service {
+  @service cookies;
+  @service currentDomain;
+
+  hasLocaleCookie() {
+    return this.cookies.exists('locale');
+  }
+
+  setLocaleCookie(locale) {
+    this.cookies.write('locale', locale, {
+      domain: `pix.${this.currentDomain.getExtension()}`,
+      maxAge: COOKIE_LOCALE_LIFESPAN_IN_SECONDS,
+      path: '/',
+      sameSite: 'Strict',
+    });
+  }
+}

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -85,6 +85,7 @@ module.exports = function (environment) {
         minValue: 1,
       }),
       sessionSupervisingPollingRate: process.env.SESSION_SUPERVISING_POLLING_RATE ?? 5000,
+      COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
     },
 
     matomo: {},

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -45,6 +45,7 @@
         "ember-cli-sri": "^2.1.1",
         "ember-cli-terser": "^4.0.2",
         "ember-composable-helpers": "^4.5.0",
+        "ember-cookies": "^0.5.2",
         "ember-data": "^4.0.2",
         "ember-dayjs": "^0.10.3",
         "ember-export-application-global": "^2.0.1",

--- a/certif/package.json
+++ b/certif/package.json
@@ -72,6 +72,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-composable-helpers": "^4.5.0",
+    "ember-cookies": "^0.5.2",
     "ember-data": "^4.0.2",
     "ember-dayjs": "^0.10.3",
     "ember-export-application-global": "^2.0.1",

--- a/certif/tests/unit/routes/application_test.js
+++ b/certif/tests/unit/routes/application_test.js
@@ -58,6 +58,54 @@ module('Unit | Route | application', function (hooks) {
         sinon.assert.calledWith(intlSetLocaleStub, ['fr', 'fr']);
         sinon.assert.calledWith(dayjsSetLocaleStub, 'fr');
       });
+
+      module('when there is no cookie locale', function () {
+        test('add a cookie locale with "fr-FR" as value', async function (assert) {
+          // given
+          const localeServiceStub = Service.create({
+            hasLocaleCookie: sinon.stub().returns(false),
+            setLocaleCookie: sinon.stub(),
+          });
+          const currentDomainStub = {
+            getExtension: () => 'fr',
+          };
+          const route = this.owner.lookup('route:application');
+
+          route.set('locale', localeServiceStub);
+          route.set('currentDomain', currentDomainStub);
+
+          // when
+          await route.handleLocale();
+
+          // then
+          sinon.assert.calledWith(localeServiceStub.setLocaleCookie, 'fr-FR');
+          assert.ok(true);
+        });
+      });
+
+      module('when there is a cookie locale', function () {
+        test('does not update cookie locale', async function (assert) {
+          // given
+          const localeServiceStub = Service.create({
+            hasLocaleCookie: sinon.stub().returns(true),
+            setLocaleCookie: sinon.stub(),
+          });
+          const currentDomainStub = {
+            getExtension: () => 'fr',
+          };
+          const route = this.owner.lookup('route:application');
+
+          route.set('locale', localeServiceStub);
+          route.set('currentDomain', currentDomainStub);
+
+          // when
+          await route.handleLocale();
+
+          // then
+          sinon.assert.notCalled(localeServiceStub.setLocaleCookie);
+          assert.ok(true);
+        });
+      });
     });
 
     module('when domain is org', function () {

--- a/scripts/local-domains/hosts.txt
+++ b/scripts/local-domains/hosts.txt
@@ -4,3 +4,4 @@
 127.0.0.1 orga.dev.pix.org
 127.0.0.1 admin.dev.pix.fr
 127.0.0.1 certif.dev.pix.fr
+127.0.0.1 certif.dev.pix.org

--- a/scripts/local-domains/nginx.conf
+++ b/scripts/local-domains/nginx.conf
@@ -40,3 +40,10 @@ server {
     proxy_pass http://host.docker.internal:4203;
   }
 }
+
+server {
+  server_name certif.dev.pix.org;
+  location / {
+    proxy_pass http://host.docker.internal:4203;
+  }
+}


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateur se connecte à certif.pix.org ou certif.pix.fr via une invitation (double mire), nous avons besoin d'enregistrer sa locale.

## :robot: Proposition

Quand un utilisateur se connecter certif.pix.org via une invitation, on récupère sa locale dans le cookie et on l'enregistre s'il n'as pas déjà de locale. 
Quand un utilisateur se connecter certif.pix.fr via une invitation, on crée un cookie avec une locale ayant pour valeur `fr-FR` et on l'enregistre s'il n'as pas déjà de locale. 

## :rainbow: Remarques

RAS

## :100: Pour tester

**Pour tester en RA :** 

- Se rendre Pix Admin 
- Sélectionner un centre de certification et aller dans l'onglet invitation puis envoyer un email d'invitation à une adresse email dont vous avez accès
- Récupérer le lien de l'email et modifier l'url pour avoir l'url de la RA en préfixe (ex: `https://certif-pr5914.review.pix.fr/rejoindre?invitationId=101285&code=NMXPBHCOIY`)

**Pour tester en local :** 

- Ajouter la variable suivante `DEBUG="pix:mailer:email"` dans le fichier .env du dossier api
- Se rendre Pix Admin 
- Sélectionner un centre de certification et aller dans l'onglet invitation puis envoyer un email d'invitation à une adresse email quelconque 
- Récupérer le lien de l'email dans la requête de votre terminal et modifier l'url pour avoir l'url des local-domains en préfixe (ex: `http://certif.dev.pix.fr/rejoindre?invitationId=101285&code=NMXPBHCOIY`)

---

### Domaine .fr - Avec un cookie
- Vérifier que vous avez déjà un cookie avec la valeur `fr-FR` (si vous n'avez pas de cookie, rendez-vous sur [Pix App](https://app-pr5914.review.pix.fr) et revenez sur [Pix Certif](https://certif-pr5914.review.pix.fr/))
- Dans la partie "J'ai déjà un compte" cliquer sur le bouton "Se connecter"
- Se connecter avec avec un seed n'ayant pas de locale
- Vérifier en BDD que la locale de l'utilisateur a la valeur `fr-FR`

### Domaine .fr - Sans cookie
- Supprimer les cookies de votre navigateur
- Dans la partie "J'ai déjà un compte" cliquer sur le bouton "Se connecter"
- Se connecter avec avec un seed n'ayant pas de locale
- Vérifier qu'un cookie avec la valeur `fr-FR` a bien été crée
- Vérifier en BDD que la locale de l'utilisateur a la valeur `fr-FR`

### Domaine .org - Avec un cookie
- Modifier l'url de l'invitation en `pix.org`
- Supprimer les cookies de votre navigateur
- Dans la partie "J'ai déjà un compte" cliquer sur le bouton "Se connecter"
- Se connecter avec avec un seed n'ayant pas de locale
- Vérifier en BDD que la locale de l'utilisateur est toujours vide

### Domaine .org  - Sans cookie
- Se rendre sur pix.org et sélectionner la locale FWB
- Modifier l'url de l'invitation en `pix.org`
- Vérifier que vous avez bien cookie "locale" avec la valeur `fr-BE`
- Dans la partie "J'ai déjà un compte" cliquer sur le bouton "Se connecter"
- Se connecter avec avec un seed n'ayant pas de locale
- Vérifier en BDD que la locale de l'utilisateur a la même valeur que la locale provenant du cookie `fr-BE`

