### PR TITLE
[FEATURE] Traduction de la page de finalisation de session sur Pix Certif (PIX-6676).

### DIFF
--- a/certif/app/components/session-finalization/complementary-information-step.hbs
+++ b/certif/app/components/session-finalization/complementary-information-step.hbs
@@ -7,9 +7,9 @@
         id="session-finalization-complementary-information-step-incident"
         {{on "click" this.onCheckIncidentDuringCertificationSession}}
       />
-      <label for="session-finalization-complementary-information-step-incident">Malgré un incident survenu pendant la
-        session, les candidats ont pu terminer leur test de certification. Un temps supplémentaire a été accordé à un ou
-        plusieurs candidats.</label>
+      <label for="session-finalization-complementary-information-step-incident">
+        {{t "pages.session-finalization.complementary-information.incident"}}
+      </label>
     </div>
     <div class="session-finalization-complementary-information-step__checkboxes">
       <Input
@@ -18,19 +18,13 @@
         id="session-finalization-complementary-information-step-candidates-joining-issue"
         {{on "click" this.onCheckIssueWithJoiningSession}}
       />
-      <label for="session-finalization-complementary-information-step-candidates-joining-issue">Un ou plusieurs
-        candidats étaient présents en session de certification mais n'ont pas pu rejoindre la session.</label>
+      <label for="session-finalization-complementary-information-step-candidates-joining-issue">
+        {{t "pages.session-finalization.complementary-information.candidates-joining-issue.label"}}
+      </label>
     </div>
     {{#if this.displayJoiningIssue}}
       <PixMessage @type="info" @withIcon={{true}}>
-        Vous trouverez
-        <a
-          class="link"
-          href="https://cloud.pix.fr/s/zf3fGimWwPQCeWF/download/Probl%C3%A8mes%20d%27acc%C3%A8s%20en%20session.pdf"
-          target="_blank"
-          rel="noreferrer noopener"
-        >ici un document pour vous aider à résoudre ce type de problème de connexion pour les prochaines sessions. (PDF,
-          131ko)</a>
+        {{t "pages.session-finalization.complementary-information.candidates-joining-issue.link" htmlSafe=true}}
       </PixMessage>
     {{/if}}
   </div>

--- a/certif/app/components/session-finalization/completed-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/completed-reports-information-step.hbs
@@ -4,19 +4,19 @@
       <caption>
         <div class="session-finalization-reports-information-step__title-completed">
           <FaIcon @icon="check-circle" class="session-finalization-reports-information-step__icon" />
-          Certification(s) terminée(s)
+          {{t "pages.session-finalization.reporting.completed-reports-information.description"}}
         </div>
         <span class="sr-only">
-          {{t "pages.sessions.finalize.finished-test-list-description"}}
+          {{t "pages.session-finalization.reporting.completed-reports-information.extra-information"}}
         </span>
       </caption>
     {{/if}}
     <thead>
       <tr>
-        <th>Nom</th>
-        <th>Prénom</th>
-        <th>N° de certification</th>
-        <th>Signalement</th>
+        <th>{{t "common.labels.candidate.lastname"}}</th>
+        <th>{{t "common.labels.candidate.firstname"}}</th>
+        <th>{{t "pages.session-finalization.reporting.table.labels.certification-number"}}</th>
+        <th>{{t "pages.session-finalization.reporting.table.labels.reporting"}}</th>
         {{#if @shouldDisplayHasSeenEndTestScreenCheckbox}}
           <th>
             <div class="session-finalization-reports-information-step__row">
@@ -57,12 +57,10 @@
                   {{t "common.actions.delete"}}
                 </button>
                 <p data-test-id="finalization-report-has-examiner-comment_{{report.certificationCourseId}}">
-                  {{#if (gt report.certificationIssueReports.length 1)}}
-                    {{report.certificationIssueReports.length}}
-                    signalements
-                  {{else}}
-                    1 signalement
-                  {{/if}}
+                  {{t
+                    "pages.session-finalization.reporting.table.reporting-count"
+                    reportingsCount=report.certificationIssueReports.length
+                  }}
                 </p>
               {{else}}
                 <button

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.hbs
@@ -7,42 +7,55 @@
         @withIcon={{true}}
         class="session-finalization-reports-information-step__title-uncompleted"
       >
-        Ces candidats n'ont pas fini leur test de certification ou le surveillant a mis fin à leur test
+        {{t "pages.session-finalization.reporting.uncompleted-reports-information.description"}}
       </PixMessage>
       <span class="sr-only">
-        {{t "pages.sessions.finalize.unfinished-test-list-description"}}
+        {{t "pages.session-finalization.reporting.uncompleted-reports-information.extra-information"}}
       </span>
     </caption>
     <thead>
       <tr>
-        <th>Nom</th>
-        <th>Prénom</th>
-        <th>N° de certification</th>
-        <th>Signalement</th>
+        <th>{{t "common.labels.candidate.lastname"}}</th>
+        <th>{{t "common.labels.candidate.firstname"}}</th>
+        <th>{{t "pages.session-finalization.reporting.table.labels.certification-number"}}</th>
+        <th>{{t "pages.session-finalization.reporting.table.labels.reporting"}}</th>
         <th>
           <div class="session-finalization-reports-information-step__header_cancel">
-            <span>Raison de l'abandon</span>
+            <span>{{t
+                "pages.session-finalization.reporting.uncompleted-reports-information.table.labels.abandonment-reason"
+              }}</span>
             <PixTooltip @id="tooltip-cancel-reason" @position="left" @isWide={{true}}>
               <:triggerElement>
                 <FaIcon
                   @icon="info-circle"
                   tabindex="0"
                   aria-describedby="tooltip-cancel-reason"
-                  aria-label="Raison de l'abandon"
+                  aria-label={{t
+                    "pages.session-finalization.reporting.uncompleted-reports-information.table.tooltip.extra-information"
+                  }}
                 />
               </:triggerElement>
               <:tooltip>
                 <ul>
-                  <li>Abandon : Manque de temps ou départ prématuré :
+                  <li>{{t
+                      "pages.session-finalization.reporting.uncompleted-reports-information.table.labels.abandonment"
+                    }}
                     <ul>
-                      <li>Le candidat n'a pas eu le temps de répondre à toutes ses questions</li>
-                      <li>Le candidat est parti volontairement avant la fin du test</li>
+                      <li>{{t
+                          "pages.session-finalization.reporting.uncompleted-reports-information.table.tooltip.abandonment.enough-time-description"
+                        }}</li>
+                      <li>{{t
+                          "pages.session-finalization.reporting.uncompleted-reports-information.table.tooltip.abandonment.left-deliberately-description"
+                        }}</li>
                     </ul>
                   </li>
-                  <li>Problème technique :
+                  <li>{{t
+                      "pages.session-finalization.reporting.uncompleted-reports-information.table.labels.technical-problem"
+                    }}
                     <ul>
-                      <li>Le candidat a rencontré un problème technique l'empêchant de poursuivre son test jusqu’à la
-                        fin</li>
+                      <li>{{t
+                          "pages.session-finalization.reporting.uncompleted-reports-information.table.tooltip.technical-problem-description"
+                        }}</li>
                     </ul>
                   </li>
                 </ul>
@@ -74,12 +87,10 @@
                   {{t "common.actions.delete"}}
                 </button>
                 <p data-test-id="finalization-report-has-examiner-comment_{{report.certificationCourseId}}">
-                  {{#if (gt report.certificationIssueReports.length 1)}}
-                    {{report.certificationIssueReports.length}}
-                    signalements
-                  {{else}}
-                    1 signalement
-                  {{/if}}
+                  {{t
+                    "pages.session-finalization.reporting.table.reporting-count"
+                    reportingsCount=report.certificationIssueReports.length
+                  }}
                 </p>
               {{else}}
                 <button
@@ -96,7 +107,7 @@
           <td class="finalization-report-abort-reason">
             <PixSelect
               @id={{concat "finalization-report-abort-reason__select" report.id}}
-              @placeholder={{"-- Choisissez --"}}
+              @placeholder="-- {{t 'common.actions.choose'}} --"
               @onChange={{fn @onChangeAbortReason report}}
               @hideDefaultOption={{true}}
               @value={{report.abortReason}}

--- a/certif/app/components/session-finalization/uncompleted-reports-information-step.js
+++ b/certif/app/components/session-finalization/uncompleted-reports-information-step.js
@@ -8,6 +8,7 @@ export default class UncompletedReportsInformationStep extends Component {
   @tracked showAddIssueReportModal = false;
   @tracked showIssueReportsModal = false;
   @service notifications;
+  @service intl;
 
   get certificationReportsAreNotEmpty() {
     return this.args.certificationReports.length !== 0;
@@ -15,8 +16,18 @@ export default class UncompletedReportsInformationStep extends Component {
 
   get abortOptions() {
     return [
-      { label: 'Abandon : Manque de temps ou départ prématuré', value: 'candidate' },
-      { label: 'Problème technique', value: 'technical' },
+      {
+        label: this.intl.t(
+          'pages.session-finalization.reporting.uncompleted-reports-information.table.labels.abandonment'
+        ),
+        value: 'candidate',
+      },
+      {
+        label: this.intl.t(
+          'pages.session-finalization.reporting.uncompleted-reports-information.table.labels.technical-problem'
+        ),
+        value: 'technical',
+      },
     ];
   }
 

--- a/certif/app/styles/components/session-finalization/reports-information-step.scss
+++ b/certif/app/styles/components/session-finalization/reports-information-step.scss
@@ -6,7 +6,8 @@
     background: $pix-success-10;
     margin: 8px;
     color: $pix-success-70;
-    font-weight: bold;
+    font-size: 0.875rem;
+    font-weight: normal;
     padding: 20px 0 20px 24px;
 
     &--hidden {
@@ -90,5 +91,10 @@
         }
       }
     }
+  }
+
+  &__icon {
+    height: 14px;
+    margin-right: 8px;
   }
 }

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -2,13 +2,13 @@
 <div class="page__title finalize">
   <div class="finalize__title">
     <PixReturnTo @route="authenticated.sessions.details" @model={{this.session.id}}>
-      Retour à la session
+      {{t "pages.session-finalization.return-to"}}
     </PixReturnTo>
-    <h1 class="page-title">Finaliser la session {{this.session.id}}</h1>
+    <h1 class="page-title">{{t "pages.session-finalization.title" sessionId=this.session.id}}</h1>
   </div>
   <SessionFinalizationStepContainer
-    @title="Signalements : Reporter, pour chaque candidat, les signalements renseignés sur le PV d'incident"
-    @subtitle="Pour que le signalement soit pris en compte, il est nécessaire d’utiliser la catégorie de signalement appropriée (exemples : C1, C2, etc)."
+    @title={{t "pages.session-finalization.reporting.title"}}
+    @subtitle={{t "pages.session-finalization.reporting.description"}}
     @icon="/icons/session-finalization-user.svg"
     @iconAlt=""
   >
@@ -34,8 +34,8 @@
   </SessionFinalizationStepContainer>
 
   <SessionFinalizationStepContainer
-    @title="Informations complémentaires (facultatif)"
-    @subtitle="Vous pouvez indiquer, le cas échéant, les événements survenus lors de la session. Il n'est pas nécessaire de renseigner les candidats absents."
+    @title={{t "pages.session-finalization.complementary-information.title"}}
+    @subtitle={{t "pages.session-finalization.complementary-information.description"}}
     @icon="/icons/edit-file.svg"
     @iconAlt=""
   >
@@ -46,7 +46,7 @@
   </SessionFinalizationStepContainer>
 
   <PixButton class="finalize__button" data-test-id="finalize__button" @triggerAction={{this.openModal}}>
-    Finaliser
+    {{t "pages.session-finalization.actions.finalise"}}
   </PixButton>
 </div>
 

--- a/certif/tests/integration/components/session-finalization/complementary-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/complementary-information-step_test.js
@@ -114,7 +114,7 @@ module('Integration | Component | SessionFinalization::ComplementaryInformationS
     assert
       .dom(
         screen.getByRole('link', {
-          name: 'ici un document pour vous aider à résoudre ce type de problème de connexion pour les prochaines sessions. (PDF, 131ko)',
+          name: 'ici un document pour vous aider à résoudre ce type de problème de connexion pour les prochaines sessions (PDF, 131ko).',
         })
       )
       .exists();

--- a/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/completed-reports-information-step_test.js
@@ -109,7 +109,7 @@ module('Integration | Component | SessionFinalization::CompletedReportsInformati
     assert
       .dom(
         screen.getByRole('table', {
-          name: `Certification(s) terminée(s) ${this.intl.t('pages.sessions.finalize.finished-test-list-description')}`,
+          name: 'Certification(s) terminée(s) Liste des candidats qui ont fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant.',
         })
       )
       .exists();

--- a/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
+++ b/certif/tests/integration/components/session-finalization/uncompleted-reports-information-step_test.js
@@ -226,9 +226,7 @@ module('Integration | Component | SessionFinalization::UncompletedReportsInforma
     assert
       .dom(
         screen.getByRole('table', {
-          name: `Ces candidats n'ont pas fini leur test de certification ou le surveillant a mis fin à leur test ${this.intl.t(
-            'pages.sessions.finalize.unfinished-test-list-description'
-          )}`,
+          name: "Ces candidats n'ont pas fini leur test de certification ou le surveillant a mis fin à leur test Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.",
         })
       )
       .exists();

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -185,10 +185,6 @@
       "actions": {
         "return": "Return to the sessions list"
       },
-      "finalize": {
-        "finished-test-list-description": "Liste des candidats qui ont fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.",
-        "unfinished-test-list-description": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon."
-      },
       "import": {
         "breadcrumb": {
           "extra-information": "Fil d'Arianne",
@@ -476,6 +472,61 @@
         "actions": {
           "cancel-extra-information": "Cancel the session change and return to the previous page",
           "edit-session": "Edit the session"
+        }
+      }
+    },
+    "session-finalization": {
+      "actions": {
+        "finalise": "Finalise"
+      },
+      "title": "Finalise the session {sessionId}",
+      "return-to": "Return to the session",
+      "reporting": {
+        "completed-reports-information": {
+          "description": "Finished certification(s)",
+          "extra-information": "List of candidates who have finished their certification exam, ordered by birth name, with a link to add a reporting if needed",
+          "table": {
+            "labels": {
+              "screen": "End of exam screen seen"
+            }
+          }
+        },
+        "description": "For the reporting to be taken into account, you must use the appropriate reporting category (examples : C1, C2, etc).",
+        "uncompleted-reports-information": {
+          "description" : "These candidates haven’t finished their Pix certification exam or the invigilator has ended their exam",
+          "extra-information": "List of candidates who haven’t finished their certification exam, ordered by birth name, with a link to add a reporting if needed and a drop-down list enabling you to select the reason for abandonment",
+          "table": {
+            "labels": {
+              "abandonment": "Abandonment : lack of time or early departure",
+              "abandonment-reason": "Reason for abandonment",
+              "technical-problem": "Technical problem"
+            },
+            "tooltip": {
+              "abandonment": {
+                "enough-time-description": "The candidate didn’t have enough time to answer all the questions",
+                "left-deliberately-description": "The candidate left deliberately before the end of the exam"
+              },
+              "extra-information": "Reason for abandonment's description",
+              "technical-problem-description": "The candidate encountered a technical problem that prevented him from finishing his exam"
+            }
+          }
+        },
+        "table": {
+          "labels": {
+            "certification-number": "Certification No.",
+            "reporting": "Reporting"
+          },
+          "reporting-count": "{reportingsCount, plural,one {1 reporting} other {# reportings}}"
+        },
+        "title": "Reporting: Signal, for each candidate, the incidents inputted into the incident report"
+      },
+      "complementary-information": {
+        "title": "Additional information (optional)",
+        "description": "You may indicate, if need be, the events that occurred during the session. It isn’t necessary to report any missing candidates.",
+        "incident": "Despite an incident having occurred during the session, the candidates have been able to finish their Pix certification exam. Additional time has been granted to at least one of the candidates.",
+        "candidates-joining-issue": {
+          "label": "At least one candidate was present during the certification session but couldn’t join the session.",
+          "link": "You may find <a class=\"link\" href=\"https://cloud.pix.fr/s/zf3fGimWwPQCeWF/download/Probl%C3%A8mes%20d%27acc%C3%A8s%20en%20session.pdf\" target=\"_blank\" rel=\"noreferrer noopener\">here a document to help you solve this kind of connection problem for the following sessions (PDF, 131ko).</a>"
         }
       }
     },

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -185,10 +185,6 @@
       "actions": {
         "return": "Revenir à la liste des sessions"
       },
-      "finalize": {
-        "finished-test-list-description": "Liste des candidats qui ont fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.",
-        "unfinished-test-list-description": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon."
-      },
       "import": {
         "breadcrumb": {
           "extra-information": "Fil d'Arianne",
@@ -475,6 +471,61 @@
         "actions": {
           "cancel-extra-information": "Annuler la modification de la session et retourner vers la page précédente",
           "edit-session": "Modifier la session"
+        }
+      }
+    },
+    "session-finalization": {
+      "actions": {
+        "finalise": "Finaliser"
+      },
+      "title": "Finaliser la session {sessionId}",
+      "return-to": "Retour à la session",
+      "reporting": {
+        "completed-reports-information": {
+          "description": "Certification(s) terminée(s)",
+          "extra-information": "Liste des candidats qui ont fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant.",
+          "table": {
+            "labels": {
+              "screen": "Écran de fin du test vu"
+            }
+          }
+        },
+        "description": "Pour que le signalement soit pris en compte, il est nécessaire d’utiliser la catégorie de signalement appropriée (exemples : C1, C2, etc).",
+        "uncompleted-reports-information": {
+          "description" : "Ces candidats n'ont pas fini leur test de certification ou le surveillant a mis fin à leur test",
+          "extra-information": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.",
+          "table": {
+            "labels": {
+              "abandonment": "Abandon : Manque de temps ou départ prématuré",
+              "abandonment-reason": "Raison de l'abandon",
+              "technical-problem": "Problème technique"
+            },
+            "tooltip": {
+              "abandonment": {
+                "enough-time-description": "Le candidat n'a pas eu le temps de répondre à toutes ses questions",
+                "left-deliberately-description": "Le candidat est parti volontairement avant la fin du test"
+              },
+              "extra-information": "Description de la raison de l'abandon",
+              "technical-problem-description": "Le candidat a rencontré un problème technique l'empêchant de poursuivre son test jusqu’à la fin"
+            }
+          }
+        },
+        "table": {
+          "labels": {
+            "certification-number": "N° de certification",
+            "reporting": "Signalement"
+          },
+          "reporting-count": "{reportingsCount, plural,one {1 signalement} other {# signalements}}"
+        },
+        "title": "Signalements : Reporter, pour chaque candidat, les signalements renseignés sur le PV d'incident"
+      },
+      "complementary-information": {
+        "title": "Informations complémentaires (facultatif)",
+        "description": "Vous pouvez indiquer, le cas échéant, les événements survenus lors de la session. Il n'est pas nécessaire de renseigner les candidats absents.",
+        "incident": "Malgré un incident survenu pendant la session, les candidats ont pu terminer leur test de certification. Un temps supplémentaire a été accordé à un ou plusieurs candidats.",
+        "candidates-joining-issue": {
+          "label": "Un ou plusieurs candidats étaient présents en session de certification mais n'ont pas pu rejoindre la session.",
+          "link": "Vous trouverez <a class=\"link\" href=\"https://cloud.pix.fr/s/zf3fGimWwPQCeWF/download/Probl%C3%A8mes%20d%27acc%C3%A8s%20en%20session.pdf\" target=\"_blank\" rel=\"noreferrer noopener\">ici un document pour vous aider à résoudre ce type de problème de connexion pour les prochaines sessions (PDF, 131ko).</a>"
         }
       }
     },


### PR DESCRIPTION
## :unicorn: Problème
La page de finalisation de session sur Pix Certif n'a toujours pas été traduite

## :robot: Proposition
Traduction de la page de finalisation de session sur Pix Certif

<img width="1501" alt="Capture d’écran 2023-03-31 à 18 03 13" src="https://user-images.githubusercontent.com/58915422/229172020-27127a85-2c82-49af-b899-438e26b918fa.png">

+ fix de style du message vert Certifications passées, pour qu'il soit iso au message jaune plus haut

AVANT
<img width="268" alt="Capture d’écran 2023-04-03 à 10 29 46" src="https://user-images.githubusercontent.com/58915422/229455111-eb058997-13e8-4203-9ae7-8d3f22d1629a.png">

APRES
<img width="268" alt="Capture d’écran 2023-04-03 à 10 30 11" src="https://user-images.githubusercontent.com/58915422/229455118-fdfba997-fa1e-4b79-ab7c-222637eb61d2.png">


## :100: Pour tester
- Se connecter sur Pix Certif en domaine org + lang=en (certifsco@example.net)
- Sélectionner la session 3 et cliquer sur le bouton Finalise the session
- Constater que la page est correctement traduite