### PR TITLE
[BUGFIX] Corriger l'affichage de la modale d'inscription d'un candidat sur Pix Certif (PIX-7630)

### DIFF
--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -172,15 +172,13 @@
   />
 {{/if}}
 
-{{#if this.showNewCertificationCandidateModal}}
-  <NewCertificationCandidateModal
-    @showModal={{this.showNewCertificationCandidateModal}}
-    @closeModal={{this.closeNewCertificationCandidateModal}}
-    @countries={{@countries}}
-    @saveCandidate={{this.addCertificationCandidate}}
-    @candidateData={{this.newCandidate}}
-    @updateCandidateData={{this.updateCertificationCandidateInStagingFieldFromEvent}}
-    @updateCandidateDataFromValue={{this.updateCertificationCandidateInStagingFieldFromValue}}
-    @shouldDisplayPaymentOptions={{@shouldDisplayPaymentOptions}}
-  />
-{{/if}}
+<NewCertificationCandidateModal
+  @showModal={{this.showNewCertificationCandidateModal}}
+  @closeModal={{this.closeNewCertificationCandidateModal}}
+  @countries={{@countries}}
+  @saveCandidate={{this.addCertificationCandidate}}
+  @candidateData={{this.newCandidate}}
+  @updateCandidateData={{this.updateCertificationCandidateInStagingFieldFromEvent}}
+  @updateCandidateDataFromValue={{this.updateCertificationCandidateInStagingFieldFromValue}}
+  @shouldDisplayPaymentOptions={{@shouldDisplayPaymentOptions}}
+/>

--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -69,6 +69,7 @@ export default class EnrolledCandidates extends Component {
       this.candidatesInStaging.removeObject(candidate);
       this.closeNewCertificationCandidateModal();
     }
+    return success;
   }
 
   @action

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -1,6 +1,6 @@
 <PixModal
   @title={{t "pages.sessions.detail.candidates.detail-modal.title"}}
-  @onCloseButtonClick={{@closeModal}}
+  @onCloseButtonClick={{this.closeModal}}
   class="new-certification-candidate-modal"
   @showModal={{@showModal}}
 >
@@ -342,7 +342,7 @@
   <:footer>
     <PixButton
       aria-label={{t "pages.sessions.detail.candidates.add-modal.actions.close-extra-information"}}
-      @triggerAction={{@closeModal}}
+      @triggerAction={{this.closeModal}}
       @backgroundColor="transparent-light"
       @isBorderVisible="true"
     >

--- a/certif/app/components/new-certification-candidate-modal.hbs
+++ b/certif/app/components/new-certification-candidate-modal.hbs
@@ -26,7 +26,6 @@
           class="input"
           @value={{@candidateData.lastName}}
           {{on "input" (fn @updateCandidateData @candidateData "lastName")}}
-          {{did-insert this.focus}}
           required
         />
       </div>

--- a/certif/app/components/new-certification-candidate-modal.js
+++ b/certif/app/components/new-certification-candidate-modal.js
@@ -17,10 +17,6 @@ export default class NewCertificationCandidateModal extends Component {
 
   @tracked isLoading = false;
 
-  focus(element) {
-    element.focus();
-  }
-
   get complementaryCertifications() {
     return this.currentUser.currentAllowedCertificationCenterAccess?.habilitations;
   }

--- a/certif/app/components/new-certification-candidate-modal.js
+++ b/certif/app/components/new-certification-candidate-modal.js
@@ -30,6 +30,11 @@ export default class NewCertificationCandidateModal extends Component {
     return `-- ${labelTranslation} --`;
   }
 
+  @action closeModal() {
+    this.args.closeModal();
+    document.getElementById('new-certification-candidate-form').reset();
+  }
+
   @action
   selectBirthGeoCodeOption(option) {
     this.selectedBirthGeoCodeOption = option;
@@ -78,8 +83,13 @@ export default class NewCertificationCandidateModal extends Component {
   async onFormSubmit(event) {
     event.preventDefault();
     this.isLoading = true;
+
     try {
-      await this.args.saveCandidate(this.args.candidateData);
+      const result = await this.args.saveCandidate(this.args.candidateData);
+
+      if (result) {
+        this._resetForm();
+      }
     } finally {
       this.isLoading = false;
     }
@@ -170,5 +180,11 @@ export default class NewCertificationCandidateModal extends Component {
   _getCountryName() {
     const country = this.args.countries.find((country) => country.code === this.selectedCountryInseeCode);
     return country.name;
+  }
+
+  _resetForm() {
+    document.getElementById('new-certification-candidate-form').reset();
+    this.selectedCountryInseeCode = FRANCE_INSEE_CODE;
+    this.selectedBirthGeoCodeOption = INSEE_CODE_OPTION;
   }
 }

--- a/certif/tests/acceptance/session-details-certification-candidates_test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates_test.js
@@ -292,8 +292,6 @@ module('Acceptance | Session Details Certification Candidates', function (hooks)
           });
           const screen = await visit(`/sessions/${sessionWithoutCandidates.id}/candidats`);
 
-          this.pauseTest();
-
           await click(screen.getByRole('button', { name: 'Inscrire un candidat' }));
           await fillIn(screen.getByLabelText('* Nom de naissance'), 'BackStreet');
           await fillIn(screen.getByLabelText('* Prénom'), 'Boys');

--- a/certif/tests/integration/components/enrolled-candidates_test.js
+++ b/certif/tests/integration/components/enrolled-candidates_test.js
@@ -22,14 +22,17 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
     });
 
     const certificationCandidate = store.createRecord('certification-candidate', candidate);
+    const countries = store.createRecord('country', { name: 'CANADA', code: 99401 });
 
     this.set('certificationCandidates', [certificationCandidate]);
+    this.set('countries', [countries]);
 
     // when
     const screen = await renderScreen(hbs`
         <EnrolledCandidates
           @sessionId="1"
           @certificationCandidates={{this.certificationCandidates}}
+          @countries={{this.countries}}
           >
         </EnrolledCandidates>
       `);
@@ -51,9 +54,11 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
       birthdate: new Date('2019-04-28'),
     });
 
+    const countries = store.createRecord('country', { name: 'CANADA', code: 99401 });
     const certificationCandidate = store.createRecord('certification-candidate', candidate);
 
     this.set('certificationCandidates', [certificationCandidate]);
+    this.set('countries', [countries]);
 
     // when
     const screen = await renderScreen(hbs`
@@ -61,6 +66,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
           @sessionId="1"
           @certificationCandidates={{this.certificationCandidates}}
           @displayComplementaryCertification={{this.displayComplementaryCertification}}
+          @countries={{this.countries}}
           >
         </EnrolledCandidates>
       `);
@@ -85,9 +91,11 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
       complementaryCertifications: null,
     });
 
+    const countries = store.createRecord('country', { name: 'CANADA', code: 99401 });
     const certificationCandidate = store.createRecord('certification-candidate', candidate);
 
     this.set('certificationCandidates', [certificationCandidate]);
+    this.set('countries', [countries]);
 
     // when
     const screen = await renderScreen(hbs`
@@ -95,6 +103,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
           @sessionId="1"
           @certificationCandidates={{this.certificationCandidates}}
           @displayComplementaryCertification={{this.displayComplementaryCertification}}
+          @countries={{this.countries}}
           >
         </EnrolledCandidates>
       `);
@@ -107,14 +116,17 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
     // given
     const candidate = _buildCertificationCandidate({});
     const certificationCandidates = [candidate];
+    const countries = store.createRecord('country', { name: 'CANADA', code: 99401 });
 
     this.set('certificationCandidates', certificationCandidates);
+    this.set('countries', [countries]);
 
     // when
     const screen = await renderScreen(hbs`
         <EnrolledCandidates
           @sessionId="1"
           @certificationCandidates={{this.certificationCandidates}}
+          @countries={{this.countries}}
         >
         </EnrolledCandidates>
     `);
@@ -134,14 +146,18 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
       _buildCertificationCandidate({ firstName: 'Fifi', lastName: 'Duck', isLinked: true }),
       _buildCertificationCandidate({ firstName: 'Loulou', lastName: 'Duck', isLinked: false }),
     ];
+    const countries = store.createRecord('country', { name: 'CANADA', code: 99401 });
 
+    this.set('countries', [countries]);
     this.set('certificationCandidates', certificationCandidates);
 
     // when
     const screen = await renderScreen(hbs`
       <EnrolledCandidates
         @sessionId="1"
-        @certificationCandidates={{this.certificationCandidates}}>
+        @certificationCandidates={{this.certificationCandidates}}
+        @countries={{this.countries}}
+        >
       </EnrolledCandidates>
     `);
 
@@ -167,7 +183,9 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
       });
 
       const certificationCandidate = store.createRecord('certification-candidate', candidate);
+      const countries = store.createRecord('country', { name: 'CANADA', code: 99401 });
 
+      this.set('countries', [countries]);
       this.set('certificationCandidates', [certificationCandidate]);
 
       // when
@@ -176,6 +194,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
             @sessionId="1"
             @certificationCandidates={{this.certificationCandidates}}
             @shouldDisplayPaymentOptions={{this.shouldDisplayPaymentOptions}}
+            @countries={{this.countries}}
             >
           </EnrolledCandidates>
         `);
@@ -202,7 +221,9 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
       test(it, async function (assert) {
         // given
         const certificationCandidates = [];
+        const countries = store.createRecord('country', { name: 'CANADA', code: 99401 });
 
+        this.set('countries', [countries]);
         this.set('certificationCandidates', certificationCandidates);
         this.set(
           'shouldDisplayPrescriptionScoStudentRegistrationFeature',
@@ -215,6 +236,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
             @sessionId="1"
             @certificationCandidates={{this.certificationCandidates}}
             @shouldDisplayPrescriptionScoStudentRegistrationFeature={{this.shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+            @countries={{this.countries}}
           >
           </EnrolledCandidates>
         `);
@@ -246,7 +268,9 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
     test(it, async function (assert) {
       // given
       const candidate = _buildCertificationCandidate({});
+      const countries = store.createRecord('country', { name: 'CANADA', code: 99401 });
 
+      this.set('countries', [countries]);
       this.set('certificationCandidates', [candidate]);
       this.set(
         'shouldDisplayPrescriptionScoStudentRegistrationFeature',
@@ -259,6 +283,7 @@ module('Integration | Component | enrolled-candidates', function (hooks) {
           @sessionId="1"
           @certificationCandidates={{this.certificationCandidates}}
           @shouldDisplayPrescriptionScoStudentRegistrationFeature={{this.shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+          @countries={{this.countries}}
         >
         </EnrolledCandidates>
     `);

--- a/mon-pix/tests/acceptance/skill-review_test.js
+++ b/mon-pix/tests/acceptance/skill-review_test.js
@@ -188,9 +188,8 @@ module('Acceptance | Campaigns | Campaigns Result', function (hooks) {
 
         // when
         await visit(`/campagnes/${campaign.code}/evaluation/resultats`);
-        //await this.pauseTest();
-        // then
 
+        // then
         assert.strictEqual(findAll('.badge-card').length, 1);
       });
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement dans la modale d’inscription candidat, lorsque l'on clique sur le choix de mode de paiement, on est automatiquement redirigé vers haut de la modale car il fait un focus sur le bouton de fermeture de cette dernière.

## :robot: Proposition
Améliorer l'affichage de la modale pour corriger ce problème.


## :robot: Remarques
Au début de l'investigation, on a remarqué que retirer la transition css du sélécteur corrigeait le problème mais pour cela il fallait override la classe du PixSelect.

En continuant l'investigation on a constaté que les modales de Pix Certif sont encore entouré d'une condition permettant leur affichage, ce qu'il ne faut plus faire depuis la mise à jour de la Pix Modal.

---

Pourquoi les modales de Pix Certif ont encore des conditions if qui conditionnent leurs affichages ?

Depuis une récente mise à jour de la Pix Modal, il n'est plus nécessaire d'avoir des conditions pour son affichage. 
Or on a détecté de nombreux soucis sur les modales assez critique suite à cette modification qui a nécessité un expedit. Il a donc été décidé de garder les if temporairement.

L'expedit : https://github.com/1024pix/pix/pull/5316

---

Au final c'est ce `if` entourant la modale qui était à l'origine de ce bug au clic.

En temps normal, lors de l'ouverture de la modale, une transition est effectué pour afficher la modale puis un focus est forcé sur le bouton de fermeture de la modale à la fin de la transition. 
Mais avec ce if, la transition (apparence) ne pouvait pas se faire, et au final, c'est au clic du select que la transition s'effectuait (le fameux bug de départ).



## :100: Pour tester
- Se connecter à Pix Certif avec le compte : certifpro@example.net
- Aller sur une session et ouvrir la modale d'inscription d'un candidat
- Cliquer sur le select "Tarification part Pix" et voir que le scroll ne bouge pas 🙏 
- Vérifier que les champs sont reset à la fermeture => Remplir quelques champs et fermer la modale sans valider puis recliquer sur le bouton pour inscrire un candidat
- Vérifier que les champs sont reset à la validation => Remplir les infos et valider puis recliquer sur le bouton pour inscrire un candidat
- Faire tous les tests possibles pour s'assurer qu'il n'y a aucune régression.
- Comme un focus est "forcé" sur le bouton de fermeture de la modale, le focus sur le premier champ "nom de naissance" ne se fait plus.