### PR TITLE
[FEATURE] Afficher les domaines de compétences sur la page de fin de campagne sur Pix-App (PIX-7012)

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
@@ -69,6 +69,7 @@ module.exports = {
           'name',
           'index',
           'areaColor',
+          'areaName',
           'masteryPercentage',
           'totalSkillsCount',
           'testedSkillsCount',

--- a/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
+++ b/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
@@ -118,6 +118,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
     const learningContent = [
       {
         id: 'recArea1',
+        name: 'AreaName1',
         color: JAFFA_COLOR,
         competences: [
           {
@@ -130,6 +131,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
       },
       {
         id: 'recArea2',
+        name: 'AreaName2',
         color: EMERALD_COLOR,
         competences: [
           {
@@ -158,6 +160,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
       },
       {
         id: 'recArea3',
+        name: 'AreaName3',
         color: WILD_STRAWBERRY_COLOR,
         competences: [
           {
@@ -305,6 +308,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
               'tested-skills-count': 0,
               'validated-skills-count': 0,
               'area-color': JAFFA_COLOR,
+              'area-name': 'AreaName1',
               'reached-stage': 0,
               'flash-pix-score': undefined,
             },
@@ -320,6 +324,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
               'tested-skills-count': 2,
               'validated-skills-count': 2,
               'area-color': EMERALD_COLOR,
+              'area-name': 'AreaName2',
               'reached-stage': 1,
               'flash-pix-score': undefined,
             },
@@ -335,6 +340,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
               'tested-skills-count': 3,
               'validated-skills-count': 1,
               'area-color': EMERALD_COLOR,
+              'area-name': 'AreaName2',
               'reached-stage': 0,
               'flash-pix-score': undefined,
             },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -193,6 +193,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
           {
             attributes: {
               'area-color': 'AreaColor',
+              'area-name': 'AreaName',
               index: '1.1',
               name: 'Competence1',
               'mastery-percentage': 50,
@@ -242,6 +243,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
               area: domainBuilder.buildArea({
                 id: 'area1',
                 color: 'area1Color',
+                name: 'AreaName1',
               }),
               pixScore: 300.3438957781,
             },
@@ -255,6 +257,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
               area: domainBuilder.buildArea({
                 id: 'area2',
                 color: 'area2Color',
+                name: 'AreaName2',
               }),
               pixScore: 74,
             },
@@ -285,6 +288,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
             name: 'competence 1',
             index: '1.1',
             'area-color': 'area1Color',
+            'area-name': 'AreaName1',
             'mastery-percentage': 0,
             'total-skills-count': 1,
             'tested-skills-count': 0,
@@ -300,6 +304,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
             name: 'competence 2',
             index: '2.1',
             'area-color': 'area2Color',
+            'area-name': 'AreaName2',
             'mastery-percentage': 0,
             'total-skills-count': 2,
             'tested-skills-count': 0,

--- a/mon-pix/app/components/campaigns/assessment/skill-review-competence-stages-result.hbs
+++ b/mon-pix/app/components/campaigns/assessment/skill-review-competence-stages-result.hbs
@@ -1,31 +1,23 @@
-<section class="skill-review-result-detail__content">
-  <div class="skill-review-result-detail__table-header">
-    <h2 class="skill-review-result-detail__subtitle">
-      {{t "pages.skill-review.details.title"}}
-    </h2>
-  </div>
-
-  <table class="skill-review-competence-stages-result__table">
-    <caption class="sr-only">{{t "pages.skill-review.details.caption"}}</caption>
-    <tbody>
-      {{#each @competenceResults as |competence|}}
-        <tr>
-          <th scope="row">{{competence.name}}</th>
-          <td>
-            <div class="skill-review-competence-stages-result__reached-stage">
-              <p class="skill-review-competence-stages-result__reached-stage-percentage">
-                {{t "pages.skill-review.stage.masteryPercentage" rate=competence.masteryRate}}
-              </p>
-              <PixStars
-                @count={{competence.reachedStage}}
-                @total={{this.total}}
-                @alt={{t "pages.skill-review.stage.starsAcquired" acquired=competence.reachedStage total=this.total}}
-                @color="yellow"
-              />
-            </div>
-          </td>
-        </tr>
-      {{/each}}
-    </tbody>
-  </table>
-</section>
+<table class="skill-review-competence-stages-result__table">
+  <caption class="sr-only">{{t "pages.skill-review.details.caption"}}</caption>
+  <tbody>
+    {{#each @competenceResults.competences as |competence|}}
+      <tr>
+        <th scope="row">{{competence.name}}</th>
+        <td>
+          <div class="skill-review-competence-stages-result__reached-stage">
+            <p class="skill-review-competence-stages-result__reached-stage-percentage">
+              {{t "pages.skill-review.stage.masteryPercentage" rate=competence.masteryRate}}
+            </p>
+            <PixStars
+              @count={{competence.reachedStage}}
+              @total={{this.total}}
+              @alt={{t "pages.skill-review.stage.starsAcquired" acquired=competence.reachedStage total=this.total}}
+              @color="yellow"
+            />
+          </div>
+        </td>
+      </tr>
+    {{/each}}
+  </tbody>
+</table>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -265,10 +265,28 @@
 
     {{#unless @model.campaign.isForAbsoluteNovice}}
       {{#if this.showStagesWithStars}}
-        <Campaigns::Assessment::SkillReviewCompetenceStagesResult
-          @competenceResults={{@model.campaignParticipationResult.competenceResults}}
-          @totalStage={{this.reachedStage.totalStage}}
-        />
+        <section class="skill-review-result-detail__content">
+          <div class="skill-review-result-detail__table-header">
+            <h2 class="skill-review-result-detail__subtitle">
+              {{t "pages.skill-review.details.title"}}
+            </h2>
+          </div>
+          {{#each-in this.competenceResultsGroupedByAreas as |area competenceResults|}}
+            <div class="skill-review-competence-stages-result__content">
+              <div class="skill-review-competence-stages-result__area">
+                <span
+                  class="skill-review-competence-stages-result__border skill-review-competence__border--{{competenceResults.areaColor}}"
+                  aria-hidden="true"
+                ></span>
+                <h3 class="skill-review-competence-stages-result__subtitle">{{area}}</h3>
+              </div>
+              <Campaigns::Assessment::SkillReviewCompetenceStagesResult
+                @competenceResults={{competenceResults}}
+                @totalStage={{this.reachedStage.totalStage}}
+              />
+            </div>
+          {{/each-in}}
+        </section>
       {{else}}
         <section class="skill-review-result-detail__content">
           <div class="skill-review-result-detail__table-header">

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -266,11 +266,9 @@
     {{#unless @model.campaign.isForAbsoluteNovice}}
       {{#if this.showStagesWithStars}}
         <section class="skill-review-result-detail__content">
-          <div class="skill-review-result-detail__table-header">
-            <h2 class="skill-review-result-detail__subtitle">
-              {{t "pages.skill-review.details.title"}}
-            </h2>
-          </div>
+          <h2 class="skill-review-competence-stages-result__title">
+            {{t "pages.skill-review.stage.title"}}
+          </h2>
           {{#each-in this.competenceResultsGroupedByAreas as |area competenceResults|}}
             <div class="skill-review-competence-stages-result__content">
               <div class="skill-review-competence-stages-result__area">

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -170,6 +170,28 @@ export default class SkillReview extends Component {
     return this.args.model.campaignParticipationResult.canImprove && !this.isShareButtonClicked;
   }
 
+  get competenceResultsGroupedByAreas() {
+    const competenceResults = this.args.model.campaignParticipationResult.get('competenceResults').toArray();
+    return competenceResults.reduce((acc, competenceResult) => {
+      const currentArea = competenceResult.areaName;
+      const competence = {
+        name: competenceResult.name,
+        reachedStage: competenceResult.reachedStage,
+        masteryRate: competenceResult.masteryRate,
+      };
+      if (acc[currentArea]) {
+        acc[currentArea].competences.push(competence);
+      } else {
+        acc[currentArea] = {
+          areaName: currentArea,
+          areaColor: competenceResult.areaColor,
+          competences: [competence],
+        };
+      }
+      return acc;
+    }, {});
+  }
+
   _buildUrl(baseUrl, params) {
     const Url = new URL(baseUrl);
     const urlParams = new URLSearchParams(Url.search);

--- a/mon-pix/app/models/competence-result.js
+++ b/mon-pix/app/models/competence-result.js
@@ -3,6 +3,7 @@ import Model, { belongsTo, attr } from '@ember-data/model';
 export default class CompetenceResult extends Model {
   // attributes
   @attr('string') areaColor;
+  @attr('string') areaName;
   @attr('string') name;
   @attr('string') index;
   @attr('number') masteryPercentage;

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -246,6 +246,36 @@
 }
 
 .skill-review-competence-stages-result {
+
+  &__content {
+    padding-top: $pix-spacing-m;
+
+    &:nth-child(2) {
+      padding-top: 0;
+    }
+  }
+
+  &__area {
+    display: flex;
+    align-items: center;
+    padding-bottom: $pix-spacing-xs;
+  }
+
+  &__subtitle {
+    @extend %pix-body-l;
+
+    color: $pix-neutral-90;
+    font-weight: $font-medium;
+  }
+
+  &__border {
+    margin-right: $pix-spacing-xs;
+    padding: 0.7rem 0;
+    border-style: solid;
+    border-width: 2.5px;
+    border-radius: 50px;
+  }
+
   &__table {
     width: 100%;
     border-collapse: collapse;

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -246,6 +246,12 @@
 }
 
 .skill-review-competence-stages-result {
+  &__title {
+    @extend %pix-title-s;
+
+    padding-bottom: $pix-spacing-m;
+    color: $pix-neutral-90;
+  }
 
   &__content {
     padding-top: $pix-spacing-m;

--- a/mon-pix/tests/acceptance/skill-review_test.js
+++ b/mon-pix/tests/acceptance/skill-review_test.js
@@ -198,6 +198,7 @@ module('Acceptance | Campaigns | Campaigns Result', function (hooks) {
         test('should display reached stage and competence reached stage', async function (assert) {
           // given
           const competenceResult = server.create('competence-result', {
+            areaName: 'area1',
             name: competenceResultName,
             masteryPercentage: 85,
             reachedStage: 2,
@@ -215,6 +216,7 @@ module('Acceptance | Campaigns | Campaigns Result', function (hooks) {
 
           // then
           assert.ok(screen.getByText('You reached Stage 1'));
+          assert.ok(screen.getByText('area1'));
           assert.ok(screen.getByText('85 % de réussite'));
           assert.ok(screen.getByText('2 étoiles acquises sur 4'));
         });

--- a/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
@@ -676,6 +676,69 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
     });
   });
 
+  module('#competenceResultsGroupedByAreas', function () {
+    test('should return a competence results object with area keys', function (assert) {
+      // given
+      component.args.model.campaignParticipationResult.competenceResults = [
+        {
+          areaColor: 'areaColor1',
+          areaName: 'area1',
+          name: 'competence1',
+          masteryRate: '33',
+          reachedStage: 1,
+        },
+        {
+          areaColor: 'areaColor1',
+          areaName: 'area1',
+          name: 'competence2',
+          masteryRate: '50',
+          reachedStage: 2,
+        },
+        {
+          areaColor: 'areaColor2',
+          areaName: 'area2',
+          name: 'competence3',
+          masteryRate: '60',
+          reachedStage: 3,
+        },
+      ];
+
+      // when
+      const competenceResults = component.competenceResultsGroupedByAreas;
+
+      // then
+      assert.deepEqual(competenceResults, {
+        area1: {
+          areaColor: 'areaColor1',
+          areaName: 'area1',
+          competences: [
+            {
+              masteryRate: '33',
+              name: 'competence1',
+              reachedStage: 1,
+            },
+            {
+              masteryRate: '50',
+              name: 'competence2',
+              reachedStage: 2,
+            },
+          ],
+        },
+        area2: {
+          areaColor: 'areaColor2',
+          areaName: 'area2',
+          competences: [
+            {
+              masteryRate: '60',
+              name: 'competence3',
+              reachedStage: 3,
+            },
+          ],
+        },
+      });
+    });
+  });
+
   module('#redirectToSignupIfUserIsAnonymous', function () {
     test('should redirect to sign up page on click when user is anonymous', async function (assert) {
       // given

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1348,7 +1348,7 @@
       "badges-title": "Your thematic results",
       "details": {
         "title": "Your results by competence",
-        "caption": "Competence results details",
+        "caption": "Details of your results in percentage and stars according to competences",
         "flash-pix-score": "{score, number, ::.} Pix",
         "header-result": "Results",
         "header-skill": "Competences tested",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1375,6 +1375,7 @@
       },
       "send-title": "Submit your results",
       "stage": {
+        "title": "Competence results details",
         "masteryPercentage": "Success rate: {rate, number, ::percent}",
         "starsAcquired": "{acquired, plural, =0 {no star} other {# stars}} acquired over {total}"
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1348,7 +1348,7 @@
       "badges-title": "Vos résultats thématiques",
       "details": {
         "title": "Vos résultats par compétence",
-        "caption": "Détails de vos résultats par compétences",
+        "caption": "Détails de vos résultats sous forme de pourcentage et d'étoiles en fonction des compétences",
         "flash-pix-score": "{score, number, ::.} Pix",
         "header-result": "Résultats",
         "header-skill": "Compétences testées",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1375,6 +1375,7 @@
       },
       "send-title": "Envoyez vos résultats",
       "stage": {
+        "title": "Détails des compétences",
         "masteryPercentage": "{rate, number, ::percent} de réussite",
         "starsAcquired": "{acquired, plural, =0 {aucune étoile acquise} other {# étoiles acquises}} sur {total}"
       },


### PR DESCRIPTION
## :unicorn: Problème
Les domaines des compétences n'étaient pas affichés sur la page de fin de campagne.

## :robot: Proposition
Afficher les domaines avec leur couleur associé.

## :rainbow: Remarques
Le titre a été changé en "Détails des résultats".
Le caption a été modifié pour apporté davantage d'informations.

## :100: Pour tester
- Aller sur la RA
- Passer une campagne avec pallier `PROBADGE1`
- Vérifier que domaines sont bien affichés sur les résultats par compétences.
