### PR TITLE
[TECH] Ajout du .buildpacks manquant pour pix1d

### DIFF
--- a/pix1d/.buildpacks
+++ b/pix1d/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/Scalingo/nodejs-buildpack
+https://github.com/Scalingo/nginx-buildpack


### PR DESCRIPTION
## :unicorn: Problème
Pix1d n'a pas de fichier buildpacks et donc ne démarre pas sur Scalingo

## :robot: Proposition
L'ajouter 

