### PR TITLE
[FEATURE] Ne pas permettre la modification d'une session inexistante lors de l'import en masse de session sur Pix Certif (PIX-7612).

### DIFF
--- a/api/lib/domain/constants/sessions-errors.js
+++ b/api/lib/domain/constants/sessions-errors.js
@@ -15,6 +15,10 @@ module.exports.CERTIFICATION_SESSIONS_ERRORS = {
     code: 'SESSION_SCHEDULED_IN_THE_PAST',
     getMessage: () => `Une session ne peut pas être programmée dans le passé`,
   },
+  SESSION_ID_NOT_EXISTING: {
+    code: 'SESSION_ID_NOT_EXISTING',
+    getMessage: () => '',
+  },
   SESSION_ID_NOT_VALID: {
     code: 'SESSION_ID_NOT_VALID',
     getMessage: () => '',

--- a/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
+++ b/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
@@ -35,6 +35,7 @@ module.exports = async function validateSessions({
     const sessionsErrors = await sessionsImportValidationService.validateSession({
       session,
       line: sessionDTO.line,
+      certificationCenterId,
       sessionRepository,
       certificationCourseRepository,
     });

--- a/api/lib/infrastructure/repositories/sessions/session-repository.js
+++ b/api/lib/infrastructure/repositories/sessions/session-repository.js
@@ -42,6 +42,11 @@ module.exports = {
     return sessions.length > 0;
   },
 
+  async isSessionExistingBySessionAndCertificationCenterIds({ sessionId, certificationCenterId }) {
+    const [session] = await knex('sessions').where({ id: sessionId, certificationCenterId });
+    return Boolean(session);
+  },
+
   async getWithCertificationCandidates(sessionId) {
     const session = await knex.from('sessions').where({ 'sessions.id': sessionId }).first();
 

--- a/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-validate-sessions_test.js
+++ b/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-validate-sessions_test.js
@@ -95,7 +95,7 @@ describe('Acceptance | Controller | certification-centers-controller-post-valida
               isActualName: true,
             });
             databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
-            const sessionId = databaseBuilder.factory.buildSession({ id: 1234 }).id;
+            const sessionId = databaseBuilder.factory.buildSession({ id: 1234, certificationCenterId }).id;
             databaseBuilder.factory.buildCertificationCandidate({ sessionId, lastName: 'Toto' });
             databaseBuilder.factory.buildCertificationCandidate({ sessionId, lastName: 'Foo' });
             databaseBuilder.factory.buildCertificationCandidate({ sessionId, lastName: 'Bar' });

--- a/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/sessions/session-repository_test.js
@@ -901,4 +901,47 @@ describe('Integration | Repository | Session', function () {
       expect(result).to.equal(false);
     });
   });
+
+  describe('#isSessionExistingBySessionAndCertificationCenterIds', function () {
+    context('when session exists', function () {
+      it('should return true', async function () {
+        // given
+        const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+        const session = databaseBuilder.factory.buildSession({
+          certificationCenterId: certificationCenter.id,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const result = await sessionRepository.isSessionExistingBySessionAndCertificationCenterIds({
+          sessionId: session.id,
+          certificationCenterId: certificationCenter.id,
+        });
+
+        // then
+        expect(result).to.be.true;
+      });
+    });
+
+    context('when session does not exist', function () {
+      it('should return false', async function () {
+        // given
+        const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+        databaseBuilder.factory.buildSession({
+          id: 567,
+          certificationCenterId: certificationCenter.id,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const result = await sessionRepository.isSessionExistingBySessionAndCertificationCenterIds({
+          sessionId: 678,
+          certificationCenterId: certificationCenter.id,
+        });
+
+        // then
+        expect(result).to.be.false;
+      });
+    });
+  });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -266,6 +266,7 @@
               "SESSION_EXAMINER_REQUIRED": "Champ obligatoire \"Surveillant(s)\" manquant",
               "SESSION_WITH_DATE_AND_TIME_ALREADY_EXISTS": "Session déjà créée avec ces critères, pour ajouter des candidats n’indiquer que le N°, pas les informations de session.",
               "SESSION_SCHEDULED_IN_THE_PAST": "Date et/ou heure indiquées antérieures à la date du jour.",
+              "SESSION_ID_NOT_EXISTING": "N° de session inexistant.",
               "SESSION_ID_NOT_VALID": "N° de session invalide.",
               "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées."
             }

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -266,6 +266,7 @@
               "SESSION_EXAMINER_REQUIRED": "Champ obligatoire \"Surveillant(s)\" manquant",
               "SESSION_WITH_DATE_AND_TIME_ALREADY_EXISTS": "Une session a déjà été créée avec ces informations. Pour ajouter des candidats à une session, indiquer uniquement le numéro (N°) de session sans les informations de session",
               "SESSION_SCHEDULED_IN_THE_PAST": "Date et/ou heure indiquées antérieures à la date du jour",
+              "SESSION_ID_NOT_EXISTING": "N° de session inexistant.",
               "SESSION_ID_NOT_VALID": "N° de session invalide.",
               "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées"
             }


### PR DESCRIPTION
## :unicorn: Problème
Actuellement dans la gestion massive des sessions sur Pix Certif, si on tente d'importer l'id d'une session qui n'existe pas dans le centre, alors on passe la première étape de validation mais on obtient une 500 à la deuxième étape.
Or il ne devrait pas être possible de passer la première étape avec cette condition.

## :robot: Proposition
Ne pas permettre la modification d'une session inexistante lors de la validation du csv (première étape) et retourner une erreur bloquante.


## :100: Pour tester


- Se connecter avec certifsup@example.net
- Cliquer sur Créer/Éditer plusieurs sessions

- Tester ces différents cas : 


Un id de session au mauvais format : 
```
N° de session;* Nom du site;* Nom de la salle;* Date de début;* Heure de début (heure locale);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: jj/mm/aaaa);* Sexe (M ou F);Code Insee;Code postal;Nom de la commune;* Pays;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant local;Temps majoré ?;Tarification part Pix;Code de prépaiement;Pix+ Droit ('oui' ou laisser vide);
A;;;;;;;Candidat;Super;02/01/2000;M;;75015;PARIS;FRANCE;;;;;Payante;;;
```
Ne doit avoir qu'une seule erreur bloquante.

<img width="1458" alt="Capture d’écran 2023-04-04 à 11 51 08" src="https://user-images.githubusercontent.com/58915422/229762323-d5d24780-3fe3-413f-9dd6-3a00d3cbec28.png">



Un id de session inexistant : 
```
N° de session;* Nom du site;* Nom de la salle;* Date de début;* Heure de début (heure locale);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: jj/mm/aaaa);* Sexe (M ou F);Code Insee;Code postal;Nom de la commune;* Pays;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant local;Temps majoré ?;Tarification part Pix;Code de prépaiement;Pix+ Droit ('oui' ou laisser vide);
7890567;;;;;;;Candidat;Super;02/01/2000;M;;75015;PARIS;FRANCE;;;;;Payante;;;
```
Doit avoir deux erreurs bloquantes. (+infos non souhaitées)

<img width="1458" alt="Capture d’écran 2023-04-04 à 14 36 19" src="https://user-images.githubusercontent.com/58915422/229793832-2699cd7d-8860-446f-85b7-1913181719b9.png">




Un id de session existant mais avec des infos : 
```
N° de session;* Nom du site;* Nom de la salle;* Date de début;* Heure de début (heure locale);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: jj/mm/aaaa);* Sexe (M ou F);Code Insee;Code postal;Nom de la commune;* Pays;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant local;Temps majoré ?;Tarification part Pix;Code de prépaiement;Pix+ Droit ('oui' ou laisser vide);
11;Site;Salle;12/01/2025;12:00;Jean-Mich;;Candidat;Super;02/01/2000;M;;75015;PARIS;FRANCE;;;;;Payante;;;
```
Ne doit avoir qu'une seule erreur bloquante.

<img width="1458" alt="Capture d’écran 2023-04-04 à 12 19 32" src="https://user-images.githubusercontent.com/58915422/229762403-3e2d172d-a106-462e-aee0-a2140d363486.png">
