### PR TITLE
[BUGFIX] Ne plus appeler le provider de mail lors de l'exécution des tests (Pix-7646)

### DIFF
--- a/api/lib/infrastructure/mail-check.js
+++ b/api/lib/infrastructure/mail-check.js
@@ -1,10 +1,12 @@
-const { promisify } = require('util');
-const dns = require('dns');
-const resolveMx = promisify(dns.resolveMx);
-
+const { Resolver } = require('node:dns').promises;
+const { mailing } = require('../config.js');
 module.exports = {
   checkDomainIsValid(address) {
+    if (!mailing.enabled) {
+      return Promise.resolve(true);
+    }
+
     const domain = address.replace(/.*@/g, '');
-    return resolveMx(domain).then(() => true);
+    return Resolver.resolveMx(domain).then(() => true);
   },
 };

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -19,7 +19,6 @@ const DatabaseBuilder = require('../db/database-builder/database-builder');
 const databaseBuilder = new DatabaseBuilder({ knex });
 
 const nock = require('nock');
-nock.disableNetConnect();
 
 const learningContentBuilder = require('./tooling/learning-content-builder');
 
@@ -31,6 +30,10 @@ const { ROLES } = require('../lib/domain/constants').PIX_ADMIN;
 const { createTempFile, removeTempFile } = require('./tooling/temporary-file');
 
 /* eslint-disable mocha/no-top-level-hooks */
+before(function () {
+  nock.disableNetConnect();
+});
+
 afterEach(function () {
   sinon.restore();
   learningContentCache.flushAll();

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -870,9 +870,6 @@ describe('Unit | Application | Router | campaign-router ', function () {
         .stub(campaignStatsController, 'getParticipationsCountByMasteryRate')
         .callsFake((request, h) => h.response('ok').code(200));
     });
-    afterEach(function () {
-      sinon.restore();
-    });
 
     it('should return 200', async function () {
       const httpTestServer = new HttpTestServer();

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -852,9 +852,6 @@ describe('Unit | Router | organization-router', function () {
   });
 
   describe('POST /api/organizations/{id}/sup-organization-learners/replace-csv', function () {
-    afterEach(function () {
-      sinon.restore();
-    });
     context(
       'when the user is an admin for the organization and the organization is SUP and manages student',
       function () {

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-finished_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-finished_test.js
@@ -66,10 +66,6 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-finished', f
     });
   });
 
-  afterEach(function () {
-    sinon.restore();
-  });
-
   it('fails when event is not of correct type', async function () {
     // given
     const event = 'not an event of the correct type';

--- a/api/tests/unit/domain/services/scorecard-service_test.js
+++ b/api/tests/unit/domain/services/scorecard-service_test.js
@@ -27,10 +27,6 @@ describe('Unit | Service | ScorecardService', function () {
       buildFromStub = sinon.stub(Scorecard, 'buildFrom');
     });
 
-    afterEach(function () {
-      sinon.restore();
-    });
-
     context('And user asks for his own scorecard', function () {
       it('should return the user scorecard', async function () {
         // given

--- a/api/tests/unit/domain/usecases/campaigns-administration/archive-campaigns_test.js
+++ b/api/tests/unit/domain/usecases/campaigns-administration/archive-campaigns_test.js
@@ -11,10 +11,6 @@ describe('Unit | UseCase | archive-campaign', function () {
     };
   });
 
-  afterEach(function () {
-    sinon.restore();
-  });
-
   context('when extracted campaignIds archived', function () {
     it('Should save these informations', async function () {
       const userId = Symbol('userId');

--- a/api/tests/unit/domain/usecases/find-tutorials_test.js
+++ b/api/tests/unit/domain/usecases/find-tutorials_test.js
@@ -28,10 +28,6 @@ describe('Unit | UseCase | find-tutorials', function () {
     locale = 'lang-country';
   });
 
-  afterEach(function () {
-    sinon.restore();
-  });
-
   context('When user is authenticated', function () {
     beforeEach(function () {
       parseIdStub.withArgs(scorecardId).returns({ competenceId, userId: authenticatedUserId });

--- a/api/tests/unit/domain/usecases/get-identity-providers_test.js
+++ b/api/tests/unit/domain/usecases/get-identity-providers_test.js
@@ -26,10 +26,6 @@ describe('Unit | UseCase | get-identity-providers', function () {
     sinon.stub(config, 'fwb').value({});
   });
 
-  afterEach(function () {
-    sinon.restore();
-  });
-
   it('returns all identity providers', async function () {
     // given & when
     const identityProviders = getIdentityProviders();

--- a/api/tests/unit/domain/usecases/get-scorecard_test.js
+++ b/api/tests/unit/domain/usecases/get-scorecard_test.js
@@ -25,10 +25,6 @@ describe('Unit | UseCase | get-scorecard', function () {
     knowledgeElementRepository = {};
   });
 
-  afterEach(function () {
-    sinon.restore();
-  });
-
   context('When user is authenticated', function () {
     beforeEach(function () {
       parseIdStub.withArgs(scorecardId).returns({ competenceId, userId: authenticatedUserId });

--- a/api/tests/unit/domain/usecases/get-user-profile-shared-for-campaign_test.js
+++ b/api/tests/unit/domain/usecases/get-user-profile-shared-for-campaign_test.js
@@ -40,10 +40,6 @@ describe('Unit | UseCase | get-user-profile-shared-for-campaign', function () {
       sinon.stub(constants, 'MAX_REACHABLE_PIX_SCORE').value(expectedMaxReachablePixScore);
     });
 
-    afterEach(function () {
-      sinon.restore();
-    });
-
     it('should return the shared profile for campaign', async function () {
       const knowledgeElements = { competence1: [], competence2: [] };
       const competences = [

--- a/api/tests/unit/domain/usecases/get-user-profile_test.js
+++ b/api/tests/unit/domain/usecases/get-user-profile_test.js
@@ -27,10 +27,6 @@ describe('Unit | UseCase | get-user-profile', function () {
     sinon.stub(Scorecard, 'buildFrom').returns(scorecard);
   });
 
-  afterEach(function () {
-    sinon.restore();
-  });
-
   context('When user is authenticated', function () {
     const userId = 2;
     const earnedPixDefaultValue = 4;

--- a/api/tests/unit/domain/usecases/import-organization-learners-from-siecle_test.js
+++ b/api/tests/unit/domain/usecases/import-organization-learners-from-siecle_test.js
@@ -39,9 +39,6 @@ describe('Unit | UseCase | import-organization-learners-from-siecle', function (
     };
     organizationRepositoryStub = { get: sinon.stub() };
   });
-  afterEach(function () {
-    sinon.restore();
-  });
 
   context('when extracted organizationLearners informations can be imported', function () {
     payload = { path: 'file.csv' };

--- a/api/tests/unit/domain/usecases/reconcile-oidc-user_test.js
+++ b/api/tests/unit/domain/usecases/reconcile-oidc-user_test.js
@@ -19,10 +19,6 @@ describe('Unit | UseCase | reconcile-oidc-user', function () {
     };
   });
 
-  afterEach(function () {
-    sinon.restore();
-  });
-
   it('should retrieve user session content', async function () {
     // given
     const sessionContent = { idToken: 'idToken' };

--- a/api/tests/unit/domain/usecases/reset-scorecard_test.js
+++ b/api/tests/unit/domain/usecases/reset-scorecard_test.js
@@ -31,10 +31,6 @@ describe('Unit | UseCase | reset-scorecard', function () {
     knowledgeElements = [{}, {}];
   });
 
-  afterEach(function () {
-    sinon.restore();
-  });
-
   context('when the user owns the competenceEvaluation', function () {
     it('should reset the competenceEvaluation', async function () {
       // given

--- a/api/tests/unit/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
+++ b/api/tests/unit/domain/usecases/send-shared-participation-results-to-pole-emploi_test.js
@@ -124,10 +124,6 @@ describe('Unit | Domain | UseCase | send-shared-participation-results-to-pole-em
     organizationId = Symbol('organizationId');
   });
 
-  afterEach(function () {
-    sinon.restore();
-  });
-
   context('when campaign is of type ASSESSMENT and organization is Pole Emploi', function () {
     beforeEach(function () {
       organizationRepository.get.withArgs(organizationId).resolves({ isPoleEmploi: true });

--- a/api/tests/unit/scripts/compare-pix-with-latest-release_test.js
+++ b/api/tests/unit/scripts/compare-pix-with-latest-release_test.js
@@ -81,10 +81,6 @@ describe('Unit | Scripts | compare-pix-with-latest-release.js', function () {
     });
   });
 
-  afterEach(async function () {
-    sinon.restore();
-  });
-
   describe('#getUserValidatedKnowledgeElements', function () {
     it('should return validated knowledgeElementsOnly', async function () {
       // when

--- a/api/tests/unit/scripts/helpers/organizations-by-external-id-helper_test.js
+++ b/api/tests/unit/scripts/helpers/organizations-by-external-id-helper_test.js
@@ -37,10 +37,6 @@ describe('Unit | Scripts | organizations-by-external-id-helper.js', function () 
   describe('#findOrganizationsByExternalIds', function () {
     let organizationRepositoryStub;
 
-    afterEach(function () {
-      sinon.restore();
-    });
-
     it('should find organizations with given externalIds', async function () {
       // given
       const checkedData = [


### PR DESCRIPTION
## :unicorn: Problème
En  mode non-connecté au réseau, certains tests sortent à tord en erreur car l'on tente toujours de faire des appels vers l'extérieur.

Bien que l'on utilise `nock` pour éviter ce comportement, celui ci ne semble pas de bloquer le trafic sortant des librairies externes.

## :robot: Proposition
Stubber le mailer service globalement.

## :rainbow: Remarques
Je ne suis pas fan de cette méthode. 
Je préfèrerais que ce soit mocké dans les fichiers appelant le mailer. 
Sauf que certains tests appellant le mailer sans de générer une erreur sur le test, il faudrait les modifier.

## :100: Pour tester
Se mettre hors ligne.
Exécuter les tests. Vérifier qu'ils passent.