### PR TITLE
[FEATURE] Ajouter les tables de gestion des fonctionnalités pour Pix (PIX-7460)

### DIFF
--- a/api/db/migrations/20230404151231_add-features-table.js
+++ b/api/db/migrations/20230404151231_add-features-table.js
@@ -1,0 +1,22 @@
+const TABLE_NAME_FEATURES = 'features';
+const TABLE_NAME_ORGANIZATION_FEATURES = 'organization-features';
+
+exports.up = async (knex) => {
+  await knex.schema.createTable(TABLE_NAME_FEATURES, (t) => {
+    t.bigIncrements().primary();
+    t.string('key').notNullable().unique();
+    t.string('description').nullable();
+  });
+
+  return knex.schema.createTable(TABLE_NAME_ORGANIZATION_FEATURES, (t) => {
+    t.bigIncrements().primary();
+    t.bigInteger('featureId').references('features.id').notNullable();
+    t.bigInteger('organizationId').references('organizations.id').notNullable();
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.dropTable(TABLE_NAME_FEATURES);
+
+  return knex.schema.dropTable(TABLE_NAME_ORGANIZATION_FEATURES);
+};


### PR DESCRIPTION
## :unicorn: Problème
Nous allons permettre d’activer depuis Pix Admin la fonctionnalité “envoi multiple” pour les campagnes d'évaluation à la maille de l’orga.

Cette epix est l’occasion d’anticiper de futures activations d’autres fonctionnalités pour des orgas depuis Pix Admin, en consolidant la partie API.

## :robot: Proposition
Ajouter une table features qui contiendra une liste exhaustive des fonctionnalités disponibles pour l'organisation

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que les tables existes