### PR TITLE
[TECH] Ajouter une contrainte en base de données sur la colonne lang de la table users (PIX-7654)

### DIFF
--- a/api/db/migrations/20230404075638_add-constraint-on-lang-column-from-users-table.js
+++ b/api/db/migrations/20230404075638_add-constraint-on-lang-column-from-users-table.js
@@ -1,0 +1,7 @@
+exports.up = async function (knex) {
+  return knex.raw('ALTER TABLE "users" ADD CONSTRAINT "users_lang_check" CHECK ( "lang" IN (\'fr\', \'en\') )');
+};
+
+exports.down = async function (knex) {
+  return knex.raw('ALTER TABLE "users" DROP CONSTRAINT "users_lang_check"');
+};

--- a/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
@@ -15,7 +15,7 @@ describe('Integration | Infrastructure | Repository | Prescriber', function () {
     firstName: 'estelle',
     lastName: 'popopo',
     email: 'estelle.popopo@example.net',
-    lang: 'someSuperCoolLanguage',
+    lang: 'fr',
     /* eslint-disable-next-line no-sync, mocha/no-setup-in-describe */
     password: bcrypt.hashSync('A124B2C3#!', 1),
     cgu: true,


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, il n’y a aucune contrainte en base de données pour la colonne `lang` de la table `users`. Ce qui implique que l’on peut insérer dans cette colonne des valeurs qui ne sont pas supportées par nos applications (`fr`, `en`).

## :robot: Proposition

Ajouter une contrainte sur la colonne `lang` avec comme valeurs autorisées : `fr` et `en`.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Exécuter la commande `npm run db:migrate`
2. Constatez en base de données que la contrainte a bien été ajoutée sur la colonne lang de la table users
3. Essayer des insertions/updates en SQL avec différentes valeurs pour `lang` et seules les valeurs `fr` et `en` doivent être acceptées 
4. Exécuter la commande `npm run db:rollback:latest`
5. Constatez en base de données que la contrainte sur la colonne lang de la table users n'existe plus
