### PR TITLE
[FEATURE] ajout de caption aux tableaux (PIX-5083)

### DIFF
--- a/orga/app/components/campaign/list.hbs
+++ b/orga/app/components/campaign/list.hbs
@@ -11,6 +11,7 @@
   />
   <div class="panel">
     <table class="table content-text content-text--small">
+      <caption class="screen-reader-only">{{this.caption}}</caption>
       <colgroup class="table__column">
         <col class="table__column--wide" />
         {{#unless @listOnlyCampaignsOfCurrentUser}}

--- a/orga/app/components/campaign/list.js
+++ b/orga/app/components/campaign/list.js
@@ -1,0 +1,15 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class List extends Component {
+  @service router;
+  @service intl;
+
+  get caption() {
+    if (this.router.currentRouteName === 'campaigns.my-campaigns') {
+      return this.intl.t('pages.campaigns-list.table.description-my-campaigns');
+    } else {
+      return this.intl.t('pages.campaigns-list.table.description-all-campaigns');
+    }
+  }
+}

--- a/orga/app/components/organization-participant/list.hbs
+++ b/orga/app/components/organization-participant/list.hbs
@@ -25,6 +25,7 @@
 </PixFilterBanner>
 <div class="panel">
   <table class="table content-text content-text--small">
+    <caption class="screen-reader-only">{{t "pages.organization-participants.table.description"}}</caption>
     <thead>
       <tr>
         <Table::HeaderSort

--- a/orga/tests/integration/components/campaign/list_test.js
+++ b/orga/tests/integration/components/campaign/list_test.js
@@ -3,6 +3,7 @@ import { render as renderScreen } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import sinon from 'sinon';
+import Service from '@ember/service';
 
 module('Integration | Component | Campaign::List', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -324,6 +325,48 @@ module('Integration | Component | Campaign::List', function (hooks) {
         // then
         assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.filter.clear'))).hasNoAttribute('disabled');
       });
+    });
+  });
+
+  module('Caption', function () {
+    test('it should display the caption for my campaigns page ', async function (assert) {
+      // given
+      class RouterStub extends Service {
+        currentRouteName = 'campaigns.my-campaigns';
+      }
+      this.owner.register('service:router', RouterStub);
+
+      const campaigns = [];
+      campaigns.meta = { rowCount: 0 };
+      this.set('campaigns', campaigns);
+
+      // when
+      const screen = await renderScreen(
+        hbs`<Campaign::List @campaigns={{this.campaigns}} @onFilter={{this.noop}} @onClickCampaign={{this.noop}} />`
+      );
+
+      // then
+      assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.table.description-my-campaigns'))).exists();
+    });
+
+    test('it should display the caption for all campaigns page ', async function (assert) {
+      // given
+      class RouterStub extends Service {
+        currentRouteName = 'campaigns.all-campaigns';
+      }
+      this.owner.register('service:router', RouterStub);
+
+      const campaigns = [];
+      campaigns.meta = { rowCount: 0 };
+      this.set('campaigns', campaigns);
+
+      // when
+      const screen = await renderScreen(
+        hbs`<Campaign::List @campaigns={{this.campaigns}} @onFilter={{this.noop}} @onClickCampaign={{this.noop}} />`
+      );
+
+      // then
+      assert.dom(screen.getByText(this.intl.t('pages.campaigns-list.table.description-all-campaigns'))).exists();
     });
   });
 });

--- a/orga/tests/integration/components/organization-participant/list_test.js
+++ b/orga/tests/integration/components/organization-participant/list_test.js
@@ -41,6 +41,23 @@ module('Integration | Component | OrganizationParticipant::List', function (hook
     assert.contains('Dernière participation');
   });
 
+  test('it should have a caption to describe the table ', async function (assert) {
+    // given
+    this.set('participants', []);
+
+    // when
+    await render(
+      hbs`<OrganizationParticipant::List
+  @participants={{this.participants}}
+  @triggerFiltering={{this.noop}}
+  @onClickLearner={{this.noop}}
+/>`
+    );
+
+    // then
+    assert.contains(this.intl.t('pages.organization-participants.table.description'));
+  });
+
   test('it should display a list of participants', async function (assert) {
     // given
     const participants = [

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -565,6 +565,8 @@
         "results": "{total, plural, =0 {0 campaigns} =1 {1 campaign} other {{total, number} campaigns}}"
       },
       "table": {
+        "description-all-campaigns": "This is the list of all the campaigns created in you Pix Orga. It includes their owner name, creation date, number of participants and number of received results.",
+        "description-my-campaigns": "This is the list of the campaigns you own. It includes their creation date, number of participants and number of received results.",
         "column": {
           "campaign": "Name of the campaign",
           "created-by": "Owner",
@@ -723,6 +725,7 @@
         }
       },
       "table": {
+        "description": "Table of participants, sorted by name.",
         "column": {
           "first-name": "First name",
           "last-name": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -565,6 +565,8 @@
         "results": "{total, plural, =0 {0 campagne} =1 {1 campagne} other {{total, number} campagnes}}"
       },
       "table": {
+        "description-all-campaigns": "Ce tableau comporte la liste de toutes les campagnes créées dans votre espace Pix Orga. Il indique pour chaque campagne leur propriétaire, leur date de création, le nombre de participants et le nombre de résultats reçus.",
+        "description-my-campaigns": "Ce tableau comporte la liste des campagnes dont vous êtes propriétaire. Il indique pour chaque campagne leur date de création, le nombre de participants et le nombre de résultats reçus.",
         "column": {
           "campaign": "Nom de la campagne",
           "created-by": "Propriétaire",
@@ -723,6 +725,7 @@
         }
       },
       "table": {
+        "description": "Tableau des participants trié par nom.",
         "column": {
           "first-name": "Prénom",
           "last-name": {


### PR DESCRIPTION
## :unicorn: Problème
Dans l'audit https://docs.google.com/spreadsheets/d/1qOU7a8lNlnCb-q-cHGg0bT2wPOwd9gKI/edit#gid=1318153235, on a eu un retour sur le manque de caption dans les tableaux (thématique 5.1)

## :robot: Proposition
Ajouter des captions aux tableaux qui n'en ont pas

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter à l'application orga, cliquer sur l'onglet participants, sélectionner un participant qui a déjà participé à des campagnes et utiliser la navigation clavier et un lecteur d'écran pour vérifier que le tableau contient un caption. 
