### PR TITLE
[BUGFIX] Corriger l'affichage des étoiles en fin de parcours sur Pix-App (PIX-7652)

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -77,11 +77,11 @@ export default class SkillReview extends Component {
   }
 
   get showStages() {
-    return Boolean(this.reachedStage?.content && !this._isCleaBadgeAcquired);
+    return this.args.model.campaignParticipationResult.hasReachedStage && !this._isCleaBadgeAcquired;
   }
 
   get showStagesWithStars() {
-    return this.reachedStage?.content && !this.showCleaCompetences;
+    return this.args.model.campaignParticipationResult.hasReachedStage && !this.showCleaCompetences;
   }
 
   get reachedStage() {

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -77,7 +77,7 @@ export default class SkillReview extends Component {
   }
 
   get showStages() {
-    return this.reachedStage && !this._isCleaBadgeAcquired;
+    return Boolean(this.reachedStage?.content && !this._isCleaBadgeAcquired);
   }
 
   get showStagesWithStars() {

--- a/mon-pix/app/models/campaign-participation-result.js
+++ b/mon-pix/app/models/campaign-participation-result.js
@@ -17,10 +17,14 @@ export default class CampaignParticipationResult extends Model {
   // includes
   @hasMany('campaignParticipationBadges') campaignParticipationBadges;
   @hasMany('competenceResult') competenceResults;
-  @belongsTo('reachedStage') reachedStage;
+  @belongsTo('reachedStage', { async: false }) reachedStage;
 
   get cleaBadge() {
     const badgeCleaKey = 'PIX_EMPLOI_CLEA';
     return this.campaignParticipationBadges.find((badge) => badge.key === badgeCleaKey);
+  }
+
+  get hasReachedStage() {
+    return this.reachedStage !== null;
   }
 }

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -8,7 +8,7 @@ import Service from '@ember/service';
 module('Integration | component | Campaigns | Evaluation | Skill Review', function (hooks) {
   setupTest(hooks);
 
-  let component, adapter, possibleBadgesCombinations;
+  let component, adapter, possibleBadgesCombinations, store;
 
   hooks.beforeEach(function () {
     possibleBadgesCombinations = [
@@ -32,14 +32,14 @@ module('Integration | component | Campaigns | Evaluation | Skill Review', functi
 
     const model = {
       campaign: EmberObject.create(),
-      campaignParticipationResult: EmberObject.create({ id: 12345 }),
+      campaignParticipationResult: EmberObject.create({ id: 12345, hasReachedStage: false }),
     };
 
     component = createGlimmerComponent('component:routes/campaigns/assessment/skill-review', {
       model,
     });
 
-    const store = this.owner.lookup('service:store');
+    store = this.owner.lookup('service:store');
     adapter = store.adapterFor('campaign-participation-result');
     sinon.stub(adapter, 'share').resolves();
     sinon.stub(adapter, 'beginImprovement').resolves();
@@ -137,9 +137,7 @@ module('Integration | component | Campaigns | Evaluation | Skill Review', functi
   module('#showStages', function () {
     test('should showStages when clea badge is not acquired and have a reachedStage', function (assert) {
       // given
-      const reachedStage = { content: { id: 123, threshold: 6 }, get: sinon.stub() };
-      reachedStage.get.withArgs('threshold').returns(6);
-      component.args.model.campaignParticipationResult.reachedStage = reachedStage;
+      component.args.model.campaignParticipationResult.hasReachedStage = true;
       const badges = [{ key: 'PIX_EMPLOI_CLEA', id: 33, isAcquired: false, isCertifiable: true, isValid: true }];
       component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
 
@@ -152,7 +150,7 @@ module('Integration | component | Campaigns | Evaluation | Skill Review', functi
 
     test('should not show showStages when clea badge is acquired and have not a reachedStage', function (assert) {
       // given
-      component.args.model.campaignParticipationResult.reachedStage = null;
+      component.args.model.campaignParticipationResult.hasReachedStage = false;
       const badges = [{ key: 'PIX_EMPLOI_CLEA', id: 33, isAcquired: true, isCertifiable: true, isValid: true }];
       component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
 
@@ -165,9 +163,7 @@ module('Integration | component | Campaigns | Evaluation | Skill Review', functi
 
     test('should not show showStages when clea badge is acquired and have a reachedStage', function (assert) {
       // given
-      const reachedStage = { content: { id: 123, threshold: 6 }, get: sinon.stub() };
-      reachedStage.get.withArgs('threshold').returns(6);
-      component.args.model.campaignParticipationResult.reachedStage = reachedStage;
+      component.args.model.campaignParticipationResult.hasReachedStage = true;
       const badges = [{ key: 'PIX_EMPLOI_CLEA', id: 33, isAcquired: true, isCertifiable: true, isValid: true }];
       component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
 

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -5,7 +5,7 @@ import EmberObject from '@ember/object';
 import createGlimmerComponent from '../../../../../helpers/create-glimmer-component';
 import Service from '@ember/service';
 
-module('Unit | component | Campaigns | Evaluation | Skill Review', function (hooks) {
+module('Integration | component | Campaigns | Evaluation | Skill Review', function (hooks) {
   setupTest(hooks);
 
   let component, adapter, possibleBadgesCombinations;

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review_test.js
@@ -134,6 +134,51 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
     });
   });
 
+  module('#showStages', function () {
+    test('should showStages when clea badge is not acquired and have a reachedStage', function (assert) {
+      // given
+      const reachedStage = { content: { id: 123, threshold: 6 }, get: sinon.stub() };
+      reachedStage.get.withArgs('threshold').returns(6);
+      component.args.model.campaignParticipationResult.reachedStage = reachedStage;
+      const badges = [{ key: 'PIX_EMPLOI_CLEA', id: 33, isAcquired: false, isCertifiable: true, isValid: true }];
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
+
+      // when
+      const showStages = component.showStages;
+
+      // then
+      assert.true(showStages);
+    });
+
+    test('should not show showStages when clea badge is acquired and have not a reachedStage', function (assert) {
+      // given
+      component.args.model.campaignParticipationResult.reachedStage = null;
+      const badges = [{ key: 'PIX_EMPLOI_CLEA', id: 33, isAcquired: true, isCertifiable: true, isValid: true }];
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
+
+      // when
+      const showStages = component.showStages;
+
+      // then
+      assert.false(showStages);
+    });
+
+    test('should not show showStages when clea badge is acquired and have a reachedStage', function (assert) {
+      // given
+      const reachedStage = { content: { id: 123, threshold: 6 }, get: sinon.stub() };
+      reachedStage.get.withArgs('threshold').returns(6);
+      component.args.model.campaignParticipationResult.reachedStage = reachedStage;
+      const badges = [{ key: 'PIX_EMPLOI_CLEA', id: 33, isAcquired: true, isCertifiable: true, isValid: true }];
+      component.args.model.campaignParticipationResult.campaignParticipationBadges = badges;
+
+      // when
+      const showStages = component.showStages;
+
+      // then
+      assert.false(showStages);
+    });
+  });
+
   module('#showCleaCompetences', function () {
     test('should showCleaCompetences when campaignParticipationResult has a clea badge', function (assert) {
       // given

--- a/mon-pix/tests/unit/models/campaign-participation-result_test.js
+++ b/mon-pix/tests/unit/models/campaign-participation-result_test.js
@@ -1,0 +1,34 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | campaign-participation-result', function (hooks) {
+  setupTest(hooks);
+
+  let store, model;
+
+  hooks.beforeEach(function () {
+    store = this.owner.lookup('service:store');
+    model = store.createRecord('campaign-participation-result');
+  });
+
+  test('exists', function (assert) {
+    assert.ok(model);
+  });
+
+  module('cleaBadge', () => {
+    test('should be undefined if no badge CLEA', function (assert) {
+      assert.strictEqual(model.cleaBadge, undefined);
+    });
+  });
+
+  module('hasReachedStage', () => {
+    test('should be false if no reached stage', function (assert) {
+      assert.false(model.hasReachedStage);
+    });
+
+    test('should be true if has a reached stage', function (assert) {
+      model.reachedStage = store.createRecord('reached-stage');
+      assert.true(model.hasReachedStage);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
En fin de parcours d'une campagne sans pallier, je peux voir un texte alternatif "NaN étoiles acquises sur NaN".

## :robot: Proposition
Corriger le conditionnement de l'affichage des étoiles lors d'une campagne avec palliers.
Ajouter des tests.

Avant : 
<img width="783" alt="Capture d’écran 2023-04-04 à 17 06 51" src="https://user-images.githubusercontent.com/49011144/230082581-98578be4-7def-4943-b27e-cb5f4ba3f697.png">


Après : 
<img width="995" alt="Capture d’écran 2023-04-04 à 17 10 12" src="https://user-images.githubusercontent.com/49011144/230082465-43e60d37-3ca5-4be0-9941-0a4550e218ed.png">


## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Aller sur Pix-App
- Aller sur la page de fin de parcours d'une campagne sans pallier `CAMPCLEA1`
- Vérifier que les étoiles au global de sont pas affichés
- Rejoindre une campagne avec pallier `PROBADGE1`
- Vérifier que les étoiles au global sont affichés
