### PR TITLE
[FEATURE] Améliorer le message d'erreur lors d'une suppression de colonne du csv d'import en masse sur Pix Certif (PIX-7090).

### DIFF
--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -215,7 +215,7 @@ function _getComplementaryCertificationLabel(key, COMPLEMENTARY_CERTIFICATION_SU
 function _verifyHeaders({ csvLineKeys, parsedCsvLine, headers }) {
   csvLineKeys.forEach((key) => {
     if (parsedCsvLine[headers[key]] === undefined) {
-      throw new FileValidationError(`La colonne : ${headers[key]} est absente du fichier`);
+      throw new FileValidationError('CSV_HEADERS_NOT_VALID');
     }
   });
 }

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -89,6 +89,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
         // then
         expect(error).to.be.instanceOf(FileValidationError);
+        expect(error.code).to.equal('CSV_HEADERS_NOT_VALID');
       });
     });
 

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -62,6 +62,10 @@ export default class ImportController extends Controller {
       if (!this.file) {
         return;
       }
+      if (this.file.type !== 'text/csv') {
+        this.notifications.error(this.intl.t(`pages.sessions.import.step-one.errors.incorrect-type-file`));
+        return;
+      }
       const {
         sessionsCount,
         sessionsWithoutCandidatesCount,

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -75,7 +75,13 @@ export default class ImportController extends Controller {
       this.cachedValidatedSessionsKey = cachedValidatedSessionsKey;
       this.errorReports = errorReports;
     } catch (errors) {
-      this.notifications.error(errors.errors[0].detail);
+      if (errors.errors[0].code === 'CSV_HEADERS_NOT_VALID') {
+        this.notifications.error(
+          this.intl.t(`pages.sessions.import.step-two.blocking-errors.errors.${errors.errors[0].code}`)
+        );
+      } else {
+        this.notifications.error(errors.errors[0].detail);
+      }
       return;
     }
     this.isImportStepOne = false;

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -186,7 +186,7 @@ module('Acceptance | Session Import', function (hooks) {
           test('it should display the sessions and candidates count', async function (assert) {
             // given
             const blob = new Blob(['foo']);
-            const file = new File([blob], 'fichier.csv');
+            const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
             this.server.post('/certification-centers/:id/sessions/validate-for-mass-import', () => {
               return new Response(
                 200,
@@ -217,7 +217,7 @@ module('Acceptance | Session Import', function (hooks) {
             test('it should allow session creation anyway', async function (assert) {
               // given
               const blob = new Blob(['foo']);
-              const file = new File([blob], 'fichier.csv');
+              const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
               this.server.post('/certification-centers/:id/sessions/validate-for-mass-import', () => {
                 return new Response(
                   200,
@@ -365,24 +365,6 @@ module('Acceptance | Session Import', function (hooks) {
           test('it should display an error notification', async function (assert) {
             //given
             const file = new Blob(['foo']);
-            this.server.post(
-              '/certification-centers/:id/sessions/validate-for-mass-import',
-              () =>
-                new Response(
-                  422,
-                  { some: 'header' },
-                  {
-                    errors: [
-                      {
-                        code: 'INVALID_DOCUMENT',
-                        status: '422',
-                        title: 'Unprocessable Entity',
-                        detail: 'Fichier non valide',
-                      },
-                    ],
-                  }
-                )
-            );
 
             // when
             screen = await visit('/sessions/import');
@@ -392,7 +374,9 @@ module('Acceptance | Session Import', function (hooks) {
             await click(importButton);
 
             // then
-            assert.dom(screen.getByText('Fichier non valide')).exists();
+            assert
+              .dom(screen.getByText('Le format du fichier est incorrect, seul le format .csv est accepté'))
+              .exists();
           });
 
           test('it should not go to step two', async function (assert) {

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -217,7 +217,7 @@ module('Acceptance | Session Import', function (hooks) {
             test('it should allow session creation anyway', async function (assert) {
               // given
               const blob = new Blob(['foo']);
-              const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
+              const file = new File([blob], 'fichier.csv');
               this.server.post('/certification-centers/:id/sessions/validate-for-mass-import', () => {
                 return new Response(
                   200,

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -146,7 +146,7 @@ module('Acceptance | Session Import', function (hooks) {
           test('it should get back to step 1', async function (assert) {
             // given
             const blob = new Blob(['foo']);
-            const file = new File([blob], 'fichier.csv');
+            const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
             screen = await visit('/sessions/import');
             const importButton = screen.getByLabelText('Importer le modèle complété');
             await triggerEvent(importButton, 'change', { files: [file] });
@@ -168,7 +168,7 @@ module('Acceptance | Session Import', function (hooks) {
           test("it should remove the file's name", async function (assert) {
             // given
             const blob = new Blob(['foo']);
-            const file = new File([blob], 'fichier.csv');
+            const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
 
             // when
             screen = await visit('/sessions/import');
@@ -195,7 +195,7 @@ module('Acceptance | Session Import', function (hooks) {
                   sessionsCount: 2,
                   sessionsWithoutCandidatesCount: 1,
                   candidatesCount: 3,
-                  errorReports: [{ code: 'EMPTY_SESSION', line: 1, blocking: false }],
+                  errorReports: [],
                 }
               );
             });
@@ -211,14 +211,43 @@ module('Acceptance | Session Import', function (hooks) {
             assert.dom(screen.getByText('2 sessions dont 1 session sans candidat')).exists();
             assert.dom(screen.getByText('3 candidats')).exists();
             assert.dom(screen.queryByLabelText('fichier.csv')).doesNotExist();
-            assert.dom(screen.getByRole('button', { name: 'Finaliser quand même la création/édition' })).exists();
+          });
+
+          module('when there is only non blocking errors', function () {
+            test('it should allow session creation anyway', async function (assert) {
+              // given
+              const blob = new Blob(['foo']);
+              const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
+              this.server.post('/certification-centers/:id/sessions/validate-for-mass-import', () => {
+                return new Response(
+                  200,
+                  {},
+                  {
+                    sessionsCount: 2,
+                    sessionsWithoutCandidatesCount: 1,
+                    candidatesCount: 3,
+                    errorReports: [{ code: 'EMPTY_SESSION', line: 1, blocking: false }],
+                  }
+                );
+              });
+
+              // when
+              screen = await visit('/sessions/import');
+              const input = screen.getByLabelText('Importer le modèle complété');
+              await triggerEvent(input, 'change', { files: [file] });
+              const importButton = screen.getByRole('button', { name: 'Continuer' });
+              await click(importButton);
+
+              // then
+              assert.dom(screen.getByRole('button', { name: 'Finaliser quand même la création/édition' })).exists();
+            });
           });
 
           module('when the user has confirmed the import', function () {
             test("it should redirect to the session's list", async function (assert) {
               // given
               const blob = new Blob(['foo']);
-              const file = new File([blob], 'fichier.csv');
+              const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
               this.server.post('/certification-centers/:id/sessions/validate-for-mass-import', () => {
                 return new Response(
                   200,
@@ -252,7 +281,7 @@ module('Acceptance | Session Import', function (hooks) {
               test('it should display a success notification', async function (assert) {
                 // given
                 const blob = new Blob(['foo']);
-                const file = new File([blob], 'fichier.csv');
+                const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
                 this.server.post('/certification-centers/:id/sessions/validate-for-mass-import', () => {
                   return new Response(
                     200,
@@ -293,7 +322,7 @@ module('Acceptance | Session Import', function (hooks) {
               test('it should display a pluralized success notification', async function (assert) {
                 // given
                 const blob = new Blob(['foo']);
-                const file = new File([blob], 'fichier.csv');
+                const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
                 this.server.post('/certification-centers/:id/sessions/validate-for-mass-import', () => {
                   return new Response(
                     200,
@@ -397,6 +426,39 @@ module('Acceptance | Session Import', function (hooks) {
 
             // then
             assert.dom(screen.getByRole('button', { name: 'Télécharger le modèle vierge' })).exists();
+          });
+        });
+
+        module('when file headers have been modified', function () {
+          test('it should display an error notification', async function (assert) {
+            //given
+            const blob = new Blob(['foo']);
+            const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
+            this.server.post(
+              '/certification-centers/:id/sessions/validate-for-mass-import',
+              () =>
+                new Response(
+                  422,
+                  { some: 'header' },
+                  {
+                    errors: [
+                      {
+                        code: 'CSV_HEADERS_NOT_VALID',
+                      },
+                    ],
+                  }
+                )
+            );
+
+            // when
+            screen = await visit('/sessions/import');
+            const input = await screen.findByLabelText('Importer le modèle complété');
+            await triggerEvent(input, 'change', { files: [file] });
+            const importButton = screen.getByRole('button', { name: 'Continuer' });
+            await click(importButton);
+
+            // then
+            assert.dom(screen.getByText('Le modèle a été altéré, merci de le télécharger à nouveau.')).exists();
           });
         });
       });

--- a/certif/tests/unit/controllers/authenticated/sessions/import_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/import_test.js
@@ -95,7 +95,9 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
       this.owner.register('service:current-user', CurrentUserStub);
       const token = 'a token';
 
-      const file = Symbol('file 1');
+      const blob = new Blob(['foo']);
+      const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
+
       controller.file = file;
 
       controller.session = {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -268,7 +268,8 @@
               "SESSION_SCHEDULED_IN_THE_PAST": "Date et/ou heure indiquées antérieures à la date du jour.",
               "SESSION_ID_NOT_EXISTING": "N° de session inexistant.",
               "SESSION_ID_NOT_VALID": "N° de session invalide.",
-              "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées."
+              "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées.",
+              "CSV_HEADERS_NOT_VALID": "Le modèle a été altéré, merci de le télécharger à nouveau."
             }
           },
           "non-blocking-errors": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -207,7 +207,8 @@
             }
           },
           "errors": {
-            "download": "Une erreur s'est produite pendant le téléchargement"
+            "download": "Une erreur s'est produite pendant le téléchargement",
+            "incorrect-type-file": "Le format du fichier est incorrect, seul le format .csv est accepté"
           },
           "instructions": {
             "creation": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -207,7 +207,8 @@
             }
           },
           "errors": {
-            "download": "Une erreur s'est produite pendant le téléchargement"
+            "download": "Une erreur s'est produite pendant le téléchargement",
+            "incorrect-type-file": "Le format du fichier est incorrect, seul le format .csv est accepté"
           },
           "instructions": {
             "title": "Comment ça marche ?",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -268,7 +268,8 @@
               "SESSION_SCHEDULED_IN_THE_PAST": "Date et/ou heure indiquées antérieures à la date du jour",
               "SESSION_ID_NOT_EXISTING": "N° de session inexistant.",
               "SESSION_ID_NOT_VALID": "N° de session invalide.",
-              "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées"
+              "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées",
+              "CSV_HEADERS_NOT_VALID": "Le modèle a été altéré, merci de le télécharger à nouveau."
             }
           },
           "non-blocking-errors": {


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'import en masse, un tableau est fourni à l'utilisateur pour remplir les sessions et candidats à importer. 

Actuellement, si les colonnes présentes dans ce tableau sont supprimées, un message d'erreur en anglais "An error occurred, file is invalid" est retourné coté front.

## :robot: Proposition
Retourner un message plus cohérent à l'utilisateur, indiquant que le modèle du fichier à été altéré

## :100: Pour tester
- Se connecter sur Pix Certif avec certifsup@example.net
- Utiliser le csv suivant avec colonne d'id de session manquante
```
* Nom du site;* Nom de la salle;* Date de début;* Heure de début (heure locale);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: jj/mm/aaaa);* Sexe (M ou F);Code Insee;Code postal;Nom de la commune;* Pays;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant local;Temps majoré ?;Tarification part Pix;Code de prépaiement;Pix+ Droit ('oui' ou laisser vide);
Site;Salle;12/01/2025;12:00;Jean-Mich;;Candidat;Super;02/01/2000;M;;75015;PARIS;FRANCE;;;;;Payante;;;
```
- Constater que le message d'erreur est bien retourné

Pour tester l'erreur du fichier au mauvais format:

- Recommencer l'import en ouvrant la consoler et en enlevant le accept="csv" du bouton "Importer"
- Importer un png/jpeg/comme vous voulez (sauf csv)
- Constater qu'une notif d'erreur empêche l'import `Le format du fichier est incorrect, seul le format .csv est accepté`
