### PR TITLE
[FEATURE] Passer la duplication de candidat en erreur non bloquante dans l'import en masse (PIX-7181).

### DIFF
--- a/api/lib/domain/constants/sessions-errors.js
+++ b/api/lib/domain/constants/sessions-errors.js
@@ -23,8 +23,8 @@ module.exports.CERTIFICATION_SESSIONS_ERRORS = {
     code: 'SESSION_ID_NOT_VALID',
     getMessage: () => '',
   },
-  DUPLICATE_CANDIDATE_NOT_ALLOWED_IN_SESSION: {
-    code: 'DUPLICATE_CANDIDATE_NOT_ALLOWED_IN_SESSION',
+  DUPLICATE_CANDIDATE_IN_SESSION: {
+    code: 'DUPLICATE_CANDIDATE_IN_SESSION',
     getMessage: () => `Une session contient au moins un élève en double.`,
   },
   SESSION_ADDRESS_REQUIRED: {

--- a/api/lib/domain/models/SessionMassImportReport.js
+++ b/api/lib/domain/models/SessionMassImportReport.js
@@ -14,7 +14,7 @@ class SessionMassImportReport {
   }
 
   get isValid() {
-    return !this.errorReports.some(({ blocking }) => blocking);
+    return !this.errorReports.some(({ isBlocking }) => isBlocking);
   }
 
   addErrorReports(errors) {

--- a/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
+++ b/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
@@ -76,7 +76,8 @@ module.exports = {
         _addToErrorList({
           errorList: sessionErrors,
           line,
-          codes: [CERTIFICATION_SESSIONS_ERRORS.DUPLICATE_CANDIDATE_NOT_ALLOWED_IN_SESSION.code],
+          codes: [CERTIFICATION_SESSIONS_ERRORS.DUPLICATE_CANDIDATE_IN_SESSION.code],
+          isBlocking: false,
         });
       }
     }

--- a/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
+++ b/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
@@ -69,7 +69,7 @@ module.exports = {
         errorList: sessionErrors,
         line,
         codes: [CERTIFICATION_SESSIONS_ERRORS.EMPTY_SESSION.code],
-        blocking: false,
+        isBlocking: false,
       });
     } else {
       if (_hasDuplicateCertificationCandidates(session.certificationCandidates)) {
@@ -148,8 +148,8 @@ function _isErrorNotDuplicated({ certificationCandidateErrors, errorCode }) {
   return !certificationCandidateErrors.some((error) => errorCode === error.code);
 }
 
-function _addToErrorList({ errorList, line, codes = [], blocking = true }) {
-  const errors = codes.map((code) => ({ code, line, blocking }));
+function _addToErrorList({ errorList, line, codes = [], isBlocking = true }) {
+  const errors = codes.map((code) => ({ code, line, isBlocking }));
   errorList.push(...errors);
 }
 

--- a/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
+++ b/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
@@ -85,6 +85,34 @@ module.exports = {
     return sessionErrors;
   },
 
+  getUniqueCandidates(candidates) {
+    const duplicateCandidateErrors = [];
+
+    const uniqueCandidates = candidates.filter((candidate, index) => {
+      const isFirstOccurence =
+        index ===
+        candidates.findIndex(
+          (other) =>
+            candidate.firstName === other.firstName &&
+            candidate.lastName === other.lastName &&
+            candidate.birthdate === other.birthdate
+        );
+
+      if (!isFirstOccurence) {
+        _addToErrorList({
+          errorList: duplicateCandidateErrors,
+          line: candidate.line,
+          codes: [CERTIFICATION_SESSIONS_ERRORS.DUPLICATE_CANDIDATE_IN_SESSION.code],
+          isBlocking: false,
+        });
+      }
+
+      return isFirstOccurence;
+    });
+
+    return { uniqueCandidates, duplicateCandidateErrors };
+  },
+
   async getValidatedCandidateBirthInformation({
     candidate,
     isSco,

--- a/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
+++ b/api/lib/domain/usecases/sessions-mass-import/validate-sessions.js
@@ -82,7 +82,13 @@ async function _createValidCertificationCandidates({
   certificationCpfCityRepository,
   complementaryCertificationRepository,
 }) {
-  return await bluebird.mapSeries(certificationCandidates, async (certificationCandidate) => {
+  const { uniqueCandidates, duplicateCandidateErrors } =
+    sessionsImportValidationService.getUniqueCandidates(certificationCandidates);
+  if (duplicateCandidateErrors.length > 0) {
+    sessionsMassImportReport.addErrorReports(duplicateCandidateErrors);
+  }
+
+  return bluebird.mapSeries(uniqueCandidates, async (certificationCandidate) => {
     const billingMode = CertificationCandidate.translateBillingMode(certificationCandidate.billingMode);
 
     const domainCertificationCandidate = new CertificationCandidate({

--- a/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-validate-sessions_test.js
+++ b/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-validate-sessions_test.js
@@ -68,7 +68,7 @@ describe('Acceptance | Controller | certification-centers-controller-post-valida
             {
               code: 'EMPTY_SESSION',
               line: 2,
-              blocking: false,
+              isBlocking: false,
             },
           ],
           sessionsCount: 1,
@@ -128,7 +128,7 @@ describe('Acceptance | Controller | certification-centers-controller-post-valida
                 {
                   code: 'INFORMATION_NOT_ALLOWED_WITH_SESSION_ID',
                   line: 3,
-                  blocking: true,
+                  isBlocking: true,
                 },
               ],
             });

--- a/api/tests/unit/domain/models/SessionMassImportReport_test.js
+++ b/api/tests/unit/domain/models/SessionMassImportReport_test.js
@@ -37,7 +37,7 @@ describe('Unit | Domain | Models | SessionMassImportReport', function () {
       it('should return false', function () {
         // given
         const sessionMassImportReport = new SessionMassImportReport({
-          errorReports: [{ blocking: true }],
+          errorReports: [{ isBlocking: true }],
         });
 
         // when
@@ -52,7 +52,7 @@ describe('Unit | Domain | Models | SessionMassImportReport', function () {
       it('should return true', function () {
         // given
         const sessionMassImportReport = new SessionMassImportReport({
-          errorReports: [{ blocking: false }],
+          errorReports: [{ isBlocking: false }],
         });
 
         // when

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -71,7 +71,7 @@ describe('Unit | Service | sessions import validation Service', function () {
                 {
                   line: 1,
                   code: 'SESSION_ID_NOT_VALID',
-                  blocking: true,
+                  isBlocking: true,
                 },
               ]);
             });
@@ -122,7 +122,7 @@ describe('Unit | Service | sessions import validation Service', function () {
           {
             line: 2,
             code: 'CANDIDATE_NOT_ALLOWED_FOR_STARTED_SESSION',
-            blocking: true,
+            isBlocking: true,
           },
         ]);
       });
@@ -148,7 +148,7 @@ describe('Unit | Service | sessions import validation Service', function () {
             {
               line: 1,
               code: 'SESSION_SCHEDULED_IN_THE_PAST',
-              blocking: true,
+              isBlocking: true,
             },
           ]);
         });
@@ -181,7 +181,7 @@ describe('Unit | Service | sessions import validation Service', function () {
                 {
                   line: 1,
                   code: 'INFORMATION_NOT_ALLOWED_WITH_SESSION_ID',
-                  blocking: true,
+                  isBlocking: true,
                 },
               ]);
             });
@@ -221,7 +221,7 @@ describe('Unit | Service | sessions import validation Service', function () {
             {
               line: 1,
               code: 'SESSION_ID_NOT_EXISTING',
-              blocking: true,
+              isBlocking: true,
             },
           ]);
         });
@@ -267,7 +267,7 @@ describe('Unit | Service | sessions import validation Service', function () {
           {
             line: 1,
             code: 'SESSION_WITH_DATE_AND_TIME_ALREADY_EXISTS',
-            blocking: true,
+            isBlocking: true,
           },
         ]);
       });
@@ -293,7 +293,7 @@ describe('Unit | Service | sessions import validation Service', function () {
           {
             line: 1,
             code: 'SESSION_DATE_NOT_VALID',
-            blocking: true,
+            isBlocking: true,
           },
         ]);
       });
@@ -319,7 +319,7 @@ describe('Unit | Service | sessions import validation Service', function () {
           {
             line: 1,
             code: 'SESSION_TIME_NOT_VALID',
-            blocking: true,
+            isBlocking: true,
           },
         ]);
       });
@@ -347,7 +347,7 @@ describe('Unit | Service | sessions import validation Service', function () {
             {
               line: 1,
               code: 'DUPLICATE_CANDIDATE_NOT_ALLOWED_IN_SESSION',
-              blocking: true,
+              isBlocking: true,
             },
           ]);
         });
@@ -373,7 +373,7 @@ describe('Unit | Service | sessions import validation Service', function () {
           {
             line: 1,
             code: 'SESSION_ROOM_REQUIRED',
-            blocking: true,
+            isBlocking: true,
           },
         ]);
       });
@@ -396,8 +396,8 @@ describe('Unit | Service | sessions import validation Service', function () {
 
         // then
         expect(sessionErrors).to.have.deep.members([
-          { line: 1, code: 'SESSION_ADDRESS_REQUIRED', blocking: true },
-          { line: 1, code: 'SESSION_ROOM_REQUIRED', blocking: true },
+          { line: 1, code: 'SESSION_ADDRESS_REQUIRED', isBlocking: true },
+          { line: 1, code: 'SESSION_ROOM_REQUIRED', isBlocking: true },
         ]);
       });
     });
@@ -417,7 +417,7 @@ describe('Unit | Service | sessions import validation Service', function () {
         });
 
         // then
-        expect(sessionErrors).to.have.deep.members([{ line: 1, code: 'EMPTY_SESSION', blocking: false }]);
+        expect(sessionErrors).to.have.deep.members([{ line: 1, code: 'EMPTY_SESSION', isBlocking: false }]);
       });
     });
   });
@@ -475,7 +475,7 @@ describe('Unit | Service | sessions import validation Service', function () {
           {
             code: 'CANDIDATE_FIRST_NAME_REQUIRED',
             line: 1,
-            blocking: true,
+            isBlocking: true,
           },
         ]);
       });
@@ -506,7 +506,7 @@ describe('Unit | Service | sessions import validation Service', function () {
               {
                 code: 'CANDIDATE_BILLING_MODE_REQUIRED',
                 line: 1,
-                blocking: true,
+                isBlocking: true,
               },
             ]);
           });
@@ -535,7 +535,7 @@ describe('Unit | Service | sessions import validation Service', function () {
               {
                 code: 'CANDIDATE_BILLING_MODE_REQUIRED',
                 line: 1,
-                blocking: true,
+                isBlocking: true,
               },
             ]);
           });
@@ -603,7 +603,7 @@ describe('Unit | Service | sessions import validation Service', function () {
 
           // then
           expect(result.certificationCandidateErrors).to.deep.equal([
-            { code: 'CANDIDATE_BIRTH_COUNTRY_REQUIRED', line: 1, blocking: true },
+            { code: 'CANDIDATE_BIRTH_COUNTRY_REQUIRED', line: 1, isBlocking: true },
           ]);
         });
       });
@@ -635,7 +635,9 @@ describe('Unit | Service | sessions import validation Service', function () {
         });
 
         // then
-        expect(result.certificationCandidateErrors).to.deep.equal([{ code: 'CPF_INCORRECT', line: 1, blocking: true }]);
+        expect(result.certificationCandidateErrors).to.deep.equal([
+          { code: 'CPF_INCORRECT', line: 1, isBlocking: true },
+        ]);
       });
     });
   });

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -346,8 +346,8 @@ describe('Unit | Service | sessions import validation Service', function () {
           expect(sessionErrors).to.deep.equal([
             {
               line: 1,
-              code: 'DUPLICATE_CANDIDATE_NOT_ALLOWED_IN_SESSION',
-              isBlocking: true,
+              code: 'DUPLICATE_CANDIDATE_IN_SESSION',
+              isBlocking: false,
             },
           ]);
         });

--- a/api/tests/unit/domain/usecases/sessions-mass-import/validate-sessions_test.js
+++ b/api/tests/unit/domain/usecases/sessions-mass-import/validate-sessions_test.js
@@ -237,7 +237,7 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
     it('should not save in temporary storage', async function () {
       // given
       sessionsImportValidationService.validateSession.resolves([
-        { code: 'Veuillez indiquer un nom de site.', blocking: true },
+        { code: 'Veuillez indiquer un nom de site.', isBlocking: true },
       ]);
       sessionsImportValidationService.getValidatedCandidateBirthInformation.resolves({
         certificationCandidateErrors: [],

--- a/certif/app/components/import/step-two-section.js
+++ b/certif/app/components/import/step-two-section.js
@@ -41,11 +41,11 @@ export default class StepTwoSectionComponent extends Component {
   }
 
   get _blockingErrors() {
-    return this.args.errorReports.filter((error) => error.blocking);
+    return this.args.errorReports.filter((error) => error.isBlocking);
   }
 
   get _nonBlockingErrors() {
-    return this.args.errorReports.filter((error) => !error.blocking);
+    return this.args.errorReports.filter((error) => !error.isBlocking);
   }
 
   get hasOnlyNonBlockingErrorReports() {

--- a/certif/tests/integration/components/sessions-import/step-two-section_test.js
+++ b/certif/tests/integration/components/sessions-import/step-two-section_test.js
@@ -139,7 +139,7 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
     ].forEach(function ({ error, expectedMessage }) {
       test('it renders a report', async function (assert) {
         // given
-        this.set('errorReports', [{ line: '5', code: error, blocking: true }]);
+        this.set('errorReports', [{ line: '5', code: error, isBlocking: true }]);
 
         // when
         const { getByText, getByRole } = await render(hbs`<Import::StepTwoSection
@@ -156,8 +156,8 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
     test('it renders a button to return to step one', async function (assert) {
       // given
       this.set('errorReports', [
-        { line: 1, code: 'CANDIDATE_FIRST_NAME_REQUIRED', blocking: true },
-        { line: 2, code: 'EMPTY_SESSION', blocking: false },
+        { line: 1, code: 'CANDIDATE_FIRST_NAME_REQUIRED', isBlocking: true },
+        { line: 2, code: 'EMPTY_SESSION', isBlocking: false },
       ]);
 
       // when
@@ -177,7 +177,7 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
     }) {
       test('it renders a report', async function (assert) {
         // given
-        this.set('errorReports', [{ line: '5', code: error, blocking: false }]);
+        this.set('errorReports', [{ line: '5', code: error, isBlocking: false }]);
 
         // when
         const { getByText, getByRole } = await render(
@@ -193,7 +193,7 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
 
     test('it renders a button to return to step one', async function (assert) {
       // given
-      this.set('errorReports', [{ line: 2, code: 'EMPTY_SESSION', blocking: false }]);
+      this.set('errorReports', [{ line: 2, code: 'EMPTY_SESSION', isBlocking: false }]);
 
       // when
       const { getByRole } = await render(hbs`<Import::StepTwoSection @errorReports={{this.errorReports}} />`);
@@ -206,7 +206,7 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
 
     test('it renders a button to create the sessions', async function (assert) {
       // given
-      this.set('errorReports', [{ line: 2, code: 'EMPTY_SESSION', blocking: false }]);
+      this.set('errorReports', [{ line: 2, code: 'EMPTY_SESSION', isBlocking: false }]);
 
       // when
       const { getByRole } = await render(hbs`<Import::StepTwoSection @errorReports={{this.errorReports}} />`);

--- a/certif/tests/integration/components/sessions-import/step-two-section_test.js
+++ b/certif/tests/integration/components/sessions-import/step-two-section_test.js
@@ -172,7 +172,7 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
       {
         error: 'DUPLICATE_CANDIDATE_IN_SESSION',
         expectedMessage:
-          'Au moins un candidat est inscrit plusieurs fois à la même session, une seule inscription sera prise en compte.',
+          'Le candidat est inscrit plusieurs fois à la même session, une seule inscription sera prise en compte.',
       },
     ].forEach(function ({ error, expectedMessage }) {
       test('it renders a report', async function (assert) {

--- a/certif/tests/integration/components/sessions-import/step-two-section_test.js
+++ b/certif/tests/integration/components/sessions-import/step-two-section_test.js
@@ -106,10 +106,6 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
         error: 'CANDIDATE_RESULT_RECIPIENT_EMAIL_NOT_VALID',
         expectedMessage: 'Donnée du champ "E-mail du destinataire des résultats (formateur, enseignant…)" invalide',
       },
-      {
-        error: 'DUPLICATE_CANDIDATE_NOT_ALLOWED_IN_SESSION',
-        expectedMessage: 'Candidat inscrit plusieurs fois à cette session',
-      },
       { error: 'SESSION_ADDRESS_REQUIRED', expectedMessage: 'Champ obligatoire "Nom du site" manquant' },
       { error: 'SESSION_ROOM_REQUIRED', expectedMessage: 'Champ obligatoire "Nom de la salle" manquant' },
       { error: 'SESSION_DATE_REQUIRED', expectedMessage: 'Champ obligatoire "Date de session" manquant' },
@@ -171,10 +167,14 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
   });
 
   module('when the imported file contains non blocking errors', function () {
-    [{ error: 'EMPTY_SESSION', expectedMessage: 'La session ne contient pas de candidat' }].forEach(function ({
-      error,
-      expectedMessage,
-    }) {
+    [
+      { error: 'EMPTY_SESSION', expectedMessage: 'La session ne contient pas de candidat' },
+      {
+        error: 'DUPLICATE_CANDIDATE_IN_SESSION',
+        expectedMessage:
+          'Au moins un candidat est inscrit plusieurs fois à la même session, une seule inscription sera prise en compte.',
+      },
+    ].forEach(function ({ error, expectedMessage }) {
       test('it renders a report', async function (assert) {
         // given
         this.set('errorReports', [{ line: '5', code: error, isBlocking: false }]);

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -257,7 +257,6 @@
               "CANDIDATE_NOT_ALLOWED_FOR_STARTED_SESSION": "Édition des candidats impossible, le numéro de session correspond à une session déjà démarrée",
               "CANDIDATE_EMAIL_NOT_VALID": "Donnée du champ \"E-mail de convocation\" invalide",
               "CANDIDATE_RESULT_RECIPIENT_EMAIL_NOT_VALID": "Donnée du champ \"E-mail du destinataire des résultats (formateur, enseignant…)\" invalide",
-              "DUPLICATE_CANDIDATE_NOT_ALLOWED_IN_SESSION": "Candidat inscrit plusieurs fois à cette session",
               "SESSION_ADDRESS_REQUIRED": "Champ obligatoire \"Nom du site\" manquant",
               "SESSION_ROOM_REQUIRED": "Champ obligatoire \"Nom de la salle\" manquant",
               "SESSION_DATE_REQUIRED": "Champ obligatoire \"Date de session\" manquant",
@@ -278,6 +277,7 @@
             "information": "Nous avons détecté {nonBlockingErrorReportsCount, plural,one {un point d’attention non bloquant} other {des points d’attention non bloquants}} lors de l’import, consultez-{nonBlockingErrorReportsCount, plural,one {le} other {les}} avant de procéder à la création ou l’édition de vos sessions :",
             "line": "Line",
             "errors": {
+              "DUPLICATE_CANDIDATE_IN_SESSION": "Le candidat inscrit plusieurs fois à la même session, une seule inscription sera prise en compte.",
               "EMPTY_SESSION": "La session ne contient pas de candidat"
             }
           },
@@ -502,7 +502,7 @@
         },
         "description": "For the reporting to be taken into account, you must use the appropriate reporting category (examples : C1, C2, etc).",
         "uncompleted-reports-information": {
-          "description" : "These candidates haven’t finished their Pix certification exam or the invigilator has ended their exam",
+          "description": "These candidates haven’t finished their Pix certification exam or the invigilator has ended their exam",
           "extra-information": "List of candidates who haven’t finished their certification exam, ordered by birth name, with a link to add a reporting if needed and a drop-down list enabling you to select the reason for abandonment",
           "table": {
             "labels": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -40,7 +40,7 @@
       },
       "login": {
         "email": "Adresse e-mail",
-        "password":"Mot de passe",
+        "password": "Mot de passe",
         "forgot-password": "Mot de passe oublié ?"
       },
       "mandatory-fields": "Les champs marqués de <abbr title=\"obligatoire\" class=\"mandatory-mark\">*</abbr>sont obligatoires.",
@@ -98,7 +98,7 @@
           "woman": "Femme"
         },
         "insee-code": "Code INSEE",
-        "lastname":  "Nom",
+        "lastname": "Nom",
         "none": "Aucune",
         "postcode": "Code postal"
       }
@@ -257,7 +257,6 @@
               "CANDIDATE_NOT_ALLOWED_FOR_STARTED_SESSION": "Édition des candidats impossible, le numéro de session correspond à une session déjà démarrée",
               "CANDIDATE_EMAIL_NOT_VALID": "Donnée du champ \"E-mail de convocation\" invalide",
               "CANDIDATE_RESULT_RECIPIENT_EMAIL_NOT_VALID": "Donnée du champ \"E-mail du destinataire des résultats (formateur, enseignant…)\" invalide",
-              "DUPLICATE_CANDIDATE_NOT_ALLOWED_IN_SESSION": "Candidat inscrit plusieurs fois à cette session",
               "SESSION_ADDRESS_REQUIRED": "Champ obligatoire \"Nom du site\" manquant",
               "SESSION_ROOM_REQUIRED": "Champ obligatoire \"Nom de la salle\" manquant",
               "SESSION_DATE_REQUIRED": "Champ obligatoire \"Date de session\" manquant",
@@ -278,6 +277,7 @@
             "information": "Nous avons détecté {nonBlockingErrorReportsCount, plural,one {un point d’attention non bloquant} other {des points d’attention non bloquants}} lors de l’import, consultez-{nonBlockingErrorReportsCount, plural,one {le} other {les}} avant de procéder à la création ou l’édition de vos sessions :",
             "line": "Ligne",
             "errors": {
+              "DUPLICATE_CANDIDATE_IN_SESSION": "Le candidat est inscrit plusieurs fois à la même session, une seule inscription sera prise en compte.",
               "EMPTY_SESSION": "La session ne contient pas de candidat"
             }
           },
@@ -501,7 +501,7 @@
         },
         "description": "Pour que le signalement soit pris en compte, il est nécessaire d’utiliser la catégorie de signalement appropriée (exemples : C1, C2, etc).",
         "uncompleted-reports-information": {
-          "description" : "Ces candidats n'ont pas fini leur test de certification ou le surveillant a mis fin à leur test",
+          "description": "Ces candidats n'ont pas fini leur test de certification ou le surveillant a mis fin à leur test",
           "extra-information": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.",
           "table": {
             "labels": {


### PR DESCRIPTION
## :unicorn: Problème

L’utilisateur Pix Certif peut avoir mal rempli son fichier d’import et avoir des erreurs à corriger avant import définitif.
Il peut notamment s’agir d’un doublon de candidats car il a inscrit par erreur plusieurs fois le même candidat à la même session.

## :robot: Proposition

• Ne pas bloquer l’import, traiter l’erreur comme une erreur non bloquante et proposer à l’utilisateur de finaliser quand même son import.
• Ignorer les doublons pour la comptabilisation des candidats inscrits à la même session.
• Afficher le texte d’erreur suivant sur toutes les lignes sauf une : “Ligne X : Le candidat est inscrit plusieurs fois à la même session, une seule inscription sera prise en compte.”

## :rainbow: Remarques

⚠️ Est dorénavant affiché le numero de la ligne du candidat et non de la session

## :100: Pour tester

• Se connecter à Pix-certif avec `certifsup@example.net`
• Créer / Editer des sessions
• Importer le fichier suivant

```
N° de session;* Nom du site;* Nom de la salle;* Date de début;* Heure de début (heure locale);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: jj/mm/aaaa);* Sexe (M ou F);Code Insee;Code postal;Nom de la commune;* Pays;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant local;Temps majoré ?;Tarification part Pix;Code de prépaiement;Pix+ Droit ('oui' ou laisser vide);
;Site;Salle;12/01/2026;12:00;Jean-Mich;;Candidat0;Super0;02/01/2000;M;;75015;PARIS;FRANCE;;;;;Payante;;;
;Site;Salle;12/01/2026;12:00;Jean-Mich;;Candidat1;Super1;02/01/2000;M;;75015;PARIS;FRANCE;;;;;Payante;;;
;Site;Salle;12/01/2026;12:00;Jean-Mich;;Candidat2;Super2;02/01/2000;M;;75015;PARIS;FRANCE;;;;;Payante;;;
;Site;Salle;12/01/2026;12:00;Jean-Mich;;Candidat1;Super1;02/01/2000;M;;75015;PARIS;FRANCE;;;;;Payante;;;
;Site;Salle;12/01/2026;12:00;Jean-Mich;;Candidat3;Super3;02/01/2000;M;;75015;PARIS;FRANCE;;;;;Payante;;;
```

• Constater désormais l'apparition d'une erreur non bloquante
• Confirmer l'import du fichier
• Constater que le `candidat 1` n'a été créé qu'une fois pour la session à importer