### PR TITLE
[FEATURE] Montée de version pix-ui@v30.0.0 sur Admin (PIX-7642)

### DIFF
--- a/admin/app/styles/authenticated/certifications/certification/informations.scss
+++ b/admin/app/styles/authenticated/certifications/certification/informations.scss
@@ -1,5 +1,4 @@
 .certification-informations {
-
   &__actions {
     display: flex;
     justify-content: center;
@@ -22,10 +21,10 @@
   }
 
   &__card {
-    box-shadow: 0 4px 8px rgba($grey-200, 0.08);
-    border: 1px solid $grey-20;
+    box-shadow: 0 4px 8px rgba($pix-neutral-110, 0.08);
+    border: 1px solid $pix-neutral-20;
     border-radius: 8px;
-    background: $white;
+    background: $pix-neutral-0;
     padding: 1rem;
     flex-grow: 1;
 
@@ -35,7 +34,6 @@
       padding-bottom: 0.5em;
       flex-wrap: wrap;
       border-bottom: 1px solid $pix-neutral-20;
-
 
       &:last-of-type {
         border-bottom: none;
@@ -89,7 +87,7 @@
 
     &__score {
       font-size: 1.125rem;
-      color: $grey-90;
+      color: $pix-neutral-90;
     }
   }
 
@@ -98,7 +96,6 @@
   }
 
   &__pix-edu {
-
     &__title {
       margin-bottom: 16px;
       font-size: 1.125rem;
@@ -149,7 +146,6 @@
   }
 
   &__complementary-certification {
-
     &__title {
       margin-bottom: 24px;
     }
@@ -160,7 +156,6 @@
   }
 
   .candidate-informations {
-
     &__actions {
       display: flex;
       margin-top: 8px;

--- a/admin/app/styles/authenticated/organizations/all-tags.scss
+++ b/admin/app/styles/authenticated/organizations/all-tags.scss
@@ -3,10 +3,9 @@
   padding: 0;
   display: flex;
   flex-wrap: wrap;
-  gap: $spacing-xs;
+  gap: $pix-spacing-xs;
 
   &__tag {
-
     button {
       border: none;
       padding: 0;

--- a/admin/app/styles/authenticated/organizations/get.scss
+++ b/admin/app/styles/authenticated/organizations/get.scss
@@ -1,6 +1,5 @@
 /* stylelint-disable selector-class-pattern */
 #organizations-get-page {
-
   .organization__information {
     display: flex;
 
@@ -52,7 +51,7 @@
         padding: 0;
         display: flex;
         flex-wrap: wrap;
-        margin-bottom: $spacing-m;
+        margin-bottom: $pix-spacing-m;
 
         &__tag {
           margin-right: 6px;

--- a/admin/app/styles/authenticated/tools.scss
+++ b/admin/app/styles/authenticated/tools.scss
@@ -21,7 +21,7 @@
 
 .tools {
   &__warning {
-    margin-bottom: $spacing-s;
+    margin-bottom: $pix-spacing-s;
   }
 
   .pix-button {

--- a/admin/app/styles/components/card.scss
+++ b/admin/app/styles/components/card.scss
@@ -8,7 +8,7 @@
     color: $pix-neutral-0;
     font-family: $font-open-sans;
     font-size: 1.5rem;
-    font-weight: $font-semi-bold;
+    font-weight: $font-medium;
     line-height: 28px;
     padding: 11px 32px;
     background: $pix-neutral-70;

--- a/admin/app/styles/components/certification-issue-report.scss
+++ b/admin/app/styles/components/certification-issue-report.scss
@@ -28,7 +28,6 @@
 
     &__resolution-message {
       font-family: $font-roboto;
-      font-weight: $font-light;
       color: $pix-neutral-50;
     }
   }

--- a/admin/app/styles/components/common/tubes-selection.scss
+++ b/admin/app/styles/components/common/tubes-selection.scss
@@ -1,9 +1,9 @@
 .tubes-selection {
   color: $pix-neutral-70;
-  margin-bottom: $spacing-m;
+  margin-bottom: $pix-spacing-m;
 
   &__card {
-    margin-bottom: $spacing-m;
+    margin-bottom: $pix-spacing-m;
   }
 
   &__inline-layout {
@@ -27,12 +27,12 @@
 
   &__multi-select {
     max-width: 300px;
-    margin-left: $spacing-s;
+    margin-left: $pix-spacing-s;
   }
 
   &__multi-select-label {
     font-weight: 500;
-    padding-right: $spacing-s;
+    padding-right: $pix-spacing-s;
   }
 }
 

--- a/admin/app/styles/components/organization-information-section.scss
+++ b/admin/app/styles/components/organization-information-section.scss
@@ -1,5 +1,4 @@
 .organization-information-section {
-
   &__content {
     display: flex;
     flex-direction: row;
@@ -15,9 +14,8 @@
   }
 
   &__details {
-
     &__list {
-      margin-bottom: $spacing-m;
+      margin-bottom: $pix-spacing-m;
     }
 
     .form-actions {

--- a/admin/app/styles/components/organizations/all-tags.scss
+++ b/admin/app/styles/components/organizations/all-tags.scss
@@ -3,11 +3,10 @@
   padding: 0;
   display: flex;
   flex-wrap: wrap;
-  gap: $spacing-xs;
-  margin-top: $spacing-xs;
+  gap: $pix-spacing-xs;
+  margin-top: $pix-spacing-xs;
 
   &__tag {
-
     button {
       border: none;
       padding: 0;
@@ -19,7 +18,7 @@
 
 .organization-tags-lists-separator {
   border: 1px solid $pix-neutral-20;
-  margin: $spacing-m 0;
+  margin: $pix-spacing-m 0;
 }
 
 .organization-recently-used-tags-list__search-input-container {

--- a/admin/app/styles/components/organizations/places-lot-creation-form.scss
+++ b/admin/app/styles/components/organizations/places-lot-creation-form.scss
@@ -4,7 +4,7 @@
 }
 
 .action-buttons__cancel {
-  margin-right: $spacing-xs;
+  margin-right: $pix-spacing-xs;
 
   &:hover {
     text-decoration: none;

--- a/admin/app/styles/components/organizations/places.scss
+++ b/admin/app/styles/components/organizations/places.scss
@@ -1,13 +1,12 @@
 .places {
-
   &__resume {
     border-bottom: 3px solid $pix-neutral-20;
-    padding-bottom: $spacing-s;
-    margin-bottom: $spacing-s;
+    padding-bottom: $pix-spacing-s;
+    margin-bottom: $pix-spacing-s;
   }
 
   &__button {
-    margin-top: $spacing-s;
+    margin-top: $pix-spacing-s;
     display: inline-flex;
 
     &:hover {
@@ -29,6 +28,6 @@
   }
 
   &__button-icon {
-    margin: 0 $spacing-xxs;
+    margin: 0 $pix-spacing-xxs;
   }
 }

--- a/admin/app/styles/components/target-profiles/badges.scss
+++ b/admin/app/styles/components/target-profiles/badges.scss
@@ -29,7 +29,6 @@
 }
 
 .badges-table-actions {
-
   &__button {
     width: 100%;
 
@@ -42,7 +41,7 @@
 }
 
 .badges-table-actions-delete {
-  margin-top: $spacing-xs;
+  margin-top: $pix-spacing-xs;
 }
 
 .key-table {

--- a/admin/app/styles/components/target-profiles/create-target-profile-form.scss
+++ b/admin/app/styles/components/target-profiles/create-target-profile-form.scss
@@ -3,7 +3,7 @@
   counter-reset: title;
 
   &__card {
-    margin-bottom: $spacing-m;
+    margin-bottom: $pix-spacing-m;
   }
 
   .card__title {
@@ -19,9 +19,9 @@
   }
 
   &__checkbox {
-    margin: 0 $spacing-xs;
-    width: $spacing-s;
-    height: $spacing-s;
+    margin: 0 $pix-spacing-xs;
+    width: $pix-spacing-s;
+    height: $pix-spacing-s;
   }
 
   &__is-public-checkbox {
@@ -71,12 +71,12 @@
   }
 
   .input-url {
-    margin-bottom: $spacing-s;
+    margin-bottom: $pix-spacing-s;
   }
 
   &__multi-select {
     max-width: 300px;
-    margin-left: $spacing-s;
+    margin-left: $pix-spacing-s;
   }
 
   .textarea-label {

--- a/admin/app/styles/components/target-profiles/stages.scss
+++ b/admin/app/styles/components/target-profiles/stages.scss
@@ -1,5 +1,4 @@
 .stages-table {
-
   &__type {
     width: 130px;
   }
@@ -39,5 +38,5 @@
 }
 
 .stages-table-actions-delete {
-  margin-top: $spacing-xs;
+  margin-top: $pix-spacing-xs;
 }

--- a/admin/app/styles/components/trainings/create-or-update-training-form.scss
+++ b/admin/app/styles/components/trainings/create-or-update-training-form.scss
@@ -19,12 +19,11 @@
   }
 
   &__card {
-    margin-bottom: $spacing-m;
+    margin-bottom: $pix-spacing-m;
   }
 }
 
 .create-training-form-card {
-
   &__duration {
     margin-top: 1rem;
     display: flex;

--- a/admin/app/styles/components/trainings/training-details-card.scss
+++ b/admin/app/styles/components/trainings/training-details-card.scss
@@ -4,7 +4,7 @@
   gap: 2rem;
 
   &__title {
-    @include h3;
+    @extend %pix-title-xs;
   }
 
   &__details {

--- a/admin/app/styles/components/trainings/training-target-profiles-tab.scss
+++ b/admin/app/styles/components/trainings/training-target-profiles-tab.scss
@@ -27,6 +27,6 @@
   }
 
   .pix-button {
-    margin-left: $spacing-xs;
+    margin-left: $pix-spacing-xs;
   }
 }

--- a/admin/app/styles/components/trainings/training-triggers-tab.scss
+++ b/admin/app/styles/components/trainings/training-triggers-tab.scss
@@ -1,6 +1,6 @@
 .training-trigger {
   &__description {
-    margin-bottom: $spacing-m;
+    margin-bottom: $pix-spacing-m;
   }
 }
 
@@ -11,14 +11,14 @@
     font-weight: 500;
     display: flex;
     align-items: baseline;
-    margin-bottom: $spacing-xs;
+    margin-bottom: $pix-spacing-xs;
   }
 
   &__threshold {
     color: $pix-neutral-90;
     font-size: 1rem;
     line-height: 1.5;
-    margin-left: $spacing-s;
+    margin-left: $pix-spacing-s;
   }
 
   &__tubes-count {
@@ -31,10 +31,10 @@
 
   &__toggler {
     display: inline-flex;
-    margin-top: $spacing-s;
+    margin-top: $pix-spacing-s;
 
     svg {
-      margin-right: $spacing-xs;
+      margin-right: $pix-spacing-xs;
     }
   }
 }
@@ -44,12 +44,12 @@
 
   &__actions {
     display: flex;
-    gap: $spacing-m;
-    margin: $spacing-m 0;
+    gap: $pix-spacing-m;
+    margin: $pix-spacing-m 0;
   }
 
   &__threshold {
-    margin-bottom: $spacing-m;
+    margin-bottom: $pix-spacing-m;
   }
 
   .card__title {
@@ -63,7 +63,7 @@
 
 .edit-training-trigger-threshold {
   &__description {
-    margin-bottom: $spacing-s;
+    margin-bottom: $pix-spacing-s;
   }
 
   &__input {

--- a/admin/app/styles/components/trainings/training-triggers-tab.scss
+++ b/admin/app/styles/components/trainings/training-triggers-tab.scss
@@ -6,7 +6,7 @@
 
 .trigger-card {
   &__title {
-    @include subheading;
+    @extend %pix-body-l;
 
     font-weight: 500;
     display: flex;
@@ -26,12 +26,13 @@
   }
 
   &__description {
-    @include text-small;
+    @extend %pix-body-m;
+
+    margin-bottom: $pix-spacing-s;
   }
 
   &__toggler {
     display: inline-flex;
-    margin-top: $pix-spacing-s;
 
     svg {
       margin-right: $pix-spacing-xs;

--- a/admin/app/styles/display/footer-modal.scss
+++ b/admin/app/styles/display/footer-modal.scss
@@ -1,10 +1,9 @@
 .pix-modal {
-
   &__footer {
     display: flex;
     flex-direction: column;
-    gap: $spacing-s;
-    margin-bottom: $spacing-s;
+    gap: $pix-spacing-s;
+    margin-bottom: $pix-spacing-s;
 
     @include device-is('tablet') {
       flex-flow: row wrap;

--- a/admin/app/styles/globals/nav.scss
+++ b/admin/app/styles/globals/nav.scss
@@ -24,7 +24,7 @@
     align-items: center;
     display: flex;
     justify-content: center;
-    padding: 0 $spacing-xs;
+    padding: 0 $pix-spacing-xs;
     cursor: pointer;
     color: $pix-neutral-45;
     font-weight: 500;
@@ -44,7 +44,6 @@
   }
 
   .navbar-list-item {
-
     &__link {
       color: $pix-neutral-45;
       font-weight: 500;
@@ -65,7 +64,7 @@
   }
 }
 
-.navbar+section {
+.navbar + section {
   @include whiteBlock;
 
   padding: 20px;

--- a/admin/app/styles/globals/page.scss
+++ b/admin/app/styles/globals/page.scss
@@ -1,6 +1,5 @@
 /* stylelint-disable selector-class-pattern */
 .page {
-
   .page-header {
     background: $pix-neutral-0;
     display: flex;
@@ -64,7 +63,7 @@
         font-weight: 600;
 
         &--sub {
-          margin-bottom: $spacing-s;
+          margin-bottom: $pix-spacing-s;
         }
       }
 

--- a/admin/app/styles/globals/table-admin.scss
+++ b/admin/app/styles/globals/table-admin.scss
@@ -1,6 +1,6 @@
 /* stylelint-disable selector-class-pattern */
 .table-admin {
-  margin-bottom: $spacing-s;
+  margin-bottom: $pix-spacing-s;
 
   a:not(.pix-button) {
     color: $pix-primary;

--- a/admin/app/styles/login.scss
+++ b/admin/app/styles/login.scss
@@ -20,7 +20,7 @@
   text-align: center;
 
   &__title {
-    margin-bottom: $spacing-s;
+    margin-bottom: $pix-spacing-s;
   }
 }
 

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.0",
-        "@1024pix/pix-ui": "^28.1.1",
+        "@1024pix/pix-ui": "^30.0.0",
         "@1024pix/stylelint-config": "^2.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@ember/optional-features": "^2.0.0",
@@ -1201,9 +1201,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-28.1.1.tgz",
-      "integrity": "sha512-z3d/wncer6b7TIvet/Hx39vfSSAJZ+zKhb/+JmtVeQoTLb0KCpee6NabDKBFUcmaMb+FVMWqsYFKxaFTHECJGA==",
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-30.0.0.tgz",
+      "integrity": "sha512-mVV15CQmXgdi+E+SCzoldX/ucSys4wcW2gPP5+aox1uQ6I69SMpKB7cFWN8zQEIqwJw6hgTn66jhNqzQpcIBjw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1213,8 +1213,7 @@
         "ember-cli-babel": "^7.26.8",
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-sass": "^11.0.1",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-click-outside": "^4.0.0",
+        "ember-click-outside": "^6.0.1",
         "ember-truth-helpers": "^3.1.1",
         "lodash.debounce": "^4.0.8"
       },
@@ -17965,302 +17964,13 @@
       "dev": true
     },
     "node_modules/ember-click-outside": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-4.0.0.tgz",
-      "integrity": "sha512-3SstFhDWu3K5PQzo0FZwk66Ehe1l6QFU/R+WjAt8yOXw2sHzJHOdx2N+fNWJHZsJ97BSqdL7L0qotJEMX46u6Q==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-6.0.1.tgz",
+      "integrity": "sha512-1aI0vaggymp8JR2gARy7kgDnJ0Bk+ZDcjOzT+Cgtr2cRCBYFuJeU0OMKJW8c7pRm2LwIDZgzdTRK+AaKQbt9mw==",
       "dev": true,
       "dependencies": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-htmlbars": "^5.7.1",
-        "ember-modifier": "^2.1.0 || ^3.0.0"
-      },
-      "engines": {
-        "node": "12.* || 14.* || >= 16"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/async-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "^2.5.1",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "rsvp": "^4.8.5",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/broccoli-persistent-filter": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
-      "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-      "dev": true,
-      "dependencies": {
-        "async-disk-cache": "^2.0.0",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^4.0.3",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^3.0.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^2.0.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/broccoli-plugin": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-node-api": "^1.7.0",
-        "broccoli-output-wrapper": "^3.2.5",
-        "fs-merger": "^3.2.1",
-        "promise-map-series": "^0.3.0",
-        "quick-temp": "^0.1.8",
-        "rimraf": "^3.0.2",
-        "symlink-or-copy": "^1.3.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/broccoli-plugin/node_modules/promise-map-series": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-      "dev": true,
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/editions": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-      "dev": true,
-      "dependencies": {
-        "errlop": "^2.0.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/editions/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/ember-cli-htmlbars": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-      "dev": true,
-      "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^3.1.2",
-        "broccoli-plugin": "^4.0.3",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-version-checker": "^5.1.2",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
-        "semver": "^7.3.4",
-        "silent-error": "^1.1.1",
-        "strip-bom": "^4.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/ember-cli-version-checker": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
-      "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
-      "dev": true,
-      "dependencies": {
-        "resolve-package-path": "^3.1.0",
-        "semver": "^7.3.4",
-        "silent-error": "^1.1.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/fs-tree-diff": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-      "dev": true,
-      "dependencies": {
-        "@types/symlink-or-copy": "^1.2.0",
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/istextorbinary": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-      "dev": true,
-      "dependencies": {
-        "binaryextensions": "^2.1.2",
-        "editions": "^2.2.0",
-        "textextensions": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/matcher-collection": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-      "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "minimatch": "^3.0.2"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/ember-click-outside/node_modules/resolve-package-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
-      "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
-      "dev": true,
-      "dependencies": {
-        "path-root": "^0.1.1",
-        "resolve": "^1.17.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/sync-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.6",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
+        "@embroider/addon-shim": "^1.0.0",
+        "ember-modifier": "^3.2.7 || ^4.0.0"
       }
     },
     "node_modules/ember-compatibility-helpers": {
@@ -22491,20 +22201,22 @@
       }
     },
     "node_modules/ember-modifier": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-2.1.1.tgz",
-      "integrity": "sha512-g9mcpFWgw5lgNU40YNf0USNWqoGTJ+EqjDQKjm7556gaRNDeGnLylFKqx9O3opwLHEt6ZODnRDy9U0S5YEMREg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-4.1.0.tgz",
+      "integrity": "sha512-YFCNpEYj6jdyy3EjslRb2ehNiDvaOrXTilR9+ngq+iUqSHYto2zKV0rleiA1XJQ27ELM1q8RihT29U6Lq5EyqQ==",
       "dev": true,
       "dependencies": {
-        "ember-cli-babel": "^7.22.1",
+        "@embroider/addon-shim": "^1.8.4",
         "ember-cli-normalize-entity-name": "^1.0.0",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^3.1.3",
-        "ember-destroyable-polyfill": "^2.0.2",
-        "ember-modifier-manager-polyfill": "^1.2.0"
+        "ember-cli-string-utils": "^1.1.0"
       },
-      "engines": {
-        "node": "10.* || >= 12"
+      "peerDependencies": {
+        "ember-source": "*"
+      },
+      "peerDependenciesMeta": {
+        "ember-source": {
+          "optional": true
+        }
       }
     },
     "node_modules/ember-modifier-manager-polyfill": {
@@ -22532,162 +22244,6 @@
       },
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/ember-modifier/node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.8.7.tgz",
-      "integrity": "sha512-7O0UsPQVNKqpHeHLpfvOG4uXmlw+MOxYvUv6Otc9uH5SYMIxvF6eBdjkWvC3f9G+VXe0RsNExyAQBeTRug/wqQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "@babel/plugin-syntax-typescript": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/ember-modifier/node_modules/debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ember-modifier/node_modules/ember-cli-typescript": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz",
-      "integrity": "sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
-        "@babel/plugin-proposal-optional-chaining": "^7.6.0",
-        "@babel/plugin-transform-typescript": "~7.8.0",
-        "ansi-to-html": "^0.6.6",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "ember-cli-babel-plugin-helpers": "^1.0.0",
-        "execa": "^3.0.0",
-        "fs-extra": "^8.0.0",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^6.3.0",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.0.0"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-modifier/node_modules/execa": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-      "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "p-finally": "^2.0.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": "^8.12.0 || >=9.7.0"
-      }
-    },
-    "node_modules/ember-modifier/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/ember-modifier/node_modules/matcher-collection": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-      "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "minimatch": "^3.0.2"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-modifier/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/ember-modifier/node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ember-modifier/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-modifier/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/ember-modifier/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
       }
     },
     "node_modules/ember-on-modifier": {
@@ -41020,9 +40576,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-28.1.1.tgz",
-      "integrity": "sha512-z3d/wncer6b7TIvet/Hx39vfSSAJZ+zKhb/+JmtVeQoTLb0KCpee6NabDKBFUcmaMb+FVMWqsYFKxaFTHECJGA==",
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-30.0.0.tgz",
+      "integrity": "sha512-mVV15CQmXgdi+E+SCzoldX/ucSys4wcW2gPP5+aox1uQ6I69SMpKB7cFWN8zQEIqwJw6hgTn66jhNqzQpcIBjw==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",
@@ -41031,8 +40587,7 @@
         "ember-cli-babel": "^7.26.8",
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-sass": "^11.0.1",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-click-outside": "^4.0.0",
+        "ember-click-outside": "^6.0.1",
         "ember-truth-helpers": "^3.1.1",
         "lodash.debounce": "^4.0.8"
       }
@@ -54574,234 +54129,13 @@
       }
     },
     "ember-click-outside": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-4.0.0.tgz",
-      "integrity": "sha512-3SstFhDWu3K5PQzo0FZwk66Ehe1l6QFU/R+WjAt8yOXw2sHzJHOdx2N+fNWJHZsJ97BSqdL7L0qotJEMX46u6Q==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-6.0.1.tgz",
+      "integrity": "sha512-1aI0vaggymp8JR2gARy7kgDnJ0Bk+ZDcjOzT+Cgtr2cRCBYFuJeU0OMKJW8c7pRm2LwIDZgzdTRK+AaKQbt9mw==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-htmlbars": "^5.7.1",
-        "ember-modifier": "^2.1.0 || ^3.0.0"
-      },
-      "dependencies": {
-        "async-disk-cache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-          "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "heimdalljs": "^0.2.3",
-            "istextorbinary": "^2.5.1",
-            "mkdirp": "^0.5.0",
-            "rimraf": "^3.0.0",
-            "rsvp": "^4.8.5",
-            "username-sync": "^1.0.2"
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
-          "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-          "dev": true,
-          "requires": {
-            "async-disk-cache": "^2.0.0",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^4.0.3",
-            "fs-tree-diff": "^2.0.0",
-            "hash-for-dep": "^1.5.0",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^3.0.0",
-            "symlink-or-copy": "^1.0.1",
-            "sync-disk-cache": "^2.0.0"
-          }
-        },
-        "broccoli-plugin": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-          "dev": true,
-          "requires": {
-            "broccoli-node-api": "^1.7.0",
-            "broccoli-output-wrapper": "^3.2.5",
-            "fs-merger": "^3.2.1",
-            "promise-map-series": "^0.3.0",
-            "quick-temp": "^0.1.8",
-            "rimraf": "^3.0.2",
-            "symlink-or-copy": "^1.3.1"
-          },
-          "dependencies": {
-            "promise-map-series": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-              "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-              "dev": true
-            }
-          }
-        },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "editions": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-          "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-          "dev": true,
-          "requires": {
-            "errlop": "^2.0.0",
-            "semver": "^6.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            }
-          }
-        },
-        "ember-cli-htmlbars": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-          "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-          "dev": true,
-          "requires": {
-            "@ember/edition-utils": "^1.2.0",
-            "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-            "broccoli-debug": "^0.6.5",
-            "broccoli-persistent-filter": "^3.1.2",
-            "broccoli-plugin": "^4.0.3",
-            "common-tags": "^1.8.0",
-            "ember-cli-babel-plugin-helpers": "^1.1.1",
-            "ember-cli-version-checker": "^5.1.2",
-            "fs-tree-diff": "^2.0.1",
-            "hash-for-dep": "^1.5.1",
-            "heimdalljs-logger": "^0.1.10",
-            "json-stable-stringify": "^1.0.1",
-            "semver": "^7.3.4",
-            "silent-error": "^1.1.1",
-            "strip-bom": "^4.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
-          "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
-          "dev": true,
-          "requires": {
-            "resolve-package-path": "^3.1.0",
-            "semver": "^7.3.4",
-            "silent-error": "^1.1.1"
-          }
-        },
-        "fs-tree-diff": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-          "dev": true,
-          "requires": {
-            "@types/symlink-or-copy": "^1.2.0",
-            "heimdalljs-logger": "^0.1.7",
-            "object-assign": "^4.1.0",
-            "path-posix": "^1.0.0",
-            "symlink-or-copy": "^1.1.8"
-          }
-        },
-        "istextorbinary": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-          "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-          "dev": true,
-          "requires": {
-            "binaryextensions": "^2.1.2",
-            "editions": "^2.2.0",
-            "textextensions": "^2.5.0"
-          }
-        },
-        "matcher-collection": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "minimatch": "^3.0.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "resolve-package-path": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
-          "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
-          "dev": true,
-          "requires": {
-            "path-root": "^0.1.1",
-            "resolve": "^1.17.0"
-          }
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "sync-disk-cache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
-          "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "heimdalljs": "^0.2.6",
-            "mkdirp": "^0.5.0",
-            "rimraf": "^3.0.0",
-            "username-sync": "^1.0.2"
-          }
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
-          }
-        }
+        "@embroider/addon-shim": "^1.0.0",
+        "ember-modifier": "^3.2.7 || ^4.0.0"
       }
     },
     "ember-compatibility-helpers": {
@@ -58174,139 +57508,14 @@
       }
     },
     "ember-modifier": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-2.1.1.tgz",
-      "integrity": "sha512-g9mcpFWgw5lgNU40YNf0USNWqoGTJ+EqjDQKjm7556gaRNDeGnLylFKqx9O3opwLHEt6ZODnRDy9U0S5YEMREg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-4.1.0.tgz",
+      "integrity": "sha512-YFCNpEYj6jdyy3EjslRb2ehNiDvaOrXTilR9+ngq+iUqSHYto2zKV0rleiA1XJQ27ELM1q8RihT29U6Lq5EyqQ==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^7.22.1",
+        "@embroider/addon-shim": "^1.8.4",
         "ember-cli-normalize-entity-name": "^1.0.0",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^3.1.3",
-        "ember-destroyable-polyfill": "^2.0.2",
-        "ember-modifier-manager-polyfill": "^1.2.0"
-      },
-      "dependencies": {
-        "@babel/plugin-transform-typescript": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.8.7.tgz",
-          "integrity": "sha512-7O0UsPQVNKqpHeHLpfvOG4uXmlw+MOxYvUv6Otc9uH5SYMIxvF6eBdjkWvC3f9G+VXe0RsNExyAQBeTRug/wqQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-create-class-features-plugin": "^7.8.3",
-            "@babel/helper-plugin-utils": "^7.8.3",
-            "@babel/plugin-syntax-typescript": "^7.8.3"
-          }
-        },
-        "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ember-cli-typescript": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz",
-          "integrity": "sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==",
-          "dev": true,
-          "requires": {
-            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
-            "@babel/plugin-proposal-optional-chaining": "^7.6.0",
-            "@babel/plugin-transform-typescript": "~7.8.0",
-            "ansi-to-html": "^0.6.6",
-            "broccoli-stew": "^3.0.0",
-            "debug": "^4.0.0",
-            "ember-cli-babel-plugin-helpers": "^1.0.0",
-            "execa": "^3.0.0",
-            "fs-extra": "^8.0.0",
-            "resolve": "^1.5.0",
-            "rsvp": "^4.8.1",
-            "semver": "^6.3.0",
-            "stagehand": "^1.0.0",
-            "walk-sync": "^2.0.0"
-          }
-        },
-        "execa": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-          "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "p-finally": "^2.0.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "matcher-collection": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "minimatch": "^3.0.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.0.0"
-          }
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
-          }
-        }
+        "ember-cli-string-utils": "^1.1.0"
       }
     },
     "ember-modifier-manager-polyfill": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.0",
-    "@1024pix/pix-ui": "^28.1.1",
+    "@1024pix/pix-ui": "^30.0.0",
     "@1024pix/stylelint-config": "^2.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
## :unicorn: Problème
Pix Admin n'a pas la dernière version de Pix UI.

## :robot: Proposition
Monter de version de Pix UI en v30.0.0.

L'idée est de pouvoir bénéficier des nouveaux Design Tokens en particulier concernant les typographies.

Voilà comment j'ai procédé :

- Reprise des variables d'espacement (pas d'impact, juste des changements de nommage)
- Reprise des variables de couleurs
- Reprise des variables, classes et mixins de typographies

C'est la suite du travail fait dans #5866, plus de détails y sont listés.

## :rainbow: Remarques
Pas de PixStars sur Admin donc la montée de v29.1.1 en v30.0.0 est gratuite.

## :100: Pour tester
Vérifier que les tests passent toujours et que Pix Admin est tout pimpant.
