### PR TITLE
[FEATURE] Montée de version pix-ui@v30.0.0 sur Certif (PIX-7640)

### DIFF
--- a/certif/app/components/dropdown/content.hbs
+++ b/certif/app/components/dropdown/content.hbs
@@ -1,7 +1,5 @@
 {{#if @display}}
-  <ClickOutside @onClickOutside={{@close}}>
-    <ul class="dropdown__content" ...attributes>
-      {{yield}}
-    </ul>
-  </ClickOutside>
+  <ul {{on-click-outside @close}} {{on-key "Escape" @close}} class="dropdown__content" ...attributes>
+    {{yield}}
+  </ul>
 {{/if}}

--- a/certif/app/styles/components/auth/toggable-login-form.scss
+++ b/certif/app/styles/components/auth/toggable-login-form.scss
@@ -2,12 +2,12 @@
   max-width: 450px;
   display: flex;
   flex-direction: column;
-  gap: $spacing-m;
+  gap: $pix-spacing-m;
   font-size: 0.875rem;
 
   &__information {
     text-align: center;
-    margin-bottom: $spacing-s;
+    margin-bottom: $pix-spacing-s;
     color: $pix-neutral-90;
     font-family: $font-roboto;
     letter-spacing: 0.0094rem;

--- a/certif/app/styles/components/login-form.scss
+++ b/certif/app/styles/components/login-form.scss
@@ -19,7 +19,6 @@
 }
 
 .login-header {
-
   &__title {
     font-family: $font-open-sans;
     font-weight: 400;
@@ -47,16 +46,14 @@
 }
 
 .login-main {
-
   &__form {
     display: flex;
     flex-direction: column;
-    gap: $spacing-s;
+    gap: $pix-spacing-s;
   }
 }
 
 .login-main-form {
-
   &__mandatory-information {
     text-align: center;
     font-family: $font-roboto;

--- a/certif/app/styles/components/register-form.scss
+++ b/certif/app/styles/components/register-form.scss
@@ -19,7 +19,7 @@
   }
 
   .input-container {
-    margin-top: $spacing-m;
+    margin-top: $pix-spacing-m;
   }
 
   .checkbox-container {

--- a/certif/app/styles/pages/authenticated/sessions.scss
+++ b/certif/app/styles/pages/authenticated/sessions.scss
@@ -8,7 +8,7 @@
   }
 
   &__mandatory-information {
-    padding-bottom: $spacing-m;
+    padding-bottom: $pix-spacing-m;
     color: $pix-neutral-70;
   }
 
@@ -19,11 +19,11 @@
   }
 
   &__actions {
-    margin-top: $spacing-l;
+    margin-top: $pix-spacing-l;
     margin-bottom: 0;
     display: flex;
     justify-content: flex-end;
-    gap: $spacing-m;
+    gap: $pix-spacing-m;
     list-style: none;
   }
 

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -140,7 +140,7 @@
 
   &__section--link-buttons {
     display: flex;
-    gap: $spacing-s;
+    gap: $pix-spacing-s;
     margin-top: 24px;
   }
 
@@ -178,7 +178,7 @@
 }
 
 .import-page__resume-section {
-  gap: $spacing-m;
+  gap: $pix-spacing-m;
 }
 
 .import-page-section {

--- a/certif/app/styles/pages/authenticated/sessions/import.scss
+++ b/certif/app/styles/pages/authenticated/sessions/import.scss
@@ -5,7 +5,6 @@
 
   > p {
     color: $pix-neutral-60;
-    font-weight: $font-light;
     margin-bottom: 8px;
   }
 
@@ -18,8 +17,6 @@
     .pix-collapsible__title {
       border-radius: 8px;
       color: $pix-neutral-70;
-      font-size: 14px;
-      font-weight: $font-light;
     }
 
     .pix-collapsible__title[aria-expanded='true'] {

--- a/certif/app/styles/pages/join.scss
+++ b/certif/app/styles/pages/join.scss
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: center;
   width: 100%;
-  background: $pix-certif-gradient;
-  box-shadow: 0 2px 8px 0 rgba($black, 0.1);
+  background: $pix-primary-certif-gradient;
+  box-shadow: 0 2px 8px 0 rgba($pix-neutral-110, 0.1);
   min-height: 100vh;
 }

--- a/certif/app/styles/pages/terms-of-service.scss
+++ b/certif/app/styles/pages/terms-of-service.scss
@@ -16,7 +16,6 @@
   background-color: white;
   border-radius: 10px;
 
-
   &__header {
     display: flex;
     flex-direction: column;
@@ -29,7 +28,7 @@
     &--title {
       margin: 0 10px 30px;
       text-align: center;
-      color: $pix-neutral-80
+      color: $pix-neutral-80;
     }
   }
 
@@ -49,16 +48,18 @@
     overflow-x: hidden;
     font-family: $font-open-sans;
 
-    p, li {
-      margin-bottom: $spacing-s;
+    p,
+    li {
+      margin-bottom: $pix-spacing-s;
     }
 
     ul {
       list-style: inside;
     }
 
-    h2, h3 {
-      margin-bottom: $spacing-m;
+    h2,
+    h3 {
+      margin-bottom: $pix-spacing-m;
     }
   }
 

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.1",
-        "@1024pix/pix-ui": "^28.1.1",
+        "@1024pix/pix-ui": "^30.0.0",
         "@1024pix/stylelint-config": "^2.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.5",
@@ -149,9 +149,9 @@
       "dev": true
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-28.1.1.tgz",
-      "integrity": "sha512-z3d/wncer6b7TIvet/Hx39vfSSAJZ+zKhb/+JmtVeQoTLb0KCpee6NabDKBFUcmaMb+FVMWqsYFKxaFTHECJGA==",
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-30.0.0.tgz",
+      "integrity": "sha512-mVV15CQmXgdi+E+SCzoldX/ucSys4wcW2gPP5+aox1uQ6I69SMpKB7cFWN8zQEIqwJw6hgTn66jhNqzQpcIBjw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -161,8 +161,7 @@
         "ember-cli-babel": "^7.26.8",
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-sass": "^11.0.1",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-click-outside": "^4.0.0",
+        "ember-click-outside": "^6.0.1",
         "ember-truth-helpers": "^3.1.1",
         "lodash.debounce": "^4.0.8"
       },
@@ -16703,201 +16702,13 @@
       "dev": true
     },
     "node_modules/ember-click-outside": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-4.0.0.tgz",
-      "integrity": "sha512-3SstFhDWu3K5PQzo0FZwk66Ehe1l6QFU/R+WjAt8yOXw2sHzJHOdx2N+fNWJHZsJ97BSqdL7L0qotJEMX46u6Q==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-6.0.1.tgz",
+      "integrity": "sha512-1aI0vaggymp8JR2gARy7kgDnJ0Bk+ZDcjOzT+Cgtr2cRCBYFuJeU0OMKJW8c7pRm2LwIDZgzdTRK+AaKQbt9mw==",
       "dev": true,
       "dependencies": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-htmlbars": "^5.7.1",
-        "ember-modifier": "^2.1.0 || ^3.0.0"
-      },
-      "engines": {
-        "node": "12.* || 14.* || >= 16"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/async-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "^2.5.1",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "rsvp": "^4.8.5",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/broccoli-persistent-filter": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
-      "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-      "dev": true,
-      "dependencies": {
-        "async-disk-cache": "^2.0.0",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^4.0.3",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^3.0.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^2.0.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/editions": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-      "dev": true,
-      "dependencies": {
-        "errlop": "^2.0.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/editions/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/ember-cli-htmlbars": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-      "dev": true,
-      "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^3.1.2",
-        "broccoli-plugin": "^4.0.3",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-version-checker": "^5.1.2",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
-        "semver": "^7.3.4",
-        "silent-error": "^1.1.1",
-        "strip-bom": "^4.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/istextorbinary": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-      "dev": true,
-      "dependencies": {
-        "binaryextensions": "^2.1.2",
-        "editions": "^2.2.0",
-        "textextensions": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/ember-click-outside/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-click-outside/node_modules/sync-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.6",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
+        "@embroider/addon-shim": "^1.0.0",
+        "ember-modifier": "^3.2.7 || ^4.0.0"
       }
     },
     "node_modules/ember-compatibility-helpers": {
@@ -35430,9 +35241,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "28.1.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-28.1.1.tgz",
-      "integrity": "sha512-z3d/wncer6b7TIvet/Hx39vfSSAJZ+zKhb/+JmtVeQoTLb0KCpee6NabDKBFUcmaMb+FVMWqsYFKxaFTHECJGA==",
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-30.0.0.tgz",
+      "integrity": "sha512-mVV15CQmXgdi+E+SCzoldX/ucSys4wcW2gPP5+aox1uQ6I69SMpKB7cFWN8zQEIqwJw6hgTn66jhNqzQpcIBjw==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",
@@ -35441,8 +35252,7 @@
         "ember-cli-babel": "^7.26.8",
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-sass": "^11.0.1",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-click-outside": "^4.0.0",
+        "ember-click-outside": "^6.0.1",
         "ember-truth-helpers": "^3.1.1",
         "lodash.debounce": "^4.0.8"
       },
@@ -48947,155 +48757,13 @@
       }
     },
     "ember-click-outside": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-4.0.0.tgz",
-      "integrity": "sha512-3SstFhDWu3K5PQzo0FZwk66Ehe1l6QFU/R+WjAt8yOXw2sHzJHOdx2N+fNWJHZsJ97BSqdL7L0qotJEMX46u6Q==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ember-click-outside/-/ember-click-outside-6.0.1.tgz",
+      "integrity": "sha512-1aI0vaggymp8JR2gARy7kgDnJ0Bk+ZDcjOzT+Cgtr2cRCBYFuJeU0OMKJW8c7pRm2LwIDZgzdTRK+AaKQbt9mw==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-htmlbars": "^5.7.1",
-        "ember-modifier": "^2.1.0 || ^3.0.0"
-      },
-      "dependencies": {
-        "async-disk-cache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-          "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "heimdalljs": "^0.2.3",
-            "istextorbinary": "^2.5.1",
-            "mkdirp": "^0.5.0",
-            "rimraf": "^3.0.0",
-            "rsvp": "^4.8.5",
-            "username-sync": "^1.0.2"
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
-          "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-          "dev": true,
-          "requires": {
-            "async-disk-cache": "^2.0.0",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^4.0.3",
-            "fs-tree-diff": "^2.0.0",
-            "hash-for-dep": "^1.5.0",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^3.0.0",
-            "symlink-or-copy": "^1.0.1",
-            "sync-disk-cache": "^2.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "editions": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-          "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-          "dev": true,
-          "requires": {
-            "errlop": "^2.0.0",
-            "semver": "^6.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            }
-          }
-        },
-        "ember-cli-htmlbars": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-          "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-          "dev": true,
-          "requires": {
-            "@ember/edition-utils": "^1.2.0",
-            "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-            "broccoli-debug": "^0.6.5",
-            "broccoli-persistent-filter": "^3.1.2",
-            "broccoli-plugin": "^4.0.3",
-            "common-tags": "^1.8.0",
-            "ember-cli-babel-plugin-helpers": "^1.1.1",
-            "ember-cli-version-checker": "^5.1.2",
-            "fs-tree-diff": "^2.0.1",
-            "hash-for-dep": "^1.5.1",
-            "heimdalljs-logger": "^0.1.10",
-            "json-stable-stringify": "^1.0.1",
-            "semver": "^7.3.4",
-            "silent-error": "^1.1.1",
-            "strip-bom": "^4.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
-        "istextorbinary": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-          "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-          "dev": true,
-          "requires": {
-            "binaryextensions": "^2.1.2",
-            "editions": "^2.2.0",
-            "textextensions": "^2.5.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.6"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "rsvp": {
-          "version": "4.8.5",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-          "dev": true
-        },
-        "sync-disk-cache": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
-          "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "heimdalljs": "^0.2.6",
-            "mkdirp": "^0.5.0",
-            "rimraf": "^3.0.0",
-            "username-sync": "^1.0.2"
-          }
-        }
+        "@embroider/addon-shim": "^1.0.0",
+        "ember-modifier": "^3.2.7 || ^4.0.0"
       }
     },
     "ember-compatibility-helpers": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.1",
-    "@1024pix/pix-ui": "^28.1.1",
+    "@1024pix/pix-ui": "^30.0.0",
     "@1024pix/stylelint-config": "^2.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.5",


### PR DESCRIPTION
## :unicorn: Problème
Pix Certif n'a pas la dernière version de Pix UI.

## :robot: Proposition
Monter de version de Pix UI en v30.0.0.

L'idée est de pouvoir bénéficier des nouveaux Design Tokens en particulier concernant les typographies.

Voilà comment j'ai procédé :

- Reprise des variables d'espacement (pas d'impact, juste des changements de nommage)
- Reprise des variables de couleurs
- Reprise des variables, classes et mixins de typographies

C'est la suite du travail fait dans https://github.com/1024pix/pix/pull/5866, plus de détails y sont listés.

## :rainbow: Remarques
La montée de version de `ember-click-outside` (embarquée dans une version de Pix UI) cassait la dropdown pour se déconnecter, j'ai corrigé le soucis et en ait profité pour que la touche "échap" ferme aussi ce menu.

Théoriquement, il n'y ait pas sensé avoir de CSS custom sur le `PixCollapsible` de la page d'import de session(s), j'ai demandé à Quentin de mettre à jour la maquette.

## :100: Pour tester
Vérifier que les tests passent toujours et que Pix Certif est tout pimpant.
