### PR TITLE
[TECH] Bump pix-ui version to 30.0.0 (PIX-7657).

### DIFF
--- a/mon-pix/app/components/campaigns/assessment/skill-review-competence-stages-result.hbs
+++ b/mon-pix/app/components/campaigns/assessment/skill-review-competence-stages-result.hbs
@@ -10,6 +10,7 @@
               {{t "pages.skill-review.stage.masteryPercentage" rate=competence.masteryRate}}
             </p>
             <PixStars
+              class="skill-review-competence-stages-result__reached-stage-stars"
               @count={{competence.reachedStage}}
               @total={{this.total}}
               @alt={{t "pages.skill-review.stage.starsAcquired" acquired=competence.reachedStage total=this.total}}

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -317,6 +317,10 @@
 
     margin-right: $pix-spacing-s;
   }
+
+  &__reached-stage-stars {
+    height: 1.5rem;
+  }
 }
 
 .skill-review-table-header {

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.0",
-        "@1024pix/pix-ui": "^29.1.1",
+        "@1024pix/pix-ui": "^30.0.0",
         "@1024pix/stylelint-config": "^2.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
@@ -1152,9 +1152,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "29.1.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-29.1.1.tgz",
-      "integrity": "sha512-tvmlFSiH/1bn+1FghOeeveYWJn4ox3hJJ+sliFD4u8+9NBoFOMcdtHOEHb7E4OfTUBi8uU4IGTrPmU2IQB2eUg==",
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-30.0.0.tgz",
+      "integrity": "sha512-mVV15CQmXgdi+E+SCzoldX/ucSys4wcW2gPP5+aox1uQ6I69SMpKB7cFWN8zQEIqwJw6hgTn66jhNqzQpcIBjw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -41355,9 +41355,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "29.1.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-29.1.1.tgz",
-      "integrity": "sha512-tvmlFSiH/1bn+1FghOeeveYWJn4ox3hJJ+sliFD4u8+9NBoFOMcdtHOEHb7E4OfTUBi8uU4IGTrPmU2IQB2eUg==",
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-30.0.0.tgz",
+      "integrity": "sha512-mVV15CQmXgdi+E+SCzoldX/ucSys4wcW2gPP5+aox1uQ6I69SMpKB7cFWN8zQEIqwJw6hgTn66jhNqzQpcIBjw==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.0",
-    "@1024pix/pix-ui": "^29.1.1",
+    "@1024pix/pix-ui": "^30.0.0",
     "@1024pix/stylelint-config": "^2.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",


### PR DESCRIPTION
## :unicorn: Problème

- Pix App n'utilise pas la toute dernière version de pix-ui
- La taille des étoiles du détail de compétences de l'écran de fin de parcours n'est toujours pas en accord avec le design

## :robot: Proposition

- Monter la version de pix-ui (v30.0.0)
- Modifier la hauteur des étoiles (36 -> 24px)

## :100: Pour tester

- [Aller sur la RA](https://app-pr5940.review.pix.fr/)
- Se connecter avec l'utilisateur `jaune.attend`
- Aller dans l'[écran "Mes parcours"](https://app-pr5940.review.pix.fr/mes-parcours) et vérifier les étoiles
- Passer un parcours `PROCOMP51`
- Vérifier les étoiles dans l'[écran de fin de parcours](https://app-pr5940.review.pix.fr/campagnes/PROCOMP51/evaluation/resultats)
