### PR TITLE
[BUGFIX] réparer la  width de la sidebar et du main-content (PIX-7678)

### DIFF
--- a/orga/app/styles/components/layout/sidebar.scss
+++ b/orga/app/styles/components/layout/sidebar.scss
@@ -4,7 +4,6 @@
   align-self: flex-start;
   height: 100vh;
   width: $app-sidebar-width;
-  min-width: 100px;
   background-color: $dark-blue-orga;
 
   &__logo {

--- a/orga/app/styles/pages/authenticated.scss
+++ b/orga/app/styles/pages/authenticated.scss
@@ -5,7 +5,8 @@
 }
 
 .main-content {
-  width: 100%;
+  // Minus 280px because it corresponds to the sidebar's width
+  width: calc(100% - 280px);
   background-color: $pix-neutral-10;
   display: flex;
   flex-direction: column;
@@ -24,5 +25,9 @@
 @include device-is('mobile') {
   .app {
     flex-direction: column;
+  }
+
+  .main-content {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
![image](https://user-images.githubusercontent.com/26883766/230427236-45aa250e-c1f1-4dda-a645-676aec0f3b0d.png)

## :robot: Proposition

- retirer la min-width de la sidebar
- calculer la taille du main-content en prenant en compte la présence de sidebar pour les versions desktop et tablette

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se rendre dans une page de campagne avec un long titre 
