### PR TITLE
[FEATURE] Modification du message par défaut d'un profil cible au palier 0 (PIX-7616)

### DIFF
--- a/admin/app/components/target-profiles/stages.js
+++ b/admin/app/components/target-profiles/stages.js
@@ -80,7 +80,7 @@ export default class Stages extends Component {
       threshold: !this.isTypeLevel && this.setFirstStage ? '0' : undefined,
       title: isFirstStage ? 'Parcours terminé !' : null,
       message: isFirstStage
-        ? 'Vous n’êtes visiblement pas tombé sur vos sujets préférés...Ou peut-être avez-vous besoin d’aide ? Dans tous les cas, rien n’est perdu d’avance ! Avec de l’accompagnement et un peu d’entraînement vous développerez à coup sûr vos compétences !'
+        ? 'Vous n’êtes visiblement pas tombé sur vos sujets préférés...Ou peut-être avez-vous besoin d’aide ? Dans tous les cas, rien n’est perdu d’avance ! Avec de l’accompagnement et un peu d’entraînement vous développerez à coup sûr vos compétences numériques !'
         : null,
     });
   }


### PR DESCRIPTION
## :unicorn: Problème
Message au palier zéro qui ne convenait pas.

## :robot: Proposition
Ajout du mot "numériques" au message qui ne convenait pas.

## :rainbow: Remarques
RAS

## :100: Pour tester
Créer un nouveau profil cible
se rendre sur la page de création de palier
et constater que le message par défaut du palier 0 a changé.
