### PR TITLE
[FEATURE] Pour un user qui se connecte à Pix Orga via invitation, si le cookie de la locale est dispo, alors enregistrer cette locale (PIX-7407)

### DIFF
--- a/api/lib/application/organization-invitations/organization-invitation-controller.js
+++ b/api/lib/application/organization-invitations/organization-invitation-controller.js
@@ -10,9 +10,15 @@ module.exports = {
   async acceptOrganizationInvitation(request) {
     const organizationInvitationId = request.params.id;
     const { code, email: rawEmail } = request.payload.data.attributes;
+    const localeFromCookie = request.state?.locale;
     const email = rawEmail?.trim().toLowerCase();
 
-    const membership = await usecases.acceptOrganizationInvitation({ organizationInvitationId, code, email });
+    const membership = await usecases.acceptOrganizationInvitation({
+      organizationInvitationId,
+      code,
+      email,
+      localeFromCookie,
+    });
     await usecases.createCertificationCenterMembershipForScoOrganizationMember({ membership });
     return null;
   },

--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -90,11 +90,11 @@ class User {
   }
 
   setLocaleIfNotAlreadySet(newLocale) {
-    this.mustBePersisted = false;
+    this.hasBeenModified = false;
     if (newLocale && !this.locale) {
       const canonicalLocale = localeService.getCanonicalLocale(newLocale);
       this.locale = canonicalLocale;
-      this.mustBePersisted = true;
+      this.hasBeenModified = true;
     }
   }
 

--- a/api/lib/domain/usecases/accept-certification-center-invitation.js
+++ b/api/lib/domain/usecases/accept-certification-center-invitation.js
@@ -31,7 +31,7 @@ module.exports = async function acceptCertificationCenterInvitation({
   if (localeFromCookie) {
     const user = await userRepository.getById(userId);
     user.setLocaleIfNotAlreadySet(localeFromCookie);
-    if (user.mustBePersisted) {
+    if (user.hasBeenModified) {
       await userRepository.update({ id: user.id, locale: user.locale });
     }
   }

--- a/api/lib/domain/usecases/accept-organization-invitation.js
+++ b/api/lib/domain/usecases/accept-organization-invitation.js
@@ -4,8 +4,10 @@ module.exports = async function acceptOrganizationInvitation({
   organizationInvitationId,
   code,
   email,
+  localeFromCookie,
   organizationInvitationRepository,
   organizationInvitedUserRepository,
+  userRepository,
 }) {
   const organizationInvitedUser = await organizationInvitedUserRepository.get({ organizationInvitationId, email });
 
@@ -16,6 +18,14 @@ module.exports = async function acceptOrganizationInvitation({
       await organizationInvitationRepository.markAsAccepted(organizationInvitationId);
     }
     throw error;
+  }
+
+  if (localeFromCookie) {
+    const user = await userRepository.getById(organizationInvitedUser.userId);
+    user.setLocaleIfNotAlreadySet(localeFromCookie);
+    if (user.hasBeenModified) {
+      await userRepository.update({ id: user.id, locale: user.locale });
+    }
   }
 
   await organizationInvitedUserRepository.save({ organizationInvitedUser });

--- a/api/lib/domain/usecases/authenticate-user.js
+++ b/api/lib/domain/usecases/authenticate-user.js
@@ -59,7 +59,7 @@ module.exports = async function authenticateUser({
     });
 
     foundUser.setLocaleIfNotAlreadySet(localeFromCookie);
-    if (foundUser.mustBePersisted) {
+    if (foundUser.hasBeenModified) {
       await userRepository.update({ id: foundUser.id, locale: foundUser.locale });
     }
 

--- a/api/tests/unit/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/unit/application/organization-invitations/organization-invitation-controller_test.js
@@ -33,6 +33,7 @@ describe('Unit | Application | Organization-Invitations | organization-invitatio
         organizationInvitationId: organizationInvitation.id,
         code,
         email,
+        localeFromCookie: undefined,
       });
     });
 

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -39,7 +39,7 @@ describe('Unit | Domain | Models | User', function () {
       // then
       expect(getCanonicalLocaleStub).to.not.have.been.called;
       expect(user.locale).to.be.undefined;
-      expect(user.mustBePersisted).to.be.false;
+      expect(user.hasBeenModified).to.be.false;
     });
 
     context('when user has no locale', function () {
@@ -55,7 +55,7 @@ describe('Unit | Domain | Models | User', function () {
         // then
         expect(getCanonicalLocaleStub).to.have.been.calledWith('fr-fr');
         expect(user.locale).to.equal('fr-FR');
-        expect(user.mustBePersisted).to.be.true;
+        expect(user.hasBeenModified).to.be.true;
       });
     });
 
@@ -72,7 +72,7 @@ describe('Unit | Domain | Models | User', function () {
         // then
         expect(getCanonicalLocaleStub).to.not.have.been.called;
         expect(user.locale).to.equal('en');
-        expect(user.mustBePersisted).to.be.false;
+        expect(user.hasBeenModified).to.be.false;
       });
     });
   });

--- a/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
+++ b/api/tests/unit/domain/usecases/accept-organization-invitation_test.js
@@ -16,7 +16,7 @@ describe('Unit | UseCase | accept-organization-invitation', function () {
     };
   });
 
-  context('when the user`s membership already exist', function () {
+  context('when the user’s membership already exist', function () {
     it('should mark the invitation as accepted', async function () {
       // given
       const code = '123AZE';
@@ -54,45 +54,47 @@ describe('Unit | UseCase | accept-organization-invitation', function () {
     });
   });
 
-  it('should return the membership id and role', async function () {
-    // given
-    const code = '123AZE';
-    const email = 'user@example.net';
-    const organization = domainBuilder.buildOrganization();
-    const organizationInvitationId = domainBuilder.buildOrganizationInvitation({
-      organizationId: organization.id,
-      code,
-    }).id;
-    const user = domainBuilder.buildUser();
+  context('when the user’s membership does not already exist', function () {
+    it('should return the membership id and role', async function () {
+      // given
+      const code = '123AZE';
+      const email = 'user@example.net';
+      const organization = domainBuilder.buildOrganization();
+      const organizationInvitationId = domainBuilder.buildOrganizationInvitation({
+        organizationId: organization.id,
+        code,
+      }).id;
+      const user = domainBuilder.buildUser();
 
-    const organizationInvitedUser = new OrganizationInvitedUser({
-      userId: user.id,
-      invitation: { code, id: organizationInvitationId },
-    });
-    organizationInvitedUserRepository.get
-      .withArgs({ organizationInvitationId, email })
-      .resolves(organizationInvitedUser);
+      const organizationInvitedUser = new OrganizationInvitedUser({
+        userId: user.id,
+        invitation: { code, id: organizationInvitationId },
+      });
+      organizationInvitedUserRepository.get
+        .withArgs({ organizationInvitationId, email })
+        .resolves(organizationInvitedUser);
 
-    sinon.stub(organizationInvitedUser, 'acceptInvitation').resolves();
+      sinon.stub(organizationInvitedUser, 'acceptInvitation').resolves();
 
-    const membership = domainBuilder.buildMembership({ user, organization, organizationRole: 'MEMBER' });
-    organizationInvitedUser.currentMembershipId = membership.id;
-    organizationInvitedUser.currentRole = membership.organizationRole;
+      const membership = domainBuilder.buildMembership({ user, organization, organizationRole: 'MEMBER' });
+      organizationInvitedUser.currentMembershipId = membership.id;
+      organizationInvitedUser.currentRole = membership.organizationRole;
 
-    // when
-    const result = await acceptOrganizationInvitation({
-      organizationInvitationId,
-      code,
-      email,
-      organizationInvitationRepository,
-      organizationInvitedUserRepository,
-    });
+      // when
+      const result = await acceptOrganizationInvitation({
+        organizationInvitationId,
+        code,
+        email,
+        organizationInvitationRepository,
+        organizationInvitedUserRepository,
+      });
 
-    // then
-    expect(organizationInvitedUserRepository.save).to.have.been.calledWith({ organizationInvitedUser });
-    expect(result).to.deep.equal({
-      id: organizationInvitedUser.currentMembershipId,
-      isAdmin: false,
+      // then
+      expect(organizationInvitedUserRepository.save).to.have.been.calledWith({ organizationInvitedUser });
+      expect(result).to.deep.equal({
+        id: organizationInvitedUser.currentMembershipId,
+        isAdmin: false,
+      });
     });
   });
 });

--- a/orga/app/services/locale.js
+++ b/orga/app/services/locale.js
@@ -1,0 +1,22 @@
+import Service, { inject as service } from '@ember/service';
+import config from 'pix-orga/config/environment';
+
+const { COOKIE_LOCALE_LIFESPAN_IN_SECONDS } = config.APP;
+
+export default class LocaleService extends Service {
+  @service cookies;
+  @service currentDomain;
+
+  hasLocaleCookie() {
+    return this.cookies.exists('locale');
+  }
+
+  setLocaleCookie(locale) {
+    this.cookies.write('locale', locale, {
+      domain: `pix.${this.currentDomain.getExtension()}`,
+      maxAge: COOKIE_LOCALE_LIFESPAN_IN_SECONDS,
+      path: '/',
+      sameSite: 'Strict',
+    });
+  }
+}

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -3,12 +3,15 @@ import SessionService from 'ember-simple-auth/services/session';
 import get from 'lodash/get';
 
 const DEFAULT_FRENCH_LOCALE = 'fr';
+const FRENCH_LOCALE = 'fr-FR';
 
 export default class CurrentSessionService extends SessionService {
   @service currentUser;
   @service intl;
   @service dayjs;
   @service url;
+  @service currentDomain;
+  @service locale;
 
   routeAfterAuthentication = 'authenticated';
 
@@ -22,10 +25,29 @@ export default class CurrentSessionService extends SessionService {
     await super.handleInvalidation(routeAfterInvalidation);
   }
 
-  async handlePrescriberLanguageAndLocale(lang = null) {
+  async handlePrescriberLanguageAndLocale(localeFromQueryParam) {
+    const domain = this.currentDomain.getExtension();
+    const defaultLocale = 'fr';
+    const domainFr = 'fr';
+
     await this.currentUser.load();
-    await this._updatePrescriberLanguage(lang);
-    this._setLocale(lang);
+    await this._updatePrescriberLanguage(localeFromQueryParam);
+
+    if (domain === domainFr) {
+      this._setLocale(defaultLocale);
+
+      if (!this.locale.hasLocaleCookie()) {
+        this.locale.setLocaleCookie(FRENCH_LOCALE);
+      }
+
+      return;
+    }
+
+    if (localeFromQueryParam) {
+      this._setLocale(localeFromQueryParam);
+    } else {
+      this._setLocale(defaultLocale);
+    }
   }
 
   async _updatePrescriberLanguage(lang) {

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -2,7 +2,7 @@ import { inject as service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
 import get from 'lodash/get';
 
-const DEFAULT_FRENCH_LOCALE = 'fr';
+const DEFAULT_LOCALE = 'fr';
 const FRENCH_LOCALE = 'fr-FR';
 
 export default class CurrentSessionService extends SessionService {
@@ -68,16 +68,16 @@ export default class CurrentSessionService extends SessionService {
     }
   }
 
-  _setLocale(lang) {
-    let locale = DEFAULT_FRENCH_LOCALE;
+  _setLocale(locale) {
+    let userLocale = DEFAULT_LOCALE;
 
     if (!this.url.isFrenchDomainExtension) {
-      locale = this.intl.get('locales').includes(lang) ? lang : DEFAULT_FRENCH_LOCALE;
+      userLocale = this.intl.get('locales').includes(locale) ? locale : DEFAULT_LOCALE;
     }
 
-    this.intl.setLocale([locale, DEFAULT_FRENCH_LOCALE]);
-    this.dayjs.setLocale(locale);
-    this.dayjs.self.locale(locale);
+    this.intl.setLocale([userLocale, DEFAULT_LOCALE]);
+    this.dayjs.setLocale(userLocale);
+    this.dayjs.self.locale(userLocale);
   }
 
   _getRouteAfterInvalidation() {

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -91,6 +91,7 @@ module.exports = function (environment) {
           I18N_KEY: 'common.api-error-messages.internal-server-error',
         },
       },
+      COOKIE_LOCALE_LIFESPAN_IN_SECONDS: 31536000, // 1 year in seconds
     },
 
     fontawesome: {

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -50,6 +50,7 @@
         "ember-cli-sri": "^2.1.1",
         "ember-cli-terser": "^4.0.2",
         "ember-click-outside": "^5.0.1",
+        "ember-cookies": "^0.5.2",
         "ember-data": "^4.0.2",
         "ember-dayjs": "^0.10.4",
         "ember-fetch": "^8.1.2",

--- a/orga/package.json
+++ b/orga/package.json
@@ -75,6 +75,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",
     "ember-click-outside": "^5.0.1",
+    "ember-cookies": "^0.5.2",
     "ember-data": "^4.0.2",
     "ember-dayjs": "^0.10.4",
     "ember-fetch": "^8.1.2",

--- a/orga/tests/unit/services/locale_test.js
+++ b/orga/tests/unit/services/locale_test.js
@@ -1,0 +1,71 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | locale', function (hooks) {
+  setupTest(hooks);
+
+  let localeService;
+  let cookiesService;
+  let currentDomainService;
+
+  hooks.beforeEach(function () {
+    localeService = this.owner.lookup('service:locale');
+
+    cookiesService = this.owner.lookup('service:cookies');
+    sinon.stub(cookiesService, 'write');
+    sinon.stub(cookiesService, 'exists');
+
+    currentDomainService = this.owner.lookup('service:currentDomain');
+    sinon.stub(currentDomainService, 'getExtension');
+  });
+
+  module('#setLocaleCookie', function () {
+    test('saves the locale in cookie locale', function (assert) {
+      // given
+      currentDomainService.getExtension.returns('fr');
+
+      // when
+      localeService.setLocaleCookie('fr-CA');
+
+      // then
+      sinon.assert.calledWith(cookiesService.write, 'locale', 'fr-CA', {
+        domain: 'pix.fr',
+        maxAge: 31536000,
+        path: '/',
+        sameSite: 'Strict',
+      });
+      assert.ok(true);
+    });
+  });
+
+  module('#hasLocaleCookie', function () {
+    module('when there is no cookie locale', function () {
+      test('returns "false"', function (assert) {
+        // given
+        cookiesService.exists.returns(false);
+
+        // when
+        const hasNoCookieLocale = localeService.hasLocaleCookie();
+
+        // then
+        sinon.assert.calledWith(cookiesService.exists, 'locale');
+        assert.notOk(hasNoCookieLocale);
+      });
+    });
+
+    module('when there is a cookie locale', function () {
+      test('returns "true"', function (assert) {
+        // given
+        cookiesService.exists.returns(true);
+
+        // when
+        const hasCookieLocale = localeService.hasLocaleCookie();
+
+        // then
+        sinon.assert.calledWith(cookiesService.exists, 'locale');
+        assert.ok(hasCookieLocale);
+      });
+    });
+  });
+});

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -128,4 +128,49 @@ module('Unit | Service | session', function (hooks) {
       assert.ok(service.handleInvalidation instanceof Function);
     });
   });
+
+  module('when the current domain  is "fr"', function (hooks) {
+    let service;
+
+    hooks.beforeEach(function () {
+      service = this.owner.lookup('service:session');
+      service.locale = {
+        setLocaleCookie: sinon.stub(),
+        hasLocaleCookie: sinon.stub(),
+      };
+      service.currentDomain = {
+        getExtension: sinon.stub(),
+      };
+    });
+
+    module('when there is no cookie locale', function () {
+      test('add a cookie locale with "fr-FR" as value', async function (assert) {
+        // given
+        service.locale.hasLocaleCookie.returns(false);
+        service.currentDomain.getExtension.returns('fr');
+
+        // when
+        await service.handlePrescriberLanguageAndLocale();
+
+        // then
+        sinon.assert.calledWith(service.locale.setLocaleCookie, 'fr-FR');
+        assert.ok(true);
+      });
+    });
+
+    module('when there is a cookie locale', function () {
+      test('does not update cookie locale', async function (assert) {
+        // given
+        service.locale.hasLocaleCookie.returns(true);
+        service.currentDomain.getExtension.returns('fr');
+
+        // when
+        await service.handlePrescriberLanguageAndLocale();
+
+        // then
+        sinon.assert.notCalled(service.locale.setLocaleCookie);
+        assert.ok(true);
+      });
+    });
+  });
 });

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -5,27 +5,42 @@ import sinon from 'sinon';
 module('Unit | Service | session', function (hooks) {
   setupTest(hooks);
 
+  let service;
+
+  hooks.beforeEach(function () {
+    service = this.owner.lookup('service:session');
+
+    service.currentUser = {
+      load: sinon.stub(),
+    };
+    service.url = {
+      isFrenchDomainExtension: sinon.stub(),
+    };
+    service.intl = {
+      setLocale: sinon.stub(),
+      get: sinon.stub(),
+    };
+    service.dayjs = {
+      setLocale: sinon.stub(),
+      self: {
+        locale: sinon.stub(),
+      },
+    };
+
+    service.locale = {
+      setLocaleCookie: sinon.stub(),
+      hasLocaleCookie: sinon.stub(),
+    };
+    service.currentDomain = {
+      getExtension: sinon.stub(),
+    };
+  });
+
   module('#handlePrescriberLanguageAndLocale', function () {
     module('when there is not prescriber', function () {
       test('should call current user and set fr locale by default', async function (assert) {
         // given
-        const service = this.owner.lookup('service:session');
-
-        service.currentUser = {
-          load: sinon.stub(),
-        };
-        service.url = {
-          isFrenchDomainExtension: true,
-        };
-        service.intl = {
-          setLocale: sinon.stub(),
-        };
-        service.dayjs = {
-          setLocale: sinon.stub(),
-          self: {
-            locale: sinon.stub(),
-          },
-        };
+        service.url.isFrenchDomainExtension.returns(true);
 
         // when
         await service.handlePrescriberLanguageAndLocale();
@@ -39,25 +54,10 @@ module('Unit | Service | session', function (hooks) {
       module('when domain extension is not .fr', function () {
         test('should set locale to en when language parameter is en', async function (assert) {
           // given
-          const service = this.owner.lookup('service:session');
-
-          service.currentUser = {
-            load: sinon.stub(),
-          };
           service.url = {
             isFrenchDomainExtension: false,
           };
-          service.intl = {
-            setLocale: sinon.stub(),
-            get: sinon.stub(),
-          };
           service.intl.get.withArgs('locales').returns(['fr', 'en']);
-          service.dayjs = {
-            setLocale: sinon.stub(),
-            self: {
-              locale: sinon.stub(),
-            },
-          };
 
           // when
           await service.handlePrescriberLanguageAndLocale('en');
@@ -72,8 +72,6 @@ module('Unit | Service | session', function (hooks) {
     module('when there is a prescriber', function () {
       test('should update prescriber lang when it is different of language parameter', async function (assert) {
         // given
-        const service = this.owner.lookup('service:session');
-
         service.currentUser = {
           load: sinon.stub(),
           prescriber: {
@@ -81,18 +79,7 @@ module('Unit | Service | session', function (hooks) {
             save: sinon.stub(),
           },
         };
-        service.url = {
-          isFrenchDomainExtension: true,
-        };
-        service.intl = {
-          setLocale: sinon.stub(),
-        };
-        service.dayjs = {
-          setLocale: sinon.stub(),
-          self: {
-            locale: sinon.stub(),
-          },
-        };
+        service.url.isFrenchDomainExtension.returns(true);
 
         // when
         await service.handlePrescriberLanguageAndLocale('en');
@@ -111,38 +98,19 @@ module('Unit | Service | session', function (hooks) {
 
   module('#handleAuthentication', function () {
     test('should override handleAuthentication method', function (assert) {
-      // when
-      const service = this.owner.lookup('service:session');
-
-      // then
+      // when & then
       assert.ok(service.handleAuthentication instanceof Function);
     });
   });
 
   module('#handleInvalidation', function () {
     test('should override handleInvalidation method', function (assert) {
-      // when
-      const service = this.owner.lookup('service:session');
-
-      // then
+      // when & then
       assert.ok(service.handleInvalidation instanceof Function);
     });
   });
 
-  module('when the current domain  is "fr"', function (hooks) {
-    let service;
-
-    hooks.beforeEach(function () {
-      service = this.owner.lookup('service:session');
-      service.locale = {
-        setLocaleCookie: sinon.stub(),
-        hasLocaleCookie: sinon.stub(),
-      };
-      service.currentDomain = {
-        getExtension: sinon.stub(),
-      };
-    });
-
+  module('when the current domain  is "fr"', function () {
     module('when there is no cookie locale', function () {
       test('add a cookie locale with "fr-FR" as value', async function (assert) {
         // given


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateur se connecte à orga.pix.org ou orga.pix.fr via une invitation (double mire), nous avons besoin d'enregistrer sa locale.

## :robot: Proposition
Quand un utilisateur se connecte à orga.pix.org via une invitation, on récupère sa locale dans le cookie et on l'enregistre s'il n'a pas déjà de locale.
Quand un utilisateur se connecte à orga.pix.fr via une invitation, on crée un cookie avec une locale ayant pour valeur fr-FR et on l'enregistre s'il n'a pas déjà de locale.

## :rainbow: Remarques
RAS.

## :100: Pour tester
**Pour tester en RA :** 

- Se rendre sur Pix Orga
- Se connecter avec un seed ayant un rôle ADMIN (ex: sco.admin)
- Cliquer sur l'onglet 'Equipe', puis sur le bouton 'Inviter un membre' 
- Envoyer un email d'invitation à une adresse email dont vous avez accès
- Récupérer le lien de l'email et modifier l'url pour avoir l'url de la RA en préfixe (ex: `https://orga-pr5944.review.pix.fr/rejoindre?invitationId=101285&code=NMXPBHCOIY`)

**Pour tester en local :** 

- Ajouter la variable suivante `DEBUG="pix:mailer:email"` dans le fichier .env du dossier api
- Se rendre sur Pix Orga
- Se connecter avec un seed ayant un rôle ADMIN (ex: sco.admin)
- Cliquer sur l'onglet 'Equipe', puis sur le bouton 'Inviter un membre' 
- Envoyer un email d'invitation à une adresse email quelconque 
- Récupérer le lien de l'email dans la requête de votre terminal et modifier l'url pour avoir l'url des local-domains en préfixe (ex: `http://orga.dev.pix.fr/rejoindre?invitationId=101285&code=NMXPBHCOIY`)

---

### Domaine .fr - Avec un cookie
- Vérifier que vous avez déjà un cookie avec la valeur `fr-FR` (si vous n'avez pas de cookie, rendez-vous sur [Pix App](https://app-pr5944.review.pix.fr/) et revenez sur [Pix Orga](https://orga-pr5944.review.pix.fr/))
- Dans la partie "J'ai déjà un compte" cliquer sur le bouton "Se connecter"
- Se connecter avec avec un seed n'ayant pas de locale
- Vérifier en BDD que la locale de l'utilisateur a la valeur `fr-FR`

### Domaine .fr - Sans cookie
- Supprimer les cookies de votre navigateur
- Dans la partie "J'ai déjà un compte" cliquer sur le bouton "Se connecter"
- Se connecter avec avec un seed n'ayant pas de locale
- Vérifier qu'un cookie avec la valeur `fr-FR` a bien été crée
- Vérifier en BDD que la locale de l'utilisateur a la valeur `fr-FR`

### Domaine .org  - Avec cookie
- Se rendre sur pix.org et sélectionner la locale FWB
- Modifier l'url de l'invitation en `pix.org`
- Vérifier que vous avez bien cookie "locale" avec la valeur `fr-BE`
- Dans la partie "J'ai déjà un compte" cliquer sur le bouton "Se connecter"
- Se connecter avec avec un seed n'ayant pas de locale
- Vérifier en BDD que la locale de l'utilisateur a la même valeur que la locale provenant du cookie `fr-BE`

### Domaine .org - Sans un cookie
- Modifier l'url de l'invitation en `pix.org`
- Supprimer les cookies de votre navigateur
- Dans la partie "J'ai déjà un compte" cliquer sur le bouton "Se connecter"
- Se connecter avec avec un seed n'ayant pas de locale
- Vérifier en BDD que la locale de l'utilisateur est toujours vide

