### PR TITLE
[BUGFIX] Réparer quelques régressions dans la mise en page de la page de détail d'un utilisateur (PIX-7671)

### DIFF
--- a/admin/app/components/users/user-overview.hbs
+++ b/admin/app/components/users/user-overview.hbs
@@ -108,34 +108,44 @@
         {{/if}}
       </div>
       <div class="user-detail-personal-information-section__content">
-        <ul>
-          <li class="user-detail-personal-information-section__user-informations">Prénom : {{@user.firstName}}</li>
-          <li class="user-detail-personal-information-section__user-informations">Nom : {{@user.lastName}}</li>
-          <li class="user-detail-personal-information-section__user-informations">Langue : {{@user.lang}}</li>
-          <li class="user-detail-personal-information-section__user-informations">Locale : {{@user.locale}}</li>
-          <li class="user-detail-personal-information-section__user-informations">Date de création :
-            {{dayjs-format @user.createdAt "DD/MM/YYYY"}}</li>
-          <li class="user-detail-personal-information-section__user-informations">Adresse e-mail : {{@user.email}}</li>
-          <li class="user-detail-personal-information-section__user-informations">Identifiant : {{@user.username}}</li>
-          <li class="user-detail-personal-information-section__user-informations">CGU Pix App validé :
-            {{this.userHasValidatePixAppTermsOfService}}</li>
-          <li class="user-detail-personal-information-section__user-informations">CGU Pix Orga validé :
-            {{this.userHasValidatePixOrgaTermsOfService}}</li>
-          <li class="user-detail-personal-information-section__user-informations">CGU Pix Certif validé :
-            {{this.userHasValidatePixCertifTermsOfService}}</li>
-          <li class="user-detail-personal-information-section__user-informations">Nombre de tentatives de connexion en
-            erreur :
-            {{@user.userLogin.failureCount}}</li>
-          {{#if @user.userLogin.blockedAt}}
-            <li class="user-detail-personal-information-section__user-informations">Utilisateur totalement bloqué le :
-              {{dayjs-format @user.userLogin.blockedAt "DD/MM/YYYY HH:mm"}}</li>
-          {{/if}}
-          {{#if this.shouldDisplayTemporaryBlockedDate}}
-            <li class="user-detail-personal-information-section__user-informations">Utilisateur temporairement bloqué
-              jusqu'au :
-              {{dayjs-format @user.userLogin.temporaryBlockedUntil "DD/MM/YYYY HH:mm"}}</li>
-          {{/if}}
-        </ul>
+        <div>
+          <ul class="user-detail-personal-information-section__infogroup">
+            <li class="user-detail-personal-information-section__user-informations">Prénom : {{@user.firstName}}</li>
+            <li class="user-detail-personal-information-section__user-informations">Nom : {{@user.lastName}}</li>
+            <li class="user-detail-personal-information-section__user-informations">Langue : {{@user.lang}}</li>
+            <li class="user-detail-personal-information-section__user-informations">Locale : {{@user.locale}}</li>
+            <li class="user-detail-personal-information-section__user-informations">Date de création :
+              {{dayjs-format @user.createdAt "DD/MM/YYYY"}}</li>
+          </ul>
+          <ul class="user-detail-personal-information-section__infogroup">
+            <li class="user-detail-personal-information-section__user-informations">Adresse e-mail :
+              {{@user.email}}</li>
+            <li class="user-detail-personal-information-section__user-informations">Identifiant :
+              {{@user.username}}</li>
+          </ul>
+          <ul class="user-detail-personal-information-section__infogroup">
+            <li class="user-detail-personal-information-section__user-informations">CGU Pix App validé :
+              {{this.userHasValidatePixAppTermsOfService}}</li>
+            <li class="user-detail-personal-information-section__user-informations">CGU Pix Orga validé :
+              {{this.userHasValidatePixOrgaTermsOfService}}</li>
+            <li class="user-detail-personal-information-section__user-informations">CGU Pix Certif validé :
+              {{this.userHasValidatePixCertifTermsOfService}}</li>
+          </ul>
+          <ul class="user-detail-personal-information-section__infogroup">
+            <li class="user-detail-personal-information-section__user-informations">Nombre de tentatives de connexion en
+              erreur :
+              {{@user.userLogin.failureCount}}</li>
+            {{#if @user.userLogin.blockedAt}}
+              <li class="user-detail-personal-information-section__user-informations">Utilisateur totalement bloqué le :
+                {{dayjs-format @user.userLogin.blockedAt "DD/MM/YYYY HH:mm"}}</li>
+            {{/if}}
+            {{#if this.shouldDisplayTemporaryBlockedDate}}
+              <li class="user-detail-personal-information-section__user-informations">Utilisateur temporairement bloqué
+                jusqu'au :
+                {{dayjs-format @user.userLogin.temporaryBlockedUntil "DD/MM/YYYY HH:mm"}}</li>
+            {{/if}}
+          </ul>
+        </div>
         <div>
           <PixButtonLink
             @backgroundColor="transparent-light"

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -63,6 +63,7 @@
 @import 'components/users/user-overview';
 @import 'components/users/organization-learners-table';
 @import 'components/users/get';
+@import 'components/users/authentication-method';
 @import 'components/target-profiles/badges';
 @import 'components/target-profiles/target-profile';
 @import 'components/target-profiles/badge-form';

--- a/admin/app/styles/components/users/user-overview.scss
+++ b/admin/app/styles/components/users/user-overview.scss
@@ -6,6 +6,10 @@
     max-width: 600px;
   }
 
+  &__infogroup {
+    margin-bottom: 1rem;
+  }
+
   &__user-informations {
     margin-bottom: 5px;
   }


### PR DESCRIPTION
## :unicorn: Problème

La PR #5855, tout en mettant en place une structure HTML plus sémantique et plus accessible, a introduit quelques régressions dans la mise en page de la page de détail d'un utilisateur. On ne veut pas remettre en cause la bonne structure HTML mise en place, mais juste corriger les quelques régressions.

## :robot: Proposition

Corriger les régressions tout en se basant sur la nouvelle structure plus sémantique et plus accessible apportée par #5855. Pour formaliser la sémantique attendue dans cette interface utilisateur, on propose de faire des groupes de `<ul>` par thématique de propriétés utilisateur.

## :rainbow: Remarques

RAS

## :100: Pour tester

1. Aller sur https://admin-pr5945.review.pix.fr/ et se connecter
2. Chercher un utilisateur et aller sur sa fiche
3. Constater que les régressions de la mise en page ne sont plus présentes :
   * Les propriétés de l'utilisateur sont présentées à nouveau de manière groupée par thématiques
   * Les coches et les croix des authentication methods sont à nouveau respectivement vertes et grises
   * L’alignement des titres de colonnes, des colonnes et des boutons de la tables des authentications methods est à nouveau correct
