### PR TITLE
[FEATURE] Ajouter la clé pour Activer l'envoi multiple sur les campagnes d'évaluation d'une organisation (PIX-7464)

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -111,7 +111,7 @@ module.exports = class DatabaseBuilder {
     const resultSet = await this.knex.raw(query, [this.knex.client.database()]);
     const rows = resultSet.rows;
     const tableNames = _.map(rows, 'table_name');
-    const tablesToDelete = _.without(tableNames, 'knex_migrations', 'knex_migrations_lock');
+    const tablesToDelete = _.without(tableNames, 'knex_migrations', 'knex_migrations_lock', 'features');
     const tables = _.map(tablesToDelete, (tableToDelete) => `"${tableToDelete}"`).join();
     // eslint-disable-next-line knex/avoid-injections
     return this.knex.raw(`TRUNCATE ${tables}`);

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -99,7 +99,7 @@ async function listAllTableNames() {
 
 async function emptyAllTables() {
   const tableNames = await listAllTableNames();
-  const tablesToDelete = _.without(tableNames, 'knex_migrations', 'knex_migrations_lock');
+  const tablesToDelete = _.without(tableNames, 'knex_migrations', 'knex_migrations_lock', 'features');
 
   const tables = _.map(tablesToDelete, (tableToDelete) => `"${tableToDelete}"`).join();
 

--- a/api/db/migrations/20230407090348_add-multiple-sending-feature.js
+++ b/api/db/migrations/20230407090348_add-multiple-sending-feature.js
@@ -1,0 +1,20 @@
+const TABLE_NAME = 'features';
+const MULTIPLE_SENDING_KEY = 'MULTIPLE_SENDING_ASSESSMENT';
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex(TABLE_NAME).insert({
+    key: MULTIPLE_SENDING_KEY,
+    description: "Permet d'activer l'envoi multiple sur les campagnes d'évaluation",
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex(TABLE_NAME).where({ key: MULTIPLE_SENDING_KEY }).delete();
+};


### PR DESCRIPTION
## :unicorn: Problème
Il n'y a pas encore de clé permettant de gérer l'activation ou non d'envoi mutliple sur les campagnes d'évaluation .

## :robot: Proposition
Cette epix est l’occasion d’anticiper de futures activations d’autres fonctionnalités pour des orgas depuis Pix Admin, en consolidant la partie API.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que la clé est bien présente en base ? 