### PR TITLE
[BUGFIX] Ajouter un espacement entre les paragraphes de réponse à une épreuve (PIX-7684).

### DIFF
--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -102,6 +102,10 @@ form .challenge-response {
     margin-top: 0;
     font-weight: $font-normal;
     font-size: 1rem;
+
+    &:not(:last-child) {
+      margin-bottom: 1rem;
+    }
   }
 
   .qroc-proposal {

--- a/mon-pix/app/styles/components/_qcm-proposals.scss
+++ b/mon-pix/app/styles/components/_qcm-proposals.scss
@@ -5,6 +5,10 @@
   justify-content: flex-start;
   margin-left: 7px;
 
+  & + .proposal-paragraph {
+    margin-top: 1rem;
+  }
+
   input[type='checkbox'] {
     flex-shrink: 0;
   }

--- a/mon-pix/app/styles/components/_qcu-proposals.scss
+++ b/mon-pix/app/styles/components/_qcu-proposals.scss
@@ -1,4 +1,7 @@
 .qcu-proposals {
+  & + .qcu-proposals {
+    margin-top: 0.5rem;
+  }
 
   a {
     color: $pix-primary;


### PR DESCRIPTION
## :unicorn: Problème

Une régression visuelle a été implémentée dans l'écran d'épreuve.
2 paragraphes qui se suivent ne sont plus bien espacés.

[Exemple](https://app.recette.pix.fr/challenges/recLt9uwa2dR3IYpi/preview)

## :robot: Proposition

- Corriger le style du bloc de réponse

## :100: Pour tester

- Aller sur la RA de PixApp
- Tester différentes épreuves listées ici https://1024pix.github.io/sos-recid-challenges/
- Vérifier que l'espacement entre les paragraphes est rétabli
