### PR TITLE
[FEATURE] Afficher Pix Certif dans la langue de l'utilisateur enregistrée dans son compte (PIX-7644)

### DIFF
--- a/api/lib/domain/read-models/CertificationPointOfContact.js
+++ b/api/lib/domain/read-models/CertificationPointOfContact.js
@@ -1,9 +1,18 @@
 class CertificationPointOfContact {
-  constructor({ id, firstName, lastName, email, pixCertifTermsOfServiceAccepted, allowedCertificationCenterAccesses }) {
+  constructor({
+    id,
+    firstName,
+    lastName,
+    email,
+    lang,
+    pixCertifTermsOfServiceAccepted,
+    allowedCertificationCenterAccesses,
+  }) {
     this.id = id;
     this.firstName = firstName;
     this.lastName = lastName;
     this.email = email;
+    this.lang = lang;
     this.pixCertifTermsOfServiceAccepted = pixCertifTermsOfServiceAccepted;
     this.allowedCertificationCenterAccesses = allowedCertificationCenterAccesses;
   }

--- a/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
+++ b/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
@@ -12,6 +12,7 @@ module.exports = {
         firstName: 'users.firstName',
         lastName: 'users.lastName',
         email: 'users.email',
+        lang: 'users.lang',
         pixCertifTermsOfServiceAccepted: 'users.pixCertifTermsOfServiceAccepted',
         certificationCenterIds: knex.raw('array_agg(?? order by ?? asc)', [
           'certificationCenterId',

--- a/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
@@ -8,6 +8,7 @@ module.exports = {
         'firstName',
         'lastName',
         'email',
+        'lang',
         'pixCertifTermsOfServiceAccepted',
         'allowedCertificationCenterAccesses',
       ],

--- a/api/tests/acceptance/application/certification-point-of-contacts/certification-point-of-contacts_test.js
+++ b/api/tests/acceptance/application/certification-point-of-contacts/certification-point-of-contacts_test.js
@@ -30,6 +30,7 @@ describe('Acceptance | Route | CertificationPointOfContact', function () {
       // then
       expect(response.statusCode).to.equal(200);
       expect(response.result.data.id).to.equal(userId.toString());
+      expect(response.result.data.attributes.lang).to.equal('fr');
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
@@ -22,6 +22,7 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
         firstName: 'Jean',
         lastName: 'Acajou',
         email: 'jean.acajou@example.net',
+        lang: 'fr',
         pixCertifTermsOfServiceAccepted: true,
       });
       databaseBuilder.factory.buildUser();
@@ -36,6 +37,7 @@ describe('Integration | Repository | CertificationPointOfContact', function () {
         firstName: 'Jean',
         lastName: 'Acajou',
         email: 'jean.acajou@example.net',
+        lang: 'fr',
         pixCertifTermsOfServiceAccepted: true,
         allowedCertificationCenterAccesses: [],
       });

--- a/api/tests/tooling/domain-builder/factory/build-certification-point-of-contact.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-point-of-contact.js
@@ -6,6 +6,7 @@ module.exports = function buildCertificationPointOfContact({
   firstName = 'Chèvre',
   lastName = 'Brebis',
   email = 'chevre.brebis@example.net',
+  lang = 'fr',
   pixCertifTermsOfServiceAccepted = true,
   allowedCertificationCenterAccesses = [buildAllowedCertificationCenterAccess()],
 } = {}) {
@@ -14,6 +15,7 @@ module.exports = function buildCertificationPointOfContact({
     firstName,
     lastName,
     email,
+    lang,
     pixCertifTermsOfServiceAccepted,
     allowedCertificationCenterAccesses,
   });

--- a/api/tests/unit/application/certification-point-of-contacts/certification-point-of-contact-controller_test.js
+++ b/api/tests/unit/application/certification-point-of-contacts/certification-point-of-contact-controller_test.js
@@ -45,6 +45,7 @@ describe('Unit | Controller | certifications-point-of-contact-controller', funct
             'first-name': 'Buffy',
             'last-name': 'Summers',
             email: 'buffy.summers@example.net',
+            lang: 'fr',
             'pix-certif-terms-of-service-accepted': true,
           },
           relationships: {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
@@ -52,6 +52,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
             'first-name': 'Buffy',
             'last-name': 'Summers',
             email: 'buffy.summers@example.net',
+            lang: 'fr',
             'pix-certif-terms-of-service-accepted': true,
           },
           relationships: {

--- a/certif/app/models/certification-point-of-contact.js
+++ b/certif/app/models/certification-point-of-contact.js
@@ -4,6 +4,7 @@ export default class CertificationPointOfContact extends Model {
   @attr() firstName;
   @attr() lastName;
   @attr() email;
+  @attr() lang;
   @attr() pixCertifTermsOfServiceAccepted;
   @hasMany('allowed-certification-center-access') allowedCertificationCenterAccesses;
 

--- a/certif/app/routes/application.js
+++ b/certif/app/routes/application.js
@@ -1,53 +1,18 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
-const FRENCH_LOCALE = 'fr-FR';
-
 export default class ApplicationRoute extends Route {
-  @service currentUser;
   @service featureToggles;
-  @service intl;
   @service currentDomain;
-  @service dayjs;
-  @service locale;
+  @service currentUser;
+  @service session;
 
   async beforeModel(transition) {
     await this.featureToggles.load();
-    const locale = transition.to.queryParams.lang;
-    await this.handleLocale(locale);
-    return this._loadCurrentUser();
-  }
-
-  _loadCurrentUser() {
-    return this.currentUser.load();
-  }
-
-  async handleLocale(localeFromQueryParam) {
-    const domain = this.currentDomain.getExtension();
-    const defaultLocale = 'fr';
-    const domainFr = 'fr';
-
-    if (domain === domainFr) {
-      this._setLocale(domainFr);
-
-      if (!this.locale.hasLocaleCookie()) {
-        this.locale.setLocaleCookie(FRENCH_LOCALE);
-      }
-
-      return;
-    }
-
-    if (localeFromQueryParam) {
-      this._setLocale(localeFromQueryParam);
-    } else {
-      this._setLocale(defaultLocale);
-    }
-  }
-
-  _setLocale(locale) {
-    const defaultLocale = 'fr';
-    this.intl.setLocale([locale, defaultLocale]);
-    this.dayjs.setLocale(locale);
-    this.dayjs.self.locale(locale);
+    const isFranceDomain = this.currentDomain.isFranceDomain;
+    const localeFromQueryParam = transition.to.queryParams.lang;
+    await this.currentUser.load();
+    const userLocale = this.currentUser.certificationPointOfContact?.lang;
+    await this.session.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
   }
 }

--- a/certif/app/services/current-domain.js
+++ b/certif/app/services/current-domain.js
@@ -1,7 +1,13 @@
 import Service from '@ember/service';
 import last from 'lodash/last';
 
+const FRANCE_TLD = 'fr';
+
 export default class CurrentDomainService extends Service {
+  get isFranceDomain() {
+    return this.getExtension() === FRANCE_TLD;
+  }
+
   getExtension() {
     return last(location.hostname.split('.'));
   }

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -35,20 +35,16 @@ export default class Url extends Service {
   }
 
   get legalNoticeUrl() {
-    const topLevelDomain = this.currentDomain.getExtension();
+    if (this.currentDomain.isFranceDomain) return 'https://pix.fr/mentions-legales';
+
     const currentLanguage = this.intl.t('current-lang');
-
-    if (topLevelDomain === 'fr') return 'https://pix.fr/mentions-legales';
-
     return currentLanguage === 'fr' ? 'https://pix.org/fr/mentions-legales' : 'https://pix.org/en-gb/legal-notice';
   }
 
   get accessibilityUrl() {
-    const topLevelDomain = this.currentDomain.getExtension();
+    if (this.currentDomain.isFranceDomain) return 'https://pix.fr/accessibilite-pix-certif';
+
     const currentLanguage = this.intl.t('current-lang');
-
-    if (topLevelDomain === 'fr') return 'https://pix.fr/accessibilite-pix-certif';
-
     return currentLanguage === 'fr'
       ? 'https://pix.org/fr/accessibilite-pix-certif'
       : 'https://pix.org/en-gb/accessibility-pix-certif';

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -316,6 +316,7 @@ export default function () {
       firstName: attributes['first-name'],
       lastName: attributes['last-name'],
       email: attributes.email,
+      lang: 'fr',
       password: 'secret',
     };
 

--- a/certif/mirage/factories/certification-point-of-contact.js
+++ b/certif/mirage/factories/certification-point-of-contact.js
@@ -13,6 +13,10 @@ export default Factory.extend({
     return 'laura.passtacertif@example.net';
   },
 
+  lang() {
+    return 'fr';
+  },
+
   pixCertifTermsOfServiceAccepted() {
     return false;
   },

--- a/certif/tests/acceptance/authentication_test.js
+++ b/certif/tests/acceptance/authentication_test.js
@@ -33,132 +33,136 @@ module('Acceptance | authentication', function (hooks) {
     });
   });
 
-  module('When certificationPointOfContact is logging in but has not accepted terms of service yet', function () {
-    test('it should redirect certificationPointOfContact to the terms-of-service page', async function (assert) {
-      // given
-      await invalidateSession();
-      certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceNotAccepted();
+  module('When certificationPointOfContact is logging in', function () {
+    module('when has not accepted terms of service yet', function () {
+      test('it should redirect certificationPointOfContact to the terms-of-service page', async function (assert) {
+        // given
+        await invalidateSession();
+        certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceNotAccepted();
 
-      await visit('/connexion');
-      await fillIn('#login-email', certificationPointOfContact.email);
-      await fillIn('#login-password', 'secret');
+        await visit('/connexion');
+        await fillIn('#login-email', certificationPointOfContact.email);
+        await fillIn('#login-password', 'secret');
 
-      // when
-      await click('button[type=submit]');
+        // when
+        await click('button[type=submit]');
 
-      // then
-      assert.strictEqual(currentURL(), '/cgu');
-      assert.ok(
-        currentSession(this.application).get('isAuthenticated'),
-        'The certificationPointOfContact is authenticated'
-      );
+        // then
+        assert.strictEqual(currentURL(), '/cgu');
+        assert.ok(
+          currentSession(this.application).get('isAuthenticated'),
+          'The certificationPointOfContact is authenticated'
+        );
+      });
+
+      test('it should not show menu nor top bar', async function (assert) {
+        // given
+        await invalidateSession();
+        certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceNotAccepted();
+
+        await visit('/connexion');
+        await fillIn('#login-email', certificationPointOfContact.email);
+        await fillIn('#login-password', 'secret');
+
+        // when
+        await click('button[type=submit]');
+
+        // then
+        assert.ok(
+          currentSession(this.application).get('isAuthenticated'),
+          'The certificationPointOfContact is authenticated'
+        );
+
+        assert.dom('.app__sidebar').doesNotExist();
+        assert.dom('.main-content__topbar').doesNotExist();
+      });
     });
 
-    test('it should not show menu nor top bar', async function (assert) {
-      // given
-      await invalidateSession();
-      certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceNotAccepted();
+    module('when has accepted terms of service', function () {
+      test('it should redirect certificationPointOfContact to the session list', async function (assert) {
+        // given
+        await invalidateSession();
+        certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
 
-      await visit('/connexion');
-      await fillIn('#login-email', certificationPointOfContact.email);
-      await fillIn('#login-password', 'secret');
+        await visit('/connexion');
+        await fillIn('#login-email', certificationPointOfContact.email);
+        await fillIn('#login-password', 'secret');
 
-      // when
-      await click('button[type=submit]');
+        // when
+        await click('button[type=submit]');
 
-      // then
-      assert.ok(
-        currentSession(this.application).get('isAuthenticated'),
-        'The certificationPointOfContact is authenticated'
-      );
+        // then
 
-      assert.dom('.app__sidebar').doesNotExist();
-      assert.dom('.main-content__topbar').doesNotExist();
+        assert.strictEqual(currentURL(), '/sessions/liste');
+        assert.ok(
+          currentSession(this.application).get('isAuthenticated'),
+          'The certificationPointOfContact is authenticated'
+        );
+      });
+
+      test('it should show certificationPointOfContact name', async function (assert) {
+        // given
+        await invalidateSession();
+        certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+
+        await visit('/connexion');
+        await fillIn('#login-email', certificationPointOfContact.email);
+        await fillIn('#login-password', 'secret');
+
+        // when
+        await click('button[type=submit]');
+
+        // then
+        assert.ok(
+          currentSession(this.application).get('isAuthenticated'),
+          'The certificationPointOfContact is authenticated'
+        );
+        assert.dom('.logged-user-summary__name').hasText('Harry Cover');
+      });
     });
   });
 
-  module('When certificationPointOfContact is logging in and has accepted terms of service', function () {
-    test('it should redirect certificationPointOfContact to the session list', async function (assert) {
-      // given
-      await invalidateSession();
-      certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+  module('When certificationPointOfContact is authenticated', function () {
+    module('When has accepted terms of service', function () {
+      test('it should let certificationPointOfContact access requested page', async function (assert) {
+        // given
+        certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+        await authenticateSession(certificationPointOfContact.id);
 
-      await visit('/connexion');
-      await fillIn('#login-email', certificationPointOfContact.email);
-      await fillIn('#login-password', 'secret');
+        // when
+        await visit('/sessions/liste');
 
-      // when
-      await click('button[type=submit]');
+        // then
+        assert.strictEqual(currentURL(), '/sessions/liste');
+        assert.ok(
+          currentSession(this.application).get('isAuthenticated'),
+          'The certificationPointOfContact is authenticated'
+        );
+      });
 
-      // then
+      test('it should show the name and externalId of certification center', async function (assert) {
+        // given
+        certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+        await authenticateSession(certificationPointOfContact.id);
 
-      assert.strictEqual(currentURL(), '/sessions/liste');
-      assert.ok(
-        currentSession(this.application).get('isAuthenticated'),
-        'The certificationPointOfContact is authenticated'
-      );
-    });
+        // when
+        await visit('/sessions/liste');
 
-    test('it should show certificationPointOfContact name', async function (assert) {
-      // given
-      await invalidateSession();
-      certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+        // then
+        assert.dom('.logged-user-summary__certification-center').hasText('Centre de certification du pix (ABC123)');
+      });
 
-      await visit('/connexion');
-      await fillIn('#login-email', certificationPointOfContact.email);
-      await fillIn('#login-password', 'secret');
+      test('it should redirect certificationPointOfContact to the session list on root url', async function (assert) {
+        // given
+        certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+        await authenticateSession(certificationPointOfContact.id);
 
-      // when
-      await click('button[type=submit]');
+        // when
+        await visit('/');
 
-      // then
-      assert.ok(
-        currentSession(this.application).get('isAuthenticated'),
-        'The certificationPointOfContact is authenticated'
-      );
-      assert.dom('.logged-user-summary__name').hasText('Harry Cover');
-    });
-  });
-
-  module('When certificationPointOfContact is already authenticated and has accepted terms of service', function () {
-    test('it should let certificationPointOfContact access requested page', async function (assert) {
-      // given
-      certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-      await authenticateSession(certificationPointOfContact.id);
-
-      // when
-      await visit('/sessions/liste');
-
-      // then
-      assert.strictEqual(currentURL(), '/sessions/liste');
-      assert.ok(
-        currentSession(this.application).get('isAuthenticated'),
-        'The certificationPointOfContact is authenticated'
-      );
-    });
-
-    test('it should show the name and externalId of certification center', async function (assert) {
-      // given
-      certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-      await authenticateSession(certificationPointOfContact.id);
-
-      // when
-      await visit('/sessions/liste');
-
-      // then
-      assert.dom('.logged-user-summary__certification-center').hasText('Centre de certification du pix (ABC123)');
-    });
-
-    test('it should redirect certificationPointOfContact to the session list on root url', async function (assert) {
-      // given
-      certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-      await authenticateSession(certificationPointOfContact.id);
-
-      // when
-      await visit('/');
-
-      // then
-      assert.strictEqual(currentURL(), '/sessions/liste');
+        // then
+        assert.strictEqual(currentURL(), '/sessions/liste');
+      });
     });
   });
 });

--- a/certif/tests/acceptance/authentication_test.js
+++ b/certif/tests/acceptance/authentication_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { visit, currentURL, click, fillIn } from '@ember/test-helpers';
+import { visit as visitScreen } from '@1024pix/ember-testing-library';
 import { setupApplicationTest } from 'ember-qunit';
 import { currentSession, invalidateSession } from 'ember-simple-auth/test-support';
 import {
@@ -162,6 +163,21 @@ module('Acceptance | authentication', function (hooks) {
 
         // then
         assert.strictEqual(currentURL(), '/sessions/liste');
+      });
+    });
+
+    module('when a lang query param is present', function () {
+      test('sets and remembers the locale to the lang query param which wins over the user’s lang', async function (assert) {
+        // given
+        certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+
+        // when
+        await visitScreen('/?lang=en');
+        await authenticateSession(certificationPointOfContact.id);
+        const screen = await visitScreen('/');
+
+        // then
+        assert.dom(screen.getByRole('link', { name: 'Invigilator’s Portal' })).exists();
       });
     });
   });

--- a/certif/tests/helpers/test-init.js
+++ b/certif/tests/helpers/test-init.js
@@ -32,6 +32,7 @@ export function createCertificationPointOfContactWithCustomCenters({
     firstName: 'Harry',
     lastName: 'Cover',
     email: 'harry@cover.com',
+    lang: 'fr',
     pixCertifTermsOfServiceAccepted,
     allowedCertificationCenterAccesses,
   });

--- a/certif/tests/integration/components/layout/footer_test.js
+++ b/certif/tests/integration/components/layout/footer_test.js
@@ -22,7 +22,7 @@ module('Integration | Component | Layout::Footer', function (hooks) {
   test('should display legal notice link', async function (assert) {
     // given
     const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+    service.currentDomain.getExtension = sinon.stub().returns('fr');
 
     // when
     const screen = await renderScreen(hbs`<Layout::Footer />}`);
@@ -36,7 +36,7 @@ module('Integration | Component | Layout::Footer', function (hooks) {
   test('should display accessibility link', async function (assert) {
     // given
     const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+    service.currentDomain.getExtension = sinon.stub().returns('fr');
 
     // when
     const screen = await renderScreen(hbs`<Layout::Footer />}`);

--- a/certif/tests/unit/routes/application_test.js
+++ b/certif/tests/unit/routes/application_test.js
@@ -3,140 +3,62 @@ import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import Service from '@ember/service';
 
-class CurrentUserStub extends Service {
-  load = sinon.stub();
-}
-class FeatureTogglesStub extends Service {
-  load = sinon.stub().resolves();
-}
-
 module('Unit | Route | application', function (hooks) {
   setupTest(hooks);
 
-  test('it should load the current user', async function (assert) {
-    // given
-    const transition = { to: { queryParams: { lang: 'fr' } } };
-    this.owner.register('service:current-user', CurrentUserStub);
-    this.owner.register('service:feature-toggles', FeatureTogglesStub);
+  hooks.beforeEach(function () {
+    class currentDomainStub extends Service {
+      get isFranceDomain() {
+        return true;
+      }
+    }
+    this.owner.register('service:currentDomain', currentDomainStub);
 
-    const route = this.owner.lookup('route:application');
-
-    // when
-    await route.beforeModel(transition);
-
-    // then
-    assert.ok(route.currentUser.load.called);
+    class CurrentUserStub extends Service {
+      load = sinon.stub();
+    }
+    this.owner.register('service:currentUser', CurrentUserStub);
   });
 
-  module('#handleLocale', function () {
-    module('when domain is fr', function () {
-      test('it should update the locale to fr-fr', async function (assert) {
-        // given
-        const intlSetLocaleStub = sinon.stub();
-        const dayjsSetLocaleStub = sinon.stub();
-        const intlStub = Service.create({
-          setLocale: intlSetLocaleStub,
-        });
-        const dayjsStub = Service.create({
-          setLocale: dayjsSetLocaleStub,
-          self: { locale: sinon.stub() },
-        });
-        const currentDomainStub = {
-          getExtension: () => 'fr',
-        };
-        const route = this.owner.lookup('route:application');
+  module('beforeModel', function () {
+    test('loads feature toggles', async function (assert) {
+      // given
+      const transition = { to: { queryParams: {} } };
+      const route = this.owner.lookup('route:application');
 
-        route.set('intl', intlStub);
-        route.set('dayjs', dayjsStub);
-        route.set('currentDomain', currentDomainStub);
+      sinon.stub(route.featureToggles, 'load');
+      route.featureToggles.load.resolves();
 
-        // when
-        await route.handleLocale('fr');
+      sinon.stub(route.session, 'handleLocale');
 
-        // then
-        assert.expect(0);
-        sinon.assert.calledWith(intlSetLocaleStub, ['fr', 'fr']);
-        sinon.assert.calledWith(dayjsSetLocaleStub, 'fr');
-      });
+      // when
+      await route.beforeModel(transition);
 
-      module('when there is no cookie locale', function () {
-        test('add a cookie locale with "fr-FR" as value', async function (assert) {
-          // given
-          const localeServiceStub = Service.create({
-            hasLocaleCookie: sinon.stub().returns(false),
-            setLocaleCookie: sinon.stub(),
-          });
-          const currentDomainStub = {
-            getExtension: () => 'fr',
-          };
-          const route = this.owner.lookup('route:application');
-
-          route.set('locale', localeServiceStub);
-          route.set('currentDomain', currentDomainStub);
-
-          // when
-          await route.handleLocale();
-
-          // then
-          sinon.assert.calledWith(localeServiceStub.setLocaleCookie, 'fr-FR');
-          assert.ok(true);
-        });
-      });
-
-      module('when there is a cookie locale', function () {
-        test('does not update cookie locale', async function (assert) {
-          // given
-          const localeServiceStub = Service.create({
-            hasLocaleCookie: sinon.stub().returns(true),
-            setLocaleCookie: sinon.stub(),
-          });
-          const currentDomainStub = {
-            getExtension: () => 'fr',
-          };
-          const route = this.owner.lookup('route:application');
-
-          route.set('locale', localeServiceStub);
-          route.set('currentDomain', currentDomainStub);
-
-          // when
-          await route.handleLocale();
-
-          // then
-          sinon.assert.notCalled(localeServiceStub.setLocaleCookie);
-          assert.ok(true);
-        });
-      });
+      // then
+      assert.ok(route.featureToggles.load.called);
     });
 
-    module('when domain is org', function () {
-      test('it should update the locale to fr', async function (assert) {
-        // given
-        const intlSetLocaleStub = sinon.stub();
-        const dayjsSetLocaleStub = sinon.stub();
-        const dayjsStub = Service.create({
-          setLocale: dayjsSetLocaleStub,
-          self: { locale: sinon.stub() },
-        });
-        const intlStub = Service.create({
-          setLocale: intlSetLocaleStub,
-        });
-        const currentDomainStub = {
-          getExtension: () => 'org',
-        };
-        const route = this.owner.lookup('route:application');
+    test('calls handleLocale', async function (assert) {
+      // given
+      const transition = { to: { queryParams: { lang: 'fr' } } };
+      const route = this.owner.lookup('route:application');
 
-        route.set('intl', intlStub);
-        route.set('currentDomain', currentDomainStub);
-        route.set('dayjs', dayjsStub);
+      sinon.stub(route.featureToggles, 'load');
+      route.featureToggles.load.resolves();
 
-        // when
-        await route.handleLocale('fr');
+      sinon.stub(route.session, 'handleLocale');
+      route.session.handleLocale.resolves();
 
-        // then
-        assert.expect(0);
-        sinon.assert.calledWith(intlSetLocaleStub, ['fr', 'fr']);
-        sinon.assert.calledWith(dayjsSetLocaleStub, 'fr');
+      // when
+      await route.beforeModel(transition);
+
+      // then
+      sinon.assert.calledWith(route.session.handleLocale, {
+        isFranceDomain: true,
+        localeFromQueryParam: 'fr',
+        userLocale: undefined,
       });
+      assert.ok(true);
     });
   });
 });

--- a/certif/tests/unit/services/current-domain_test.js
+++ b/certif/tests/unit/services/current-domain_test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+const FRANCE_TLD = 'fr';
+const INTERNATIONAL_TLD = 'org';
+
+module('Unit | Service | currentDomain', function (hooks) {
+  setupTest(hooks);
+
+  module('#isFranceDomain', function () {
+    test('returns true when TLD is the France domain (.fr)', function (assert) {
+      // given
+      const service = this.owner.lookup('service:currentDomain');
+      service.getExtension = sinon.stub().returns(FRANCE_TLD);
+
+      // when
+      const isFranceDomain = service.isFranceDomain;
+
+      // then
+      assert.true(isFranceDomain);
+    });
+
+    test('returns false when TLD is the international domain (.org)', function (assert) {
+      // given
+      const service = this.owner.lookup('service:currentDomain');
+      service.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
+
+      // when
+      const isFranceDomain = service.isFranceDomain;
+
+      // then
+      assert.false(isFranceDomain);
+    });
+  });
+});

--- a/certif/tests/unit/services/session_test.js
+++ b/certif/tests/unit/services/session_test.js
@@ -1,0 +1,309 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+import Service from '@ember/service';
+
+const DEFAULT_LOCALE = 'fr';
+const FRENCH_INTERNATIONAL_LOCALE = 'fr';
+const FRENCH_FRANCE_LOCALE = 'fr-FR';
+
+module('Unit | Service | session', function (hooks) {
+  setupTest(hooks);
+
+  let routerService;
+  let sessionService;
+  let localeService;
+
+  hooks.beforeEach(function () {
+    routerService = this.owner.lookup('service:router');
+    routerService.transitionTo = sinon.stub();
+
+    sessionService = this.owner.lookup('service:session');
+    sessionService.currentUser = { load: sinon.stub(), certificationPointOfContact: null };
+
+    localeService = this.owner.lookup('service:locale');
+    Object.assign(localeService, {
+      setLocaleCookie: sinon.stub(),
+      hasLocaleCookie: sinon.stub(),
+    });
+  });
+
+  module('#handleAuthentication', function () {
+    test('calls handleLocale', async function (assert) {
+      // given
+      class UrlStub extends Service {
+        get isFranceDomain() {
+          return true;
+        }
+      }
+      this.owner.register('service:url', UrlStub);
+
+      sessionService.currentUser = {
+        load: sinon.stub(),
+        certificationPointOfContact: { isMemberOfACertificationCenter: false },
+      };
+      sessionService.handleLocale = sinon.stub();
+
+      // when
+      await sessionService.handleAuthentication();
+
+      // then
+      sinon.assert.called(sessionService.handleLocale);
+      assert.ok(true);
+    });
+  });
+
+  module('#handleLocale', function () {
+    module('when domain is .fr', function () {
+      module('when there is no cookie locale', function () {
+        test('adds a cookie locale with "fr-FR" as value', async function (assert) {
+          // given
+          localeService.hasLocaleCookie.returns(false);
+
+          // when
+          const isFranceDomain = true;
+          const localeFromQueryParam = undefined;
+          const userLocale = undefined;
+          await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+          // then
+          sinon.assert.calledWith(localeService.setLocaleCookie, FRENCH_FRANCE_LOCALE);
+          assert.ok(true);
+        });
+      });
+
+      module('when there is a cookie locale', function () {
+        test('does not update cookie locale', async function (assert) {
+          // given
+          localeService.hasLocaleCookie.returns(true);
+
+          // when
+          const isFranceDomain = true;
+          const localeFromQueryParam = undefined;
+          const userLocale = undefined;
+          await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+          // then
+          sinon.assert.notCalled(localeService.setLocaleCookie);
+          assert.ok(true);
+        });
+      });
+
+      module('when no lang query param', function () {
+        module('when user is not loaded', function () {
+          test('sets the locale to be French international in every case', async function (assert) {
+            // given
+            sessionService._setLocale = sinon.stub();
+
+            // when
+            const isFranceDomain = true;
+            const localeFromQueryParam = undefined;
+            const userLocale = undefined;
+            await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+            // then
+            sinon.assert.calledWith(sessionService._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            assert.ok(true);
+          });
+        });
+
+        module('when user is loaded', function () {
+          test('sets the locale to be French international in every case', async function (assert) {
+            // given
+            sessionService._setLocale = sinon.stub();
+
+            // when
+            const isFranceDomain = true;
+            const localeFromQueryParam = undefined;
+            const userLocale = 'user’s lang';
+            await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+            // then
+            sinon.assert.calledWith(sessionService._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            assert.ok(true);
+          });
+        });
+      });
+
+      module('when a lang query param is present', function () {
+        module('when user is not loaded', function () {
+          test('sets the locale to be French international in every case', async function (assert) {
+            // given
+            sessionService._setLocale = sinon.stub();
+
+            // when
+            const isFranceDomain = true;
+            const localeFromQueryParam = 'en';
+            const userLocale = undefined;
+            await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+            // then
+            sinon.assert.calledWith(sessionService._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            assert.ok(true);
+          });
+        });
+
+        module('when user is loaded', function () {
+          test('sets the locale to be French international in every case', async function (assert) {
+            // given
+            sessionService._setLocale = sinon.stub();
+
+            // when
+            const isFranceDomain = true;
+            const localeFromQueryParam = 'en';
+            const userLocale = 'user’s lang';
+            await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+            // then
+            sinon.assert.calledWith(sessionService._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            assert.ok(true);
+          });
+        });
+      });
+    });
+
+    module('when domain is .org', function () {
+      test('does not set the cookie locale', async function (assert) {
+        // given
+        localeService.hasLocaleCookie.returns(false);
+
+        // when
+        const isFranceDomain = false;
+        const localeFromQueryParam = undefined;
+        const userLocale = undefined;
+        await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+        // then
+        sinon.assert.notCalled(localeService.setLocaleCookie);
+        assert.ok(true);
+      });
+
+      module('when no lang query param', function () {
+        module('when user is not loaded', function () {
+          test('sets the default locale', async function (assert) {
+            // given
+            sessionService._setLocale = sinon.stub();
+
+            // when
+            const isFranceDomain = false;
+            const localeFromQueryParam = undefined;
+            const userLocale = undefined;
+            await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+            // then
+            sinon.assert.calledWith(sessionService._setLocale, DEFAULT_LOCALE);
+            assert.ok(true);
+          });
+        });
+
+        module('when user is loaded', function () {
+          test('sets the locale to the user’s lang', async function (assert) {
+            // given
+            sessionService._setLocale = sinon.stub();
+
+            // when
+            const isFranceDomain = false;
+            const localeFromQueryParam = undefined;
+            const userLocale = 'en';
+            await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+            // then
+            sinon.assert.calledWith(sessionService._setLocale, 'en');
+            assert.ok(true);
+          });
+        });
+      });
+
+      module('when a lang query param is present', function () {
+        module('when the lang query param is invalid', function () {
+          module('when user is not loaded', function () {
+            test('sets the default locale', async function (assert) {
+              // given
+              sessionService._setLocale = sinon.stub();
+
+              // when
+              const isFranceDomain = false;
+              const localeFromQueryParam = 'an invalid locale';
+              const userLocale = undefined;
+              await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+              // then
+              sinon.assert.calledWith(sessionService._setLocale, DEFAULT_LOCALE);
+              assert.ok(true);
+            });
+          });
+
+          module('when user is loaded', function () {
+            test('sets the locale to the user’s lang', async function (assert) {
+              // given
+              sessionService._setLocale = sinon.stub();
+
+              // when
+              const isFranceDomain = false;
+              const localeFromQueryParam = 'an invalid locale';
+              const userLocale = 'en';
+              await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+              // then
+              sinon.assert.calledWith(sessionService._setLocale, 'en');
+              assert.ok(true);
+            });
+          });
+        });
+
+        module('when the lang query param is valid', function () {
+          module('when user is not loaded', function () {
+            test('sets the locale to the lang query param', async function (assert) {
+              // given
+              sessionService._setLocale = sinon.stub();
+
+              // when
+              const isFranceDomain = false;
+              const localeFromQueryParam = 'en';
+              const userLocale = undefined;
+              await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+              // then
+              sinon.assert.calledWith(sessionService._setLocale, 'en');
+              assert.ok(true);
+            });
+          });
+
+          module('when user is loaded', function () {
+            test('sets the locale to the lang query param which wins over', async function (assert) {
+              // given
+              sessionService._setLocale = sinon.stub();
+
+              // when
+              const isFranceDomain = false;
+              const localeFromQueryParam = 'en';
+              const userLocale = 'fr';
+              await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+              // then
+              sinon.assert.calledWith(sessionService._setLocale, 'en');
+              assert.ok(true);
+            });
+          });
+        });
+      });
+    });
+  });
+
+  module('#_setLocale', function () {
+    test('calls intl and dayjs services', async function (assert) {
+      // given
+      sessionService.intl = { setLocale: sinon.stub() };
+      sessionService.dayjs = { setLocale: sinon.stub(), self: { locale: sinon.stub() } };
+
+      // when
+      await sessionService._setLocale('some locale');
+
+      // then
+      sinon.assert.calledWith(sessionService.intl.setLocale, ['some locale', 'fr']);
+      sinon.assert.calledWith(sessionService.dayjs.setLocale, 'some locale');
+      sinon.assert.calledWith(sessionService.dayjs.self.locale, 'some locale');
+      assert.ok(true);
+    });
+  });
+});

--- a/certif/tests/unit/services/url_test.js
+++ b/certif/tests/unit/services/url_test.js
@@ -3,6 +3,9 @@ import { setupTest } from 'ember-qunit';
 import setupIntl from '../../helpers/setup-intl';
 import sinon from 'sinon';
 
+const FRANCE_TLD = 'fr';
+const INTERNATIONAL_TLD = 'org';
+
 module('Unit | Service | url', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks);
@@ -12,7 +15,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedDataProtectionPolicyUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
-      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+      service.currentDomain.getExtension = sinon.stub().returns(FRANCE_TLD);
 
       // when
       const dataProtectionPolicyUrl = service.dataProtectionPolicyUrl;
@@ -25,7 +28,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedDataProtectionPolicyUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
       service.intl = { t: sinon.stub().returns('en') };
 
       // when
@@ -39,7 +42,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedDataProtectionPolicyUrl = 'https://pix.org/politique-protection-donnees-personnelles-app';
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
       service.intl = { t: sinon.stub().returns('fr') };
 
       // when
@@ -55,7 +58,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
-      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+      service.currentDomain.getExtension = sinon.stub().returns(FRANCE_TLD);
 
       // when
       const cguUrl = service.cguUrl;
@@ -68,7 +71,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.org/en-gb/terms-and-conditions';
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
       service.intl = { t: sinon.stub().returns('en') };
 
       // when
@@ -82,7 +85,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.org/conditions-generales-d-utilisation';
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
       service.intl = { t: sinon.stub().returns('fr') };
 
       // when
@@ -98,7 +101,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedForgottenPasswordUrl = 'https://app.pix.fr/mot-de-passe-oublie';
-      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+      service.currentDomain.getExtension = sinon.stub().returns(FRANCE_TLD);
 
       // when
       const forgottenPasswordUrl = service.forgottenPasswordUrl;
@@ -111,7 +114,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedForgottenPasswordUrl = 'https://app.pix.org/mot-de-passe-oublie?lang=en';
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
       service.intl = { t: sinon.stub().returns('en') };
 
       // when
@@ -125,7 +128,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedForgottenPasswordUrl = 'https://app.pix.org/mot-de-passe-oublie';
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
       service.intl = { t: sinon.stub().returns('fr') };
 
       // when
@@ -141,7 +144,7 @@ module('Unit | Service | url', function (hooks) {
       test('should return "pix.fr" url', function (assert) {
         // given
         const service = this.owner.lookup('service:url');
-        service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+        service.currentDomain.getExtension = sinon.stub().returns(FRANCE_TLD);
 
         // when
         const legalNoticeUrl = service.legalNoticeUrl;
@@ -156,7 +159,7 @@ module('Unit | Service | url', function (hooks) {
         test('should return "pix.org/en-gb" url', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
-          service.currentDomain = { getExtension: sinon.stub().returns('org') };
+          service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
           service.intl = { t: sinon.stub().returns('en') };
 
           // when
@@ -171,7 +174,7 @@ module('Unit | Service | url', function (hooks) {
         test('should return "pix.org/fr" url', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
-          service.currentDomain = { getExtension: sinon.stub().returns('org') };
+          service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
           service.intl = { t: sinon.stub().returns('fr') };
 
           // when
@@ -189,7 +192,7 @@ module('Unit | Service | url', function (hooks) {
       test('should return "pix.fr" url', function (assert) {
         // given
         const service = this.owner.lookup('service:url');
-        service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+        service.currentDomain.getExtension = sinon.stub().returns(FRANCE_TLD);
 
         // when
         const accessibilityUrl = service.accessibilityUrl;
@@ -204,7 +207,7 @@ module('Unit | Service | url', function (hooks) {
         test('should return "pix.org/en-gb" url', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
-          service.currentDomain = { getExtension: sinon.stub().returns('org') };
+          service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
           service.intl = { t: sinon.stub().returns('en') };
 
           // when
@@ -219,7 +222,7 @@ module('Unit | Service | url', function (hooks) {
         test('should return "pix.org/fr" url', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
-          service.currentDomain = { getExtension: sinon.stub().returns('org') };
+          service.currentDomain.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
           service.intl = { t: sinon.stub().returns('fr') };
 
           // when


### PR DESCRIPTION
## :unicorn: Problème

Quand un utilisateur se connecte sur certif.pix.org le site web n'est pas dans la langue que l'utilisateur a configurée dans son compte. On souhaite que l'application Pix Certif soit traduite dans la langue que l'utilisateur a configurée dans son compte.

On rappelle ci-dessous la règle de priorité de la lang/locale des différents éléments.

**Règle de priorité** : `lang` utilisateur < `lang` query param < `lang` domaine `.fr`

## :robot: Proposition

On fait « remonter » la `lang` de la BDD jusque dans le modèle `CertificationPointOfContact` du front.

## :rainbow: Remarques

Implémentation : L'implémentation proposée est basée sur le fait que tous les utilisateurs ont obligatoirement la colonne `lang` remplie dans la table `users` comme l'exige le schéma de la BDD. Faire une requête en production pour s'assurer que c'est bien le cas.

Nommage dans le code : _TLD_ veut dire [Top-level domain](https://en.wikipedia.org/wiki/Top-level_domain), _domaine de premier niveau_ en français. Et donc la constante `FRANCE_TLD = 'fr'` correspond au _domaine de premier niveau_ pour la France.

## :100: Pour tester

1. Choisir un utilisateur ayant accès à Pix Certif, par exemple `certifsco@example.net`
2. Se connecter sur Pix App **.org** https://app-pr5948.review.pix.org/
3. Aller dans « Mon compte »
4. Changer la langue de « Français » à « Anglais »
5. Aller sur Pix Certif **.fr** https://certif-pr5948.review.pix.fr/connexion puis avec le même URL mais en passant en plus le paramètre `?lang=en`  https://certif-pr5948.review.pix.fr/connexion?lang=en et constater que dans les deux cas le domaine est l'élément le plus prioritaire pour la sélection de la langue d'affichage, c'est à dire que le site web est toujours en français peu importe la présence du paramètre `lang`
6. Se connecter sur Pix Certif **.fr** https://certif-pr5948.review.pix.fr/ avec le même user que précédemment choisi et constater que le domaine est l'élément le plus prioritaire pour la sélection de la langue d'affichage, c'est à dire que le site web est toujours en français peu importe que l'utilisateur soit connecté ou non
7. Aller sur Pix Certif **.org**  https://certif-pr5948.review.pix.org/ sans être connecté et constater que le site web est en français par défaut
8. Se connecter sur Pix Certif **.org**  https://certif-pr5948.review.pix.org/ avec le même user que précédemment choisi et constater que le site web passe en anglais, qui est la `lang` de l'utilisateur
9. Aller sur Pix Certif **.org** https://certif-pr5948.review.pix.org/ avec l'utilisateur toujours connecté en faisant varier les valeurs du paramètre `lang`, en mettant alternativement `?lang=fr` https://certif-pr5948.review.pix.org/?lang=fr et `?lang=en` https://certif-pr5948.review.pix.org/?lang=en et constater que le query param est pris en compte prioritairement à la langue de l'utilisateur
10. Recharger la page de Pix Certif **.org**  https://certif-pr5948.review.pix.org/ avec l'utilisateur toujours connecté et constater que le site web s'affiche en anglais, qui est la `lang` de l'utilisateur, c'est à dire que le query param qui était « mémorisé » dans l'application web Pix Certif pour la précédente visite du site web est oublié et que c'est maintenant la `lang` de l'utilisateur qui est prise en compte
11. Vérifier qu'une valeur invalide pour `lang`, c'est à dire autre que `fr` ou `en`, ne fait jamais planter l'application Ember Pix Certif https://certif-pr5948.review.pix.fr/?lang=invalid-value  https://certif-pr5948.review.pix.org/?lang=invalid-value : ouvrir la console et constater qu'il n'y a pas d'erreur et on doit pouvoir naviguer normalement sans que certaines actions soient impossibles