### PR TITLE
[FEATURE] Améliorer l'affichage du nom de l'organisation dans le menu sur Pix Orga (PIX-7662)

### DIFF
--- a/orga/app/styles/components/layout/user-logged-menu.scss
+++ b/orga/app/styles/components/layout/user-logged-menu.scss
@@ -38,7 +38,6 @@
 
   &__text > *:last-child {
     font-weight: normal;
-    font-size: 0.8125rem;
   }
 
   &__chevron {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -122,7 +122,7 @@
       },
       "loader": "Chargement des proportions par statut",
       "title": "Statuts",
-      "screen-reader-only-title": "Détail par statut"
+      "a11y-title": "Détail par statut"
     },
     "participants-by-day": {
       "labels-a11y": {


### PR DESCRIPTION
## :unicorn: Problème
Le titre contenant le nom de l'organisation sélectionné n'était pas très lisible

## :robot: Proposition
Augmenter la taille de la police afin de résoudre ce problème

## :rainbow: Remarques
Aligner la clé de trad fr/en du titre des charts afin que la même soit utilisé dans le hbs et les json .
## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
