### PR TITLE
[FEATURE] Affichage des contenus formatifs liés à un profil cible sur Pix Admin (PIX-7392).

### DIFF
--- a/admin/app/adapters/training-summary.js
+++ b/admin/app/adapters/training-summary.js
@@ -2,4 +2,13 @@ import ApplicationAdapter from './application';
 
 export default class TrainingSummaryAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
+
+  urlForQuery(query) {
+    if (query.targetProfileId) {
+      const targetProfileId = query.targetProfileId;
+      delete query.targetProfileId;
+      return `${this.host}/${this.namespace}/target-profiles/${targetProfileId}/training-summaries`;
+    }
+    return super.urlForQuery(...arguments);
+  }
 }

--- a/admin/app/components/target-profiles/target-profile.hbs
+++ b/admin/app/components/target-profiles/target-profile.hbs
@@ -109,6 +109,14 @@
     <LinkTo @route="authenticated.target-profiles.target-profile.insights" @model={{@model}} class="navbar-item">
       Clés de lecture
     </LinkTo>
+    <LinkTo
+      @route="authenticated.target-profiles.target-profile.training-summaries"
+      @model={{@model}}
+      class="navbar-item"
+      aria-label="Contenus formatifs du profil cible"
+    >
+      Contenus formatifs
+    </LinkTo>
   </nav>
 
   {{yield}}

--- a/admin/app/components/target-profiles/training-summaries.hbs
+++ b/admin/app/components/target-profiles/training-summaries.hbs
@@ -1,0 +1,7 @@
+<section class="page-section">
+  <header class="page-section__header">
+    <h2 class="page-section__title">Contenus Formatifs</h2>
+  </header>
+
+  <Trainings::ListSummaryItems @summaries={{@trainingSummaries}} />
+</section>

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -32,6 +32,7 @@ export default class TargetProfile extends Model {
 
   @hasMany('badge') badges;
   @hasMany('stage') stages;
+  @hasMany('training-summary') trainingSummaries;
 
   @attr() isNewFormat;
   @hasMany('old-area') oldAreas;

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -103,6 +103,7 @@ Router.map(function () {
         this.route('stages', function () {
           this.route('stage', { path: '/:stage_id' });
         });
+        this.route('training-summaries');
       });
     });
 

--- a/admin/app/routes/authenticated/target-profiles/target-profile/training-summaries.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/training-summaries.js
@@ -1,0 +1,45 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import isEmpty from 'lodash/isEmpty';
+
+export default class TargetProfileTrainingsRoute extends Route {
+  @service accessControl;
+  @service notifications;
+  @service store;
+
+  queryParams = {
+    pageNumber: { refreshModel: true },
+    pageSize: { refreshModel: true },
+  };
+
+  beforeModel() {
+    this.accessControl.restrictAccessTo(['isSuperAdmin', 'isSupport', 'isMetier'], 'authenticated');
+  }
+
+  async model(params) {
+    const targetProfile = this.modelFor('authenticated.target-profiles.target-profile');
+    let trainingSummaries;
+
+    try {
+      trainingSummaries = await this.store.query('training-summary', {
+        targetProfileId: targetProfile.id,
+        page: {
+          number: params.pageNumber,
+          size: params.pageSize,
+        },
+      });
+    } catch (errorResponse) {
+      if (!isEmpty(errorResponse)) {
+        errorResponse.errors.forEach((error) => this.notifications.error(error.detail));
+      }
+      return [];
+    }
+    return { targetProfile, trainingSummaries };
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.set('pageNumber', null);
+    }
+  }
+}

--- a/admin/app/templates/authenticated/target-profiles/target-profile/training-summaries.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile/training-summaries.hbs
@@ -1,0 +1,2 @@
+{{page-title "Profil " @model.targetProfile.id " Contenus formatifs | Pix Admin" replace=true}}
+<TargetProfiles::TrainingSummaries @trainingSummaries={{@model.trainingSummaries}} />

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -298,6 +298,7 @@ export default function () {
   this.put('/admin/target-profiles/:id/outdate', outdate);
   this.post('/admin/target-profiles/:id/badges', createBadge);
   this.put('/admin/target-profiles/:id/simplified-access', markTargetProfileAsSimplifiedAccess);
+  this.get('/admin/target-profiles/:id/training-summaries', findPaginatedTrainingSummaries);
 
   this.get('/admin/target-profile-summaries', findPaginatedFilteredTargetProfileSummaries);
 

--- a/admin/mirage/handlers/trainings.js
+++ b/admin/mirage/handlers/trainings.js
@@ -1,7 +1,14 @@
 import { getPaginationFromQueryParams, applyPagination } from './pagination-utils';
 
 function findPaginatedTrainingSummaries(schema, request) {
-  const trainingSummaries = schema.trainingSummaries.all().models;
+  let trainingSummaries = schema.trainingSummaries.all().models;
+
+  if (request.params.id) {
+    const targetProfileId = parseInt(request.params.id, 10);
+    trainingSummaries = trainingSummaries.filter((trainingSummary) => {
+      return trainingSummary.targetProfileIds.includes(targetProfileId);
+    });
+  }
 
   const queryParams = request.queryParams;
 

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/training-summaries_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/training-summaries_test.js
@@ -1,0 +1,95 @@
+import { clickByName, visit } from '@1024pix/ember-testing-library';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { module, test } from 'qunit';
+import { authenticateAdminMemberWithRole } from '../../../../helpers/test-init';
+import { currentURL } from '@ember/test-helpers';
+
+module('Acceptance | Target Profile Training Summaries', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('Access restriction stuff', function () {
+    module('When admin member is not logged in', function () {
+      test('it should not be accessible by an unauthenticated user', async function (assert) {
+        // when
+        await visit('/target-profiles/1/training-summaries');
+
+        // then
+        assert.strictEqual(currentURL(), '/login');
+      });
+    });
+
+    module('When admin member is logged in', function () {
+      module('when admin member has role "SUPER_ADMIN", "SUPPORT" or "METIER"', function (hooks) {
+        hooks.beforeEach(async function () {
+          await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+          server.create('training', { id: 456, title: 'My training' });
+          server.create('target-profile', { id: 1, trainingsSummaries: [456], name: 'Mon super profil cible' });
+        });
+
+        test('it should be accessible for an authenticated user', async function (assert) {
+          // when
+          await visit('/target-profiles/1/training-summaries');
+
+          // then
+          assert.strictEqual(currentURL(), '/target-profiles/1/training-summaries');
+        });
+      });
+
+      module('when admin member has role "CERTIF"', function () {
+        test('it should be redirected to Organizations page', async function (assert) {
+          // given
+          await authenticateAdminMemberWithRole({ isCertif: true })(server);
+          server.create('training', { id: 456, title: 'My training' });
+          server.create('target-profile', { id: 2, trainingsSummaries: [456], name: 'Mon super profil cible' });
+
+          // when
+          await visit('/target-profiles/2/training-summaries');
+
+          // then
+          assert.strictEqual(currentURL(), '/organizations/list');
+        });
+      });
+    });
+  });
+
+  module('Target profile training summaries', function (hooks) {
+    hooks.beforeEach(async function () {
+      await authenticateAdminMemberWithRole({ isSuperAdmin: true })(server);
+      server.create('target-profile', { id: 1, name: 'Profil cible du ghetto' });
+    });
+
+    module('with multiple trainings', function (hooks) {
+      hooks.beforeEach(async function () {
+        server.create('training', { id: 456, title: 'My training', targetProfileIds: [1] });
+        server.create('training-summary', { id: 456, title: 'My training', targetProfileIds: [1] });
+        server.create('training-summary', { id: 789, title: 'My other training', targetProfileIds: [1] });
+      });
+
+      test('should list trainings', async function (assert) {
+        // then
+        const screen = await visit('/target-profiles/1');
+
+        // when
+        await clickByName('Contenus formatifs du profil cible');
+
+        // then
+        assert.dom(screen.getByText('My training')).exists();
+        assert.dom(screen.getByText('My other training')).exists();
+      });
+
+      test('it should redirect to training details on click', async function (assert) {
+        // given
+        await visit('/target-profiles/1/training-summaries');
+        await clickByName('Contenus formatifs du profil cible');
+
+        // when
+        await clickByName('My training');
+
+        // then
+        assert.deepEqual(currentURL(), '/trainings/456/triggers');
+      });
+    });
+  });
+});

--- a/admin/tests/unit/adapters/training-summary_test.js
+++ b/admin/tests/unit/adapters/training-summary_test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | TrainingSummary', function (hooks) {
+  setupTest(hooks);
+  let adapter;
+
+  hooks.beforeEach(function () {
+    adapter = this.owner.lookup('adapter:training-summary');
+  });
+
+  module('#urlForQuery', function () {
+    test('should build query url from targetProfileId', async function (assert) {
+      const query = { targetProfileId: 123 };
+      const url = await adapter.urlForQuery(query, 'training-summary');
+
+      assert.ok(url.endsWith('/api/admin/target-profiles/123/training-summaries'));
+      assert.strictEqual(query.targetProfileId, undefined);
+    });
+
+    test('should build query url', async function (assert) {
+      const url = await adapter.urlForQuery({}, 'training-summary');
+
+      assert.ok(url.endsWith('/api/admin/training-summaries'));
+    });
+  });
+});

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -156,6 +156,34 @@ exports.register = async (server) => {
       },
     },
     {
+      method: 'GET',
+      path: '/api/admin/target-profiles/{id}/training-summaries',
+      config: {
+        pre: [
+          {
+            method: (request, h) =>
+              securityPreHandlers.adminMemberHasAtLeastOneAccessOf([
+                securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+                securityPreHandlers.checkAdminMemberHasRoleSupport,
+                securityPreHandlers.checkAdminMemberHasRoleMetier,
+              ])(request, h),
+            assign: 'hasAuthorizationToAccessAdminScope',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.targetProfileId,
+          }),
+        },
+        handler: targetProfileController.findPaginatedTrainings,
+        tags: ['api', 'admin', 'target-profiles', 'trainings'],
+        notes: [
+          "- **Cette route est restreinte aux utilisateurs authentifiés ayant les droits d'accès**\n" +
+            '- Elle permet de récupérer les résumés des contenus formatifs liés au profil cible',
+        ],
+      },
+    },
+    {
       method: 'POST',
       path: '/api/admin/target-profiles',
       config: {

--- a/api/lib/application/target-profiles/target-profile-controller.js
+++ b/api/lib/application/target-profiles/target-profile-controller.js
@@ -13,6 +13,7 @@ const stageSerializer = require('../../infrastructure/serializers/jsonapi/stage-
 const targetProfileAttachOrganizationSerializer = require('../../infrastructure/serializers/jsonapi/target-profile-attach-organization-serializer.js');
 const learningContentPDFPresenter = require('./presenter/pdf/learning-content-pdf-presenter.js');
 const DomainTransaction = require('../../infrastructure/DomainTransaction.js');
+const trainingSummarySerializer = require('../../infrastructure/serializers/jsonapi/training-summary-serializer');
 
 module.exports = {
   async findPaginatedFilteredTargetProfileSummariesForAdmin(request) {
@@ -107,6 +108,17 @@ module.exports = {
 
     const stages = await usecases.findTargetProfileStages({ targetProfileId });
     return stageSerializer.serialize(stages);
+  },
+
+  async findPaginatedTrainings(request) {
+    const { page } = queryParamsUtils.extractParameters(request.query);
+    const targetProfileId = request.params.id;
+
+    const { trainings, meta } = await usecases.findPaginatedTargetProfileTrainingSummaries({
+      targetProfileId,
+      page,
+    });
+    return trainingSummarySerializer.serialize(trainings, meta);
   },
 
   async createBadge(request, h) {

--- a/api/lib/domain/usecases/find-paginated-target-profile-training-summaries.js
+++ b/api/lib/domain/usecases/find-paginated-target-profile-training-summaries.js
@@ -1,0 +1,11 @@
+module.exports = async function findPaginatedTargetProfileTrainings({ targetProfileId, page, trainingRepository }) {
+  const { trainings, pagination } = await trainingRepository.findPaginatedSummariesByTargetProfileId({
+    targetProfileId,
+    page,
+  });
+
+  return {
+    trainings,
+    meta: { pagination },
+  };
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -477,6 +477,7 @@ const findPaginatedFilteredTargetProfileSummariesForAdmin = require('./find-pagi
 const findPaginatedFilteredTutorials = require('./find-paginated-filtered-tutorials.js');
 const findPaginatedFilteredUsers = require('./find-paginated-filtered-users.js');
 const findPaginatedParticipationsForCampaignManagement = require('./find-paginated-participations-for-campaign-management.js');
+const findPaginatedTargetProfileTrainingSummaries = require('./find-paginated-target-profile-training-summaries.js');
 const findPaginatedTrainingSummaries = require('./find-paginated-training-summaries.js');
 const findPaginatedUserRecommendedTrainings = require('./find-paginated-user-recommended-trainings.js');
 const findPendingCertificationCenterInvitations = require('./find-pending-certification-center-invitations.js');
@@ -765,6 +766,7 @@ const usecasesWithoutInjectedDependencies = {
   findPaginatedFilteredTutorials,
   findPaginatedFilteredUsers,
   findPaginatedParticipationsForCampaignManagement,
+  findPaginatedTargetProfileTrainingSummaries,
   findPaginatedTrainingSummaries,
   findPaginatedUserRecommendedTrainings,
   findPendingCertificationCenterInvitations,

--- a/api/lib/infrastructure/repositories/training-repository.js
+++ b/api/lib/infrastructure/repositories/training-repository.js
@@ -45,6 +45,24 @@ async function findPaginatedSummaries({ page, domainTransaction = DomainTransact
   return { trainings, pagination };
 }
 
+async function findPaginatedSummariesByTargetProfileId({
+  targetProfileId,
+  page,
+  domainTransaction = DomainTransaction.emptyTransaction(),
+}) {
+  const knexConn = domainTransaction?.knexTransaction || knex;
+  const query = knexConn(TABLE_NAME)
+    .select('trainings.*')
+    .innerJoin('target-profile-trainings', `${TABLE_NAME}.id`, 'target-profile-trainings.trainingId')
+    .where({ 'target-profile-trainings.targetProfileId': targetProfileId })
+    .orderBy('id', 'asc');
+
+  const { results, pagination } = await fetchPage(query, page);
+
+  const trainings = results.map((training) => new TrainingSummary(training));
+  return { trainings, pagination };
+}
+
 async function findWithTriggersByCampaignParticipationIdAndLocale({
   campaignParticipationId,
   locale,
@@ -129,6 +147,7 @@ module.exports = {
   get,
   getWithTriggersForAdmin,
   findPaginatedSummaries,
+  findPaginatedSummariesByTargetProfileId,
   findWithTriggersByCampaignParticipationIdAndLocale,
   create,
   update,

--- a/api/tests/acceptance/application/target-profiles/index_test.js
+++ b/api/tests/acceptance/application/target-profiles/index_test.js
@@ -864,4 +864,43 @@ describe('Acceptance | Route | target-profiles', function () {
       expect(response.headers['content-type']).to.equal('text/json;charset=utf-8');
     });
   });
+
+  describe('GET /api/admin/target-profiles/{id}/training-summaries', function () {
+    let user;
+    let targetProfileId;
+    let training;
+
+    beforeEach(async function () {
+      targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      training = databaseBuilder.factory.buildTraining();
+      databaseBuilder.factory.buildTargetProfileTraining({ targetProfileId, trainingId: training.id });
+      user = databaseBuilder.factory.buildUser.withRole();
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return 200', async function () {
+      const options = {
+        method: 'GET',
+        url: `/api/admin/target-profiles/${targetProfileId}/training-summaries`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      const expectedData = [
+        {
+          type: 'training-summaries',
+          id: training.id.toString(),
+          attributes: {
+            title: 'title',
+          },
+        },
+      ];
+      expect(response.result.data).to.deep.equal(expectedData);
+    });
+  });
 });

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -1508,4 +1508,79 @@ describe('Unit | Application | Target Profiles | Routes', function () {
       });
     });
   });
+
+  describe('GET /api/admin/target-profiles/{id}/training-summaries', function () {
+    const method = 'GET';
+    const url = '/api/admin/target-profiles/1/training-summaries';
+
+    context('when user has role "SUPER_ADMIN", "SUPPORT" or "METIER"', function () {
+      it('should return a response with an HTTP status code 200', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .withArgs([
+            securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            securityPreHandlers.checkAdminMemberHasRoleSupport,
+            securityPreHandlers.checkAdminMemberHasRoleMetier,
+          ])
+          .callsFake(() => (request, h) => h.response(true));
+        sinon
+          .stub(targetProfileController, 'findPaginatedTrainings')
+          .callsFake((request, h) => h.response('ok').code(200));
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const { statusCode } = await httpTestServer.request(method, url);
+
+        // then
+        expect(statusCode).to.equal(200);
+      });
+
+      context('when id is not an integer', function () {
+        it('should reject request with HTTP code 400', async function () {
+          // given
+          const httpTestServer = new HttpTestServer();
+          await httpTestServer.register(moduleUnderTest);
+
+          // when
+          const { statusCode } = await httpTestServer.request(
+            method,
+            '/api/admin/target-profiles/azerty/training-summaries'
+          );
+
+          // then
+          expect(statusCode).to.equal(400);
+        });
+      });
+    });
+
+    context('when user has role "CERTIF"', function () {
+      it('should return a response with an HTTP status code 403', async function () {
+        // given
+        sinon
+          .stub(securityPreHandlers, 'adminMemberHasAtLeastOneAccessOf')
+          .withArgs([
+            securityPreHandlers.checkAdminMemberHasRoleSuperAdmin,
+            securityPreHandlers.checkAdminMemberHasRoleSupport,
+            securityPreHandlers.checkAdminMemberHasRoleMetier,
+          ])
+          .callsFake(
+            () => (request, h) =>
+              h
+                .response({ errors: new Error('forbidden') })
+                .code(403)
+                .takeover()
+          );
+        const httpTestServer = new HttpTestServer();
+        await httpTestServer.register(moduleUnderTest);
+
+        // when
+        const { statusCode } = await httpTestServer.request(method, url);
+
+        // then
+        expect(statusCode).to.equal(403);
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/find-paginated-target-profile-training-summaries_test.js
+++ b/api/tests/unit/domain/usecases/find-paginated-target-profile-training-summaries_test.js
@@ -1,0 +1,30 @@
+const { sinon, expect } = require('../../../test-helper');
+const findTargetProfileSummariesForTraining = require('../../../../lib/domain/usecases/find-paginated-target-profile-training-summaries');
+
+describe('Unit | UseCase | findPaginatedTargetProfileTrainingSummaries', function () {
+  it('should call the repository with the right arguments and return summaries', async function () {
+    // given
+    const page = Symbol('page');
+    const targetProfileId = Symbol('targetProfileId');
+    const trainingRepository = {
+      findPaginatedSummariesByTargetProfileId: sinon.stub(),
+    };
+    const response = { trainings: Symbol('trainingSummaries'), pagination: Symbol('pagination') };
+    trainingRepository.findPaginatedSummariesByTargetProfileId.resolves(response);
+
+    // when
+    const result = await findTargetProfileSummariesForTraining({
+      targetProfileId,
+      page,
+      trainingRepository,
+    });
+
+    // then
+    expect(trainingRepository.findPaginatedSummariesByTargetProfileId).to.have.been.calledWith({
+      targetProfileId,
+      page,
+    });
+    expect(result.trainings).to.equal(response.trainings);
+    expect(result.meta.pagination).to.equal(response.pagination);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il est difficile de retrouver tous les contenus formatifs liés à un profil cible.
Il faut en effet parcourir chaque contenu formatif et regarder à quel profil cible il est associé

## :robot: Proposition
Ajouter un onglet dans les profils cibles qui liste tous les contenus formatifs auquel il est lié.

![Screenshot 2023-04-07 at 16 46 39](https://user-images.githubusercontent.com/26384707/230628698-ec99de1d-9eae-4f15-baa3-fa246c5c651f.gif)

## :rainbow: Remarques

On peut voir dans la route créée que je n'utilise pas le modèle targetProfile pour récupérer ses contenus formatifs. Cela est du au fait [qu'EmberData ne sait pas gérer les relations `hasMany` paginés](https://github.com/1024pix/pix/blob/dev/docs/adr/0017-utilisation-de-hasMany-dans-Ember.md)

On peut voir dans la fonction `urlForQuery` que je supprime le paramètre `targetProfileId` en faisant `delete query.targetProfileId;`, c'est pour éviter qu'EmberData l'ajoute en queryParams comme on s'en sert déjà en params.

## :100: Pour tester
- Se connecter sur Pix Admin 
- Aller sur l'onglet profil cible
- Aller sur [le détail d'un PC](https://admin-pr5950.review.pix.fr/target-profiles/8/details)  (le 8)
- Aller dans l'onglet Contenus Formatifs 
- Constater le bon fonctionnement affichage + lien 