### PR TITLE
[BUGFIX] Traduire les domaines affichés dans l'écran de fin de parcours (PIX-7704) (PIX-7012))

### DIFF
--- a/api/lib/domain/read-models/participant-results/CompetenceResult.js
+++ b/api/lib/domain/read-models/participant-results/CompetenceResult.js
@@ -14,6 +14,7 @@ class CompetenceResult {
     this.name = competence.name;
     this.index = competence.index;
     this.areaName = area.name;
+    this.areaTitle = area.title;
     this.areaColor = area.color;
     this.totalSkillsCount = totalSkillsCount;
     this.testedSkillsCount = knowledgeElements.length;

--- a/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/participant-result-serializer.js
@@ -69,7 +69,7 @@ module.exports = {
           'name',
           'index',
           'areaColor',
-          'areaName',
+          'areaTitle',
           'masteryPercentage',
           'totalSkillsCount',
           'testedSkillsCount',

--- a/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
+++ b/api/tests/acceptance/application/users/get-user-campaign-assessment-result_test.js
@@ -118,7 +118,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
     const learningContent = [
       {
         id: 'recArea1',
-        name: 'AreaName1',
+        titleFr: 'DomaineNom1',
         color: JAFFA_COLOR,
         competences: [
           {
@@ -131,7 +131,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
       },
       {
         id: 'recArea2',
-        name: 'AreaName2',
+        titleFr: 'DomaineNom2',
         color: EMERALD_COLOR,
         competences: [
           {
@@ -160,7 +160,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
       },
       {
         id: 'recArea3',
-        name: 'AreaName3',
+        titleFr: 'DomaineNom3',
         color: WILD_STRAWBERRY_COLOR,
         competences: [
           {
@@ -308,7 +308,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
               'tested-skills-count': 0,
               'validated-skills-count': 0,
               'area-color': JAFFA_COLOR,
-              'area-name': 'AreaName1',
+              'area-title': 'DomaineNom1',
               'reached-stage': 0,
               'flash-pix-score': undefined,
             },
@@ -324,7 +324,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
               'tested-skills-count': 2,
               'validated-skills-count': 2,
               'area-color': EMERALD_COLOR,
-              'area-name': 'AreaName2',
+              'area-title': 'DomaineNom2',
               'reached-stage': 1,
               'flash-pix-score': undefined,
             },
@@ -340,7 +340,7 @@ describe('Acceptance | API | Campaign Assessment Result', function () {
               'tested-skills-count': 3,
               'validated-skills-count': 1,
               'area-color': EMERALD_COLOR,
-              'area-name': 'AreaName2',
+              'area-title': 'DomaineNom2',
               'reached-stage': 0,
               'flash-pix-score': undefined,
             },

--- a/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/participant-result-repository_test.js
@@ -18,8 +18,20 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
 
       const learningContent = {
         areas: [
-          { id: 'recArea1', name: 'area1', competenceIds: ['rec1'], color: 'colorArea1' },
-          { id: 'recArea2', name: 'area2', competenceIds: ['rec2'], color: 'colorArea2' },
+          {
+            id: 'recArea1',
+            name: 'area1',
+            title_i18n: { fr: 'domaine1' },
+            competenceIds: ['rec1'],
+            color: 'colorArea1',
+          },
+          {
+            id: 'recArea2',
+            name: 'area2',
+            title_i18n: { fr: 'domaine2' },
+            competenceIds: ['rec2'],
+            color: 'colorArea2',
+          },
         ],
         competences: [
           {
@@ -540,6 +552,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         name: 'comp1Fr',
         index: '1.1',
         areaName: 'area1',
+        areaTitle: 'domaine1',
         areaColor: 'colorArea1',
         testedSkillsCount: 2,
         totalSkillsCount: 2,
@@ -553,6 +566,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
         name: 'comp2Fr',
         index: '2.1',
         areaName: 'area2',
+        areaTitle: 'domaine2',
         areaColor: 'colorArea2',
         testedSkillsCount: 2,
         totalSkillsCount: 2,
@@ -1084,6 +1098,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
             name: 'comp1Fr',
             index: '1.1',
             areaName: 'area1',
+            areaTitle: 'domaine1',
             areaColor: 'colorArea1',
             testedSkillsCount: 0,
             totalSkillsCount: 2,
@@ -1097,6 +1112,7 @@ describe('Integration | Repository | ParticipantResultRepository', function () {
             name: 'comp2Fr',
             index: '2.1',
             areaName: 'area2',
+            areaTitle: 'domaine2',
             areaColor: 'colorArea2',
             testedSkillsCount: 0,
             totalSkillsCount: 3,

--- a/api/tests/unit/domain/read-models/participant-results/CompetenceResult_test.js
+++ b/api/tests/unit/domain/read-models/participant-results/CompetenceResult_test.js
@@ -11,7 +11,8 @@ describe('Unit | Domain | Read-Models | ParticipantResult | CompetenceResult', f
     });
 
     const area = domainBuilder.buildArea({
-      name: 'Domaine1',
+      name: 'DomaineNom1',
+      title: 'DomaineTitre1',
       color: 'Couleur1',
     });
 
@@ -39,7 +40,8 @@ describe('Unit | Domain | Read-Models | ParticipantResult | CompetenceResult', f
       id: 'rec1',
       name: 'C1',
       index: '1.1',
-      areaName: 'Domaine1',
+      areaName: 'DomaineNom1',
+      areaTitle: 'DomaineTitre1',
       areaColor: 'Couleur1',
       testedSkillsCount: 2,
       totalSkillsCount: 3,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/participant-result-serializer_test.js
@@ -47,7 +47,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
             index: '1.1',
           }),
           area: domainBuilder.buildArea({
-            name: 'AreaName',
+            title: 'DomaineNom',
             color: 'AreaColor',
           }),
           targetedSkillIds: ['skill1', 'skill2'],
@@ -193,7 +193,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
           {
             attributes: {
               'area-color': 'AreaColor',
-              'area-name': 'AreaName',
+              'area-title': 'DomaineNom',
               index: '1.1',
               name: 'Competence1',
               'mastery-percentage': 50,
@@ -243,7 +243,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
               area: domainBuilder.buildArea({
                 id: 'area1',
                 color: 'area1Color',
-                name: 'AreaName1',
+                title: 'DomaineNom1',
               }),
               pixScore: 300.3438957781,
             },
@@ -257,7 +257,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
               area: domainBuilder.buildArea({
                 id: 'area2',
                 color: 'area2Color',
-                name: 'AreaName2',
+                title: 'DomaineNom2',
               }),
               pixScore: 74,
             },
@@ -288,7 +288,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
             name: 'competence 1',
             index: '1.1',
             'area-color': 'area1Color',
-            'area-name': 'AreaName1',
+            'area-title': 'DomaineNom1',
             'mastery-percentage': 0,
             'total-skills-count': 1,
             'tested-skills-count': 0,
@@ -304,7 +304,7 @@ describe('Unit | Serializer | JSON API | participant-result-serializer', functio
             name: 'competence 2',
             index: '2.1',
             'area-color': 'area2Color',
-            'area-name': 'AreaName2',
+            'area-title': 'DomaineNom2',
             'mastery-percentage': 0,
             'total-skills-count': 2,
             'tested-skills-count': 0,

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -173,7 +173,7 @@ export default class SkillReview extends Component {
   get competenceResultsGroupedByAreas() {
     const competenceResults = this.args.model.campaignParticipationResult.get('competenceResults').toArray();
     return competenceResults.reduce((acc, competenceResult) => {
-      const currentArea = competenceResult.areaName;
+      const currentArea = competenceResult.areaTitle;
       const competence = {
         name: competenceResult.name,
         reachedStage: competenceResult.reachedStage,
@@ -183,7 +183,7 @@ export default class SkillReview extends Component {
         acc[currentArea].competences.push(competence);
       } else {
         acc[currentArea] = {
-          areaName: currentArea,
+          areaTitle: currentArea,
           areaColor: competenceResult.areaColor,
           competences: [competence],
         };

--- a/mon-pix/app/models/competence-result.js
+++ b/mon-pix/app/models/competence-result.js
@@ -3,7 +3,7 @@ import Model, { belongsTo, attr } from '@ember-data/model';
 export default class CompetenceResult extends Model {
   // attributes
   @attr('string') areaColor;
-  @attr('string') areaName;
+  @attr('string') areaTitle;
   @attr('string') name;
   @attr('string') index;
   @attr('number') masteryPercentage;

--- a/mon-pix/tests/acceptance/skill-review_test.js
+++ b/mon-pix/tests/acceptance/skill-review_test.js
@@ -198,7 +198,7 @@ module('Acceptance | Campaigns | Campaigns Result', function (hooks) {
         test('should display reached stage and competence reached stage', async function (assert) {
           // given
           const competenceResult = server.create('competence-result', {
-            areaName: 'area1',
+            areaTitle: 'area1',
             name: competenceResultName,
             masteryPercentage: 85,
             reachedStage: 2,

--- a/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/assessment/skill-review_test.js
@@ -682,21 +682,21 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
       component.args.model.campaignParticipationResult.competenceResults = [
         {
           areaColor: 'areaColor1',
-          areaName: 'area1',
+          areaTitle: 'area1',
           name: 'competence1',
           masteryRate: '33',
           reachedStage: 1,
         },
         {
           areaColor: 'areaColor1',
-          areaName: 'area1',
+          areaTitle: 'area1',
           name: 'competence2',
           masteryRate: '50',
           reachedStage: 2,
         },
         {
           areaColor: 'areaColor2',
-          areaName: 'area2',
+          areaTitle: 'area2',
           name: 'competence3',
           masteryRate: '60',
           reachedStage: 3,
@@ -710,7 +710,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
       assert.deepEqual(competenceResults, {
         area1: {
           areaColor: 'areaColor1',
-          areaName: 'area1',
+          areaTitle: 'area1',
           competences: [
             {
               masteryRate: '33',
@@ -726,7 +726,7 @@ module('Unit | component | Campaigns | Evaluation | Skill Review', function (hoo
         },
         area2: {
           areaColor: 'areaColor2',
-          areaName: 'area2',
+          areaTitle: 'area2',
           competences: [
             {
               masteryRate: '60',


### PR DESCRIPTION
## :unicorn: Problèmes
- Les domaines affichés dans l'écran de fin de parcours ne sont pas traduits
- On ne souhaite pas afficher le numéro de domaine

![image](https://user-images.githubusercontent.com/5855339/230641568-4db576ba-eb70-4fb6-8102-9fcc160d3a0d.png)

## :robot: Proposition
Utiliser le champ `title` des `area` plutôt que le `name`.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que les domaines affichés dans l'écran de fin de parcours (Profil Cible avec paliers) sont : 
- sans numéro
- traduits selon la langue de l'utilisateur
