### PR TITLE
[BUGFIX] Ne pas bloquer l'utilisateur sur le type du fichier dans l'import en masse de sessions sur Pix Certif (PIX-7708)

### DIFF
--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -63,10 +63,6 @@ export default class ImportController extends Controller {
       if (!this.file) {
         return;
       }
-      if (this.file.type !== 'text/csv') {
-        this.notifications.error(this.intl.t(`pages.sessions.import.step-one.errors.incorrect-type-file`));
-        return;
-      }
       const {
         sessionsCount,
         sessionsWithoutCandidatesCount,

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -365,6 +365,23 @@ module('Acceptance | Session Import', function (hooks) {
           test('it should display an error notification', async function (assert) {
             //given
             const file = new Blob(['foo']);
+            this.server.post(
+              '/certification-centers/:id/sessions/validate-for-mass-import',
+              () =>
+                new Response(
+                  422,
+                  { some: 'header' },
+                  {
+                    errors: [
+                      {
+                        code: 'CSV_HEADERS_NOT_VALID',
+                        status: '422',
+                        title: 'Unprocessable Entity',
+                      },
+                    ],
+                  }
+                )
+            );
 
             // when
             screen = await visit('/sessions/import');
@@ -374,9 +391,7 @@ module('Acceptance | Session Import', function (hooks) {
             await click(importButton);
 
             // then
-            assert
-              .dom(screen.getByText('Le format du fichier est incorrect, seul le format .csv est accepté'))
-              .exists();
+            assert.dom(screen.getByText('Le modèle a été altéré, merci de le télécharger à nouveau')).exists();
           });
 
           test('it should not go to step two', async function (assert) {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -209,8 +209,7 @@
           "errors": {
             "download": "Une erreur s'est produite pendant le téléchargement",
             "CSV_DATA_REQUIRED": "Le modèle importé n'a pas été rempli, merci de le compléter avant de l'importer à nouveau",
-            "CSV_HEADERS_NOT_VALID": "Le modèle a été altéré, merci de le télécharger à nouveau",
-            "incorrect-type-file": "Le format du fichier est incorrect, seul le format .csv est accepté"
+            "CSV_HEADERS_NOT_VALID": "Le modèle a été altéré, merci de le télécharger à nouveau"
           },
           "instructions": {
             "creation": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -209,8 +209,7 @@
           "errors": {
             "download": "Une erreur s'est produite pendant le téléchargement",
             "CSV_DATA_REQUIRED": "Le modèle importé n'a pas été rempli, merci de le compléter avant de l'importer à nouveau",
-            "CSV_HEADERS_NOT_VALID": "Le modèle a été altéré, merci de le télécharger à nouveau",
-            "incorrect-type-file": "Le format du fichier est incorrect, seul le format .csv est accepté"
+            "CSV_HEADERS_NOT_VALID": "Le modèle a été altéré, merci de le télécharger à nouveau"
           },
           "instructions": {
             "title": "Comment ça marche ?",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement dans l'import en masse de session sur Pix Certif, lorsqu'un utilisateur tente d'importer un fichier qui n'est pas de type "text/csv", un message d'erreur apparaît. (introduit dans ce ticket https://github.com/1024pix/pix/pull/5933)

En effet, comme le fichier attendu est un csv, le type de ce fichier est "text/csv" (d'après la liste [des types MIME communs](https://developer.mozilla.org/fr/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types))

Or lors d'un test fonctionnel avec un fichier provenant d'un excel, on s'est aperçu que le type du fichier (exporté pourtant en csv) était un `"application/vnd.ms-excel"` sur **Firefox**. Il ne passait alors pas la condition existante.

## :robot: Proposition
Retirer cette condition sur le type du fichier coté front. 
On a trouvé cette exception, il est probable qu'il en existe d'autres, il est donc risqué de garder cette condition. 


## :100: Pour tester
- Se connecter à Pix Certif avec le compte : [certifpro@example.net](mailto:certifpro@example.net)
- Cliquer sur le bouton pour importer en masse des sessions
- Ouvrir la console et retirer le `accept=".csv" `du bouton "Importer"
- Importer un fichier bidon (png..)
- Valider l'import
- Constater l'erreur suivante : Le modèle à été altéré...
- En effet le back ne vérifie pas le format du fichier mais comme ce dernier ne contient pas les colonnes attendues, il jette une erreur lié à celle-ci (est-ce qu'on s'en contente ou on cherche à traiter le format coté back ?)
