### PR TITLE
[FEATURE] Améliorer le message d'erreur lorsque le fichier d'import en masse de session est vide sur Pix Certif (PIX-7672).

### DIFF
--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -196,7 +196,7 @@ module.exports = {
 
     const parsedCsvData = await csvHelpers.parseCsvWithHeader(request.payload.path);
     if (parsedCsvData.length === 0) {
-      throw new UnprocessableEntityError('No session data in csv');
+      throw new UnprocessableEntityError('No session data in csv', 'CSV_DATA_REQUIRED');
     }
     const sessions = csvSerializer.deserializeForSessionsImport(parsedCsvData);
     const sessionMassImportReport = await usecases.validateSessions({

--- a/api/tests/unit/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/unit/application/certification-centers/certification-center-controller_test.js
@@ -561,7 +561,8 @@ describe('Unit | Controller | certifications-center-controller', function () {
 
         // then
         expect(error).to.be.instanceOf(UnprocessableEntityError);
-        expect(error.message).to.equal(`No session data in csv`);
+        expect(error.message).to.equal('No session data in csv');
+        expect(error.code).to.equal('CSV_DATA_REQUIRED');
       });
     });
   });

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -79,13 +79,16 @@ export default class ImportController extends Controller {
       this.cachedValidatedSessionsKey = cachedValidatedSessionsKey;
       this.errorReports = errorReports;
     } catch (errors) {
-      if (errors.errors[0].code === 'CSV_HEADERS_NOT_VALID') {
+      if (errors?.errors[0].code === 'CSV_HEADERS_NOT_VALID') {
         this.notifications.error(
           this.intl.t(`pages.sessions.import.step-two.blocking-errors.errors.${errors.errors[0].code}`)
         );
+      } else if (errors?.errors[0].code === 'CSV_DATA_REQUIRED') {
+        this.notifications.error(this.intl.t(`pages.sessions.import.step-one.errors.${errors.errors[0].code}`));
       } else {
         this.notifications.error(errors.errors[0].detail);
       }
+
       return;
     }
     this.isImportStepOne = false;

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -484,6 +484,31 @@ module('Acceptance | Session Import', function (hooks) {
               .exists();
           });
         });
+
+        module('when sessions validation fails with a 500 http error', function () {
+          test('it should display an error notification with the default error message', async function (assert) {
+            //given
+            const blob = new Blob(['foo']);
+            const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
+            this.server.post('/certification-centers/:id/sessions/validate-for-mass-import', () => new Response(500));
+
+            // when
+            screen = await visit('/sessions/import');
+            const input = await screen.findByLabelText('Importer le modèle complété');
+            await triggerEvent(input, 'change', { files: [file] });
+            const importButton = screen.getByRole('button', { name: 'Continuer' });
+            await click(importButton);
+
+            // then
+            assert
+              .dom(
+                screen.getByText(
+                  'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.'
+                )
+              )
+              .exists();
+          });
+        });
       });
     });
   });

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -445,6 +445,45 @@ module('Acceptance | Session Import', function (hooks) {
             assert.dom(screen.getByText('Le modèle a été altéré, merci de le télécharger à nouveau')).exists();
           });
         });
+
+        module('when the file is empty', function () {
+          test('it should display an error notification', async function (assert) {
+            //given
+            const blob = new Blob(['foo']);
+            const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
+            this.server.post(
+              '/certification-centers/:id/sessions/validate-for-mass-import',
+              () =>
+                new Response(
+                  422,
+                  { some: 'header' },
+                  {
+                    errors: [
+                      {
+                        code: 'CSV_DATA_REQUIRED',
+                      },
+                    ],
+                  }
+                )
+            );
+
+            // when
+            screen = await visit('/sessions/import');
+            const input = await screen.findByLabelText('Importer le modèle complété');
+            await triggerEvent(input, 'change', { files: [file] });
+            const importButton = screen.getByRole('button', { name: 'Continuer' });
+            await click(importButton);
+
+            // then
+            assert
+              .dom(
+                screen.getByText(
+                  "Le modèle importé n'a pas été rempli, merci de le compléter avant de l'importer à nouveau"
+                )
+              )
+              .exists();
+          });
+        });
       });
     });
   });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -209,6 +209,7 @@
           "errors": {
             "download": "Une erreur s'est produite pendant le téléchargement",
             "CSV_DATA_REQUIRED": "Le modèle importé n'a pas été rempli, merci de le compléter avant de l'importer à nouveau",
+            "CSV_HEADERS_NOT_VALID": "Le modèle a été altéré, merci de le télécharger à nouveau",
             "incorrect-type-file": "Le format du fichier est incorrect, seul le format .csv est accepté"
           },
           "instructions": {
@@ -269,8 +270,7 @@
               "SESSION_SCHEDULED_IN_THE_PAST": "Date et/ou heure indiquées antérieures à la date du jour",
               "SESSION_ID_NOT_EXISTING": "Numéro de session inexistant",
               "SESSION_ID_NOT_VALID": "Donnée du champ \"Numéro de session\" invalide",
-              "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées",
-              "CSV_HEADERS_NOT_VALID": "Le modèle a été altéré, merci de le télécharger à nouveau"
+              "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées"
             }
           },
           "non-blocking-errors": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -208,6 +208,7 @@
           },
           "errors": {
             "download": "Une erreur s'est produite pendant le téléchargement",
+            "CSV_DATA_REQUIRED": "Le modèle importé n'a pas été rempli, merci de le compléter avant de l'importer à nouveau",
             "incorrect-type-file": "Le format du fichier est incorrect, seul le format .csv est accepté"
           },
           "instructions": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -209,6 +209,7 @@
           "errors": {
             "download": "Une erreur s'est produite pendant le téléchargement",
             "CSV_DATA_REQUIRED": "Le modèle importé n'a pas été rempli, merci de le compléter avant de l'importer à nouveau",
+            "CSV_HEADERS_NOT_VALID": "Le modèle a été altéré, merci de le télécharger à nouveau",
             "incorrect-type-file": "Le format du fichier est incorrect, seul le format .csv est accepté"
           },
           "instructions": {
@@ -269,8 +270,7 @@
               "SESSION_SCHEDULED_IN_THE_PAST": "Date et/ou heure indiquées antérieures à la date du jour",
               "SESSION_ID_NOT_EXISTING": "Numéro de session inexistant",
               "SESSION_ID_NOT_VALID": "Donnée du champ \"Numéro de session\" invalide",
-              "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées",
-              "CSV_HEADERS_NOT_VALID": "Le modèle a été altéré, merci de le télécharger à nouveau"
+              "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées"
             }
           },
           "non-blocking-errors": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -208,6 +208,7 @@
           },
           "errors": {
             "download": "Une erreur s'est produite pendant le téléchargement",
+            "CSV_DATA_REQUIRED": "Le modèle importé n'a pas été rempli, merci de le compléter avant de l'importer à nouveau",
             "incorrect-type-file": "Le format du fichier est incorrect, seul le format .csv est accepté"
           },
           "instructions": {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement lorsqu'on tente d'importer un fichier csv vide ou n'ayant que les colonnes, on obtient un message d'erreur en anglais indiquant : `No session data in csv`.

## :robot: Proposition
Améliorer le message retourné.

## :rainbow: Remarques
Remplacement des if par un switch pour une meilleure lisibilité du code.
J'en ai profité pour jeter le message de l'erreur 500 dans le default du switch 

## :100: Pour tester
- Se connecter sur Pix Certif avec certifsup@example.net
- Cliquer sur l'import en masse des sessions
- Importer un fichier vide
- Constater que le message d'erreur est le suivant : `Le modèle importé n'a pas été rempli, merci de le compléter avant de l'importer à nouveau`
- Simuler une erreur 500 et constater le message suivant : `Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.`