### PR TITLE
[FEATURE] Utiliser les nouvelles classes css de Pix UI pour les titres de la page des cgu sur Pix Certif (PIX-7703).

### DIFF
--- a/certif/app/components/terms-of-service/page-en.hbs
+++ b/certif/app/components/terms-of-service/page-en.hbs
@@ -1,4 +1,4 @@
-<h2 class="pix-h3">Article 1. Preamble</h2>
+<h2 class="pix-title-s">Article 1. Preamble</h2>
 
 <p>
   The Pix “Groupement d’Intérêt Public” (French public interest group or “GIP”) approved by the decree of 27 April 2017
@@ -28,7 +28,7 @@
   particularly management of registrations and editing of the documentation necessary for their implantation.
 </p>
 
-<h2 class="pix-h3">Article 2. Definitions</h2>
+<h2 class="pix-title-s">Article 2. Definitions</h2>
 
 <ul>
   <li>
@@ -94,16 +94,16 @@
   </li>
 </ul>
 
-<h2 class="pix-h3">Article 3. Purpose</h2>
+<h2 class="pix-title-s">Article 3. Purpose</h2>
 
 <p>
   The purpose of these terms and conditions is to define the conditions for using and accessing the Pix Certif platform
   that is accessible at the aforementioned address.
 </p>
 
-<h2 class="pix-h3">Article 4. Acceptance and enforcement</h2>
+<h2 class="pix-title-s">Article 4. Acceptance and enforcement</h2>
 
-<h3 class="pix-h4">4.1 Acceptance</h3>
+<h3 class="pix-title-xs">4.1 Acceptance</h3>
 
 <p>
   The user may only use the Pix Certif platform and benefit from the services provided that these terms and conditions
@@ -121,7 +121,7 @@
   of all the stipulations defined within these terms and conditions.
 </p>
 
-<h3 class="pix-h4">4.2 Enforcement</h3>
+<h3 class="pix-title-xs">4.2 Enforcement</h3>
 
 <p>
   These terms and conditions are legally binding to the user as soon as they have accepted them when creating a user
@@ -146,9 +146,9 @@
   The user may at any time forego the use of the services, but remains responsible for any previous use.
 </p>
 
-<h2 class="pix-h3">Article 5. User account</h2>
+<h2 class="pix-title-s">Article 5. User account</h2>
 
-<h3 class="pix-h4">Step 1.</h3>
+<h3 class="pix-title-xs">Step 1.</h3>
 
 <p>The user fills in a web form on the Pix platform.</p>
 <p>
@@ -169,21 +169,21 @@
   The user must confirm, by checking the box, that they have read and accepted the Pix platform terms and conditions.
 </p>
 
-<h3 class="pix-h4">Step 2.</h3>
+<h3 class="pix-title-xs">Step 2.</h3>
 
 <p>
   The user asks the centre to transfer to the GIP Pix a request to attach their user account on Pix Platform, to the Pix
   Certif service.
 </p>
 
-<h3 class="pix-h4">Step 3.</h3>
+<h3 class="pix-title-xs">Step 3.</h3>
 
 <p>
   The GIP Pix attaches the user account on the Pix platform to the Pix Certif services within the time necessary for the
   usual security checks, which will allow the user to access the services.
 </p>
 
-<h3 class="pix-h4">Step 4.</h3>
+<h3 class="pix-title-xs">Step 4.</h3>
 
 <p>
   The user logs into their user account and to Pix Certif services with their login credentials, it being recalled that
@@ -199,7 +199,7 @@
   email address. An email will be sent to the user, enabling them to define a new password that must also comply with
   the aforementioned requirements.</p>
 
-<h2 class="pix-h3">Article 6. Description of services</h2>
+<h2 class="pix-title-s">Article 6. Description of services</h2>
 
 <p>Pix Certif enables the user to access the following services :</p>
 <ul>
@@ -219,7 +219,7 @@
     improve their quality (models, instructions,etc.).</li>
 </ul>
 
-<h2 class="pix-h3">Article 7. Access to Pix Certif</h2>
+<h2 class="pix-title-s">Article 7. Access to Pix Certif</h2>
 
 <p>The services are normally available 24 hours a day, 7 days a week.</p>
 <p>The GIP Pix reserves the right to restrict access to the services either totally or partially, with an impact on
@@ -235,7 +235,7 @@
 </p>
 <p>In the event that GIP Pix has entered into a service level agreement with the organisation, the latter prevails.</p>
 
-<h2 class="pix-h3">Article 8. Technical features </h2>
+<h2 class="pix-title-s">Article 8. Technical features </h2>
 
 <p>
   The Pix GIP endeavours to provide a quality service. It enables users to use the services provided to them under the
@@ -265,7 +265,7 @@
   <li>a satisfactory internet connection.</li>
 </ul>
 
-<h2 class="pix-h3">Article 9. Management of certification sessions</h2>
+<h2 class="pix-title-s">Article 9. Management of certification sessions</h2>
 
 <p>
   It is up to the user to ensure with the centre(s) to which they are attached, at least 2 working days before the
@@ -274,7 +274,7 @@
   under the conditions provided for the approval of their centre of attachment.
 </p>
 
-<h2 class="pix-h3">Article 10. Use</h2>
+<h2 class="pix-title-s">Article 10. Use</h2>
 
 <p>
   The user undertakes to use the services only under the conditions defined in these conditions of use and in addition:
@@ -293,7 +293,7 @@
   intellectual and industrial property, the protection of personal data and private life.
 </p>
 
-<h2 class="pix-h3">Article 11. Security</h2>
+<h2 class="pix-title-s">Article 11. Security</h2>
 
 <p>Any fraudulent access to the platform is prohibited and subject to criminal penalties.</p>
 <p>
@@ -306,9 +306,9 @@
   and/or software and/or devices used against infection by any viruses on the internet network.
 </p>
 
-<h2 class="pix-h3">Article 12. Maintenance and support</h2>
+<h2 class="pix-title-s">Article 12. Maintenance and support</h2>
 
-<h3 class="pix-h4">12.1 Support and assistance to the user</h3>
+<h3 class="pix-title-xs">12.1 Support and assistance to the user</h3>
 
 <p>
   The GIP Pix provides support of an exclusively technical nature to the user, who is responsible for reporting any
@@ -317,7 +317,7 @@
 <p>The user can reach GIP Pix technical support by email at the address support@pix.fr</p>
 <p>GIP Pix may offer different levels of assistance and support services to the user, under a separate contract.</p>
 
-<h3 class="pix-h4">12.2 Progressive maintenance</h3>
+<h3 class="pix-title-xs">12.2 Progressive maintenance</h3>
 
 <p>
   The services are likely to evolve over time to take into account the technological upgrades and needs of organisations
@@ -334,9 +334,9 @@
   of the services due to maintenance operations.
 </p>
 
-<h2 class="pix-h3">Article 13. Liability</h2>
+<h2 class="pix-title-s">Article 13. Liability</h2>
 
-<h3 class="pix-h4">13.1 User’s liability</h3>
+<h3 class="pix-title-xs">13.1 User’s liability</h3>
 
 <p>
   The user accesses and uses the services at their own risk and under their responsibility and that of the centre which
@@ -368,7 +368,7 @@
   of the latter resulting from the user’s failure to observe the terms and conditions.
 </p>
 
-<h3 class="pix-h4">13.2 The Pix HIP’s liability</h3>
+<h3 class="pix-title-xs">13.2 The Pix HIP’s liability</h3>
 
 <p>
   Given the diversity of the sources of data concerning the user, the conditions of its consultation and the time scales
@@ -409,7 +409,7 @@
   and void.
 </p>
 
-<h2 class="pix-h3">Article 14. Intellectual property rights</h2>
+<h2 class="pix-title-s">Article 14. Intellectual property rights</h2>
 
 <p>
   The GIP Pix is, and remains, the exclusive owner of the protected elements of the Pix platform and Pix Certif platform
@@ -437,7 +437,7 @@
   explicitly authorised by the GIP Pix under these terms and conditions is illegal.
 </p>
 
-<h2 class="pix-h3">Article 15. Hyperlinks</h2>
+<h2 class="pix-title-s">Article 15. Hyperlinks</h2>
 
 <p>
   The Pix GIP reserves the right to put in place hyperlinks on the Pix Certif giving access to web pages other than
@@ -453,9 +453,9 @@
   and written consent from the Pix GIP.
 </p>
 
-<h2 class="pix-h3">Article 16. Personal data</h2>
+<h2 class="pix-title-s">Article 16. Personal data</h2>
 
-<h3 class="pix-h4">16.1 Information of use</h3>
+<h3 class="pix-title-xs">16.1 Information of use</h3>
 
 <p>
   As part of its relations with users, GIP Pix, as data controller, may be required to process the following personal
@@ -487,7 +487,7 @@
   </li>
 </ul>
 
-<h3 class="pix-h4">16.2 Subcontracting</h3>
+<h3 class="pix-title-xs">16.2 Subcontracting</h3>
 
 <p>
   The user is likely to process the personal data of candidates as a subcontractor of the centre (or a second-tier
@@ -506,7 +506,7 @@
 </p>
 <p>The user can request communication of this agreement from the centre.</p>
 
-<h2 class="pix-h3">Article 17. Cookies</h2>
+<h2 class="pix-title-s">Article 17. Cookies</h2>
 
 <p>The user is informed that, when accessing the Pix platform, one or more cookies may be automatically installed on his
   terminal.</p>
@@ -520,9 +520,9 @@
   extent where it complies with the recommendations of the CNIL.
 </p>
 
-<h2 class="pix-h3">18. Termination</h2>
+<h2 class="pix-title-s">18. Termination</h2>
 
-<h3 class="pix-h4">18.1 De-registration</h3>
+<h3 class="pix-title-xs">18.1 De-registration</h3>
 
 <p>
   Access to the services by the user is effective as long as the user logs in to the Pix Certif platform, uses its
@@ -535,7 +535,7 @@
   from any access and any use of the services.
 </p>
 
-<h3 class="pix-h4">18.2 Suspension and exclusion</h3>
+<h3 class="pix-title-xs">18.2 Suspension and exclusion</h3>
 
 <p>
   Should the user fail to meet the obligations of these terms and conditions, the GIP Pix reserves the right, without
@@ -557,7 +557,7 @@
   under common law which may be taken against them.
 </p>
 
-<h2 class="pix-h3">19. Agreement of proof</h2>
+<h2 class="pix-title-s">19. Agreement of proof</h2>
 
 <p>Online acceptance of these terms and conditions electronically between the parties has the same evidential value as
   the agreement on paper.</p>
@@ -570,7 +570,7 @@
   as evidence.
 </p>
 
-<h2 class="pix-h3">20. Invalidity</h2>
+<h2 class="pix-title-s">20. Invalidity</h2>
 
 <p>
   If one or more stipulations of these terms and conditions are held to be invalid or declared as such pursuant to the
@@ -578,7 +578,7 @@
   stipulations shall retain their full force and scope.
 </p>
 
-<h2 class="pix-h3">21. Applicable law</h2>
+<h2 class="pix-title-s">21. Applicable law</h2>
 
 <p>
   These terms and conditions are governed by French law. This applies to the rules of substance and rules of form,

--- a/certif/app/components/terms-of-service/page-fr.hbs
+++ b/certif/app/components/terms-of-service/page-fr.hbs
@@ -1,4 +1,4 @@
-<h2 class="pix-h3">Article 1. Préambule</h2>
+<h2 class="pix-title-s">Article 1. Préambule</h2>
 
 <p>
   Le Groupement d’intérêt public (GIP) « Pix », approuvé par arrêté du 27 avril 2017 portant approbation de la
@@ -30,7 +30,7 @@
   œuvre.
 </p>
 
-<h2 class="pix-h3">Article 2. Définitions</h2>
+<h2 class="pix-title-s">Article 2. Définitions</h2>
 
 <ul>
   {{! template-lint-disable no-whitespace-within-word }}
@@ -107,13 +107,13 @@
   </li>
 </ul>
 
-<h2 class="pix-h3">Article 3. Objet</h2>
+<h2 class="pix-title-s">Article 3. Objet</h2>
 
 <p>
   Les présentes ont pour objet de définir les conditions d’accès et d’utilisation, par les utilisateurs, de Pix Certif
   et des services.
 </p>
-<h2 class="pix-h3">Article 4. Entrée en vigueur - Durée</h2>
+<h2 class="pix-title-s">Article 4. Entrée en vigueur - Durée</h2>
 <p>
   Les présentes conditions générales sont applicables pendant toute la durée de l’utilisation par l’utilisateur.
 </p>
@@ -122,9 +122,9 @@
   son centre de rattachement.
 </p>
 
-<h2 class="pix-h3">Article 5. Acceptation et opposabilité des conditions générales</h2>
+<h2 class="pix-title-s">Article 5. Acceptation et opposabilité des conditions générales</h2>
 
-<h3 class="pix-h4">5.1 Acceptation</h3>
+<h3 class="pix-title-xs">5.1 Acceptation</h3>
 <p>
   Les utilisateurs peuvent utiliser les services Pix Certif sous réserve de l’acceptation préalable des présentes
   conditions générales d’utilisation et de l’engagement qu’ils respectent les prérequis suivants :
@@ -191,7 +191,7 @@
   prescriptions définies au sein des présentes conditions d’utilisation.
 </p>
 
-<h3 class="pix-h4">5.2 Modification</h3>
+<h3 class="pix-title-xs">5.2 Modification</h3>
 <p>
   Les conditions générales sont susceptibles d’être modifiées ou aménagées à tout moment par le GIP Pix, notamment afin
   de faire évoluer les services.
@@ -214,7 +214,7 @@
   acceptation par ce dernier des nouvelles conditions d’utilisation.
 </p>
 
-<h3 class="pix-h4">5.3 Opposabilité</h3>
+<h3 class="pix-title-xs">5.3 Opposabilité</h3>
 <p>
   Les présentes conditions d’utilisation sont opposables à l’utilisateur dès leur acceptation par ce dernier lors de la
   création d’un compte utilisateur ou avant tout premier accès aux services.
@@ -231,13 +231,13 @@
   utilisation antérieure.
 </p>
 
-<h2 class="pix-h3">Article 6. Compte utilisateur</h2>
+<h2 class="pix-title-s">Article 6. Compte utilisateur</h2>
 
 <p>
   La procédure de création d’un compte utilisateur comprend les étapes suivantes.
 </p>
 
-<h3 class="pix-h4">Etape 1.</h3>
+<h3 class="pix-title-xs">Etape 1.</h3>
 
 <p>L’utilisateur complète un formulaire internet sur la plateforme Pix.</p>
 <p>
@@ -261,21 +261,21 @@
   de la plateforme Pix.
 </p>
 
-<h3 class="pix-h4">Etape 2.</h3>
+<h3 class="pix-title-xs">Etape 2.</h3>
 
 <p>
   L’utilisateur demande au Centre de transmettre au GIP Pix une demande de rattachement de son compte utilisateur sur la
   plateforme Pix, au service Pix Certif.
 </p>
 
-<h3 class="pix-h4">Etape 3.</h3>
+<h3 class="pix-title-xs">Etape 3.</h3>
 
 <p>
   Le GIP Pix effectue le rattachement du compte utilisateur de la plateforme Pix aux services Pix Certif dans un délai
   nécessaire aux vérifications de sécurité d’usage, qui permettra l’accès de l’utilisateur aux services.
 </p>
 
-<h3 class="pix-h4">Etape 4.</h3>
+<h3 class="pix-title-xs">Etape 4.</h3>
 
 <p>
   L’utilisateur se connecte à son compte utilisateur et aux services Pix Certif aux moyens de ses identifiants de
@@ -299,7 +299,7 @@
   nouveau mot de passe qui devra lui aussi être conforme aux spécifications susvisées.
 </p>
 
-<h2 class="pix-h3">Article 7. Description des services</h2>
+<h2 class="pix-title-s">Article 7. Description des services</h2>
 
 <p>
   Pix Certif permet à l’utilisateur de bénéficier des services suivants :
@@ -323,7 +323,7 @@
   </li>
 </ul>
 
-<h2 class="pix-h3">Article 8. Accès à Pix Certif</h2>
+<h2 class="pix-title-s">Article 8. Accès à Pix Certif</h2>
 
 <p>
   Les services sont normalement accessibles 24/24 heures, 7/7 jours.
@@ -343,7 +343,7 @@
   problème rencontré le cas échéant sur la base de documents associés : support@pix.fr.
 </p>
 
-<h2 class="pix-h3">Article 9. Spécificités techniques</h2>
+<h2 class="pix-title-s">Article 9. Spécificités techniques</h2>
 
 <p>
   Le GIP Pix s’efforce de fournir un service de qualité. Il permet aux utilisateurs d'utiliser les services mis à leur
@@ -378,7 +378,7 @@
   </li>
 </ul>
 
-<h2 class="pix-h3">Article 10. Gestion des sessions de certification</h2>
+<h2 class="pix-title-s">Article 10. Gestion des sessions de certification</h2>
 
 <p>
   Il appartient à l’utilisateur de s’assurer avec le ou les centres au(x)quel(s) il est rattaché, au minimum 2 jours
@@ -387,7 +387,7 @@
   sessions de certification, dans les conditions prévues à l’agrément de son centre de rattachement
 </p>
 
-<h2 class="pix-h3">Article 11. Utilisation</h2>
+<h2 class="pix-title-s">Article 11. Utilisation</h2>
 
 <p>
   L’utilisateur s’engage à n’utiliser les services que dans les seules conditions définies aux présentes conditions
@@ -408,7 +408,7 @@
   à la vie privée.
 </p>
 
-<h2 class="pix-h3">Article 12. Sécurité</h2>
+<h2 class="pix-title-s">Article 12. Sécurité</h2>
 
 <p>
   Le GIP Pix fait ses meilleurs efforts, conformément aux règles de l’art, pour sécuriser la plateforme au regard du
@@ -461,9 +461,9 @@
   Pix Certif.
 </p>
 
-<h2 class="pix-h3">Article 13. Maintenance et support</h2>
+<h2 class="pix-title-s">Article 13. Maintenance et support</h2>
 
-<h3 class="pix-h4">13.1 Support et assistance auprès de l’utilisateur</h3>
+<h3 class="pix-title-xs">13.1 Support et assistance auprès de l’utilisateur</h3>
 <p>
   Le GIP Pix assure un support de nature exclusivement technique auprès de l’utilisateur qui se charge de remonter les
   éventuels dysfonctionnements des services constatés par lui-même.
@@ -475,7 +475,7 @@
   Le GIP Pix met à disposition des utilisateurs une FAQ permettant de répondre aux besoins les plus courants.
 </p>
 
-<h3 class="pix-h4">13.2 Maintenance évolutive</h3>
+<h3 class="pix-title-xs">13.2 Maintenance évolutive</h3>
 <p>
   Les services sont susceptibles d’évoluer dans le temps, pour tenir compte des évolutions technologiques, des besoins
   des centres et des utilisateurs.
@@ -494,9 +494,9 @@
   interruption des services.
 </p>
 
-<h2 class="pix-h3">Article 14. Responsabilité</h2>
+<h2 class="pix-title-s">Article 14. Responsabilité</h2>
 
-<h3 class="pix-h4">14.1 Responsabilité de l’utilisateur</h3>
+<h3 class="pix-title-xs">14.1 Responsabilité de l’utilisateur</h3>
 <p>
   L’utilisateur accède et utilise les services à ses propres risques et sous sa responsabilité et celle du centre qui
   l’a habilité, en accord avec la législation française en vigueur ainsi qu’avec les présentes conditions d’utilisation.
@@ -530,7 +530,7 @@
   l’utilisateur.
 </p>
 
-<h3 class="pix-h4">14.2 Responsabilité du GIP Pix</h3>
+<h3 class="pix-title-xs">14.2 Responsabilité du GIP Pix</h3>
 <p>
   Le GIP Pix s’efforcera de réaliser les opérations qui lui incombent relatives au compte utilisateur et aux services,
   conformément aux règles de l’art.
@@ -603,7 +603,7 @@
   relations contractuelles.
 </p>
 
-<h2 class="pix-h3">Article 15. Propriété intellectuelle</h2>
+<h2 class="pix-title-s">Article 15. Propriété intellectuelle</h2>
 
 <p>
   Le GIP Pix est, et reste, propriétaire exclusif des éléments protégés des services selon les termes du Code de la
@@ -632,7 +632,7 @@
   non expressément autorisée par le GIP Pix au titre des présentes conditions d’utilisation est illicite.
 </p>
 
-<h2 class="pix-h3">Article 16. Liens hypertextes</h2>
+<h2 class="pix-title-s">Article 16. Liens hypertextes</h2>
 
 <p>
   Le GIP Pix se réserve la possibilité de mettre en place des hyperliens sur Pix Certif donnant accès à des pages web
@@ -650,9 +650,9 @@
   plateforme Pix requiert l’autorisation préalable et écrite du GIP Pix.
 </p>
 
-<h2 class="pix-h3">Article 17. Données à caractère personnel</h2>
+<h2 class="pix-title-s">Article 17. Données à caractère personnel</h2>
 
-<h3 class="pix-h4">17.1 Information de l’utilisation</h3>
+<h3 class="pix-title-xs">17.1 Information de l’utilisation</h3>
 <p>
   Dans le cadre de ses rapports avec les utilisateurs, le GIP Pix, en qualité de responsable de traitement, peut être
   amené à traiter les données à caractère personnel suivantes relatives à l’identité d’un utilisateur, à savoir : nom(s)
@@ -718,7 +718,7 @@
   Commission nationale Informatique et libertés (ci-après « CNIL ») et de retirer son consentement à tout moment.
 </p>
 
-<h3 class="pix-h4">17.2 Sous-traitance</h3>
+<h3 class="pix-title-xs">17.2 Sous-traitance</h3>
 <p>
   L’utilisateur est susceptible de traiter les données à caractère personnel des candidats en qualité de sous-traitant
   du centre (ou de sous-traitant de second rang du GIP Pix), le centre étant lui-même sous-traitant du GIP Pix.
@@ -738,9 +738,9 @@
   L’utilisateur peut demander communication de cette convention auprès du centre.
 </p>
 
-<h2 class="pix-h3">18. Résolution et résiliation</h2>
+<h2 class="pix-title-s">18. Résolution et résiliation</h2>
 
-<h3 class="pix-h4">18.1 Désinscription</h3>
+<h3 class="pix-title-xs">18.1 Désinscription</h3>
 <p>
   L’accès aux services par l’utilisateur est effectif et valide tant que l’utilisateur :
 </p>
@@ -757,7 +757,7 @@
   tout accès et de toute utilisation des services.
 </p>
 
-<h3 class="pix-h4">18.2 Suspension et exclusion</h3>
+<h3 class="pix-title-xs">18.2 Suspension et exclusion</h3>
 <p>
   En cas de manquement aux obligations des présentes conditions d’utilisation par l’utilisateur, le GIP Pix se réserve
   le droit, sans indemnité ni remboursement, huit (8) jours après l’envoi à l’utilisateur d’un courrier électronique lui
@@ -772,7 +772,7 @@
   services, sans préjudice de toute action de droit commun qui pourrait lui être ouverte.
 </p>
 
-<h2 class="pix-h3">19. Convention de preuve</h2>
+<h2 class="pix-title-s">19. Convention de preuve</h2>
 
 <p>
   L’acceptation en ligne des présentes conditions d’utilisation par voie électronique a entre les parties la même valeur
@@ -788,7 +788,7 @@
   pouvant être produit à titre de preuve.
 </p>
 
-<h2 class="pix-h3">20. Nullité</h2>
+<h2 class="pix-title-s">20. Nullité</h2>
 
 <p>
   Si une ou plusieurs stipulations des présentes conditions d’utilisation sont tenues pour non valides ou déclarées
@@ -796,7 +796,7 @@
   d’une juridiction compétente, les autres stipulations garderont toute leur force et leur portée.
 </p>
 
-<h2 class="pix-h3">21. Loi applicable</h2>
+<h2 class="pix-title-s">21. Loi applicable</h2>
 
 <p>
   Les présentes conditions d’utilisation sont régies par la loi française. Il en est ainsi pour les règles de fond et

--- a/certif/app/templates/terms-of-service.hbs
+++ b/certif/app/templates/terms-of-service.hbs
@@ -6,7 +6,7 @@
     <header class="terms-of-service-form__header">
       <img src="/pix-certif-logo.svg" alt="Pix Certif" class="terms-of-service-form__header--logo" />
 
-      <h1 class="terms-of-service-form__header--title pix-h4">
+      <h1 class="terms-of-service-form__header--title pix-title-m">
         {{t "pages.terms-of-service.title"}}
       </h1>
     </header>


### PR DESCRIPTION
## :unicorn: Problème
Actuellement la page des cgu utilise les anciennes classes css du design tokens pix-ui : pix-h3, pix-h4... 
Or les classes ont récemment été modifiés et la page des cgu n'a plus de style sur ses titres.

## :robot: Proposition
Utiliser les nouvelles classes de Pix UI sur la page

## :100: Pour tester
- Se connecter à Pix Certif avec certifpro@example.net
- Constater que les titres de la page des cgu sont à nouveau stylisés