### PR TITLE
[FEATURE] Filtrer par id ou titre le tableau des contenus formatifs (PIX-7391).

### DIFF
--- a/admin/app/components/trainings/list-summary-items.hbs
+++ b/admin/app/components/trainings/list-summary-items.hbs
@@ -1,11 +1,34 @@
 <div class="content-text content-text--small">
   <div class="table-admin">
     <table>
+      <caption class="sr-only">Liste des contenus formatifs</caption>
       <thead>
         <tr>
-          <th class="table__column table__column--id" id="training-id">ID</th>
-          <th id="training-titre">Titre</th>
+          <th class="table__column table__column--id" id="training-id" scope="col">ID</th>
+          <th id="training-titre" scope="col">Titre</th>
         </tr>
+        {{#if @triggerFiltering}}
+          <tr>
+            <td class="table__column table__column--id">
+              <input
+                type="text"
+                value={{@id}}
+                oninput={{fn @triggerFiltering "id"}}
+                class="table-admin-input"
+                aria-label="Filtrer les contenus formatifs par un id"
+              />
+            </td>
+            <td>
+              <input
+                type="text"
+                value={{@title}}
+                oninput={{fn @triggerFiltering "title"}}
+                class="table-admin-input"
+                aria-label="Filtrer les contenus formatifs par un titre"
+              />
+            </td>
+          </tr>
+        {{/if}}
       </thead>
 
       {{#if @summaries}}

--- a/admin/app/controllers/authenticated/trainings/list.js
+++ b/admin/app/controllers/authenticated/trainings/list.js
@@ -1,10 +1,36 @@
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import debounce from 'lodash/debounce';
+import config from 'pix-admin/config/environment';
+
+const DEFAULT_PAGE_NUMBER = 1;
 
 export default class ListController extends Controller {
   @service accessControl;
 
   get canCreateTrainings() {
     return this.accessControl.hasAccessToTrainingsActionsScope;
+  }
+
+  queryParams = ['pageNumber', 'pageSize', 'id', 'title'];
+  DEBOUNCE_MS = config.pagination.debounce;
+
+  @tracked pageNumber = DEFAULT_PAGE_NUMBER;
+  @tracked pageSize = 10;
+  @tracked id = null;
+  @tracked title = null;
+
+  updateFilters(filters) {
+    Object.keys(filters).forEach((filterKey) => (this[filterKey] = filters[filterKey]));
+    this.pageNumber = DEFAULT_PAGE_NUMBER;
+  }
+
+  debouncedUpdateFilters = debounce(this.updateFilters, this.DEBOUNCE_MS);
+
+  @action
+  triggerFiltering(fieldName, event) {
+    this.debouncedUpdateFilters({ [fieldName]: event.target.value });
   }
 }

--- a/admin/app/routes/authenticated/trainings/list.js
+++ b/admin/app/routes/authenticated/trainings/list.js
@@ -4,13 +4,14 @@ import { inject as service } from '@ember/service';
 
 export default class ListRoute extends Route {
   @service accessControl;
+  @service notifications;
   @service store;
 
   queryParams = {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
     id: { refreshModel: true },
-    name: { refreshModel: true },
+    title: { refreshModel: true },
   };
 
   beforeModel() {
@@ -22,6 +23,10 @@ export default class ListRoute extends Route {
 
     try {
       trainingSummaries = await this.store.query('training-summary', {
+        filter: {
+          id: params.id ? params.id.trim() : '',
+          title: params.title ? params.title.trim() : '',
+        },
         page: {
           number: params.pageNumber,
           size: params.pageSize,
@@ -34,5 +39,14 @@ export default class ListRoute extends Route {
       return [];
     }
     return trainingSummaries;
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.pageNumber = 1;
+      controller.pageSize = 10;
+      controller.id = null;
+      controller.title = null;
+    }
   }
 }

--- a/admin/app/templates/authenticated/trainings/list.hbs
+++ b/admin/app/templates/authenticated/trainings/list.hbs
@@ -16,6 +16,11 @@
 
 <main class="page-body">
   <section class="page-section">
-    <Trainings::ListSummaryItems @summaries={{@model}} @id={{this.id}} @name={{this.name}} />
+    <Trainings::ListSummaryItems
+      @summaries={{@model}}
+      @id={{this.id}}
+      @title={{this.title}}
+      @triggerFiltering={{this.triggerFiltering}}
+    />
   </section>
 </main>

--- a/admin/tests/acceptance/authenticated/trainings/list_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/list_test.js
@@ -48,6 +48,33 @@ module('Acceptance | Trainings | List', function (hooks) {
         assert.dom(screen.getByText('Formation 12')).exists();
       });
 
+      module('when filters are used', function (hooks) {
+        hooks.beforeEach(async () => {
+          server.create('training-summary', { id: 1, title: 'Premier' });
+          server.create('training-summary', { id: 2, title: 'Deuxième' });
+        });
+
+        test('it should display the current filter when trainings are filtered by title', async function (assert) {
+          // when
+          const screen = await visit('/trainings/list?title=Premier');
+
+          // then
+          assert
+            .dom(screen.getByRole('textbox', { name: 'Filtrer les contenus formatifs par un titre' }))
+            .hasValue('Premier');
+          assert.dom(screen.getByText('Premier')).exists();
+        });
+
+        test('it should display the current filter when trainings are filtered by id', async function (assert) {
+          // when
+          const screen = await visit('/trainings/list?id=2');
+
+          // then
+          assert.dom(screen.getByRole('textbox', { name: 'Filtrer les contenus formatifs par un id' })).hasValue('2');
+          assert.dom(screen.getByText('Deuxième')).exists();
+        });
+      });
+
       test('it should redirect to training creation form on click "Nouveau contenu formatif"', async function (assert) {
         // given
         await visit('/trainings/list');

--- a/admin/tests/integration/components/routes/authenticated/trainings/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/trainings/list-items_test.js
@@ -6,9 +6,13 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Component | routes/authenticated/trainings | list-items', function (hooks) {
   setupRenderingTest(hooks);
 
+  hooks.beforeEach(function () {
+    this.set('noop', () => {});
+  });
+
   test('it should display header with id and title', async function (assert) {
     // when
-    const screen = await render(hbs`<Trainings::ListSummaryItems />`);
+    const screen = await render(hbs`<Trainings::ListSummaryItems @triggerFiltering={{this.noop}} />`);
 
     // then
     assert.dom(screen.getByText('ID')).exists();
@@ -27,7 +31,9 @@ module('Integration | Component | routes/authenticated/trainings | list-items', 
     this.summaries = summaries;
 
     // when
-    const screen = await render(hbs`<Trainings::ListSummaryItems @summaries={{this.summaries}} />`);
+    const screen = await render(
+      hbs`<Trainings::ListSummaryItems @summaries={{this.summaries}} @triggerFiltering={{this.noop}} />`
+    );
 
     // then
     assert.strictEqual(screen.getAllByLabelText('Contenu formatif').length, 2);
@@ -42,7 +48,9 @@ module('Integration | Component | routes/authenticated/trainings | list-items', 
     this.summaries = summaries;
 
     // when
-    const screen = await render(hbs`<Trainings::ListSummaryItems @summaries={{this.summaries}} />`);
+    const screen = await render(
+      hbs`<Trainings::ListSummaryItems @summaries={{this.summaries}} @triggerFiltering={{this.noop}} />`
+    );
 
     // then
     assert.dom(screen.getByLabelText('Contenu formatif')).containsText(123);

--- a/admin/tests/unit/controllers/authenticated/trainings/list_test.js
+++ b/admin/tests/unit/controllers/authenticated/trainings/list_test.js
@@ -1,0 +1,41 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | authenticated/trainings/list', function (hooks) {
+  setupTest(hooks);
+  let controller;
+
+  hooks.beforeEach(function () {
+    controller = this.owner.lookup('controller:authenticated/trainings/list');
+  });
+
+  module('#updateFilters', function () {
+    module('updating id', function () {
+      test('it should update controller id field', async function (assert) {
+        // given
+        controller.id = 1;
+        const expectedValue = 2;
+
+        // when
+        await controller.updateFilters({ id: expectedValue });
+
+        // then
+        assert.strictEqual(controller.id, expectedValue);
+      });
+    });
+
+    module('updating title', function () {
+      test('it should update controller title field', async function (assert) {
+        // given
+        controller.title = 'someTitle';
+        const expectedValue = 'someOtherTitle';
+
+        // when
+        await controller.updateFilters({ title: expectedValue });
+
+        // then
+        assert.strictEqual(controller.title, expectedValue);
+      });
+    });
+  });
+});

--- a/admin/tests/unit/routes/authenticated/trainings/list_test.js
+++ b/admin/tests/unit/routes/authenticated/trainings/list_test.js
@@ -24,13 +24,38 @@ module('Unit | Route | authenticated/trainings/list', function (hooks) {
       };
     });
 
-    test('it should call store.query', async function (assert) {
-      // when
-      await route.model(params);
+    module('when queryParams filters are falsy', function () {
+      test('it should call store.query with no filters on name and id', async function (assert) {
+        // when
+        await route.model(params);
+        expectedQueryArgs.filter = {
+          title: '',
+          id: '',
+        };
 
-      // then
-      sinon.assert.calledWith(route.store.query, 'training-summary', expectedQueryArgs);
-      assert.ok(true);
+        // then
+        sinon.assert.calledWith(route.store.query, 'training-summary', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+    module('when queryParams filters are truthy', function () {
+      test('it should call store.query with filters containing trimmed values', async function (assert) {
+        // given
+        params.title = 'someTitle';
+        params.id = 'someId';
+        expectedQueryArgs.filter = {
+          title: 'someTitle',
+          id: 'someId',
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'training-summary', expectedQueryArgs);
+        assert.ok(true);
+      });
     });
   });
 });

--- a/api/lib/application/trainings/index.js
+++ b/api/lib/application/trainings/index.js
@@ -3,7 +3,7 @@ const Joi = require('joi');
 const trainingsController = require('./training-controller.js');
 const identifiersType = require('../../domain/types/identifiers-type.js');
 const securityPreHandlers = require('../security-pre-handlers.js');
-const { sendJsonApiError, NotFoundError } = require('../http-errors.js');
+const { sendJsonApiError, NotFoundError, BadRequestError } = require('../http-errors.js');
 
 exports.register = async (server) => {
   server.route([
@@ -27,9 +27,14 @@ exports.register = async (server) => {
             allowUnknown: true,
           },
           query: Joi.object({
+            'filter[id]': Joi.number().empty('').allow(null).optional(),
+            'filter[title]': Joi.string().empty('').allow(null).optional(),
             'page[number]': Joi.number().integer().empty('').allow(null).optional(),
             'page[size]': Joi.number().integer().empty('').allow(null).optional(),
           }),
+          failAction: (request, h) => {
+            return sendJsonApiError(new BadRequestError('Un des champs de recherche saisis est invalide.'), h);
+          },
         },
         handler: trainingsController.findPaginatedTrainingSummaries,
         tags: ['api', 'admin', 'trainings'],

--- a/api/lib/application/trainings/training-controller.js
+++ b/api/lib/application/trainings/training-controller.js
@@ -7,8 +7,8 @@ const queryParamsUtils = require('../../infrastructure/utils/query-params-utils.
 
 module.exports = {
   async findPaginatedTrainingSummaries(request, h, dependencies = { trainingSummarySerializer, queryParamsUtils }) {
-    const { page } = dependencies.queryParamsUtils.extractParameters(request.query);
-    const { trainings, meta } = await usecases.findPaginatedTrainingSummaries({ page });
+    const { filter, page } = dependencies.queryParamsUtils.extractParameters(request.query);
+    const { trainings, meta } = await usecases.findPaginatedTrainingSummaries({ filter, page });
     return dependencies.trainingSummarySerializer.serialize(trainings, meta);
   },
 

--- a/api/lib/domain/usecases/find-paginated-training-summaries.js
+++ b/api/lib/domain/usecases/find-paginated-training-summaries.js
@@ -1,5 +1,5 @@
-module.exports = async function findPaginatedTrainingSummaries({ page, trainingRepository }) {
-  const { trainings, pagination } = await trainingRepository.findPaginatedSummaries({ page });
+module.exports = async function findPaginatedTrainingSummaries({ filter, page, trainingRepository }) {
+  const { trainings, pagination } = await trainingRepository.findPaginatedSummaries({ filter, page });
 
   return {
     trainings,

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -172,10 +172,11 @@ describe('Integration | Repository | training-repository', function () {
         databaseBuilder.factory.buildTraining({ ...trainingSummary3 });
 
         await databaseBuilder.commit();
+        const filter = {};
         const page = { size: 2, number: 2 };
 
         // when
-        const { trainings, pagination } = await trainingRepository.findPaginatedSummaries({ page });
+        const { trainings, pagination } = await trainingRepository.findPaginatedSummaries({ filter, page });
 
         // then
         expect(trainings).to.have.lengthOf(1);
@@ -183,15 +184,63 @@ describe('Integration | Repository | training-repository', function () {
         expect(trainings[0]).to.deep.equal(trainingSummary3);
         expect(pagination).to.deep.equal({ page: 2, pageSize: 2, rowCount: 3, pageCount: 2 });
       });
+
+      it('should return filtered by id result', async function () {
+        // given
+        const trainingSummary1 = domainBuilder.buildTrainingSummary({ id: 1 });
+        const trainingSummary2 = domainBuilder.buildTrainingSummary({ id: 2 });
+        const trainingSummary3 = domainBuilder.buildTrainingSummary({ id: 3 });
+
+        databaseBuilder.factory.buildTraining({ ...trainingSummary1 });
+        databaseBuilder.factory.buildTraining({ ...trainingSummary2 });
+        databaseBuilder.factory.buildTraining({ ...trainingSummary3 });
+
+        await databaseBuilder.commit();
+        const filter = { id: 2 };
+        const page = {};
+
+        // when
+        const { trainings } = await trainingRepository.findPaginatedSummaries({ filter, page });
+
+        // then
+        expect(trainings).to.have.lengthOf(1);
+        expect(trainings[0]).to.be.instanceOf(TrainingSummary);
+        expect(trainings[0]).to.deep.equal(trainingSummary2);
+      });
+
+      it('should return filtered by title results', async function () {
+        // given
+        const trainingSummary1 = domainBuilder.buildTrainingSummary({ id: 1, title: 'test' });
+        const trainingSummary2 = domainBuilder.buildTrainingSummary({ id: 2, title: 'test 2' });
+        const trainingSummary3 = domainBuilder.buildTrainingSummary({ id: 3, title: 'dummy' });
+
+        databaseBuilder.factory.buildTraining({ ...trainingSummary1 });
+        databaseBuilder.factory.buildTraining({ ...trainingSummary2 });
+        databaseBuilder.factory.buildTraining({ ...trainingSummary3 });
+
+        await databaseBuilder.commit();
+        const filter = { title: 'test' };
+        const page = {};
+
+        // when
+        const { trainings } = await trainingRepository.findPaginatedSummaries({ filter, page });
+
+        // then
+        expect(trainings).to.have.lengthOf(2);
+        expect(trainings[0]).to.be.instanceOf(TrainingSummary);
+        expect(trainings[0]).to.deep.equal(trainingSummary1);
+        expect(trainings[1]).to.deep.equal(trainingSummary2);
+      });
     });
 
     context("when trainings don't exist", function () {
       it('should return an empty array', async function () {
         // given
+        const filter = {};
         const page = { size: 2, number: 1 };
 
         // when
-        const { trainings, pagination } = await trainingRepository.findPaginatedSummaries({ page });
+        const { trainings, pagination } = await trainingRepository.findPaginatedSummaries({ filter, page });
 
         // then
         expect(trainings).to.deep.equal([]);

--- a/api/tests/unit/application/trainings/training-controller_test.js
+++ b/api/tests/unit/application/trainings/training-controller_test.js
@@ -11,6 +11,7 @@ describe('Unit | Controller | training-controller', function () {
       const trainingSummaries = Symbol('trainingSummary');
       const meta = Symbol('meta');
       const useCaseParameters = {
+        filter: { id: 1 },
         page: { size: 2, number: 1 },
       };
 
@@ -25,6 +26,7 @@ describe('Unit | Controller | training-controller', function () {
       const response = await trainingController.findPaginatedTrainingSummaries(
         {
           params: {
+            filter: { id: 1 },
             page: { size: 2, number: 1 },
           },
         },

--- a/api/tests/unit/domain/usecases/find-paginated-trainings-summary_test.js
+++ b/api/tests/unit/domain/usecases/find-paginated-trainings-summary_test.js
@@ -2,8 +2,9 @@ const { expect, sinon } = require('../../../test-helper');
 const findPaginatedTrainingSummaries = require('../../../../lib/domain/usecases/find-paginated-training-summaries');
 
 describe('Unit | UseCase | find-paginated-training-summaries', function () {
-  it('should find all training summaries with pagination', async function () {
+  it('should find filtered training summaries with pagination', async function () {
     // given
+    const filter = { id: 1 };
     const page = { number: 1, size: 2 };
 
     const trainingRepository = {
@@ -13,15 +14,16 @@ describe('Unit | UseCase | find-paginated-training-summaries', function () {
     const resolvedPagination = Symbol('pagination');
     const trainingSummaries = Symbol('training-summaries');
 
-    trainingRepository.findPaginatedSummaries
-      .withArgs({ page })
-      .resolves({ trainings: trainingSummaries, pagination: resolvedPagination });
+    trainingRepository.findPaginatedSummaries.resolves({
+      trainings: trainingSummaries,
+      pagination: resolvedPagination,
+    });
 
     // when
-    const response = await findPaginatedTrainingSummaries({ page, trainingRepository });
+    const response = await findPaginatedTrainingSummaries({ filter, page, trainingRepository });
 
     // then
-    expect(trainingRepository.findPaginatedSummaries).to.have.been.calledWithExactly({ page });
+    expect(trainingRepository.findPaginatedSummaries).to.have.been.calledWithExactly({ filter, page });
     expect(response.trainings).to.equal(trainingSummaries);
     expect(response.meta.pagination).to.equal(resolvedPagination);
   });


### PR DESCRIPTION
## :unicorn: Problème

Jusqu'à présent, il n'était pas possible de filtrer le tableau qui liste les contenus formatifs dans Admin.

## :robot: Proposition

Comme dans les profils cibles, ajouter les 2 champs de texte en tête de liste pour filtrer, au choix, les colonnes "id" ou "titre".

## :100: Pour tester

- Aller dans la [page des contenus formatifs d'Admin en RA](https://admin-pr5963.review.pix.fr/trainings/list)
- Essayer chacun des 2 filtres
- Constater que la liste évolue comme souhaité
