### PR TITLE
[FEATURE] Améliorer l'a11y du formulaire de signalisation de problème (PIX-5782)

### DIFF
--- a/mon-pix/app/components/feedback-panel.hbs
+++ b/mon-pix/app/components/feedback-panel.hbs
@@ -1,6 +1,6 @@
 {{! template-lint-disable require-input-label no-unknown-arguments-for-builtin-components }}
 <div class="feedback-panel">
-  <h3 class="sr-only">{{t "pages.challenge.parts.feedback"}}</h3>
+  <h2 class="screen-reader-only">{{t "pages.challenge.parts.feedback"}}</h2>
   <div class="feedback-panel__view feedback-panel__view--link">
     <button
       class="feedback-panel__open-button"
@@ -17,7 +17,7 @@
 
   {{#if this.isExpanded}}
     {{#if this.isFormSubmitted}}
-      <div class="feedback-panel__view feedback-panel__view--mercix" id="feedback-panel-submitted">
+      <div class="feedback-panel__view feedback-panel__view--mercix" id="feedback-panel-submitted" role="status">
         {{t "pages.challenge.feedback-panel.form.status.success" htmlSafe=true}}
       </div>
     {{else}}


### PR DESCRIPTION
## :unicorn: Problème

Le formulaire de signalisation ne correspond pas aux standards d'accessibilité.

## :robot: Proposition

Ajouter la balise status et respecter la hiérarchie des titres.

## :100: Pour tester

- Aller sur une question en RA
- Tester le formulaire de signalisation du problème sur l'écran d'épreuve et sur l'écran de checkpoint ( modal réponse et tutos ), vérifier qu'il n'y a aucune régression graphique ou fonctionnelle.
