### PR TITLE
[FEATURE] Améliorer les tests de Pix App avec Testing Library (PIX-7712).

### DIFF
--- a/mon-pix/app/components/campaign-participation-overview/card/ongoing.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card/ongoing.hbs
@@ -14,8 +14,12 @@
       class="button button--link campaign-participation-overview-card-content__action"
       @route="campaigns.entry-point"
       @model={{@model.campaignCode}}
+      aria-label={{t
+        "pages.campaign-participation-overview.card.resume.extra-information"
+        campaignTitle=@model.campaignTitle
+      }}
     >
-      {{t "pages.campaign-participation-overview.card.resume"}}
+      {{t "pages.campaign-participation-overview.card.resume.information"}}
     </LinkTo>
   </section>
 </article>

--- a/mon-pix/app/components/competence-card-default.hbs
+++ b/mon-pix/app/components/competence-card-default.hbs
@@ -73,6 +73,7 @@
           class="button button--extra-thin button--round button--link button--green competence-card__button"
           @model={{@scorecard.competenceId}}
           @route="authenticated.competences.resume"
+          aria-label={{this.ariaLabelButton}}
         >
           <span class="competence-card-button__label">
             {{#if @scorecard.isStarted}}

--- a/mon-pix/app/components/competence-card-default.js
+++ b/mon-pix/app/components/competence-card-default.js
@@ -7,6 +7,7 @@ export default class CompetenceCardDefault extends Component {
   @service store;
   @service router;
   @service competenceEvaluation;
+  @service intl;
 
   get displayedLevel() {
     if (this.args.scorecard.isNotStarted) {
@@ -17,6 +18,13 @@ export default class CompetenceCardDefault extends Component {
 
   get shouldWaitBeforeImproving() {
     return this.args.scorecard.remainingDaysBeforeImproving > 0;
+  }
+
+  get ariaLabelButton() {
+    const ariaLabel = this.args.scorecard.isStarted
+      ? 'pages.competence-details.actions.continue.extra-information'
+      : 'pages.competence-details.actions.start.extra-information';
+    return this.intl.t(ariaLabel, { competenceName: this.args.scorecard.name });
   }
 
   @action

--- a/mon-pix/app/components/dashboard/content.hbs
+++ b/mon-pix/app/components/dashboard/content.hbs
@@ -64,7 +64,6 @@
 
     {{#if this.hasStartedCompetences}}
       <Dashboard::Section
-        data-test-started-competences
         @title={{t "pages.dashboard.started-competences.title"}}
         @subtitle={{t "pages.dashboard.started-competences.subtitle"}}
       >
@@ -74,11 +73,11 @@
 
     {{#if this.hasRecommendedCompetences}}
       <Dashboard::Section
-        data-test-recommended-competences
         @title={{t "pages.dashboard.recommended-competences.title"}}
         @subtitle={{t "pages.dashboard.recommended-competences.subtitle"}}
         @linkRoute="authenticated.profile"
         @linkText={{t "pages.dashboard.recommended-competences.profile-link"}}
+        @ariaLabelLink={{t "pages.dashboard.recommended-competences.extra-information"}}
       >
         <CompetenceCard::List @scorecards={{this.recommendedScorecards}} />
       </Dashboard::Section>
@@ -90,6 +89,7 @@
         @subtitle={{t "pages.dashboard.improvable-competences.subtitle"}}
         @linkRoute="authenticated.profile"
         @linkText={{t "pages.dashboard.improvable-competences.profile-link"}}
+        @ariaLabelLink={{t "pages.dashboard.improvable-competences.extra-information"}}
       >
         <CompetenceCard::List @scorecards={{this.improvableScorecards}} />
       </Dashboard::Section>

--- a/mon-pix/app/components/dashboard/section.hbs
+++ b/mon-pix/app/components/dashboard/section.hbs
@@ -5,7 +5,11 @@
       <p class="dashboard-section__subtitle">{{@subtitle}}</p>
     </div>
     {{#if this.hasLink}}
-      <LinkTo @route={{@linkRoute}} class="dashboard-section__button">{{@linkText}}</LinkTo>
+      <LinkTo
+        @route={{@linkRoute}}
+        class="dashboard-section__button"
+        aria-label={{@ariaLabelLink}}
+      >{{@linkText}}</LinkTo>
     {{/if}}
   </div>
 

--- a/mon-pix/app/components/feedback-panel.hbs
+++ b/mon-pix/app/components/feedback-panel.hbs
@@ -36,7 +36,6 @@
                     class="feedback-panel__dropdown"
                     {{on "change" this.displayCategoryOptions}}
                     aria-label={{t "pages.challenge.feedback-panel.form.fields.detail-selection.aria-first"}}
-                    data-test-feedback-category-dropdown
                   >
                     <option value="" disabled selected>{{t
                         "pages.challenge.feedback-panel.form.fields.category-selection.label"
@@ -50,7 +49,6 @@
                       class="feedback-panel__dropdown"
                       {{on "change" this.showFeedback}}
                       aria-label={{t "pages.challenge.feedback-panel.form.fields.detail-selection.aria-secondary"}}
-                      data-test-feedback-subcategory-dropdown
                     >
                       <option value="default" selected>{{t
                           "pages.challenge.feedback-panel.form.fields.detail-selection.label"

--- a/mon-pix/app/components/new-information.hbs
+++ b/mon-pix/app/components/new-information.hbs
@@ -36,7 +36,7 @@
 
   {{#if @closeaction}}
     <button class="new-information__close {{@textColorClass}}" {{on "click" @closeaction}} type="button">
-      <FaIcon @icon="xmark" /><span class="sr-only">{{t "common.new-information-banner.close-label"}}.</span>
+      <FaIcon @icon="xmark" /><span class="sr-only">{{t "common.new-information-banner.close-label"}}</span>
     </button>
   {{/if}}
 </div>

--- a/mon-pix/tests/acceptance/challenge-page-banner_test.js
+++ b/mon-pix/tests/acceptance/challenge-page-banner_test.js
@@ -1,10 +1,9 @@
-import { click, find } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { visit } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { clickByLabel } from '../helpers/click-by-label';
 import setupIntl from '../helpers/setup-intl';
 
 module('Acceptance | Challenge page banner', function (hooks) {
@@ -23,12 +22,13 @@ module('Acceptance | Challenge page banner', function (hooks) {
   module('When user is starting a campaign assessment', function () {
     test('should display a campaign banner', async function (assert) {
       // when
-      await visit(`campagnes/${campaign.code}`);
-      await click('.campaign-landing-page__start-button');
-      await clickByLabel(this.intl.t('pages.tutorial.pass'));
+      const screen = await visit(`campagnes/${campaign.code}`);
+      await click(screen.getByRole('button', { name: 'Je commence' }));
+      await click(screen.getByRole('button', { name: 'Ignorer' }));
 
       // then
-      assert.ok(find('.assessment-banner'));
+      assert.dom(screen.getByRole('img', { name: 'pix' })).exists();
+      assert.dom(screen.getByRole('link', { name: 'Quitter' })).exists();
     });
 
     test('should display accessibility information in the banner', async function (assert) {
@@ -36,27 +36,11 @@ module('Acceptance | Challenge page banner', function (hooks) {
       server.create('campaign-participation', { campaign, user, isShared: false, createdAt: Date.now() });
 
       // when
-      await visit(`campagnes/${campaign.code}`);
-      await clickByLabel(this.intl.t('pages.tutorial.pass'));
-      const title = find('.assessment-banner__title');
-      const a11yText = title.firstChild.textContent;
+      const screen = await visit(`campagnes/${campaign.code}`);
+      await click(screen.getByRole('button', { name: 'Ignorer' }));
 
       // then
-      assert.strictEqual(a11yText, "Épreuve pour l'évaluation : ");
-    });
-
-    test('should display the campaign name in the banner', async function (assert) {
-      // given
-      server.create('campaign-participation', { campaign, user, isShared: false, createdAt: Date.now() });
-
-      // when
-      await visit(`campagnes/${campaign.code}`);
-      await clickByLabel(this.intl.t('pages.tutorial.pass'));
-      const title = find('.assessment-banner__title');
-      const campaignName = title.lastChild.textContent;
-
-      // then
-      assert.strictEqual(campaignName, campaign.title);
+      assert.dom(screen.getByRole('heading', { name: "Épreuve pour l'évaluation : SomeTitle", level: 1 })).exists();
     });
   });
 });

--- a/mon-pix/tests/acceptance/user-account_test.js
+++ b/mon-pix/tests/acceptance/user-account_test.js
@@ -1,10 +1,9 @@
-import { currentURL, visit } from '@ember/test-helpers';
+import { currentURL, click } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { module, test } from 'qunit';
 import { authenticate } from '../helpers/authentication';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import { contains } from '../helpers/contains';
-import { clickByLabel } from '../helpers/click-by-label';
 import setupIntl from '../helpers/setup-intl';
 
 module('Acceptance | User account page', function (hooks) {
@@ -42,20 +41,26 @@ module('Acceptance | User account page', function (hooks) {
     module('My account menu', function () {
       test('should display my account menu', async function (assert) {
         // when
-        await visit('/mon-compte');
+        const screen = await visit('/mon-compte');
 
         // then
-        assert.ok(contains(this.intl.t('pages.user-account.personal-information.menu-link-title')));
-        assert.ok(contains(this.intl.t('pages.user-account.connexion-methods.menu-link-title')));
-        assert.ok(contains(this.intl.t('pages.user-account.language.menu-link-title')));
+        assert.ok(
+          screen.getByRole('link', { name: this.intl.t('pages.user-account.personal-information.menu-link-title') })
+        );
+        assert.ok(
+          screen.getByRole('link', { name: this.intl.t('pages.user-account.connexion-methods.menu-link-title') })
+        );
+        assert.ok(screen.getByRole('link', { name: this.intl.t('pages.user-account.language.menu-link-title') }));
       });
 
       test('should display personal information on click on "Informations personnelles"', async function (assert) {
         // given
-        await visit('/mon-compte');
+        const screen = await visit('/mon-compte');
 
         // when
-        await clickByLabel(this.intl.t('pages.user-account.personal-information.menu-link-title'));
+        await click(
+          screen.getByRole('link', { name: this.intl.t('pages.user-account.personal-information.menu-link-title') })
+        );
 
         // then
         assert.strictEqual(currentURL(), '/mon-compte/informations-personnelles');
@@ -63,10 +68,12 @@ module('Acceptance | User account page', function (hooks) {
 
       test('should display connection methods on click on "Méthodes de connexion"', async function (assert) {
         // given
-        await visit('/mon-compte');
+        const screen = await visit('/mon-compte');
 
         // when
-        await clickByLabel(this.intl.t('pages.user-account.connexion-methods.menu-link-title'));
+        await click(
+          screen.getByRole('link', { name: this.intl.t('pages.user-account.connexion-methods.menu-link-title') })
+        );
 
         // then
         assert.strictEqual(currentURL(), '/mon-compte/methodes-de-connexion');
@@ -74,10 +81,10 @@ module('Acceptance | User account page', function (hooks) {
 
       test('should display language on click on "Choisir ma langue"', async function (assert) {
         // given
-        await visit('/mon-compte');
+        const screen = await visit('/mon-compte');
 
         // when
-        await clickByLabel(this.intl.t('pages.user-account.language.menu-link-title'));
+        await click(screen.getByRole('link', { name: this.intl.t('pages.user-account.language.menu-link-title') }));
 
         // then
         assert.strictEqual(currentURL(), '/mon-compte/langue');

--- a/mon-pix/tests/helpers/authentication.js
+++ b/mon-pix/tests/helpers/authentication.js
@@ -1,4 +1,5 @@
-import { fillIn, visit } from '@ember/test-helpers';
+import { fillIn } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
 import { clickByLabel } from './click-by-label';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 
@@ -19,10 +20,11 @@ export async function authenticateByEmail(user) {
 }
 
 export async function authenticateByUsername(user) {
-  await visit('/connexion');
+  const screen = await visit('/connexion');
   await fillIn('#login', user.username);
   await fillIn('#password', user.password);
   await clickByLabel('Je me connecte');
+  return screen;
 }
 
 export function generateGarAuthenticationURLHash(user) {

--- a/mon-pix/tests/integration/components/badge-card_test.js
+++ b/mon-pix/tests/integration/components/badge-card_test.js
@@ -1,27 +1,28 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { find, render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | Badge Card', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  hooks.beforeEach(function () {
+  test('should render the badge acquired card', async function (assert) {
+    // given
     this.set('title', 'Badge de winner');
     this.set('message', 'Bravo ! Tu as ton badge !');
     this.set('imageUrl', '/images/background/hexa-pix.svg');
     this.set('altMessage', 'Ceci est un badge.');
-  });
 
-  test('should render the badge acquired card', async function (assert) {
     // when
-    await render(
+    const screen = await render(
       hbs`<BadgeCard @message={{this.message}} @title={{this.title}} @imageUrl={{this.imageUrl}} @altMessage={{this.altMessage}} />`
     );
 
     // then
-    assert.dom('.badge-card').exists();
-    assert.strictEqual(find('.badge-card-text__title').textContent.trim(), 'Badge de winner');
-    assert.strictEqual(find('.badge-card-text__message').textContent.trim(), 'Bravo ! Tu as ton badge !');
+    assert.dom(screen.getByRole('heading', { name: 'Badge de winner', level: 3 })).exists();
+    assert
+      .dom(screen.getByRole('img', { name: 'Ceci est un badge.' }))
+      .hasAttribute('src', '/images/background/hexa-pix.svg');
+    assert.dom(screen.getByText('Bravo ! Tu as ton badge !')).exists();
   });
 });

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card/ongoing_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card/ongoing_test.js
@@ -1,19 +1,14 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
-import { contains } from '../../../../helpers/contains';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | CampaignParticipationOverview | Card | Ongoing ', function (hooks) {
   setupIntlRenderingTest(hooks);
-  let store;
-
-  hooks.beforeEach(function () {
-    store = this.owner.lookup('service:store');
-  });
 
   test('should render card info when card has "ONGOING" status', async function (assert) {
     // given
+    const store = this.owner.lookup('service:store');
     const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
       isShared: false,
       createdAt: '2020-12-10T15:16:20.109Z',
@@ -24,13 +19,15 @@ module('Integration | Component | CampaignParticipationOverview | Card | Ongoing
     this.set('campaignParticipationOverview', campaignParticipationOverview);
 
     // when
-    await render(hbs`<CampaignParticipationOverview::Card @model={{this.campaignParticipationOverview}} />`);
+    const screen = await render(
+      hbs`<CampaignParticipationOverview::Card @model={{this.campaignParticipationOverview}} />`
+    );
 
     // then
-    assert.ok(contains('My organization'));
-    assert.ok(contains('My campaign'));
-    assert.ok(contains(this.intl.t('pages.campaign-participation-overview.card.tag.started').toUpperCase()));
-    assert.ok(contains(this.intl.t('pages.campaign-participation-overview.card.resume')));
-    assert.ok(contains(this.intl.t('pages.campaign-participation-overview.card.started-at', { date: '10/12/2020' })));
+    assert.dom(screen.getByRole('link', { name: 'Reprendre le parcours My campaign' })).exists();
+    assert.dom(screen.getByRole('heading', { name: 'My organization', level: 2 })).exists();
+    assert.dom(screen.getByText('My campaign')).exists();
+    assert.dom(screen.getByText('En cours')).exists();
+    assert.dom(screen.getByText('Commencé le 10/12/2020')).exists();
   });
 });

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card_test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card_test.js
@@ -1,18 +1,15 @@
 import { module, test } from 'qunit';
-import { render } from '@ember/test-helpers';
-import { contains } from '../../../helpers/contains';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | CampaignParticipationOverview | Card', function (hooks) {
   setupIntlRenderingTest(hooks);
-  let store;
 
-  hooks.beforeEach(function () {
-    store = this.owner.lookup('service:store');
-  });
   module('when the participation status is ONGOING', function () {
     test('should display CardOngoing', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
       const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
         isShared: false,
         createdAt: '2020-12-10T15:16:20.109Z',
@@ -23,13 +20,20 @@ module('Integration | Component | CampaignParticipationOverview | Card', functio
 
       this.set('campaignParticipationOverview', campaignParticipationOverview);
 
-      await render(hbs`<CampaignParticipationOverview::Card @model={{this.campaignParticipationOverview}} />}`);
-      assert.ok(contains('EN COURS'));
+      // when
+      const screen = await render(
+        hbs`<CampaignParticipationOverview::Card @model={{this.campaignParticipationOverview}} />}`
+      );
+
+      // then
+      assert.dom(screen.getByText('En cours')).exists();
     });
   });
 
   module('when the participation status is TO_SHARE', function () {
     test('should display CardToShare', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
       const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
         isShared: false,
         createdAt: '2020-12-10T15:16:20.109Z',
@@ -40,13 +44,20 @@ module('Integration | Component | CampaignParticipationOverview | Card', functio
 
       this.set('campaignParticipationOverview', campaignParticipationOverview);
 
-      await render(hbs`<CampaignParticipationOverview::Card @model={{this.campaignParticipationOverview}} />}`);
-      assert.ok(contains('À ENVOYER'));
+      // when
+      const screen = await render(
+        hbs`<CampaignParticipationOverview::Card @model={{this.campaignParticipationOverview}} />}`
+      );
+
+      // then
+      assert.dom(screen.getByText('À envoyer')).exists();
     });
   });
 
   module('when the participation status is ENDED', function () {
     test('should display CardEnded', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
       const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
         isShared: true,
         createdAt: '2020-12-10T15:16:20.109Z',
@@ -58,13 +69,20 @@ module('Integration | Component | CampaignParticipationOverview | Card', functio
 
       this.set('campaignParticipationOverview', campaignParticipationOverview);
 
-      await render(hbs`<CampaignParticipationOverview::Card @model={{this.campaignParticipationOverview}} />}`);
-      assert.ok(contains('TERMINÉ'));
+      // when
+      const screen = await render(
+        hbs`<CampaignParticipationOverview::Card @model={{this.campaignParticipationOverview}} />}`
+      );
+
+      // then
+      assert.dom(screen.getByText('Terminé')).exists();
     });
   });
 
   module('when the participation status is DISABLED', function () {
     test('should display CardDisabled', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
       const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
         isShared: false,
         createdAt: '2020-12-18T15:16:20.109Z',
@@ -75,8 +93,13 @@ module('Integration | Component | CampaignParticipationOverview | Card', functio
 
       this.set('campaignParticipationOverview', campaignParticipationOverview);
 
-      await render(hbs`<CampaignParticipationOverview::Card @model={{this.campaignParticipationOverview}} />}`);
-      assert.ok(contains('INACTIF'));
+      // when
+      const screen = await render(
+        hbs`<CampaignParticipationOverview::Card @model={{this.campaignParticipationOverview}} />}`
+      );
+
+      // then
+      assert.dom(screen.getByText('Inactif')).exists();
     });
   });
 });

--- a/mon-pix/tests/integration/components/campaign-start-block_test.js
+++ b/mon-pix/tests/integration/components/campaign-start-block_test.js
@@ -1,10 +1,9 @@
 import { module, test } from 'qunit';
 import Service from '@ember/service';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
-import { contains } from '../../helpers/contains';
+import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { clickByLabel } from '../../helpers/click-by-label';
 import sinon from 'sinon';
 
 module('Integration | Component | campaign-start-block', function (hooks) {
@@ -21,16 +20,23 @@ module('Integration | Component | campaign-start-block', function (hooks) {
       this.set('startCampaignParticipation', sinon.stub());
 
       // when
-      await render(hbs`
+      const screen = await render(hbs`
         <CampaignStartBlock
           @campaign={{this.campaign}}
           @startCampaignParticipation={{this.startCampaignParticipation}}
         />`);
 
       // then
-      assert.dom('[src="http://orga.com/logo.png"][alt="My organisation"]').exists();
-      assert.ok(contains(this.intl.t('pages.campaign-landing.profiles-collection.announcement')));
-      assert.ok(contains('My campaign text'));
+      assert.dom(screen.getByRole('img', { name: 'My organisation' })).hasAttribute('src', 'http://orga.com/logo.png');
+      assert
+        .dom(
+          screen.getByRole('heading', {
+            name: this.intl.t('pages.campaign-landing.profiles-collection.announcement'),
+            level: 2,
+          })
+        )
+        .exists();
+      assert.dom(screen.getByText('My campaign text')).exists();
     });
   });
 
@@ -61,7 +67,7 @@ module('Integration | Component | campaign-start-block', function (hooks) {
 
     test('should display the link to disconnect', async function (assert) {
       // when
-      await render(hbs`
+      const screen = await render(hbs`
         <CampaignStartBlock
           @campaign={{this.campaign}}
           @startCampaignParticipation={{this.startCampaignParticipation}}
@@ -69,20 +75,24 @@ module('Integration | Component | campaign-start-block', function (hooks) {
 
       // then
       assert.ok(
-        contains(this.intl.t('pages.campaign-landing.warning-message', { firstName: 'Izuku', lastName: 'Midorya' }))
+        screen.getByText(
+          this.intl.t('pages.campaign-landing.warning-message', { firstName: 'Izuku', lastName: 'Midorya' })
+        )
       );
-      assert.ok(contains(this.intl.t('pages.campaign-landing.warning-message-logout')));
+      assert
+        .dom(screen.getByRole('link', { name: this.intl.t('pages.campaign-landing.warning-message-logout') }))
+        .exists();
     });
 
     test('should call session.invalidate to shut down the session when user click on disconnect', async function (assert) {
       // when
-      await render(hbs`
+      const screen = await render(hbs`
         <CampaignStartBlock
           @campaign={{this.campaign}}
           @startCampaignParticipation={{this.startCampaignParticipation}}
         />`);
 
-      await clickByLabel(this.intl.t('pages.campaign-landing.warning-message-logout'));
+      await click(screen.getByRole('link', { name: this.intl.t('pages.campaign-landing.warning-message-logout') }));
 
       // then
       sinon.assert.calledOnce(session.invalidate);
@@ -96,28 +106,47 @@ module('Integration | Component | campaign-start-block', function (hooks) {
 
       test('should display all text arguments correctly', async function (assert) {
         // when
-        await render(hbs`
+        const screen = await render(hbs`
           <CampaignStartBlock
             @campaign={{this.campaign}}
             @startCampaignParticipation={{this.startCampaignParticipation}}
           />`);
+
         // then
-        assert.notOk(contains(this.intl.t('pages.campaign-landing.profiles-collection.announcement')));
-        assert.ok(contains(this.intl.t('pages.campaign-landing.profiles-collection.action')));
-        assert.ok(contains(this.intl.t('pages.campaign-landing.profiles-collection.legal')));
+        assert
+          .dom(
+            screen.queryByRole('heading', {
+              name: this.intl.t('pages.campaign-landing.profiles-collection.announcement'),
+            })
+          )
+          .doesNotExist();
+        assert
+          .dom(
+            screen.getByRole('button', {
+              name: this.intl.t('pages.campaign-landing.profiles-collection.action'),
+            })
+          )
+          .exists();
+        assert.dom(screen.getByText(this.intl.t('pages.campaign-landing.profiles-collection.legal'))).exists();
       });
 
       test('should display the userName', async function (assert) {
         // when
-        await render(hbs`
+        const screen = await render(hbs`
           <CampaignStartBlock
             @campaign={{this.campaign}}
             @startCampaignParticipation={{this.startCampaignParticipation}}
           />`);
 
         // then
-        assert.ok(contains('Izuku'));
-        assert.ok(contains('envoyez votre profil'));
+        assert
+          .dom(
+            screen.getByRole('heading', {
+              name: 'Izuku, envoyez votre profil',
+              level: 1,
+            })
+          )
+          .exists();
       });
     });
 
@@ -127,28 +156,47 @@ module('Integration | Component | campaign-start-block', function (hooks) {
       });
       test('should display all text arguments correctly', async function (assert) {
         // when
-        await render(hbs`
+        const screen = await render(hbs`
           <CampaignStartBlock
             @campaign={{this.campaign}}
             @startCampaignParticipation={{this.startCampaignParticipation}}
           />`);
+
         // then
-        assert.notOk(contains(this.intl.t('pages.campaign-landing.profiles-collection.announcement')));
-        assert.ok(contains(this.intl.t('pages.campaign-landing.assessment.action')));
-        assert.ok(contains(this.intl.t('pages.campaign-landing.assessment.legal')));
+        assert
+          .dom(
+            screen.queryByRole('heading', {
+              name: this.intl.t('pages.campaign-landing.profiles-collection.announcement'),
+            })
+          )
+          .doesNotExist();
+        assert
+          .dom(
+            screen.getByRole('button', {
+              name: this.intl.t('pages.campaign-landing.assessment.action'),
+            })
+          )
+          .exists();
+        assert.dom(screen.getByText(this.intl.t('pages.campaign-landing.assessment.legal'))).exists();
       });
 
       test('should display the userName', async function (assert) {
         // when
-        await render(hbs`
+        const screen = await render(hbs`
           <CampaignStartBlock
             @campaign={{this.campaign}}
             @startCampaignParticipation={{this.startCampaignParticipation}}
           />`);
 
         // then
-        assert.ok(contains('Izuku'));
-        assert.ok(contains('commencez votre parcours'));
+        assert
+          .dom(
+            screen.getByRole('heading', {
+              name: 'Izuku, commencez votre parcours',
+              level: 1,
+            })
+          )
+          .exists();
       });
     });
   });
@@ -177,17 +225,23 @@ module('Integration | Component | campaign-start-block', function (hooks) {
 
     test('should not display the link to disconnect', async function (assert) {
       // when
-      await render(hbs`
+      const screen = await render(hbs`
         <CampaignStartBlock
           @campaign={{this.campaign}}
           @startCampaignParticipation={{this.startCampaignParticipation}}
         />`);
 
       // then
-      assert.notOk(
-        contains(this.intl.t('pages.campaign-landing.warning-message', { firstName: 'Izuku', lastName: 'Midorya' }))
-      );
-      assert.notOk(contains(this.intl.t('pages.campaign-landing.warning-message-logout')));
+      assert
+        .dom(screen.queryByRole('link', { name: this.intl.t('pages.campaign-landing.warning-message-logout') }))
+        .doesNotExist();
+      assert
+        .dom(
+          screen.queryByText(
+            this.intl.t('pages.campaign-landing.warning-message', { firstName: 'Izuku', lastName: 'Midorya' })
+          )
+        )
+        .doesNotExist();
     });
 
     module('when the campaign is a PROFILES_COLLECTION type', function (hooks) {
@@ -197,13 +251,21 @@ module('Integration | Component | campaign-start-block', function (hooks) {
 
       test('should not display the userName', async function (assert) {
         // when
-        await render(hbs`
+        const screen = await render(hbs`
           <CampaignStartBlock
             @campaign={{this.campaign}}
             @startCampaignParticipation={{this.startCampaignParticipation}}
           />`);
+
         // then
-        assert.ok(contains(this.intl.t('pages.campaign-landing.profiles-collection.title')));
+        assert
+          .dom(
+            screen.getByRole('heading', {
+              name: 'Envoyez votre profil',
+              level: 1,
+            })
+          )
+          .exists();
       });
     });
 
@@ -214,13 +276,21 @@ module('Integration | Component | campaign-start-block', function (hooks) {
 
       test('should not display the userName', async function (assert) {
         // when
-        await render(hbs`
+        const screen = await render(hbs`
           <CampaignStartBlock
             @campaign={{this.campaign}}
             @startCampaignParticipation={{this.startCampaignParticipation}}
           />`);
+
         // then
-        assert.ok(contains(this.intl.t('pages.campaign-landing.assessment.title')));
+        assert
+          .dom(
+            screen.getByRole('heading', {
+              name: 'Commencez votre parcours Pix',
+              level: 1,
+            })
+          )
+          .exists();
       });
     });
   });
@@ -249,17 +319,23 @@ module('Integration | Component | campaign-start-block', function (hooks) {
 
     test('should not display the link to disconnect', async function (assert) {
       // when
-      await render(hbs`
+      const screen = await render(hbs`
         <CampaignStartBlock
           @campaign={{this.campaign}}
           @startCampaignParticipation={{this.startCampaignParticipation}}
         />`);
 
       // then
-      assert.notOk(
-        contains(this.intl.t('pages.campaign-landing.warning-message', { firstName: 'Izuku', lastName: 'Midorya' }))
-      );
-      assert.notOk(contains(this.intl.t('pages.campaign-landing.warning-message-logout')));
+      assert
+        .dom(screen.queryByRole('link', { name: this.intl.t('pages.campaign-landing.warning-message-logout') }))
+        .doesNotExist();
+      assert
+        .dom(
+          screen.queryByText(
+            this.intl.t('pages.campaign-landing.warning-message', { firstName: 'Izuku', lastName: 'Midorya' })
+          )
+        )
+        .doesNotExist();
     });
 
     module('when the campaign is a PROFILES_COLLECTION type', function (hooks) {
@@ -269,13 +345,21 @@ module('Integration | Component | campaign-start-block', function (hooks) {
 
       test('should not display the userName', async function (assert) {
         // when
-        await render(hbs`
+        const screen = await render(hbs`
           <CampaignStartBlock
             @campaign={{this.campaign}}
             @startCampaignParticipation={{this.startCampaignParticipation}}
           />`);
+
         // then
-        assert.ok(contains(this.intl.t('pages.campaign-landing.profiles-collection.title')));
+        assert
+          .dom(
+            screen.getByRole('heading', {
+              name: 'Envoyez votre profil',
+              level: 1,
+            })
+          )
+          .exists();
       });
     });
 
@@ -286,13 +370,21 @@ module('Integration | Component | campaign-start-block', function (hooks) {
 
       test('should not display the userName', async function (assert) {
         // when
-        await render(hbs`
+        const screen = await render(hbs`
           <CampaignStartBlock
             @campaign={{this.campaign}}
             @startCampaignParticipation={{this.startCampaignParticipation}}
           />`);
+
         // then
-        assert.ok(contains(this.intl.t('pages.campaign-landing.assessment.title')));
+        assert
+          .dom(
+            screen.getByRole('heading', {
+              name: 'Commencez votre parcours Pix',
+              level: 1,
+            })
+          )
+          .exists();
       });
     });
   });

--- a/mon-pix/tests/integration/components/certification-banner_test.js
+++ b/mon-pix/tests/integration/components/certification-banner_test.js
@@ -1,7 +1,7 @@
 import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { find, render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | Certification Banner', function (hooks) {
@@ -26,18 +26,19 @@ module('Integration | Component | Certification Banner', function (hooks) {
 
     test('should render component with user fullName', async function (assert) {
       // when
-      await render(hbs`<CertificationBanner @certification={{this.certification}} />`);
+      const screen = await render(hbs`<CertificationBanner @certification={{this.certification}} />`);
 
       // then
-      assert.strictEqual(find('.assessment-banner__title').textContent.trim(), fullName);
+      assert.dom(screen.getByRole('heading', { name: fullName })).exists();
     });
 
     test('should render component with certificationNumber', async function (assert) {
       // when
-      await render(hbs`<CertificationBanner @certificationNumber={{this.certificationNumber}} />`);
+      const screen = await render(hbs`<CertificationBanner @certificationNumber={{this.certificationNumber}} />`);
 
       // then
-      assert.strictEqual(find('.certification-number__value').textContent.trim(), `${certificationNumber}`);
+      assert.dom(screen.getByText('N° de certification')).exists();
+      assert.dom(screen.getByText(certificationNumber)).exists();
     });
   });
 });

--- a/mon-pix/tests/integration/components/choice-chip_test.js
+++ b/mon-pix/tests/integration/components/choice-chip_test.js
@@ -1,16 +1,16 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { render } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | pix-choice-chip', function (hooks) {
   setupIntlRenderingTest(hooks);
 
-  test('renders', async function (assert) {
-    //when
-    await render(hbs`<ChoiceChip>Test</ChoiceChip>`);
+  test('display a link', async function (assert) {
+    // given & when
+    const screen = await render(hbs`<ChoiceChip>Test</ChoiceChip>`);
 
-    //then
-    assert.dom('.pix-choice-chip').exists();
+    // then
+    assert.dom(screen.getByRole('link', { name: 'Test' })).exists();
   });
 });

--- a/mon-pix/tests/integration/components/dashboard/content_test.js
+++ b/mon-pix/tests/integration/components/dashboard/content_test.js
@@ -138,7 +138,9 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
         .dom(screen.getByRole('heading', { name: this.intl.t('pages.dashboard.recommended-competences.title') }))
         .exists();
       assert
-        .dom(screen.getByRole('link', { name: this.intl.t('pages.dashboard.recommended-competences.profile-link') }))
+        .dom(
+          screen.getByRole('link', { name: this.intl.t('pages.dashboard.recommended-competences.extra-information') })
+        )
         .exists();
     });
 

--- a/mon-pix/tests/integration/components/feedback-panel_test.js
+++ b/mon-pix/tests/integration/components/feedback-panel_test.js
@@ -2,31 +2,15 @@ import { resolve } from 'rsvp';
 import Service from '@ember/service';
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { blur, click, find, findAll, fillIn, render } from '@ember/test-helpers';
+import { click, fillIn } from '@ember/test-helpers';
+import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
-import { clickByLabel } from '../../helpers/click-by-label';
-import { contains } from '../../helpers/contains';
-
-const OPEN_FEEDBACK_BUTTON = '.feedback-panel__open-button';
-const BUTTON_SEND = '.feedback-panel__button--send';
-
-const TEXTAREA = 'textarea.feedback-panel__field--content';
-const DROPDOWN = '.feedback-panel__dropdown';
-const CATEGORY_DROPDOWN = 'select[data-test-feedback-category-dropdown]';
-const SUBCATEGORY_DROPDOWN = 'select[data-test-feedback-subcategory-dropdown]';
-const TUTORIAL_AREA = '.feedback-panel__quick-help';
 
 const PICK_SELECT_OPTION_WITH_NESTED_LEVEL = 'question';
 const PICK_ANOTHER_SELECT_OPTION_WITH_NESTED_LEVEL = 'embed';
 const PICK_SELECT_OPTION_WITH_TEXTAREA = 'accessibility';
 const PICK_SELECT_OPTION_WITH_TUTORIAL = 'picture';
 const PICK_SELECT_OPTION_WITH_TEXTAREA_AND_TUTORIAL = '3';
-
-async function setContent(content) {
-  await fillIn(DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA);
-  await fillIn(TEXTAREA, content);
-  await blur(TEXTAREA);
-}
 
 module('Integration | Component | feedback-panel', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -51,149 +35,255 @@ module('Integration | Component | feedback-panel', function (hooks) {
 
       this.owner.unregister('service:store');
       this.owner.register('service:store', StoreStub);
-
-      await render(hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`);
     });
 
     test('should not display the feedback form', async function (assert) {
+      // given & when
+      const screen = await render(hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`);
+
       // then
-      assert.dom('.feedback-panel__form').doesNotExist();
+      assert
+        .dom(screen.queryByText('Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*'))
+        .doesNotExist();
     });
 
     test('should display the "mercix" view when clicking on send button', async function (assert) {
       // given
-      await click(OPEN_FEEDBACK_BUTTON);
-      const CONTENT_VALUE = 'Prêtes-moi ta plume, pour écrire un mot';
-      await setContent(CONTENT_VALUE);
+      const screen = await render(hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`);
+
+      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+
+      await fillIn(
+        screen.getByRole('combobox', { name: 'Sélectionner la catégorie du problème rencontré' }),
+        PICK_SELECT_OPTION_WITH_TEXTAREA
+      );
+
+      const contentValue = 'Prêtes-moi ta plume, pour écrire un mot';
+      await fillIn(screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' }), contentValue);
 
       // when
-      await clickByLabel(this.intl.t('pages.challenge.feedback-panel.form.actions.submit'));
+      await click(screen.getByRole('button', { name: 'Envoyer' }));
 
       // then
-      assert.dom('.feedback-panel__view--form').doesNotExist();
-      assert.dom('.feedback-panel__view--mercix').exists();
+      assert
+        .dom(screen.queryByText('Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*'))
+        .doesNotExist();
+      assert.dom(screen.getByText('Votre commentaire a bien été transmis à l’équipe du projet Pix.')).exists();
+      assert.dom(screen.getByText('Mercix !')).exists();
     });
 
     module('when selecting a category', function () {
       test('should display a second dropdown with the list of questions when category have a nested level', async function (assert) {
+        // given
+        const screen = await render(
+          hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`
+        );
+
         // when
-        await click(OPEN_FEEDBACK_BUTTON);
-        await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_NESTED_LEVEL);
+        await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+
+        await fillIn(
+          screen.getByRole('combobox', { name: 'Sélectionner la catégorie du problème rencontré' }),
+          PICK_SELECT_OPTION_WITH_NESTED_LEVEL
+        );
 
         // then
-        assert.strictEqual(findAll(DROPDOWN).length, 2);
-        assert.dom(TEXTAREA).doesNotExist();
-        assert.dom(BUTTON_SEND).doesNotExist();
+        const textareaLabel = screen.queryByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' });
+        const submitButtonLabel = screen.queryByRole('button', { name: 'Envoyer' });
+        assert.dom(textareaLabel).doesNotExist();
+        assert.dom(submitButtonLabel).doesNotExist();
+
+        assert.dom(screen.getByRole('option', { name: 'Je ne comprends pas la question' })).exists();
+        assert
+          .dom(screen.getByRole('option', { name: 'Je souhaite proposer une amélioration de la question' }))
+          .exists();
       });
 
       test('should directly display the message box and the submit button when category has a textarea', async function (assert) {
+        // given
+        const screen = await render(
+          hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`
+        );
+
         // when
-        await click(OPEN_FEEDBACK_BUTTON);
-        await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA);
+        await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+
+        await fillIn(
+          screen.getByRole('combobox', { name: 'Sélectionner la catégorie du problème rencontré' }),
+          PICK_SELECT_OPTION_WITH_TEXTAREA
+        );
 
         // then
-        assert.strictEqual(findAll(DROPDOWN).length, 1);
-        assert.dom(TEXTAREA).exists();
-        assert.ok(contains(this.intl.t('pages.challenge.feedback-panel.form.actions.submit')));
+        const textareaLabel = screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' });
+        const submitButtonLabel = screen.getByRole('button', { name: 'Envoyer' });
+        assert.dom(textareaLabel).exists();
+        assert.dom(submitButtonLabel).exists();
       });
 
       test('should directly display the tuto without the textbox or the send button when category has a tutorial', async function (assert) {
+        // given
+        const screen = await render(
+          hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`
+        );
+
         // when
-        await click(OPEN_FEEDBACK_BUTTON);
-        await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TUTORIAL);
+        await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+
+        await fillIn(
+          screen.getByRole('combobox', { name: 'Sélectionner la catégorie du problème rencontré' }),
+          PICK_SELECT_OPTION_WITH_TUTORIAL
+        );
 
         // then
-        assert.strictEqual(findAll(DROPDOWN).length, 2);
-        assert.dom(BUTTON_SEND).doesNotExist();
-        assert.dom(TEXTAREA).doesNotExist();
+        const textareaLabel = screen.queryByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' });
+        const submitButtonLabel = screen.queryByRole('button', { name: 'Envoyer' });
+        assert.dom(textareaLabel).doesNotExist();
+        assert.dom(submitButtonLabel).doesNotExist();
+
+        assert.dom(screen.getByRole('option', { name: "L'image ne s'affiche pas" })).exists();
+        assert.dom(screen.getByRole('option', { name: "L'image a un autre problème" })).exists();
       });
 
       test('should show the correct feedback action when selecting two different categories', async function (assert) {
+        // given
+        const screen = await render(
+          hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`
+        );
+        await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+
         // when
-        await click(OPEN_FEEDBACK_BUTTON);
-        await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TUTORIAL);
-        await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA);
+        const selectInputLabel = screen.getByRole('combobox', {
+          name: 'Sélectionner la catégorie du problème rencontré',
+        });
+        await fillIn(selectInputLabel, PICK_SELECT_OPTION_WITH_TUTORIAL);
+        await fillIn(selectInputLabel, PICK_SELECT_OPTION_WITH_TEXTAREA);
 
         // then
-        assert.strictEqual(findAll(DROPDOWN).length, 1);
-        assert.dom(TUTORIAL_AREA).doesNotExist();
-        assert.ok(contains(this.intl.t('pages.challenge.feedback-panel.form.actions.submit')));
-        assert.dom(TEXTAREA).exists();
+        assert.dom(screen.queryByText('Votre connexion internet est peut-être trop faible.')).doesNotExist();
+
+        const textareaLabel = screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' });
+        const submitButtonLabel = screen.getByRole('button', { name: 'Envoyer' });
+        assert.dom(textareaLabel).exists();
+        assert.dom(submitButtonLabel).exists();
       });
 
       test('should hide the second dropdown when category has fewer levels after a deeper category', async function (assert) {
+        // given
+        const screen = await render(
+          hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`
+        );
+        await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+
         // when
-        await click(OPEN_FEEDBACK_BUTTON);
-        await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_NESTED_LEVEL);
-        await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA);
+        const selectInputLabel = screen.getByRole('combobox', {
+          name: 'Sélectionner la catégorie du problème rencontré',
+        });
+        await fillIn(selectInputLabel, PICK_SELECT_OPTION_WITH_NESTED_LEVEL);
+        await fillIn(selectInputLabel, PICK_SELECT_OPTION_WITH_TEXTAREA);
 
         // then
-        assert.strictEqual(findAll(DROPDOWN).length, 1);
-        assert.dom(TUTORIAL_AREA).doesNotExist();
-        assert.ok(contains(this.intl.t('pages.challenge.feedback-panel.form.actions.submit')));
-        assert.dom(TEXTAREA).exists();
+        assert.dom(screen.queryByText('Votre connexion internet est peut-être trop faible.')).doesNotExist();
+
+        const textareaLabel = screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' });
+        const submitButtonLabel = screen.getByRole('button', { name: 'Envoyer' });
+        assert.dom(textareaLabel).exists();
+        assert.dom(submitButtonLabel).exists();
       });
 
       test('should display tutorial with textarea with selecting related category and subcategory', async function (assert) {
+        // given
+        const screen = await render(
+          hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`
+        );
+        await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+
         // when
-        await click(OPEN_FEEDBACK_BUTTON);
-        await fillIn(CATEGORY_DROPDOWN, PICK_ANOTHER_SELECT_OPTION_WITH_NESTED_LEVEL);
-        await fillIn(SUBCATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA_AND_TUTORIAL);
+        const firstSelectInputLabel = screen.getByRole('combobox', {
+          name: 'Sélectionner la catégorie du problème rencontré',
+        });
+        await fillIn(firstSelectInputLabel, PICK_ANOTHER_SELECT_OPTION_WITH_NESTED_LEVEL);
+
+        const secondSelectInputLabel = screen.getByRole('combobox', {
+          name: 'Sélectionner une option pour préciser votre problème',
+        });
+        await fillIn(secondSelectInputLabel, PICK_SELECT_OPTION_WITH_TEXTAREA_AND_TUTORIAL);
 
         // then
-        assert.strictEqual(findAll(DROPDOWN).length, 2);
-        assert.dom(TUTORIAL_AREA).exists();
-        assert.dom(TEXTAREA).exists();
-        assert.ok(contains(this.intl.t('pages.challenge.feedback-panel.form.actions.submit')));
+        assert
+          .dom(
+            screen.getByText(
+              'Nous faisons notre possible pour que les simulateurs fonctionnent sur tous les appareils, tous les OS et tous les navigateurs mais il se peut que vous utilisiez un système particulier.' +
+                "Précisez votre problème en indiquant votre type d'appareil (smartphone, tablette...), votre système d'exploitation et votre navigateur."
+            )
+          )
+          .exists();
+
+        const textareaLabel = screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' });
+        const submitButtonLabel = screen.getByRole('button', { name: 'Envoyer' });
+        assert.dom(textareaLabel).exists();
+        assert.dom(submitButtonLabel).exists();
       });
     });
   });
 
-  module('When assessment is not of type certification', function (hooks) {
-    hooks.beforeEach(async function () {
-      await render(hbs`<FeedbackPanel />`);
-    });
+  module('When assessment is not of type certification', function () {
+    test('should display the feedback panel', async function (assert) {
+      // given & when
+      const screen = await render(hbs`<FeedbackPanel />`);
 
-    test('should display the feedback panel', function (assert) {
-      assert.dom('.feedback-panel__view--link').exists();
+      // then
+      assert.dom(screen.getByRole('button', { name: 'Signaler un problème' })).exists();
     });
 
     test('should toggle the form view when clicking on the toggle link', async function (assert) {
+      // given
+      const screen = await render(hbs`<FeedbackPanel />`);
+
       // when
-      await click(OPEN_FEEDBACK_BUTTON);
+      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
       // then
-      assert.dom('.feedback-panel__view--form').exists();
+      assert
+        .dom(screen.getByText('Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*'))
+        .exists();
 
-      // then when
-      await click(OPEN_FEEDBACK_BUTTON);
+      // when
+      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
       // then
-      assert.dom('.feedback-panel__view--form').doesNotExist();
+      assert
+        .dom(screen.queryByText('Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*'))
+        .doesNotExist();
     });
   });
 
-  module('When assessment is of type certification', function (hooks) {
-    hooks.beforeEach(async function () {
+  module('When assessment is of type certification', function () {
+    test('should display the feedback certification section', async function (assert) {
+      // given
       const assessment = {
         isCertification: true,
       };
       this.set('assessment', assessment);
 
-      await render(hbs`<FeedbackPanel @assessment={{this.assessment}} @context={{this.context}} />`);
-    });
+      const screen = await render(hbs`<FeedbackPanel @assessment={{this.assessment}} @context={{this.context}} />`);
 
-    test('should display the feedback certification section', async function (assert) {
       // when
-      await click(OPEN_FEEDBACK_BUTTON);
+      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
       // then
-      assert.dom('.feedback-certification-section__div').exists();
+      assert
+        .dom(
+          screen.getByText(
+            'Pour signaler un problème, appelez votre surveillant et communiquez-lui les informations suivantes :'
+          )
+        )
+        .exists();
     });
   });
 
-  module('When FeedbackPanel is rendered initially opened (e.g. in a comparison-window)', function (hooks) {
-    hooks.beforeEach(async function () {
+  module('When FeedbackPanel is rendered initially opened (e.g. in a comparison-window)', function () {
+    test('should display the "form" view', async function (assert) {
+      // given
       const assessment = { id: 'assessment_id' };
       const challenge = { id: 'challenge_id' };
 
@@ -201,20 +291,37 @@ module('Integration | Component | feedback-panel', function (hooks) {
       this.set('challenge', challenge);
       this.set('alwaysOpenForm', true);
 
-      await render(
+      // when
+      const screen = await render(
         hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} @alwaysOpenForm={{this.alwaysOpenForm}} />`
       );
-    });
 
-    test('should display the "form" view', async function (assert) {
-      assert.dom('.feedback-panel__view--form').exists();
-      assert.strictEqual(findAll(DROPDOWN).length, 1);
+      // then
+      const selectInputLabel = screen.getByRole('combobox', {
+        name: 'Sélectionner la catégorie du problème rencontré',
+      });
+      assert.dom(selectInputLabel).exists();
     });
 
     test('should not be able to hide the form view', async function (assert) {
+      // given
+      const assessment = { id: 'assessment_id' };
+      const challenge = { id: 'challenge_id' };
+
+      this.set('assessment', assessment);
+      this.set('challenge', challenge);
+      this.set('alwaysOpenForm', true);
+
+      // when
+      const screen = await render(
+        hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} @alwaysOpenForm={{this.alwaysOpenForm}} />`
+      );
+
       // then
-      assert.true(find(OPEN_FEEDBACK_BUTTON).disabled);
-      assert.dom('.feedback-panel__form').exists();
+      assert.true(screen.getByRole('button', { name: 'Signaler un problème' }).disabled);
+      assert
+        .dom(screen.getByText('Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*'))
+        .exists();
     });
   });
 
@@ -225,64 +332,91 @@ module('Integration | Component | feedback-panel', function (hooks) {
 
       this.set('assessment', assessment);
       this.set('challenge', challenge);
-
-      await render(hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`);
-      await click(OPEN_FEEDBACK_BUTTON);
     });
 
     test('should display the "form" view', async function (assert) {
-      assert.dom('.feedback-panel__view--form').exists();
-      assert.strictEqual(findAll(DROPDOWN).length, 1);
+      // given
+      const screen = await render(hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`);
+      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+
+      // then
+      assert
+        .dom(screen.getByText('Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*'))
+        .exists();
     });
 
     test('should be able to hide the form view', async function (assert) {
+      // given
+      const screen = await render(hbs`<FeedbackPanel @assessment={{this.assessment}} @challenge={{this.challenge}} />`);
+      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+
       // when
-      await click(OPEN_FEEDBACK_BUTTON);
+      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
       // then
-      assert.dom('.feedback-panel__form').doesNotExist();
+      assert
+        .dom(screen.queryByText('Pix est à l’écoute de vos remarques pour améliorer les épreuves proposées !*'))
+        .doesNotExist();
     });
   });
 
-  module('Error management', function (hooks) {
-    hooks.beforeEach(async function () {
-      await render(hbs`<FeedbackPanel />`);
-      await click(OPEN_FEEDBACK_BUTTON);
-    });
-
+  module('Error management', function () {
     test('should display error if "content" is empty', async function (assert) {
       // given
-      await fillIn(CATEGORY_DROPDOWN, PICK_SELECT_OPTION_WITH_TEXTAREA);
+      const screen = await render(hbs`<FeedbackPanel />`);
+      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+
+      const selectInputLabel = screen.getByRole('combobox', {
+        name: 'Sélectionner la catégorie du problème rencontré',
+      });
+      await fillIn(selectInputLabel, PICK_SELECT_OPTION_WITH_TEXTAREA);
 
       // when
-      await clickByLabel(this.intl.t('pages.challenge.feedback-panel.form.actions.submit'));
+      await click(screen.getByRole('button', { name: 'Envoyer' }));
 
       // then
-      assert.dom('.feedback-panel__alert').exists();
+      assert.dom(screen.getByText('Vous devez saisir un message.')).exists();
     });
 
     test('should display error if "content" is blank', async function (assert) {
       // given
-      await setContent('');
+      const screen = await render(hbs`<FeedbackPanel />`);
+      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+
+      const selectInputLabel = screen.getByRole('combobox', {
+        name: 'Sélectionner la catégorie du problème rencontré',
+      });
+      await fillIn(selectInputLabel, PICK_SELECT_OPTION_WITH_TEXTAREA);
+
+      await fillIn(screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' }), '');
 
       // when
-      await clickByLabel(this.intl.t('pages.challenge.feedback-panel.form.actions.submit'));
+      await click(screen.getByRole('button', { name: 'Envoyer' }));
 
       // then
-      assert.dom('.feedback-panel__alert').exists();
+      assert.dom(screen.getByText('Vous devez saisir un message.')).exists();
     });
 
     test('should not display error if "form" view (with error) was closed and re-opened', async function (assert) {
       // given
-      await setContent('   ');
-      await clickByLabel(this.intl.t('pages.challenge.feedback-panel.form.actions.submit'));
+      const screen = await render(hbs`<FeedbackPanel />`);
+      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+
+      const selectInputLabel = screen.getByRole('combobox', {
+        name: 'Sélectionner la catégorie du problème rencontré',
+      });
+      await fillIn(selectInputLabel, PICK_SELECT_OPTION_WITH_TEXTAREA);
+
+      await fillIn(screen.getByRole('textbox', { name: 'Décrivez votre problème ou votre suggestion' }), '    ');
+
+      await click(screen.getByRole('button', { name: 'Envoyer' }));
 
       // when
-      await click(OPEN_FEEDBACK_BUTTON);
-      await click(OPEN_FEEDBACK_BUTTON);
+      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
+      await click(screen.getByRole('button', { name: 'Signaler un problème' }));
 
       // then
-      assert.dom('.feedback-panel__alert').doesNotExist();
+      assert.dom(screen.queryByText('Vous devez saisir un message.')).doesNotExist();
     });
   });
 });

--- a/mon-pix/tests/integration/components/qrocm-proposal_test.js
+++ b/mon-pix/tests/integration/components/qrocm-proposal_test.js
@@ -1,18 +1,12 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { find, findAll, render, click } from '@ember/test-helpers';
+import { click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { clickByName, render as renderScreen } from '@1024pix/ember-testing-library';
+import { clickByName, render } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
 
 module('Integration | Component | QROCm proposal', function (hooks) {
   setupIntlRenderingTest(hooks);
-
-  test('renders', async function (assert) {
-    await render(hbs`<QrocmProposal />`);
-
-    assert.dom('.qrocm-proposal').exists();
-  });
 
   module('When block type is select', function (hooks) {
     hooks.beforeEach(function () {
@@ -24,7 +18,7 @@ module('Integration | Component | QROCm proposal', function (hooks) {
       const onChangeSelectStub = sinon.stub();
       this.set('answersValue', { potato: null });
       this.set('onChangeSelect', onChangeSelectStub);
-      const screen = await renderScreen(
+      const screen = await render(
         hbs`<QrocmProposal @proposals={{this.proposals}} @answersValue={{this.answersValue}} @onChangeSelect={{this.onChangeSelect}}/>`
       );
 
@@ -47,10 +41,10 @@ module('Integration | Component | QROCm proposal', function (hooks) {
         this.set('format', 'paragraphe');
 
         // when
-        await render(hbs`<QrocmProposal @proposals={{this.proposals}} @format={{this.format}} />`);
+        const screen = await render(hbs`<QrocmProposal @proposals={{this.proposals}} @format={{this.format}} />`);
 
         // then
-        assert.strictEqual(find('.challenge-response__proposal--paragraph').tagName, 'TEXTAREA');
+        assert.strictEqual(screen.getByRole('textbox', { name: 'Réponse 1' }).tagName, 'TEXTAREA');
       });
     });
 
@@ -61,10 +55,10 @@ module('Integration | Component | QROCm proposal', function (hooks) {
         this.set('format', 'phrase');
 
         // when
-        await render(hbs`<QrocmProposal @proposals={{this.proposals}} @format={{this.format}} />`);
+        const screen = await render(hbs`<QrocmProposal @proposals={{this.proposals}} @format={{this.format}} />`);
 
         // then
-        assert.strictEqual(find('.challenge-response__proposal--sentence').tagName, 'INPUT');
+        assert.strictEqual(screen.getByRole('textbox', { name: 'Réponse 1' }).tagName, 'INPUT');
       });
     });
 
@@ -80,22 +74,23 @@ module('Integration | Component | QROCm proposal', function (hooks) {
           this.set('format', data.format);
 
           // when
-          await render(hbs`<QrocmProposal @proposals={{this.proposals}} @format={{this.format}} />`);
+          const screen = await render(hbs`<QrocmProposal @proposals={{this.proposals}} @format={{this.format}} />`);
 
           // then
-          assert.dom('.challenge-response__proposal--paragraph').doesNotExist();
-          assert.strictEqual(find('.challenge-response__proposal').tagName, 'INPUT');
-          assert.strictEqual(find('.challenge-response__proposal').getAttribute('size'), data.expectedSize);
+          const input = screen.getByRole('textbox', { name: 'Réponse 1' });
+
+          assert.strictEqual(input.tagName, 'INPUT');
+          assert.strictEqual(input.getAttribute('size'), data.expectedSize);
         });
       });
     });
 
     module('Whatever the format', function () {
       [
-        { format: 'mots', cssClass: '.challenge-response__proposal', inputType: 'input' },
-        { format: 'phrase', cssClass: '.challenge-response__proposal--sentence', inputType: 'input' },
-        { format: 'paragraphe', cssClass: '.challenge-response__proposal--paragraph', inputType: 'textarea' },
-        { format: 'unreferenced_format', cssClass: '.challenge-response__proposal', inputType: 'input' },
+        { format: 'mots', inputType: 'input' },
+        { format: 'phrase', inputType: 'input' },
+        { format: 'paragraphe', inputType: 'textarea' },
+        { format: 'unreferenced_format', inputType: 'input' },
       ].forEach((data) => {
         module(`Component behavior when the user clicks on the ${data.inputType}`, function () {
           test('should not display autocompletion answers', async function (assert) {
@@ -106,102 +101,54 @@ module('Integration | Component | QROCm proposal', function (hooks) {
             this.set('format', `${data.format}`);
 
             // when
-            await render(
+            const screen = await render(
               hbs`<QrocmProposal @proposals={{this.proposals}} @format={{this.format}} @answerValue={{this.answerValue}} />`
             );
 
             // then
-            assert.strictEqual(find(`${data.cssClass}`).getAttribute('autocomplete'), 'nope');
+            assert.strictEqual(screen.getByRole('textbox', { name: 'Réponse 1' }).getAttribute('autocomplete'), 'nope');
           });
         });
       });
 
-      [
-        { proposals: '${input}', expectedAriaLabel: ['Réponse 1'] },
-        { proposals: '${rep1}, ${rep2} ${rep3}', expectedAriaLabel: ['Réponse 1', 'Réponse 2', 'Réponse 3'] },
-      ].forEach((data) => {
-        module(`Component aria-label accessibility when proposal is ${data.proposals}`, function (hooks) {
-          let allInputElements;
-
-          hooks.beforeEach(async function () {
+      module('when there are multiple proposals', function () {
+        module('when there is no label associated with input', function () {
+          test('should each have a specific aria-label', async function (assert) {
             // given
-            this.set('proposals', data.proposals);
+            this.set('proposals', '${rep1}, ${rep2} ${rep3}');
             this.set('answerValue', '');
             this.set('format', 'phrase');
 
             // when
-            await render(
+            const screen = await render(
               hbs`<QrocmProposal @proposals={{this.proposals}} @format={{this.format}} @answerValue={{this.answerValue}} />`
             );
 
-            //then
-            allInputElements = findAll('.challenge-response__proposal');
-          });
-
-          // TODO: Fix this the next time the file is edited.
-          // eslint-disable-next-line qunit/require-expect
-          test('should have an aria-label', async function (assert) {
             // then
-            assert.strictEqual(allInputElements.length, data.expectedAriaLabel.length);
-            allInputElements.forEach((element, index) => {
-              assert.ok(element.getAttribute('aria-label').includes(data.expectedAriaLabel[index]));
-            });
+            assert.dom(screen.getByRole('textbox', { name: 'Réponse 1' })).exists();
+            assert.dom(screen.getByRole('textbox', { name: 'Réponse 2' })).exists();
+            assert.dom(screen.getByRole('textbox', { name: 'Réponse 3' })).exists();
           });
+        });
 
-          test('should not have a label', async function (assert) {
+        module('when there is a label associated with input', function () {
+          test('should render label', async function (assert) {
+            // given
+            this.set('proposals', 'texte : ${rep1}\nautre texte : ${rep2}');
+            this.set('answerValue', '');
+            this.set('format', 'phrase');
+
+            // when
+            const screen = await render(
+              hbs`<QrocmProposal @proposals={{this.proposals}} @format={{this.format}} @answerValue={{this.answerValue}} />`
+            );
+
             // then
-            assert.dom('label').doesNotExist();
+            assert.dom(screen.getByRole('textbox', { name: 'texte :' })).exists();
+            assert.dom(screen.getByRole('textbox', { name: 'autre texte :' })).exists();
           });
         });
       });
-
-      [{ proposals: 'texte : ${rep1}\nautre texte : ${rep2}', expectedLabel: ['texte :', 'autre texte :'] }].forEach(
-        (data) => {
-          module(`Component label accessibility when proposal is ${data.proposals}`, function (hooks) {
-            let allLabelElements, allInputElements;
-
-            hooks.beforeEach(async function () {
-              // given
-              this.set('proposals', data.proposals);
-              this.set('answerValue', '');
-              this.set('format', 'phrase');
-
-              // when
-              await render(
-                hbs`<QrocmProposal @proposals={{this.proposals}} @format={{this.format}} @answerValue={{this.answerValue}} />`
-              );
-
-              //then
-              allLabelElements = findAll('label');
-              allInputElements = findAll('.challenge-response__proposal');
-            });
-
-            // TODO: Fix this the next time the file is edited.
-            // eslint-disable-next-line qunit/require-expect
-            test('should have a label', async function (assert) {
-              // then
-              assert.strictEqual(allLabelElements.length, allInputElements.length);
-              assert.strictEqual(allLabelElements.length, data.expectedLabel.length);
-              allLabelElements.forEach((element, index) => {
-                assert.strictEqual(element.textContent.trim(), data.expectedLabel[index]);
-              });
-            });
-
-            test('should not have an aria-label', async function (assert) {
-              // then
-              assert.notOk(find('.challenge-response__proposal').getAttribute('aria-label'));
-            });
-
-            test('should connect the label with the input', async function (assert) {
-              // then
-              assert.strictEqual(allInputElements.length, allLabelElements.length);
-              const allInputElementsId = allInputElements.map((inputElement) => inputElement.getAttribute('id'));
-              const allLabelElementsFor = allLabelElements.map((labelElement) => labelElement.getAttribute('for'));
-              assert.deepEqual(allInputElementsId, allLabelElementsFor);
-            });
-          });
-        }
-      );
     });
   });
 });

--- a/mon-pix/tests/integration/components/routes/register-form_test.js
+++ b/mon-pix/tests/integration/components/routes/register-form_test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { click, fillIn, find, triggerEvent } from '@ember/test-helpers';
+import { click, fillIn, triggerEvent } from '@ember/test-helpers';
 import { render } from '@1024pix/ember-testing-library';
 
 import Service from '@ember/service';
@@ -7,9 +7,11 @@ import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
-import { clickByLabel } from '../../../helpers/click-by-label';
 
 import ENV from '../../../../config/environment';
+
+const EMAIL_INPUT_LABEL = 'obligatoire Adresse e-mail (ex: nom@exemple.fr)';
+const PASSWORD_INPUT_LABEL = '* Mot de passe (8 caractères minimum, dont une majuscule, une minuscule et un chiffre)';
 
 const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'Votre prénom n’est pas renseigné.';
 const EMPTY_LASTNAME_ERROR_MESSAGE = 'Votre nom n’est pas renseigné.';
@@ -19,6 +21,17 @@ const INVALID_YEAR_OF_BIRTH_ERROR_MESSAGE = 'Votre année de naissance n’est p
 const EMPTY_EMAIL_ERROR_MESSAGE = 'Votre email n’est pas valide.';
 const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE =
   'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
+
+const S53_ERROR_MESSAGE = 'Vous possédez déjà un compte Pix via l’ENT.Utilisez-le pour rejoindre le parcours.';
+const R51_ERROR_MESSAGE = '(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga > Documentation - Code R51)';
+const R52_ERROR_MESSAGE = '(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga > Documentation - Code R52)';
+const R61_ERROR_MESSAGE = '(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga > Documentation - Code R61)';
+const R62_ERROR_MESSAGE = '(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga > Documentation - Code R62)';
+const R63_ERROR_MESSAGE = '(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga > Documentation - Code R63)';
+const EMAIL_ERROR_MESSAGE = 'Vous possédez déjà un compte Pix avec l’adresse e-mailj***@example.net';
+const ENT_ERROR_MESSAGE = 'Vous possédez déjà un compte Pix via l’ENT dans un autre établissement scolaire.';
+const USERNAME_ERROR_MESSAGE =
+  'Vous possédez déjà un compte Pix utilisé avec l’identifiant sous la forme prénom.nom suivi de 4 chiffres:j***.h***2';
 
 module('Integration | Component | routes/register-form', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -64,18 +77,21 @@ module('Integration | Component | routes/register-form', function (hooks) {
       const screen = await render(hbs`<Routes::RegisterForm />`);
 
       await fillInputReconciliationForm({ screen, intl: this.intl });
-      await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
-      await click('.pix-toggle-deprecated__off');
+      await click(
+        screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+      );
 
-      await fillIn('#email', 'shi@fu.me');
-      await fillIn('#password', 'Mypassword1');
+      await click(screen.getByText('Mon adresse e-mail'));
+
+      await fillIn(screen.getByRole('textbox', { name: EMAIL_INPUT_LABEL }), 'shi@fu.me');
+      await fillIn(screen.getByLabelText(PASSWORD_INPUT_LABEL), 'Mypassword1');
 
       // when
-      await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+      await click(
+        screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+      );
 
       // then
-      assert.dom('.form-textfield__input--error').doesNotExist();
-      assert.dom('.join-restricted-campaign__error').doesNotExist();
       sinon.assert.calledWith(authenticateStub, 'authenticator:oauth2', {
         login: 'shi@fu.me',
         password: 'Mypassword1',
@@ -89,16 +105,17 @@ module('Integration | Component | routes/register-form', function (hooks) {
       const screen = await render(hbs`<Routes::RegisterForm />`);
 
       await fillInputReconciliationForm({ screen, intl: this.intl });
-      await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
-
-      await fillIn('#password', 'Mypassword1');
+      await click(
+        screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+      );
+      await fillIn(screen.getByLabelText(PASSWORD_INPUT_LABEL), 'Mypassword1');
 
       // when
-      await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+      await click(
+        screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+      );
 
       // then
-      assert.dom('.form-textfield__input--error').doesNotExist();
-      assert.dom('.join-restricted-campaign__error').doesNotExist();
       sinon.assert.calledWith(authenticateStub, 'authenticator:oauth2', {
         login: 'pix.pix1010',
         password: 'Mypassword1',
@@ -113,7 +130,9 @@ module('Integration | Component | routes/register-form', function (hooks) {
       await fillInputReconciliationForm({ screen, intl: this.intl });
 
       // when
-      await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+      await click(
+        screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+      );
 
       // then
       assert.ok(screen.getByText(this.intl.t('pages.login-or-register.register-form.rgpd-legal-notice')));
@@ -128,36 +147,28 @@ module('Integration | Component | routes/register-form', function (hooks) {
       [{ stringFilledIn: '' }, { stringFilledIn: ' ' }].forEach(function ({ stringFilledIn }) {
         test(`should display an error message on firstName field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
           // given
-          await render(hbs`<Routes::RegisterForm />`);
+          const screen = await render(hbs`<Routes::RegisterForm />`);
 
           // when
-          await fillIn('#firstName', stringFilledIn);
-          await triggerEvent('#firstName', 'focusout');
+          await fillIn(screen.getByRole('textbox', { name: 'obligatoire Prénom' }), stringFilledIn);
+          await triggerEvent(screen.getByRole('textbox', { name: 'obligatoire Prénom' }), 'focusout');
 
           // then
-          assert.strictEqual(
-            find('#register-firstName-container #validationMessage-firstName').textContent,
-            EMPTY_FIRSTNAME_ERROR_MESSAGE
-          );
-          assert.dom('#register-firstName-container .form-textfield__input-container--error').exists();
+          assert.dom(screen.getByText(EMPTY_FIRSTNAME_ERROR_MESSAGE)).exists();
         });
       });
 
       [{ stringFilledIn: '' }, { stringFilledIn: ' ' }].forEach(function ({ stringFilledIn }) {
         test(`should display an error message on lastName field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
           // given
-          await render(hbs`<Routes::RegisterForm />`);
+          const screen = await render(hbs`<Routes::RegisterForm />`);
 
           // when
-          await fillIn('#lastName', stringFilledIn);
-          await triggerEvent('#lastName', 'focusout');
+          await fillIn(screen.getByRole('textbox', { name: 'obligatoire Nom' }), stringFilledIn);
+          await triggerEvent(screen.getByRole('textbox', { name: 'obligatoire Nom' }), 'focusout');
 
           // then
-          assert.strictEqual(
-            find('#register-lastName-container #validationMessage-lastName').textContent,
-            EMPTY_LASTNAME_ERROR_MESSAGE
-          );
-          assert.dom('#register-lastName-container .form-textfield__input-container--error').exists();
+          assert.dom(screen.getByText(EMPTY_LASTNAME_ERROR_MESSAGE)).exists();
         });
       });
 
@@ -166,18 +177,14 @@ module('Integration | Component | routes/register-form', function (hooks) {
       }) {
         test(`should display an error message on dayOfBirth field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
           // given
-          await render(hbs`<Routes::RegisterForm />`);
+          const screen = await render(hbs`<Routes::RegisterForm />`);
 
           // when
-          await fillIn('#dayOfBirth', stringFilledIn);
-          await triggerEvent('#dayOfBirth', 'focusout');
+          await fillIn(screen.getByRole('spinbutton', { name: 'Jour de naissance' }), stringFilledIn);
+          await triggerEvent(screen.getByRole('spinbutton', { name: 'Jour de naissance' }), 'focusout');
 
           // then
-          assert.strictEqual(
-            find('#register-birthdate-container #dayValidationMessage').textContent,
-            INVALID_DAY_OF_BIRTH_ERROR_MESSAGE
-          );
-          assert.dom('#register-birthdate-container .form-textfield__input-container--error').exists();
+          assert.dom(screen.getByText(INVALID_DAY_OF_BIRTH_ERROR_MESSAGE)).exists();
         });
       });
 
@@ -186,18 +193,14 @@ module('Integration | Component | routes/register-form', function (hooks) {
       }) {
         test(`should display an error message on monthOfBirth field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
           // given
-          await render(hbs`<Routes::RegisterForm />`);
+          const screen = await render(hbs`<Routes::RegisterForm />`);
 
           // when
-          await fillIn('#monthOfBirth', stringFilledIn);
-          await triggerEvent('#monthOfBirth', 'focusout');
+          await fillIn(screen.getByRole('spinbutton', { name: 'Mois de naissance' }), stringFilledIn);
+          await triggerEvent(screen.getByRole('spinbutton', { name: 'Mois de naissance' }), 'focusout');
 
           // then
-          assert.strictEqual(
-            find('#register-birthdate-container #monthValidationMessage').textContent,
-            INVALID_MONTH_OF_BIRTH_ERROR_MESSAGE
-          );
-          assert.dom('#register-birthdate-container .form-textfield__input-container--error').exists();
+          assert.dom(screen.getByText(INVALID_MONTH_OF_BIRTH_ERROR_MESSAGE)).exists();
         });
       });
 
@@ -206,18 +209,14 @@ module('Integration | Component | routes/register-form', function (hooks) {
       }) {
         test(`should display an error message on yearOfBirth field, when '${stringFilledIn}' is typed and focused out`, async function (assert) {
           // given
-          await render(hbs`<Routes::RegisterForm />`);
+          const screen = await render(hbs`<Routes::RegisterForm />`);
 
           // when
-          await fillIn('#yearOfBirth', stringFilledIn);
-          await triggerEvent('#yearOfBirth', 'focusout');
+          await fillIn(screen.getByRole('spinbutton', { name: 'Année de naissance' }), stringFilledIn);
+          await triggerEvent(screen.getByRole('spinbutton', { name: 'Année de naissance' }), 'focusout');
 
           // then
-          assert.strictEqual(
-            find('#register-birthdate-container #yearValidationMessage').textContent,
-            INVALID_YEAR_OF_BIRTH_ERROR_MESSAGE
-          );
-          assert.dom('#register-birthdate-container .form-textfield__input-container--error').exists();
+          assert.dom(screen.getByText(INVALID_YEAR_OF_BIRTH_ERROR_MESSAGE)).exists();
         });
       });
 
@@ -229,19 +228,17 @@ module('Integration | Component | routes/register-form', function (hooks) {
           const screen = await render(hbs`<Routes::RegisterForm /> `);
 
           await fillInputReconciliationForm({ screen, intl: this.intl });
-          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+          await click(
+            screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+          );
 
           // when
-          await click('.pix-toggle-deprecated__off');
-          await fillIn('#email', stringFilledIn);
-          await triggerEvent('#email', 'focusout');
+          await click(screen.getByText('Mon adresse e-mail'));
+          await fillIn(screen.getByRole('textbox', { name: EMAIL_INPUT_LABEL }), stringFilledIn);
+          await triggerEvent(screen.getByRole('textbox', { name: EMAIL_INPUT_LABEL }), 'focusout');
 
           // then
-          assert.strictEqual(
-            find('#register-email-container #validationMessage-email').textContent,
-            EMPTY_EMAIL_ERROR_MESSAGE
-          );
-          assert.dom('#register-email-container .form-textfield__input-container--error').exists();
+          assert.dom(screen.getByText(EMPTY_EMAIL_ERROR_MESSAGE)).exists();
         });
       });
     });
@@ -257,18 +254,16 @@ module('Integration | Component | routes/register-form', function (hooks) {
           const screen = await render(hbs`<Routes::RegisterForm /> `);
 
           await fillInputReconciliationForm({ screen, intl: this.intl });
-          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+          await click(
+            screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+          );
 
           // when
-          await fillIn('#password', stringFilledIn);
-          await triggerEvent('#password', 'focusout');
+          await fillIn(screen.getByLabelText(PASSWORD_INPUT_LABEL), stringFilledIn);
+          await triggerEvent(screen.getByLabelText(PASSWORD_INPUT_LABEL), 'focusout');
 
           // then
-          assert.strictEqual(
-            find('#register-password-container #validationMessage-password').textContent,
-            INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE
-          );
-          assert.dom('#register-password-container .form-textfield__input-container--error').exists();
+          assert.dom(screen.getByText(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE)).exists();
         });
       });
     });
@@ -278,20 +273,20 @@ module('Integration | Component | routes/register-form', function (hooks) {
       const screen = await render(hbs`<Routes::RegisterForm /> `);
 
       await fillInputReconciliationForm({ screen, intl: this.intl });
-      await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+      await click(
+        screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+      );
 
       // when
-      await click('.pix-toggle-deprecated__off');
-      await fillIn('#email', 'shi.fu');
-      await triggerEvent('#email', 'focusout');
-      await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+      await click(screen.getByText('Mon adresse e-mail'));
+      await fillIn(screen.getByRole('textbox', { name: EMAIL_INPUT_LABEL }), 'shi.fu');
+      await triggerEvent(screen.getByRole('textbox', { name: EMAIL_INPUT_LABEL }), 'focusout');
+      await click(
+        screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+      );
 
       // then
-      assert.strictEqual(
-        find('#register-email-container #validationMessage-email').textContent,
-        EMPTY_EMAIL_ERROR_MESSAGE
-      );
-      assert.dom('#register-email-container .form-textfield__input-container--error').exists();
+      assert.dom(screen.getByText(EMPTY_EMAIL_ERROR_MESSAGE)).exists();
       sinon.assert.notCalled(saveDependentUserStub);
       assert.ok(true);
     });
@@ -299,26 +294,27 @@ module('Integration | Component | routes/register-form', function (hooks) {
     module('When create and reconcile service fails', function () {
       test('Should display registerErrorMessage when authentication service fails with error', async function (assert) {
         // given
-        const expectedRegisterErrorMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY);
         saveDependentUserStub.rejects({ errors: [{ status: '400' }] });
 
         // when
         const screen = await render(hbs`<Routes::RegisterForm />`);
 
         await fillInputReconciliationForm({ screen, intl: this.intl });
-        await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+        await click(
+          screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+        );
 
-        await fillIn('#password', 'Mypassword1');
-        await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+        await fillIn(screen.getByLabelText(PASSWORD_INPUT_LABEL), 'Mypassword1');
+        await click(
+          screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+        );
 
         // then
-        assert.dom('div[id="register-display-error-message"').exists();
-        assert.ok(find('div[id="register-display-error-message"').innerHTML.includes(expectedRegisterErrorMessage));
+        assert.dom(screen.getByText(this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.I18N_KEY))).exists();
       });
 
       test('Should display username specific errors when authentication service fails with username error', async function (assert) {
         // given
-        const expectedRegisterErrorMessage = this.intl.t('api-error-messages.register-error.s50');
         saveDependentUserStub.rejects({
           errors: [
             {
@@ -337,14 +333,17 @@ module('Integration | Component | routes/register-form', function (hooks) {
         const screen = await render(hbs`<Routes::RegisterForm />`);
 
         await fillInputReconciliationForm({ screen, intl: this.intl });
-        await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+        await click(
+          screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+        );
 
-        await fillIn('#password', 'Mypassword1');
-        await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+        await fillIn(screen.getByLabelText(PASSWORD_INPUT_LABEL), 'Mypassword1');
+        await click(
+          screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+        );
 
         // then
-        assert.dom('div[id="register-display-error-message"').exists();
-        assert.ok(find('div[id="register-display-error-message"').innerHTML.includes(expectedRegisterErrorMessage));
+        assert.dom(screen.getByText(this.intl.t('api-error-messages.register-error.s50'))).exists();
       });
     });
 
@@ -353,19 +352,19 @@ module('Integration | Component | routes/register-form', function (hooks) {
       const screen = await render(hbs`<Routes::RegisterForm /> `);
 
       await fillInputReconciliationForm({ screen, intl: this.intl });
-      await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+      await click(
+        screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+      );
 
       // when
-      await fillIn('#password', 'toto');
-      await triggerEvent('#password', 'focusout');
-      await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+      await fillIn(screen.getByLabelText(PASSWORD_INPUT_LABEL), 'toto');
+      await triggerEvent(screen.getByLabelText(PASSWORD_INPUT_LABEL), 'focusout');
+      await click(
+        screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+      );
 
       // then
-      assert.strictEqual(
-        find('#register-password-container #validationMessage-password').textContent,
-        INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE
-      );
-      assert.dom('#register-password-container .form-textfield__input-container--error').exists();
+      assert.dom(screen.getByText(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE)).exists();
       sinon.assert.notCalled(saveDependentUserStub);
       assert.ok(true);
     });
@@ -377,7 +376,7 @@ module('Integration | Component | routes/register-form', function (hooks) {
       {
         status: '404',
         errorMessage:
-          'Vous êtes un élève ? <br> Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant. <br><br> Vous êtes un enseignant ? <br> L’accès à un parcours n’est pas disponible pour le moment.',
+          'Vous êtes un élève ? Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant. Vous êtes un enseignant ? L’accès à un parcours n’est pas disponible pour le moment.',
       },
       { status: '500', errorMessage: internalServerErrorMessage },
     ].forEach(({ status, errorMessage }) => {
@@ -387,10 +386,12 @@ module('Integration | Component | routes/register-form', function (hooks) {
         await fillInputReconciliationForm({ screen, intl: this.intl });
 
         // when
-        await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+        await click(
+          screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+        );
 
         // then
-        assert.strictEqual(find('div[id="register-error-message"').innerHTML, errorMessage);
+        assert.dom(screen.getByText(errorMessage)).exists();
       });
     });
 
@@ -399,8 +400,6 @@ module('Integration | Component | routes/register-form', function (hooks) {
         test('should display the error message related to the short code S61)', async function (assert) {
           // given
           const meta = { shortCode: 'S61', value: 'j***@example.net' };
-          const expectedErrorMessage = this.intl.t('api-error-messages.register-error.s61', { value: meta.value });
-
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
@@ -415,10 +414,15 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await fillInputReconciliationForm({ screen, intl: this.intl });
 
           // when
-          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+          await click(
+            screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+          );
 
           // then
-          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          const errorMessage = screen.getByText(
+            (errorMessage) => errorMessage.startsWith(EMAIL_ERROR_MESSAGE) && errorMessage.endsWith(R61_ERROR_MESSAGE)
+          );
+          assert.dom(errorMessage).exists();
         });
       });
 
@@ -426,8 +430,6 @@ module('Integration | Component | routes/register-form', function (hooks) {
         test('should display the error message related to the short code S62)', async function (assert) {
           // given
           const meta = { shortCode: 'S62', value: 'j***.h***2' };
-          const expectedErrorMessage = this.intl.t('api-error-messages.register-error.s62', { value: meta.value });
-
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
@@ -442,10 +444,16 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await fillInputReconciliationForm({ screen, intl: this.intl });
 
           // when
-          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+          await click(
+            screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+          );
 
           // then
-          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          const errorMessage = screen.getByText(
+            (errorMessage) =>
+              errorMessage.startsWith(USERNAME_ERROR_MESSAGE) && errorMessage.endsWith(R62_ERROR_MESSAGE)
+          );
+          assert.dom(errorMessage).exists();
         });
       });
 
@@ -453,8 +461,6 @@ module('Integration | Component | routes/register-form', function (hooks) {
         test('should display the error message related to the short code S63)', async function (assert) {
           // given
           const meta = { shortCode: 'S63', value: undefined };
-          const expectedErrorMessage = this.intl.t('api-error-messages.register-error.s63', { value: meta.value });
-
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
@@ -469,10 +475,15 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await fillInputReconciliationForm({ screen, intl: this.intl });
 
           // when
-          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+          await click(
+            screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+          );
 
           // then
-          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          const errorMessage = screen.getByText(
+            (errorMessage) => errorMessage.startsWith(ENT_ERROR_MESSAGE) && errorMessage.endsWith(R63_ERROR_MESSAGE)
+          );
+          assert.dom(errorMessage).exists();
         });
       });
 
@@ -480,8 +491,6 @@ module('Integration | Component | routes/register-form', function (hooks) {
         test('should display the error message related to the short code S63)', async function (assert) {
           // given
           const meta = { shortCode: 'S63', value: undefined };
-          const expectedErrorMessage = this.intl.t('api-error-messages.register-error.s63', { value: meta.value });
-
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
@@ -496,10 +505,15 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await fillInputReconciliationForm({ screen, intl: this.intl });
 
           // when
-          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+          await click(
+            screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+          );
 
           // then
-          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          const errorMessage = screen.getByText(
+            (errorMessage) => errorMessage.startsWith(ENT_ERROR_MESSAGE) && errorMessage.endsWith(R63_ERROR_MESSAGE)
+          );
+          assert.dom(errorMessage).exists();
         });
       });
 
@@ -507,8 +521,6 @@ module('Integration | Component | routes/register-form', function (hooks) {
         test('should display the error message related to the short code S63)', async function (assert) {
           // given
           const meta = { shortCode: 'S63', value: undefined };
-          const expectedErrorMessage = this.intl.t('api-error-messages.register-error.s63', { value: meta.value });
-
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
@@ -523,10 +535,15 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await fillInputReconciliationForm({ screen, intl: this.intl });
 
           // when
-          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+          await click(
+            screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+          );
 
           // then
-          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          const errorMessage = screen.getByText(
+            (errorMessage) => errorMessage.startsWith(ENT_ERROR_MESSAGE) && errorMessage.endsWith(R63_ERROR_MESSAGE)
+          );
+          assert.dom(errorMessage).exists();
         });
       });
 
@@ -534,8 +551,6 @@ module('Integration | Component | routes/register-form', function (hooks) {
         test('should display the error message related to the short code S63)', async function (assert) {
           // given
           const meta = { shortCode: 'S63', value: undefined };
-          const expectedErrorMessage = this.intl.t('api-error-messages.register-error.s63', { value: meta.value });
-
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
@@ -550,10 +565,15 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await fillInputReconciliationForm({ screen, intl: this.intl });
 
           // when
-          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+          await click(
+            screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+          );
 
           // then
-          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          const errorMessage = screen.getByText(
+            (errorMessage) => errorMessage.startsWith(ENT_ERROR_MESSAGE) && errorMessage.endsWith(R63_ERROR_MESSAGE)
+          );
+          assert.dom(errorMessage).exists();
         });
       });
 
@@ -561,8 +581,6 @@ module('Integration | Component | routes/register-form', function (hooks) {
         test('should display the error message related to the short code S62)', async function (assert) {
           // given
           const meta = { shortCode: 'S62', value: 'j***.h***2' };
-          const expectedErrorMessage = this.intl.t('api-error-messages.register-error.s62', { value: meta.value });
-
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
@@ -577,10 +595,16 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await fillInputReconciliationForm({ screen, intl: this.intl });
 
           // when
-          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+          await click(
+            screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+          );
 
           // then
-          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          const errorMessage = screen.getByText(
+            (errorMessage) =>
+              errorMessage.startsWith(USERNAME_ERROR_MESSAGE) && errorMessage.endsWith(R62_ERROR_MESSAGE)
+          );
+          assert.dom(errorMessage).exists();
         });
       });
     });
@@ -590,8 +614,6 @@ module('Integration | Component | routes/register-form', function (hooks) {
         test('should display the error message related to the short code S51)', async function (assert) {
           // given
           const meta = { shortCode: 'S51', value: 'j***@example.net' };
-          const expectedErrorMessage = this.intl.t('api-error-messages.register-error.s51', { value: meta.value });
-
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
@@ -606,10 +628,15 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await fillInputReconciliationForm({ screen, intl: this.intl });
 
           // when
-          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+          await click(
+            screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+          );
 
           // then
-          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          const errorMessage = screen.getByText(
+            (errorMessage) => errorMessage.startsWith(EMAIL_ERROR_MESSAGE) && errorMessage.endsWith(R51_ERROR_MESSAGE)
+          );
+          assert.dom(errorMessage).exists();
         });
       });
 
@@ -617,8 +644,6 @@ module('Integration | Component | routes/register-form', function (hooks) {
         test('should display the error message related to the short code S52)', async function (assert) {
           // given
           const meta = { shortCode: 'S52', value: 'j***.h***2' };
-          const expectedErrorMessage = this.intl.t('api-error-messages.register-error.s52', { value: meta.value });
-
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
@@ -633,10 +658,16 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await fillInputReconciliationForm({ screen, intl: this.intl });
 
           // when
-          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+          await click(
+            screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+          );
 
           // then
-          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          const errorMessage = screen.getByText(
+            (errorMessage) =>
+              errorMessage.startsWith(USERNAME_ERROR_MESSAGE) && errorMessage.endsWith(R52_ERROR_MESSAGE)
+          );
+          assert.dom(errorMessage).exists();
         });
       });
 
@@ -644,8 +675,6 @@ module('Integration | Component | routes/register-form', function (hooks) {
         test('should display the error message related to the short code S53)', async function (assert) {
           // given
           const meta = { shortCode: 'S53', value: undefined };
-          const expectedErrorMessage = this.intl.t('api-error-messages.register-error.s53', { value: meta.value });
-
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
@@ -660,10 +689,12 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await fillInputReconciliationForm({ screen, intl: this.intl });
 
           // when
-          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+          await click(
+            screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+          );
 
           // then
-          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          assert.dom(screen.getByText(S53_ERROR_MESSAGE)).exists();
         });
       });
 
@@ -671,8 +702,6 @@ module('Integration | Component | routes/register-form', function (hooks) {
         test('should display the error message related to the short code S53)', async function (assert) {
           // given
           const meta = { shortCode: 'S53', value: undefined };
-          const expectedErrorMessage = this.intl.t('api-error-messages.register-error.s53', { value: meta.value });
-
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
@@ -687,10 +716,12 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await fillInputReconciliationForm({ screen, intl: this.intl });
 
           // when
-          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+          await click(
+            screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+          );
 
           // then
-          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          assert.dom(screen.getByText(S53_ERROR_MESSAGE)).exists();
         });
       });
 
@@ -698,8 +729,6 @@ module('Integration | Component | routes/register-form', function (hooks) {
         test('should display the error message related to the short code S53)', async function (assert) {
           // given
           const meta = { shortCode: 'S53', value: undefined };
-          const expectedErrorMessage = this.intl.t('api-error-messages.register-error.s53', { value: meta.value });
-
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
@@ -714,10 +743,12 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await fillInputReconciliationForm({ screen, intl: this.intl });
 
           // when
-          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+          await click(
+            screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+          );
 
           // then
-          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          assert.dom(screen.getByText(S53_ERROR_MESSAGE)).exists();
         });
       });
 
@@ -725,8 +756,6 @@ module('Integration | Component | routes/register-form', function (hooks) {
         test('should display the error message related to the short code S53)', async function (assert) {
           // given
           const meta = { shortCode: 'S53', value: undefined };
-          const expectedErrorMessage = this.intl.t('api-error-messages.register-error.s53', { value: meta.value });
-
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
@@ -741,10 +770,12 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await fillInputReconciliationForm({ screen, intl: this.intl });
 
           // when
-          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+          await click(
+            screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+          );
 
           // then
-          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          assert.dom(screen.getByText(S53_ERROR_MESSAGE)).exists();
         });
       });
 
@@ -752,8 +783,6 @@ module('Integration | Component | routes/register-form', function (hooks) {
         test('should display the error message related to the short code S52)', async function (assert) {
           // given
           const meta = { shortCode: 'S52', value: 'j***.h***2' };
-          const expectedErrorMessage = this.intl.t('api-error-messages.register-error.s52', { value: meta.value });
-
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
@@ -768,10 +797,16 @@ module('Integration | Component | routes/register-form', function (hooks) {
           await fillInputReconciliationForm({ screen, intl: this.intl });
 
           // when
-          await clickByLabel(this.intl.t('pages.login-or-register.register-form.button-form'));
+          await click(
+            screen.getByRole('button', { name: this.intl.t('pages.login-or-register.register-form.button-form') })
+          );
 
           // then
-          assert.strictEqual(find('div[id="register-error-message"').innerHTML, expectedErrorMessage);
+          const errorMessage = screen.getByText(
+            (errorMessage) =>
+              errorMessage.startsWith(USERNAME_ERROR_MESSAGE) && errorMessage.endsWith(R52_ERROR_MESSAGE)
+          );
+          assert.dom(errorMessage).exists();
         });
       });
     });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -452,8 +452,8 @@
               }
             },
             "detail-selection": {
-              "aria-first": "You have a problem with",
-              "aria-secondary": "Specify your problem",
+              "aria-first": "Select the category of the problem encountered",
+              "aria-secondary": "Select an option to specify your problem",
               "label": "Please specify",
               "options": {
                 "answer-not-accepted": "My answer is correct but has not been approved",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -211,7 +211,10 @@
       "card": {
         "finished-at": "Finished the {date}",
         "results": "Success rate: {result, number, ::percent}",
-        "resume": "Resume",
+        "resume": {
+          "extra-information": "Resume the customised test {campaignTitle}",
+          "information": "Resume"
+        },
         "see-more": "See more",
         "send": "Submit my results",
         "stages": "{count} { count, plural, =0 {star} =1 {star} other {stars} } out of {total}",
@@ -674,6 +677,7 @@
       "title": "Competence",
       "actions": {
         "continue": {
+          "extra-information": "Resume competence {competenceName}",
           "label": "Resume"
         },
         "improve": {
@@ -699,6 +703,7 @@
           }
         },
         "start": {
+          "extra-information": "Start competence {competenceName}",
           "label": "Start"
         }
       },
@@ -737,6 +742,7 @@
         "message": "<h2>Congrats! You've finished all the competences recommended for you!</h2> <p> Want to continue your Pix experience? You can try a competence again. </p>"
       },
       "improvable-competences": {
+        "extra-information": "Access all the competences to retry",
         "title": "Try again",
         "profile-link": "See all",
         "subtitle": "Ready to improve your score?"
@@ -749,6 +755,7 @@
         "message": "<h2>Hi {firstname}, welcome to your dashboard.</h2><p>Quickly and easily access all your tests in progress.<br>Follow the evolution of your Pix score and check if your profile is ready for certification.</p>"
       },
       "recommended-competences": {
+        "extra-information": "Access all recommended competences",
         "title": "Recommended",
         "profile-link": "See all competences",
         "subtitle": "Discover the competences recommended for you."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -211,7 +211,10 @@
       "card": {
         "finished-at": "Terminé le {date}",
         "results": "{result, number, ::percent} de réussite",
-        "resume": "Reprendre",
+        "resume": {
+          "extra-information": "Reprendre le parcours {campaignTitle}",
+          "information": "Reprendre"
+        },
         "see-more": "Voir le détail",
         "send": "Envoyer mes résultats",
         "stages": "{count} { count, plural, =0 {étoile} =1 {étoile} other {étoiles} } sur {total}",
@@ -674,6 +677,7 @@
       "title": "Compétence",
       "actions": {
         "continue": {
+          "extra-information": "Reprendre la compétence {competenceName}",
           "label": "Reprendre"
         },
         "improve": {
@@ -699,6 +703,7 @@
           }
         },
         "start": {
+          "extra-information": "Commencer la compétence {competenceName}",
           "label": "Commencer"
         }
       },
@@ -737,6 +742,7 @@
         "message": "<h2>Bravo vous avez terminé les compétences recommandées !</h2> <p> Pour aller plus loin continuez à vous entraîner en retentant des compétences. </p>"
       },
       "improvable-competences": {
+        "extra-information": "Accéder à toutes les compétences à retenter",
         "title": "Retenter une compétence",
         "profile-link": "Toutes les compétences",
         "subtitle": "Prêt à faire passer votre compétence au niveau supérieur ?"
@@ -749,6 +755,7 @@
         "message": "<h2>Bonjour { firstname }, découvrez votre tableau de bord.</h2><p>Accédez rapidement et facilement à vos parcours et vos tests de compétence déjà commencés.<br/>Retrouvez l’évolution de votre score Pix et vérifiez si votre profil est prêt pour la certification Pix.</p>"
       },
       "recommended-competences": {
+        "extra-information": "Accéder à toutes les compétences recommandées",
         "title": "Compétences recommandées",
         "profile-link": "Toutes les compétences",
         "subtitle": "Explorez les compétences recommandées pour vous."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -452,8 +452,8 @@
               }
             },
             "detail-selection": {
-              "aria-first": "Vous avez un problème avec",
-              "aria-secondary": "Précisez votre problème",
+              "aria-first": "Sélectionner la catégorie du problème rencontré",
+              "aria-secondary": "Sélectionner une option pour préciser votre problème",
               "label": "Précisez",
               "options": {
                 "answer-not-accepted": "Ma réponse est correcte mais n’a pas été validée",


### PR DESCRIPTION
## :unicorn: Problème
Nous avons désormais [un package Pix](https://www.npmjs.com/package/@1024pix/ember-testing-library) qui contient des [méthodes utilisant testing library](https://github.com/1024pix/ember-testing-library/blob/dev/addon/index.js). 

Il est de plus en plus présent dans nos tests front mais nombre d'entre eux se basent toujours sur du html ou du css.
Or une bonne pratique pour les tests consiste à séparer les préoccupations entre le style et les tests. Les noms de classe et la structure DOM changent avec le temps.

## :robot: Proposition
Unifier nos tests sur Pix App en utilisants les méthodes du package et de testing library.

## :rainbow: Remarques
D'autres PR seront nécessaires pour couvrir tous les tests de l'appli. Il y en a beauuuucoup.

Des ajouts d'aria-label sont fait pour distinguer les boutons qui portent le même label.

Exemple du bouton "Reprendre" sur une carte de compétence. Chaque carte possède ce bouton portant le même label. En précisant le nom de la carte, on gagne en précision et on apporte une aide aux utilisateurs qui parcourent l'appli avec un lecteur d'écran:

"Reprendre" => "Reprendre la compétence "Collaborer""

## :100: Pour tester
Rien a tester
