### PR TITLE
[TECH] Faire de l'injection de dépendance dans les controllers (part-1)

### DIFF
--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -6,7 +6,7 @@ module.exports = {
   /**
    * @see https://tools.ietf.org/html/rfc6749#section-4.3
    */
-  async createToken(request, h) {
+  async createToken(request, h, dependencies = { tokenService }) {
     let accessToken, refreshToken;
     let expirationDelaySeconds;
 
@@ -38,7 +38,7 @@ module.exports = {
       .response({
         token_type: 'bearer',
         access_token: accessToken,
-        user_id: tokenService.extractUserId(accessToken),
+        user_id: dependencies.tokenService.extractUserId(accessToken),
         refresh_token: refreshToken,
         expires_in: expirationDelaySeconds,
       })

--- a/api/lib/application/authentication/oidc/oidc-controller.js
+++ b/api/lib/application/authentication/oidc/oidc-controller.js
@@ -1,5 +1,4 @@
 const authenticationServiceRegistry = require('../../../domain/services/authentication/authentication-service-registry.js');
-const authenticationRegistry = require('../../../domain/services/authentication/authentication-service-registry.js');
 const serializer = require('../../../infrastructure/serializers/jsonapi/oidc-identity-providers-serializer.js');
 const usecases = require('../../../domain/usecases/index.js');
 const { UnauthorizedError } = require('../../http-errors.js');
@@ -11,10 +10,17 @@ module.exports = {
     return h.response(serializer.serialize(identityProviders)).code(200);
   },
 
-  async getRedirectLogoutUrl(request, h) {
+  async getRedirectLogoutUrl(
+    request,
+    h,
+    dependencies = {
+      authenticationServiceRegistry,
+    }
+  ) {
     const userId = request.auth.credentials.userId;
     const { identity_provider: identityProvider, logout_url_uuid: logoutUrlUUID } = request.query;
-    const oidcAuthenticationService = authenticationServiceRegistry.lookupAuthenticationService(identityProvider);
+    const oidcAuthenticationService =
+      dependencies.authenticationServiceRegistry.lookupAuthenticationService(identityProvider);
     const redirectLogoutUrl = await oidcAuthenticationService.getRedirectLogoutUrl({
       userId,
       logoutUrlUUID,
@@ -23,7 +29,13 @@ module.exports = {
     return h.response({ redirectLogoutUrl }).code(200);
   },
 
-  async findUserForReconciliation(request, h) {
+  async findUserForReconciliation(
+    request,
+    h,
+    dependencies = {
+      oidcSerializer,
+    }
+  ) {
     const { email, password, identityProvider, authenticationKey } = request.deserializedPayload;
 
     const result = await usecases.findUserForOidcReconciliation({
@@ -33,12 +45,19 @@ module.exports = {
       authenticationKey,
     });
 
-    return h.response(oidcSerializer.serialize(result)).code(200);
+    return h.response(dependencies.oidcSerializer.serialize(result)).code(200);
   },
 
-  async reconcileUser(request, h) {
+  async reconcileUser(
+    request,
+    h,
+    dependencies = {
+      authenticationServiceRegistry,
+    }
+  ) {
     const { identityProvider, authenticationKey } = request.deserializedPayload;
-    const oidcAuthenticationService = authenticationRegistry.lookupAuthenticationService(identityProvider);
+    const oidcAuthenticationService =
+      dependencies.authenticationServiceRegistry.lookupAuthenticationService(identityProvider);
 
     const result = await usecases.reconcileOidcUser({
       authenticationKey,
@@ -48,17 +67,31 @@ module.exports = {
     return h.response({ access_token: result.accessToken, logout_url_uuid: result.logoutUrlUUID }).code(200);
   },
 
-  async getAuthenticationUrl(request, h) {
+  async getAuthenticationUrl(
+    request,
+    h,
+    dependencies = {
+      authenticationServiceRegistry,
+    }
+  ) {
     const { identity_provider: identityProvider } = request.query;
-    const oidcAuthenticationService = authenticationRegistry.lookupAuthenticationService(identityProvider);
+    const oidcAuthenticationService =
+      dependencies.authenticationServiceRegistry.lookupAuthenticationService(identityProvider);
     const result = oidcAuthenticationService.getAuthenticationUrl({ redirectUri: request.query['redirect_uri'] });
     return h.response(result).code(200);
   },
 
-  async authenticateUser(request, h) {
+  async authenticateUser(
+    request,
+    h,
+    dependencies = {
+      authenticationServiceRegistry,
+    }
+  ) {
     const { code, identityProvider, redirectUri, stateSent, stateReceived } = request.deserializedPayload;
 
-    const oidcAuthenticationService = authenticationRegistry.lookupAuthenticationService(identityProvider);
+    const oidcAuthenticationService =
+      dependencies.authenticationServiceRegistry.lookupAuthenticationService(identityProvider);
 
     const result = await usecases.authenticateOidcUser({
       code,
@@ -79,11 +112,18 @@ module.exports = {
     }
   },
 
-  async createUser(request, h) {
+  async createUser(
+    request,
+    h,
+    dependencies = {
+      authenticationServiceRegistry,
+    }
+  ) {
     const { identityProvider, authenticationKey } = request.deserializedPayload;
     const localeFromCookie = request.state?.locale;
 
-    const oidcAuthenticationService = await authenticationServiceRegistry.lookupAuthenticationService(identityProvider);
+    const oidcAuthenticationService =
+      dependencies.authenticationServiceRegistry.lookupAuthenticationService(identityProvider);
     const { accessToken, logoutUrlUUID } = await usecases.createOidcUser({
       authenticationKey,
       identityProvider,

--- a/api/lib/application/passwords/password-controller.js
+++ b/api/lib/application/passwords/password-controller.js
@@ -6,7 +6,13 @@ const userSerializer = require('../../infrastructure/serializers/jsonapi/user-se
 const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils.js');
 
 module.exports = {
-  async createResetDemand(request, h) {
+  async createResetDemand(
+    request,
+    h,
+    dependencies = {
+      passwordResetSerializer,
+    }
+  ) {
     const { email } = request.payload.data.attributes;
     const locale = extractLocaleFromRequest(request);
 
@@ -14,15 +20,15 @@ module.exports = {
       email,
       locale,
     });
-    const serializedPayload = passwordResetSerializer.serialize(passwordResetDemand.attributes);
+    const serializedPayload = dependencies.passwordResetSerializer.serialize(passwordResetDemand.attributes);
 
     return h.response(serializedPayload).created();
   },
 
-  async checkResetDemand(request) {
+  async checkResetDemand(request, h, dependencies = { userSerializer }) {
     const temporaryKey = request.params.temporaryKey;
     const user = await usecases.getUserByResetPasswordDemand({ temporaryKey });
-    return userSerializer.serialize(user);
+    return dependencies.userSerializer.serialize(user);
   },
 
   async updateExpiredPassword(request, h) {

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -33,10 +33,14 @@ describe('Unit | Application | Controller | Authentication', function () {
       };
 
       sinon.stub(usecases, 'authenticateUser').resolves({ accessToken, refreshToken, expirationDelaySeconds });
-      sinon.stub(tokenService, 'extractUserId').returns(USER_ID);
+
+      const tokenServiceStub = { extractUserId: sinon.stub() };
+      tokenServiceStub.extractUserId.withArgs(accessToken).returns(USER_ID);
+
+      const dependencies = { tokenService: tokenServiceStub };
 
       // when
-      const response = await authenticationController.createToken(request, hFake);
+      const response = await authenticationController.createToken(request, hFake, dependencies);
 
       // then
       const expectedResponseResult = {
@@ -76,10 +80,13 @@ describe('Unit | Application | Controller | Authentication', function () {
           },
         };
         sinon.stub(usecases, 'authenticateUser').resolves({ accessToken, refreshToken, expirationDelaySeconds });
-        sinon.stub(tokenService, 'extractUserId').returns(USER_ID);
+        const tokenServiceStub = { extractUserId: sinon.stub() };
+        tokenServiceStub.extractUserId.withArgs(accessToken).returns(USER_ID);
+
+        const dependencies = { tokenService: tokenServiceStub };
 
         // when
-        await authenticationController.createToken(request, hFake);
+        await authenticationController.createToken(request, hFake, dependencies);
 
         // then
         expect(usecases.authenticateUser).to.have.been.calledWithExactly({
@@ -178,14 +185,18 @@ describe('Unit | Application | Controller | Authentication', function () {
           scope,
         },
       };
-      sinon.stub(tokenService, 'extractClientId').returns(client_id);
+      const tokenServiceStub = { extractUserId: sinon.stub() };
+      tokenServiceStub.extractUserId.returns(client_id);
+
+      const dependencies = { tokenService: tokenServiceStub };
+
       sinon
         .stub(usecases, 'authenticateApplication')
         .withArgs({ clientId: client_id, clientSecret: client_secret, scope })
         .resolves(access_token);
 
       // when
-      const response = await authenticationController.authenticateApplication(request, hFake);
+      const response = await authenticationController.authenticateApplication(request, hFake, dependencies);
 
       // then
       const expectedResponseResult = {

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -1,5 +1,4 @@
 const { sinon, expect, hFake } = require('../../../test-helper');
-const tokenService = require('../../../../lib/domain/services/token-service');
 const usecases = require('../../../../lib/domain/usecases/index.js');
 
 const authenticationController = require('../../../../lib/application/authentication/authentication-controller');

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -36,16 +36,23 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
         const oidcAuthenticationService = {
           getRedirectLogoutUrl: sinon.stub(),
         };
-        sinon
-          .stub(authenticationServiceRegistry, 'lookupAuthenticationService')
+
+        const authenticationServiceRegistryStub = {
+          lookupAuthenticationService: sinon.stub(),
+        };
+
+        authenticationServiceRegistryStub.lookupAuthenticationService
           .withArgs(identityProvider)
           .returns(oidcAuthenticationService);
 
+        const dependencies = {
+          authenticationServiceRegistry: authenticationServiceRegistryStub,
+        };
+
         // when
-        await oidcController.getRedirectLogoutUrl(request, hFake);
+        await oidcController.getRedirectLogoutUrl(request, hFake, dependencies);
 
         // then
-        expect(authenticationServiceRegistry.lookupAuthenticationService).to.have.been.calledWith(identityProvider);
         expect(oidcAuthenticationService.getRedirectLogoutUrl).to.have.been.calledWith({
           userId: '123',
           logoutUrlUUID: '1f3dbb71-f399-4c1c-85ae-0a863c78aeea',
@@ -62,14 +69,21 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       const oidcAuthenticationService = {
         getAuthenticationUrl: getAuthenticationUrlStub,
       };
-      sinon
-        .stub(authenticationServiceRegistry, 'lookupAuthenticationService')
+      const authenticationServiceRegistryStub = {
+        lookupAuthenticationService: sinon.stub(),
+      };
+
+      authenticationServiceRegistryStub.lookupAuthenticationService
         .withArgs(identityProvider)
         .returns(oidcAuthenticationService);
+
+      const dependencies = {
+        authenticationServiceRegistry: authenticationServiceRegistryStub,
+      };
       getAuthenticationUrlStub.returns('an authentication url');
 
       // when
-      await oidcController.getAuthenticationUrl(request, hFake);
+      await oidcController.getAuthenticationUrl(request, hFake, dependencies);
 
       //then
       expect(oidcAuthenticationService.getAuthenticationUrl).to.have.been.calledWith({
@@ -106,10 +120,17 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
     it('should authenticate the user with payload parameters', async function () {
       // given
       const oidcAuthenticationService = {};
-      sinon
-        .stub(authenticationServiceRegistry, 'lookupAuthenticationService')
+      const authenticationServiceRegistryStub = {
+        lookupAuthenticationService: sinon.stub(),
+      };
+
+      authenticationServiceRegistryStub.lookupAuthenticationService
         .withArgs(identityProvider)
         .returns(oidcAuthenticationService);
+
+      const dependencies = {
+        authenticationServiceRegistry: authenticationServiceRegistryStub,
+      };
 
       usecases.authenticateOidcUser.resolves({
         pixAccessToken,
@@ -118,7 +139,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       });
 
       // when
-      await oidcController.authenticateUser(request, hFake);
+      await oidcController.authenticateUser(request, hFake, dependencies);
 
       // then
       expect(usecases.authenticateOidcUser).to.have.been.calledWith({
@@ -133,10 +154,17 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
     it('should return PIX access token and logout url uuid when authentication is complete', async function () {
       // given
       const oidcAuthenticationService = {};
-      sinon
-        .stub(authenticationServiceRegistry, 'lookupAuthenticationService')
+      const authenticationServiceRegistryStub = {
+        lookupAuthenticationService: sinon.stub(),
+      };
+
+      authenticationServiceRegistryStub.lookupAuthenticationService
         .withArgs(identityProvider)
         .returns(oidcAuthenticationService);
+
+      const dependencies = {
+        authenticationServiceRegistry: authenticationServiceRegistryStub,
+      };
       usecases.authenticateOidcUser.resolves({
         pixAccessToken,
         logoutUrlUUID: '0208f50b-f612-46aa-89a0-7cdb5fb0d312',
@@ -144,7 +172,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       });
 
       // when
-      const response = await oidcController.authenticateUser(request, hFake);
+      const response = await oidcController.authenticateUser(request, hFake, dependencies);
 
       // then
       const expectedResult = {
@@ -157,17 +185,24 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
     it('should return UnauthorizedError if pix access token does not exist', async function () {
       // given
       const oidcAuthenticationService = {};
-      sinon
-        .stub(authenticationServiceRegistry, 'lookupAuthenticationService')
+      const authenticationServiceRegistryStub = {
+        lookupAuthenticationService: sinon.stub(),
+      };
+
+      authenticationServiceRegistryStub.lookupAuthenticationService
         .withArgs(identityProvider)
         .returns(oidcAuthenticationService);
+
+      const dependencies = {
+        authenticationServiceRegistry: authenticationServiceRegistryStub,
+      };
       const authenticationKey = 'aaa-bbb-ccc';
       const givenName = 'Mélusine';
       const familyName = 'TITEGOUTTE';
       usecases.authenticateOidcUser.resolves({ authenticationKey, givenName, familyName });
 
       // when
-      const error = await catchErr(oidcController.authenticateUser)(request, hFake);
+      const error = await catchErr(oidcController.authenticateUser)(request, hFake, dependencies);
 
       // then
       expect(error).to.be.an.instanceOf(UnauthorizedError);
@@ -188,10 +223,17 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
       };
       const accessToken = 'access.token';
       const oidcAuthenticationService = {};
-      sinon
-        .stub(authenticationServiceRegistry, 'lookupAuthenticationService')
+      const authenticationServiceRegistryStub = {
+        lookupAuthenticationService: sinon.stub(),
+      };
+
+      authenticationServiceRegistryStub.lookupAuthenticationService
         .withArgs(identityProvider)
         .returns(oidcAuthenticationService);
+
+      const dependencies = {
+        authenticationServiceRegistry: authenticationServiceRegistryStub,
+      };
       sinon
         .stub(usecases, 'createOidcUser')
         .withArgs({
@@ -203,7 +245,7 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
         .resolves({ accessToken, logoutUrlUUID: 'logoutUrlUUID' });
 
       // when
-      const result = await oidcController.createUser(request, hFake);
+      const result = await oidcController.createUser(request, hFake, dependencies);
 
       //then
       expect(result.source.access_token).to.equal(accessToken);
@@ -228,20 +270,28 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
           authenticationKey,
         },
       };
-      sinon.stub(authenticationServiceRegistry, 'lookupAuthenticationService');
-      sinon.stub(usecases, 'findUserForOidcReconciliation').resolves({
-        firstName: 'sarah',
-        lastName: 'croche',
-        authenticationMethods: [pixAuthenticationMethod],
-      });
-      sinon.stub(oidcSerializer, 'serialize').returns({
+
+      const serializerStub = {
+        serialize: sinon.stub(),
+      };
+
+      serializerStub.serialize.returns({
         'full-name-from-pix': 'Sarah Pix',
         'full-name-from-external-identity-provider': 'Sarah Idp',
         'authentication-methods': [pixAuthenticationMethod],
       });
 
+      const dependencies = {
+        oidcSerializer: serializerStub,
+      };
+      sinon.stub(usecases, 'findUserForOidcReconciliation').resolves({
+        firstName: 'sarah',
+        lastName: 'croche',
+        authenticationMethods: [pixAuthenticationMethod],
+      });
+
       // when
-      const result = await oidcController.findUserForReconciliation(request, hFake);
+      const result = await oidcController.findUserForReconciliation(request, hFake, dependencies);
 
       // then
       expect(result.source).to.deep.equal({
@@ -261,14 +311,20 @@ describe('Unit | Application | Controller | Authentication | OIDC', function () 
           authenticationKey: '123abc',
         },
       };
-      sinon.stub(authenticationServiceRegistry, 'lookupAuthenticationService');
+      const authenticationServiceRegistryStub = {
+        lookupAuthenticationService: sinon.stub(),
+      };
+
+      const dependencies = {
+        authenticationServiceRegistry: authenticationServiceRegistryStub,
+      };
       sinon.stub(usecases, 'reconcileOidcUser').resolves({
         accessToken: 'accessToken',
         logoutUrlUUID: 'logoutUrlUUID',
       });
 
       // when
-      const result = await oidcController.reconcileUser(request, hFake);
+      const result = await oidcController.reconcileUser(request, hFake, dependencies);
 
       // then
       expect(result.source).to.deep.equal({ access_token: 'accessToken', logout_url_uuid: 'logoutUrlUUID' });

--- a/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
+++ b/api/tests/unit/application/authentication/oidc/oidc-controller_test.js
@@ -1,7 +1,5 @@
 const { sinon, expect, hFake, catchErr, domainBuilder } = require('../../../../test-helper');
-const authenticationServiceRegistry = require('../../../../../lib/domain/services/authentication/authentication-service-registry');
 const oidcController = require('../../../../../lib/application/authentication/oidc/oidc-controller');
-const oidcSerializer = require('../../../../../lib/infrastructure/serializers/jsonapi/oidc-serializer');
 const usecases = require('../../../../../lib/domain/usecases/index.js');
 const { UnauthorizedError } = require('../../../../../lib/application/http-errors');
 


### PR DESCRIPTION
## :unicorn: Problème
Le passage des modules en ESM est bloqué par nos stub de dépendances. Pour régler cela nous devons injecter les dépendances.

## :robot: Proposition
Comme convenu au tech time, nous injectons les dépendances via un 3 arguments `dependencies`. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- CI OK 
- Effectuer des tests des routes 