### PR TITLE
[FEATURE] Traduire la modale de fermeture de l'espace surveillant sur Pix Certif (PIX-7674).

### DIFF
--- a/certif/app/components/session-supervising/header.js
+++ b/certif/app/components/session-supervising/header.js
@@ -10,14 +10,16 @@ export default class Header extends Component {
   @tracked modalInstructionText = 'Information';
   @tracked isConfirmationModalDisplayed = false;
   @service router;
+  @service intl;
 
   @action
   askUserToConfirmLeaving() {
-    this.modalDescriptionText =
-      'Attention, assurez-vous que tous les candidats aient terminé leur test avant de quitter la surveillance. Pour reprendre la surveillance de cette session, vous devrez entrer à nouveau son numéro de session et son mot de passe.';
-    this.modalCancelText = 'Annuler';
-    this.modalConfirmationText = `Quitter la surveillance`;
-    this.modalInstructionText = `Quitter la surveillance de la session ${this.args.session.id}`;
+    this.modalDescriptionText = this.intl.t('pages.session-supervising.header.information');
+    this.modalCancelText = this.intl.t('common.actions.cancel');
+    this.modalConfirmationText = this.intl.t('pages.session-supervising.header.actions.confirmation');
+    this.modalInstructionText = this.intl.t('pages.session-supervising.header.actions.exit-extra-information', {
+      sessionId: this.args.session.id,
+    });
     this.isConfirmationModalDisplayed = true;
   }
 

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -568,9 +568,11 @@
       },
       "header": {
         "actions": {
-          "exit-extra-information": "Exit the invigilation of session {sessionId}"
+          "confirmation": "Exit the invigilation",
+          "exit-extra-information": "Exit the session’s invigilation {sessionId}"
         },
         "access-code": "Access code (candidates)",
+        "information": "Warning, make sure that all the candidates have finished their exam before exiting the invigilation. To resume the invigilation of this session, you will have to enter again it’s session number and it’s password.",
         "session-id": "Session {sessionId}"
       },
       "candidate-list": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -567,9 +567,11 @@
       },
       "header": {
         "actions": {
+          "confirmation": "Quitter la surveillance",
           "exit-extra-information": "Quitter la surveillance de la session {sessionId}"
         },
         "access-code": "Code d'accès (candidats)",
+        "information": "Attention, assurez-vous que tous les candidats aient terminé leur test avant de quitter la surveillance. Pour reprendre la surveillance de cette session, vous devrez entrer à nouveau son numéro de session et son mot de passe.",
         "session-id": "Session {sessionId}"
       },
       "candidate-list": {


### PR DESCRIPTION
## :unicorn: Problème
L'application Pix Certif n'est pas entièrement traduite en anglais.

## :robot: Proposition
Traduire la modale de fermeture de surveillance d'une session

## :100: Pour tester

- Se connecter a Certif avec [certifsco@example.net](mailto:certifsco@example.net) en .org + ?lang=en
- Choisir une session avec des candidats, prendre son numéro de session et le mot de passe surveillant.
- Accéder à l'espace surveillant et remplir les 2 champs
- Cliquer sur le bouton pour quitter l'espace
- Constater que la modale est correctement traduite
