### PR TITLE
[TECH] Traduction de la modale d'ajout de signalement (PIX-6677).

### DIFF
--- a/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
@@ -1,7 +1,7 @@
 <PixModal
   @showModal={{@showModal}}
   class="add-issue-report-modal"
-  @title="Signalement du candidat : {{@report.firstName}} {{@report.lastName}}"
+  @title="{{t 'pages.session-finalization.add-issue-modal.title'}} {{@report.firstName}} {{@report.lastName}}"
   @onCloseButtonClick={{@closeModal}}
 >
   <:content>
@@ -48,17 +48,23 @@
       </div>
 
       {{#if this.showCategoryMissingError}}
-        <PixMessage @type="alert">Veuillez selectionner une catégorie</PixMessage>
+        <PixMessage @type="alert">{{t
+            "pages.session-finalization.add-issue-modal.actions.select-category"
+          }}</PixMessage>
       {{/if}}
 
       {{#if this.showIssueReportSubmitError}}
-        <PixMessage @type="alert">Une erreur s'est produite lors de l'ajout du signalement. Merci de réessayer</PixMessage>
+        <PixMessage @type="alert">{{t "pages.session-finalization.add-issue-modal.errors.add-reporting"}}</PixMessage>
       {{/if}}
     </form>
   </:content>
   <:footer>
     <PixButton @triggerAction={{@closeModal}} @backgroundColor="transparent-light">
       {{t "common.actions.cancel"}}</PixButton>
-    <PixButton form="add-issue-report-form" @type="submit" aria-label="Ajouter le signalement">Valider</PixButton>
+    <PixButton
+      form="add-issue-report-form"
+      @type="submit"
+      aria-label={{t "pages.session-finalization.add-issue-modal.actions.add-reporting"}}
+    >{{t "common.actions.validate"}}</PixButton>
   </:footer>
 </PixModal>

--- a/certif/app/components/issue-report-modal/add-issue-report-modal.js
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.js
@@ -14,10 +14,10 @@ import {
 export class RadioButtonCategory {
   @tracked isChecked;
 
-  constructor({ name, isChecked = false }) {
+  constructor({ name, isChecked = false, intl }) {
     this.name = name;
     this.isChecked = isChecked;
-    this.categoryLabel = categoryToLabel[name];
+    this.categoryLabel = intl.t(categoryToLabel[name]);
     this.categoryCode = categoryToCode[name];
   }
 
@@ -53,8 +53,8 @@ export class RadioButtonCategoryWithDescription extends RadioButtonCategory {
 export class RadioButtonCategoryWithSubcategory extends RadioButtonCategory {
   @tracked subcategory;
 
-  constructor({ name, subcategory, isChecked }) {
-    super({ name, isChecked });
+  constructor({ name, subcategory, isChecked, intl }) {
+    super({ name, isChecked, intl });
     this.subcategory = subcategory;
     this.subcategoryCode = subcategoryToCode[name];
   }
@@ -105,27 +105,35 @@ export class RadioButtonCategoryWithSubcategoryAndQuestionNumber extends RadioBu
 
 export default class AddIssueReportModal extends Component {
   @service store;
+  @service intl;
 
   @tracked signatureIssueCategory = new RadioButtonCategoryWithDescription({
     name: certificationIssueReportCategories.SIGNATURE_ISSUE,
+    intl: this.intl,
   });
 
   @tracked candidateInformationChangeCategory = new RadioButtonCategoryWithSubcategoryWithDescription({
     name: certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES,
     subcategory: certificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
+    intl: this.intl,
   });
+
   @tracked inChallengeCategory = new RadioButtonCategoryWithSubcategoryAndQuestionNumber({
     name: certificationIssueReportCategories.IN_CHALLENGE,
     subcategory: certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
+    intl: this.intl,
   });
   @tracked fraudCategory = new RadioButtonCategory({
     name: certificationIssueReportCategories.FRAUD,
+    intl: this.intl,
   });
   @tracked nonBlockingTechnicalIssueCategory = new RadioButtonCategoryWithDescription({
     name: certificationIssueReportCategories.NON_BLOCKING_TECHNICAL_ISSUE,
+    intl: this.intl,
   });
   @tracked nonBlockingCandidateIssueCategory = new RadioButtonCategoryWithDescription({
     name: certificationIssueReportCategories.NON_BLOCKING_CANDIDATE_ISSUE,
+    intl: this.intl,
   });
   categories = [
     this.signatureIssueCategory,

--- a/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.hbs
@@ -12,7 +12,9 @@
   </div>
   {{#if @candidateInformationChangeCategory.isChecked}}
     <div class="candidate-information-change-certification-issue-report-fields__details">
-      <label for="subcategory-for-category-candidate-information-change">Sélectionnez une sous-catégorie :</label>
+      <label for="subcategory-for-category-candidate-information-change">{{t
+          "pages.session-finalization.add-issue-modal.actions.select-subcategory"
+        }}</label>
       <PixSelect
         @id="subcategory-for-category-candidate-information-change"
         @options={{this.options}}

--- a/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 
 import {
   certificationIssueReportSubcategories,
@@ -10,27 +11,31 @@ import {
 } from 'pix-certif/models/certification-issue-report';
 
 export default class CandidateInformationChangeCertificationIssueReportFieldsComponent extends Component {
+  @service intl;
+
   @tracked
-  subcategoryTextAreaLabel = subcategoryToTextareaLabel[this.args.candidateInformationChangeCategory.subcategory];
+  subcategoryTextAreaLabel = this.intl.t(
+    subcategoryToTextareaLabel[this.args.candidateInformationChangeCategory.subcategory]
+  );
 
   @action
   onChangeSubcategory(option) {
     this.args.candidateInformationChangeCategory.subcategory = option;
-    this.subcategoryTextAreaLabel = subcategoryToTextareaLabel[option];
+    this.subcategoryTextAreaLabel = this.intl.t(subcategoryToTextareaLabel[option]);
   }
 
   options = [
     {
       value: certificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
-      label: `${subcategoryToCode[certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]} ${
+      label: `${subcategoryToCode[certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]} ${this.intl.t(
         subcategoryToLabel[certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]
-      }`,
+      )}`,
     },
     {
       value: certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE,
-      label: `${subcategoryToCode[certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]} ${
+      label: `${subcategoryToCode[certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]} ${this.intl.t(
         subcategoryToLabel[certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]
-      }`,
+      )}`,
     },
   ];
 }

--- a/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.hbs
@@ -12,7 +12,10 @@
   </div>
   {{#if @fraudCategory.isChecked}}
     <div class="fraud-certification-issue-report-fields__details">
-      <p>{{t "pages.session-finalization.add-issue-modal.actions.transmit-report" htmlSafe=true}}</p>
+      <p>{{t "pages.session-finalization.add-issue-modal.actions.transmit-report" htmlSafe=true}}
+        <FaIcon @icon="up-right-from-square" aria-hidden="true" />
+        <span class="sr-only">{{t "navigation.external-link-title"}}</span>
+      </p>
     </div>
   {{/if}}
 </fieldset>

--- a/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.hbs
@@ -12,17 +12,7 @@
   </div>
   {{#if @fraudCategory.isChecked}}
     <div class="fraud-certification-issue-report-fields__details">
-      <p>Merci de transmettre le procès-verbal de fraude rempli pendant la session de certification en utilisant
-        <span>
-          <a
-            class="link"
-            href="https://form-eu.123formbuilder.com/41052/form"
-            target="_blank"
-            rel="noreferrer noopener"
-          >
-            ce formulaire</a>
-        </span>
-      </p>
+      <p>{{t "pages.session-finalization.add-issue-modal.actions.transmit-report" htmlSafe=true}}</p>
     </div>
   {{/if}}
 </fieldset>

--- a/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.hbs
@@ -2,7 +2,9 @@
   <div class="candidate-information-change-certification-issue-report-fields__radio-button">
     {{! template-lint-disable require-input-label }}
     <input
-      aria-label="Sélectionner la catégorie '{{@inChallengeCategory.categoryLabel}}'"
+      aria-label="{{t
+        'pages.session-finalization.add-issue-modal.actions.select-category-label'
+      }} '{{@inChallengeCategory.categoryLabel}}'"
       id="input-radio-for-category-in-challenge"
       type="radio"
       name="in-challenge"
@@ -14,7 +16,9 @@
   </div>
   {{#if @inChallengeCategory.isChecked}}
     <div class="candidate-information-change-certification-issue-report-fields__details">
-      <label for="input-for-category-in-challenge-question-number">Numéro de question :</label>
+      <label for="input-for-category-in-challenge-question-number">{{t
+          "pages.session-finalization.add-issue-modal.actions.enter-question-number"
+        }}</label>
       <Input
         id="input-for-category-in-challenge-question-number"
         name="question-number"
@@ -24,9 +28,11 @@
         @value={{@inChallengeCategory.questionNumber}}
         placeholder="7"
       />
-      <label for="subcategory-for-category-in-challenge">Sélectionnez une sous-catégorie :</label>
+      <label for="subcategory-for-category-in-challenge">{{t
+          "pages.session-finalization.add-issue-modal.actions.select-subcategory"
+        }}</label>
       <PixSelect
-        aria-label="Sélectionner la sous-catégorie"
+        aria-label="{{t 'pages.session-finalization.add-issue-modal.actions.select-subcategory-label'}}"
         @id="subcategory-for-category-in-challenge"
         @options={{this.options}}
         @value={{@inChallengeCategory.subcategory}}

--- a/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.js
@@ -5,8 +5,11 @@ import {
   subcategoryToCode,
   subcategoryToLabel,
 } from 'pix-certif/models/certification-issue-report';
+import { inject as service } from '@ember/service';
 
 export default class InChallengeCertificationIssueReportFields extends Component {
+  @service intl;
+
   @action
   onChangeSubcategory(option) {
     this.args.inChallengeCategory.subcategory = option;
@@ -33,7 +36,7 @@ export default class InChallengeCertificationIssueReportFields extends Component
       const labelForSubcategory = subcategoryToLabel[subcategory];
       return {
         value: certificationIssueReportSubcategories[subcategory],
-        label: `${subcategoryToCode[subcategory]} ${labelForSubcategory}`,
+        label: `${subcategoryToCode[subcategory]} ${this.intl.t(labelForSubcategory)}`,
       };
     })
     .filter(Boolean);

--- a/certif/app/components/issue-report-modal/issue-reports-modal.hbs
+++ b/certif/app/components/issue-report-modal/issue-reports-modal.hbs
@@ -1,39 +1,42 @@
 <PixModal
   @showModal={{@showModal}}
-  @title="Signalement du candidat : {{@report.firstName}} {{@report.lastName}}"
+  @title="{{t 'pages.session-finalization.issue-reports-modal.title'}} {{@report.firstName}} {{@report.lastName}}"
   @onCloseButtonClick={{@closeModal}}
   class="issue-report-modal"
 >
   <:content>
-    <h2>Mes signalements ({{@report.certificationIssueReports.length}})</h2>
+    <h2>{{t "pages.session-finalization.issue-reports-modal.subtitle"}}
+      ({{@report.certificationIssueReports.length}})</h2>
     <div class="issue-report-modal__frame">
       <ul>
         {{#each @report.certificationIssueReports as |issueReport|}}
           <li class="issue-report-modal__report">
             <p class="issue-report-modal__category-label">
-              {{issueReport.categoryCode}}&nbsp;{{issueReport.categoryLabel}}
+              {{issueReport.categoryCode}}&nbsp;{{t issueReport.categoryLabel}}
               <PixIconButton
                 @icon="trash"
-                aria-label="Supprimer le signalement"
+                aria-label={{t "pages.session-finalization.issue-reports-modal.actions.delete-reporting"}}
                 @triggerAction={{fn this.handleClickOnDeleteButton issueReport}}
               />
             </p>
             {{#if issueReport.subcategoryLabel}}
-              <p
-                class="issue-report-modal__subcategory-label"
-              >{{issueReport.subcategoryCode}}&nbsp;{{issueReport.subcategoryLabel}}</p>
+              <p class="issue-report-modal__subcategory-label">{{issueReport.subcategoryCode}}&nbsp;{{t
+                  issueReport.subcategoryLabel
+                }}</p>
             {{/if}}
           </li>
         {{/each}}
       </ul>
       <PixButton @triggerAction={{fn @onClickIssueReport @report}} class="issue-report-modal__add-button">
         <FaIcon @icon="plus" />
-        Ajouter un signalement
+        {{t "pages.session-finalization.issue-reports-modal.actions.add-reporting"}}
       </PixButton>
     </div>
 
     {{#if this.showDeletionError}}
-      <PixMessage @type="alert">Une erreur s'est produite lors de la suppression du signalement. Merci de réessayer</PixMessage>
+      <PixMessage @type="alert">{{t
+          "pages.session-finalization.issue-reports-modal.errors.delete-reporting"
+        }}</PixMessage>
     {{/if}}
   </:content>
 </PixModal>

--- a/certif/app/components/issue-report-modal/non-blocking-candidate-issue-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/non-blocking-candidate-issue-certification-issue-report-fields.hbs
@@ -19,18 +19,18 @@
         />
       </:triggerElement>
       <:tooltip>
-        <span>a quitté temporairement, sous surveillance, la salle d’examen, est arrivé en retard, a rencontré des
-          difficultés pour se connecter à la session, a dû se reconnecter à la session, avait oublié son mot de passe...</span>
+        <span>{{t "pages.session-finalization.add-issue-modal.non-blocking-issues.candidate-examples"}}</span>
       </:tooltip>
     </PixTooltip>
   </div>
   {{#if @nonBlockingCandidateIssueCategory.isChecked}}
     <PixMessage @type="info" @withIcon={{true}}>
-      Signalement à titre informatif, le problème rencontré n'a pas empêché le candidat de continuer à répondre aux
-      questions.
+      {{t "pages.session-finalization.add-issue-modal.non-blocking-issues.candidate-information"}}
     </PixMessage>
     <div class="non-blocking-candidate-issue-certification-issue-report-fields__details">
-      <label for="text-area-for-category-candidate-issue">Décrivez l'incident rencontré</label>
+      <label for="text-area-for-category-candidate-issue">{{t
+          "pages.session-finalization.add-issue-modal.actions.describe"
+        }}</label>
       <PixTextarea
         id="text-area-for-category-candidate-issue"
         @value={{@nonBlockingCandidateIssueCategory.description}}

--- a/certif/app/components/issue-report-modal/non-blocking-technical-issue-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/non-blocking-technical-issue-certification-issue-report-fields.hbs
@@ -15,21 +15,22 @@
           @icon="info-circle"
           tabindex="0"
           aria-describedby="tooltip-technical-issue"
-          aria-label="Incident technique"
+          aria-label="{{t 'pages.session-finalization.add-issue-modal.errors.technical-issue'}}"
         />
       </:triggerElement>
       <:tooltip>
-        <span>l’ordinateur s’est éteint, lenteur significative du réseau et/ou de l’appareil, etc.</span>
+        <span>{{t "pages.session-finalization.add-issue-modal.non-blocking-issues.technical-examples"}}</span>
       </:tooltip>
     </PixTooltip>
   </div>
   {{#if @nonBlockingTechnicalIssueCategory.isChecked}}
     <PixMessage @type="info" @withIcon={{true}}>
-      Signalement à titre informatif, le problème rencontré n'a pas empêché le candidat de continuer à répondre aux
-      questions. En cas d’incident sur une question focus, merci de vous reporter à la catégorie E10.
+      {{t "pages.session-finalization.add-issue-modal.non-blocking-issues.technical-information"}}
     </PixMessage>
     <div class="non-blocking-technical-issue-certification-issue-report-fields__details">
-      <label for="text-area-for-category-technical-issue">Décrivez l'incident rencontré</label>
+      <label for="text-area-for-category-technical-issue">{{t
+          "pages.session-finalization.add-issue-modal.actions.describe"
+        }}</label>
       <PixTextarea
         id="text-area-for-category-technical-issue"
         @value={{@nonBlockingTechnicalIssueCategory.description}}

--- a/certif/app/components/issue-report-modal/signature-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/signature-issue-report-fields.hbs
@@ -12,7 +12,9 @@
   </div>
   {{#if @signatureIssueCategory.isChecked}}
     <div>
-      <label for="text-area-for-category-signature-issue">Précisez</label>
+      <label for="text-area-for-category-signature-issue">{{t
+          "pages.session-finalization.add-issue-modal.actions.specify"
+        }}</label>
       <PixTextarea
         @id="text-area-for-category-signature-issue"
         @value={{@signatureIssueCategory.description}}

--- a/certif/app/models/certification-issue-report.js
+++ b/certif/app/models/certification-issue-report.js
@@ -25,36 +25,44 @@ export const certificationIssueReportSubcategories = {
 };
 
 export const categoryToLabel = {
-  [certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES]: 'Modification infos candidat',
+  [certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES]:
+    'pages.session-finalization.add-issue-modal.category-labels.candidate-informations-changes',
   [certificationIssueReportCategories.SIGNATURE_ISSUE]:
-    'Était présent(e) mais a oublié de signer, ou a signé sur la mauvaise ligne',
-  [certificationIssueReportCategories.FRAUD]: 'Suspicion de fraude',
-  [certificationIssueReportCategories.NON_BLOCKING_TECHNICAL_ISSUE]: 'Incident technique non bloquant',
-  [certificationIssueReportCategories.NON_BLOCKING_CANDIDATE_ISSUE]: 'Incident lié au candidat non bloquant',
-  [certificationIssueReportCategories.IN_CHALLENGE]: 'Problème technique sur une question',
+    'pages.session-finalization.add-issue-modal.category-labels.signature-issue',
+  [certificationIssueReportCategories.FRAUD]: 'pages.session-finalization.add-issue-modal.category-labels.fraud',
+  [certificationIssueReportCategories.NON_BLOCKING_TECHNICAL_ISSUE]:
+    'pages.session-finalization.add-issue-modal.category-labels.non-blocking-technical-issue',
+  [certificationIssueReportCategories.NON_BLOCKING_CANDIDATE_ISSUE]:
+    'pages.session-finalization.add-issue-modal.category-labels.non-blocking-candidate-issue',
+  [certificationIssueReportCategories.IN_CHALLENGE]:
+    'pages.session-finalization.add-issue-modal.category-labels.in-challenge',
 };
 
 export const subcategoryToLabel = {
-  [certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'Modification des prénom/nom/date de naissance',
-  [certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]: 'Ajout/modification du temps majoré',
-  [certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]: "L'image ne s'affiche pas",
-  [certificationIssueReportSubcategories.EMBED_NOT_WORKING]: "Le simulateur/l'application ne s'affiche pas",
+  [certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]:
+    'pages.session-finalization.add-issue-modal.subcategory-labels.name-or-birthdate',
+  [certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]:
+    'pages.session-finalization.add-issue-modal.subcategory-labels.extra-time-percentage',
+  [certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]:
+    'pages.session-finalization.add-issue-modal.subcategory-labels.image-not-displaying',
+  [certificationIssueReportSubcategories.EMBED_NOT_WORKING]:
+    'pages.session-finalization.add-issue-modal.subcategory-labels.embed-not-working',
   [certificationIssueReportSubcategories.FILE_NOT_OPENING]:
-    "Le fichier à télécharger ne se télécharge pas ou ne s'ouvre pas",
+    'pages.session-finalization.add-issue-modal.subcategory-labels.file-not-opening',
   [certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]:
-    'Le site à visiter est indisponible/en maintenance/inaccessible',
+    'pages.session-finalization.add-issue-modal.subcategory-labels.website-unavailable',
   [certificationIssueReportSubcategories.WEBSITE_BLOCKED]:
-    "Le site est bloqué par les restrictions réseau de l'établissement (réseaux sociaux par ex.)",
+    'pages.session-finalization.add-issue-modal.subcategory-labels.website-blocked',
   [certificationIssueReportSubcategories.EXTRA_TIME_EXCEEDED]:
-    "Le candidat bénéficie d'un temps majoré et n'a pas pu répondre à la question dans le temps imparti",
+    'pages.session-finalization.add-issue-modal.subcategory-labels.extra-time-exceeded',
   [certificationIssueReportSubcategories.SOFTWARE_NOT_WORKING]:
-    "Le logiciel installé sur l'ordinateur n'a pas fonctionné",
+    'pages.session-finalization.add-issue-modal.subcategory-labels.software-not-working',
   [certificationIssueReportSubcategories.UNINTENTIONAL_FOCUS_OUT]:
-    'Le candidat a été contraint de cliquer en dehors du cadre autorisé pour une question en mode focus',
+    'pages.session-finalization.add-issue-modal.subcategory-labels.unintentional-focus-out',
   [certificationIssueReportSubcategories.SKIP_ON_OOPS]:
-    'Un problème technique lié à la plateforme Pix a empêché le candidat de répondre à la question',
+    'pages.session-finalization.add-issue-modal.subcategory-labels.skip-on-oops',
   [certificationIssueReportSubcategories.ACCESSIBILITY_ISSUE]:
-    'Problème avec l’accessibilité de la question (ex : daltonisme)',
+    'pages.session-finalization.add-issue-modal.subcategory-labels.accessibility-issue',
 };
 
 export const categoryToCode = {
@@ -82,8 +90,10 @@ export const subcategoryToCode = {
 };
 
 export const subcategoryToTextareaLabel = {
-  [certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'Renseignez les informations correctes',
-  [certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]: 'Précisez le temps majoré',
+  [certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]:
+    'pages.session-finalization.add-issue-modal.subcategory-to-textarea-labels.name-or-birthdate',
+  [certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]:
+    'pages.session-finalization.add-issue-modal.subcategory-to-textarea-labels.extra-time-percentage',
 };
 
 export default class CertificationIssueReport extends Model {

--- a/certif/mirage/factories/certification-issue-report.js
+++ b/certif/mirage/factories/certification-issue-report.js
@@ -2,7 +2,7 @@ import { Factory } from 'miragejs';
 
 export default Factory.extend({
   category() {
-    return 'Issue report category';
+    return 'CANDIDATE_INFORMATIONS_CHANGES';
   },
 
   subcategory() {

--- a/certif/tests/integration/components/issue-report-modal/add-issue-report-modal_test.js
+++ b/certif/tests/integration/components/issue-report-modal/add-issue-report-modal_test.js
@@ -67,7 +67,11 @@ module('Integration | Component | add-issue-report-modal', function (hooks) {
     // then
     for (const category of Object.values(certificationIssueReportCategories)) {
       assert
-        .dom(screen.getByLabelText(`${categoryToCode[category]} ${categoryToLabel[category]}`, { exact: false }))
+        .dom(
+          screen.getByLabelText(`${categoryToCode[category]} ${this.intl.t(categoryToLabel[category])}`, {
+            exact: false,
+          })
+        )
         .exists();
     }
   });

--- a/certif/tests/integration/components/issue-report-modal/candidate-information-change-certification-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/candidate-information-change-certification-issue-report-fields_test.js
@@ -35,7 +35,10 @@ module('Integration | Component | candidate-information-change-certification-iss
   test('it should show dropdown menu with subcategories when category is checked', async function (assert) {
     // given
     const toggleOnCategory = sinon.stub();
-    const candidateInformationChangeCategory = { isChecked: true };
+    const candidateInformationChangeCategory = {
+      isChecked: true,
+      subcategory: certificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
+    };
     this.set('toggleOnCategory', toggleOnCategory);
     this.set('candidateInformationChangeCategory', candidateInformationChangeCategory);
 

--- a/certif/tests/integration/components/issue-report-modal/in-challenge-certification-issue-report-fields_test.js
+++ b/certif/tests/integration/components/issue-report-modal/in-challenge-certification-issue-report-fields_test.js
@@ -19,9 +19,11 @@ module('Integration | Component | in-challenge-certification-issue-report-fields
   test('it should call toggle function on click radio button', async function (assert) {
     // given
     const toggleOnCategory = sinon.stub();
+    const intl = this.owner.lookup('service:intl');
     const inChallengeCategory = new RadioButtonCategoryWithSubcategoryAndQuestionNumber({
       name: 'IN_CHALLENGE',
       isChecked: false,
+      intl,
     });
     this.set('toggleOnCategory', toggleOnCategory);
     this.set('inChallengeCategory', inChallengeCategory);
@@ -33,8 +35,11 @@ module('Integration | Component | in-challenge-certification-issue-report-fields
         @toggleOnCategory={{this.toggleOnCategory}}
         @maxlength={{500}}
       />`);
+
     await click(
-      `[aria-label="Sélectionner la catégorie '${categoryToLabel[certificationIssueReportCategories.IN_CHALLENGE]}'"]`
+      `[aria-label="${this.intl.t(
+        'pages.session-finalization.add-issue-modal.actions.select-category-label'
+      )} '${this.intl.t(categoryToLabel[certificationIssueReportCategories.IN_CHALLENGE])}'"]`
     );
 
     // then
@@ -76,9 +81,12 @@ module('Integration | Component | in-challenge-certification-issue-report-fields
     test(`it should select the subcategory: ${subcategory} when category is checked`, async function (assert) {
       // given
       const toggleOnCategory = sinon.stub();
+      const [subcategoryCode, subcategoryLabel] = subcategory.split(' ');
+      const intl = this.owner.lookup('service:intl');
       const inChallengeCategory = new RadioButtonCategoryWithSubcategoryAndQuestionNumber({
         name: 'IN_CHALLENGE',
         isChecked: true,
+        intl,
       });
       this.set('toggleOnCategory', toggleOnCategory);
       this.set('inChallengeCategory', inChallengeCategory);
@@ -90,10 +98,14 @@ module('Integration | Component | in-challenge-certification-issue-report-fields
         @toggleOnCategory={{this.toggleOnCategory}}
         @maxlength={{500}}
       />`);
-      await click(screen.getByLabelText('Sélectionnez une sous-catégorie :'));
+
+      await click(
+        screen.getByLabelText(this.intl.t('pages.session-finalization.add-issue-modal.actions.select-subcategory'))
+      );
+
       await click(
         await screen.findByRole('option', {
-          name: subcategory,
+          name: `${subcategoryCode} ${this.intl.t(subcategoryLabel)}`,
         })
       );
 
@@ -102,7 +114,7 @@ module('Integration | Component | in-challenge-certification-issue-report-fields
         .dom(
           screen.getByRole('option', {
             selected: true,
-            name: subcategory,
+            name: `${subcategoryCode} ${this.intl.t(subcategoryLabel)}`,
           })
         )
         .exists();
@@ -112,8 +124,10 @@ module('Integration | Component | in-challenge-certification-issue-report-fields
   test('category', async function (assert) {
     // given
     const toggleOnCategory = () => {};
+    const intl = this.owner.lookup('service:intl');
     const inChallengeCategory = new RadioButtonCategoryWithSubcategoryAndQuestionNumber({
       name: 'IN_CHALLENGE',
+      intl,
     });
     this.set('toggleOnCategory', toggleOnCategory);
     this.set('inChallengeCategory', inChallengeCategory);
@@ -132,9 +146,11 @@ module('Integration | Component | in-challenge-certification-issue-report-fields
   test('subcategory FILE_NOT_OPENING', async function (assert) {
     // given
     const toggleOnCategory = sinon.stub();
+    const intl = this.owner.lookup('service:intl');
     const inChallengeCategory = new RadioButtonCategoryWithSubcategoryAndQuestionNumber({
       name: 'IN_CHALLENGE',
       isChecked: true,
+      intl,
     });
     this.set('toggleOnCategory', toggleOnCategory);
     this.set('inChallengeCategory', inChallengeCategory);
@@ -146,12 +162,14 @@ module('Integration | Component | in-challenge-certification-issue-report-fields
         @toggleOnCategory={{this.toggleOnCategory}}
         @maxlength={{500}}
       />`);
-    await click(screen.getByLabelText('Sélectionnez une sous-catégorie :'));
+    await click(
+      screen.getByLabelText(this.intl.t('pages.session-finalization.add-issue-modal.actions.select-subcategory'))
+    );
     await click(
       await screen.findByRole('option', {
-        name: `${subcategoryToCode[certificationIssueReportSubcategories.FILE_NOT_OPENING]} ${
+        name: `${subcategoryToCode[certificationIssueReportSubcategories.FILE_NOT_OPENING]} ${this.intl.t(
           subcategoryToLabel[certificationIssueReportSubcategories.FILE_NOT_OPENING]
-        }`,
+        )}`,
       })
     );
 
@@ -159,9 +177,9 @@ module('Integration | Component | in-challenge-certification-issue-report-fields
     assert
       .dom(
         screen.getByRole('option', {
-          name: `${subcategoryToCode[certificationIssueReportSubcategories.FILE_NOT_OPENING]} ${
+          name: `${subcategoryToCode[certificationIssueReportSubcategories.FILE_NOT_OPENING]} ${this.intl.t(
             subcategoryToLabel[certificationIssueReportSubcategories.FILE_NOT_OPENING]
-          }`,
+          )}`,
         })
       )
       .exists();

--- a/certif/tests/integration/components/issue-report-modal/issue-report-modal_test.js
+++ b/certif/tests/integration/components/issue-report-modal/issue-report-modal_test.js
@@ -5,6 +5,12 @@ import sinon from 'sinon';
 import EmberObject from '@ember/object';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
+import {
+  certificationIssueReportCategories,
+  categoryToLabel,
+  subcategoryToLabel,
+  certificationIssueReportSubcategories,
+} from 'pix-certif/models/certification-issue-report';
 
 module('Integration | Component | issue-report-modal', function (hooks) {
   setupIntlRenderingTest(hooks);
@@ -41,10 +47,12 @@ module('Integration | Component | issue-report-modal', function (hooks) {
     // given
     const issue1 = EmberObject.create({
       description: 'issue1',
+      categoryLabel: categoryToLabel[certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES],
     });
 
     const issue2 = EmberObject.create({
       description: 'issue2',
+      categoryLabel: categoryToLabel[certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES],
     });
 
     const report = EmberObject.create({
@@ -77,13 +85,13 @@ module('Integration | Component | issue-report-modal', function (hooks) {
   test('it shows a list of issue reports', async function (assert) {
     // given
     const issue1 = EmberObject.create({
-      categoryLabel: 'categoryLabel1',
-      subcategoryLabel: 'subcategoryLabel1',
+      categoryLabel: categoryToLabel[certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES],
+      subcategoryLabel: subcategoryToLabel[certificationIssueReportSubcategories.WEBSITE_BLOCKED],
     });
 
     const issue2 = EmberObject.create({
-      categoryLabel: 'categoryLabel2',
-      subcategoryLabel: 'subcategoryLabel2',
+      categoryLabel: categoryToLabel[certificationIssueReportCategories.FRAUD],
+      subcategoryLabel: subcategoryToLabel[certificationIssueReportSubcategories.SOFTWARE_NOT_WORKING],
     });
 
     const report = EmberObject.create({
@@ -110,10 +118,10 @@ module('Integration | Component | issue-report-modal', function (hooks) {
     `);
 
     // then
-    assert.contains('categoryLabel1');
-    assert.contains('subcategoryLabel1');
-    assert.contains('categoryLabel2');
-    assert.contains('subcategoryLabel2');
+    assert.contains(this.intl.t(categoryToLabel[certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES]));
+    assert.contains(this.intl.t(subcategoryToLabel[certificationIssueReportSubcategories.WEBSITE_BLOCKED]));
+    assert.contains(this.intl.t(categoryToLabel[certificationIssueReportCategories.FRAUD]));
+    assert.contains(this.intl.t(subcategoryToLabel[certificationIssueReportSubcategories.SOFTWARE_NOT_WORKING]));
   });
 
   test('it calls a function linked to the close button', async function (assert) {
@@ -185,8 +193,8 @@ module('Integration | Component | issue-report-modal', function (hooks) {
   test('it calls a function linked to the delete button', async function (assert) {
     // given
     const issue = EmberObject.create({
-      categoryLabel: 'categoryLabel1',
-      subcategoryLabel: 'subcategoryLabel1',
+      categoryLabel: categoryToLabel[certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES],
+      subcategoryLabel: subcategoryToLabel[certificationIssueReportSubcategories.WEBSITE_BLOCKED],
     });
 
     const report = EmberObject.create({

--- a/certif/tests/integration/components/issue-reports-modal_test.js
+++ b/certif/tests/integration/components/issue-reports-modal_test.js
@@ -76,10 +76,12 @@ module('Integration | Component | issue-reports-modal', function (hooks) {
     // given
     const issue1 = EmberObject.create({
       category: certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES,
+      categoryLabel: categoryToLabel[certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES],
     });
 
     const issue2 = EmberObject.create({
       category: certificationIssueReportCategories.SIGNATURE_ISSUE,
+      categoryLabel: categoryToLabel[certificationIssueReportCategories.SIGNATURE_ISSUE],
     });
 
     const report = EmberObject.create({
@@ -147,9 +149,9 @@ module('Integration | Component | issue-reports-modal', function (hooks) {
     `);
 
     // then
-    assert.contains(categoryToLabel[certificationIssueReportCategories.SIGNATURE_ISSUE]);
-    assert.contains(categoryToLabel[certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES]);
-    assert.contains(subcategoryToLabel[certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]);
+    assert.contains(this.intl.t(categoryToLabel[certificationIssueReportCategories.SIGNATURE_ISSUE]));
+    assert.contains(this.intl.t(categoryToLabel[certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES]));
+    assert.contains(this.intl.t(subcategoryToLabel[certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]));
     assert.dom('li').exists({ count: 2 });
   });
 });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -10,7 +10,8 @@
       "delete": "Delete",
       "quit": "Quit",
       "update": "Edit",
-      "exit": "Exit"
+      "exit": "Exit",
+      "validate": "Validate"
     },
     "api-error-messages": {
       "bad-request-error": "The data entered was not in the correct format.",
@@ -502,10 +503,61 @@
       }
     },
     "session-finalization": {
+      "title": "Finalise the session {sessionId}",
       "actions": {
         "finalise": "Finalise"
       },
-      "title": "Finalise the session {sessionId}",
+      "add-issue-modal": {
+        "title": "Reporting for candidate :",
+        "actions": {
+          "add-reporting": "Add the reporting",
+          "cancel": "Cancel",
+          "describe": "Describe the incident encountered",
+          "enter-question-number": "Question number :",
+          "specify": "Specify",
+          "select-category": "Please select a category",
+          "select-category-label": "Select a category ",
+          "select-subcategory": "Select a subcategory:",
+          "select-subcategory-label": "Select a subcategory",
+          "transmit-report": "Please transmit the Fraud report filled in during the certification session by using <span><a class=\"link\" href=\"https://form-eu.123formbuilder.com/41052/form\" target=\"_blank\" rel=\"noreferrer noopener\">this form</a></span>"
+        },
+        "category-labels": {
+          "candidate-informations-changes": "Edit the candidate’s details",
+          "fraud": "Suspected fraud",
+          "in-challenge": "Technical problem with a question",
+          "non-blocking-candidate-issue": "Non-blocking incident linked to the candidate",
+          "non-blocking-technical-issue": "Non-blocking technical incident",
+          "signature-issue": "Was present but forgot to sign or signed on the wrong line"
+        },
+        "errors": {
+          "add-reporting": "An error occurred while adding a reporting. Please try again.",
+          "technical-issue": "Technical issue"
+        },
+        "non-blocking-issues": {
+          "candidate-examples": "Left temporarily, under invigilation, the exam room, arrived late, encountered difficulties to connect to the session, had to reconnect to the session, had forgotten their password…",
+          "candidate-information": "Reporting on an indicative basis, the problem encountered didn’t prevent the candidate from continuing to answer the questions.",
+          "technical-examples": "The computer switched off, significant slowness of the network and/or of the machine etc…",
+          "technical-information": "Reporting on an indicative basis, the problem encountered didn’t prevent the candidate from continuing to answer the questions. In case of an incident during a focus mode question, please refer to the E10 category."
+        },
+        "subcategory-labels": {
+          "accessibility-issue": "Problem with the accessibility of the question (ex : colour blindness)",
+          "embed-not-working": "The simulator/the application isn’t displayed",
+          "extra-time-exceeded": "The candidate profits from extra time and hasn’t been able to answer the question within the time allocated",
+          "extra-time-percentage": "Add/edit the extra time",
+          "file-not-opening": "The file to download can’t be downloaded or doesn’t open",
+          "image-not-displaying": "The picture isn’t displayed",
+          "name-or-birthdate": "Edit the first name/last name/date of birth",
+          "skip-on-oops": "A technical problem due to the Pix platform prevented the candidate from answering the question",
+          "software-not-working": "The software installed on the computer didn’t work",
+          "unintentional-focus-out": "The candidate was forced to click outside the authorised frame for a focus mode question",
+          "website-blocked": "The website is blocked by the establishment’s network restrictions (social media for ex.)",
+          "website-unavailable": "The website to visit is unavailable/under maintenance/unreachable"
+        },
+        "subcategory-to-textarea-labels": {
+          "name-or-birthdate": "Fill in the correct details",
+          "extra-time-percentage": "Specify extra time"
+        }
+      },
       "return-to": "Return to the session",
       "reporting": {
         "completed-reports-information": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "actions": {
-      "back": "Retour",
+      "back": "Back",
       "cancel": "Cancel",
       "choose": "Choose",
       "close": "Close",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -558,6 +558,17 @@
           "extra-time-percentage": "Specify extra time"
         }
       },
+      "issue-reports-modal": {
+        "title": "Reporting for candidate :",
+        "subtitle": "My reporting",
+        "actions": {
+          "add-reporting": "Add a reporting",
+          "delete-reporting": "Delete the reporting"
+        },
+        "errors": {
+          "delete-reporting": "An error has occurred while deleting the reporting. Please try again"
+        }
+      },
       "return-to": "Return to the session",
       "reporting": {
         "completed-reports-information": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -1,12 +1,12 @@
 {
   "common": {
     "actions": {
+      "add": "Add",
       "back": "Back",
       "cancel": "Cancel",
       "choose": "Choose",
       "close": "Close",
       "continue": "Continue",
-      "add": "Add",
       "delete": "Delete",
       "quit": "Quit",
       "update": "Edit",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -111,6 +111,7 @@
   },
   "current-lang": "en",
   "navigation": {
+    "external-link-title": "Open in a new window",
     "main": {
       "sessions": "Sessions",
       "sessions-label": "Certification sessions",
@@ -519,7 +520,7 @@
           "select-category-label": "Select a category ",
           "select-subcategory": "Select a subcategory:",
           "select-subcategory-label": "Select a subcategory",
-          "transmit-report": "Please transmit the Fraud report filled in during the certification session by using <span><a class=\"link\" href=\"https://form-eu.123formbuilder.com/41052/form\" target=\"_blank\" rel=\"noreferrer noopener\">this form</a></span>"
+          "transmit-report": "Please transmit the fraud report filled in during the certification session by using <span><a class=\"link\" href=\"https://form-eu.123formbuilder.com/41052/form\" target=\"_blank\" rel=\"noreferrer\">this form</a></span>"
         },
         "category-labels": {
           "candidate-informations-changes": "Edit the candidate’s details",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -10,7 +10,8 @@
       "delete": "Supprimer",
       "quit": "Quitter",
       "update": "Modifier",
-      "exit": "Quitter"
+      "exit": "Quitter",
+      "validate": "Valider"
     },
     "api-error-messages": {
       "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
@@ -501,10 +502,61 @@
       }
     },
     "session-finalization": {
+      "title": "Finaliser la session {sessionId}",
       "actions": {
         "finalise": "Finaliser"
       },
-      "title": "Finaliser la session {sessionId}",
+      "add-issue-modal": {
+        "title": "Signalement du candidat :",
+        "actions": {
+          "add-reporting": "Ajouter le signalement",
+          "cancel": "Annuler",
+          "describe": "Décrivez l'incident rencontré",
+          "enter-question-number": "Numéro de question :",
+          "specify": "Précisez",
+          "select-category": "Veuillez selectionner une catégorie",
+          "select-category-label": "Sélectionner la catégorie",
+          "select-subcategory": "Sélectionnez une sous-catégorie :",
+          "select-subcategory-label": "Sélectionner la sous-catégorie",
+          "transmit-report": "Merci de transmettre le procès-verbal de fraude rempli pendant la session de certification en utilisant <span><a class=\"link\" href=\"https://form-eu.123formbuilder.com/41052/form\" target=\"_blank\" rel=\"noreferrer noopener\">ce formulaire</a></span>"
+        },
+        "category-labels": {
+          "candidate-informations-changes": "Modification infos candidat",
+          "fraud": "Suspicion de fraude",
+          "in-challenge": "Problème technique sur une question",
+          "non-blocking-candidate-issue": "Incident lié au candidat non bloquant",
+          "non-blocking-technical-issue": "Incident technique non bloquant",
+          "signature-issue": "Était présent(e) mais a oublié de signer, ou a signé sur la mauvaise ligne"
+        },
+        "errors": {
+          "add-reporting": "Une erreur s'est produite lors de l'ajout du signalement. Merci de réessayer.",
+          "technical-issue": "Incident technique"
+        },
+        "non-blocking-issues": {
+          "candidate-examples": "a quitté temporairement, sous surveillance, la salle d’examen, est arrivé en retard, a rencontré des difficultés pour se connecter à la session, a dû se reconnecter à la session, avait oublié son mot de passe...",
+          "candidate-information": "Signalement à titre informatif, le problème rencontré n'a pas empêché le candidat de continuer à répondre aux questions. ",
+          "technical-examples": "L’ordinateur s’est éteint, lenteur significative du réseau et/ou de l’appareil etc.",
+          "technical-information": "Signalement à titre informatif, le problème rencontré n'a pas empêché le candidat de continuer à répondre aux questions. En cas d’incident sur une question focus, merci de vous reporter à la catégorie E10."
+        },
+        "subcategory-labels": {
+          "accessibility-issue": "Problème avec l’accessibilité de la question (ex : daltonisme)",
+          "embed-not-working": "Le simulateur/l'application ne s'affiche pas",
+          "extra-time-exceeded": "Le candidat bénéficie d'un temps majoré et n'a pas pu répondre à la question dans le temps imparti",
+          "extra-time-percentage": "Ajout/modification du temps majoré",
+          "file-not-opening": "Le fichier à télécharger ne se télécharge pas ou ne s'ouvre pas",
+          "image-not-displaying": "L'image ne s'affiche pas",
+          "name-or-birthdate": "Modification des prénom/nom/date de naissance",
+          "skip-on-oops": "Un problème technique lié à la plateforme Pix a empêché le candidat de répondre à la question",
+          "software-not-working": "Le logiciel installé sur l'ordinateur n'a pas fonctionné",
+          "unintentional-focus-out": "Le candidat a été contraint de cliquer en dehors du cadre autorisé pour une question en mode focus",
+          "website-blocked": "Le site est bloqué par les restrictions réseau de l'établissement (réseaux sociaux par ex.)",
+          "website-unavailable": "Le site à visiter est indisponible/en maintenance/inaccessible"
+        },
+        "subcategory-to-textarea-labels": {
+          "name-or-birthdate": "Renseignez les informations correctes",
+          "extra-time-percentage": "Précisez le temps majoré"
+        }
+      },
       "return-to": "Retour à la session",
       "reporting": {
         "completed-reports-information": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -111,6 +111,7 @@
   },
   "current-lang": "fr",
   "navigation": {
+    "external-link-title": "Ouverture dans une nouvelle fenêtre",
     "main": {
       "sessions": "Sessions",
       "sessions-label": "Sessions de certification",
@@ -518,7 +519,7 @@
           "select-category-label": "Sélectionner la catégorie",
           "select-subcategory": "Sélectionnez une sous-catégorie :",
           "select-subcategory-label": "Sélectionner la sous-catégorie",
-          "transmit-report": "Merci de transmettre le procès-verbal de fraude rempli pendant la session de certification en utilisant <span><a class=\"link\" href=\"https://form-eu.123formbuilder.com/41052/form\" target=\"_blank\" rel=\"noreferrer noopener\">ce formulaire</a></span>"
+          "transmit-report": "Merci de transmettre le procès-verbal de fraude rempli pendant la session de certification en utilisant <span><a class=\"link\" href=\"https://form-eu.123formbuilder.com/41052/form\" target=\"_blank\" rel=\"noreferrer\">ce formulaire</a></span>"
         },
         "category-labels": {
           "candidate-informations-changes": "Modification infos candidat",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -557,6 +557,17 @@
           "extra-time-percentage": "Précisez le temps majoré"
         }
       },
+      "issue-reports-modal": {
+        "title": "Signalement du candidat :",
+        "subtitle": "Mes signalements",
+        "actions": {
+          "add-reporting": "Ajouter un signalement",
+          "delete-reporting": "Supprimer le signalement"
+        },
+        "errors": {
+          "delete-reporting": "Une erreur s'est produite lors de la suppression du signalement. Merci de réessayer"
+        }
+      },
       "return-to": "Retour à la session",
       "reporting": {
         "completed-reports-information": {


### PR DESCRIPTION
## :unicorn: Problème

La modale d'ajout de signalements de Pix-Certif n'est pas traduite.

## :robot: Proposition

Ajout des traductions.

## :rainbow: Remarques

Pour coller à la strcuture initiale des catégories et sous catégories, les traductions reprennent le même schéma. Ceci est bien évidemment challengeable.

## :100: Pour tester

• Se connecter à `https://certif-pr5973.review.pix.org/connexion` avec `certifsup@example.net` et passer le site en anglais. `?lang=en`
• Aller sur le détail de la session `XXXXX`
• Cliquer sur `Finaliser`
• Essayer d'ajouter des signalements.
• Constater de la traduction de l'ensemble des champs.