### PR TITLE
[TECH] Faire de l'injection de dépendance dans les controllers (part-2)

### DIFF
--- a/api/lib/application/account-recovery/account-recovery-controller.js
+++ b/api/lib/application/account-recovery/account-recovery-controller.js
@@ -11,10 +11,10 @@ module.exports = {
     return h.response().code(204);
   },
 
-  async checkAccountRecoveryDemand(request) {
+  async checkAccountRecoveryDemand(request, h, dependencies = { studentInformationForAccountRecoverySerializer }) {
     const temporaryKey = request.params.temporaryKey;
     const studentInformation = await usecases.getAccountRecoveryDetails({ temporaryKey });
-    return studentInformationForAccountRecoverySerializer.serializeAccountRecovery(studentInformation);
+    return dependencies.studentInformationForAccountRecoverySerializer.serializeAccountRecovery(studentInformation);
   },
 
   async updateUserAccountFromRecoveryDemand(request, h) {

--- a/api/lib/application/answers/answer-controller.js
+++ b/api/lib/application/answers/answer-controller.js
@@ -4,33 +4,33 @@ const usecases = require('../../domain/usecases/index.js');
 const requestResponseUtils = require('../../infrastructure/utils/request-response-utils.js');
 
 module.exports = {
-  async save(request, h) {
-    const answer = answerSerializer.deserialize(request.payload);
-    const userId = requestResponseUtils.extractUserIdFromRequest(request);
-    const locale = requestResponseUtils.extractLocaleFromRequest(request);
+  async save(request, h, dependencies = { answerSerializer, requestResponseUtils }) {
+    const answer = dependencies.answerSerializer.deserialize(request.payload);
+    const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+    const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
     const createdAnswer = await usecases.correctAnswerThenUpdateAssessment({ answer, userId, locale });
 
-    return h.response(answerSerializer.serialize(createdAnswer)).created();
+    return h.response(dependencies.answerSerializer.serialize(createdAnswer)).created();
   },
 
-  async get(request) {
-    const userId = requestResponseUtils.extractUserIdFromRequest(request);
+  async get(request, _h, dependencies = { requestResponseUtils }) {
+    const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
     const answerId = request.params.id;
     const answer = await usecases.getAnswer({ answerId, userId });
 
     return answerSerializer.serialize(answer);
   },
 
-  async update(request) {
-    const userId = requestResponseUtils.extractUserIdFromRequest(request);
+  async update(request, _h, dependencies = { requestResponseUtils }) {
+    const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
     const answerId = request.params.id;
     const answer = await usecases.getAnswer({ answerId, userId });
 
     return answerSerializer.serialize(answer);
   },
 
-  async find(request) {
-    const userId = requestResponseUtils.extractUserIdFromRequest(request);
+  async find(request, _h, dependencies = { requestResponseUtils }) {
+    const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
     const challengeId = request.query.challengeId;
     const assessmentId = request.query.assessmentId;
     let answers = [];
@@ -44,9 +44,9 @@ module.exports = {
     return answerSerializer.serialize(answers);
   },
 
-  async getCorrection(request) {
-    const userId = requestResponseUtils.extractUserIdFromRequest(request);
-    const locale = requestResponseUtils.extractLocaleFromRequest(request);
+  async getCorrection(request, _h, dependencies = { correctionSerializer, requestResponseUtils }) {
+    const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+    const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
     const answerId = request.params.id;
 
     const correction = await usecases.getCorrectionForAnswer({
@@ -55,6 +55,6 @@ module.exports = {
       locale,
     });
 
-    return correctionSerializer.serialize(correction);
+    return dependencies.correctionSerializer.serialize(correction);
   },
 };

--- a/api/lib/application/assessment-results/assessment-result-controller.js
+++ b/api/lib/application/assessment-results/assessment-result-controller.js
@@ -27,12 +27,12 @@ function _deserializeResultsAdd(json) {
 }
 
 module.exports = {
-  async save(request) {
+  async save(request, h, dependencies = { assessmentResultService }) {
     const jsonResult = request.payload.data.attributes;
     const { assessmentResult, competenceMarks } = _deserializeResultsAdd(jsonResult);
     const juryId = request.auth.credentials.userId;
     // FIXME (re)calculate partner certifications which may be invalidated/validated
-    await assessmentResultService.save({ ...assessmentResult, juryId }, competenceMarks);
+    await dependencies.assessmentResultService.save({ ...assessmentResult, juryId }, competenceMarks);
     return null;
   },
 };

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -27,13 +27,13 @@ module.exports = {
     return h.response(assessmentSerializer.serialize(createdAssessment)).created();
   },
 
-  async get(request) {
+  async get(request, _, dependencies = { assessmentSerializer }) {
     const assessmentId = request.params.id;
     const locale = extractLocaleFromRequest(request);
 
     const assessment = await usecases.getAssessment({ assessmentId, locale });
 
-    return assessmentSerializer.serialize(assessment);
+    return dependencies.assessmentSerializer.serialize(assessment);
   },
 
   async getLastChallengeId(request, h) {

--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -19,11 +19,11 @@ const Examiner = require('../../domain/models/Examiner.js');
 const ValidatorAlwaysOK = require('../../domain/models/ValidatorAlwaysOK.js');
 
 module.exports = {
-  async save(request, h) {
+  async save(request, h, dependencies = { assessmentRepository }) {
     const assessment = assessmentSerializer.deserialize(request.payload);
     assessment.userId = extractUserIdFromRequest(request);
     assessment.state = 'started';
-    const createdAssessment = await assessmentRepository.save({ assessment });
+    const createdAssessment = await dependencies.assessmentRepository.save({ assessment });
     return h.response(assessmentSerializer.serialize(createdAssessment)).created();
   },
 

--- a/api/lib/application/cache/cache-controller.js
+++ b/api/lib/application/cache/cache-controller.js
@@ -4,8 +4,8 @@ const logger = require('../../infrastructure/logger.js');
 const _ = require('lodash');
 
 module.exports = {
-  refreshCacheEntries(request, h) {
-    learningContentDatasource
+  refreshCacheEntries(_, h, dependencies = { learningContentDatasource }) {
+    dependencies.learningContentDatasource
       .refreshLearningContentCacheRecords()
       .catch((e) => logger.error('Error while reloading cache', e));
     return h.response({}).code(202);

--- a/api/lib/application/campaigns-administration/campaign-controller.js
+++ b/api/lib/application/campaigns-administration/campaign-controller.js
@@ -1,10 +1,10 @@
 const usecases = require('../../domain/usecases/index.js');
-const csvCampaingsIdsParser = require('../../infrastructure/serializers/csv/campaigns-administration/csv-campaigns-ids-parser.js');
+const csvCampaignsIdsParser = require('../../infrastructure/serializers/csv/campaigns-administration/csv-campaigns-ids-parser.js');
 
 module.exports = {
-  async archiveCampaigns(request, h) {
+  async archiveCampaigns(request, h, dependencies = { csvCampaignsIdsParser }) {
     const { userId } = request.auth.credentials;
-    const campaignIds = await csvCampaingsIdsParser.extractCampaignsIds(request.payload.path);
+    const campaignIds = await dependencies.csvCampaignsIdsParser.extractCampaignsIds(request.payload.path);
 
     await usecases.campaignAdministrationArchiveCampaign({
       userId,

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -17,13 +17,13 @@ const { getHeaders } = require('../../infrastructure/files/sessions-import.js');
 const { UnprocessableEntityError } = require('../../application/http-errors.js');
 
 module.exports = {
-  async saveSession(request) {
+  async saveSession(request, _h, dependencies = { sessionSerializer }) {
     const userId = request.auth.credentials.userId;
-    const session = sessionSerializer.deserialize(request.payload);
+    const session = dependencies.sessionSerializer.deserialize(request.payload);
 
     const newSession = await usecases.createSession({ userId, session });
 
-    return sessionSerializer.serialize({ session: newSession });
+    return dependencies.sessionSerializer.serialize({ session: newSession });
   },
 
   async create(request) {
@@ -104,13 +104,17 @@ module.exports = {
     return divisionSerializer.serialize(divisions);
   },
 
-  async findCertificationCenterMembershipsByCertificationCenter(request) {
+  async findCertificationCenterMembershipsByCertificationCenter(
+    request,
+    _h,
+    dependencies = { certificationCenterMembershipSerializer }
+  ) {
     const certificationCenterId = request.params.certificationCenterId;
     const certificationCenterMemberships = await usecases.findCertificationCenterMembershipsByCertificationCenter({
       certificationCenterId,
     });
 
-    return certificationCenterMembershipSerializer.serialize(certificationCenterMemberships);
+    return dependencies.certificationCenterMembershipSerializer.serialize(certificationCenterMemberships);
   },
 
   async findCertificationCenterMemberships(request) {

--- a/api/lib/application/countries/country-controller.js
+++ b/api/lib/application/countries/country-controller.js
@@ -2,8 +2,8 @@ const usecases = require('../../domain/usecases/index.js');
 const countrySerializer = require('../../infrastructure/serializers/jsonapi/country-serializer.js');
 
 module.exports = {
-  async findCountries() {
+  async findCountries(_request, _h, dependencies = { countrySerializer }) {
     const countries = await usecases.findCountries();
-    return countrySerializer.serialize(countries);
+    return dependencies.countrySerializer.serialize(countries);
   },
 };

--- a/api/lib/application/courses/course-controller.js
+++ b/api/lib/application/courses/course-controller.js
@@ -3,10 +3,10 @@ const courseService = require('../../../lib/domain/services/course-service.js');
 const { extractUserIdFromRequest } = require('../../infrastructure/utils/request-response-utils.js');
 
 module.exports = {
-  get(request) {
+  get(request, h, dependencies = { courseService, courseSerializer }) {
     const courseId = request.params.id;
     const userId = extractUserIdFromRequest(request);
 
-    return courseService.getCourse({ courseId, userId }).then(courseSerializer.serialize);
+    return dependencies.courseService.getCourse({ courseId, userId }).then(dependencies.courseSerializer.serialize);
   },
 };

--- a/api/tests/unit/application/account-recovery/account-recovery-controller_test.js
+++ b/api/tests/unit/application/account-recovery/account-recovery-controller_test.js
@@ -56,15 +56,23 @@ describe('Unit | Controller | account-recovery-controller', function () {
         params: { temporaryKey },
       };
       sinon.stub(usecases, 'getAccountRecoveryDetails');
-      sinon.stub(studentInformationForAccountRecoverySerializer, 'serializeAccountRecovery');
+
+      const studentInformationForAccountRecoverySerializerStub = {
+        serializeAccountRecovery: sinon.stub(),
+      };
+
+      const dependencies = {
+        studentInformationForAccountRecoverySerializer: studentInformationForAccountRecoverySerializerStub,
+      };
+
       usecases.getAccountRecoveryDetails.resolves(studentInformation);
 
       // when
-      await accountRecoveryController.checkAccountRecoveryDemand(request, hFake);
+      await accountRecoveryController.checkAccountRecoveryDemand(request, hFake, dependencies);
 
       // then
       expect(usecases.getAccountRecoveryDetails).to.have.been.calledWith({ temporaryKey });
-      expect(studentInformationForAccountRecoverySerializer.serializeAccountRecovery).to.have.been.calledWith(
+      expect(studentInformationForAccountRecoverySerializerStub.serializeAccountRecovery).to.have.been.calledWith(
         studentInformation
       );
     });

--- a/api/tests/unit/application/answers/answer-controller_test.js
+++ b/api/tests/unit/application/answers/answer-controller_test.js
@@ -1,19 +1,22 @@
 const { expect, sinon, domainBuilder, hFake } = require('../../../test-helper');
 
 const answerController = require('../../../../lib/application/answers/answer-controller');
-const answerRepository = require('../../../../lib/infrastructure/repositories/answer-repository');
-const answerSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/answer-serializer');
-const correctionSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/correction-serializer');
 const usecases = require('../../../../lib/domain/usecases/index.js');
-const requestResponseUtils = require('../../../../lib/infrastructure/utils/request-response-utils');
 
 describe('Unit | Controller | answer-controller', function () {
+  let answerSerializerStub;
+  let requestResponseUtilsStub;
+
   beforeEach(function () {
-    sinon.stub(answerSerializer, 'serialize');
-    sinon.stub(answerRepository, 'findByChallengeAndAssessment');
+    answerSerializerStub = {
+      serialize: sinon.stub(),
+      deserialize: sinon.stub(),
+    };
+    requestResponseUtilsStub = {
+      extractUserIdFromRequest: sinon.stub(),
+      extractLocaleFromRequest: sinon.stub(),
+    };
     sinon.stub(usecases, 'correctAnswerThenUpdateAssessment');
-    sinon.stub(requestResponseUtils, 'extractUserIdFromRequest');
-    sinon.stub(requestResponseUtils, 'extractLocaleFromRequest');
   });
 
   describe('#save', function () {
@@ -111,13 +114,17 @@ describe('Unit | Controller | answer-controller', function () {
         deserializedAnswer.id = undefined;
         deserializedAnswer.timeSpent = undefined;
         createdAnswer = domainBuilder.buildAnswer({ assessmentId });
-        answerSerializer.serialize.returns(serializedAnswer);
+        answerSerializerStub.serialize.returns(serializedAnswer);
+        answerSerializerStub.deserialize.returns(deserializedAnswer);
         usecases.correctAnswerThenUpdateAssessment.resolves(createdAnswer);
-        requestResponseUtils.extractUserIdFromRequest.withArgs(request).returns(userId);
-        requestResponseUtils.extractLocaleFromRequest.withArgs(request).returns(locale);
+        requestResponseUtilsStub.extractUserIdFromRequest.withArgs(request).returns(userId);
+        requestResponseUtilsStub.extractLocaleFromRequest.withArgs(request).returns(locale);
 
         // when
-        response = await answerController.save(request, hFake);
+        response = await answerController.save(request, hFake, {
+          answerSerializer: answerSerializerStub,
+          requestResponseUtils: requestResponseUtilsStub,
+        });
       });
 
       it('should call the usecase to save the answer', function () {
@@ -131,7 +138,7 @@ describe('Unit | Controller | answer-controller', function () {
 
       it('should serialize the answer', function () {
         // then
-        expect(answerSerializer.serialize).to.have.been.calledWith(createdAnswer);
+        expect(answerSerializerStub.serialize).to.have.been.calledWith(createdAnswer);
       });
       it('should return the serialized answer', function () {
         // then
@@ -145,21 +152,25 @@ describe('Unit | Controller | answer-controller', function () {
     const answerId = 1;
     const userId = 'userId';
     const locale = 'lang-country';
+    let correctionSerializerStub;
 
     beforeEach(function () {
       sinon.stub(usecases, 'getCorrectionForAnswer');
-      sinon.stub(correctionSerializer, 'serialize');
+      correctionSerializerStub = { serialize: sinon.stub() };
     });
 
     it('should return ok', async function () {
       // given
-      requestResponseUtils.extractUserIdFromRequest.returns(userId);
-      requestResponseUtils.extractLocaleFromRequest.returns(locale);
+      requestResponseUtilsStub.extractUserIdFromRequest.returns(userId);
+      requestResponseUtilsStub.extractLocaleFromRequest.returns(locale);
       usecases.getCorrectionForAnswer.withArgs({ answerId, userId, locale }).resolves({});
-      correctionSerializer.serialize.withArgs({}).returns('ok');
+      correctionSerializerStub.serialize.withArgs({}).returns('ok');
 
       // when
-      const response = await answerController.getCorrection({ params: { id: answerId } });
+      const response = await answerController.getCorrection({ params: { id: answerId } }, hFake, {
+        correctionSerializer: correctionSerializerStub,
+        requestResponseUtils: requestResponseUtilsStub,
+      });
 
       // then
       expect(response).to.be.equal('ok');

--- a/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
+++ b/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
@@ -1,7 +1,6 @@
 const { sinon, expect, hFake } = require('../../../test-helper');
 
 const assessmentResultController = require('../../../../lib/application/assessment-results/assessment-result-controller');
-const assessmentResultService = require('../../../../lib/domain/services/assessment-result-service');
 
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 const CompetenceMark = require('../../../../lib/domain/models/CompetenceMark');
@@ -31,7 +30,9 @@ describe('Unit | Controller | assessment-results', function () {
         competence_code: 1.3,
         competenceId: 'rec456789',
       });
-      sinon.stub(assessmentResultService, 'save').resolves();
+      const assessmentResultServiceStub = { save: sinon.stub() };
+      assessmentResultServiceStub.save.resolves();
+
       const request = {
         payload: {
           data: {
@@ -80,7 +81,9 @@ describe('Unit | Controller | assessment-results', function () {
       };
 
       // when
-      const response = await assessmentResultController.save(request, hFake);
+      const response = await assessmentResultController.save(request, hFake, {
+        assessmentResultService: assessmentResultServiceStub,
+      });
 
       // then
       const expectedAssessmentResult = new AssessmentResult({
@@ -95,7 +98,7 @@ describe('Unit | Controller | assessment-results', function () {
         juryId: 1,
       });
       expect(response).to.be.null;
-      expect(assessmentResultService.save).to.have.been.calledWithMatch(expectedAssessmentResult, [
+      expect(assessmentResultServiceStub.save).to.have.been.calledWithMatch(expectedAssessmentResult, [
         competenceMark1,
         competenceMark2,
         competenceMark3,

--- a/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-get-next-challenge_test.js
@@ -1,9 +1,5 @@
 const { sinon, expect, domainBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 const assessmentController = require('../../../../lib/application/assessments/assessment-controller');
-const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
-const challengeRepository = require('../../../../lib/infrastructure/repositories/challenge-repository');
-const certificationChallengeRepository = require('../../../../lib/infrastructure/repositories/certification-challenge-repository');
-const usecases = require('../../../../lib/domain/usecases/index.js');
 const { AssessmentEndedError } = require('../../../../lib/domain/errors');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const { FRENCH_FRANCE, FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
@@ -13,8 +9,10 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
     let assessmentWithoutScore;
     let assessmentWithScore;
     let scoredAsssessment;
-    let updateLastQuestionDateStub;
-    let updateWhenNewChallengeIsAsked;
+    let assessmentRepository;
+    let certificationChallengeRepository;
+    let usecases;
+    let dependencies;
 
     beforeEach(function () {
       assessmentWithoutScore = new Assessment({
@@ -36,17 +34,24 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
         assessmentPix: assessmentWithScore,
       };
 
-      sinon.stub(assessmentRepository, 'get');
-      updateLastQuestionDateStub = sinon.stub(assessmentRepository, 'updateLastQuestionDate');
-      updateWhenNewChallengeIsAsked = sinon.stub(assessmentRepository, 'updateWhenNewChallengeIsAsked');
-      sinon.stub(challengeRepository, 'get').resolves({});
+      assessmentRepository = {
+        get: sinon.stub(),
+        updateLastQuestionDate: sinon.stub(),
+        updateWhenNewChallengeIsAsked: sinon.stub(),
+      };
 
-      sinon.stub(usecases, 'getAssessment').resolves(scoredAsssessment);
-      sinon.stub(usecases, 'getNextChallengeForCertification').resolves();
-      sinon.stub(usecases, 'getNextChallengeForDemo').resolves();
-      sinon.stub(usecases, 'getNextChallengeForCampaignAssessment').resolves();
-      sinon.stub(usecases, 'getNextChallengeForCompetenceEvaluation').resolves();
-      sinon.stub(certificationChallengeRepository, 'getNextNonAnsweredChallengeByCourseId').resolves();
+      usecases = {
+        getAssessment: sinon.stub(),
+        getNextChallengeForCertification: sinon.stub(),
+        getNextChallengeForDemo: sinon.stub(),
+        getNextChallengeForCampaignAssessment: sinon.stub(),
+        getNextChallengeForCompetenceEvaluation: sinon.stub(),
+        getNextChallengeForPreview: sinon.stub(),
+      };
+      usecases.getAssessment.resolves(scoredAsssessment);
+      certificationChallengeRepository = { getNextNonAnsweredChallengeByCourseId: sinon.stub() };
+
+      dependencies = { usecases, certificationChallengeRepository, assessmentRepository };
     });
 
     // TODO: Que faire si l'assessment n'existe pas pas ?
@@ -54,7 +59,8 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
     describe('when the assessment is a preview', function () {
       const PREVIEW_ASSESSMENT_ID = 245;
 
-      beforeEach(function () {
+      it('should return a null data directly', async function () {
+        // given
         assessmentRepository.get.resolves(
           new Assessment({
             id: 1,
@@ -65,11 +71,12 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
             type: 'PREVIEW',
           })
         );
-      });
 
-      it('should return a null data directly', async function () {
+        const request = { params: { id: PREVIEW_ASSESSMENT_ID } };
+        usecases.getNextChallengeForPreview.returns(null);
+
         // when
-        const response = await assessmentController.getNextChallenge({ params: { id: PREVIEW_ASSESSMENT_ID } });
+        const response = await assessmentController.getNextChallenge(request, null, dependencies);
 
         // then
         expect(response).to.deep.equal({ data: null });
@@ -87,7 +94,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
       context('when the assessment is a DEMO', function () {
         it('should reply with no data', async function () {
           // when
-          const response = await assessmentController.getNextChallenge({ params: { id: 7531 } });
+          const response = await assessmentController.getNextChallenge({ params: { id: 7531 } }, null, dependencies);
 
           // then
           expect(response).to.deep.equal({ data: null });
@@ -107,18 +114,21 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
 
       it('should not evaluate assessment score', async function () {
         // when
-        await assessmentController.getNextChallenge({ params: { id: 7531 } });
+        await assessmentController.getNextChallenge({ params: { id: 7531 } }, null, dependencies);
 
         // then
         expect(usecases.getAssessment).not.to.have.been.called;
       });
 
       it('should update information when new challenge is asked', async function () {
+        // given
+        const request = { params: { id: assessmentWithoutScore.id } };
+
         // when
-        await assessmentController.getNextChallenge({ params: { id: assessmentWithoutScore.id } });
+        await assessmentController.getNextChallenge(request, null, dependencies);
 
         // then
-        expect(updateWhenNewChallengeIsAsked).to.be.calledWith({
+        expect(assessmentRepository.updateWhenNewChallengeIsAsked).to.be.calledWith({
           id: assessmentWithoutScore.id,
           lastChallengeId: newChallenge.id,
         });
@@ -130,10 +140,10 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
         assessmentRepository.get.resolves(assessmentWithoutScore);
 
         // when
-        await assessmentController.getNextChallenge({ params: { id: assessmentWithoutScore.id } });
+        await assessmentController.getNextChallenge({ params: { id: assessmentWithoutScore.id } }, null, dependencies);
 
         // then
-        expect(updateWhenNewChallengeIsAsked).to.not.have.been.called;
+        expect(assessmentRepository.updateWhenNewChallengeIsAsked).to.not.have.been.called;
       });
     });
 
@@ -153,7 +163,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
         usecases.getNextChallengeForCertification.resolves();
 
         // when
-        await assessmentController.getNextChallenge({ params: { id: 12 } });
+        await assessmentController.getNextChallenge({ params: { id: 12 } }, null, dependencies);
 
         // then
         expect(usecases.getNextChallengeForCertification).to.have.been.calledOnce;
@@ -167,7 +177,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
         usecases.getNextChallengeForCertification.rejects(new AssessmentEndedError());
 
         // when
-        const response = await assessmentController.getNextChallenge({ params: { id: 12 } });
+        const response = await assessmentController.getNextChallenge({ params: { id: 12 } }, null, dependencies);
 
         // then
         expect(response).to.deep.equal({ data: null });
@@ -189,7 +199,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
 
       it('should call the usecase getNextChallengeForCampaignAssessment', async function () {
         // when
-        await assessmentController.getNextChallenge({ params: { id: 1 } });
+        await assessmentController.getNextChallenge({ params: { id: 1 } }, null, dependencies);
 
         // then
         expect(usecases.getNextChallengeForCampaignAssessment).to.have.been.calledWith({
@@ -203,12 +213,16 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
         const locale = FRENCH_SPOKEN;
 
         // when
-        await assessmentController.getNextChallenge({
-          params: { id: 1 },
-          headers: {
-            'accept-language': locale,
+        await assessmentController.getNextChallenge(
+          {
+            params: { id: 1 },
+            headers: {
+              'accept-language': locale,
+            },
           },
-        });
+          null,
+          dependencies
+        );
 
         // then
         expect(usecases.getNextChallengeForCampaignAssessment).to.have.been.calledWith({
@@ -244,7 +258,7 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
             },
           };
           // when
-          await assessmentController.getNextChallenge(request);
+          await assessmentController.getNextChallenge(request, null, dependencies);
 
           // then
           expect(usecases.getNextChallengeForCompetenceEvaluation).to.have.been.calledWith({
@@ -278,10 +292,13 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
             };
 
             // when
-            await assessmentController.getNextChallenge(request);
+            await assessmentController.getNextChallenge(request, null, dependencies);
 
             // then
-            expect(updateLastQuestionDateStub).to.be.calledWith({ id: request.params.id, lastQuestionDate: now });
+            expect(assessmentRepository.updateLastQuestionDate).to.be.calledWith({
+              id: request.params.id,
+              lastQuestionDate: now,
+            });
           });
         });
       });
@@ -315,10 +332,10 @@ describe('Unit | Controller | assessment-controller-get-next-challenge', functio
             };
 
             // when
-            await assessmentController.getNextChallenge(request);
+            await assessmentController.getNextChallenge(request, null, dependencies);
 
             // then
-            expect(updateLastQuestionDateStub).to.have.not.been.called;
+            expect(assessmentRepository.updateLastQuestionDate).to.have.not.been.called;
           });
         });
       });

--- a/api/tests/unit/application/assessments/assessment-controller-save_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller-save_test.js
@@ -2,7 +2,6 @@ const { sinon, expect, hFake } = require('../../../test-helper');
 
 const controller = require('../../../../lib/application/assessments/assessment-controller');
 
-const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 
 describe('Unit | Controller | assessment-controller-save', function () {
@@ -30,9 +29,11 @@ describe('Unit | Controller | assessment-controller-save', function () {
           },
         },
       };
+      let assessmentRepositoryStub;
 
       beforeEach(function () {
-        sinon.stub(assessmentRepository, 'save').resolves({});
+        assessmentRepositoryStub = { save: sinon.stub() };
+        assessmentRepositoryStub.save.resolves({});
       });
 
       it('should save an assessment with type PREVIEW', async function () {
@@ -47,10 +48,10 @@ describe('Unit | Controller | assessment-controller-save', function () {
         });
 
         // when
-        await controller.save(request, hFake);
+        await controller.save(request, hFake, { assessmentRepository: assessmentRepositoryStub });
 
         // then
-        expect(assessmentRepository.save).to.have.been.calledWith({ assessment: expected });
+        expect(assessmentRepositoryStub.save).to.have.been.calledWith({ assessment: expected });
       });
     });
   });

--- a/api/tests/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller_test.js
@@ -2,7 +2,6 @@ const { sinon, expect, hFake, domainBuilder } = require('../../../test-helper');
 const assessmentController = require('../../../../lib/application/assessments/assessment-controller');
 const usecases = require('../../../../lib/domain/usecases/index.js');
 const events = require('../../../../lib/domain/events/index.js');
-const assessmentSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/assessment-serializer');
 const AssessmentCompleted = require('../../../../lib/domain/events/AssessmentCompleted');
 const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 
@@ -13,10 +12,12 @@ describe('Unit | Controller | assessment-controller', function () {
     const assessmentId = 104974;
 
     const assessment = { id: assessmentId, title: 'Ordinary Wizarding Level assessment' };
+    let assessmentSerializerStub;
 
     beforeEach(function () {
       sinon.stub(usecases, 'getAssessment').withArgs({ assessmentId, locale }).resolves(assessment);
-      sinon.stub(assessmentSerializer, 'serialize').resolvesArg(0);
+      assessmentSerializerStub = { serialize: sinon.stub() };
+      assessmentSerializerStub.serialize.resolvesArg(0);
     });
 
     it('should call the expected usecase', async function () {
@@ -34,7 +35,7 @@ describe('Unit | Controller | assessment-controller', function () {
       };
 
       // when
-      const result = await assessmentController.get(request, hFake);
+      const result = await assessmentController.get(request, hFake, { assessmentSerializer: assessmentSerializerStub });
 
       // then
       expect(result).to.be.equal(assessment);

--- a/api/tests/unit/application/cache/cache-controller_test.js
+++ b/api/tests/unit/application/cache/cache-controller_test.js
@@ -1,7 +1,6 @@
 const { expect, sinon, hFake } = require('../../../test-helper');
 const cacheController = require('../../../../lib/application/cache/cache-controller');
 const learningContentDatasources = require('../../../../lib/infrastructure/datasources/learning-content');
-const learningContentDatasource = require('../../../../lib/infrastructure/datasources/learning-content/datasource');
 const logger = require('../../../../lib/infrastructure/logger');
 
 describe('Unit | Controller | cache-controller', function () {
@@ -51,18 +50,25 @@ describe('Unit | Controller | cache-controller', function () {
 
   describe('#refreshCacheEntries', function () {
     const request = {};
+    let learningContentDatasourceStub;
+
+    beforeEach(function () {
+      learningContentDatasourceStub = { refreshLearningContentCacheRecords: sinon.stub() };
+    });
 
     context('nominal case', function () {
       it('should reply with http status 202', async function () {
         // given
         const numberOfDeletedKeys = 0;
-        sinon.stub(learningContentDatasource, 'refreshLearningContentCacheRecords').resolves(numberOfDeletedKeys);
+        learningContentDatasourceStub.refreshLearningContentCacheRecords.resolves(numberOfDeletedKeys);
 
         // when
-        const response = await cacheController.refreshCacheEntries(request, hFake);
+        const response = await cacheController.refreshCacheEntries(request, hFake, {
+          learningContentDatasource: learningContentDatasourceStub,
+        });
 
         // then
-        expect(learningContentDatasource.refreshLearningContentCacheRecords).to.have.been.calledOnce;
+        expect(learningContentDatasourceStub.refreshLearningContentCacheRecords).to.have.been.calledOnce;
         expect(response.statusCode).to.equal(202);
       });
     });
@@ -73,10 +79,12 @@ describe('Unit | Controller | cache-controller', function () {
       beforeEach(async function () {
         // given
         sinon.stub(logger, 'error');
-        sinon.stub(learningContentDatasource, 'refreshLearningContentCacheRecords').rejects();
+        learningContentDatasourceStub.refreshLearningContentCacheRecords.rejects();
 
         // when
-        response = await cacheController.refreshCacheEntries(request, hFake);
+        response = await cacheController.refreshCacheEntries(request, hFake, {
+          learningContentDatasource: learningContentDatasourceStub,
+        });
       });
 
       it('should reply with http status 202', async function () {

--- a/api/tests/unit/application/campaigns-administration/campaign-controller_test.js
+++ b/api/tests/unit/application/campaigns-administration/campaign-controller_test.js
@@ -1,14 +1,14 @@
 const { sinon, expect, hFake } = require('../../../test-helper');
 
-const csvCampaingsIdsParser = require('../../../../lib/infrastructure/serializers/csv/campaigns-administration/csv-campaigns-ids-parser');
 const campaignController = require('../../../../lib/application/campaigns-administration/campaign-controller');
 const usecases = require('../../../../lib/domain/usecases/index.js');
 
 describe('Unit | Application | Controller | Campaign Administration', function () {
   describe('#archiveCampaigns', function () {
+    let csvCampaignsIdsParserStub;
     beforeEach(function () {
       sinon.stub(usecases, 'campaignAdministrationArchiveCampaign');
-      sinon.stub(csvCampaingsIdsParser, 'extractCampaignsIds');
+      csvCampaignsIdsParserStub = { extractCampaignsIds: sinon.stub() };
     });
 
     it('should return a 204', async function () {
@@ -18,11 +18,13 @@ describe('Unit | Application | Controller | Campaign Administration', function (
       const ids = [1, 2];
       const request = { auth: { credentials: { userId } }, payload: path };
 
-      csvCampaingsIdsParser.extractCampaignsIds.withArgs(path).returns(ids);
+      csvCampaignsIdsParserStub.extractCampaignsIds.withArgs(path).returns(ids);
       usecases.campaignAdministrationArchiveCampaign.withArgs({ userId, ids });
 
       // when
-      const response = await campaignController.archiveCampaigns(request, hFake);
+      const response = await campaignController.archiveCampaigns(request, hFake, {
+        csvCampaignsIdsParser: csvCampaignsIdsParserStub,
+      });
 
       // then
       expect(response.statusCode).to.be.equal(204);

--- a/api/tests/unit/application/certification-center-invitations/certification-center-invitation-controller_test.js
+++ b/api/tests/unit/application/certification-center-invitations/certification-center-invitation-controller_test.js
@@ -2,7 +2,6 @@ const { expect, sinon, hFake, domainBuilder } = require('../../../test-helper');
 const certificationCenterInvitationController = require('../../../../lib/application/certification-center-invitations/certification-center-invitation-controller');
 const usecases = require('../../../../lib/domain/usecases/index.js');
 const CertificationCenterInvitation = require('../../../../lib/domain/models/CertificationCenterInvitation');
-const certificationCenterInvitationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/certification-center-invitation-serializer');
 
 describe('Unit | Application | Certification-center-Invitations | Certification-center-invitation-controller', function () {
   describe('#acceptCertificationCenterInvitation', function () {
@@ -54,12 +53,6 @@ describe('Unit | Application | Certification-center-Invitations | Certification-
           certificationCenterInvitationId: cancelledCertificationCenterInvitation.id,
         })
         .resolves(cancelledCertificationCenterInvitation);
-      const serializedResponse = Symbol('serializedCancelledCertificationCenterInvitation');
-
-      sinon
-        .stub(certificationCenterInvitationSerializer, 'serialize')
-        .withArgs(cancelledCertificationCenterInvitation)
-        .returns(serializedResponse);
 
       // when
       const response = await certificationCenterInvitationController.cancelCertificationCenterInvitation(

--- a/api/tests/unit/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/unit/application/certification-centers/certification-center-controller_test.js
@@ -2,7 +2,6 @@ const { expect, sinon, domainBuilder, hFake, catchErr } = require('../../../test
 const usecases = require('../../../../lib/domain/usecases/index.js');
 const certificationCenterMembershipSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer');
 const certificationCenterInvitationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/certification-center-invitation-serializer');
-const sessionSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/session-serializer');
 const Session = require('../../../../lib/domain/models/Session');
 
 const certificationCenterController = require('../../../../lib/application/certification-centers/certification-center-controller');
@@ -14,7 +13,9 @@ describe('Unit | Controller | certifications-center-controller', function () {
   describe('#saveSession', function () {
     let request;
     let expectedSession;
+    let sessionSerializerStub;
     const userId = 274939274;
+
     beforeEach(function () {
       expectedSession = new Session({
         certificationCenter: 'Université de dressage de loutres',
@@ -28,8 +29,11 @@ describe('Unit | Controller | certifications-center-controller', function () {
       });
 
       sinon.stub(usecases, 'createSession').resolves();
-      sinon.stub(sessionSerializer, 'deserialize').returns(expectedSession);
-      sinon.stub(sessionSerializer, 'serialize');
+      sessionSerializerStub = {
+        serialize: sinon.stub(),
+        deserialize: sinon.stub(),
+      };
+      sessionSerializerStub.deserialize.returns(expectedSession);
 
       request = {
         payload: {
@@ -56,7 +60,7 @@ describe('Unit | Controller | certifications-center-controller', function () {
 
     it('should save the session', async function () {
       // when
-      await certificationCenterController.saveSession(request, hFake);
+      await certificationCenterController.saveSession(request, hFake, { sessionSerializer: sessionSerializerStub });
 
       // then
       expect(usecases.createSession).to.have.been.calledWith({ userId, session: expectedSession });
@@ -77,14 +81,16 @@ describe('Unit | Controller | certifications-center-controller', function () {
       });
 
       usecases.createSession.resolves(savedSession);
-      sessionSerializer.serialize.returns(jsonApiSession);
+      sessionSerializerStub.serialize.returns(jsonApiSession);
 
       // when
-      const response = await certificationCenterController.saveSession(request, hFake);
+      const response = await certificationCenterController.saveSession(request, hFake, {
+        sessionSerializer: sessionSerializerStub,
+      });
 
       // then
       expect(response).to.deep.equal(jsonApiSession);
-      expect(sessionSerializer.serialize).to.have.been.calledWith({ session: savedSession });
+      expect(sessionSerializerStub.serialize).to.have.been.calledWith({ session: savedSession });
     });
   });
 
@@ -196,10 +202,13 @@ describe('Unit | Controller | certifications-center-controller', function () {
         certificationCenterId,
       },
     };
+    let certificationCenterMembershipSerializerStub;
 
     beforeEach(function () {
       sinon.stub(usecases, 'findCertificationCenterMembershipsByCertificationCenter');
-      sinon.stub(certificationCenterMembershipSerializer, 'serialize');
+      certificationCenterMembershipSerializerStub = {
+        serialize: sinon.stub(),
+      };
     });
 
     it('should call usecase and serializer and return ok', async function () {
@@ -209,11 +218,13 @@ describe('Unit | Controller | certifications-center-controller', function () {
           certificationCenterId,
         })
         .resolves({});
-      certificationCenterMembershipSerializer.serialize.withArgs({}).returns('ok');
+      certificationCenterMembershipSerializerStub.serialize.withArgs({}).returns('ok');
 
       // when
       const response = await certificationCenterController.findCertificationCenterMembershipsByCertificationCenter(
-        request
+        request,
+        hFake,
+        { certificationCenterMembershipSerializer: certificationCenterMembershipSerializerStub }
       );
 
       // then

--- a/api/tests/unit/application/countries/country-controller_test.js
+++ b/api/tests/unit/application/countries/country-controller_test.js
@@ -7,7 +7,6 @@ const {
 } = require('../../../test-helper');
 
 const usecases = require('../../../../lib/domain/usecases/index.js');
-const countrySerializer = require('../../../../lib/infrastructure/serializers/jsonapi/country-serializer');
 
 const countryController = require('../../../../lib/application/countries/country-controller');
 
@@ -40,11 +39,11 @@ describe('Unit | Controller | country-controller', function () {
       ];
 
       const userId = 42;
-      sinon.stub(countrySerializer, 'serialize');
+      const countrySerializerStub = { serialize: sinon.stub() };
       sinon.stub(usecases, 'findCountries');
 
       usecases.findCountries.resolves(countries);
-      countrySerializer.serialize.withArgs(countries).resolves(serializedCountries);
+      countrySerializerStub.serialize.withArgs(countries).resolves(serializedCountries);
 
       const request = {
         params: { id: 'course_id' },
@@ -53,12 +52,13 @@ describe('Unit | Controller | country-controller', function () {
       };
 
       // when
-      const response = await countryController.findCountries(request, hFake);
+      const response = await countryController.findCountries(request, hFake, {
+        countrySerializer: countrySerializerStub,
+      });
 
       // then
       expect(usecases.findCountries).to.have.been.called;
-      expect(countrySerializer.serialize).to.have.been.called;
-      expect(countrySerializer.serialize).to.have.been.calledWithExactly(countries);
+      expect(countrySerializerStub.serialize).to.have.been.calledWithExactly(countries);
       expect(response).to.deep.equal(serializedCountries);
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Suite de #5971

Le passage des modules en ESM est bloqué par nos stub de dépendances. Pour régler cela nous devons injecter les dépendances.

## :robot: Proposition
Comme convenu au tech time, nous injectons les dépendances via un 3 arguments `dependencies`. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- CI OK 
- Effectuer des tests des routes 