### PR TITLE
[FEATURE] Permettre au service CPF de renvoyer plusieurs erreurs (PIX-7727)

### DIFF
--- a/api/lib/domain/constants/certification-candidates-errors.js
+++ b/api/lib/domain/constants/certification-candidates-errors.js
@@ -39,6 +39,10 @@ module.exports.CERTIFICATION_CANDIDATES_ERRORS = {
     code: 'CANDIDATE_FOREIGN_BIRTH_CITY_REQUIRED',
     getMessage: () => "Candidat né à l'étranger, champ obligatoire nom de commune de naissance manquant",
   },
+  CANDIDATE_BIRTH_CITY_MUST_BE_EMPTY: {
+    code: 'CANDIDATE_BIRTH_CITY_MUST_BE_EMPTY',
+    getMessage: () => 'Le champ "nom de la commune" doit rester vide (dans le cas d\'un code INSEE\')',
+  },
   CANDIDATE_BIRTH_COUNTRY_NOT_FOUND: {
     code: 'CANDIDATE_BIRTH_COUNTRY_NOT_FOUND',
     getMessage: ({ birthCountry }) => `Le pays "${birthCountry}" n'a pas été trouvé.`,

--- a/api/lib/domain/constants/certification-candidates-errors.js
+++ b/api/lib/domain/constants/certification-candidates-errors.js
@@ -51,6 +51,10 @@ module.exports.CERTIFICATION_CANDIDATES_ERRORS = {
     code: 'CANDIDATE_BIRTH_COUNTRY_REQUIRED',
     getMessage: () => 'Le champ pays est obligatoire.',
   },
+  CANDIDATE_BIRTH_INFORMATION_REQUIRED: {
+    code: 'CANDIDATE_BIRTH_INFORMATION_REQUIRED',
+    getMessage: () => 'Renseigner les données de naissance du candidat',
+  },
   CANDIDATE_BIRTH_INSEE_CODE_NOT_VALID: {
     code: 'CANDIDATE_BIRTH_INSEE_CODE_NOT_VALID',
     getMessage: ({ birthINSEECode }) => `Le code INSEE "${birthINSEECode}" n'est pas valide.`,

--- a/api/lib/domain/constants/certification-candidates-errors.js
+++ b/api/lib/domain/constants/certification-candidates-errors.js
@@ -55,8 +55,8 @@ module.exports.CERTIFICATION_CANDIDATES_ERRORS = {
     code: 'CANDIDATE_BIRTH_INSEE_CODE_NOT_VALID',
     getMessage: ({ birthINSEECode }) => `Le code INSEE "${birthINSEECode}" n'est pas valide.`,
   },
-  CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED: {
-    code: 'CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED',
+  CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED: {
+    code: 'CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED',
     getMessage: () => 'Renseigner soit un code INSEE soit un code postal et un nom de commune de naissance',
   },
   CANDIDATE_BIRTH_POSTAL_CODE_NOT_FOUND: {

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -64,21 +64,9 @@ const certificationCandidateValidationForMassImportJoiSchema = Joi.object({
     'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SEX_REQUIRED.code,
     'any.only': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_SEX_NOT_VALID.code,
   }),
-  birthPostalCode: Joi.alternatives().conditional('birthINSEECode', {
-    is: Joi.string().empty(['', null]).required(),
-    then: Joi.string().empty(['', null]).forbidden().messages({
-      'any.unknown': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED.code,
-    }),
-    otherwise: Joi.alternatives().conditional('birthCity', {
-      is: Joi.string().empty(['', null]).required(),
-      then: Joi.string().empty(['', null]).required().messages({
-        'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED.code,
-      }),
-      otherwise: Joi.string().empty(['', null]).required().messages({
-        'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED.code,
-      }),
-    }),
-  }),
+  birthPostalCode: Joi.string().allow(null).empty(['', null]).optional(),
+  birthINSEECode: Joi.string().allow(null).empty(['', null]).optional(),
+  birthCity: Joi.string().allow(null).empty(['', null]).optional(),
   birthCountry: Joi.string().required().empty(['', null]).messages({
     'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_REQUIRED.code,
   }),

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -67,9 +67,7 @@ const certificationCandidateValidationForMassImportJoiSchema = Joi.object({
   birthPostalCode: Joi.string().allow(null).empty(['', null]).optional(),
   birthINSEECode: Joi.string().allow(null).empty(['', null]).optional(),
   birthCity: Joi.string().allow(null).empty(['', null]).optional(),
-  birthCountry: Joi.string().required().empty(['', null]).messages({
-    'any.required': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_REQUIRED.code,
-  }),
+  birthCountry: Joi.string().empty(['', null]),
   email: Joi.string().email().allow(null).empty('').optional().messages({
     'string.email': CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_EMAIL_NOT_VALID.code,
   }),

--- a/api/lib/domain/services/certification-candidates-ods-service.js
+++ b/api/lib/domain/services/certification-candidates-ods-service.js
@@ -159,7 +159,9 @@ function _handleFieldValidationError(err, tableHeaderTargetPropertyMap, line) {
 
 function _handleBirthInformationValidationError(cpfBirthInformation, line) {
   line = parseInt(line) + 1;
-  throw new CertificationCandidatesImportError({ message: `Ligne ${line} : ${cpfBirthInformation.message}` });
+  throw new CertificationCandidatesImportError({
+    message: `Ligne ${line} : ${cpfBirthInformation.firstErrorMessage}`,
+  });
 }
 
 function _handleVersionError() {

--- a/api/lib/domain/services/certification-cpf-service.js
+++ b/api/lib/domain/services/certification-cpf-service.js
@@ -23,7 +23,6 @@ class CpfBirthInformationValidation {
   failure({ certificationCandidateError, data }) {
     const message = certificationCandidateError.getMessage(data);
     this.errors.push({ message, code: certificationCandidateError.code });
-    return this;
   }
 
   success({ birthCountry, birthINSEECode, birthPostalCode, birthCity }) {
@@ -31,7 +30,6 @@ class CpfBirthInformationValidation {
     this.birthINSEECode = birthINSEECode;
     this.birthPostalCode = birthPostalCode;
     this.birthCity = birthCity;
-    return this;
   }
 
   hasFailed() {
@@ -150,23 +148,26 @@ async function getBirthInformation({
   const cpfBirthInformationValidation = new CpfBirthInformationValidation();
 
   if (!birthCountry && !birthINSEECode && !birthPostalCode && !birthCity) {
-    return cpfBirthInformationValidation.failure({
+    cpfBirthInformationValidation.failure({
       certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INFORMATION_REQUIRED,
     });
+    return cpfBirthInformationValidation;
   }
 
   if (!birthCountry) {
-    return cpfBirthInformationValidation.failure({
+    cpfBirthInformationValidation.failure({
       certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_REQUIRED,
     });
+    return cpfBirthInformationValidation;
   }
 
   const foundCountry = await _getCountry({ birthCountry, certificationCpfCountryRepository });
   if (!foundCountry) {
-    return cpfBirthInformationValidation.failure({
+    cpfBirthInformationValidation.failure({
       certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_NOT_FOUND,
       data: { birthCountry },
     });
+    return cpfBirthInformationValidation;
   }
 
   if (foundCountry.isForeign()) {
@@ -183,22 +184,25 @@ async function getBirthInformation({
       (birthINSEECode && birthPostalCode) ||
       (birthINSEECode && birthCity)
     ) {
-      return cpfBirthInformationValidation.failure({
+      cpfBirthInformationValidation.failure({
         certificationCandidateError:
           CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED,
       });
+      return cpfBirthInformationValidation;
     }
 
     if (birthCity && !birthPostalCode) {
-      return cpfBirthInformationValidation.failure({
+      cpfBirthInformationValidation.failure({
         certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED,
       });
+      return cpfBirthInformationValidation;
     }
 
     if (!birthCity && birthPostalCode) {
-      return cpfBirthInformationValidation.failure({
+      cpfBirthInformationValidation.failure({
         certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_CITY_REQUIRED,
       });
+      return cpfBirthInformationValidation;
     }
 
     if (birthINSEECode) {

--- a/api/lib/domain/services/certification-cpf-service.js
+++ b/api/lib/domain/services/certification-cpf-service.js
@@ -155,20 +155,20 @@ async function getBirthInformation({
     });
   }
 
-  const country = await _getCountry({ birthCountry, certificationCpfCountryRepository });
-  if (!country) {
+  const foundCountry = await _getCountry({ birthCountry, certificationCpfCountryRepository });
+  if (!foundCountry) {
     return cpfBirthInformationValidation.failure({
       certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_NOT_FOUND,
       data: { birthCountry },
     });
   }
 
-  if (country.isForeign()) {
+  if (foundCountry.isForeign()) {
     _getForeignCountryBirthInformation({
       birthCity,
       birthINSEECode,
       birthPostalCode,
-      country,
+      country: foundCountry,
       cpfBirthInformationValidation,
     });
   } else {
@@ -179,7 +179,7 @@ async function getBirthInformation({
     ) {
       return cpfBirthInformationValidation.failure({
         certificationCandidateError:
-          CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED,
+          CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED,
       });
     }
 
@@ -198,7 +198,7 @@ async function getBirthInformation({
     if (birthINSEECode) {
       await _getBirthInformationByINSEECode({
         birthINSEECode,
-        country,
+        country: foundCountry,
         cpfBirthInformationValidation,
         certificationCpfCityRepository,
       });
@@ -208,7 +208,7 @@ async function getBirthInformation({
       await _getBirthInformationByPostalCode({
         birthCity,
         birthPostalCode,
-        country,
+        country: foundCountry,
         cpfBirthInformationValidation,
         certificationCpfCityRepository,
       });

--- a/api/lib/domain/services/certification-cpf-service.js
+++ b/api/lib/domain/services/certification-cpf-service.js
@@ -149,6 +149,12 @@ async function getBirthInformation({
 }) {
   const cpfBirthInformationValidation = new CpfBirthInformationValidation();
 
+  if (!birthCountry && !birthINSEECode && !birthPostalCode && !birthCity) {
+    return cpfBirthInformationValidation.failure({
+      certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INFORMATION_REQUIRED,
+    });
+  }
+
   if (!birthCountry) {
     return cpfBirthInformationValidation.failure({
       certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_REQUIRED,

--- a/api/lib/domain/services/certification-cpf-service.js
+++ b/api/lib/domain/services/certification-cpf-service.js
@@ -177,22 +177,22 @@ async function getBirthInformation({
       (birthINSEECode && birthPostalCode) ||
       (birthINSEECode && birthCity)
     ) {
-      cpfBirthInformationValidation.failure({
+      return cpfBirthInformationValidation.failure({
         certificationCandidateError:
           CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED,
       });
-    } else {
-      if (birthCity && !birthPostalCode) {
-        return cpfBirthInformationValidation.failure({
-          certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED,
-        });
-      }
+    }
 
-      if (!birthCity && birthPostalCode) {
-        return cpfBirthInformationValidation.failure({
-          certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_CITY_REQUIRED,
-        });
-      }
+    if (birthCity && !birthPostalCode) {
+      return cpfBirthInformationValidation.failure({
+        certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED,
+      });
+    }
+
+    if (!birthCity && birthPostalCode) {
+      return cpfBirthInformationValidation.failure({
+        certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_CITY_REQUIRED,
+      });
     }
 
     if (birthINSEECode) {

--- a/api/lib/domain/services/certification-cpf-service.js
+++ b/api/lib/domain/services/certification-cpf-service.js
@@ -42,7 +42,7 @@ class CpfBirthInformationValidation {
   }
 }
 
-function getForeignCountryBirthInformation(birthCity, birthINSEECode, birthPostalCode, country) {
+function _getForeignCountryBirthInformation(birthCity, birthINSEECode, birthPostalCode, country) {
   if (!birthCity) {
     return CpfBirthInformationValidation.failure({
       certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FOREIGN_BIRTH_CITY_REQUIRED,
@@ -69,7 +69,7 @@ function getForeignCountryBirthInformation(birthCity, birthINSEECode, birthPosta
   });
 }
 
-async function getBirthInformationByINSEECode(birthCity, birthINSEECode, country, certificationCpfCityRepository) {
+async function _getBirthInformationByINSEECode({ birthCity, birthINSEECode, country, certificationCpfCityRepository }) {
   if (birthCity) {
     return CpfBirthInformationValidation.failure({
       certificationCandidateError:
@@ -94,7 +94,12 @@ async function getBirthInformationByINSEECode(birthCity, birthINSEECode, country
   });
 }
 
-async function getBirthInformationByPostalCode(birthCity, birthPostalCode, country, certificationCpfCityRepository) {
+async function _getBirthInformationByPostalCode({
+  birthCity,
+  birthPostalCode,
+  country,
+  certificationCpfCityRepository,
+}) {
   if (!birthCity) {
     return CpfBirthInformationValidation.failure({
       certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_CITY_REQUIRED,
@@ -152,7 +157,7 @@ async function getBirthInformation({
     });
   }
   if (country.isForeign()) {
-    return getForeignCountryBirthInformation(birthCity, birthINSEECode, birthPostalCode, country);
+    return _getForeignCountryBirthInformation(birthCity, birthINSEECode, birthPostalCode, country);
   } else {
     if (!birthINSEECode && !birthPostalCode && !birthCity) {
       return CpfBirthInformationValidation.failure({
@@ -169,11 +174,21 @@ async function getBirthInformation({
     }
 
     if (birthINSEECode) {
-      return await getBirthInformationByINSEECode(birthCity, birthINSEECode, country, certificationCpfCityRepository);
+      return await _getBirthInformationByINSEECode({
+        birthCity,
+        birthINSEECode,
+        country,
+        certificationCpfCityRepository,
+      });
     }
 
     if (birthPostalCode) {
-      return await getBirthInformationByPostalCode(birthCity, birthPostalCode, country, certificationCpfCityRepository);
+      return await _getBirthInformationByPostalCode({
+        birthCity,
+        birthPostalCode,
+        country,
+        certificationCpfCityRepository,
+      });
     }
 
     if (birthCity) {

--- a/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
+++ b/api/lib/domain/services/sessions-mass-import/sessions-import-validation-service.js
@@ -134,14 +134,16 @@ module.exports = {
     });
 
     if (cpfBirthInformation.hasFailed()) {
-      if (
-        _isErrorNotDuplicated({
-          certificationCandidateErrors,
-          errorCode: cpfBirthInformation.code,
-        })
-      ) {
-        _addToErrorList({ errorList: certificationCandidateErrors, line, codes: [cpfBirthInformation.code] });
-      }
+      cpfBirthInformation.errors.forEach(({ code: errorCode }) => {
+        if (
+          _isErrorNotDuplicated({
+            certificationCandidateErrors,
+            errorCode,
+          })
+        ) {
+          _addToErrorList({ errorList: certificationCandidateErrors, line, codes: [errorCode] });
+        }
+      });
     }
 
     candidate.convertExtraTimePercentageToDecimal();

--- a/api/lib/domain/usecases/add-certification-candidate-to-session.js
+++ b/api/lib/domain/usecases/add-certification-candidate-to-session.js
@@ -1,8 +1,8 @@
 const {
   CertificationCandidateByPersonalInfoTooManyMatchesError,
-  CpfBirthInformationValidationError,
   CertificationCandidateAddError,
   CertificationCandidateOnFinalizedSessionError,
+  CpfBirthInformationValidationError,
 } = require('../errors.js');
 
 module.exports = async function addCertificationCandidateToSession({
@@ -50,7 +50,7 @@ module.exports = async function addCertificationCandidateToSession({
   });
 
   if (cpfBirthInformation.hasFailed()) {
-    throw new CpfBirthInformationValidationError(cpfBirthInformation.message);
+    throw new CpfBirthInformationValidationError(cpfBirthInformation.firstErrorMessage);
   }
 
   certificationCandidate.updateBirthInformation(cpfBirthInformation);

--- a/api/lib/domain/usecases/correct-candidate-identity-in-certification-course.js
+++ b/api/lib/domain/usecases/correct-candidate-identity-in-certification-course.js
@@ -1,4 +1,4 @@
-const { CpfBirthInformationValidationError } = require('../errors.js');
+const { CpfBirthInformationValidationError } = require('../errors');
 
 module.exports = async function correctCandidateIdentityInCertificationCourse({
   command: {
@@ -34,7 +34,7 @@ module.exports = async function correctCandidateIdentityInCertificationCourse({
   });
 
   if (cpfBirthInformation.hasFailed()) {
-    throw new CpfBirthInformationValidationError(cpfBirthInformation.message);
+    throw new CpfBirthInformationValidationError(cpfBirthInformation.firstErrorMessage);
   }
 
   certificationCourse.correctBirthInformation(cpfBirthInformation);

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -409,7 +409,6 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
     [
       { field: 'firstName', expectedCode: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FIRST_NAME_REQUIRED.code },
       { field: 'lastName', expectedCode: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_LAST_NAME_REQUIRED.code },
-      { field: 'birthCountry', expectedCode: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_REQUIRED.code },
       { field: 'birthdate', expectedCode: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTHDATE_REQUIRED.code },
       {
         field: 'sex',
@@ -693,110 +692,6 @@ describe('Unit | Domain | Models | Certification Candidate', function () {
             // then
             expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_PREPAYMENT_CODE_REQUIRED.code]);
           });
-        });
-      });
-    });
-
-    context('when birthPostalCode and birthInseeCode fields are presents', function () {
-      context('when there is a birthCity', function () {
-        it('should return a report if both birthPostalCode and birthInseeCode are empty', async function () {
-          // given
-          const certificationCandidate = domainBuilder.buildCertificationCandidate({
-            ...validAttributes,
-            birthPostalCode: null,
-            birthINSEECode: null,
-            birthCity: 'PARIS',
-          });
-
-          // when
-          const report = certificationCandidate.validateForMassSessionImport();
-
-          // then
-          expect(report).to.deep.equal([CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED.code]);
-        });
-        it('should return a report if birthPostalCode and birthInseeCode are present', async function () {
-          // given
-          const certificationCandidate = domainBuilder.buildCertificationCandidate({
-            ...validAttributes,
-            birthPostalCode: 'TUTU',
-            birthINSEECode: 'TATA',
-            birthCity: 'TOTO',
-          });
-
-          // when
-          const report = certificationCandidate.validateForMassSessionImport();
-
-          // then
-          expect(report).to.deep.equal([
-            CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED.code,
-          ]);
-        });
-        it('should return nothing if birthPostalCode is present and birthInseeCode is empty', async function () {
-          // given
-          const certificationCandidate = domainBuilder.buildCertificationCandidate({
-            ...validAttributes,
-            billingMode: 'FREE',
-            birthPostalCode: 'tutu',
-            birthINSEECode: null,
-            birthCity: 'tata',
-          });
-
-          // when
-          const report = certificationCandidate.validateForMassSessionImport();
-
-          // then
-          expect(report).to.be.undefined;
-        });
-      });
-      context('when there is no birthCity', function () {
-        it('should return a report if both birthPostalCode and birthInseeCode are empty', async function () {
-          // given
-          const certificationCandidate = domainBuilder.buildCertificationCandidate({
-            ...validAttributes,
-            birthPostalCode: null,
-            birthINSEECode: null,
-            birthCity: null,
-          });
-
-          // when
-          const report = certificationCandidate.validateForMassSessionImport();
-
-          // then
-          expect(report).to.deep.equal([
-            CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED.code,
-          ]);
-        });
-        it('should return a report if both birthPostalCode and birthInseeCode are present', async function () {
-          // given
-          const certificationCandidate = domainBuilder.buildCertificationCandidate({
-            ...validAttributes,
-            birthPostalCode: null,
-            birthINSEECode: null,
-            birthCity: null,
-          });
-
-          // when
-          const report = certificationCandidate.validateForMassSessionImport();
-
-          // then
-          expect(report).to.deep.equal([
-            CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED.code,
-          ]);
-        });
-        it('should return nothing if birthInseeCode is present and birthPostalCode is empty', async function () {
-          // given
-          const certificationCandidate = domainBuilder.buildCertificationCandidate({
-            ...validAttributes,
-            billingMode: 'FREE',
-            birthPostalCode: '',
-            birthINSEECode: '75115',
-          });
-
-          // when
-          const report = certificationCandidate.validateForMassSessionImport();
-
-          // then
-          expect(report).to.be.undefined;
         });
       });
     });

--- a/api/tests/unit/domain/services/certification-cpf-service_test.js
+++ b/api/tests/unit/domain/services/certification-cpf-service_test.js
@@ -48,6 +48,11 @@ describe('Unit | Service | Certification CPF service', function () {
         const birthCity = 'GOTHAM CITY';
         const birthPostalCode = null;
         const birthINSEECode = '12345';
+        const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+        cpfBirthInformationValidation.failure({
+          certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_NOT_FOUND,
+          data: { birthCountry },
+        });
 
         certificationCpfCountryRepository.getByMatcher.resolves(null);
 
@@ -62,12 +67,7 @@ describe('Unit | Service | Certification CPF service', function () {
         });
 
         // then
-        expect(result).to.deep.equal(
-          new CpfBirthInformationValidation().failure({
-            certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_NOT_FOUND,
-            data: { birthCountry },
-          })
-        );
+        expect(result).to.deep.equal(cpfBirthInformationValidation);
       });
     });
 
@@ -79,6 +79,10 @@ describe('Unit | Service | Certification CPF service', function () {
           const birthCity = null;
           const birthPostalCode = null;
           const birthINSEECode = '99';
+          const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+          cpfBirthInformationValidation.failure({
+            certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FOREIGN_BIRTH_CITY_REQUIRED,
+          });
 
           const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry({
             code: '1234',
@@ -100,11 +104,7 @@ describe('Unit | Service | Certification CPF service', function () {
           });
 
           // then
-          expect(result).to.deep.equal(
-            new CpfBirthInformationValidation().failure({
-              certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FOREIGN_BIRTH_CITY_REQUIRED,
-            })
-          );
+          expect(result).to.deep.equal(cpfBirthInformationValidation);
         });
 
         it('should return a validation failure when postal code is defined', async function () {
@@ -113,6 +113,10 @@ describe('Unit | Service | Certification CPF service', function () {
           const birthCity = 'Porto';
           const birthPostalCode = '1234';
           const birthINSEECode = '99';
+          const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+          cpfBirthInformationValidation.failure({
+            certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FOREIGN_POSTAL_CODE_MUST_BE_EMPTY,
+          });
 
           const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry({
             code: '1234',
@@ -134,11 +138,7 @@ describe('Unit | Service | Certification CPF service', function () {
           });
 
           // then
-          expect(result).to.deep.equal(
-            new CpfBirthInformationValidation().failure({
-              certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FOREIGN_POSTAL_CODE_MUST_BE_EMPTY,
-            })
-          );
+          expect(result).to.deep.equal(cpfBirthInformationValidation);
         });
 
         it('should return a validation failure when INSEE code is not defined', async function () {
@@ -147,6 +147,10 @@ describe('Unit | Service | Certification CPF service', function () {
           const birthCity = 'Porto';
           const birthPostalCode = null;
           const birthINSEECode = null;
+          const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+          cpfBirthInformationValidation.failure({
+            certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID,
+          });
 
           const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry({
             code: '1234',
@@ -168,11 +172,7 @@ describe('Unit | Service | Certification CPF service', function () {
           });
 
           // then
-          expect(result).to.deep.equal(
-            new CpfBirthInformationValidation().failure({
-              certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID,
-            })
-          );
+          expect(result).to.deep.equal(cpfBirthInformationValidation);
         });
 
         it('should return a validation failure when INSEE code is not 99', async function () {
@@ -181,6 +181,10 @@ describe('Unit | Service | Certification CPF service', function () {
           const birthCity = 'Porto';
           const birthPostalCode = null;
           const birthINSEECode = '1234';
+          const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+          cpfBirthInformationValidation.failure({
+            certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID,
+          });
 
           const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry({
             code: '1234',
@@ -202,11 +206,7 @@ describe('Unit | Service | Certification CPF service', function () {
           });
 
           // then
-          expect(result).to.deep.equal(
-            new CpfBirthInformationValidation().failure({
-              certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID,
-            })
-          );
+          expect(result).to.deep.equal(cpfBirthInformationValidation);
         });
 
         it('should return birth information when city name is defined', async function () {
@@ -256,6 +256,10 @@ describe('Unit | Service | Certification CPF service', function () {
               const birthCity = 'Tours';
               const birthPostalCode = null;
               const birthINSEECode = null;
+              const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+              cpfBirthInformationValidation.failure({
+                certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED,
+              });
 
               const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
               certificationCpfCountryRepository.getByMatcher
@@ -273,11 +277,7 @@ describe('Unit | Service | Certification CPF service', function () {
               });
 
               // then
-              expect(result).to.deep.equal(
-                new CpfBirthInformationValidation().failure({
-                  certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED,
-                })
-              );
+              expect(result).to.deep.equal(cpfBirthInformationValidation);
             });
           });
           context('when birthcity is not defined', function () {
@@ -287,6 +287,11 @@ describe('Unit | Service | Certification CPF service', function () {
               const birthCity = null;
               const birthPostalCode = null;
               const birthINSEECode = null;
+              const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+              cpfBirthInformationValidation.failure({
+                certificationCandidateError:
+                  CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED,
+              });
 
               const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
               certificationCpfCountryRepository.getByMatcher
@@ -304,12 +309,7 @@ describe('Unit | Service | Certification CPF service', function () {
               });
 
               // then
-              expect(result).to.deep.equal(
-                new CpfBirthInformationValidation().failure({
-                  certificationCandidateError:
-                    CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED,
-                })
-              );
+              expect(result).to.deep.equal(cpfBirthInformationValidation);
             });
           });
         });
@@ -322,6 +322,11 @@ describe('Unit | Service | Certification CPF service', function () {
               const birthCity = 'MARSEILLE';
               const birthPostalCode = '1234';
               const birthINSEECode = '1234';
+              const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+              cpfBirthInformationValidation.failure({
+                certificationCandidateError:
+                  CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED,
+              });
 
               const marseilleCpf = domainBuilder.buildCertificationCpfCity({
                 postalCode: '1234',
@@ -347,12 +352,7 @@ describe('Unit | Service | Certification CPF service', function () {
               });
 
               // then
-              expect(result).to.deep.equal(
-                new CpfBirthInformationValidation().failure({
-                  certificationCandidateError:
-                    CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED,
-                })
-              );
+              expect(result).to.deep.equal(cpfBirthInformationValidation);
             });
           });
           context('when birthcity is not defined', function () {
@@ -362,6 +362,11 @@ describe('Unit | Service | Certification CPF service', function () {
               const birthCity = null;
               const birthPostalCode = '1234';
               const birthINSEECode = '1234';
+              const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+              cpfBirthInformationValidation.failure({
+                certificationCandidateError:
+                  CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED,
+              });
 
               const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
               certificationCpfCountryRepository.getByMatcher
@@ -379,12 +384,7 @@ describe('Unit | Service | Certification CPF service', function () {
               });
 
               // then
-              expect(result).to.deep.equal(
-                new CpfBirthInformationValidation().failure({
-                  certificationCandidateError:
-                    CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED,
-                })
-              );
+              expect(result).to.deep.equal(cpfBirthInformationValidation);
             });
           });
         });
@@ -396,6 +396,13 @@ describe('Unit | Service | Certification CPF service', function () {
             const birthCity = null;
             const birthPostalCode = null;
             const birthINSEECode = '12345';
+            const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+            cpfBirthInformationValidation.success({
+              birthCountry: 'FRANCE',
+              birthINSEECode: '12345',
+              birthPostalCode: null,
+              birthCity: 'GOTHAM CITY',
+            });
 
             const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
             certificationCpfCountryRepository.getByMatcher
@@ -424,14 +431,7 @@ describe('Unit | Service | Certification CPF service', function () {
             });
 
             // then
-            expect(result).to.deep.equal(
-              new CpfBirthInformationValidation().success({
-                birthCountry: 'FRANCE',
-                birthINSEECode: '12345',
-                birthPostalCode: null,
-                birthCity: 'GOTHAM CITY',
-              })
-            );
+            expect(result).to.deep.equal(cpfBirthInformationValidation);
             expect(certificationCpfCityRepository.findByINSEECode).to.have.been.calledWith({
               INSEECode: birthINSEECode,
             });
@@ -443,6 +443,11 @@ describe('Unit | Service | Certification CPF service', function () {
             const birthCity = null;
             const birthPostalCode = null;
             const birthINSEECode = '12345';
+            const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+            cpfBirthInformationValidation.failure({
+              certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_NOT_VALID,
+              data: { birthINSEECode },
+            });
 
             const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
 
@@ -463,12 +468,7 @@ describe('Unit | Service | Certification CPF service', function () {
             });
 
             // then
-            expect(result).to.deep.equal(
-              new CpfBirthInformationValidation().failure({
-                certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_NOT_VALID,
-                data: { birthINSEECode },
-              })
-            );
+            expect(result).to.deep.equal(cpfBirthInformationValidation);
           });
 
           it('should return a validation failure when birth city is provided along with INSEE code', async function () {
@@ -477,6 +477,11 @@ describe('Unit | Service | Certification CPF service', function () {
             const birthCity = 'GOTHAM CITY';
             const birthPostalCode = null;
             const birthINSEECode = '12345';
+            const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+            cpfBirthInformationValidation.failure({
+              certificationCandidateError:
+                CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED,
+            });
 
             const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
             certificationCpfCountryRepository.getByMatcher
@@ -500,12 +505,7 @@ describe('Unit | Service | Certification CPF service', function () {
             });
 
             // then
-            expect(result).to.deep.equal(
-              new CpfBirthInformationValidation().failure({
-                certificationCandidateError:
-                  CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED,
-              })
-            );
+            expect(result).to.deep.equal(cpfBirthInformationValidation);
           });
         });
 
@@ -516,6 +516,13 @@ describe('Unit | Service | Certification CPF service', function () {
             const birthCity = 'GOTHAM CITY';
             const birthPostalCode = '12345';
             const birthINSEECode = null;
+            const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+            cpfBirthInformationValidation.success({
+              birthCountry: 'FRANCE',
+              birthINSEECode: null,
+              birthPostalCode: '12345',
+              birthCity: 'GOTHAM CITY',
+            });
 
             const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
             const certificationCPFCity = domainBuilder.buildCertificationCpfCity({
@@ -539,14 +546,7 @@ describe('Unit | Service | Certification CPF service', function () {
             });
 
             // then
-            expect(result).to.deep.equal(
-              new CpfBirthInformationValidation().success({
-                birthCountry: 'FRANCE',
-                birthINSEECode: null,
-                birthPostalCode: '12345',
-                birthCity: 'GOTHAM CITY',
-              })
-            );
+            expect(result).to.deep.equal(cpfBirthInformationValidation);
             expect(certificationCpfCityRepository.findByPostalCode).to.have.been.calledWith({
               postalCode: birthPostalCode,
             });
@@ -559,6 +559,13 @@ describe('Unit | Service | Certification CPF service', function () {
               const birthCity = 'Losse-en-Gelaisse';
               const birthPostalCode = '12345';
               const birthINSEECode = null;
+              const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+              cpfBirthInformationValidation.success({
+                birthCountry: 'FRANCE',
+                birthINSEECode: null,
+                birthPostalCode: '12345',
+                birthCity: 'LOSSE EN GELAISSE',
+              });
 
               const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
               certificationCpfCountryRepository.getByMatcher
@@ -588,14 +595,7 @@ describe('Unit | Service | Certification CPF service', function () {
               });
 
               // then
-              expect(result).to.deep.equal(
-                new CpfBirthInformationValidation().success({
-                  birthCountry: 'FRANCE',
-                  birthINSEECode: null,
-                  birthPostalCode: '12345',
-                  birthCity: 'LOSSE EN GELAISSE',
-                })
-              );
+              expect(result).to.deep.equal(cpfBirthInformationValidation);
               expect(certificationCpfCityRepository.findByPostalCode).to.have.been.calledWith({
                 postalCode: birthPostalCode,
               });
@@ -608,6 +608,11 @@ describe('Unit | Service | Certification CPF service', function () {
             const birthCity = 'GOTHAM CITY';
             const birthPostalCode = '12345';
             const birthINSEECode = null;
+            const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+            cpfBirthInformationValidation.failure({
+              certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_POSTAL_CODE_NOT_FOUND,
+              data: { birthPostalCode },
+            });
 
             const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
 
@@ -627,12 +632,7 @@ describe('Unit | Service | Certification CPF service', function () {
             });
 
             // then
-            expect(result).to.deep.equal(
-              new CpfBirthInformationValidation().failure({
-                certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_POSTAL_CODE_NOT_FOUND,
-                data: { birthPostalCode },
-              })
-            );
+            expect(result).to.deep.equal(cpfBirthInformationValidation);
           });
 
           it('should return a validation failure when birth city is not defined', async function () {
@@ -641,6 +641,10 @@ describe('Unit | Service | Certification CPF service', function () {
             const birthCity = null;
             const birthPostalCode = '12345';
             const birthINSEECode = null;
+            const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+            cpfBirthInformationValidation.failure({
+              certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_CITY_REQUIRED,
+            });
 
             const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
             certificationCpfCountryRepository.getByMatcher
@@ -658,11 +662,7 @@ describe('Unit | Service | Certification CPF service', function () {
             });
 
             // then
-            expect(result).to.deep.equal(
-              new CpfBirthInformationValidation().failure({
-                certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_CITY_REQUIRED,
-              })
-            );
+            expect(result).to.deep.equal(cpfBirthInformationValidation);
           });
 
           it('should return a validation failure when postal code does not match city name', async function () {
@@ -671,6 +671,11 @@ describe('Unit | Service | Certification CPF service', function () {
             const birthCity = 'METROPOLIS';
             const birthPostalCode = '12345';
             const birthINSEECode = null;
+            const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+            cpfBirthInformationValidation.failure({
+              certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_POSTAL_CODE_CITY_NOT_VALID,
+              data: { birthPostalCode, birthCity },
+            });
 
             const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
 
@@ -695,12 +700,7 @@ describe('Unit | Service | Certification CPF service', function () {
             });
 
             // then
-            expect(result).to.deep.equal(
-              new CpfBirthInformationValidation().failure({
-                certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_POSTAL_CODE_CITY_NOT_VALID,
-                data: { birthPostalCode, birthCity },
-              })
-            );
+            expect(result).to.deep.equal(cpfBirthInformationValidation);
           });
         });
       });

--- a/api/tests/unit/domain/services/certification-cpf-service_test.js
+++ b/api/tests/unit/domain/services/certification-cpf-service_test.js
@@ -249,76 +249,143 @@ describe('Unit | Service | Certification CPF service', function () {
 
       context('when country is FRANCE', function () {
         context('when postal code and INSEE code are not defined', function () {
-          it('should return a validation failure', async function () {
-            // given
-            const birthCountry = 'FRANCE';
-            const birthCity = null;
-            const birthPostalCode = null;
-            const birthINSEECode = null;
+          context('when birthcity is defined', function () {
+            it('should return a validation failure', async function () {
+              // given
+              const birthCountry = 'FRANCE';
+              const birthCity = 'Tours';
+              const birthPostalCode = null;
+              const birthINSEECode = null;
 
-            const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
-            certificationCpfCountryRepository.getByMatcher
-              .withArgs({ matcher: 'ACEFNR' })
-              .resolves(certificationCPFCountry);
+              const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
+              certificationCpfCountryRepository.getByMatcher
+                .withArgs({ matcher: 'ACEFNR' })
+                .resolves(certificationCPFCountry);
 
-            // when
-            const result = await getBirthInformation({
-              birthCountry,
-              birthCity,
-              birthPostalCode,
-              birthINSEECode,
-              certificationCpfCountryRepository,
-              certificationCpfCityRepository,
+              // when
+              const result = await getBirthInformation({
+                birthCountry,
+                birthCity,
+                birthPostalCode,
+                birthINSEECode,
+                certificationCpfCountryRepository,
+                certificationCpfCityRepository,
+              });
+
+              // then
+              expect(result).to.deep.equal(
+                new CpfBirthInformationValidation().failure({
+                  certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED,
+                })
+              );
             });
+          });
+          context('when birthcity is not defined', function () {
+            it('should return a validation failure', async function () {
+              // given
+              const birthCountry = 'FRANCE';
+              const birthCity = null;
+              const birthPostalCode = null;
+              const birthINSEECode = null;
 
-            // then
-            expect(result).to.deep.equal(
-              new CpfBirthInformationValidation().failure({
-                certificationCandidateError:
-                  CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED,
-              })
-            );
+              const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
+              certificationCpfCountryRepository.getByMatcher
+                .withArgs({ matcher: 'ACEFNR' })
+                .resolves(certificationCPFCountry);
+
+              // when
+              const result = await getBirthInformation({
+                birthCountry,
+                birthCity,
+                birthPostalCode,
+                birthINSEECode,
+                certificationCpfCountryRepository,
+                certificationCpfCityRepository,
+              });
+
+              // then
+              expect(result).to.deep.equal(
+                new CpfBirthInformationValidation().failure({
+                  certificationCandidateError:
+                    CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED,
+                })
+              );
+            });
           });
         });
 
         context('when both postal code and INSEE code are defined', function () {
-          it('should return a validation failure', async function () {
-            // given
-            const birthCountry = 'FRANCE';
-            const birthCity = 'MARSEILLE';
-            const birthPostalCode = '1234';
-            const birthINSEECode = '1234';
+          context('when birthcity is defined', function () {
+            it('should return a validation failure', async function () {
+              // given
+              const birthCountry = 'FRANCE';
+              const birthCity = 'MARSEILLE';
+              const birthPostalCode = '1234';
+              const birthINSEECode = '1234';
 
-            const marseilleCpf = domainBuilder.buildCertificationCpfCity({
-              postalCode: '1234',
-              INSEECode: '1234',
-              name: 'MARSEILLE',
+              const marseilleCpf = domainBuilder.buildCertificationCpfCity({
+                postalCode: '1234',
+                INSEECode: '1234',
+                name: 'MARSEILLE',
+              });
+              certificationCpfCityRepository.findByINSEECode.withArgs({ INSEECode: '1234' }).resolves([marseilleCpf]);
+              certificationCpfCityRepository.findByPostalCode.withArgs({ postalCode: '1234' }).resolves([marseilleCpf]);
+
+              const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
+              certificationCpfCountryRepository.getByMatcher
+                .withArgs({ matcher: 'ACEFNR' })
+                .resolves(certificationCPFCountry);
+
+              // when
+              const result = await getBirthInformation({
+                birthCountry,
+                birthCity,
+                birthPostalCode,
+                birthINSEECode,
+                certificationCpfCountryRepository,
+                certificationCpfCityRepository,
+              });
+
+              // then
+              expect(result).to.deep.equal(
+                new CpfBirthInformationValidation().failure({
+                  certificationCandidateError:
+                    CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED,
+                })
+              );
             });
-            certificationCpfCityRepository.findByINSEECode.withArgs({ INSEECode: '1234' }).resolves([marseilleCpf]);
-            certificationCpfCityRepository.findByPostalCode.withArgs({ postalCode: '1234' }).resolves([marseilleCpf]);
+          });
+          context('when birthcity is not defined', function () {
+            it('should return a validation failure', async function () {
+              // given
+              const birthCountry = 'FRANCE';
+              const birthCity = null;
+              const birthPostalCode = '1234';
+              const birthINSEECode = '1234';
 
-            const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
-            certificationCpfCountryRepository.getByMatcher
-              .withArgs({ matcher: 'ACEFNR' })
-              .resolves(certificationCPFCountry);
+              const certificationCPFCountry = domainBuilder.buildCertificationCpfCountry.FRANCE();
+              certificationCpfCountryRepository.getByMatcher
+                .withArgs({ matcher: 'ACEFNR' })
+                .resolves(certificationCPFCountry);
 
-            // when
-            const result = await getBirthInformation({
-              birthCountry,
-              birthCity,
-              birthPostalCode,
-              birthINSEECode,
-              certificationCpfCountryRepository,
-              certificationCpfCityRepository,
+              // when
+              const result = await getBirthInformation({
+                birthCountry,
+                birthCity,
+                birthPostalCode,
+                birthINSEECode,
+                certificationCpfCountryRepository,
+                certificationCpfCityRepository,
+              });
+
+              // then
+              expect(result).to.deep.equal(
+                new CpfBirthInformationValidation().failure({
+                  certificationCandidateError:
+                    CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED,
+                })
+              );
             });
-
-            // then
-            expect(result).to.deep.equal(
-              new CpfBirthInformationValidation().failure({
-                certificationCandidateError:
-                  CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED,
-              })
-            );
           });
         });
 

--- a/api/tests/unit/domain/services/certification-cpf-service_test.js
+++ b/api/tests/unit/domain/services/certification-cpf-service_test.js
@@ -23,8 +23,8 @@ describe('Unit | Service | Certification CPF service', function () {
     context('when country name is not defined', function () {
       it('should return a validation failure', async function () {
         // when
-        const cpfBirthInformationValidationRes = new CpfBirthInformationValidation();
-        cpfBirthInformationValidationRes.failure({
+        const cpfBirthInformationValidationResult = new CpfBirthInformationValidation();
+        cpfBirthInformationValidationResult.failure({
           certificationCandidateError: CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_REQUIRED,
         });
         const result = await getBirthInformation({
@@ -37,7 +37,7 @@ describe('Unit | Service | Certification CPF service', function () {
         });
 
         // then
-        expect(result).to.deep.equal(cpfBirthInformationValidationRes);
+        expect(result).to.deep.equal(cpfBirthInformationValidationResult);
       });
     });
 
@@ -307,7 +307,7 @@ describe('Unit | Service | Certification CPF service', function () {
               expect(result).to.deep.equal(
                 new CpfBirthInformationValidation().failure({
                   certificationCandidateError:
-                    CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED,
+                    CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED,
                 })
               );
             });
@@ -350,7 +350,7 @@ describe('Unit | Service | Certification CPF service', function () {
               expect(result).to.deep.equal(
                 new CpfBirthInformationValidation().failure({
                   certificationCandidateError:
-                    CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED,
+                    CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED,
                 })
               );
             });
@@ -382,7 +382,7 @@ describe('Unit | Service | Certification CPF service', function () {
               expect(result).to.deep.equal(
                 new CpfBirthInformationValidation().failure({
                   certificationCandidateError:
-                    CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED,
+                    CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED,
                 })
               );
             });
@@ -503,7 +503,7 @@ describe('Unit | Service | Certification CPF service', function () {
             expect(result).to.deep.equal(
               new CpfBirthInformationValidation().failure({
                 certificationCandidateError:
-                  CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED,
+                  CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED,
               })
             );
           });

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -437,10 +437,10 @@ describe('Unit | Service | sessions import validation Service', function () {
           birthINSEECode: '67890',
         };
         const candidate = _buildValidCandidateData();
+        const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+        cpfBirthInformationValidation.success(candidateInformation);
 
-        certificationCpfService.getBirthInformation.resolves(
-          new CpfBirthInformationValidation().success(candidateInformation)
-        );
+        certificationCpfService.getBirthInformation.resolves(cpfBirthInformationValidation);
 
         // when
         const { certificationCandidateErrors } =
@@ -460,9 +460,9 @@ describe('Unit | Service | sessions import validation Service', function () {
         const isSco = false;
         const candidate = _buildValidCandidateData();
         candidate.firstName = null;
-        certificationCpfService.getBirthInformation.resolves(
-          new CpfBirthInformationValidation().success({ ...candidate })
-        );
+        const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+        cpfBirthInformationValidation.success({ ...candidate });
+        certificationCpfService.getBirthInformation.resolves(cpfBirthInformationValidation);
 
         // when
         const { certificationCandidateErrors } =
@@ -491,9 +491,9 @@ describe('Unit | Service | sessions import validation Service', function () {
             const isSco = false;
             const candidate = _buildValidCandidateData();
             candidate.billingMode = null;
-            certificationCpfService.getBirthInformation.resolves(
-              new CpfBirthInformationValidation().success({ ...candidate })
-            );
+            const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+            cpfBirthInformationValidation.success({ ...candidate });
+            certificationCpfService.getBirthInformation.resolves(cpfBirthInformationValidation);
 
             // when
             const { certificationCandidateErrors } =
@@ -520,9 +520,9 @@ describe('Unit | Service | sessions import validation Service', function () {
             const isSco = false;
             const candidate = _buildValidCandidateData();
             candidate.billingMode = '';
-            certificationCpfService.getBirthInformation.resolves(
-              new CpfBirthInformationValidation().success({ ...candidate })
-            );
+            const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+            cpfBirthInformationValidation.success({ ...candidate });
+            certificationCpfService.getBirthInformation.resolves(cpfBirthInformationValidation);
 
             // when
             const { certificationCandidateErrors } =
@@ -556,10 +556,10 @@ describe('Unit | Service | sessions import validation Service', function () {
           };
           const candidate = _buildValidCandidateData();
           candidate.billingMode = null;
+          const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+          cpfBirthInformationValidation.success(candidateInformation);
 
-          certificationCpfService.getBirthInformation.resolves(
-            new CpfBirthInformationValidation().success(candidateInformation)
-          );
+          certificationCpfService.getBirthInformation.resolves(cpfBirthInformationValidation);
 
           // when
           const { certificationCandidateErrors } =
@@ -583,6 +583,8 @@ describe('Unit | Service | sessions import validation Service', function () {
           const certificationCpfCountryRepository = Symbol();
           const certificationCpfCityRepository = Symbol();
           const certificationCandidateError = CERTIFICATION_CANDIDATES_ERRORS.CANDIDATE_BIRTH_COUNTRY_REQUIRED;
+          const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+          cpfBirthInformationValidation.failure({ certificationCandidateError });
           certificationCpfService.getBirthInformation
             .withArgs({
               birthCountry: '',
@@ -592,7 +594,7 @@ describe('Unit | Service | sessions import validation Service', function () {
               certificationCpfCountryRepository,
               certificationCpfCityRepository,
             })
-            .resolves(new CpfBirthInformationValidation().failure({ certificationCandidateError }));
+            .resolves(cpfBirthInformationValidation);
 
           // when
           const result = await sessionsImportValidationService.getValidatedCandidateBirthInformation({
@@ -617,7 +619,8 @@ describe('Unit | Service | sessions import validation Service', function () {
         const certificationCpfCityRepository = Symbol();
         const certificationCandidateError = { code: 'CPF_INCORRECT', getMessage: noop };
         const certificationCandidateError2 = { code: 'CPF_INCORRECT 2', getMessage: noop };
-        const cpfBirthInformationValidation = new CpfBirthInformationValidation().failure({
+        const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+        cpfBirthInformationValidation.failure({
           certificationCandidateError: certificationCandidateError,
         });
         cpfBirthInformationValidation.failure({ certificationCandidateError: certificationCandidateError2 });

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -644,6 +644,7 @@ describe('Unit | Service | sessions import validation Service', function () {
         // then
         expect(result.certificationCandidateErrors).to.deep.equal([
           { code: 'CPF_INCORRECT', line: 1, isBlocking: true },
+          { code: 'CPF_INCORRECT 2', line: 1, isBlocking: true },
         ]);
       });
     });

--- a/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
+++ b/api/tests/unit/domain/services/sessions-mass-import/sessions-import-validation-service_test.js
@@ -439,7 +439,7 @@ describe('Unit | Service | sessions import validation Service', function () {
         const candidate = _buildValidCandidateData();
 
         certificationCpfService.getBirthInformation.resolves(
-          CpfBirthInformationValidation.success(candidateInformation)
+          new CpfBirthInformationValidation().success(candidateInformation)
         );
 
         // when
@@ -460,7 +460,9 @@ describe('Unit | Service | sessions import validation Service', function () {
         const isSco = false;
         const candidate = _buildValidCandidateData();
         candidate.firstName = null;
-        certificationCpfService.getBirthInformation.resolves(CpfBirthInformationValidation.success({ ...candidate }));
+        certificationCpfService.getBirthInformation.resolves(
+          new CpfBirthInformationValidation().success({ ...candidate })
+        );
 
         // when
         const { certificationCandidateErrors } =
@@ -490,7 +492,7 @@ describe('Unit | Service | sessions import validation Service', function () {
             const candidate = _buildValidCandidateData();
             candidate.billingMode = null;
             certificationCpfService.getBirthInformation.resolves(
-              CpfBirthInformationValidation.success({ ...candidate })
+              new CpfBirthInformationValidation().success({ ...candidate })
             );
 
             // when
@@ -519,7 +521,7 @@ describe('Unit | Service | sessions import validation Service', function () {
             const candidate = _buildValidCandidateData();
             candidate.billingMode = '';
             certificationCpfService.getBirthInformation.resolves(
-              CpfBirthInformationValidation.success({ ...candidate })
+              new CpfBirthInformationValidation().success({ ...candidate })
             );
 
             // when
@@ -556,7 +558,7 @@ describe('Unit | Service | sessions import validation Service', function () {
           candidate.billingMode = null;
 
           certificationCpfService.getBirthInformation.resolves(
-            CpfBirthInformationValidation.success(candidateInformation)
+            new CpfBirthInformationValidation().success(candidateInformation)
           );
 
           // when
@@ -590,7 +592,7 @@ describe('Unit | Service | sessions import validation Service', function () {
               certificationCpfCountryRepository,
               certificationCpfCityRepository,
             })
-            .resolves(CpfBirthInformationValidation.failure({ certificationCandidateError }));
+            .resolves(new CpfBirthInformationValidation().failure({ certificationCandidateError }));
 
           // when
           const result = await sessionsImportValidationService.getValidatedCandidateBirthInformation({
@@ -608,12 +610,17 @@ describe('Unit | Service | sessions import validation Service', function () {
         });
       });
 
-      it('should return a certificationCandidateErrors that contains the incorrect CPF message', async function () {
+      it('should return multiple certificationCandidateErrors that contains the incorrect CPF message', async function () {
         // given
         const candidate = _buildValidCandidateData();
         const certificationCpfCountryRepository = Symbol();
         const certificationCpfCityRepository = Symbol();
         const certificationCandidateError = { code: 'CPF_INCORRECT', getMessage: noop };
+        const certificationCandidateError2 = { code: 'CPF_INCORRECT 2', getMessage: noop };
+        const cpfBirthInformationValidation = new CpfBirthInformationValidation().failure({
+          certificationCandidateError: certificationCandidateError,
+        });
+        cpfBirthInformationValidation.failure({ certificationCandidateError: certificationCandidateError2 });
         certificationCpfService.getBirthInformation
           .withArgs({
             birthCountry: candidate.birthCountry,
@@ -623,7 +630,7 @@ describe('Unit | Service | sessions import validation Service', function () {
             certificationCpfCountryRepository,
             certificationCpfCityRepository,
           })
-          .resolves(CpfBirthInformationValidation.failure({ certificationCandidateError }));
+          .resolves(cpfBirthInformationValidation);
 
         // when
         const result = await sessionsImportValidationService.getValidatedCandidateBirthInformation({

--- a/api/tests/unit/domain/usecases/add-certification-candidate-to-session_test.js
+++ b/api/tests/unit/domain/usecases/add-certification-candidate-to-session_test.js
@@ -136,7 +136,8 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
           sessionId: null,
           complementaryCertifications,
         });
-        const cpfBirthInformationValidation = new CpfBirthInformationValidation().success({
+        const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+        cpfBirthInformationValidation.success({
           birthCountry: 'COUNTRY',
           birthINSEECode: 'INSEE_CODE',
           birthPostalCode: null,
@@ -173,7 +174,8 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
         const certificationCandidate = domainBuilder.buildCertificationCandidate.pro({
           sessionId: null,
         });
-        const cpfBirthInformationValidation = new CpfBirthInformationValidation().success({
+        const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+        cpfBirthInformationValidation.success({
           birthCountry: 'COUNTRY',
           birthINSEECode: 'INSEE_CODE',
           birthPostalCode: null,
@@ -209,7 +211,8 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
           sessionId: null,
         });
         certificationCandidate.validate = sinon.stub();
-        const cpfBirthInformationValidation = new CpfBirthInformationValidation().success({
+        const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+        cpfBirthInformationValidation.success({
           birthCountry: 'COUNTRY',
           birthINSEECode: 'INSEE_CODE',
           birthPostalCode: null,
@@ -247,7 +250,8 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
             complementaryCertifications: [],
           });
           const certificationCandidateError = { code: '', getMessage: () => 'Failure message' };
-          const cpfBirthInformationValidation = new CpfBirthInformationValidation().failure({
+          const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+          cpfBirthInformationValidation.failure({
             certificationCandidateError,
           });
           certificationCandidateRepository.findBySessionIdAndPersonalInfo.resolves([]);

--- a/api/tests/unit/domain/usecases/add-certification-candidate-to-session_test.js
+++ b/api/tests/unit/domain/usecases/add-certification-candidate-to-session_test.js
@@ -252,7 +252,6 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
           });
           certificationCandidateRepository.findBySessionIdAndPersonalInfo.resolves([]);
           certificationCpfService.getBirthInformation.resolves(cpfBirthInformationValidation);
-          certificationCandidateRepository.saveInSession.resolves();
 
           // when
           const error = await catchErr(addCertificationCandidateToSession)({
@@ -268,7 +267,8 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
 
           // then
           expect(error).to.be.an.instanceOf(CpfBirthInformationValidationError);
-          expect(error.message).to.equal(cpfBirthInformationValidation.message);
+          expect(error.message).to.equal('Failure message');
+          expect(certificationCandidateRepository.saveInSession).not.to.have.been.called;
         });
       });
     });

--- a/api/tests/unit/domain/usecases/add-certification-candidate-to-session_test.js
+++ b/api/tests/unit/domain/usecases/add-certification-candidate-to-session_test.js
@@ -136,7 +136,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
           sessionId: null,
           complementaryCertifications,
         });
-        const cpfBirthInformationValidation = CpfBirthInformationValidation.success({
+        const cpfBirthInformationValidation = new CpfBirthInformationValidation().success({
           birthCountry: 'COUNTRY',
           birthINSEECode: 'INSEE_CODE',
           birthPostalCode: null,
@@ -173,7 +173,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
         const certificationCandidate = domainBuilder.buildCertificationCandidate.pro({
           sessionId: null,
         });
-        const cpfBirthInformationValidation = CpfBirthInformationValidation.success({
+        const cpfBirthInformationValidation = new CpfBirthInformationValidation().success({
           birthCountry: 'COUNTRY',
           birthINSEECode: 'INSEE_CODE',
           birthPostalCode: null,
@@ -209,7 +209,7 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
           sessionId: null,
         });
         certificationCandidate.validate = sinon.stub();
-        const cpfBirthInformationValidation = CpfBirthInformationValidation.success({
+        const cpfBirthInformationValidation = new CpfBirthInformationValidation().success({
           birthCountry: 'COUNTRY',
           birthINSEECode: 'INSEE_CODE',
           birthPostalCode: null,
@@ -247,7 +247,9 @@ describe('Unit | UseCase | add-certification-candidate-to-session', function () 
             complementaryCertifications: [],
           });
           const certificationCandidateError = { code: '', getMessage: () => 'Failure message' };
-          const cpfBirthInformationValidation = CpfBirthInformationValidation.failure({ certificationCandidateError });
+          const cpfBirthInformationValidation = new CpfBirthInformationValidation().failure({
+            certificationCandidateError,
+          });
           certificationCandidateRepository.findBySessionIdAndPersonalInfo.resolves([]);
           certificationCpfService.getBirthInformation.resolves(cpfBirthInformationValidation);
           certificationCandidateRepository.saveInSession.resolves();

--- a/api/tests/unit/domain/usecases/correct-candidate-identity-in-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/correct-candidate-identity-in-certification-course_test.js
@@ -54,7 +54,9 @@ describe('Unit | UseCase | correct-candidate-identity-in-certification-course', 
         certificationCpfCountryRepository,
         certificationCpfCityRepository,
       })
-      .resolves(CpfBirthInformationValidation.success({ birthCountry, birthINSEECode, birthPostalCode, birthCity }));
+      .resolves(
+        new CpfBirthInformationValidation().success({ birthCountry, birthINSEECode, birthPostalCode, birthCity })
+      );
 
     const command = {
       certificationCourseId: 4,
@@ -123,7 +125,7 @@ describe('Unit | UseCase | correct-candidate-identity-in-certification-course', 
         certificationCpfCountryRepository,
         certificationCpfCityRepository,
       })
-      .resolves(CpfBirthInformationValidation.failure({ certificationCandidateError }));
+      .resolves(new CpfBirthInformationValidation().failure({ certificationCandidateError }));
 
     const command = {
       certificationCourseId: 4,

--- a/api/tests/unit/domain/usecases/correct-candidate-identity-in-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/correct-candidate-identity-in-certification-course_test.js
@@ -43,6 +43,8 @@ describe('Unit | UseCase | correct-candidate-identity-in-certification-course', 
       birthCountry: 'ETATS-UNIS',
       birthINSEECode: '99404',
     });
+    const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+    cpfBirthInformationValidation.success({ birthCountry, birthINSEECode, birthPostalCode, birthCity });
 
     certificationCourseRepository.get.withArgs(4).resolves(certificationCourseToBeModified);
     certificationCpfService.getBirthInformation
@@ -54,9 +56,7 @@ describe('Unit | UseCase | correct-candidate-identity-in-certification-course', 
         certificationCpfCountryRepository,
         certificationCpfCityRepository,
       })
-      .resolves(
-        new CpfBirthInformationValidation().success({ birthCountry, birthINSEECode, birthPostalCode, birthCity })
-      );
+      .resolves(cpfBirthInformationValidation);
 
     const command = {
       certificationCourseId: 4,
@@ -116,6 +116,8 @@ describe('Unit | UseCase | correct-candidate-identity-in-certification-course', 
 
     certificationCourseRepository.get.withArgs(4).resolves(certificationCourseToBeModified);
     const certificationCandidateError = { code: '', getMessage: () => 'Failure message' };
+    const cpfBirthInformationValidation = new CpfBirthInformationValidation();
+    cpfBirthInformationValidation.failure({ certificationCandidateError });
     certificationCpfService.getBirthInformation
       .withArgs({
         birthCountry,
@@ -125,7 +127,7 @@ describe('Unit | UseCase | correct-candidate-identity-in-certification-course', 
         certificationCpfCountryRepository,
         certificationCpfCityRepository,
       })
-      .resolves(new CpfBirthInformationValidation().failure({ certificationCandidateError }));
+      .resolves(cpfBirthInformationValidation);
 
     const command = {
       certificationCourseId: 4,

--- a/api/tests/unit/domain/usecases/sessions-mass-import/validate-sessions_test.js
+++ b/api/tests/unit/domain/usecases/sessions-mass-import/validate-sessions_test.js
@@ -167,9 +167,9 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           },
         ];
 
-        const cpfBirthInformationValidation1 = CpfBirthInformationValidation.success({ ...candidate1 });
-        const cpfBirthInformationValidation2 = CpfBirthInformationValidation.success({ ...candidate2 });
-        const cpfBirthInformationValidation3 = CpfBirthInformationValidation.success({ ...candidate3 });
+        const cpfBirthInformationValidation1 = new CpfBirthInformationValidation().success({ ...candidate1 });
+        const cpfBirthInformationValidation2 = new CpfBirthInformationValidation().success({ ...candidate2 });
+        const cpfBirthInformationValidation3 = new CpfBirthInformationValidation().success({ ...candidate3 });
         sessionsImportValidationService.getValidatedCandidateBirthInformation
           .onCall(0)
           .resolves({ cpfBirthInformation: cpfBirthInformationValidation1 });

--- a/api/tests/unit/domain/usecases/sessions-mass-import/validate-sessions_test.js
+++ b/api/tests/unit/domain/usecases/sessions-mass-import/validate-sessions_test.js
@@ -167,9 +167,12 @@ describe('Unit | UseCase | sessions-mass-import | validate-sessions', function (
           },
         ];
 
-        const cpfBirthInformationValidation1 = new CpfBirthInformationValidation().success({ ...candidate1 });
-        const cpfBirthInformationValidation2 = new CpfBirthInformationValidation().success({ ...candidate2 });
-        const cpfBirthInformationValidation3 = new CpfBirthInformationValidation().success({ ...candidate3 });
+        const cpfBirthInformationValidation1 = new CpfBirthInformationValidation();
+        cpfBirthInformationValidation1.success({ ...candidate1 });
+        const cpfBirthInformationValidation2 = new CpfBirthInformationValidation();
+        cpfBirthInformationValidation2.success({ ...candidate2 });
+        const cpfBirthInformationValidation3 = new CpfBirthInformationValidation();
+        cpfBirthInformationValidation3.success({ ...candidate3 });
         sessionsImportValidationService.getValidatedCandidateBirthInformation
           .onCall(0)
           .resolves({ cpfBirthInformation: cpfBirthInformationValidation1 });

--- a/certif/tests/integration/components/sessions-import/step-two-section_test.js
+++ b/certif/tests/integration/components/sessions-import/step-two-section_test.js
@@ -35,7 +35,7 @@ module('Integration | Component | Import::StepTwoSection', function (hooks) {
         expectedMessage: 'Donnée du champ "Code INSEE" invalide',
       },
       {
-        error: 'CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED',
+        error: 'CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED',
         expectedMessage: 'Renseigner soit un code INSEE, soit un code postal et un nom de commune de naissance',
       },
       { error: 'CANDIDATE_BIRTH_COUNTRY_REQUIRED', expectedMessage: 'Champ obligatoire "Pays de naissance" manquant' },

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -239,7 +239,7 @@
               "CANDIDATE_SEX_REQUIRED": "Champ obligatoire \"Sexe\" manquant",
               "CANDIDATE_SEX_NOT_VALID": "Donnée du champ \"Sexe\" invalide (format accepté \"M\"/\"F\")",
               "CANDIDATE_BIRTH_INSEE_CODE_NOT_VALID": "Donnée du champ \"Code INSEE\" invalide",
-              "CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED": "Renseigner soit un code INSEE, soit un code postal et un nom de commune de naissance",
+              "CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED": "Renseigner soit un code INSEE, soit un code postal et un nom de commune de naissance",
               "CANDIDATE_BIRTH_COUNTRY_REQUIRED": "Champ obligatoire \"Pays de naissance\" manquant",
               "CANDIDATE_BIRTH_CITY_REQUIRED": "Champ obligatoire \"Nom de la commune\" manquant",
               "CANDIDATE_BIRTH_COUNTRY_NOT_FOUND": "Champ \"Pays de naissance\" non trouvé",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -243,6 +243,7 @@
               "CANDIDATE_BIRTH_COUNTRY_REQUIRED": "Champ obligatoire \"Pays de naissance\" manquant",
               "CANDIDATE_BIRTH_CITY_REQUIRED": "Champ obligatoire \"Nom de la commune\" manquant",
               "CANDIDATE_BIRTH_COUNTRY_NOT_FOUND": "Champ \"Pays de naissance\" non trouvé",
+              "CANDIDATE_BIRTH_INFORMATION_REQUIRED": "Renseigner les données de naissance du candidat",
               "CANDIDATE_BIRTH_POSTAL_CODE_CITY_NOT_VALID": "Le code postal et le nom de la commune ne correspondent pas",
               "CANDIDATE_BIRTH_POSTAL_CODE_NOT_FOUND": "Champ \"Code postal\" non trouvé",
               "CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED": "Champ obligatoire \"Code postal\" manquant",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -253,7 +253,7 @@
               "CANDIDATE_EXTRA_TIME_INTEGER": "Donnée du champ \"Temps majoré\" invalide (exemple de format accepté: 30%)",
               "CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID": "Candidat né à l'étranger, inscrire 99 dans le champ \"Code INSEE\"",
               "CANDIDATE_FOREIGN_BIRTH_CITY_REQUIRED": "Candidat né à l'étranger, champ obligatoire \"Nom de la commune\" manquant",
-              "CANDIDATE_FOREIGN_POSTAL_CODE_MUST_BE_EMPTY": "Candidat né à l'étranger, le champ \"Code postal\" doit rester vide.",
+              "CANDIDATE_FOREIGN_POSTAL_CODE_MUST_BE_EMPTY": "Candidat né à l'étranger, le champ \"Code postal\" doit rester vide",
               "CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION": "Inscription possible qu'à une seule certification complémentaire par candidat",
               "CANDIDATE_BILLING_MODE_REQUIRED": "Champ obligatoire \"Tarification part Pix\" manquant",
               "CANDIDATE_BILLING_MODE_NOT_VALID": "Donnée du champ \"Tarification part Pix\" invalide (formats acceptés \"Gratuite\", \"Payante\" ou \"Prépayée\")",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -239,7 +239,7 @@
               "CANDIDATE_SEX_REQUIRED": "Champ obligatoire \"Sexe\" manquant",
               "CANDIDATE_SEX_NOT_VALID": "Donnée du champ \"Sexe\" invalide (format accepté \"M\"/\"F\")",
               "CANDIDATE_BIRTH_INSEE_CODE_NOT_VALID": "Donnée du champ \"Code INSEE\" invalide",
-              "CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_REQUIRED": "Renseigner soit un code INSEE, soit un code postal et un nom de commune de naissance",
+              "CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED": "Renseigner soit un code INSEE, soit un code postal et un nom de commune de naissance",
               "CANDIDATE_BIRTH_COUNTRY_REQUIRED": "Champ obligatoire \"Pays de naissance\" manquant",
               "CANDIDATE_BIRTH_CITY_REQUIRED": "Champ obligatoire \"Nom de la commune\" manquant",
               "CANDIDATE_BIRTH_COUNTRY_NOT_FOUND": "Donnée du champ \"Pays de naissance\" n'existe pas",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -253,7 +253,7 @@
               "CANDIDATE_EXTRA_TIME_INTEGER": "Donnée du champ \"Temps majoré\" invalide (exemple de format accepté: 30%)",
               "CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID": "Candidat né à l'étranger, inscrire 99 dans le champ \"Code INSEE\"",
               "CANDIDATE_FOREIGN_BIRTH_CITY_REQUIRED": "Candidat né à l'étranger, champ obligatoire \"Nom de la commune\" manquant",
-              "CANDIDATE_FOREIGN_POSTAL_CODE_MUST_BE_EMPTY": "Candidat né à l'étranger, le champ \"Code postal\" doit rester vide.",
+              "CANDIDATE_FOREIGN_POSTAL_CODE_MUST_BE_EMPTY": "Candidat né à l'étranger, le champ \"Code postal\" doit rester vide",
               "CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION": "Inscription possible qu'à une seule certification complémentaire par candidat",
               "CANDIDATE_BILLING_MODE_REQUIRED": "Champ obligatoire \"Tarification part Pix\" manquant",
               "CANDIDATE_BILLING_MODE_NOT_VALID": "Donnée du champ \"Tarification part Pix\" invalide (formats acceptés \"Gratuite\", \"Payante\" ou \"Prépayée\")",

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -243,6 +243,7 @@
               "CANDIDATE_BIRTH_COUNTRY_REQUIRED": "Champ obligatoire \"Pays de naissance\" manquant",
               "CANDIDATE_BIRTH_CITY_REQUIRED": "Champ obligatoire \"Nom de la commune\" manquant",
               "CANDIDATE_BIRTH_COUNTRY_NOT_FOUND": "Donnée du champ \"Pays de naissance\" n'existe pas",
+              "CANDIDATE_BIRTH_INFORMATION_REQUIRED": "Renseigner les données de naissance du candidat",
               "CANDIDATE_BIRTH_POSTAL_CODE_CITY_NOT_VALID": "Le code postal et le nom de la commune ne correspondent pas",
               "CANDIDATE_BIRTH_POSTAL_CODE_NOT_FOUND": "Donnée du champ \"Code postal\" n'existe pas",
               "CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED": "Champ obligatoire \"Code postal\" manquant",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le service qui vérifie les informations candidat pour le CPF renvoie la 1ere erreur trouvée.

Or pour l'import en masse des sessions et candidats, il nous faut récupérer toutes les erreurs nécessaires à la correction du fichier.

## :robot: Proposition
Renvoyer une liste d'erreur dans ce service

## :rainbow: Remarques
L'import en masse récupère ainsi une liste d'erreur mais les autres fonctionnalités qui utilisent le service CPF reprennent pour l'instant que la 1ere erreur dans la liste (par soucis de non-regression)

## :100: Pour tester
**Non regression sur l'import ODS d'une session :** 

1. Se connecter sur pix certif avec certifpro@example.net
2. Aller sur une session
3. Dans le champ candidat, cliquer sur import avec le fichier ods suivant :
[liste-candidats-session-erreurs-cpf.ods](https://github.com/1024pix/pix/files/11252592/liste-candidats-session-erreurs-cpf.ods)
4. Constater une seule erreur dans le toaster :
![Capture d’écran 2023-04-17 à 17 36 45](https://user-images.githubusercontent.com/103997660/232538414-6fe620d1-5c79-4f8d-9ba6-8227bbb59641.png)

**Non regression sur l'ajout d'un candidat non sco sur une session via le formulaire :**
1. Se connecter sur pix certif avec certifpro@example.net
2. Aller sur une session
3. Dans le champ candidat, cliquer sur ajouter un candidat
4. Remplir les champs et observer que le comportement n'a pas changé

**Non regression sur la modification d'un candidat d'une session sur admin :**
1. Se connecter sur pix admin avec superadmin@example.net
2. Aller dans l'onglet Sessions de certification
3. Cliquer sur une session et aller dans l'onglet Certification
4. Cliquer sur un candidat et sur le bouton Modifier et observer que le comportement n'a pas changé

**Voir qu'on peut afficher plusieurs erreurs CPF sur l'import en masse :**

1. Se connecter sur pix certif avec certifpro@example.net
5. Cliquer sur "Créer plusieurs sessions"
6. Importer le csv ci dessous
````
"Numéro de session préexistante";"* Nom du site";"* Nom de la salle";"* Date de début (format: JJ/MM/AAAA)";"* Heure de début (heure locale format: HH:MM)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: JJ/MM/AAAA)";"* Sexe (M ou F)";"Code INSEE de la commune de naissance";"Code postal de la commune de naissance";"Nom de la commune de naissance";"* Pays de naissance";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant externe";"Temps majoré ? (exemple format: 33%)";"* Tarification part Pix (Gratuite, Prépayée ou Payante)";"Code de prépaiement (si Tarification part Pix Prépayée)";"CléA Numérique ('oui' ou laisser vide)"
;Site;Salle;10/10/2029;12:00;Ginette;;Juliette;Durand;10/10/2000;M;;75015;;togo;;;;;Payante;
````
7. Constater qu'il y a bien plusieurs erreurs cpf :
![Capture d’écran 2023-04-17 à 17 17 47](https://user-images.githubusercontent.com/103997660/232535222-84ebb946-c2ff-4e4f-9eb8-cf0929f664db.png)
