### PR TITLE
[BUGFIX] Permettre d'utiliser l'autofill sur les pages d'inscription de Pix App-Certif-Orga (PIX-7685)

### DIFF
--- a/certif/app/components/auth/register-form.hbs
+++ b/certif/app/components/auth/register-form.hbs
@@ -7,7 +7,7 @@
         @label={{t "common.labels.candidate.firstname"}}
         name="firstName"
         type="firstName"
-        {{on "focusout" this.validateFirstName}}
+        {{on "change" this.validateFirstName}}
         required={{true}}
         aria-required={{true}}
         autocomplete="given-name"
@@ -22,7 +22,7 @@
         @label={{t "common.labels.candidate.lastname"}}
         name="lastName"
         type="lastName"
-        {{on "focusout" this.validateLastName}}
+        {{on "change" this.validateLastName}}
         required={{true}}
         aria-required={{true}}
         autocomplete="family-name"
@@ -37,7 +37,7 @@
         @label={{t "common.forms.login.email"}}
         name="email"
         type="email"
-        {{on "focusout" this.validateEmail}}
+        {{on "change" this.validateEmail}}
         required={{true}}
         aria-required={{true}}
         autocomplete="email"
@@ -54,8 +54,7 @@
         autocomplete="current-password"
         required={{true}}
         aria-required={{true}}
-        {{on "input" this.validatePassword}}
-        {{on "focusout" this.validatePassword}}
+        {{on "change" this.validatePassword}}
         @validationStatus={{this.validation.password.status}}
         @errorMessage={{this.validation.password.message}}
       />

--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -28,7 +28,7 @@
           @id="firstName"
           name="firstName"
           @label={{t "pages.sign-up.fields.firstname.label"}}
-          {{on "focusout" this.validateFirstName}}
+          {{on "change" this.validateFirstName}}
           @validationStatus={{this.validation.firstName.status}}
           @errorMessage={{this.validation.firstName.message}}
           required
@@ -41,7 +41,7 @@
           @id="lastName"
           name="lastName"
           @label={{t "pages.sign-up.fields.lastname.label"}}
-          {{on "focusout" this.validateLastName}}
+          {{on "change" this.validateLastName}}
           @validationStatus={{this.validation.lastName.status}}
           @errorMessage={{this.validation.lastName.message}}
           required
@@ -55,7 +55,7 @@
           name="email"
           @label="{{t 'pages.sign-up.fields.email.label'}}"
           @information="{{t 'pages.sign-up.fields.email.help'}}"
-          {{on "focusout" this.validateEmail}}
+          {{on "change" this.validateEmail}}
           @validationStatus={{this.validation.email.status}}
           @errorMessage={{this.validation.email.message}}
           required
@@ -70,7 +70,7 @@
           @label="{{t 'pages.sign-up.fields.password.label'}}"
           @information="{{t 'pages.sign-up.fields.password.help'}}"
           @value={{this.password}}
-          {{on "focusout" this.validatePassword}}
+          {{on "change" this.validatePassword}}
           @validationStatus={{this.validation.password.status}}
           @errorMessage={{this.validation.password.message}}
           required

--- a/orga/app/components/auth/register-form.hbs
+++ b/orga/app/components/auth/register-form.hbs
@@ -7,7 +7,7 @@
         @label={{t "pages.login-or-register.register-form.fields.first-name.label"}}
         name="firstName"
         type="firstName"
-        {{on "focusout" this.validateFirstName}}
+        {{on "change" this.validateFirstName}}
         @errorMessage={{this.firstNameValidationMessage}}
         @validationStatus={{if this.firstNameValidationMessage "error" "default"}}
         required={{true}}
@@ -22,7 +22,7 @@
         @label={{t "pages.login-or-register.register-form.fields.last-name.label"}}
         name="lastName"
         type="lastName"
-        {{on "focusout" this.validateLastName}}
+        {{on "change" this.validateLastName}}
         @errorMessage={{this.lastNameValidationMessage}}
         @validationStatus={{if this.lastNameValidationMessage "error" "default"}}
         required={{true}}
@@ -37,7 +37,7 @@
         @label={{t "pages.login-or-register.register-form.fields.email.label"}}
         name="email"
         type="email"
-        {{on "focusout" this.validateEmail}}
+        {{on "change" this.validateEmail}}
         @errorMessage={{this.emailValidationMessage}}
         @validationStatus={{if this.emailValidationMessage "error" "default"}}
         required={{true}}
@@ -54,8 +54,7 @@
         autocomplete="current-password"
         required={{true}}
         aria-required={{true}}
-        {{on "input" this.validatePassword}}
-        {{on "focusout" this.validatePassword}}
+        {{on "change" this.validatePassword}}
         @errorMessage={{this.passwordValidationMessage}}
         @validationStatus={{if this.passwordValidationMessage "error" "default"}}
       />

--- a/orga/app/components/auth/register-form.hbs
+++ b/orga/app/components/auth/register-form.hbs
@@ -8,8 +8,8 @@
         name="firstName"
         type="firstName"
         {{on "change" this.validateFirstName}}
-        @errorMessage={{this.firstNameValidationMessage}}
-        @validationStatus={{if this.firstNameValidationMessage "error" "default"}}
+        @errorMessage={{this.validation.firstName.message}}
+        @validationStatus={{this.validation.firstName.status}}
         required={{true}}
         aria-required={{true}}
         autocomplete="given-name"
@@ -23,8 +23,8 @@
         name="lastName"
         type="lastName"
         {{on "change" this.validateLastName}}
-        @errorMessage={{this.lastNameValidationMessage}}
-        @validationStatus={{if this.lastNameValidationMessage "error" "default"}}
+        @errorMessage={{this.validation.lastName.message}}
+        @validationStatus={{this.validation.lastName.status}}
         required={{true}}
         aria-required={{true}}
         autocomplete="family-name"
@@ -38,8 +38,8 @@
         name="email"
         type="email"
         {{on "change" this.validateEmail}}
-        @errorMessage={{this.emailValidationMessage}}
-        @validationStatus={{if this.emailValidationMessage "error" "default"}}
+        @errorMessage={{this.validation.email.message}}
+        @validationStatus={{this.validation.email.status}}
         required={{true}}
         aria-required={{true}}
         autocomplete="email"
@@ -55,8 +55,8 @@
         required={{true}}
         aria-required={{true}}
         {{on "change" this.validatePassword}}
-        @errorMessage={{this.passwordValidationMessage}}
-        @validationStatus={{if this.passwordValidationMessage "error" "default"}}
+        @errorMessage={{this.validation.password.message}}
+        @validationStatus={{this.validation.password.status}}
       />
     </div>
 

--- a/orga/app/components/auth/register-form.js
+++ b/orga/app/components/auth/register-form.js
@@ -7,6 +7,39 @@ import isEmailValid from '../../utils/email-validator';
 import isPasswordValid from '../../utils/password-validator';
 import get from 'lodash/get';
 
+const STATUS = {
+  DEFAULT: 'default',
+  SUCCESS: 'success',
+  ERROR: 'error',
+};
+
+class LastName {
+  @tracked status = STATUS.DEFAULT;
+  @tracked message = null;
+}
+
+class FirstName {
+  @tracked status = STATUS.DEFAULT;
+  @tracked message = null;
+}
+
+class Email {
+  @tracked status = STATUS.DEFAULT;
+  @tracked message = null;
+}
+
+class Password {
+  @tracked status = STATUS.DEFAULT;
+  @tracked message = null;
+}
+
+class SignupFormValidation {
+  lastName = new LastName();
+  firstName = new FirstName();
+  email = new Email();
+  password = new Password();
+}
+
 export default class RegisterForm extends Component {
   @service session;
   @service store;
@@ -18,12 +51,9 @@ export default class RegisterForm extends Component {
   @tracked lastName = null;
   @tracked email = null;
   @tracked password = null;
-  @tracked passwordValidationMessage = null;
-  @tracked emailValidationMessage = null;
-  @tracked firstNameValidationMessage = null;
-  @tracked lastNameValidationMessage = null;
   @tracked cguValidationMessage = null;
   @tracked errorMessage = null;
+  @tracked validation = new SignupFormValidation();
 
   get cguUrl() {
     return this.url.cguUrl;
@@ -75,45 +105,61 @@ export default class RegisterForm extends Component {
 
   @action
   validatePassword(event) {
-    this.passwordValidationMessage = null;
+    this.validation.password.status = STATUS.DEFAULT;
+    this.validation.password.message = null;
     this.password = event.target.value;
     const isInvalidInput = !isPasswordValid(this.password);
 
     if (isInvalidInput) {
-      this.passwordValidationMessage = this.intl.t('pages.login-or-register.register-form.fields.password.error');
+      this.validation.password.status = STATUS.ERROR;
+      this.validation.password.message = this.intl.t('pages.login-or-register.register-form.fields.password.error');
+    } else {
+      this.validation.password.status = STATUS.SUCCESS;
     }
   }
 
   @action
   validateEmail(event) {
-    this.emailValidationMessage = null;
+    this.validation.email.status = STATUS.DEFAULT;
+    this.validation.email.message = null;
     this.email = event.target.value?.trim().toLowerCase();
     const isInvalidInput = !isEmailValid(this.email);
 
     if (isInvalidInput) {
-      this.emailValidationMessage = this.intl.t('pages.login-or-register.register-form.fields.email.error');
+      this.validation.email.status = STATUS.ERROR;
+      this.validation.email.message = this.intl.t('pages.login-or-register.register-form.fields.email.error');
+    } else {
+      this.validation.email.status = STATUS.SUCCESS;
     }
   }
 
   @action
   validateFirstName(event) {
-    this.firstNameValidationMessage = null;
+    this.validation.firstName.status = STATUS.DEFAULT;
+    this.validation.firstName.message = null;
     this.firstName = event.target.value?.trim();
     const isInvalidInput = isEmpty(this.firstName);
 
     if (isInvalidInput) {
-      this.firstNameValidationMessage = this.intl.t('pages.login-or-register.register-form.fields.first-name.error');
+      this.validation.firstName.status = STATUS.ERROR;
+      this.validation.firstName.message = this.intl.t('pages.login-or-register.register-form.fields.first-name.error');
+    } else {
+      this.validation.firstName.status = STATUS.SUCCESS;
     }
   }
 
   @action
   validateLastName(event) {
-    this.lastNameValidationMessage = null;
+    this.validation.lastName.status = STATUS.DEFAULT;
+    this.validation.lastName.message = null;
     this.lastName = event.target.value?.trim();
     const isInvalidInput = isEmpty(this.lastName);
 
     if (isInvalidInput) {
-      this.lastNameValidationMessage = this.intl.t('pages.login-or-register.register-form.fields.last-name.error');
+      this.validation.lastName.status = STATUS.ERROR;
+      this.validation.lastName.message = this.intl.t('pages.login-or-register.register-form.fields.last-name.error');
+    } else {
+      this.validation.lastName.status = STATUS.SUCCESS;
     }
   }
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu’on utilise l’autofill pour remplir le formulaire d’inscription, il n'est pas possible d’envoyer le formulaire car Ember considère que les champs n’ont pas été remplis.

Signalé par un utilisateur sur [Github](https://github.com/1024pix/pix/issues/5943).

## :robot: Proposition

Sur les formulaires d'inscription de Pix App, Pix Certif et Pix Orga, remplacer l'évènement `onfocusout` qui ne prend pas en compte la validation des champs lorsque l'autofill est utilisé. 

- Dans un premier temps, l'idée était de remplacer la validation des champs sur [`oninput`](https://www.w3schools.com/jsref/event_oninput.asp) au lieu de `onfocusout`, comme cela était déjà fait sur les formulaires de connexion. Le problème de cette proposition, est que l'évènement `oninput` se produit immédiatement après la modification du contenu. Ainsi, dès qu'un utilisateur écrit une lettre dans un des champs du formulaire, un message de succès ou d'erreur s'affiche. Ce qui n'est pas une bonne chose en terme d'UX.

- La seconde proposition est donc de changer les évènements `onfocusout` par des [`onchange`](https://www.w3schools.com/jsref/event_onchange.asp). Grâce à cela, l'utilisateur peut utiliser l'autofill pour remplir le formulaire d'inscription et les champs ne seront pas considérés comme 'vide' comme cétait le cas avec le `onfocusout`. De plus, si il rempli le formulaire champ par champ, la validation s'effectuera lorsque l'utilisateur sortira du champ.

## :rainbow: Remarques
Le composant du formulaire d'inscription de la double mire sco sur Pix App n'a pas été modifié car il utilise encore les anciens composants (`<FormTextfield />`). Il faudrait effectuer un refacto afin de lui passer les composants Pix UI.

Sur le formulaire d'inscription de la double mire Pix Orga, nous avons remarqué que le statut `succès` des champs n'était pas mis en place. Un refacto a donc été également proposé dans cette PR afin d'améliorer l'expérience utilisateur sur le formulaire d'inscription.

## :100: Pour tester

### Pix App

- Se rendre la page d'inscription de Pix App
- Remplir le formulaire avec l'autofill du navigateur
- Cliquer sur le bouton 'S'inscrire' et vérifier que vous vous inscrivez sans problème
- Revenir sur la page d'inscription et remplir le formulaire champ par champ
- Vérifier que les messages d'erreur et succès s'affiche correctement lorsque vous sortez du champs

### Pix Certif

- Se rendre la double mire de Pix Certif
- Dans la partie 'Je m’inscris', remplir le formulaire avec l'autofill du navigateur
- Cliquer sur le bouton 'S'inscrire' et vérifier que vous vous inscrivez sans problème
- Revenir sur la page d'inscription et remplir le formulaire champ par champ
- Vérifier que les messages d'erreur et succès s'affiche correctement lorsque vous sortez du champs

### Pix Orga

- Se rendre la double mire de Pix Orga 
- Dans la partie 'Je m’inscris', remplir le formulaire avec l'autofill du navigateur
- Cliquer sur le bouton 'S'inscrire' et vérifier que vous vous inscrivez sans problème
- Revenir sur la page d'inscription et remplir le formulaire champ par champ
- Vérifier que les messages d'erreur et succès s'affiche correctement lorsque vous sortez du champs

