### PR TITLE
[TECH] Faire de l'injection de dépendance dans les controllers (part-3)

### DIFF
--- a/api/lib/application/challenges/challenge-controller.js
+++ b/api/lib/application/challenges/challenge-controller.js
@@ -2,7 +2,8 @@ const challengeRepository = require('../../infrastructure/repositories/challenge
 const challengeSerializer = require('../../infrastructure/serializers/jsonapi/challenge-serializer.js');
 
 module.exports = {
-  get(request) {
-    return challengeRepository.get(request.params.id).then((challenge) => challengeSerializer.serialize(challenge));
+  async get(request, h, dependencies = { challengeRepository, challengeSerializer }) {
+    const challenge = await dependencies.challengeRepository.get(request.params.id);
+    return dependencies.challengeSerializer.serialize(challenge);
   },
 };

--- a/api/lib/application/competence-evaluations/competence-evaluation-controller.js
+++ b/api/lib/application/competence-evaluations/competence-evaluation-controller.js
@@ -1,9 +1,9 @@
 const usecases = require('../../domain/usecases/index.js');
-const serializer = require('../../infrastructure/serializers/jsonapi/competence-evaluation-serializer.js');
+const competenceEvaluationSerializer = require('../../infrastructure/serializers/jsonapi/competence-evaluation-serializer.js');
 const DomainTransaction = require('../../infrastructure/DomainTransaction.js');
 
 module.exports = {
-  async startOrResume(request, h) {
+  async startOrResume(request, h, dependencies = { competenceEvaluationSerializer }) {
     const userId = request.auth.credentials.userId;
     const competenceId = request.payload.competenceId;
 
@@ -11,12 +11,12 @@ module.exports = {
       competenceId,
       userId,
     });
-    const serializedCompetenceEvaluation = serializer.serialize(competenceEvaluation);
+    const serializedCompetenceEvaluation = dependencies.competenceEvaluationSerializer.serialize(competenceEvaluation);
 
     return created ? h.response(serializedCompetenceEvaluation).created() : serializedCompetenceEvaluation;
   },
 
-  async improve(request, h) {
+  async improve(request, h, dependencies = { competenceEvaluationSerializer }) {
     const userId = request.auth.credentials.userId;
     const competenceId = request.payload.competenceId;
 
@@ -29,7 +29,7 @@ module.exports = {
       return competenceEvaluation;
     });
 
-    const serializedCompetenceEvaluation = serializer.serialize(competenceEvaluation);
+    const serializedCompetenceEvaluation = dependencies.competenceEvaluationSerializer.serialize(competenceEvaluation);
     return h.response(serializedCompetenceEvaluation);
   },
 };

--- a/api/lib/application/frameworks/frameworks-controller.js
+++ b/api/lib/application/frameworks/frameworks-controller.js
@@ -4,23 +4,34 @@ const frameworkSerializer = require('../../infrastructure/serializers/jsonapi/fr
 const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils.js');
 
 module.exports = {
-  async getFrameworks() {
+  async getFrameworks(request, h, dependencies = { frameworkSerializer }) {
     const frameworks = await usecases.getFrameworks();
-    return frameworkSerializer.serialize(frameworks);
+    return dependencies.frameworkSerializer.serialize(frameworks);
   },
-  async getFrameworkAreas(request) {
+
+  async getFrameworkAreas(request, h, dependencies = { frameworkAreasSerializer }) {
     const frameworkId = request.params.id;
     const framework = await usecases.getFrameworkAreas({ frameworkId });
-    return frameworkAreasSerializer.serialize(framework);
+    return dependencies.frameworkAreasSerializer.serialize(framework);
   },
-  async getPixFrameworkAreasWithoutThematics(request) {
-    const locale = extractLocaleFromRequest(request);
+
+  async getPixFrameworkAreasWithoutThematics(
+    request,
+    h,
+    dependencies = { extractLocaleFromRequest, frameworkAreasSerializer }
+  ) {
+    const locale = dependencies.extractLocaleFromRequest(request);
     const framework = await usecases.getFrameworkAreas({ frameworkName: 'Pix', locale });
-    return frameworkAreasSerializer.serialize(framework, { withoutThematics: true });
+    return dependencies.frameworkAreasSerializer.serialize(framework, { withoutThematics: true });
   },
-  async getFrameworksForTargetProfileSubmission(request) {
-    const locale = extractLocaleFromRequest(request);
+
+  async getFrameworksForTargetProfileSubmission(
+    request,
+    h,
+    dependencies = { extractLocaleFromRequest, frameworkSerializer }
+  ) {
+    const locale = dependencies.extractLocaleFromRequest(request);
     const learningContent = await usecases.getLearningContentForTargetProfileSubmission({ locale });
-    return frameworkSerializer.serializeDeepWithoutSkills(learningContent.frameworks);
+    return dependencies.frameworkSerializer.serializeDeepWithoutSkills(learningContent.frameworks);
   },
 };

--- a/api/lib/application/memberships/membership-controller.js
+++ b/api/lib/application/memberships/membership-controller.js
@@ -4,20 +4,20 @@ const usecases = require('../../domain/usecases/index.js');
 const { BadRequestError } = require('../http-errors.js');
 
 module.exports = {
-  async create(request, h) {
+  async create(request, h, dependencies = { membershipSerializer }) {
     const userId = request.payload.data.relationships.user.data.id;
     const organizationId = request.payload.data.relationships.organization.data.id;
 
     const membership = await usecases.createMembership({ userId, organizationId });
     await usecases.createCertificationCenterMembershipForScoOrganizationMember({ membership });
 
-    return h.response(membershipSerializer.serializeForAdmin(membership)).created();
+    return h.response(dependencies.membershipSerializer.serializeForAdmin(membership)).created();
   },
 
-  async update(request, h) {
+  async update(request, h, dependencies = { requestResponseUtils, membershipSerializer }) {
     const membershipId = request.params.id;
-    const userId = requestResponseUtils.extractUserIdFromRequest(request);
-    const membership = membershipSerializer.deserialize(request.payload);
+    const userId = dependencies.requestResponseUtils.extractUserIdFromRequest(request);
+    const membership = dependencies.membershipSerializer.deserialize(request.payload);
     // eslint-disable-next-line no-restricted-syntax
     const membershipIdFromPayload = parseInt(membership.id);
     if (membershipId !== membershipIdFromPayload) {
@@ -28,7 +28,7 @@ module.exports = {
     const updatedMembership = await usecases.updateMembership({ membership });
     await usecases.createCertificationCenterMembershipForScoOrganizationMember({ membership });
 
-    return h.response(membershipSerializer.serialize(updatedMembership));
+    return h.response(dependencies.membershipSerializer.serialize(updatedMembership));
   },
 
   async disable(request, h) {

--- a/api/tests/unit/application/challenges/challenge-controller_test.js
+++ b/api/tests/unit/application/challenges/challenge-controller_test.js
@@ -1,39 +1,35 @@
-const { expect, HttpTestServer, sinon } = require('../../../test-helper');
+const { sinon, expect, hFake } = require('../../../test-helper');
 
-const ChallengeRepository = require('../../../../lib/infrastructure/repositories/challenge-repository');
-const ChallengeSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/challenge-serializer');
-
-const moduleUnderTest = require('../../../../lib/application/challenges');
+const challengeController = require('../../../../lib/application/challenges/challenge-controller');
 
 describe('Unit | Controller | challenge-controller', function () {
-  let httpTestServer;
-
-  let ChallengeRepoStub;
-  let ChallengeSerializerStub;
+  let challengeRepository;
+  let challengeSerializer;
 
   beforeEach(async function () {
-    ChallengeRepoStub = sinon.stub(ChallengeRepository, 'get');
-    ChallengeSerializerStub = sinon.stub(ChallengeSerializer, 'serialize');
-
-    httpTestServer = new HttpTestServer();
-    await httpTestServer.register(moduleUnderTest);
+    challengeRepository = { get: sinon.stub() };
+    challengeSerializer = { serialize: sinon.stub() };
   });
 
   describe('#get', function () {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const challenge = Symbol('someChallenge');
-
     it('should fetch and return the given challenge, serialized as JSONAPI', async function () {
       // given
-      ChallengeRepoStub.resolves(challenge);
-      ChallengeSerializerStub.resolves({ serialized: challenge });
+      const challengeId = 123;
+      const challenge = Symbol('someChallenge');
+      const expectedResult = Symbol('serialized-challenge');
+      challengeRepository.get.resolves(challenge);
+      challengeSerializer.serialize.resolves(expectedResult);
 
       // when
-      const response = await httpTestServer.request('GET', '/api/challenges/challenge_id');
+      const response = await challengeController.get({ params: { id: challengeId } }, hFake, {
+        challengeRepository,
+        challengeSerializer,
+      });
 
       // then
-      expect(response.result).to.deep.equal({ serialized: challenge });
+      expect(challengeRepository.get).to.have.been.calledWith(challengeId);
+      expect(challengeSerializer.serialize).to.have.been.calledOnce;
+      expect(response).to.deep.equal(expectedResult);
     });
   });
 });

--- a/api/tests/unit/application/competence-evaluations/competence-evaluation-controller_test.js
+++ b/api/tests/unit/application/competence-evaluations/competence-evaluation-controller_test.js
@@ -1,17 +1,17 @@
 const { sinon, expect, domainBuilder, hFake } = require('../../../test-helper');
 const competenceEvaluationController = require('../../../../lib/application/competence-evaluations/competence-evaluation-controller');
-const serializer = require('../../../../lib/infrastructure/serializers/jsonapi/competence-evaluation-serializer');
 const usecases = require('../../../../lib/domain/usecases/index.js');
 
 describe('Unit | Application | Controller | Competence-Evaluation', function () {
-  describe('#start', function () {
-    let request;
+  describe('#startOrResume', function () {
     const competenceId = 'recABCD1234';
     const userId = 6;
+    let request;
+    let competenceEvaluationSerializer;
 
     beforeEach(function () {
       sinon.stub(usecases, 'startOrResumeCompetenceEvaluation');
-      sinon.stub(serializer, 'serialize');
+      competenceEvaluationSerializer = { serialize: sinon.stub() };
       request = {
         headers: { authorization: 'token' },
         auth: { credentials: { userId } },
@@ -24,7 +24,7 @@ describe('Unit | Application | Controller | Competence-Evaluation', function () 
       usecases.startOrResumeCompetenceEvaluation.resolves({});
 
       // when
-      await competenceEvaluationController.startOrResume(request, hFake);
+      await competenceEvaluationController.startOrResume(request, hFake, { competenceEvaluationSerializer });
 
       // then
       expect(usecases.startOrResumeCompetenceEvaluation).to.have.been.calledOnce;
@@ -46,13 +46,15 @@ describe('Unit | Application | Controller | Competence-Evaluation', function () 
         userId: competenceEvaluation.userId,
         competenceId,
       };
-      serializer.serialize.returns(serializedCompetenceEvaluation);
+      competenceEvaluationSerializer.serialize.returns(serializedCompetenceEvaluation);
 
       // when
-      const response = await competenceEvaluationController.startOrResume(request, hFake);
+      const response = await competenceEvaluationController.startOrResume(request, hFake, {
+        competenceEvaluationSerializer,
+      });
 
       // then
-      expect(serializer.serialize).to.have.been.calledWith(competenceEvaluation);
+      expect(competenceEvaluationSerializer.serialize).to.have.been.calledWith(competenceEvaluation);
       expect(response.statusCode).to.equal(201);
       expect(response.source).to.deep.equal(serializedCompetenceEvaluation);
     });

--- a/api/tests/unit/application/frameworks/frameworks-controller_test.js
+++ b/api/tests/unit/application/frameworks/frameworks-controller_test.js
@@ -1,13 +1,14 @@
-const { expect, sinon } = require('../../../test-helper');
+const { expect, sinon, hFake } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases/index.js');
-const frameworkAreasSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/framework-areas-serializer');
-const frameworkSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/framework-serializer');
 const frameworksController = require('../../../../lib/application/frameworks/frameworks-controller');
 
 describe('Unit | Controller | frameworks-controller', function () {
   let frameworks;
   let areas;
   let serializedAreas;
+  let frameworkAreasSerializer;
+  let frameworkSerializer;
+  let requestResponseUtils;
   let serializedFrameworks;
 
   beforeEach(function () {
@@ -17,15 +18,20 @@ describe('Unit | Controller | frameworks-controller', function () {
     serializedFrameworks = Symbol('serializedFrameworks');
 
     sinon.stub(usecases, 'getFrameworks').returns(frameworks);
-    sinon.stub(frameworkAreasSerializer, 'serialize').returns(serializedAreas);
-    sinon.stub(frameworkSerializer, 'serialize').returns(serializedFrameworks);
     sinon.stub(usecases, 'getFrameworkAreas').returns(areas);
+    sinon.stub(usecases, 'getLearningContentForTargetProfileSubmission').returns({ frameworks });
+    frameworkAreasSerializer = { serialize: sinon.stub().returns(serializedAreas) };
+    frameworkSerializer = {
+      serialize: sinon.stub().returns(serializedFrameworks),
+      serializeDeepWithoutSkills: sinon.stub().returns(serializedFrameworks),
+    };
+    requestResponseUtils = { extractLocaleFromRequest: sinon.stub().returns('en') };
   });
 
   describe('#getFrameworks', function () {
     it('should fetch and return frameworks, serialized as JSONAPI', async function () {
       // when
-      const result = await frameworksController.getFrameworks();
+      const result = await frameworksController.getFrameworks({}, hFake, { frameworkSerializer });
 
       // then
       expect(result).to.equal(serializedFrameworks);
@@ -45,7 +51,7 @@ describe('Unit | Controller | frameworks-controller', function () {
       };
 
       // when
-      const result = await frameworksController.getFrameworkAreas(request);
+      const result = await frameworksController.getFrameworkAreas(request, hFake, { frameworkAreasSerializer });
 
       // then
       expect(result).to.equal(serializedAreas);
@@ -64,12 +70,37 @@ describe('Unit | Controller | frameworks-controller', function () {
       };
 
       // when
-      const result = await frameworksController.getPixFrameworkAreasWithoutThematics(request);
+      const result = await frameworksController.getPixFrameworkAreasWithoutThematics(request, hFake, {
+        extractLocaleFromRequest: requestResponseUtils.extractLocaleFromRequest,
+        frameworkAreasSerializer,
+      });
 
       // then
       expect(result).to.equal(serializedAreas);
       expect(usecases.getFrameworkAreas).to.have.been.calledWithExactly({ frameworkName: 'Pix', locale: 'en' });
       expect(frameworkAreasSerializer.serialize).to.have.been.calledWithExactly(areas, { withoutThematics: true });
+    });
+  });
+
+  describe('#getFrameworksForTargetProfileSubmission', function () {
+    it('should fetch and return frameworks, serialized as JSONAPI', async function () {
+      // given
+      const request = {
+        headers: {
+          'accept-language': 'en',
+        },
+      };
+
+      // when
+      const result = await frameworksController.getFrameworksForTargetProfileSubmission(request, hFake, {
+        extractLocaleFromRequest: requestResponseUtils.extractLocaleFromRequest,
+        frameworkSerializer,
+      });
+
+      // then
+      expect(result).to.equal(serializedFrameworks);
+      expect(usecases.getLearningContentForTargetProfileSubmission).to.have.been.calledWithExactly({ locale: 'en' });
+      expect(frameworkSerializer.serializeDeepWithoutSkills).to.have.been.calledWithExactly(frameworks);
     });
   });
 });

--- a/api/tests/unit/application/memberships/membership-controller_test.js
+++ b/api/tests/unit/application/memberships/membership-controller_test.js
@@ -2,9 +2,7 @@ const { expect, sinon, hFake, domainBuilder } = require('../../../test-helper');
 
 const membershipController = require('../../../../lib/application/memberships/membership-controller');
 const usecases = require('../../../../lib/domain/usecases/index.js');
-const membershipSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/membership-serializer');
 const Membership = require('../../../../lib/domain/models/Membership');
-const requestResponseUtils = require('../../../../lib/infrastructure/utils/request-response-utils');
 
 describe('Unit | Controller | membership-controller', function () {
   describe('#create', function () {
@@ -26,15 +24,14 @@ describe('Unit | Controller | membership-controller', function () {
         },
       };
 
-      sinon
-        .stub(usecases, 'createMembership')
-        .withArgs({ userId: user.id, organizationId: organization.id })
-        .resolves(membership);
+      const createMembershipUsecase = sinon.stub(usecases, 'createMembership');
+      createMembershipUsecase.withArgs({ userId: user.id, organizationId: organization.id }).resolves(membership);
       sinon.stub(usecases, 'createCertificationCenterMembershipForScoOrganizationMember').resolves();
-      sinon.stub(membershipSerializer, 'serializeForAdmin').withArgs(membership).returns(serializedMembership);
+      const membershipSerializer = { serializeForAdmin: sinon.stub() };
+      membershipSerializer.serializeForAdmin.withArgs(membership).returns(serializedMembership);
 
       // when
-      const result = await membershipController.create(request, hFake);
+      const result = await membershipController.create(request, hFake, { membershipSerializer });
 
       // then
       expect(usecases.createMembership).to.have.been.calledOnce;
@@ -58,14 +55,14 @@ describe('Unit | Controller | membership-controller', function () {
         },
       };
 
-      sinon
-        .stub(usecases, 'createMembership')
-        .withArgs({ userId: user.id, organizationId: organization.id })
-        .resolves(membership);
+      const createMembershipUsecase = sinon.stub(usecases, 'createMembership');
+      createMembershipUsecase.withArgs({ userId: user.id, organizationId: organization.id }).resolves(membership);
       sinon.stub(usecases, 'createCertificationCenterMembershipForScoOrganizationMember').resolves();
+      const membershipSerializer = { serializeForAdmin: sinon.stub() };
+      membershipSerializer.serializeForAdmin.withArgs(membership).returns('ok');
 
       // when
-      await membershipController.create(request, hFake);
+      await membershipController.create(request, hFake, { membershipSerializer });
 
       // then
       expect(usecases.createCertificationCenterMembershipForScoOrganizationMember).calledWith({
@@ -115,19 +112,21 @@ describe('Unit | Controller | membership-controller', function () {
         },
       };
 
-      sinon.stub(requestResponseUtils, 'extractUserIdFromRequest').returns(userWhoUpdateMemberRole.id);
-      sinon.stub(membershipSerializer, 'deserialize').withArgs(request.payload).returns(membership);
-      sinon.stub(membershipSerializer, 'serialize').withArgs(updatedMembership).returns(serializedMembership);
-      sinon
-        .stub(usecases, 'updateMembership')
+      const requestResponseUtils = { extractUserIdFromRequest: sinon.stub() };
+      requestResponseUtils.extractUserIdFromRequest.returns(userWhoUpdateMemberRole.id);
+      const updateMembershipUsecase = sinon.stub(usecases, 'updateMembership');
+      updateMembershipUsecase
         .withArgs({
           membership,
         })
         .resolves(updatedMembership);
       sinon.stub(usecases, 'createCertificationCenterMembershipForScoOrganizationMember').resolves();
+      const membershipSerializer = { deserialize: sinon.stub(), serialize: sinon.stub() };
+      membershipSerializer.deserialize.withArgs(request.payload).returns(membership);
+      membershipSerializer.serialize.withArgs(updatedMembership).returns(serializedMembership);
 
       // when
-      const result = await membershipController.update(request, hFake);
+      const result = await membershipController.update(request, hFake, { requestResponseUtils, membershipSerializer });
 
       // then
       expect(usecases.updateMembership).to.have.been.calledOnce;
@@ -172,14 +171,15 @@ describe('Unit | Controller | membership-controller', function () {
           },
         },
       };
-
-      sinon.stub(requestResponseUtils, 'extractUserIdFromRequest').returns(userWhoUpdateMemberRole.id);
-      sinon.stub(membershipSerializer, 'deserialize').withArgs(request.payload).returns(membership);
+      const requestResponseUtils = { extractUserIdFromRequest: sinon.stub() };
+      requestResponseUtils.extractUserIdFromRequest.returns(userWhoUpdateMemberRole.id);
+      const membershipSerializer = { deserialize: sinon.stub(), serialize: sinon.stub() };
+      membershipSerializer.deserialize.withArgs(request.payload).returns(membership);
       sinon.stub(usecases, 'updateMembership').resolves(updatedMembership);
       sinon.stub(usecases, 'createCertificationCenterMembershipForScoOrganizationMember').resolves();
 
       // when
-      await membershipController.update(request, hFake);
+      await membershipController.update(request, hFake, { requestResponseUtils, membershipSerializer });
 
       // then
       expect(usecases.createCertificationCenterMembershipForScoOrganizationMember).calledWith({


### PR DESCRIPTION
## :unicorn: Problème
Suite de #5974

Le passage des modules en ESM est bloqué par nos stub de dépendances. Pour régler cela nous devons injecter les dépendances.

## :robot: Proposition
Comme convenu au tech time, nous injectons les dépendances via un 3 arguments dependencies.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- CI OK
- Effectuer des tests des routes

