### PR TITLE
[TECH] Faire de l'injection de dépendance dans les controllers (part-4)

### DIFF
--- a/api/lib/application/certifications/certification-controller.js
+++ b/api/lib/application/certifications/certification-controller.js
@@ -15,10 +15,10 @@ module.exports = {
     return privateCertificateSerializer.serialize(privateCertificates);
   },
 
-  async getCertification(request) {
+  async getCertification(request, h, dependencies = { requestResponseUtils }) {
     const userId = request.auth.credentials.userId;
     const certificationId = request.params.id;
-    const locale = requestResponseUtils.extractLocaleFromRequest(request);
+    const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
 
     const privateCertificate = await usecases.getPrivateCertificate({
       userId,
@@ -28,15 +28,15 @@ module.exports = {
     return privateCertificateSerializer.serialize(privateCertificate);
   },
 
-  async getCertificationByVerificationCode(request) {
+  async getCertificationByVerificationCode(request, h, dependencies = { requestResponseUtils }) {
     const verificationCode = request.payload.verificationCode;
-    const locale = requestResponseUtils.extractLocaleFromRequest(request);
+    const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
 
     const shareableCertificate = await usecases.getShareableCertificate({ verificationCode, locale });
     return shareableCertificateSerializer.serialize(shareableCertificate);
   },
 
-  async getPDFAttestation(request, h) {
+  async getPDFAttestation(request, h, dependencies = { certificationAttestationPdf }) {
     const userId = request.auth.credentials.userId;
     const certificationId = request.params.id;
     const isFrenchDomainExtension = request.query.isFrenchDomainExtension;
@@ -45,7 +45,7 @@ module.exports = {
       certificationId,
     });
 
-    const { buffer } = await certificationAttestationPdf.getCertificationAttestationsPdfBuffer({
+    const { buffer } = await dependencies.certificationAttestationPdf.getCertificationAttestationsPdfBuffer({
       certificates: [attestation],
       isFrenchDomainExtension,
     });
@@ -57,7 +57,7 @@ module.exports = {
       .header('Content-Type', 'application/pdf');
   },
 
-  async neutralizeChallenge(request, h) {
+  async neutralizeChallenge(request, h, dependencies = { events }) {
     const challengeRecId = request.payload.data.attributes.challengeRecId;
     const certificationCourseId = request.payload.data.attributes.certificationCourseId;
     const juryId = request.auth.credentials.userId;
@@ -66,11 +66,11 @@ module.exports = {
       certificationCourseId,
       juryId,
     });
-    await events.eventDispatcher.dispatch(event);
+    await dependencies.events.eventDispatcher.dispatch(event);
     return h.response().code(204);
   },
 
-  async deneutralizeChallenge(request, h) {
+  async deneutralizeChallenge(request, h, dependencies = { events }) {
     const challengeRecId = request.payload.data.attributes.challengeRecId;
     const certificationCourseId = request.payload.data.attributes.certificationCourseId;
     const juryId = request.auth.credentials.userId;
@@ -79,7 +79,7 @@ module.exports = {
       certificationCourseId,
       juryId,
     });
-    await events.eventDispatcher.dispatch(event);
+    await dependencies.events.eventDispatcher.dispatch(event);
     return h.response().code(204);
   },
 };

--- a/api/lib/application/trainings/training-controller.js
+++ b/api/lib/application/trainings/training-controller.js
@@ -12,10 +12,10 @@ module.exports = {
     return dependencies.trainingSummarySerializer.serialize(trainings, meta);
   },
 
-  async findTargetProfileSummaries(request) {
+  async findTargetProfileSummaries(request, h, dependencies = { targetProfileSummaryForAdminSerializer }) {
     const { trainingId } = request.params;
     const targetProfileSummaries = await usecases.findTargetProfileSummariesForTraining({ trainingId });
-    return targetProfileSummaryForAdminSerializer.serialize(targetProfileSummaries);
+    return dependencies.targetProfileSummaryForAdminSerializer.serialize(targetProfileSummaries);
   },
 
   async getById(request, h, dependencies = { trainingSerializer }) {

--- a/api/lib/application/trainings/training-controller.js
+++ b/api/lib/application/trainings/training-controller.js
@@ -30,11 +30,11 @@ module.exports = {
     return h.response(dependencies.trainingSerializer.serialize(createdTraining)).created();
   },
 
-  async update(request) {
+  async update(request, h, dependencies = { trainingSerializer }) {
     const { trainingId } = request.params;
-    const training = await trainingSerializer.deserialize(request.payload);
+    const training = await dependencies.trainingSerializer.deserialize(request.payload);
     const updatedTraining = await usecases.updateTraining({ training: { ...training, id: trainingId } });
-    return trainingSerializer.serialize(updatedTraining);
+    return dependencies.trainingSerializer.serialize(updatedTraining);
   },
 
   async createOrUpdateTrigger(request) {

--- a/api/lib/application/trainings/training-controller.js
+++ b/api/lib/application/trainings/training-controller.js
@@ -6,32 +6,37 @@ const usecases = require('../../domain/usecases/index.js');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils.js');
 
 module.exports = {
-  async findPaginatedTrainingSummaries(request) {
-    const { page } = queryParamsUtils.extractParameters(request.query);
+  async findPaginatedTrainingSummaries(request, h, dependencies = { trainingSummarySerializer, queryParamsUtils }) {
+    const { page } = dependencies.queryParamsUtils.extractParameters(request.query);
     const { trainings, meta } = await usecases.findPaginatedTrainingSummaries({ page });
-    return trainingSummarySerializer.serialize(trainings, meta);
+    return dependencies.trainingSummarySerializer.serialize(trainings, meta);
   },
+
   async findTargetProfileSummaries(request) {
     const { trainingId } = request.params;
     const targetProfileSummaries = await usecases.findTargetProfileSummariesForTraining({ trainingId });
     return targetProfileSummaryForAdminSerializer.serialize(targetProfileSummaries);
   },
-  async getById(request) {
+
+  async getById(request, h, dependencies = { trainingSerializer }) {
     const { trainingId } = request.params;
     const training = await usecases.getTraining({ trainingId });
-    return trainingSerializer.serializeForAdmin(training);
+    return dependencies.trainingSerializer.serializeForAdmin(training);
   },
-  async create(request, h) {
-    const deserializedTraining = await trainingSerializer.deserialize(request.payload);
+
+  async create(request, h, dependencies = { trainingSerializer }) {
+    const deserializedTraining = await dependencies.trainingSerializer.deserialize(request.payload);
     const createdTraining = await usecases.createTraining({ training: deserializedTraining });
-    return h.response(trainingSerializer.serialize(createdTraining)).created();
+    return h.response(dependencies.trainingSerializer.serialize(createdTraining)).created();
   },
+
   async update(request) {
     const { trainingId } = request.params;
     const training = await trainingSerializer.deserialize(request.payload);
     const updatedTraining = await usecases.updateTraining({ training: { ...training, id: trainingId } });
     return trainingSerializer.serialize(updatedTraining);
   },
+
   async createOrUpdateTrigger(request) {
     const { trainingId } = request.params;
     const { threshold, tubes, type } = await trainingTriggerSerializer.deserialize(request.payload);
@@ -43,6 +48,7 @@ module.exports = {
     });
     return trainingTriggerSerializer.serialize(createdOrUpdatedTrainingTrigger);
   },
+
   async attachTargetProfiles(request, h) {
     const { id: trainingId } = request.params;
     const targetProfileIds = request.payload['target-profile-ids'];

--- a/api/lib/application/trainings/training-controller.js
+++ b/api/lib/application/trainings/training-controller.js
@@ -37,16 +37,16 @@ module.exports = {
     return dependencies.trainingSerializer.serialize(updatedTraining);
   },
 
-  async createOrUpdateTrigger(request) {
+  async createOrUpdateTrigger(request, h, dependencies = { trainingTriggerSerializer }) {
     const { trainingId } = request.params;
-    const { threshold, tubes, type } = await trainingTriggerSerializer.deserialize(request.payload);
+    const { threshold, tubes, type } = await dependencies.trainingTriggerSerializer.deserialize(request.payload);
     const createdOrUpdatedTrainingTrigger = await usecases.createOrUpdateTrainingTrigger({
       trainingId,
       threshold,
       tubes,
       type,
     });
-    return trainingTriggerSerializer.serialize(createdOrUpdatedTrainingTrigger);
+    return dependencies.trainingTriggerSerializer.serialize(createdOrUpdatedTrainingTrigger);
   },
 
   async attachTargetProfiles(request, h) {

--- a/api/lib/application/tutorial-evaluations/tutorial-evaluations-controller.js
+++ b/api/lib/application/tutorial-evaluations/tutorial-evaluations-controller.js
@@ -3,10 +3,12 @@ const tutorialEvaluationSerializer = require('../../infrastructure/serializers/j
 const TutorialEvaluation = require('../../../lib/domain/models/TutorialEvaluation.js');
 
 module.exports = {
-  async evaluate(request, h) {
+  async evaluate(request, h, dependencies = { tutorialEvaluationSerializer }) {
     const { userId } = request.auth.credentials;
     const { tutorialId } = request.params;
-    const { status = TutorialEvaluation.statuses.LIKED } = tutorialEvaluationSerializer.deserialize(request.payload);
+    const { status = TutorialEvaluation.statuses.LIKED } = dependencies.tutorialEvaluationSerializer.deserialize(
+      request.payload
+    );
 
     const tutorialEvaluation = await usecases.addTutorialEvaluation({ userId, tutorialId, status });
 

--- a/api/lib/application/user-orga-settings/user-orga-settings-controller.js
+++ b/api/lib/application/user-orga-settings/user-orga-settings-controller.js
@@ -3,7 +3,7 @@ const { UserNotAuthorizedToCreateResourceError } = require('../../domain/errors.
 const usecases = require('../../domain/usecases/index.js');
 
 module.exports = {
-  async createOrUpdate(request) {
+  async createOrUpdate(request, h, dependencies = { userOrgaSettingsSerializer }) {
     const authenticatedUserId = request.auth.credentials.userId;
     const userId = request.params.id;
     const organizationId = request.payload.data.relationships.organization.data.id;
@@ -14,6 +14,6 @@ module.exports = {
 
     const result = await usecases.createOrUpdateUserOrgaSettings({ userId, organizationId });
 
-    return userOrgaSettingsSerializer.serialize(result);
+    return dependencies.userOrgaSettingsSerializer.serialize(result);
   },
 };

--- a/api/lib/application/user-tutorials/user-tutorials-controller.js
+++ b/api/lib/application/user-tutorials/user-tutorials-controller.js
@@ -6,34 +6,34 @@ const queryParamsUtils = require('../../infrastructure/utils/query-params-utils.
 const requestResponseUtils = require('../../infrastructure/utils/request-response-utils.js');
 
 module.exports = {
-  async add(request, h) {
+  async add(request, h, dependencies = { userSavedTutorialSerializer }) {
     const { userId } = request.auth.credentials;
     const { tutorialId } = request.params;
-    const userSavedTutorial = userSavedTutorialSerializer.deserialize(request.payload);
+    const userSavedTutorial = dependencies.userSavedTutorialSerializer.deserialize(request.payload);
 
     const createdUserSavedTutorial = await usecases.addTutorialToUser({ ...userSavedTutorial, userId, tutorialId });
 
-    return h.response(userSavedTutorialSerializer.serialize(createdUserSavedTutorial)).created();
+    return h.response(dependencies.userSavedTutorialSerializer.serialize(createdUserSavedTutorial)).created();
   },
 
-  async find(request) {
+  async find(request, h, dependencies = { queryParamsUtils, requestResponseUtils, tutorialSerializer }) {
     const { userId } = request.auth.credentials;
-    const { page, filter: filters } = queryParamsUtils.extractParameters(request.query);
-    const locale = requestResponseUtils.extractLocaleFromRequest(request);
+    const { page, filter: filters } = dependencies.queryParamsUtils.extractParameters(request.query);
+    const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
     const { tutorials, meta } = await usecases.findPaginatedFilteredTutorials({
       userId,
       filters,
       page,
       locale,
     });
-    return tutorialSerializer.serialize(tutorials, meta);
+    return dependencies.tutorialSerializer.serialize(tutorials, meta);
   },
 
-  async removeFromUser(request, h) {
+  async removeFromUser(request, h, dependencies = { userSavedTutorialRepository }) {
     const { userId } = request.auth.credentials;
     const { tutorialId } = request.params;
 
-    await userSavedTutorialRepository.removeFromUser({ userId, tutorialId });
+    await dependencies.userSavedTutorialRepository.removeFromUser({ userId, tutorialId });
 
     return h.response().code(204);
   },

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -2,22 +2,21 @@ const { sinon, expect, domainBuilder, hFake, catchErr } = require('../../../test
 
 const campaignController = require('../../../../lib/application/campaigns/campaign-controller');
 
-const campaignAnalysisSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-analysis-serializer');
-const campaignReportSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-report-serializer');
-const campaignCollectiveResultSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-collective-result-serializer');
-const campaignParticipantsActivitySerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-participant-activity-serializer');
-
-const tokenService = require('../../../../lib/domain/services/token-service');
 const usecases = require('../../../../lib/domain/usecases/index.js');
 const { UserNotAuthorizedToAccessEntityError, ForbiddenAccess } = require('../../../../lib/domain/errors');
-const queryParamsUtils = require('../../../../lib/infrastructure/utils/query-params-utils');
 const { FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 
 describe('Unit | Application | Controller | Campaign', function () {
   describe('#save', function () {
+    let campaignReportSerializerStub;
+
     beforeEach(function () {
       sinon.stub(usecases, 'createCampaign');
-      sinon.stub(campaignReportSerializer, 'serialize');
+      // sinon.stub(campaignReportSerializer, 'serialize');
+
+      campaignReportSerializerStub = {
+        serialize: sinon.stub(),
+      };
     });
 
     it('should return a serialized campaign when the campaign has been successfully created', async function () {
@@ -63,10 +62,11 @@ describe('Unit | Application | Controller | Campaign', function () {
       const expectedResult = Symbol('result');
       const createdCampaign = Symbol('created campaign');
       usecases.createCampaign.withArgs({ campaign }).resolves(createdCampaign);
-      campaignReportSerializer.serialize.withArgs(createdCampaign).returns(expectedResult);
+      campaignReportSerializerStub.serialize.withArgs(createdCampaign).returns(expectedResult);
+      const dependencies = { campaignReportSerializer: campaignReportSerializerStub };
 
       // when
-      const response = await campaignController.save(request, hFake);
+      const response = await campaignController.save(request, hFake, dependencies);
 
       // then
       expect(response.source).to.equal(expectedResult);
@@ -114,10 +114,11 @@ describe('Unit | Application | Controller | Campaign', function () {
       const expectedResult = Symbol('result');
       const createdCampaign = Symbol('created campaign');
       usecases.createCampaign.withArgs({ campaign }).resolves(createdCampaign);
-      campaignReportSerializer.serialize.withArgs(createdCampaign).returns(expectedResult);
+      campaignReportSerializerStub.serialize.withArgs(createdCampaign).returns(expectedResult);
+      const dependencies = { campaignReportSerializer: campaignReportSerializerStub };
 
       // when
-      const response = await campaignController.save(request, hFake);
+      const response = await campaignController.save(request, hFake, dependencies);
 
       // then
       expect(response.source).to.equal(expectedResult);
@@ -131,11 +132,14 @@ describe('Unit | Application | Controller | Campaign', function () {
       const campaignId = 2;
       const request = _getRequestForCampaignId(campaignId);
 
-      sinon.stub(tokenService, 'extractCampaignResultsTokenContent').returns({ userId, campaignId });
+      const tokenServiceStub = {
+        extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId }),
+      };
       sinon.stub(usecases, 'startWritingCampaignAssessmentResultsToStream').resolves({ fileName: 'any file name' });
+      const dependencies = { tokenService: tokenServiceStub };
 
       // when
-      await campaignController.getCsvAssessmentResults(request);
+      await campaignController.getCsvAssessmentResults(request, hFake, dependencies);
 
       // then
       expect(usecases.startWritingCampaignAssessmentResultsToStream).to.have.been.calledOnce;
@@ -150,13 +154,16 @@ describe('Unit | Application | Controller | Campaign', function () {
       const campaignId = 2;
       const request = _getRequestForCampaignId(campaignId);
 
-      sinon.stub(tokenService, 'extractCampaignResultsTokenContent').returns({ userId, campaignId });
+      const tokenServiceStub = {
+        extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId }),
+      };
       sinon
         .stub(usecases, 'startWritingCampaignAssessmentResultsToStream')
         .resolves({ fileName: 'expected file name' });
+      const dependencies = { tokenService: tokenServiceStub };
 
       // when
-      const response = await campaignController.getCsvAssessmentResults(request);
+      const response = await campaignController.getCsvAssessmentResults(request, hFake, dependencies);
 
       // then
       expect(response.headers['content-type']).to.equal('text/csv;charset=utf-8');
@@ -170,13 +177,16 @@ describe('Unit | Application | Controller | Campaign', function () {
       const campaignId = 2;
       const request = _getRequestForCampaignId(campaignId);
 
-      sinon.stub(tokenService, 'extractCampaignResultsTokenContent').returns({ userId, campaignId });
+      const tokenServiceStub = {
+        extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId }),
+      };
       sinon.stub(usecases, 'startWritingCampaignAssessmentResultsToStream').resolves({
         fileName: 'file-name with invalid_chars •’<>:"/\\|?*"\n.csv',
       });
+      const dependencies = { tokenService: tokenServiceStub };
 
       // when
-      const response = await campaignController.getCsvAssessmentResults(request);
+      const response = await campaignController.getCsvAssessmentResults(request, hFake, dependencies);
 
       // then
       expect(response.headers['content-disposition']).to.equal(
@@ -191,11 +201,14 @@ describe('Unit | Application | Controller | Campaign', function () {
         const campaignId = 2;
         const request = _getRequestForCampaignId(campaignId);
 
-        sinon.stub(tokenService, 'extractCampaignResultsTokenContent').returns({ userId, campaignId: 19 });
+        const tokenServiceStub = {
+          extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId: 19 }),
+        };
         sinon.stub(usecases, 'startWritingCampaignAssessmentResultsToStream').resolves();
+        const dependencies = { tokenService: tokenServiceStub };
 
         // when
-        const error = await catchErr(campaignController.getCsvAssessmentResults)(request);
+        const error = await catchErr(campaignController.getCsvAssessmentResults)(request, hFake, dependencies);
 
         // then
         expect(error).to.be.an.instanceOf(ForbiddenAccess);
@@ -208,11 +221,14 @@ describe('Unit | Application | Controller | Campaign', function () {
         // given
         const request = _getRequestForCampaignId(1);
 
-        sinon.stub(tokenService, 'extractCampaignResultsTokenContent').throws(new ForbiddenAccess());
+        const tokenServiceStub = {
+          extractCampaignResultsTokenContent: sinon.stub().throws(new ForbiddenAccess()),
+        };
         sinon.stub(usecases, 'startWritingCampaignAssessmentResultsToStream').resolves();
+        const dependencies = { tokenService: tokenServiceStub };
 
         // when
-        const error = await catchErr(campaignController.getCsvAssessmentResults)(request);
+        const error = await catchErr(campaignController.getCsvAssessmentResults)(request, hFake, dependencies);
 
         // then
         expect(error).to.be.an.instanceOf(ForbiddenAccess);
@@ -231,10 +247,13 @@ describe('Unit | Application | Controller | Campaign', function () {
       sinon
         .stub(usecases, 'startWritingCampaignProfilesCollectionResultsToStream')
         .resolves({ fileName: 'any file name' });
-      sinon.stub(tokenService, 'extractCampaignResultsTokenContent').returns({ userId, campaignId });
+
+      const tokenServiceStub = {
+        extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId }),
+      };
 
       // when
-      await campaignController.getCsvProfilesCollectionResults(request);
+      await campaignController.getCsvProfilesCollectionResults(request, hFake, { tokenService: tokenServiceStub });
 
       // then
       expect(usecases.startWritingCampaignProfilesCollectionResultsToStream).to.have.been.calledOnce;
@@ -252,10 +271,15 @@ describe('Unit | Application | Controller | Campaign', function () {
       sinon
         .stub(usecases, 'startWritingCampaignProfilesCollectionResultsToStream')
         .resolves({ fileName: 'expected file name' });
-      sinon.stub(tokenService, 'extractCampaignResultsTokenContent').returns({ userId, campaignId });
+
+      const tokenServiceStub = {
+        extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId }),
+      };
 
       // when
-      const response = await campaignController.getCsvProfilesCollectionResults(request);
+      const response = await campaignController.getCsvProfilesCollectionResults(request, hFake, {
+        tokenService: tokenServiceStub,
+      });
 
       // then
       expect(response.headers['content-type']).to.equal('text/csv;charset=utf-8');
@@ -272,10 +296,15 @@ describe('Unit | Application | Controller | Campaign', function () {
       sinon.stub(usecases, 'startWritingCampaignProfilesCollectionResultsToStream').resolves({
         fileName: 'file-name with invalid_chars •’<>:"/\\|?*"\n.csv',
       });
-      sinon.stub(tokenService, 'extractCampaignResultsTokenContent').returns({ userId, campaignId });
+
+      const tokenServiceStub = {
+        extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId }),
+      };
 
       // when
-      const response = await campaignController.getCsvProfilesCollectionResults(request);
+      const response = await campaignController.getCsvProfilesCollectionResults(request, hFake, {
+        tokenService: tokenServiceStub,
+      });
 
       // then
       expect(response.headers['content-disposition']).to.equal(
@@ -290,11 +319,15 @@ describe('Unit | Application | Controller | Campaign', function () {
         const campaignId = 2;
         const request = _getRequestForCampaignId(campaignId);
 
-        sinon.stub(tokenService, 'extractCampaignResultsTokenContent').returns({ userId, campaignId: 19 });
         sinon.stub(usecases, 'startWritingCampaignProfilesCollectionResultsToStream');
+        const tokenServiceStub = {
+          extractCampaignResultsTokenContent: sinon.stub().returns({ userId, campaignId: 19 }),
+        };
 
         // when
-        const error = await catchErr(campaignController.getCsvProfilesCollectionResults)(request);
+        const error = await catchErr(campaignController.getCsvProfilesCollectionResults)(request, hFake, {
+          tokenService: tokenServiceStub,
+        });
 
         // then
         expect(error).to.be.an.instanceOf(ForbiddenAccess);
@@ -307,11 +340,15 @@ describe('Unit | Application | Controller | Campaign', function () {
         // given
         const request = _getRequestForCampaignId(1);
 
-        sinon.stub(tokenService, 'extractCampaignResultsTokenContent').throws(new ForbiddenAccess());
         sinon.stub(usecases, 'startWritingCampaignProfilesCollectionResultsToStream').resolves();
+        const tokenServiceStub = {
+          extractCampaignResultsTokenContent: sinon.stub().throws(new ForbiddenAccess()),
+        };
 
         // when
-        const error = await catchErr(campaignController.getCsvProfilesCollectionResults)(request);
+        const error = await catchErr(campaignController.getCsvProfilesCollectionResults)(request, hFake, {
+          tokenService: tokenServiceStub,
+        });
 
         // then
         expect(error).to.be.an.instanceOf(ForbiddenAccess);
@@ -372,6 +409,9 @@ describe('Unit | Application | Controller | Campaign', function () {
     const userId = 1;
 
     let request, campaign;
+    let campaignReportSerializerStub;
+    let queryParamsUtilsStub;
+    let tokenServiceStub;
 
     beforeEach(function () {
       campaign = {
@@ -391,12 +431,12 @@ describe('Unit | Application | Controller | Campaign', function () {
       };
 
       sinon.stub(usecases, 'getCampaign');
-      sinon.stub(campaignReportSerializer, 'serialize');
-      sinon.stub(queryParamsUtils, 'extractParameters');
-      sinon.stub(tokenService, 'createTokenForCampaignResults');
-
-      queryParamsUtils.extractParameters.withArgs({}).returns({});
-      tokenService.createTokenForCampaignResults.returns('token');
+      campaignReportSerializerStub = {
+        serialize: sinon.stub(),
+      };
+      queryParamsUtilsStub = { extractParameters: sinon.stub() };
+      tokenServiceStub = { createTokenForCampaignResults: sinon.stub().returns('token') };
+      queryParamsUtilsStub.extractParameters.withArgs({}).returns({});
       usecases.getCampaign.resolves(campaign);
     });
 
@@ -404,14 +444,21 @@ describe('Unit | Application | Controller | Campaign', function () {
       // given
       const expectedResult = Symbol('ok');
       const tokenForCampaignResults = 'token';
-      campaignReportSerializer.serialize.withArgs(campaign, {}, { tokenForCampaignResults }).returns(expectedResult);
+      campaignReportSerializerStub.serialize
+        .withArgs(campaign, {}, { tokenForCampaignResults })
+        .returns(expectedResult);
 
+      const dependencies = {
+        campaignReportSerializer: campaignReportSerializerStub,
+        queryParamsUtils: queryParamsUtilsStub,
+        tokenService: tokenServiceStub,
+      };
       // when
-      const response = await campaignController.getById(request, hFake);
+      const response = await campaignController.getById(request, hFake, dependencies);
 
       // then
       expect(usecases.getCampaign).calledWith({ campaignId, userId });
-      expect(tokenService.createTokenForCampaignResults).to.have.been.calledWith({ userId, campaignId });
+      expect(tokenServiceStub.createTokenForCampaignResults).to.have.been.calledWith({ userId, campaignId });
       expect(response).to.deep.equal(expectedResult);
     });
   });
@@ -437,10 +484,14 @@ describe('Unit | Application | Controller | Campaign', function () {
         .stub(usecases, 'updateCampaign')
         .withArgs({ userId: 1, campaignId: 1, ...request.deserializedPayload })
         .resolves(updatedCampaign);
-      sinon.stub(campaignReportSerializer, 'serialize').withArgs(updatedCampaign).returns(updatedCampaignSerialized);
-
+      const campaignReportSerializerStub = {
+        serialize: sinon.stub(),
+      };
+      campaignReportSerializerStub.serialize.withArgs(updatedCampaign).returns(updatedCampaignSerialized);
       // when
-      const response = await campaignController.update(request, hFake);
+      const response = await campaignController.update(request, hFake, {
+        campaignReportSerializer: campaignReportSerializerStub,
+      });
 
       // then
       expect(response).to.deep.equal(updatedCampaignSerialized);
@@ -451,10 +502,12 @@ describe('Unit | Application | Controller | Campaign', function () {
     const campaignId = 1;
     const userId = 1;
     const locale = FRENCH_SPOKEN;
-
+    let campaignCollectiveResultSerializerStub;
     beforeEach(function () {
       sinon.stub(usecases, 'computeCampaignCollectiveResult');
-      sinon.stub(campaignCollectiveResultSerializer, 'serialize');
+      campaignCollectiveResultSerializerStub = {
+        serialize: sinon.stub(),
+      };
     });
 
     it('should return expected results', async function () {
@@ -464,7 +517,7 @@ describe('Unit | Application | Controller | Campaign', function () {
       usecases.computeCampaignCollectiveResult
         .withArgs({ userId, campaignId, locale })
         .resolves(campaignCollectiveResult);
-      campaignCollectiveResultSerializer.serialize.withArgs(campaignCollectiveResult).returns(expectedResults);
+      campaignCollectiveResultSerializerStub.serialize.withArgs(campaignCollectiveResult).returns(expectedResults);
 
       const request = {
         auth: { credentials: { userId } },
@@ -473,7 +526,9 @@ describe('Unit | Application | Controller | Campaign', function () {
       };
 
       // when
-      const response = await campaignController.getCollectiveResult(request);
+      const response = await campaignController.getCollectiveResult(request, hFake, {
+        campaignCollectiveResultSerializer: campaignCollectiveResultSerializerStub,
+      });
 
       // then
       expect(response).to.equal(expectedResults);
@@ -504,10 +559,13 @@ describe('Unit | Application | Controller | Campaign', function () {
     const campaignId = 1;
     const userId = 1;
     const locale = FRENCH_SPOKEN;
+    let campaignAnalysisSerializerStub;
 
     beforeEach(function () {
       sinon.stub(usecases, 'computeCampaignAnalysis');
-      sinon.stub(campaignAnalysisSerializer, 'serialize');
+      campaignAnalysisSerializerStub = {
+        serialize: sinon.stub(),
+      };
     });
 
     it('should return expected results', async function () {
@@ -515,7 +573,7 @@ describe('Unit | Application | Controller | Campaign', function () {
       const campaignAnalysis = Symbol('campaignAnalysis');
       const expectedResults = Symbol('results');
       usecases.computeCampaignAnalysis.withArgs({ userId, campaignId, locale }).resolves(campaignAnalysis);
-      campaignAnalysisSerializer.serialize.withArgs(campaignAnalysis).returns(expectedResults);
+      campaignAnalysisSerializerStub.serialize.withArgs(campaignAnalysis).returns(expectedResults);
 
       const request = {
         auth: { credentials: { userId } },
@@ -524,7 +582,9 @@ describe('Unit | Application | Controller | Campaign', function () {
       };
 
       // when
-      const response = await campaignController.getAnalysis(request);
+      const response = await campaignController.getAnalysis(request, hFake, {
+        campaignAnalysisSerializer: campaignAnalysisSerializerStub,
+      });
 
       // then
       expect(response).to.equal(expectedResults);
@@ -555,10 +615,12 @@ describe('Unit | Application | Controller | Campaign', function () {
 
     const campaignId = 1;
     const userId = 1;
-
+    let campaignReportSerializerStub;
     beforeEach(function () {
       sinon.stub(usecases, 'archiveCampaign');
-      sinon.stub(campaignReportSerializer, 'serialize').withArgs(updatedCampaign).resolves(serializedCampaign);
+      campaignReportSerializerStub = {
+        serialize: sinon.stub(),
+      };
       updatedCampaign = Symbol('updated campaign');
       serializedCampaign = Symbol('serialized campaign');
     });
@@ -566,15 +628,19 @@ describe('Unit | Application | Controller | Campaign', function () {
     it('should return the updated campaign properly serialized', async function () {
       // given
       usecases.archiveCampaign.withArgs({ userId, campaignId }).resolves(updatedCampaign);
-      campaignReportSerializer.serialize.withArgs(updatedCampaign).returns(serializedCampaign);
+      campaignReportSerializerStub.serialize.withArgs(updatedCampaign).returns(serializedCampaign);
 
       // when
-      const response = await campaignController.archiveCampaign({
-        params: { id: campaignId },
-        auth: {
-          credentials: { userId },
+      const response = await campaignController.archiveCampaign(
+        {
+          params: { id: campaignId },
+          auth: {
+            credentials: { userId },
+          },
         },
-      });
+        hFake,
+        { campaignReportSerializer: campaignReportSerializerStub }
+      );
 
       // then
       expect(response).to.be.equal(serializedCampaign);
@@ -587,10 +653,13 @@ describe('Unit | Application | Controller | Campaign', function () {
 
     const campaignId = 1;
     const userId = 1;
-
+    let campaignReportSerializerStub;
     beforeEach(function () {
       sinon.stub(usecases, 'unarchiveCampaign');
-      sinon.stub(campaignReportSerializer, 'serialize').withArgs(updatedCampaign).resolves(serializedCampaign);
+
+      campaignReportSerializerStub = {
+        serialize: sinon.stub(),
+      };
       updatedCampaign = Symbol('updated campaign');
       serializedCampaign = Symbol('serialized campaign');
     });
@@ -598,15 +667,19 @@ describe('Unit | Application | Controller | Campaign', function () {
     it('should return the updated campaign properly serialized', async function () {
       // given
       usecases.unarchiveCampaign.withArgs({ userId, campaignId }).resolves(updatedCampaign);
-      campaignReportSerializer.serialize.withArgs(updatedCampaign).returns(serializedCampaign);
+      campaignReportSerializerStub.serialize.withArgs(updatedCampaign).returns(serializedCampaign);
 
       // when
-      const response = await campaignController.unarchiveCampaign({
-        params: { id: campaignId },
-        auth: {
-          credentials: { userId },
+      const response = await campaignController.unarchiveCampaign(
+        {
+          params: { id: campaignId },
+          auth: {
+            credentials: { userId },
+          },
         },
-      });
+        hFake,
+        { campaignReportSerializer: campaignReportSerializerStub }
+      );
 
       // then
       expect(response).to.be.equal(serializedCampaign);
@@ -620,15 +693,14 @@ describe('Unit | Application | Controller | Campaign', function () {
 
     const campaignId = 1;
     const userId = 1;
-
+    let campaignParticipantsActivitySerializerStub;
     beforeEach(function () {
       participantsActivities = Symbol('participants activities');
       serializedParticipantsActivities = Symbol('serialized participants activities');
       sinon.stub(usecases, 'findPaginatedCampaignParticipantsActivities');
-      sinon
-        .stub(campaignParticipantsActivitySerializer, 'serialize')
-        .withArgs({ participantsActivities })
-        .resolves(serializedParticipantsActivities);
+      campaignParticipantsActivitySerializerStub = {
+        serialize: sinon.stub(),
+      };
     });
 
     it('should return the participants activities properly serialized', async function () {
@@ -636,24 +708,28 @@ describe('Unit | Application | Controller | Campaign', function () {
       usecases.findPaginatedCampaignParticipantsActivities
         .withArgs({ campaignId, userId, page: { number: 3 }, filters })
         .resolves(participantsActivities);
-      campaignParticipantsActivitySerializer.serialize
+      campaignParticipantsActivitySerializerStub.serialize
         .withArgs(participantsActivities)
         .returns(serializedParticipantsActivities);
 
       // when
-      const response = await campaignController.findParticipantsActivity({
-        params: { id: campaignId },
-        auth: {
-          credentials: { userId },
-        },
+      const response = await campaignController.findParticipantsActivity(
+        {
+          params: { id: campaignId },
+          auth: {
+            credentials: { userId },
+          },
 
-        query: {
-          'page[number]': 3,
-          'filter[groups][]': ['L1'],
-          'filter[status]': 'SHARED',
-          'filter[search]': 'Choupette',
+          query: {
+            'page[number]': 3,
+            'filter[groups][]': ['L1'],
+            'filter[status]': 'SHARED',
+            'filter[search]': 'Choupette',
+          },
         },
-      });
+        hFake,
+        { campaignParticipantsActivitySerializer: campaignParticipantsActivitySerializerStub }
+      );
 
       // then
       expect(response).to.be.equal(serializedParticipantsActivities);

--- a/api/tests/unit/application/certifications/certification-controller_test.js
+++ b/api/tests/unit/application/certifications/certification-controller_test.js
@@ -2,11 +2,8 @@ const { expect, sinon, domainBuilder, hFake } = require('../../../test-helper');
 
 const certificationController = require('../../../../lib/application/certifications/certification-controller');
 const usecases = require('../../../../lib/domain/usecases/index.js');
-const certificationAttestationPdf = require('../../../../lib/infrastructure/utils/pdf/certification-attestation-pdf');
-const events = require('../../../../lib/domain/events/index.js');
 const ChallengeNeutralized = require('../../../../lib/domain/events/ChallengeNeutralized');
 const ChallengeDeneutralized = require('../../../../lib/domain/events/ChallengeDeneutralized');
-const requestResponseUtils = require('../../../../lib/infrastructure/utils/request-response-utils');
 
 describe('Unit | Controller | certifications-controller', function () {
   describe('#findUserCertifications', function () {
@@ -79,8 +76,7 @@ describe('Unit | Controller | certifications-controller', function () {
         params: { id: certificationId },
       };
       const locale = 'fr-fr';
-      sinon.stub(requestResponseUtils, 'extractLocaleFromRequest');
-
+      const requestResponseUtilsStub = { extractLocaleFromRequest: sinon.stub() };
       const privateCertificate = domainBuilder.buildPrivateCertificate.validated({
         id: certificationId,
         firstName: 'Dorothé',
@@ -99,10 +95,12 @@ describe('Unit | Controller | certifications-controller', function () {
       });
       sinon.stub(usecases, 'getPrivateCertificate');
       usecases.getPrivateCertificate.withArgs({ userId, certificationId, locale }).resolves(privateCertificate);
-      requestResponseUtils.extractLocaleFromRequest.withArgs(request).returns(locale);
+      requestResponseUtilsStub.extractLocaleFromRequest.withArgs(request).returns(locale);
 
       // when
-      const response = await certificationController.getCertification(request, hFake);
+      const response = await certificationController.getCertification(request, hFake, {
+        requestResponseUtils: requestResponseUtilsStub,
+      });
 
       // then
       expect(response).to.deep.equal({
@@ -140,7 +138,7 @@ describe('Unit | Controller | certifications-controller', function () {
       // given
       const request = { payload: { verificationCode: 'P-123456BB' } };
       const locale = 'fr-fr';
-      sinon.stub(requestResponseUtils, 'extractLocaleFromRequest');
+      const requestResponseUtilsStub = { extractLocaleFromRequest: sinon.stub() };
       const shareableCertificate = domainBuilder.buildShareableCertificate({
         id: 123,
         firstName: 'Dorothé',
@@ -159,10 +157,12 @@ describe('Unit | Controller | certifications-controller', function () {
       usecases.getShareableCertificate
         .withArgs({ verificationCode: 'P-123456BB', locale })
         .resolves(shareableCertificate);
-      requestResponseUtils.extractLocaleFromRequest.withArgs(request).returns(locale);
+      requestResponseUtilsStub.extractLocaleFromRequest.withArgs(request).returns(locale);
 
       // when
-      const response = await certificationController.getCertificationByVerificationCode(request, hFake);
+      const response = await certificationController.getCertificationByVerificationCode(request, hFake, {
+        requestResponseUtils: requestResponseUtilsStub,
+      });
 
       // then
       expect(response).to.deep.equal({
@@ -213,14 +213,17 @@ describe('Unit | Controller | certifications-controller', function () {
           certificationId: certification.id,
         })
         .resolves(certification);
-
-      sinon
-        .stub(certificationAttestationPdf, 'getCertificationAttestationsPdfBuffer')
+      const certificationAttestationPdfStub = {
+        getCertificationAttestationsPdfBuffer: sinon.stub(),
+      };
+      certificationAttestationPdfStub.getCertificationAttestationsPdfBuffer
         .withArgs({ certificates: [certification], isFrenchDomainExtension: true })
         .resolves({ buffer: attestationPDF, fileName });
 
       // when
-      const response = await certificationController.getPDFAttestation(request, hFake);
+      const response = await certificationController.getPDFAttestation(request, hFake, {
+        certificationAttestationPdf: certificationAttestationPdfStub,
+      });
 
       // then
       expect(response.source).to.deep.equal(attestationPDF);
@@ -243,12 +246,14 @@ describe('Unit | Controller | certifications-controller', function () {
         auth: { credentials: { userId: 7 } },
       };
       sinon.stub(usecases, 'neutralizeChallenge');
-      sinon.stub(events, 'eventDispatcher').value({
-        dispatch: sinon.stub(),
-      });
+      const eventsStub = {
+        eventDispatcher: {
+          dispatch: sinon.stub(),
+        },
+      };
 
       // when
-      await certificationController.neutralizeChallenge(request, hFake);
+      await certificationController.neutralizeChallenge(request, hFake, { events: eventsStub });
 
       // then
       expect(usecases.neutralizeChallenge).to.have.been.calledWith({
@@ -272,12 +277,14 @@ describe('Unit | Controller | certifications-controller', function () {
         auth: { credentials: { userId: 7 } },
       };
       sinon.stub(usecases, 'neutralizeChallenge');
-      sinon.stub(events, 'eventDispatcher').value({
-        dispatch: sinon.stub(),
-      });
 
+      const eventsStub = {
+        eventDispatcher: {
+          dispatch: sinon.stub(),
+        },
+      };
       // when
-      const response = await certificationController.neutralizeChallenge(request, hFake);
+      const response = await certificationController.neutralizeChallenge(request, hFake, { events: eventsStub });
 
       // then
       expect(response.statusCode).to.equal(204);
@@ -298,15 +305,17 @@ describe('Unit | Controller | certifications-controller', function () {
       };
       const eventToBeDispatched = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
       sinon.stub(usecases, 'neutralizeChallenge').resolves(eventToBeDispatched);
-      sinon.stub(events, 'eventDispatcher').value({
-        dispatch: sinon.stub(),
-      });
+      const eventsStub = {
+        eventDispatcher: {
+          dispatch: sinon.stub(),
+        },
+      };
 
       // when
-      await certificationController.neutralizeChallenge(request, hFake);
+      await certificationController.neutralizeChallenge(request, hFake, { events: eventsStub });
 
       // then
-      expect(events.eventDispatcher.dispatch).to.have.been.calledWithExactly(eventToBeDispatched);
+      expect(eventsStub.eventDispatcher.dispatch).to.have.been.calledWithExactly(eventToBeDispatched);
     });
   });
 
@@ -325,10 +334,14 @@ describe('Unit | Controller | certifications-controller', function () {
         auth: { credentials: { userId: 7 } },
       };
       sinon.stub(usecases, 'deneutralizeChallenge');
-      sinon.stub(events, 'eventDispatcher');
+      const eventsStub = {
+        eventDispatcher: {
+          dispatch: sinon.stub(),
+        },
+      };
 
       // when
-      await certificationController.deneutralizeChallenge(request, hFake);
+      await certificationController.deneutralizeChallenge(request, hFake, { events: eventsStub });
 
       // then
       expect(usecases.deneutralizeChallenge).to.have.been.calledWith({
@@ -352,10 +365,13 @@ describe('Unit | Controller | certifications-controller', function () {
         auth: { credentials: { userId: 7 } },
       };
       sinon.stub(usecases, 'deneutralizeChallenge');
-      sinon.stub(events, 'eventDispatcher');
-
+      const eventsStub = {
+        eventDispatcher: {
+          dispatch: sinon.stub(),
+        },
+      };
       // when
-      const response = await certificationController.deneutralizeChallenge(request, hFake);
+      const response = await certificationController.deneutralizeChallenge(request, hFake, { events: eventsStub });
 
       // then
       expect(response.statusCode).to.equal(204);
@@ -377,15 +393,17 @@ describe('Unit | Controller | certifications-controller', function () {
       const eventToBeDispatched = new ChallengeDeneutralized({ certificationCourseId: 1, juryId: 7 });
 
       sinon.stub(usecases, 'deneutralizeChallenge').resolves(eventToBeDispatched);
-      sinon.stub(events, 'eventDispatcher').value({
-        dispatch: sinon.stub(),
-      });
+      const eventsStub = {
+        eventDispatcher: {
+          dispatch: sinon.stub(),
+        },
+      };
 
       // when
-      await certificationController.deneutralizeChallenge(request, hFake);
+      await certificationController.deneutralizeChallenge(request, hFake, { events: eventsStub });
 
       // then
-      expect(events.eventDispatcher.dispatch).to.have.been.calledWith(eventToBeDispatched);
+      expect(eventsStub.eventDispatcher.dispatch).to.have.been.calledWith(eventToBeDispatched);
     });
   });
 });

--- a/api/tests/unit/application/trainings/training-controller_test.js
+++ b/api/tests/unit/application/trainings/training-controller_test.js
@@ -1,7 +1,6 @@
 const { sinon, expect, hFake } = require('../../../test-helper');
 const trainingController = require('../../../../lib/application/trainings/training-controller');
 const usecases = require('../../../../lib/domain/usecases/index.js');
-const trainingSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/training-serializer');
 const trainingTriggerSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/training-trigger-serializer');
 const targetProfileSummaryForAdminSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer');
 const TrainingTrigger = require('../../../../lib/domain/models/TrainingTrigger');
@@ -51,8 +50,8 @@ describe('Unit | Controller | training-controller', function () {
       const trainingId = 1;
 
       sinon.stub(usecases, 'getTraining').resolves(training);
-      const stubedTrainingSerializer = { serializeForAdmin: sinon.stub() };
-      stubedTrainingSerializer.serializeForAdmin.returns(expectedResult);
+      const trainingSerializer = { serializeForAdmin: sinon.stub() };
+      trainingSerializer.serializeForAdmin.returns(expectedResult);
 
       // when
       const response = await trainingController.getById(
@@ -62,14 +61,12 @@ describe('Unit | Controller | training-controller', function () {
           },
         },
         hFake,
-        {
-          trainingSerializer: stubedTrainingSerializer,
-        }
+        { trainingSerializer }
       );
 
       // then
       expect(usecases.getTraining).to.have.been.calledWith({ trainingId });
-      expect(stubedTrainingSerializer.serializeForAdmin).to.have.been.calledOnce;
+      expect(trainingSerializer.serializeForAdmin).to.have.been.calledOnce;
       expect(response).to.deep.equal(expectedResult);
     });
   });
@@ -87,14 +84,14 @@ describe('Unit | Controller | training-controller', function () {
         minutes: 2,
       },
     };
-    let stubedTrainingSerializer;
+    let trainingSerializer;
 
     beforeEach(function () {
-      stubedTrainingSerializer = {
+      trainingSerializer = {
         deserialize: sinon.stub(),
         serialize: sinon.stub(),
       };
-      stubedTrainingSerializer.deserialize.returns(deserializedTraining);
+      trainingSerializer.deserialize.returns(deserializedTraining);
       sinon.stub(usecases, 'createTraining').resolves(createdTraining);
     });
 
@@ -115,10 +112,10 @@ describe('Unit | Controller | training-controller', function () {
       };
 
       // when
-      await trainingController.create({ payload }, hFake, { trainingSerializer: stubedTrainingSerializer });
+      await trainingController.create({ payload }, hFake, { trainingSerializer });
 
       // then
-      expect(stubedTrainingSerializer.deserialize).to.have.been.calledWith(payload);
+      expect(trainingSerializer.deserialize).to.have.been.calledWith(payload);
       expect(usecases.createTraining).to.have.been.calledOnceWithExactly({ training: deserializedTraining });
     });
 
@@ -131,7 +128,7 @@ describe('Unit | Controller | training-controller', function () {
         },
       };
 
-      stubedTrainingSerializer.serialize.returns(expectedSerializedTraining);
+      trainingSerializer.serialize.returns(expectedSerializedTraining);
 
       // when
       const response = await trainingController.create(
@@ -146,11 +143,11 @@ describe('Unit | Controller | training-controller', function () {
           },
         },
         hFake,
-        { trainingSerializer: stubedTrainingSerializer }
+        { trainingSerializer }
       );
 
       // then
-      expect(stubedTrainingSerializer.serialize).to.have.been.calledWith(createdTraining);
+      expect(trainingSerializer.serialize).to.have.been.calledWith(createdTraining);
       expect(response.source).to.deep.equal(expectedSerializedTraining);
     });
   });
@@ -159,9 +156,14 @@ describe('Unit | Controller | training-controller', function () {
     const deserializedTraining = { title: 'new title' };
     const updatedTraining = { title: 'new title' };
 
+    let trainingSerializer;
+
     beforeEach(function () {
-      sinon.stub(trainingSerializer, 'deserialize').returns(deserializedTraining);
-      sinon.stub(trainingSerializer, 'serialize');
+      trainingSerializer = {
+        serialize: sinon.stub(),
+        deserialize: sinon.stub(),
+      };
+      trainingSerializer.deserialize.returns(deserializedTraining);
       sinon.stub(usecases, 'updateTraining').resolves(updatedTraining);
     });
 
@@ -188,7 +190,8 @@ describe('Unit | Controller | training-controller', function () {
             },
             payload,
           },
-          hFake
+          hFake,
+          { trainingSerializer }
         );
 
         // then
@@ -217,7 +220,8 @@ describe('Unit | Controller | training-controller', function () {
             },
             payload,
           },
-          hFake
+          hFake,
+          { trainingSerializer }
         );
 
         // then

--- a/api/tests/unit/application/trainings/training-controller_test.js
+++ b/api/tests/unit/application/trainings/training-controller_test.js
@@ -1,7 +1,6 @@
 const { sinon, expect, hFake } = require('../../../test-helper');
 const trainingController = require('../../../../lib/application/trainings/training-controller');
 const usecases = require('../../../../lib/domain/usecases/index.js');
-const trainingTriggerSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/training-trigger-serializer');
 const targetProfileSummaryForAdminSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer');
 const TrainingTrigger = require('../../../../lib/domain/models/TrainingTrigger');
 
@@ -272,9 +271,13 @@ describe('Unit | Controller | training-controller', function () {
 
       const createdTrigger = Symbol('createdTrigger');
       const serializedTrigger = Symbol('serializedTrigger');
-      sinon.stub(trainingTriggerSerializer, 'deserialize').withArgs(payload).returns(deserializedTrigger);
       sinon.stub(usecases, 'createOrUpdateTrainingTrigger').resolves(createdTrigger);
-      sinon.stub(trainingTriggerSerializer, 'serialize').withArgs(createdTrigger).returns(serializedTrigger);
+      const stubedTrainingTriggerSerializer = {
+        deserialize: sinon.stub(),
+        serialize: sinon.stub(),
+      };
+      stubedTrainingTriggerSerializer.deserialize.withArgs(payload).returns(deserializedTrigger);
+      stubedTrainingTriggerSerializer.serialize.withArgs(createdTrigger).returns(serializedTrigger);
 
       // when
       const result = await trainingController.createOrUpdateTrigger(
@@ -282,7 +285,8 @@ describe('Unit | Controller | training-controller', function () {
           params: { trainingId: 145 },
           payload,
         },
-        hFake
+        hFake,
+        { trainingTriggerSerializer: stubedTrainingTriggerSerializer }
       );
 
       // then

--- a/api/tests/unit/application/trainings/training-controller_test.js
+++ b/api/tests/unit/application/trainings/training-controller_test.js
@@ -1,7 +1,6 @@
 const { sinon, expect, hFake } = require('../../../test-helper');
 const trainingController = require('../../../../lib/application/trainings/training-controller');
 const usecases = require('../../../../lib/domain/usecases/index.js');
-const targetProfileSummaryForAdminSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/target-profile-summary-for-admin-serializer');
 const TrainingTrigger = require('../../../../lib/domain/models/TrainingTrigger');
 
 describe('Unit | Controller | training-controller', function () {
@@ -272,12 +271,12 @@ describe('Unit | Controller | training-controller', function () {
       const createdTrigger = Symbol('createdTrigger');
       const serializedTrigger = Symbol('serializedTrigger');
       sinon.stub(usecases, 'createOrUpdateTrainingTrigger').resolves(createdTrigger);
-      const stubedTrainingTriggerSerializer = {
+      const trainingTriggerSerializer = {
         deserialize: sinon.stub(),
         serialize: sinon.stub(),
       };
-      stubedTrainingTriggerSerializer.deserialize.withArgs(payload).returns(deserializedTrigger);
-      stubedTrainingTriggerSerializer.serialize.withArgs(createdTrigger).returns(serializedTrigger);
+      trainingTriggerSerializer.deserialize.withArgs(payload).returns(deserializedTrigger);
+      trainingTriggerSerializer.serialize.withArgs(createdTrigger).returns(serializedTrigger);
 
       // when
       const result = await trainingController.createOrUpdateTrigger(
@@ -286,7 +285,7 @@ describe('Unit | Controller | training-controller', function () {
           payload,
         },
         hFake,
-        { trainingTriggerSerializer: stubedTrainingTriggerSerializer }
+        { trainingTriggerSerializer: trainingTriggerSerializer }
       );
 
       // then
@@ -307,13 +306,18 @@ describe('Unit | Controller | training-controller', function () {
       const targetProfileSummaries = Symbol('targetProfileSummaries');
       const serializedTargetProfileSummaries = Symbol('serializedTargetProfileSummaries');
       sinon.stub(usecases, 'findTargetProfileSummariesForTraining').resolves(targetProfileSummaries);
-      sinon
-        .stub(targetProfileSummaryForAdminSerializer, 'serialize')
+
+      const targetProfileSummaryForAdminSerializer = {
+        serialize: sinon.stub(),
+      };
+      targetProfileSummaryForAdminSerializer.serialize
         .withArgs(targetProfileSummaries)
         .returns(serializedTargetProfileSummaries);
 
       // when
-      const result = await trainingController.findTargetProfileSummaries({ params: { trainingId } }, hFake);
+      const result = await trainingController.findTargetProfileSummaries({ params: { trainingId } }, hFake, {
+        targetProfileSummaryForAdminSerializer: targetProfileSummaryForAdminSerializer,
+      });
 
       // then
       expect(usecases.findTargetProfileSummariesForTraining).to.have.been.calledWith({ trainingId });

--- a/api/tests/unit/application/tutorial-evaluations/tutorial-evaluations-controller_test.js
+++ b/api/tests/unit/application/tutorial-evaluations/tutorial-evaluations-controller_test.js
@@ -2,7 +2,6 @@ const { sinon, expect, hFake } = require('../../../test-helper');
 const tutorialEvaluationsController = require('../../../../lib/application/tutorial-evaluations/tutorial-evaluations-controller');
 const usecases = require('../../../../lib/domain/usecases/index.js');
 const TutorialEvaluation = require('../../../../lib/domain/models/TutorialEvaluation');
-const tutorialEvaluationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/tutorial-evaluation-serializer');
 
 describe('Unit | Controller | Tutorial-evaluations', function () {
   describe('#evaluate', function () {
@@ -11,7 +10,10 @@ describe('Unit | Controller | Tutorial-evaluations', function () {
       const tutorialId = 'tutorialId';
       const userId = 'userId';
       const status = TutorialEvaluation.statuses.LIKED;
-      sinon.stub(tutorialEvaluationSerializer, 'deserialize').returns({
+      const tutorialEvaluationSerializer = {
+        deserialize: sinon.stub(),
+      };
+      tutorialEvaluationSerializer.deserialize.returns({
         status,
       });
       sinon.stub(usecases, 'addTutorialEvaluation').returns({
@@ -31,7 +33,7 @@ describe('Unit | Controller | Tutorial-evaluations', function () {
       };
 
       // when
-      await tutorialEvaluationsController.evaluate(request, hFake);
+      await tutorialEvaluationsController.evaluate(request, hFake, { tutorialEvaluationSerializer });
 
       // then
       const addTutorialEvaluationArgs = usecases.addTutorialEvaluation.firstCall.args[0];

--- a/api/tests/unit/application/user-orga-settings/user-orga-settings-controller_test.js
+++ b/api/tests/unit/application/user-orga-settings/user-orga-settings-controller_test.js
@@ -1,10 +1,8 @@
-const { sinon, expect } = require('../../../test-helper');
+const { sinon, expect, hFake } = require('../../../test-helper');
 
 const userOrgaSettingsController = require('../../../../lib/application/user-orga-settings/user-orga-settings-controller');
 
 const usecases = require('../../../../lib/domain/usecases/index.js');
-
-const userOrgaSettingsSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-orga-settings-serializer');
 
 describe('Unit | Controller | user-orga-settings-controller', function () {
   describe('#createOrUpdate', function () {
@@ -54,15 +52,19 @@ describe('Unit | Controller | user-orga-settings-controller', function () {
     let expectedUserOrgaSettings;
     let response;
 
+    let userOrgaSettingsSerializer;
+
     beforeEach(async function () {
       sinon.stub(usecases, 'createOrUpdateUserOrgaSettings');
-      sinon.stub(userOrgaSettingsSerializer, 'serialize');
+      userOrgaSettingsSerializer = {
+        serialize: sinon.stub(),
+      };
 
       expectedUserOrgaSettings = { id: 1, user: { id: userId }, organization: { id: organizationId } };
       usecases.createOrUpdateUserOrgaSettings.resolves(expectedUserOrgaSettings);
       userOrgaSettingsSerializer.serialize.resolves(serializedUseOrgaSettings);
 
-      response = await userOrgaSettingsController.createOrUpdate(request);
+      response = await userOrgaSettingsController.createOrUpdate(request, hFake, { userOrgaSettingsSerializer });
     });
 
     it('should call the usecase to update the userOrgaSetting', async function () {

--- a/api/tests/unit/application/user-tutorials/user-tutorials-controller_test.js
+++ b/api/tests/unit/application/user-tutorials/user-tutorials-controller_test.js
@@ -1,11 +1,6 @@
 const { sinon, expect, hFake } = require('../../../test-helper');
 const userTutorialsController = require('../../../../lib/application/user-tutorials/user-tutorials-controller');
 const usecases = require('../../../../lib/domain/usecases/index.js');
-const userSavedTutorialSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-saved-tutorial-serializer');
-const userSavedTutorialRepository = require('../../../../lib/infrastructure/repositories/user-saved-tutorial-repository');
-const queryParamsUtils = require('../../../../lib/infrastructure/utils/query-params-utils');
-const requestResponseUtils = require('../../../../lib/infrastructure/utils/request-response-utils');
-const tutorialSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/tutorial-serializer');
 
 describe('Unit | Controller | User-tutorials', function () {
   describe('#add', function () {
@@ -14,7 +9,11 @@ describe('Unit | Controller | User-tutorials', function () {
       const tutorialId = 'tutorialId';
       const userId = 'userId';
       sinon.stub(usecases, 'addTutorialToUser').returns({ id: 'userTutorialId' });
-      sinon.stub(userSavedTutorialSerializer, 'deserialize').returns({});
+      const userSavedTutorialSerializer = {
+        deserialize: sinon.stub(),
+        serialize: sinon.stub(),
+      };
+      userSavedTutorialSerializer.deserialize.returns({});
 
       const request = {
         auth: { credentials: { userId } },
@@ -22,7 +21,9 @@ describe('Unit | Controller | User-tutorials', function () {
       };
 
       // when
-      await userTutorialsController.add(request, hFake);
+      await userTutorialsController.add(request, hFake, {
+        userSavedTutorialSerializer,
+      });
 
       // then
       const addTutorialToUserArgs = usecases.addTutorialToUser.firstCall.args[0];
@@ -37,7 +38,11 @@ describe('Unit | Controller | User-tutorials', function () {
         const tutorialId = 'tutorialId';
         const userId = 'userId';
         sinon.stub(usecases, 'addTutorialToUser').returns({ id: 'userTutorialId' });
-        sinon.stub(userSavedTutorialSerializer, 'deserialize').returns({ skillId });
+        const userSavedTutorialSerializer = {
+          deserialize: sinon.stub(),
+          serialize: sinon.stub(),
+        };
+        userSavedTutorialSerializer.deserialize.returns({ skillId });
 
         const request = {
           auth: { credentials: { userId } },
@@ -46,7 +51,9 @@ describe('Unit | Controller | User-tutorials', function () {
         };
 
         // when
-        await userTutorialsController.add(request, hFake);
+        await userTutorialsController.add(request, hFake, {
+          userSavedTutorialSerializer,
+        });
 
         // then
         const addTutorialToUserArgs = usecases.addTutorialToUser.firstCall.args[0];
@@ -81,16 +88,26 @@ describe('Unit | Controller | User-tutorials', function () {
       };
       const returnedTutorials = Symbol('returned-tutorials');
       const returnedMeta = Symbol('returned-meta');
-      sinon.stub(requestResponseUtils, 'extractLocaleFromRequest').withArgs(request).returns(expectedLocale);
-      sinon.stub(queryParamsUtils, 'extractParameters').withArgs(request.query).returns(extractedParams);
+      const requestResponseUtils = { extractLocaleFromRequest: sinon.stub() };
+      requestResponseUtils.extractLocaleFromRequest.withArgs(request).returns(expectedLocale);
+      const queryParamsUtils = { extractParameters: sinon.stub() };
+      queryParamsUtils.extractParameters.withArgs(request.query).returns(extractedParams);
       sinon.stub(usecases, 'findPaginatedFilteredTutorials').resolves({
         tutorials: returnedTutorials,
         meta: returnedMeta,
       });
-      sinon.stub(tutorialSerializer, 'serialize').returns(expectedTutorials);
+      const tutorialSerializer = {
+        deserialize: sinon.stub(),
+        serialize: sinon.stub(),
+      };
+      tutorialSerializer.serialize.returns(expectedTutorials);
 
       // when
-      const result = await userTutorialsController.find(request);
+      const result = await userTutorialsController.find(request, hFake, {
+        tutorialSerializer,
+        queryParamsUtils,
+        requestResponseUtils,
+      });
 
       // then
       expect(tutorialSerializer.serialize).to.have.been.calledWithExactly(returnedTutorials, returnedMeta);
@@ -109,7 +126,9 @@ describe('Unit | Controller | User-tutorials', function () {
       // given
       const userId = 'userId';
       const tutorialId = 'tutorialId';
-      sinon.stub(userSavedTutorialRepository, 'removeFromUser');
+      const userSavedTutorialRepository = {
+        removeFromUser: sinon.stub(),
+      };
 
       const request = {
         auth: { credentials: { userId } },
@@ -117,7 +136,7 @@ describe('Unit | Controller | User-tutorials', function () {
       };
 
       // when
-      await userTutorialsController.removeFromUser(request, hFake);
+      await userTutorialsController.removeFromUser(request, hFake, { userSavedTutorialRepository });
 
       // then
       const removeFromUserArgs = userSavedTutorialRepository.removeFromUser.firstCall.args[0];

--- a/api/tests/unit/application/users/user-controller_test.js
+++ b/api/tests/unit/application/users/user-controller_test.js
@@ -4,33 +4,23 @@ const User = require('../../../../lib/domain/models/User');
 const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
 const queryParamsUtils = require('../../../../lib/infrastructure/utils/query-params-utils');
 const requestResponseUtils = require('../../../../lib/infrastructure/utils/request-response-utils');
-const encryptionService = require('../../../../lib/domain/services/encryption-service');
-const mailService = require('../../../../lib/domain/services/mail-service');
 const { getI18n } = require('../../../tooling/i18n/i18n');
 
 const usecases = require('../../../../lib/domain/usecases/index.js');
 
-const campaignParticipationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-participation-serializer');
-const campaignParticipationOverviewSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer');
-const scorecardSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/scorecard-serializer');
-const profileSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/profile-serializer');
-const userSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-serializer');
-const userForAdminSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-for-admin-serializer');
-const userWithActivitySerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-with-activity-serializer');
-const userAnonymizedDetailsForAdminSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-anonymized-details-for-admin-serializer');
-const userDetailsForAdminSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer');
-const validationErrorSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/validation-error-serializer');
-const updateEmailSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/update-email-serializer');
-const authenticationMethodsSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/authentication-methods-serializer');
-const userOrganizationForAdminSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-organization-for-admin-serializer');
-const certificationCenterMembershipSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer');
-const trainingSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/training-serializer');
-
 const userController = require('../../../../lib/application/users/user-controller');
 const UserOrganizationForAdmin = require('../../../../lib/domain/read-models/UserOrganizationForAdmin');
-const localeService = require('../../../../lib/domain/services/locale-service');
 
 describe('Unit | Controller | user-controller', function () {
+  let userSerializer;
+
+  beforeEach(function () {
+    userSerializer = {
+      deserialize: sinon.stub(),
+      serialize: sinon.stub(),
+    };
+  });
+
   describe('#save', function () {
     const email = 'to-be-free@ozone.airplane';
     const password = 'Password123';
@@ -38,14 +28,34 @@ describe('Unit | Controller | user-controller', function () {
     const deserializedUser = new User();
     const savedUser = new User({ email });
     const localeFromHeader = 'fr-fr';
+    let dependencies;
 
     beforeEach(function () {
-      sinon.stub(userSerializer, 'deserialize').returns(deserializedUser);
-      sinon.stub(userSerializer, 'serialize');
-      sinon.stub(validationErrorSerializer, 'serialize');
-      sinon.stub(encryptionService, 'hashPassword');
-      sinon.stub(mailService, 'sendAccountCreationEmail');
-      sinon.stub(localeService, 'getCanonicalLocale');
+      userSerializer.deserialize.returns(deserializedUser);
+
+      const validationErrorSerializer = {
+        deserialize: sinon.stub(),
+        serialize: sinon.stub(),
+      };
+      const encryptionService = {
+        hashPassword: sinon.stub(),
+      };
+      const mailService = {
+        sendAccountCreationEmail: sinon.stub(),
+      };
+      const localeService = {
+        getCanonicalLocale: sinon.stub(),
+      };
+
+      dependencies = {
+        userSerializer,
+        validationErrorSerializer,
+        encryptionService,
+        mailService,
+        localeService,
+        requestResponseUtils,
+      };
+
       sinon.stub(usecases, 'createUser').returns(savedUser);
     });
 
@@ -71,12 +81,13 @@ describe('Unit | Controller | user-controller', function () {
                 },
               },
             },
-            hFake
+            hFake,
+            dependencies
           );
 
           // then
-          expect(userSerializer.serialize).to.have.been.calledWith(savedUser);
-          expect(localeService.getCanonicalLocale).to.not.have.been.called;
+          expect(dependencies.userSerializer.serialize).to.have.been.calledWith(savedUser);
+          expect(dependencies.localeService.getCanonicalLocale).to.not.have.been.called;
           expect(response.source).to.deep.equal(expectedSerializedUser);
           expect(response.statusCode).to.equal(201);
         });
@@ -96,8 +107,8 @@ describe('Unit | Controller | user-controller', function () {
             campaignCode: null,
           };
 
-          localeService.getCanonicalLocale.returns(localeFromCookie);
-          userSerializer.serialize.returns(expectedSerializedUser);
+          dependencies.localeService.getCanonicalLocale.returns(localeFromCookie);
+          dependencies.userSerializer.serialize.returns(expectedSerializedUser);
           usecases.createUser.resolves(savedUser);
 
           // when
@@ -118,13 +129,14 @@ describe('Unit | Controller | user-controller', function () {
                 locale: localeFromCookie,
               },
             },
-            hFake
+            hFake,
+            dependencies
           );
 
           // then
           expect(usecases.createUser).to.have.been.calledWith(useCaseParameters);
-          expect(localeService.getCanonicalLocale).to.have.been.calledWith(localeFromCookie);
-          expect(userSerializer.serialize).to.have.been.calledWith(savedUser);
+          expect(dependencies.localeService.getCanonicalLocale).to.have.been.calledWith(localeFromCookie);
+          expect(dependencies.userSerializer.serialize).to.have.been.calledWith(savedUser);
           expect(response.statusCode).to.equal(201);
         });
       });
@@ -154,13 +166,14 @@ describe('Unit | Controller | user-controller', function () {
 
     beforeEach(function () {
       sinon.stub(usecases, 'updateUserPassword');
-      sinon.stub(userSerializer, 'serialize');
-      sinon.stub(userSerializer, 'deserialize');
     });
 
     it('should update password', async function () {
       // given
-      userSerializer.deserialize.withArgs(payload).returns({ password: userPassword, temporaryKey: userTemporaryKey });
+      userSerializer.deserialize.withArgs(payload).returns({
+        password: userPassword,
+        temporaryKey: userTemporaryKey,
+      });
       usecases.updateUserPassword
         .withArgs({
           userId,
@@ -171,7 +184,7 @@ describe('Unit | Controller | user-controller', function () {
       userSerializer.serialize.withArgs({}).returns('ok');
 
       // when
-      const response = await userController.updatePassword(request);
+      const response = await userController.updatePassword(request, hFake, { userSerializer });
 
       // then
       expect(response).to.be.equal('ok');
@@ -181,11 +194,14 @@ describe('Unit | Controller | user-controller', function () {
   describe('#updateUserDetailsForAdministration', function () {
     const userId = 1132;
     const newEmail = 'partiel@update.com';
+    let dependencies;
 
     beforeEach(function () {
       sinon.stub(usecases, 'updateUserDetailsForAdministration');
-      sinon.stub(userDetailsForAdminSerializer, 'serializeForUpdate');
-      sinon.stub(userDetailsForAdminSerializer, 'deserialize');
+      const userDetailsForAdminSerializer = { serializeForUpdate: sinon.stub(), deserialize: sinon.stub() };
+      dependencies = {
+        userDetailsForAdminSerializer,
+      };
     });
 
     it('should update email,firstName,lastName', async function () {
@@ -208,12 +224,16 @@ describe('Unit | Controller | user-controller', function () {
       };
 
       // given
-      userDetailsForAdminSerializer.deserialize.withArgs(payload).returns({ email: newEmail, lastName, firstName });
+      dependencies.userDetailsForAdminSerializer.deserialize.withArgs(payload).returns({
+        email: newEmail,
+        lastName,
+        firstName,
+      });
       usecases.updateUserDetailsForAdministration.resolves({ email: newEmail, lastName, firstName });
-      userDetailsForAdminSerializer.serializeForUpdate.returns('updated');
+      dependencies.userDetailsForAdminSerializer.serializeForUpdate.returns('updated');
 
       // when
-      const response = await userController.updateUserDetailsForAdministration(request);
+      const response = await userController.updateUserDetailsForAdministration(request, hFake, dependencies);
 
       // then
       expect(response).to.be.equal('updated');
@@ -235,12 +255,12 @@ describe('Unit | Controller | user-controller', function () {
         payload,
       };
 
-      userDetailsForAdminSerializer.deserialize.withArgs(payload).returns({ email: newEmail });
+      dependencies.userDetailsForAdminSerializer.deserialize.withArgs(payload).returns({ email: newEmail });
       usecases.updateUserDetailsForAdministration.resolves({ email: newEmail });
-      userDetailsForAdminSerializer.serializeForUpdate.returns(newEmail);
+      dependencies.userDetailsForAdminSerializer.serializeForUpdate.returns(newEmail);
 
       // when
-      const response = await userController.updateUserDetailsForAdministration(request);
+      const response = await userController.updateUserDetailsForAdministration(request, hFake, dependencies);
 
       // then
       expect(response).to.be.equal(newEmail);
@@ -258,7 +278,6 @@ describe('Unit | Controller | user-controller', function () {
       };
 
       sinon.stub(usecases, 'acceptPixLastTermsOfService');
-      sinon.stub(userSerializer, 'serialize');
     });
 
     it('should accept pix terms of service', async function () {
@@ -268,7 +287,7 @@ describe('Unit | Controller | user-controller', function () {
       userSerializer.serialize.withArgs({}).returns(stubSerializedObject);
 
       // when
-      const response = await userController.acceptPixLastTermsOfService(request);
+      const response = await userController.acceptPixLastTermsOfService(request, hFake, { userSerializer });
 
       // then
       expect(response).to.be.equal(stubSerializedObject);
@@ -286,7 +305,6 @@ describe('Unit | Controller | user-controller', function () {
       };
 
       sinon.stub(usecases, 'acceptPixOrgaTermsOfService');
-      sinon.stub(userSerializer, 'serialize');
     });
 
     it('should accept pix orga terms of service', async function () {
@@ -295,7 +313,7 @@ describe('Unit | Controller | user-controller', function () {
       userSerializer.serialize.withArgs({}).returns('ok');
 
       // when
-      const response = await userController.acceptPixOrgaTermsOfService(request);
+      const response = await userController.acceptPixOrgaTermsOfService(request, hFake, { userSerializer });
 
       // then
       expect(response).to.be.equal('ok');
@@ -334,7 +352,6 @@ describe('Unit | Controller | user-controller', function () {
       };
 
       sinon.stub(usecases, 'changeUserLang');
-      sinon.stub(userSerializer, 'serialize');
     });
 
     it('should modify lang of user', async function () {
@@ -343,7 +360,7 @@ describe('Unit | Controller | user-controller', function () {
       userSerializer.serialize.withArgs({}).returns('ok');
 
       // when
-      const response = await userController.changeLang(request);
+      const response = await userController.changeLang(request, hFake, { userSerializer });
 
       // then
       expect(response).to.be.equal('ok');
@@ -361,7 +378,6 @@ describe('Unit | Controller | user-controller', function () {
       };
 
       sinon.stub(usecases, 'rememberUserHasSeenAssessmentInstructions');
-      sinon.stub(userSerializer, 'serialize');
     });
 
     it('should remember user has seen assessment instructions', async function () {
@@ -370,7 +386,9 @@ describe('Unit | Controller | user-controller', function () {
       userSerializer.serialize.withArgs({}).returns('ok');
 
       // when
-      const response = await userController.rememberUserHasSeenAssessmentInstructions(request);
+      const response = await userController.rememberUserHasSeenAssessmentInstructions(request, hFake, {
+        userSerializer,
+      });
 
       // then
       expect(response).to.be.equal('ok');
@@ -388,7 +406,6 @@ describe('Unit | Controller | user-controller', function () {
       };
 
       sinon.stub(usecases, 'rememberUserHasSeenNewDashboardInfo');
-      sinon.stub(userSerializer, 'serialize');
     });
 
     it('should remember user has seen new dashboard info', async function () {
@@ -397,7 +414,7 @@ describe('Unit | Controller | user-controller', function () {
       userSerializer.serialize.withArgs({}).returns('ok');
 
       // when
-      const response = await userController.rememberUserHasSeenNewDashboardInfo(request);
+      const response = await userController.rememberUserHasSeenNewDashboardInfo(request, hFake, { userSerializer });
 
       // then
       expect(response).to.be.equal('ok');
@@ -411,7 +428,6 @@ describe('Unit | Controller | user-controller', function () {
 
     beforeEach(function () {
       sinon.stub(usecases, 'rememberUserHasSeenChallengeTooltip');
-      sinon.stub(userSerializer, 'serialize');
     });
 
     it('should remember user has seen focused challenge tooltip', async function () {
@@ -426,7 +442,7 @@ describe('Unit | Controller | user-controller', function () {
       userSerializer.serialize.withArgs({}).returns('ok');
 
       // when
-      const response = await userController.rememberUserHasSeenChallengeTooltip(request);
+      const response = await userController.rememberUserHasSeenChallengeTooltip(request, hFake, { userSerializer });
 
       // then
       expect(response).to.be.equal('ok');
@@ -444,7 +460,7 @@ describe('Unit | Controller | user-controller', function () {
       userSerializer.serialize.withArgs({}).returns('ok');
 
       // when
-      const response = await userController.rememberUserHasSeenChallengeTooltip(request);
+      const response = await userController.rememberUserHasSeenChallengeTooltip(request, hFake, { userSerializer });
 
       // then
       expect(response).to.be.equal('ok');
@@ -457,38 +473,40 @@ describe('Unit | Controller | user-controller', function () {
       const request = { auth: { credentials: { userId: 1 } } };
       const currentUser = Symbol('current-user');
       const getCurrentUserStub = sinon.stub(usecases, 'getCurrentUser');
-      const userWithActivitySerializerStub = sinon.stub(userWithActivitySerializer, 'serialize');
+      const userWithActivitySerializer = { serialize: sinon.stub() };
 
       usecases.getCurrentUser.withArgs({ authenticatedUserId: 1 }).resolves(currentUser);
       userWithActivitySerializer.serialize.withArgs(currentUser).returns('ok');
 
       // when
-      const response = await userController.getCurrentUser(request);
+      const response = await userController.getCurrentUser(request, hFake, { userWithActivitySerializer });
 
       // then
       expect(response).to.be.equal('ok');
       expect(getCurrentUserStub).to.have.been.calledWithExactly({ authenticatedUserId: 1 });
-      expect(userWithActivitySerializerStub).to.have.been.calledWithExactly(currentUser);
+      expect(userWithActivitySerializer.serialize).to.have.been.calledWithExactly(currentUser);
     });
   });
 
   describe('#getUserDetailsForAdmin', function () {
     let request;
+    let dependencies;
 
     beforeEach(function () {
       request = { params: { id: 123 } };
 
       sinon.stub(usecases, 'getUserDetailsForAdmin');
-      sinon.stub(userDetailsForAdminSerializer, 'serialize');
+      const userDetailsForAdminSerializer = { serialize: sinon.stub() };
+      dependencies = { userDetailsForAdminSerializer };
     });
 
     it('should get the specified user for admin context', async function () {
       // given
       usecases.getUserDetailsForAdmin.withArgs({ userId: 123 }).resolves('userDetail');
-      userDetailsForAdminSerializer.serialize.withArgs('userDetail').returns('ok');
+      dependencies.userDetailsForAdminSerializer.serialize.withArgs('userDetail').returns('ok');
 
       // when
-      const response = await userController.getUserDetailsForAdmin(request);
+      const response = await userController.getUserDetailsForAdmin(request, hFake, dependencies);
 
       // then
       expect(response).to.be.equal('ok');
@@ -496,25 +514,31 @@ describe('Unit | Controller | user-controller', function () {
   });
 
   describe('#findPaginatedFilteredUsers', function () {
+    let dependencies;
+
     beforeEach(function () {
-      sinon.stub(queryParamsUtils, 'extractParameters');
       sinon.stub(usecases, 'findPaginatedFilteredUsers');
-      sinon.stub(userForAdminSerializer, 'serialize');
+      const queryParamsUtils = { extractParameters: sinon.stub() };
+      const userForAdminSerializer = { serialize: sinon.stub() };
+      dependencies = {
+        queryParamsUtils,
+        userForAdminSerializer,
+      };
     });
 
     it('should return a list of JSON API users fetched from the data repository', async function () {
       // given
       const request = { query: {} };
-      queryParamsUtils.extractParameters.withArgs({}).returns({});
+      dependencies.queryParamsUtils.extractParameters.withArgs({}).returns({});
       usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
-      userForAdminSerializer.serialize.returns({ data: {}, meta: {} });
+      dependencies.userForAdminSerializer.serialize.returns({ data: {}, meta: {} });
 
       // when
-      await userController.findPaginatedFilteredUsers(request, hFake);
+      await userController.findPaginatedFilteredUsers(request, hFake, dependencies);
 
       // then
       expect(usecases.findPaginatedFilteredUsers).to.have.been.calledOnce;
-      expect(userForAdminSerializer.serialize).to.have.been.calledOnce;
+      expect(dependencies.userForAdminSerializer.serialize).to.have.been.calledOnce;
     });
 
     it('should return a JSON API response with pagination information', async function () {
@@ -522,25 +546,28 @@ describe('Unit | Controller | user-controller', function () {
       const request = { query: {} };
       const expectedResults = [new User({ id: 1 }), new User({ id: 2 }), new User({ id: 3 })];
       const expectedPagination = { page: 2, pageSize: 25, itemsCount: 100, pagesCount: 4 };
-      queryParamsUtils.extractParameters.withArgs({}).returns({});
+      dependencies.queryParamsUtils.extractParameters.withArgs({}).returns({});
       usecases.findPaginatedFilteredUsers.resolves({ models: expectedResults, pagination: expectedPagination });
 
       // when
-      await userController.findPaginatedFilteredUsers(request, hFake);
+      await userController.findPaginatedFilteredUsers(request, hFake, dependencies);
 
       // then
-      expect(userForAdminSerializer.serialize).to.have.been.calledWithExactly(expectedResults, expectedPagination);
+      expect(dependencies.userForAdminSerializer.serialize).to.have.been.calledWithExactly(
+        expectedResults,
+        expectedPagination
+      );
     });
 
     it('should allow to filter users by first name', async function () {
       // given
       const query = { filter: { firstName: 'Alexia' }, page: {} };
       const request = { query };
-      queryParamsUtils.extractParameters.withArgs(query).returns(query);
+      dependencies.queryParamsUtils.extractParameters.withArgs(query).returns(query);
       usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
 
       // when
-      await userController.findPaginatedFilteredUsers(request, hFake);
+      await userController.findPaginatedFilteredUsers(request, hFake, dependencies);
 
       // then
       expect(usecases.findPaginatedFilteredUsers).to.have.been.calledWithMatch(query);
@@ -550,11 +577,11 @@ describe('Unit | Controller | user-controller', function () {
       // given
       const query = { filter: { lastName: 'Granjean' }, page: {} };
       const request = { query };
-      queryParamsUtils.extractParameters.withArgs(query).returns(query);
+      dependencies.queryParamsUtils.extractParameters.withArgs(query).returns(query);
       usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
 
       // when
-      await userController.findPaginatedFilteredUsers(request, hFake);
+      await userController.findPaginatedFilteredUsers(request, hFake, dependencies);
 
       // then
       expect(usecases.findPaginatedFilteredUsers).to.have.been.calledWithMatch(query);
@@ -564,11 +591,11 @@ describe('Unit | Controller | user-controller', function () {
       // given
       const query = { filter: { email: 'alexiagranjean' }, page: {} };
       const request = { query };
-      queryParamsUtils.extractParameters.withArgs(query).returns(query);
+      dependencies.queryParamsUtils.extractParameters.withArgs(query).returns(query);
       usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
 
       // when
-      await userController.findPaginatedFilteredUsers(request, hFake);
+      await userController.findPaginatedFilteredUsers(request, hFake, dependencies);
 
       // then
       expect(usecases.findPaginatedFilteredUsers).to.have.been.calledWithMatch(query);
@@ -578,11 +605,11 @@ describe('Unit | Controller | user-controller', function () {
       // given
       const query = { filter: { email: 'alexiagranjean' }, page: { number: 2, size: 25 } };
       const request = { query };
-      queryParamsUtils.extractParameters.withArgs(query).returns(query);
+      dependencies.queryParamsUtils.extractParameters.withArgs(query).returns(query);
       usecases.findPaginatedFilteredUsers.resolves({ models: {}, pagination: {} });
 
       // when
-      await userController.findPaginatedFilteredUsers(request, hFake);
+      await userController.findPaginatedFilteredUsers(request, hFake, dependencies);
 
       // then
       expect(usecases.findPaginatedFilteredUsers).to.have.been.calledWithMatch(query);
@@ -607,13 +634,21 @@ describe('Unit | Controller | user-controller', function () {
       const expectedResult = Symbol('serialized-trainings');
       const userRecommendedTrainings = Symbol('userRecommendedTrainings');
       const meta = Symbol('meta');
-      sinon.stub(requestResponseUtils, 'extractLocaleFromRequest').withArgs(request).returns(locale);
-      sinon.stub(queryParamsUtils, 'extractParameters').withArgs(query).returns({ page });
+      const queryParamsUtils = { extractParameters: sinon.stub() };
+      queryParamsUtils.extractParameters.withArgs(query).returns({ page });
+      const requestResponseUtils = { extractLocaleFromRequest: sinon.stub() };
+      requestResponseUtils.extractLocaleFromRequest.withArgs(request).returns(locale);
       sinon.stub(usecases, 'findPaginatedUserRecommendedTrainings').resolves({ userRecommendedTrainings, meta });
-      sinon.stub(trainingSerializer, 'serialize').returns(expectedResult);
+      const trainingSerializer = { serialize: sinon.stub() };
+      trainingSerializer.serialize.returns(expectedResult);
 
       // when
-      const response = await userController.findPaginatedUserRecommendedTrainings(request);
+      const response = await userController.findPaginatedUserRecommendedTrainings(request, hFake, {
+        queryParamsUtils,
+        requestResponseUtils,
+        usecases,
+        trainingSerializer,
+      });
 
       // then
       expect(queryParamsUtils.extractParameters).to.have.been.calledOnce;
@@ -644,17 +679,19 @@ describe('Unit | Controller | user-controller', function () {
     };
 
     beforeEach(function () {
-      sinon.stub(campaignParticipationSerializer, 'serialize');
       sinon.stub(usecases, 'findLatestOngoingUserCampaignParticipations');
     });
 
     it('should return serialized campaignParticipations', async function () {
       // given
+      const campaignParticipationSerializer = { serialize: sinon.stub() };
       usecases.findLatestOngoingUserCampaignParticipations.withArgs({ userId }).resolves([]);
       campaignParticipationSerializer.serialize.withArgs([]).returns({});
 
       // when
-      const response = await userController.getCampaignParticipations(request, hFake);
+      const response = await userController.getCampaignParticipations(request, hFake, {
+        campaignParticipationSerializer,
+      });
 
       // then
       expect(response).to.deep.equal({});
@@ -663,11 +700,18 @@ describe('Unit | Controller | user-controller', function () {
 
   describe('#getCampaignParticipationOverviews', function () {
     const userId = '1';
+    let dependencies;
 
     beforeEach(function () {
-      sinon.stub(campaignParticipationOverviewSerializer, 'serialize');
-      sinon.stub(campaignParticipationOverviewSerializer, 'serializeForPaginatedList');
+      const campaignParticipationOverviewSerializer = {
+        serialize: sinon.stub(),
+        serializeForPaginatedList: sinon.stub(),
+      };
       sinon.stub(usecases, 'findUserCampaignParticipationOverviews');
+      dependencies = {
+        campaignParticipationOverviewSerializer,
+        queryParamsUtils,
+      };
     });
 
     it('should return serialized campaignParticipationOverviews', async function () {
@@ -683,18 +727,18 @@ describe('Unit | Controller | user-controller', function () {
         },
       };
       usecases.findUserCampaignParticipationOverviews.withArgs({ userId, states: undefined, page: {} }).resolves([]);
-      campaignParticipationOverviewSerializer.serializeForPaginatedList.withArgs([]).returns({
+      dependencies.campaignParticipationOverviewSerializer.serializeForPaginatedList.withArgs([]).returns({
         id: 'campaignParticipationOverviews',
       });
 
       // when
-      const response = await userController.getCampaignParticipationOverviews(request, hFake);
+      const response = await userController.getCampaignParticipationOverviews(request, hFake, dependencies);
 
       // then
       expect(response).to.deep.equal({
         id: 'campaignParticipationOverviews',
       });
-      expect(campaignParticipationOverviewSerializer.serializeForPaginatedList).to.have.been.calledOnce;
+      expect(dependencies.campaignParticipationOverviewSerializer.serializeForPaginatedList).to.have.been.calledOnce;
     });
 
     it('should forward state and page query parameters', async function () {
@@ -713,18 +757,18 @@ describe('Unit | Controller | user-controller', function () {
       usecases.findUserCampaignParticipationOverviews
         .withArgs({ userId, states: 'ONGOING', page: { number: 1, size: 10 } })
         .resolves([]);
-      campaignParticipationOverviewSerializer.serializeForPaginatedList.withArgs([]).returns({
+      dependencies.campaignParticipationOverviewSerializer.serializeForPaginatedList.withArgs([]).returns({
         id: 'campaignParticipationOverviews',
       });
 
       // when
-      const response = await userController.getCampaignParticipationOverviews(request, hFake);
+      const response = await userController.getCampaignParticipationOverviews(request, hFake, dependencies);
 
       // then
       expect(response).to.deep.equal({
         id: 'campaignParticipationOverviews',
       });
-      expect(campaignParticipationOverviewSerializer.serializeForPaginatedList).to.have.been.calledOnce;
+      expect(dependencies.campaignParticipationOverviewSerializer.serializeForPaginatedList).to.have.been.calledOnce;
     });
   });
 
@@ -771,11 +815,12 @@ describe('Unit | Controller | user-controller', function () {
         pixScore: 3,
         scorecards: [],
       });
-      sinon.stub(profileSerializer, 'serialize').resolves();
     });
 
     it('should call the expected usecase', async function () {
       // given
+      const profileSerializer = { serialize: sinon.stub() };
+      profileSerializer.serialize.resolves();
       const userId = '12';
       const locale = 'fr';
 
@@ -792,7 +837,7 @@ describe('Unit | Controller | user-controller', function () {
       };
 
       // when
-      await userController.getProfile(request);
+      await userController.getProfile(request, hFake, { profileSerializer, requestResponseUtils });
 
       // then
       expect(usecases.getUserProfile).to.have.been.calledWith({ userId, locale });
@@ -805,11 +850,12 @@ describe('Unit | Controller | user-controller', function () {
         pixScore: 3,
         scorecards: [],
       });
-      sinon.stub(profileSerializer, 'serialize').resolves();
     });
 
     it('should call the expected usecase', async function () {
       // given
+      const profileSerializer = { serialize: sinon.stub() };
+      profileSerializer.serialize.resolves();
       const userId = '12';
       const locale = 'fr';
 
@@ -821,7 +867,7 @@ describe('Unit | Controller | user-controller', function () {
       };
 
       // when
-      await userController.getProfileForAdmin(request);
+      await userController.getProfileForAdmin(request, hFake, { profileSerializer, requestResponseUtils });
 
       // then
       expect(usecases.getUserProfile).to.have.been.calledWith({ userId, locale });
@@ -833,11 +879,12 @@ describe('Unit | Controller | user-controller', function () {
       sinon.stub(usecases, 'resetScorecard').resolves({
         name: 'Comp1',
       });
-      sinon.stub(scorecardSerializer, 'serialize').resolves();
     });
 
     it('should call the expected usecase', async function () {
       // given
+      const scorecardSerializer = { serialize: sinon.stub() };
+      scorecardSerializer.serialize.resolves();
       const userId = '12';
       const competenceId = '875432';
       const locale = 'fr-fr';
@@ -855,7 +902,7 @@ describe('Unit | Controller | user-controller', function () {
       };
 
       // when
-      await userController.resetScorecard(request);
+      await userController.resetScorecard(request, hFake, { scorecardSerializer, requestResponseUtils });
 
       // then
       expect(usecases.resetScorecard).to.have.been.calledWith({ userId, competenceId, locale });
@@ -863,39 +910,33 @@ describe('Unit | Controller | user-controller', function () {
   });
 
   describe('#getUserCampaignParticipationToCampaign', function () {
-    const userId = 789;
-    const campaignId = 456;
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const campaignParticipation = Symbol('campaign participation');
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line mocha/no-setup-in-describe
-    const expectedCampaignParticipation = Symbol('expected campaign participation');
-
-    const request = {
-      auth: {
-        credentials: {
-          userId,
-        },
-      },
-      params: {
-        userId,
-        campaignId,
-      },
-    };
-
-    beforeEach(function () {
-      sinon.stub(campaignParticipationSerializer, 'serialize');
-      sinon.stub(usecases, 'getUserCampaignParticipationToCampaign');
-    });
-
     it('should return serialized campaign participation', async function () {
       // given
+      const userId = 789;
+      const campaignId = 456;
+      const campaignParticipation = Symbol('campaign participation');
+      const expectedCampaignParticipation = Symbol('expected campaign participation');
+
+      const request = {
+        auth: {
+          credentials: {
+            userId,
+          },
+        },
+        params: {
+          userId,
+          campaignId,
+        },
+      };
+      const campaignParticipationSerializer = { serialize: sinon.stub() };
+      sinon.stub(usecases, 'getUserCampaignParticipationToCampaign');
       usecases.getUserCampaignParticipationToCampaign.withArgs({ userId, campaignId }).resolves(campaignParticipation);
       campaignParticipationSerializer.serialize.withArgs(campaignParticipation).returns(expectedCampaignParticipation);
 
       // when
-      const response = await userController.getUserCampaignParticipationToCampaign(request, hFake);
+      const response = await userController.getUserCampaignParticipationToCampaign(request, hFake, {
+        campaignParticipationSerializer,
+      });
 
       // then
       expect(response).to.equal(expectedCampaignParticipation);
@@ -910,7 +951,8 @@ describe('Unit | Controller | user-controller', function () {
       const anonymizedUserSerialized = Symbol('anonymizedUserSerialized');
       const userDetailsForAdmin = Symbol('userDetailsForAdmin');
       sinon.stub(usecases, 'anonymizeUser').resolves(userDetailsForAdmin);
-      sinon.stub(userAnonymizedDetailsForAdminSerializer, 'serialize').returns(anonymizedUserSerialized);
+      const userAnonymizedDetailsForAdminSerializer = { serialize: sinon.stub() };
+      userAnonymizedDetailsForAdminSerializer.serialize.returns(anonymizedUserSerialized);
 
       // when
       const response = await userController.anonymizeUser(
@@ -918,7 +960,8 @@ describe('Unit | Controller | user-controller', function () {
           auth: { credentials: { userId: updatedByUserId } },
           params: { id: userId },
         },
-        hFake
+        hFake,
+        { userAnonymizedDetailsForAdminSerializer }
       );
 
       // then
@@ -985,7 +1028,7 @@ describe('Unit | Controller | user-controller', function () {
 
       const responseSerialized = Symbol('an response serialized');
       sinon.stub(usecases, 'updateUserEmailWithValidation');
-      sinon.stub(updateEmailSerializer, 'serialize');
+      const updateEmailSerializer = { serialize: sinon.stub() };
 
       usecases.updateUserEmailWithValidation.withArgs({ code, userId }).resolves(updatedEmail);
       updateEmailSerializer.serialize.withArgs(updatedEmail).returns(responseSerialized);
@@ -1010,7 +1053,7 @@ describe('Unit | Controller | user-controller', function () {
       };
 
       // when
-      const response = await userController.updateUserEmailWithValidation(request);
+      const response = await userController.updateUserEmailWithValidation(request, hFake, { updateEmailSerializer });
 
       // then
       expect(usecases.updateUserEmailWithValidation).to.have.been.calledWith({
@@ -1031,7 +1074,7 @@ describe('Unit | Controller | user-controller', function () {
 
       const responseSerialized = Symbol('an response serialized');
       sinon.stub(usecases, 'findUserAuthenticationMethods');
-      sinon.stub(authenticationMethodsSerializer, 'serialize');
+      const authenticationMethodsSerializer = { serialize: sinon.stub() };
 
       usecases.findUserAuthenticationMethods.withArgs({ userId: user.id }).resolves(authenticationMethods);
       authenticationMethodsSerializer.serialize.withArgs(authenticationMethods).returns(responseSerialized);
@@ -1048,7 +1091,9 @@ describe('Unit | Controller | user-controller', function () {
       };
 
       // when
-      const response = await userController.getUserAuthenticationMethods(request);
+      const response = await userController.getUserAuthenticationMethods(request, hFake, {
+        authenticationMethodsSerializer,
+      });
 
       // then
       expect(response).to.deep.equal(responseSerialized);
@@ -1066,7 +1111,8 @@ describe('Unit | Controller | user-controller', function () {
         .stub(usecases, 'addPixAuthenticationMethodByEmail')
         .withArgs({ userId: user.id, email: 'user@example.net' })
         .resolves(updatedUser);
-      sinon.stub(userDetailsForAdminSerializer, 'serialize').withArgs(updatedUser).returns(updatedUserSerialized);
+      const userDetailsForAdminSerializer = { serialize: sinon.stub() };
+      userDetailsForAdminSerializer.serialize.withArgs(updatedUser).returns(updatedUserSerialized);
 
       // when
       const request = {
@@ -1086,7 +1132,9 @@ describe('Unit | Controller | user-controller', function () {
           },
         },
       };
-      const result = await userController.addPixAuthenticationMethodByEmail(request, hFake);
+      const result = await userController.addPixAuthenticationMethodByEmail(request, hFake, {
+        userDetailsForAdminSerializer,
+      });
 
       // then
       expect(result.source).to.be.equal(updatedUserSerialized);
@@ -1144,8 +1192,8 @@ describe('Unit | Controller | user-controller', function () {
       const organizationMemberships = [new UserOrganizationForAdmin()];
       const organizationMembershipsSerialized = Symbol('an array of user’s organization memberships serialized');
 
-      sinon
-        .stub(userOrganizationForAdminSerializer, 'serialize')
+      const userOrganizationForAdminSerializer = { serialize: sinon.stub() };
+      userOrganizationForAdminSerializer.serialize
         .withArgs(organizationMemberships)
         .returns(organizationMembershipsSerialized);
 
@@ -1157,7 +1205,7 @@ describe('Unit | Controller | user-controller', function () {
           id: 1,
         },
       };
-      await userController.findUserOrganizationsForAdmin(request, hFake);
+      await userController.findUserOrganizationsForAdmin(request, hFake, { userOrganizationForAdminSerializer });
 
       // then
       expect(usecases.findUserOrganizationsForAdmin).to.have.been.calledWith({ userId: 1 });
@@ -1172,8 +1220,8 @@ describe('Unit | Controller | user-controller', function () {
         "a list of user's certification center memberships serialized"
       );
 
-      sinon
-        .stub(certificationCenterMembershipSerializer, 'serializeForAdmin')
+      const certificationCenterMembershipSerializer = { serializeForAdmin: sinon.stub() };
+      certificationCenterMembershipSerializer.serializeForAdmin
         .withArgs(certificationCenterMemberships)
         .returns(certificationCenterMembershipsSerialized);
 
@@ -1188,7 +1236,9 @@ describe('Unit | Controller | user-controller', function () {
           id: 12345,
         },
       };
-      const result = await userController.findCertificationCenterMembershipsByUser(request, hFake);
+      const result = await userController.findCertificationCenterMembershipsByUser(request, hFake, {
+        certificationCenterMembershipSerializer,
+      });
 
       // then
       expect(result.source).to.equal(certificationCenterMembershipsSerialized);
@@ -1200,14 +1250,18 @@ describe('Unit | Controller | user-controller', function () {
       // given
       sinon.stub(usecases, 'rememberUserHasSeenLastDataProtectionPolicyInformation');
       usecases.rememberUserHasSeenLastDataProtectionPolicyInformation.withArgs({ userId: 1 }).resolves({});
-      sinon.stub(userSerializer, 'serialize');
+      const userSerializer = { serialize: sinon.stub() };
       userSerializer.serialize.withArgs({}).returns('ok');
 
       // when
-      const response = await userController.rememberUserHasSeenLastDataProtectionPolicyInformation({
-        auth: { credentials: { userId: 1 } },
-        params: { id: 1 },
-      });
+      const response = await userController.rememberUserHasSeenLastDataProtectionPolicyInformation(
+        {
+          auth: { credentials: { userId: 1 } },
+          params: { id: 1 },
+        },
+        hFake,
+        { userSerializer }
+      );
 
       // then
       expect(response).to.be.equal('ok');


### PR DESCRIPTION
## :unicorn: Problème
Suite de #5978

Le passage des modules en ESM est bloqué par nos stub de dépendances. Pour régler cela nous devons injecter les dépendances.

## :robot: Proposition
Comme convenu au tech time, nous injectons les dépendances via un 3 arguments `dependencies`.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- CI OK
- Effectuer des tests des routes

