### PR TITLE
[BUGFIX] Remplacement de mot dans le nom de ville alternatif (PIX-7734)

### DIFF
--- a/api/scripts/certification/import-certification-cpf-cities.js
+++ b/api/scripts/certification/import-certification-cpf-cities.js
@@ -337,29 +337,41 @@ function buildCities({ csvData }) {
   const citiesWithAlternates = csvData.flatMap((data) => {
     const result = [];
 
-    result.push({
-      name: data[headers.cityName],
+    const codes = {
       postalCode: data[headers.postalCode],
       INSEECode: data[headers.inseeCode],
-      isActualName: true,
-    });
+    };
 
-    if (data[headers.cityAlternateName]) {
-      result.push({
-        name: data[headers.cityAlternateName],
-        postalCode: data[headers.postalCode],
-        INSEECode: data[headers.inseeCode],
-        isActualName: false,
-      });
-    }
+    // Generate cities for current city names
+    result.push({
+      name: data[headers.cityName],
+      isActualName: true,
+      ...codes,
+    });
 
     if (_doesCityNameContainWordToReplace(data[headers.cityName])) {
       result.push({
         name: _buildCityNameWithWordReplaced(data[headers.cityName]),
-        postalCode: data[headers.postalCode],
-        INSEECode: data[headers.inseeCode],
         isActualName: false,
+        ...codes,
       });
+    }
+
+    // Generate cities for current alternate city names
+    if (data[headers.cityAlternateName]) {
+      result.push({
+        name: data[headers.cityAlternateName],
+        isActualName: false,
+        ...codes,
+      });
+
+      if (_doesCityNameContainWordToReplace(data[headers.cityAlternateName])) {
+        result.push({
+          name: _buildCityNameWithWordReplaced(data[headers.cityAlternateName]),
+          isActualName: false,
+          ...codes,
+        });
+      }
     }
 
     return result;

--- a/api/tests/unit/scripts/import-certification-cpf-cities_test.js
+++ b/api/tests/unit/scripts/import-certification-cpf-cities_test.js
@@ -24,7 +24,7 @@ describe('Unit | Scripts | import-certification-cpf-cities.js', function () {
             code_commune_insee: '44184',
             nom_de_la_commune: 'NAZAIRE',
             code_postal: '44600',
-            ligne_5: 'ST MARC SUR MER',
+            ligne_5: 'ALTERNATE NAZAIRE',
           },
           {
             code_commune_insee: '66186',
@@ -60,7 +60,7 @@ describe('Unit | Scripts | import-certification-cpf-cities.js', function () {
           {
             INSEECode: '44184',
             isActualName: false,
-            name: 'ST MARC SUR MER',
+            name: 'ALTERNATE NAZAIRE',
             postalCode: '44600',
           },
           {
@@ -70,6 +70,59 @@ describe('Unit | Scripts | import-certification-cpf-cities.js', function () {
             postalCode: '66570',
           },
         ]);
+      });
+
+      context('#when there is a word to replace in the city alternate name', function () {
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        [
+          {
+            cityName: 'DUNKERQUE',
+            cityAlternateName: 'ST POL SUR MER',
+            expectedCityAlternateName: 'SAINT POL SUR MER',
+          },
+          {
+            cityName: 'NEUSSARGUES EN PINATELLE',
+            cityAlternateName: 'STE ANASTASIE',
+            expectedCityAlternateName: 'SAINTE ANASTASIE',
+          },
+        ].forEach(({ cityName, cityAlternateName, expectedCityAlternateName }) => {
+          it('should return 3 lines,  for the city name and two both long and short alternate city names', function () {
+            // given
+            const csvData = [
+              {
+                code_commune_insee: '50453',
+                nom_de_la_commune: cityName,
+                code_postal: '50800',
+                ligne_5: cityAlternateName,
+              },
+            ];
+
+            // when
+            const cities = buildCities({ csvData });
+
+            // then
+            expect(cities).to.deep.equal([
+              {
+                INSEECode: '50453',
+                isActualName: true,
+                name: cityName,
+                postalCode: '50800',
+              },
+              {
+                INSEECode: '50453',
+                isActualName: false,
+                name: cityAlternateName,
+                postalCode: '50800',
+              },
+              {
+                INSEECode: '50453',
+                isActualName: false,
+                name: expectedCityAlternateName,
+                postalCode: '50800',
+              },
+            ]);
+          });
+        });
       });
     });
 
@@ -97,45 +150,45 @@ describe('Unit | Scripts | import-certification-cpf-cities.js', function () {
           },
         ]);
       });
-    });
 
-    describe('#when there is a word to replace in the city name', function () {
-      // eslint-disable-next-line mocha/no-setup-in-describe
-      [
-        { cityName: 'STE CECILE', expectedCityName: 'SAINTE CECILE' },
-        { cityName: 'ST NAZAIRE', expectedCityName: 'SAINT NAZAIRE' },
-        { cityName: 'NAZAIRE STE CECILE', expectedCityName: 'NAZAIRE SAINTE CECILE' },
-        { cityName: 'CECILE ST NAZAIRE', expectedCityName: 'CECILE SAINT NAZAIRE' },
-      ].forEach(({ cityName, expectedCityName }) => {
-        it('should return 2 lines with both long and short city names', function () {
-          // given
-          const csvData = [
-            {
-              code_commune_insee: '50453',
-              nom_de_la_commune: cityName,
-              code_postal: '50800',
-              ligne_5: null,
-            },
-          ];
+      context('#when there is a word to replace in the city name', function () {
+        // eslint-disable-next-line mocha/no-setup-in-describe
+        [
+          { cityName: 'STE CECILE', expectedCityName: 'SAINTE CECILE' },
+          { cityName: 'ST NAZAIRE', expectedCityName: 'SAINT NAZAIRE' },
+          { cityName: 'NAZAIRE STE CECILE', expectedCityName: 'NAZAIRE SAINTE CECILE' },
+          { cityName: 'CECILE ST NAZAIRE', expectedCityName: 'CECILE SAINT NAZAIRE' },
+        ].forEach(({ cityName, expectedCityName }) => {
+          it('should return 2 lines with both long and short city names', function () {
+            // given
+            const csvData = [
+              {
+                code_commune_insee: '50453',
+                nom_de_la_commune: cityName,
+                code_postal: '50800',
+                ligne_5: null,
+              },
+            ];
 
-          // when
-          const cities = buildCities({ csvData });
+            // when
+            const cities = buildCities({ csvData });
 
-          // then
-          expect(cities).to.deep.equal([
-            {
-              INSEECode: '50453',
-              isActualName: true,
-              name: cityName,
-              postalCode: '50800',
-            },
-            {
-              INSEECode: '50453',
-              isActualName: false,
-              name: expectedCityName,
-              postalCode: '50800',
-            },
-          ]);
+            // then
+            expect(cities).to.deep.equal([
+              {
+                INSEECode: '50453',
+                isActualName: true,
+                name: cityName,
+                postalCode: '50800',
+              },
+              {
+                INSEECode: '50453',
+                isActualName: false,
+                name: expectedCityName,
+                postalCode: '50800',
+              },
+            ]);
+          });
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème

Lors de l’inscription d’un candidat à une session de certification (qu’elle soit faite individuellement ou bien via la liste des candidats), le lieu de naissance doit être indiqué en remplissant les champs suivants :

code postal et nom de la commune de naissance

ou

code INSEE

Dans le cas où c’est le code postal et la commune de naissance qui sont renseignés, il faut qu’ils se correspondent.

Certaines villes peuvent s'écrire selon 2 orthographes (exemple : 59430 St Pol sur Mer ou Saint Pol sur Mer). 
Les deux écritures sont admises pour les noms actuels des villes.

Lorsque les communes ont changé de nom, les anciens noms qui ne correspondraient pas strictement à l’écriture dans le fichier de référence de la Poste ne sont pas reconnus (exemple : 59430 St Pol sur Mer est reconnu alors que Saint Pol sur Mer est rejeté avec une erreur).

## :robot: Proposition

Appliquer la fonction de remplacement pour le cas où la colonne `ligne_5` du fichier CSV (cityAlternateName) contient un acronyme `ST` ou `STE`.

## :rainbow: Remarques

Le resultat sur l'instance de RA montrant que le script corrige bien le problème remonté (il peut être comparé avec le résultat qui était dans la partie reproduction dans les commentaires du ticket JIRA pour visualiser la difference). 

```

pix_api_rev_1659=> SELECT id, "name", "postalCode", "INSEECode", "isActualName", "createdAt"
pix_api_rev_1659-> FROM public."certification-cpf-cities"
pix_api_rev_1659-> where "name" LIKE '%ST POL%' OR "name" like '%SAINT POL%'
pix_api_rev_1659-> order by id asc;
   id   |          name          | postalCode | INSEECode | isActualName |           createdAt           
--------+------------------------+------------+-----------+--------------+-------------------------------
 108928 | ST POL DE LEON         | 29250      | 29259     | t            | 2023-04-13 13:24:19.525432+00
 108929 | SAINT POL DE LEON      | 29250      | 29259     | f            | 2023-04-13 13:24:19.525432+00
 123681 | ST POLYCARPE           | 11300      | 11364     | t            | 2023-04-13 13:24:19.525432+00
 123682 | SAINT POLYCARPE        | 11300      | 11364     | f            | 2023-04-13 13:24:19.525432+00
 124648 | ST POL SUR MER         | 59430      | 59183     | f            | 2023-04-13 13:24:19.525432+00
 124649 | SAINT POL SUR MER      | 59430      | 59183     | f            | 2023-04-13 13:24:19.525432+00
 129641 | ST POL SUR TERNOISE    | 62130      | 62767     | t            | 2023-04-13 13:24:19.525432+00
 129642 | SAINT POL SUR TERNOISE | 62130      | 62767     | f            | 2023-04-13 13:24:19.525432+00
 141410 | ST POLGUES             | 42260      | 42274     | t            | 2023-04-13 13:24:19.525432+00
 141411 | SAINT POLGUES          | 42260      | 42274     | f            | 2023-04-13 13:24:19.525432+00
(10 rows)

```

Voici un exemple avec `STE` (le ticket contient un exemple avec `ST`)

```
code_commune_insee	nom_de_la_commune	code_postal	ligne_5	libelle_d_acheminement	coordonnees_gps	
15141	NEUSSARGUES EN PINATELLE	15170	STE ANASTASIE	NEUSSARGUES EN PINATELLE	45.150152022	2.942924918
```

## :100: Pour tester

Le script a été importé sur l'instance de RA. Pour tester il est possible donc de tenter de créer une inscription à une session de certification sur avec comme indication de nom de commune `Saint Pol sur Mer` ou `Sainte Anastasie`.
Si ce n'est pas rejeté, alors cela signifie que le bug est corrigé.
