### PR TITLE
[FEATURE] Visualiser si un CF est actif ou non depuis la liste sur Pix Admin (PIX-7741).

### DIFF
--- a/admin/app/components/trainings/list-summary-items.hbs
+++ b/admin/app/components/trainings/list-summary-items.hbs
@@ -6,6 +6,7 @@
         <tr>
           <th class="table__column table__column--id" id="training-id" scope="col">ID</th>
           <th id="training-titre" scope="col">Titre</th>
+          <th id="training-recommendable" scope="col" class="col-status">Statut</th>
         </tr>
         {{#if @triggerFiltering}}
           <tr>
@@ -40,6 +41,13 @@
                 <LinkTo @route="authenticated.trainings.training" @model={{summary.id}}>
                   {{summary.title}}
                 </LinkTo>
+              </td>
+              <td headers="training-recommendable">
+                {{#if this.isTrainingRecommendationEnabled}}
+                  {{if summary.isRecommendable "Actif" "Inactif"}}
+                {{else}}
+                  Actif
+                {{/if}}
               </td>
             </tr>
           {{/each}}

--- a/admin/app/components/trainings/list-summary-items.js
+++ b/admin/app/components/trainings/list-summary-items.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class ListSummaryItems extends Component {
+  @service featureToggles;
+
+  get isTrainingRecommendationEnabled() {
+    return this.featureToggles.featureToggles.isTrainingRecommendationEnabled;
+  }
+}

--- a/admin/app/models/feature-toggle.js
+++ b/admin/app/models/feature-toggle.js
@@ -1,3 +1,5 @@
-import Model from '@ember-data/model';
+import Model, { attr } from '@ember-data/model';
 
-export default class FeatureToggle extends Model {}
+export default class FeatureToggle extends Model {
+  @attr('boolean') isTrainingRecommendationEnabled;
+}

--- a/admin/app/models/training-summary.js
+++ b/admin/app/models/training-summary.js
@@ -2,4 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class TrainingSummary extends Model {
   @attr() title;
+  @attr('boolean') isRecommendable;
 }

--- a/admin/tests/acceptance/authenticated/trainings/list_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/list_test.js
@@ -35,9 +35,10 @@ module('Acceptance | Trainings | List', function (hooks) {
 
       test('it should list training summaries', async function (assert) {
         // given
+        server.create('feature-toggle', { id: 0, isTrainingRecommendationEnabled: true });
         server.createList('training-summary', 10);
-        server.create('training-summary', { id: 11, title: 'Formation 11' });
-        server.create('training-summary', { id: 12, title: 'Formation 12' });
+        server.create('training-summary', { id: 11, title: 'Formation 11', isRecommendable: false });
+        server.create('training-summary', { id: 12, title: 'Formation 12', isRecommendable: true });
 
         // when
         const screen = await visit('/trainings/list');
@@ -45,7 +46,29 @@ module('Acceptance | Trainings | List', function (hooks) {
 
         // then
         assert.dom(screen.getByText('Formation 11')).exists();
+        assert.dom(screen.getByText('Actif')).exists();
         assert.dom(screen.getByText('Formation 12')).exists();
+        assert.dom(screen.getByText('Inactif')).exists();
+      });
+
+      module('when training recommendation feature toggle is disabled', function () {
+        test('it should list training summaries', async function (assert) {
+          // given
+          server.create('feature-toggle', { id: 0, isTrainingRecommendationEnabled: false });
+          server.createList('training-summary', 10);
+          server.create('training-summary', { id: 11, title: 'Formation 11', isRecommendable: false });
+          server.create('training-summary', { id: 12, title: 'Formation 12', isRecommendable: true });
+
+          // when
+          const screen = await visit('/trainings/list');
+          await click(screen.getByRole('button', { name: 'Aller à la page suivante' }));
+
+          // then
+          assert.dom(screen.getByText('Formation 11')).exists();
+          assert.strictEqual(screen.queryAllByText('Actif').length, 2);
+          assert.dom(screen.getByText('Formation 12')).exists();
+          assert.dom(screen.queryByText('Inactif')).doesNotExist();
+        });
       });
 
       module('when filters are used', function (hooks) {

--- a/admin/tests/integration/components/routes/authenticated/trainings/list-items_test.js
+++ b/admin/tests/integration/components/routes/authenticated/trainings/list-items_test.js
@@ -11,6 +11,12 @@ module('Integration | Component | routes/authenticated/trainings | list-items', 
   });
 
   test('it should display header with id and title', async function (assert) {
+    // given
+    const featureToggles = this.owner.lookup('service:feature-toggles');
+    featureToggles.featureToggles = {
+      isTrainingRecommendationEnabled: true,
+    };
+
     // when
     const screen = await render(hbs`<Trainings::ListSummaryItems @triggerFiltering={{this.noop}} />`);
 
@@ -21,6 +27,10 @@ module('Integration | Component | routes/authenticated/trainings | list-items', 
 
   test('it should display trainings summaries list', async function (assert) {
     // given
+    const featureToggles = this.owner.lookup('service:feature-toggles');
+    featureToggles.featureToggles = {
+      isTrainingRecommendationEnabled: true,
+    };
     const summaries = [
       { id: 1, title: "Apprendre en s'amusant" },
       { id: 2, title: 'Speed training' },
@@ -41,6 +51,10 @@ module('Integration | Component | routes/authenticated/trainings | list-items', 
 
   test('it should display trainings summaries data', async function (assert) {
     // given
+    const featureToggles = this.owner.lookup('service:feature-toggles');
+    featureToggles.featureToggles = {
+      isTrainingRecommendationEnabled: true,
+    };
     const summaries = [{ id: 123, title: 'Comment toiletter son chien' }];
     summaries.meta = {
       pagination: { rowCount: 2 },

--- a/api/lib/domain/read-models/TrainingSummary.js
+++ b/api/lib/domain/read-models/TrainingSummary.js
@@ -1,7 +1,9 @@
 class TrainingSummary {
-  constructor({ id, title } = {}) {
+  constructor({ id, title, isRecommendable } = {}) {
     this.id = id;
     this.title = title;
+    this.isRecommendable = isRecommendable;
   }
 }
+
 module.exports = TrainingSummary;

--- a/api/lib/infrastructure/serializers/jsonapi/training-summary-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/training-summary-serializer.js
@@ -3,7 +3,7 @@ const { Serializer } = require('jsonapi-serializer');
 module.exports = {
   serialize(trainingSummaries, meta) {
     return new Serializer('training-summaries', {
-      attributes: ['title'],
+      attributes: ['title', 'isRecommendable'],
       meta,
     }).serialize(trainingSummaries);
   },

--- a/api/tests/acceptance/application/target-profiles/index_test.js
+++ b/api/tests/acceptance/application/target-profiles/index_test.js
@@ -897,6 +897,7 @@ describe('Acceptance | Route | target-profiles', function () {
           id: training.id.toString(),
           attributes: {
             title: 'title',
+            'is-recommendable': undefined,
           },
         },
       ];

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -302,6 +302,7 @@ describe('Acceptance | Controller | training-controller', function () {
             id: '1',
             attributes: {
               title: training.title,
+              'is-recommendable': false,
             },
           },
         };
@@ -315,7 +316,7 @@ describe('Acceptance | Controller | training-controller', function () {
         expect(response.statusCode).to.equal(200);
         expect(response.result.data[0].type).to.deep.equal(expectedResponse.data.type);
         expect(response.result.data[0].id).to.exist;
-        expect(response.result.data[0].attributes.title).to.deep.equal(expectedResponse.data.attributes.title);
+        expect(response.result.data[0].attributes).to.deep.equal(expectedResponse.data.attributes);
         expect(response.result.meta.pagination).to.deep.equal(expectedPagination);
       });
     });

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -163,26 +163,29 @@ describe('Integration | Repository | training-repository', function () {
     context('when trainings exist', function () {
       it('should return paginated results', async function () {
         // given
-        const trainingSummary1 = domainBuilder.buildTrainingSummary({ id: 1 });
-        const trainingSummary2 = domainBuilder.buildTrainingSummary({ id: 2 });
+        const trainingSummary1 = domainBuilder.buildTrainingSummary({ id: 1, isRecommendable: true });
+        const trainingSummary2 = domainBuilder.buildTrainingSummary({ id: 2, isRecommendable: false });
         const trainingSummary3 = domainBuilder.buildTrainingSummary({ id: 3 });
 
         databaseBuilder.factory.buildTraining({ ...trainingSummary1 });
         databaseBuilder.factory.buildTraining({ ...trainingSummary2 });
         databaseBuilder.factory.buildTraining({ ...trainingSummary3 });
 
+        databaseBuilder.factory.buildTrainingTrigger({ trainingId: trainingSummary1.id });
+
         await databaseBuilder.commit();
         const filter = {};
-        const page = { size: 2, number: 2 };
+        const page = { size: 2, number: 1 };
 
         // when
         const { trainings, pagination } = await trainingRepository.findPaginatedSummaries({ filter, page });
 
         // then
-        expect(trainings).to.have.lengthOf(1);
+        expect(trainings).to.have.lengthOf(2);
         expect(trainings[0]).to.be.instanceOf(TrainingSummary);
-        expect(trainings[0]).to.deep.equal(trainingSummary3);
-        expect(pagination).to.deep.equal({ page: 2, pageSize: 2, rowCount: 3, pageCount: 2 });
+        expect(trainings[0]).to.deep.equal(trainingSummary1);
+        expect(trainings[1]).to.deep.equal(trainingSummary2);
+        expect(pagination).to.deep.equal({ page: 1, pageSize: 2, rowCount: 3, pageCount: 2 });
       });
 
       it('should return filtered by id result', async function () {
@@ -283,9 +286,9 @@ describe('Integration | Repository | training-repository', function () {
         // then
         expect(trainings).to.have.lengthOf(2);
         expect(trainings[0]).to.be.instanceOf(TrainingSummary);
-        expect(trainings[0]).to.deep.equal(trainingSummary1);
+        expect(trainings[0].title).to.deep.equal(trainingSummary1.title);
         expect(trainings[1]).to.be.instanceOf(TrainingSummary);
-        expect(trainings[1]).to.deep.equal(trainingSummary2);
+        expect(trainings[1].title).to.deep.equal(trainingSummary2.title);
         expect(pagination).to.deep.equal({ page: 1, pageSize: 2, rowCount: 2, pageCount: 1 });
       });
     });

--- a/api/tests/tooling/domain-builder/factory/build-training-summary.js
+++ b/api/tests/tooling/domain-builder/factory/build-training-summary.js
@@ -1,7 +1,7 @@
-const Training = require('../../../../lib/domain/read-models/TrainingSummary');
+const TrainingSummary = require('../../../../lib/domain/read-models/TrainingSummary');
 
 module.exports = function buildTrainingSummary({ id = 1, title = 'Training Summary 1' } = {}) {
-  return new Training({
+  return new TrainingSummary({
     id,
     title,
   });

--- a/api/tests/tooling/domain-builder/factory/build-training-summary.js
+++ b/api/tests/tooling/domain-builder/factory/build-training-summary.js
@@ -1,8 +1,9 @@
 const TrainingSummary = require('../../../../lib/domain/read-models/TrainingSummary');
 
-module.exports = function buildTrainingSummary({ id = 1, title = 'Training Summary 1' } = {}) {
+module.exports = function buildTrainingSummary({ id = 1, title = 'Training Summary 1', isRecommendable = false } = {}) {
   return new TrainingSummary({
     id,
     title,
+    isRecommendable,
   });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-summary-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-summary-serializer_test.js
@@ -6,7 +6,7 @@ describe('Unit | Serializer | JSONAPI | training-summary-serializer', function (
     it('should serialize training summaries to JSONAPI with meta data', function () {
       // given
       const trainingSummaries = [
-        domainBuilder.buildTrainingSummary({ id: 1, title: 'Training Summary 1' }),
+        domainBuilder.buildTrainingSummary({ id: 1, title: 'Training Summary 1', isRecommendable: true }),
         domainBuilder.buildTrainingSummary({ id: 2, title: 'Training Summary 2' }),
       ];
       const meta = { pagination: { page: 1, pageSize: 3, pageCount: 1, rowCount: 2 } };
@@ -22,6 +22,7 @@ describe('Unit | Serializer | JSONAPI | training-summary-serializer', function (
             id: '1',
             attributes: {
               title: 'Training Summary 1',
+              'is-recommendable': true,
             },
           },
           {
@@ -29,6 +30,7 @@ describe('Unit | Serializer | JSONAPI | training-summary-serializer', function (
             id: '2',
             attributes: {
               title: 'Training Summary 2',
+              'is-recommendable': false,
             },
           },
         ],


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le seul moyen de savoir qu’un CF sera recommandé c’est de regarder si il a des déclencheurs. Cependant, toutes les personnes du métier ne le savent pas. 

Nous souhaitons afficher clairement l’information si un CF sera recommandé ou non

## :robot: Proposition
Cette PR ajoute l'information au niveau de la liste des CF, d'autres PR se chargeront de l'ajouter à différents autres endroits.

Ce qui a été fait pour calculer ce nouveau champ `isRecommendable` c'est de renvoyer une colonne calculée en SQL : 
Nous l'avons fait de cette manière : 
```javascript
  const query = knexConn(TABLE_NAME)
    .select(
      'id',
      'title',
      knex.raw(
        '(CASE WHEN EXISTS (SELECT 1 FROM "training-triggers" WHERE "training-triggers"."trainingId" = trainings.id) THEN true ELSE false END) AS "isRecommendable"'
      )
    )
    .orderBy('id', 'asc');
```

Cette manière de faire permet d'effectuer une unique requête à la base et celle-ci nous retourne directement tous les bons champs.


## :rainbow: Remarques
Lorsque le FT est désactivé le statut est toujours "actif" car c'est le comportement actuel, nous proposons tous les CF associé au profil cible de la campagne.

Nous avons pris le partie de tester uniquement le champ title dans le test de la méthode `#findPaginatedSummariesByTargetProfileId` car nous allons faire la PR ensuite pour ajouter le champ et que ça simplifie la modification de code à faire. Nous avons fait de même avec le test d'acceptance en ajoutant le `undefined` pour les mêmes raisons.

Dans l'onglet "Contenus formatifs" d'un profil cible, tous les CF auront "Inactif" en attendant la prochaine PR.

## :100: Pour tester
- Se connecter sur Pix Admin 
- Aller dans l'onglet CF 
- Constater la nouvelle colonne "Statut" (Pour que cela soit lié aux déclencheurs il faut activer le FT `FT_TRAINING_RECOMMENDATION`) 