### PR TITLE
[FEATURE] Améliorer le design de l'entête des épreuves sur Pix-App (PIX-7715)

### DIFF
--- a/mon-pix/app/components/assessment-banner.hbs
+++ b/mon-pix/app/components/assessment-banner.hbs
@@ -1,8 +1,6 @@
-<div class="background-banner assessment-banner">
+<div class="assessment-banner">
   <header class="assessment-banner-container" role="banner">
-    <div class="assessment-banner__pix-logo">
-      <img src="/images/pix-logo-blanc.svg" alt="{{t 'common.pix'}}" />
-    </div>
+    <img class="assessment-banner__pix-logo" src="/images/pix-logo-blanc.svg" alt="{{t 'common.pix'}}" />
     {{#if @title}}
       <div class="assessment-banner__splitter"></div>
       <h1 class="assessment-banner__title"><span class="sr-only">{{t

--- a/mon-pix/app/components/progress-bar.hbs
+++ b/mon-pix/app/components/progress-bar.hbs
@@ -13,14 +13,16 @@
       {{/each}}
     </div>
 
-    <div class="progress-bar-background"></div>
+    <div class="progress-bar-content">
+      <div class="progress-bar-background"></div>
 
-    <div class="progress-bar-progression" style={{this.progressionWidth}}></div>
+      <div class="progress-bar-progression" style={{this.progressionWidth}}></div>
 
-    <div class="progress-bar-steps">
-      {{#each this.steps as |step|}}
-        <span class="progress-bar-step" style={{step.background}}></span>
-      {{/each}}
+      <div class="progress-bar-steps">
+        {{#each this.steps as |step|}}
+          <span class="progress-bar-step" style={{step.background}}></span>
+        {{/each}}
+      </div>
     </div>
   </div>
 {{else}}

--- a/mon-pix/app/styles/components/_assessment-banner.scss
+++ b/mon-pix/app/styles/components/_assessment-banner.scss
@@ -2,6 +2,11 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-around;
+  width: 100%;
+  min-height: 180px;
+  color: $pix-neutral-0;
+  background: $pix-primary-app-gradient;
+  box-shadow: 0 2px 8px 0 rgb(0 0 0 / 10%);
 }
 
 .assessment-banner-container {
@@ -9,19 +14,17 @@
   align-items: center;
   width: 100%;
   max-width: 990px;
-  min-height: 80px;
-  margin-top: 5px;
+  margin-top: $pix-spacing-m;
   padding: 0 10px;
 
   @include device-is('desktop') {
-    min-height: 100px;
     padding: 0;
   }
 }
 
 .assessment-banner__title {
   margin: 0;
-  font-size: 1.094rem;
+  font-size: 1rem;
 
   @include device-is('mobile') {
     position: absolute;
@@ -40,18 +43,18 @@
   }
 }
 
-.assessment-banner__pix-logo img {
-  height: 47px;
+.assessment-banner__pix-logo {
+  height: 24px;
 }
 
 .assessment-banner__splitter {
   width: 1px;
-  height: 40px;
+  height: 16px;
   margin: 0 10px;
   background: $pix-neutral-15;
 
   @include device-is('desktop') {
-    margin: 0 20px;
+    margin: 0 12px;
   }
 }
 

--- a/mon-pix/app/styles/components/_progress-bar.scss
+++ b/mon-pix/app/styles/components/_progress-bar.scss
@@ -4,16 +4,16 @@
 
 .progress-bar-container {
   position: relative;
-  margin-top: 15px;
-  margin-bottom: 50px;
+  margin-top: 12px;
+  margin-bottom: 40px;
 }
 
 .progress-bar-stepnums {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 10px;
+  margin-bottom: 7px;
   padding: 0 4px;
-  font-size: 0.938rem;
+  font-size: 1rem;
 }
 
 .progress-bar-stepnum {
@@ -26,8 +26,12 @@
   }
 }
 
+.progress-bar-content {
+  display: flex;
+  align-items: center;
+}
+
 .progress-bar-background {
-  position: absolute;
   width: 100%;
   height: 16px;
   background: rgb(0 0 0 / 20%);
@@ -63,7 +67,6 @@
 
   &__label {
     text-transform: uppercase;
-    opacity: 0.5;
   }
 
   &__value {

--- a/mon-pix/app/styles/pages/_challenge.scss
+++ b/mon-pix/app/styles/pages/_challenge.scss
@@ -42,7 +42,7 @@
 
   &__banner {
     width: 100%;
-    margin-bottom: 30px;
+    margin-bottom: 73px;
   }
 
   &__focused-out-overlay {


### PR DESCRIPTION
## :unicorn: Problème
L'entête des épreuves doit être améliorée pour une meilleure expérience utilisateur. De plus, il y avait des problèmes d'accessibilité au niveau du contraste du texte "QUESTION" en tablette/mobile.

## :robot: Proposition
Modifier le css : 
- De la taille de l'entête
- De la taille du logo 
- Des espacements padding/margin
- De l'opacité du texte "QUESTION" en tablette/mobile qui n'était pas accessible.

## :100: Pour tester
- Aller sur une épreuve et vérifier le nouveau design en desktop, tablette et mobile.
