### PR TITLE
[FEATURE] Ajout d'une migration pour creer les colonnes deletedAt & deletedBy sur la table organization-learners (PIX-7681).

### DIFF
--- a/api/db/migrations/20230413141704_add-deleted-on-organization-learners.js
+++ b/api/db/migrations/20230413141704_add-deleted-on-organization-learners.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'organization-learners';
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  await knex.schema.table(TABLE_NAME, function (table) {
+    table.dateTime('deletedAt').nullable();
+    table.bigInteger('deletedBy').index().references('users.id').nullable();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.table(TABLE_NAME, function (table) {
+    table.dropColumn('deletedAt');
+    table.dropColumn('deletedBy');
+  });
+};

--- a/api/lib/infrastructure/repositories/campaign-participation-info-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-info-repository.js
@@ -19,7 +19,7 @@ module.exports = {
           .from('campaign-participations')
           .join('assessments', 'campaign-participations.id', 'assessments.campaignParticipationId')
           .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
-          .where({ campaignId, isImproved: false, deletedAt: null });
+          .where({ campaignId, isImproved: false, 'campaign-participations.deletedAt': null });
       })
       .from('campaignParticipationWithUserAndRankedAssessment')
       .where({ rank: 1 });

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -64,7 +64,7 @@ module.exports = {
         'organization-learners.lastName',
       ])
       .join('organization-learners', 'organization-learners.id', 'campaign-participations.organizationLearnerId')
-      .where({ campaignId, isImproved: false, deletedAt: null });
+      .where({ campaignId, isImproved: false, 'campaign-participations.deletedAt': null });
 
     return results.map(_rowToResult);
   },


### PR DESCRIPTION
## :unicorn: Problème
Pour permettre de supprimer des prescrits tout en conservant des statistiques consolidées, nous avons retenu la solution avec “vue”. Il faut ajouter de nouvelles colonnes à la table des organization-learners en BDD pour pouvoir créer cette vue.

## :robot: Proposition
Ajouter les colonnes deletedAt et deletedBy dans table organization-learners.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Lancer les migrations sur les bdd pix et pix test, 
- ( Verifier aussi sur la bdd de la RA ) 
- Verifier que sur la table organization-learners les colonnes deletedAt & deletedBy existent bien
- 🎉 
