### PR TITLE
[TECH] Faire de l'injection de dépendance dans les controllers (part-5)

### DIFF
--- a/api/lib/application/organization-invitations/organization-invitation-controller.js
+++ b/api/lib/application/organization-invitations/organization-invitation-controller.js
@@ -4,7 +4,7 @@ const { MissingQueryParamError } = require('../http-errors.js');
 const usecases = require('../../domain/usecases/index.js');
 const organizationInvitationSerializer = require('../../infrastructure/serializers/jsonapi/organization-invitation-serializer.js');
 const scoOrganizationInvitationSerializer = require('../../infrastructure/serializers/jsonapi/sco-organization-invitation-serializer.js');
-const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils.js');
+const requestResponseUtils = require('../../infrastructure/utils/request-response-utils.js');
 
 module.exports = {
   async acceptOrganizationInvitation(request) {
@@ -23,17 +23,17 @@ module.exports = {
     return null;
   },
 
-  async sendScoInvitation(request, h) {
+  async sendScoInvitation(request, h, dependencies = { requestResponseUtils, scoOrganizationInvitationSerializer }) {
     const { uai, 'first-name': firstName, 'last-name': lastName } = request.payload.data.attributes;
 
-    const locale = extractLocaleFromRequest(request);
+    const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
 
     const organizationScoInvitation = await usecases.sendScoInvitation({ uai, firstName, lastName, locale });
 
-    return h.response(scoOrganizationInvitationSerializer.serialize(organizationScoInvitation)).created();
+    return h.response(dependencies.scoOrganizationInvitationSerializer.serialize(organizationScoInvitation)).created();
   },
 
-  async getOrganizationInvitation(request) {
+  async getOrganizationInvitation(request, h, dependencies = { organizationInvitationSerializer }) {
     const organizationInvitationId = request.params.id;
     const organizationInvitationCode = request.query.code;
 
@@ -45,6 +45,6 @@ module.exports = {
       organizationInvitationId,
       organizationInvitationCode,
     });
-    return organizationInvitationSerializer.serialize(organizationInvitation);
+    return dependencies.organizationInvitationSerializer.serialize(organizationInvitation);
   },
 };

--- a/api/lib/application/organization-learners/organization-learner-controller.js
+++ b/api/lib/application/organization-learners/organization-learner-controller.js
@@ -10,7 +10,7 @@ module.exports = {
     return h.response().code(204);
   },
 
-  async findAssociation(request, h) {
+  async findAssociation(request, h, dependencies = { organizationLearnerIdentitySerializer }) {
     const authenticatedUserId = request.auth.credentials.userId;
     // eslint-disable-next-line no-restricted-syntax
     const requestedUserId = parseInt(request.query.userId);
@@ -22,18 +22,18 @@ module.exports = {
       campaignCode,
     });
 
-    return h.response(organizationLearnerIdentitySerializer.serialize(organizationLearner)).code(200);
+    return h.response(dependencies.organizationLearnerIdentitySerializer.serialize(organizationLearner)).code(200);
   },
 
-  async getActivity(request, h) {
+  async getActivity(request, h, dependencies = { organizationLearnerActivitySerializer }) {
     const organizationLearnerId = request.params.id;
     const activity = await usecases.getOrganizationLearnerActivity({ organizationLearnerId });
-    return h.response(organizationLearnerActivitySerializer.serialize(activity)).code(200);
+    return h.response(dependencies.organizationLearnerActivitySerializer.serialize(activity)).code(200);
   },
 
-  async getLearner(request, h) {
+  async getLearner(request, h, dependencies = { organizationLearnerSerializer }) {
     const organizationLearnerId = request.params.id;
     const learner = await usecases.getOrganizationLearner({ organizationLearnerId });
-    return h.response(organizationLearnerSerializer.serialize(learner)).code(200);
+    return h.response(dependencies.organizationLearnerSerializer.serialize(learner)).code(200);
   },
 };

--- a/api/lib/application/prescribers/prescriber-controller.js
+++ b/api/lib/application/prescribers/prescriber-controller.js
@@ -3,11 +3,11 @@ const prescriberSerializer = require('../../infrastructure/serializers/jsonapi/p
 const usecases = require('../../domain/usecases/index.js');
 
 module.exports = {
-  get(request) {
+  get(request, h, dependencies = { prescriberSerializer }) {
     const authenticatedUserId = request.auth.credentials.userId;
 
     return usecases
       .getPrescriber({ userId: authenticatedUserId })
-      .then((prescriber) => prescriberSerializer.serialize(prescriber));
+      .then((prescriber) => dependencies.prescriberSerializer.serialize(prescriber));
   },
 };

--- a/api/lib/application/scorecards/scorecard-controller.js
+++ b/api/lib/application/scorecards/scorecard-controller.js
@@ -1,22 +1,34 @@
 const scorecardSerializer = require('../../infrastructure/serializers/jsonapi/scorecard-serializer.js');
 const tutorialSerializer = require('../../infrastructure/serializers/jsonapi/tutorial-serializer.js');
-const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils.js');
+const requestResponseUtils = require('../../infrastructure/utils/request-response-utils.js');
 const usecases = require('../../domain/usecases/index.js');
 
 module.exports = {
-  getScorecard(request) {
-    const locale = extractLocaleFromRequest(request);
+  getScorecard(request, h, dependencies = { requestResponseUtils, scorecardSerializer }) {
+    const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
     const authenticatedUserId = request.auth.credentials.userId;
     const scorecardId = request.params.id;
 
-    return usecases.getScorecard({ authenticatedUserId, scorecardId, locale }).then(scorecardSerializer.serialize);
+    return usecases
+      .getScorecard({
+        authenticatedUserId,
+        scorecardId,
+        locale,
+      })
+      .then(dependencies.scorecardSerializer.serialize);
   },
 
-  findTutorials(request) {
-    const locale = extractLocaleFromRequest(request);
+  findTutorials(request, h, dependencies = { requestResponseUtils, tutorialSerializer }) {
+    const locale = dependencies.requestResponseUtils.extractLocaleFromRequest(request);
     const authenticatedUserId = request.auth.credentials.userId;
     const scorecardId = request.params.id;
 
-    return usecases.findTutorials({ authenticatedUserId, scorecardId, locale }).then(tutorialSerializer.serialize);
+    return usecases
+      .findTutorials({
+        authenticatedUserId,
+        scorecardId,
+        locale,
+      })
+      .then(dependencies.tutorialSerializer.serialize);
   },
 };

--- a/api/lib/application/sessions/finalized-session-controller.js
+++ b/api/lib/application/sessions/finalized-session-controller.js
@@ -3,13 +3,13 @@ const toBePublishedSessionSerializer = require('../../infrastructure/serializers
 const withRequiredActionSessionSerializer = require('../../infrastructure/serializers/jsonapi/with-required-action-session-serializer.js');
 
 module.exports = {
-  async findFinalizedSessionsToPublish() {
+  async findFinalizedSessionsToPublish(request, h, dependencies = { toBePublishedSessionSerializer }) {
     const finalizedSessionsToPublish = await usecases.findFinalizedSessionsToPublish();
-    return toBePublishedSessionSerializer.serialize(finalizedSessionsToPublish);
+    return dependencies.toBePublishedSessionSerializer.serialize(finalizedSessionsToPublish);
   },
 
-  async findFinalizedSessionsWithRequiredAction() {
+  async findFinalizedSessionsWithRequiredAction(request, h, dependencies = { withRequiredActionSessionSerializer }) {
     const finalizedSessionsWithRequiredAction = await usecases.findFinalizedSessionsWithRequiredAction();
-    return withRequiredActionSessionSerializer.serialize(finalizedSessionsWithRequiredAction);
+    return dependencies.withRequiredActionSessionSerializer.serialize(finalizedSessionsWithRequiredAction);
   },
 };

--- a/api/lib/application/sessions/session-with-clea-certified-candidate-controller.js
+++ b/api/lib/application/sessions/session-with-clea-certified-candidate-controller.js
@@ -3,10 +3,12 @@ const certificationResultUtils = require('../../infrastructure/utils/csv/certifi
 const dayjs = require('dayjs');
 
 module.exports = {
-  async getCleaCertifiedCandidateDataCsv(request, h) {
+  async getCleaCertifiedCandidateDataCsv(request, h, dependencies = { certificationResultUtils }) {
     const sessionId = request.params.id;
     const { session, cleaCertifiedCandidateData } = await usecases.getCleaCertifiedCandidateBySession({ sessionId });
-    const csvResult = await certificationResultUtils.getCleaCertifiedCandidateCsv(cleaCertifiedCandidateData);
+    const csvResult = await dependencies.certificationResultUtils.getCleaCertifiedCandidateCsv(
+      cleaCertifiedCandidateData
+    );
 
     const dateWithTime = dayjs(session.date + ' ' + session.time)
       .locale('fr')

--- a/api/lib/application/tags/tag-controller.js
+++ b/api/lib/application/tags/tag-controller.js
@@ -2,20 +2,20 @@ const tagSerializer = require('../../infrastructure/serializers/jsonapi/tag-seri
 const usecases = require('../../domain/usecases/index.js');
 
 module.exports = {
-  async create(request, h) {
+  async create(request, h, dependencies = { tagSerializer }) {
     const tagName = request.payload.data.attributes['name'].toUpperCase();
     const createdTag = await usecases.createTag({ tagName });
-    return h.response(tagSerializer.serialize(createdTag)).created();
+    return h.response(dependencies.tagSerializer.serialize(createdTag)).created();
   },
 
-  async findAllTags() {
+  async findAllTags(request, h, dependencies = { tagSerializer }) {
     const organizationsTags = await usecases.findAllTags();
-    return tagSerializer.serialize(organizationsTags);
+    return dependencies.tagSerializer.serialize(organizationsTags);
   },
 
-  async getRecentlyUsedTags(request) {
+  async getRecentlyUsedTags(request, h, dependencies = { tagSerializer }) {
     const tagId = request.params.id;
     const recentlyUsedTags = await usecases.getRecentlyUsedTags({ tagId });
-    return tagSerializer.serialize(recentlyUsedTags);
+    return dependencies.tagSerializer.serialize(recentlyUsedTags);
   },
 };

--- a/api/tests/unit/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/unit/application/organization-invitations/organization-invitation-controller_test.js
@@ -1,9 +1,8 @@
-const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
+const { expect, sinon, catchErr, domainBuilder, hFake } = require('../../../test-helper');
 
 const { MissingQueryParamError } = require('../../../../lib/application/http-errors');
 const organizationInvitationController = require('../../../../lib/application/organization-invitations/organization-invitation-controller');
 const usecases = require('../../../../lib/domain/usecases/index.js');
-const organizationInvitationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-invitation-serializer');
 
 describe('Unit | Application | Organization-Invitations | organization-invitation-controller', function () {
   describe('#acceptOrganizationInvitation', function () {
@@ -77,10 +76,14 @@ describe('Unit | Application | Organization-Invitations | organization-invitatio
       };
 
       sinon.stub(usecases, 'getOrganizationInvitation').resolves();
-      sinon.stub(organizationInvitationSerializer, 'serialize').returns();
+      const organizationInvitationSerializer = {
+        serialize: sinon.stub().returns(),
+      };
 
       // when
-      await organizationInvitationController.getOrganizationInvitation(request);
+      await organizationInvitationController.getOrganizationInvitation(request, hFake, {
+        organizationInvitationSerializer,
+      });
 
       // then
       expect(usecases.getOrganizationInvitation).to.have.been.calledWith({

--- a/api/tests/unit/application/organization-learners/organization-learner-controller_test.js
+++ b/api/tests/unit/application/organization-learners/organization-learner-controller_test.js
@@ -1,7 +1,5 @@
 const { sinon, expect, hFake } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases/index.js');
-const organizationLearnerParticipationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-learner-activity-serializer');
-const organizationLearnerSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-learner-follow-up/organization-learner-serializer');
 const organizationLearnerController = require('../../../../lib/application/organization-learners/organization-learner-controller');
 
 describe('Unit | Application | Organization-Learner | organization-learner-controller', function () {
@@ -12,14 +10,14 @@ describe('Unit | Application | Organization-Learner | organization-learner-contr
       const organizationLearnerActivity = Symbol('activity returned by use case');
       const serializedActivity = Symbol('serialized activity');
 
-      sinon.stub(organizationLearnerParticipationSerializer, 'serialize');
+      const organizationLearnerActivitySerializer = {
+        serialize: sinon.stub(),
+      };
       sinon.stub(usecases, 'getOrganizationLearnerActivity');
 
       usecases.getOrganizationLearnerActivity.withArgs({ organizationLearnerId }).resolves(organizationLearnerActivity);
 
-      organizationLearnerParticipationSerializer.serialize
-        .withArgs(organizationLearnerActivity)
-        .returns(serializedActivity);
+      organizationLearnerActivitySerializer.serialize.withArgs(organizationLearnerActivity).returns(serializedActivity);
 
       const request = {
         params: {
@@ -28,11 +26,13 @@ describe('Unit | Application | Organization-Learner | organization-learner-contr
       };
 
       // when
-      const response = await organizationLearnerController.getActivity(request, hFake);
+      const response = await organizationLearnerController.getActivity(request, hFake, {
+        organizationLearnerActivitySerializer,
+      });
 
       // then
       expect(usecases.getOrganizationLearnerActivity).to.have.been.calledWith({ organizationLearnerId });
-      expect(organizationLearnerParticipationSerializer.serialize).to.have.been.calledWith(organizationLearnerActivity);
+      expect(organizationLearnerActivitySerializer.serialize).to.have.been.calledWith(organizationLearnerActivity);
       expect(response.statusCode).to.equal(200);
       expect(response.source).to.equal(serializedActivity);
     });
@@ -45,7 +45,9 @@ describe('Unit | Application | Organization-Learner | organization-learner-contr
       const organizationLearner = Symbol('learner returned by use case');
       const serializedLearner = Symbol('serialized learner');
 
-      sinon.stub(organizationLearnerSerializer, 'serialize');
+      const organizationLearnerSerializer = {
+        serialize: sinon.stub(),
+      };
       sinon.stub(usecases, 'getOrganizationLearner');
 
       usecases.getOrganizationLearner.withArgs({ organizationLearnerId }).resolves(organizationLearner);
@@ -59,7 +61,9 @@ describe('Unit | Application | Organization-Learner | organization-learner-contr
       };
 
       // when
-      const response = await organizationLearnerController.getLearner(request, hFake);
+      const response = await organizationLearnerController.getLearner(request, hFake, {
+        organizationLearnerSerializer,
+      });
 
       // then
       expect(usecases.getOrganizationLearner).to.have.been.calledWith({ organizationLearnerId });

--- a/api/tests/unit/application/prescribers/prescriber-controller_test.js
+++ b/api/tests/unit/application/prescribers/prescriber-controller_test.js
@@ -1,7 +1,6 @@
-const { sinon, expect } = require('../../../test-helper');
+const { sinon, expect, hFake } = require('../../../test-helper');
 
 const usecases = require('../../../../lib/domain/usecases/index.js');
-const prescriberSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/prescriber-serializer');
 
 const prescriberController = require('../../../../lib/application/prescribers/prescriber-controller');
 
@@ -13,16 +12,18 @@ describe('Unit | Controller | prescriber-controller', function () {
       request = { auth: { credentials: { userId: 1 } } };
 
       sinon.stub(usecases, 'getPrescriber');
-      sinon.stub(prescriberSerializer, 'serialize');
     });
 
     it('should get the prescriber', async function () {
       // given
+      const prescriberSerializer = {
+        serialize: sinon.stub(),
+      };
       usecases.getPrescriber.withArgs({ userId: 1 }).resolves({});
       prescriberSerializer.serialize.withArgs({}).returns('ok');
 
       // when
-      const response = await prescriberController.get(request);
+      const response = await prescriberController.get(request, hFake, { prescriberSerializer });
 
       // then
       expect(response).to.be.equal('ok');

--- a/api/tests/unit/application/sco-organization-learners/sco-organization-learner-controller_test.js
+++ b/api/tests/unit/application/sco-organization-learners/sco-organization-learner-controller_test.js
@@ -3,7 +3,6 @@ const { expect, hFake, sinon } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases/index.js');
 
 const scoOrganizationLearnerController = require('../../../../lib/application/sco-organization-learners/sco-organization-learner-controller');
-const studentInformationForAccountRecoverySerializer = require('../../../../lib/infrastructure/serializers/jsonapi/student-information-for-account-recovery-serializer');
 
 describe('Unit | Application | Controller | sco-organization-learner', function () {
   describe('#createUserAndReconcileToOrganizationLearnerFromExternalUser', function () {
@@ -59,14 +58,14 @@ describe('Unit | Application | Controller | sco-organization-learner', function 
     beforeEach(function () {
       sinon.stub(usecases, 'checkScoAccountRecovery');
       usecases.checkScoAccountRecovery.resolves();
-      sinon.stub(studentInformationForAccountRecoverySerializer, 'serialize');
-      studentInformationForAccountRecoverySerializer.serialize.resolves();
-      sinon.stub(studentInformationForAccountRecoverySerializer, 'deserialize');
-      studentInformationForAccountRecoverySerializer.deserialize.resolves();
     });
 
     it('should return student account information serialized', async function () {
       // given
+      const studentInformationForAccountRecoverySerializer = {
+        serialize: sinon.stub(),
+        deserialize: sinon.stub(),
+      };
       hFake.request = { path: {} };
       const studentInformation = {
         ineIna: '1234567890A',
@@ -97,7 +96,9 @@ describe('Unit | Application | Controller | sco-organization-learner', function 
         .returns(studentInformationForAccountRecoveryJSONAPI);
 
       // when
-      const response = await scoOrganizationLearnerController.checkScoAccountRecovery(request, hFake);
+      const response = await scoOrganizationLearnerController.checkScoAccountRecovery(request, hFake, {
+        studentInformationForAccountRecoverySerializer,
+      });
 
       // then
       expect(response.source).to.deep.equal(studentInformationForAccountRecoveryJSONAPI);

--- a/api/tests/unit/application/scorecards/scorecard-controller_test.js
+++ b/api/tests/unit/application/scorecards/scorecard-controller_test.js
@@ -3,9 +3,7 @@ const { sinon, expect, hFake } = require('../../../test-helper');
 const scorecardController = require('../../../../lib/application/scorecards/scorecard-controller');
 
 const usecases = require('../../../../lib/domain/usecases/index.js');
-
-const scorecardSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/scorecard-serializer');
-const tutorialSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/tutorial-serializer');
+const requestResponseUtils = require('../../../../lib/infrastructure/utils/request-response-utils.js');
 
 describe('Unit | Controller | scorecard-controller', function () {
   const authenticatedUserId = '12';
@@ -19,11 +17,13 @@ describe('Unit | Controller | scorecard-controller', function () {
 
     beforeEach(function () {
       sinon.stub(usecases, 'getScorecard').withArgs({ authenticatedUserId, scorecardId, locale }).resolves(scorecard);
-      sinon.stub(scorecardSerializer, 'serialize').resolvesArg(0);
     });
 
     it('should call the expected usecase', async function () {
       // given
+      const scorecardSerializer = {
+        serialize: sinon.stub().resolvesArg(0),
+      };
       const scorecardId = 'foo';
       const locale = 'fr';
 
@@ -40,7 +40,10 @@ describe('Unit | Controller | scorecard-controller', function () {
       };
 
       // when
-      const result = await scorecardController.getScorecard(request, hFake);
+      const result = await scorecardController.getScorecard(request, hFake, {
+        scorecardSerializer,
+        requestResponseUtils,
+      });
 
       // then
       expect(result).to.be.equal(scorecard);
@@ -52,11 +55,14 @@ describe('Unit | Controller | scorecard-controller', function () {
 
     beforeEach(function () {
       sinon.stub(usecases, 'findTutorials').withArgs({ authenticatedUserId, scorecardId, locale }).resolves(tutorials);
-      sinon.stub(tutorialSerializer, 'serialize').withArgs(tutorials).resolves('ok');
     });
 
     it('should call the expected usecase', async function () {
       // given
+      const tutorialSerializer = {
+        serialize: sinon.stub(),
+      };
+      tutorialSerializer.serialize.resolvesArg(0);
       const request = {
         auth: {
           credentials: {
@@ -70,10 +76,13 @@ describe('Unit | Controller | scorecard-controller', function () {
       };
 
       // when
-      const result = await scorecardController.findTutorials(request, hFake);
+      const result = await scorecardController.findTutorials(request, hFake, {
+        tutorialSerializer,
+        requestResponseUtils,
+      });
 
       // then
-      expect(result).to.be.equal('ok');
+      expect(result).to.be.equal(tutorials);
     });
   });
 });

--- a/api/tests/unit/application/session/finalized-session-controller_test.js
+++ b/api/tests/unit/application/session/finalized-session-controller_test.js
@@ -1,8 +1,6 @@
 const { expect, sinon, hFake } = require('../../../test-helper');
 const finalizedSessionController = require('../../../../lib/application/sessions/finalized-session-controller');
 const usecases = require('../../../../lib/domain/usecases/index.js');
-const toBePublishedSessionSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/to-be-published-session-serializer');
-const withRequiredActionSessionSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/with-required-action-session-serializer');
 
 describe('Unit | Controller | finalized-session', function () {
   let request;
@@ -11,7 +9,6 @@ describe('Unit | Controller | finalized-session', function () {
   describe('#findFinalizedSessionsToPublish', function () {
     beforeEach(function () {
       sinon.stub(usecases, 'findFinalizedSessionsToPublish').resolves();
-      sinon.stub(toBePublishedSessionSerializer, 'serialize');
 
       request = {
         payload: {},
@@ -26,13 +23,18 @@ describe('Unit | Controller | finalized-session', function () {
     context('When there are finalized publishable sessions', function () {
       it('should find finalized publishable sessions', async function () {
         // given
+        const toBePublishedSessionSerializer = {
+          serialize: sinon.stub(),
+        };
         const foundFinalizedSessions = Symbol('foundSession');
         const serializedFinalizedSessions = Symbol('serializedSession');
         usecases.findFinalizedSessionsToPublish.resolves(foundFinalizedSessions);
         toBePublishedSessionSerializer.serialize.withArgs(foundFinalizedSessions).resolves(serializedFinalizedSessions);
 
         // when
-        const response = await finalizedSessionController.findFinalizedSessionsToPublish(request, hFake);
+        const response = await finalizedSessionController.findFinalizedSessionsToPublish(request, hFake, {
+          toBePublishedSessionSerializer,
+        });
 
         // then
         expect(response).to.deep.equal(serializedFinalizedSessions);
@@ -57,14 +59,18 @@ describe('Unit | Controller | finalized-session', function () {
         sinon.stub(usecases, 'findFinalizedSessionsWithRequiredAction');
         usecases.findFinalizedSessionsWithRequiredAction.resolves(foundFinalizedSessions);
 
-        sinon.stub(withRequiredActionSessionSerializer, 'serialize');
+        const withRequiredActionSessionSerializer = {
+          serialize: sinon.stub(),
+        };
         const serializedFinalizedSessions = Symbol('serializedSession');
         withRequiredActionSessionSerializer.serialize
           .withArgs(foundFinalizedSessions)
           .resolves(serializedFinalizedSessions);
 
         // when
-        const response = await finalizedSessionController.findFinalizedSessionsWithRequiredAction(request, hFake);
+        const response = await finalizedSessionController.findFinalizedSessionsWithRequiredAction(request, hFake, {
+          withRequiredActionSessionSerializer,
+        });
 
         // then
         expect(response).to.deep.equal(serializedFinalizedSessions);

--- a/api/tests/unit/application/session/session-with-clea-certified-candidate-controller_test.js
+++ b/api/tests/unit/application/session/session-with-clea-certified-candidate-controller_test.js
@@ -1,6 +1,5 @@
 const { domainBuilder, sinon, hFake, expect } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases/index.js');
-const certificationResultUtils = require('../../../../lib/infrastructure/utils/csv/certification-results');
 const sessionWithCleaCertifiedCandidateController = require('../../../../lib/application/sessions/session-with-clea-certified-candidate-controller');
 
 describe('Unit | Controller | session-with-clea-certified-candidate', function () {
@@ -22,15 +21,16 @@ describe('Unit | Controller | session-with-clea-certified-candidate', function (
         .withArgs({ sessionId: 1 })
         .resolves({ session, cleaCertifiedCandidateData: cleaCertifiedCandidates });
 
-      sinon
-        .stub(certificationResultUtils, 'getCleaCertifiedCandidateCsv')
-        .withArgs(cleaCertifiedCandidates)
-        .resolves('csv-string');
+      const certificationResultUtils = {
+        getCleaCertifiedCandidateCsv: sinon.stub(),
+      };
+      certificationResultUtils.getCleaCertifiedCandidateCsv.withArgs(cleaCertifiedCandidates).resolves('csv-string');
 
       // when
       const response = await sessionWithCleaCertifiedCandidateController.getCleaCertifiedCandidateDataCsv(
         request,
-        hFake
+        hFake,
+        { certificationResultUtils }
       );
 
       // then

--- a/api/tests/unit/application/tags/tag-controller_test.js
+++ b/api/tests/unit/application/tags/tag-controller_test.js
@@ -2,7 +2,6 @@ const { expect, sinon, domainBuilder, hFake } = require('../../../test-helper');
 
 const tagController = require('../../../../lib/application/tags/tag-controller');
 const usecases = require('../../../../lib/domain/usecases/index.js');
-const tagSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/tag-serializer');
 
 describe('Unit | Application | Tags | tag-controller', function () {
   describe('#create', function () {
@@ -12,12 +11,15 @@ describe('Unit | Application | Tags | tag-controller', function () {
       const serializedTag = Symbol('a serialized tag');
 
       sinon.stub(usecases, 'createTag').resolves(createdTag);
-      sinon.stub(tagSerializer, 'serialize').withArgs(createdTag).returns(serializedTag);
+      const tagSerializer = {
+        serialize: sinon.stub(),
+      };
+      tagSerializer.serialize.withArgs(createdTag).returns(serializedTag);
 
       const request = { payload: { data: { attributes: { name: 'tag1' } } } };
 
       // when
-      const result = await tagController.create(request, hFake);
+      const result = await tagController.create(request, hFake, { tagSerializer });
 
       // then
       expect(result.statusCode).to.be.equal(201);
@@ -35,10 +37,12 @@ describe('Unit | Application | Tags | tag-controller', function () {
       const tags = [tag1, tag2, tag3];
 
       sinon.stub(usecases, 'findAllTags').resolves(tags);
-      sinon.stub(tagSerializer, 'serialize').resolves();
+      const tagSerializer = {
+        serialize: sinon.stub(),
+      };
 
       // when
-      await tagController.findAllTags();
+      await tagController.findAllTags({}, hFake, { tagSerializer });
 
       // then
       expect(usecases.findAllTags).to.have.been.calledOnce;


### PR DESCRIPTION
## :unicorn: Problème
Suite de #5979

Le passage des modules en ESM est bloqué par nos stub de dépendances. Pour régler cela nous devons injecter les dépendances.

## :robot: Proposition
Comme convenu au tech time, nous injectons les dépendances via un 3 arguments `dependencies`.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- CI OK
- Effectuer des tests des routes

