### PR TITLE
[FEATURE] Visualiser si un CF est actif ou non depuis la liste des CF d'un PC sur Pix Admin (PIX-7745).

### DIFF
--- a/api/lib/infrastructure/repositories/training-repository.js
+++ b/api/lib/infrastructure/repositories/training-repository.js
@@ -61,7 +61,13 @@ async function findPaginatedSummariesByTargetProfileId({
 }) {
   const knexConn = domainTransaction?.knexTransaction || knex;
   const query = knexConn(TABLE_NAME)
-    .select('trainings.*')
+    .select(
+      'trainings.id',
+      'trainings.title',
+      knex.raw(
+        '(CASE WHEN EXISTS (SELECT 1 FROM "training-triggers" WHERE "training-triggers"."trainingId" = trainings.id) THEN true ELSE false END) AS "isRecommendable"'
+      )
+    )
     .innerJoin('target-profile-trainings', `${TABLE_NAME}.id`, 'target-profile-trainings.trainingId')
     .where({ 'target-profile-trainings.targetProfileId': targetProfileId })
     .orderBy('id', 'asc');

--- a/api/tests/acceptance/application/target-profiles/index_test.js
+++ b/api/tests/acceptance/application/target-profiles/index_test.js
@@ -897,7 +897,7 @@ describe('Acceptance | Route | target-profiles', function () {
           id: training.id.toString(),
           attributes: {
             title: 'title',
-            'is-recommendable': undefined,
+            'is-recommendable': false,
           },
         },
       ];

--- a/api/tests/integration/infrastructure/repositories/training-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/training-repository_test.js
@@ -256,8 +256,8 @@ describe('Integration | Repository | training-repository', function () {
     context('when trainings exist', function () {
       it('should return paginated results', async function () {
         // given
-        const trainingSummary1 = domainBuilder.buildTrainingSummary({ id: 1 });
-        const trainingSummary2 = domainBuilder.buildTrainingSummary({ id: 2 });
+        const trainingSummary1 = domainBuilder.buildTrainingSummary({ id: 1, isRecommendable: true });
+        const trainingSummary2 = domainBuilder.buildTrainingSummary({ id: 2, isRecommendable: false });
         const trainingSummaryLinkToAnotherTargetProfile = domainBuilder.buildTrainingSummary({ id: 3 });
 
         databaseBuilder.factory.buildTraining({ ...trainingSummary1 });
@@ -274,6 +274,8 @@ describe('Integration | Repository | training-repository', function () {
           trainingId: trainingSummaryLinkToAnotherTargetProfile.id,
         });
 
+        databaseBuilder.factory.buildTrainingTrigger({ trainingId: trainingSummary1.id });
+
         await databaseBuilder.commit();
         const page = { size: 2, number: 1 };
 
@@ -286,9 +288,9 @@ describe('Integration | Repository | training-repository', function () {
         // then
         expect(trainings).to.have.lengthOf(2);
         expect(trainings[0]).to.be.instanceOf(TrainingSummary);
-        expect(trainings[0].title).to.deep.equal(trainingSummary1.title);
+        expect(trainings[0]).to.deep.equal(trainingSummary1);
         expect(trainings[1]).to.be.instanceOf(TrainingSummary);
-        expect(trainings[1].title).to.deep.equal(trainingSummary2.title);
+        expect(trainings[1]).to.deep.equal(trainingSummary2);
         expect(pagination).to.deep.equal({ page: 1, pageSize: 2, rowCount: 2, pageCount: 1 });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Suite de la #5981 

Actuellement, le seul moyen de savoir qu’un CF sera recommandé c’est de regarder s'il a des déclencheurs. Cependant, toutes les personnes du métier ne le savent pas. 

Nous souhaitons afficher clairement l’information si un CF sera recommandé ou non

## :robot: Proposition
Cette PR ajoute l'information au niveau de la liste des CF d'un profil cible (PC), la PR précédente faisait l'ajout au niveau de la liste des CF, la suivante l'ajoutera dans le détail d'un CF.

Ce qui a été fait pour calculer ce nouveau champ `isRecommendable` c'est de renvoyer une colonne calculée en SQL : 
Nous l'avons fait de cette manière : 
```javascript
  const query = knexConn(TABLE_NAME)
    .select(
      'id',
      'title',
      knex.raw(
        '(CASE WHEN EXISTS (SELECT 1 FROM "training-triggers" WHERE "training-triggers"."trainingId" = trainings.id) THEN true ELSE false END) AS "isRecommendable"'
      )
    )
    .orderBy('id', 'asc');
```

Cette manière de faire permet d'effectuer une unique requête à la base et celle-ci nous retourne directement tous les bons champs.

## :rainbow: Remarques
Lorsque le FT est désactivé le statut est toujours "actif" car c'est le comportement actuel, nous proposons tous les CF associé au profil cible de la campagne.

## :100: Pour tester
- Se connecter sur Pix Admin 
- Aller dans l'onglet PC
- Trouver un PC qui a des CF
- Constater la nouvelle colonne "Statut" (Pour que cela soit lié aux déclencheurs il faut activer le FT `FT_TRAINING_RECOMMENDATION`) 
