### PR TITLE
[BUGFIX] Enlever les noms accessibles sur les résultats par compétences en fin de campagne sur Pix-App (PIX-7267)

### DIFF
--- a/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
@@ -55,7 +55,7 @@ When(`je vois {int} résultats par compétence`, (numberOfResultsByCompetence) =
 });
 
 When(`je vois {int} résultats pour la compétence`, (numberOfResultsByCompetence) => {
-  cy.get('[aria-label="Votre résultat pour la compétence"]').should('have.lengthOf', numberOfResultsByCompetence);
+  cy.get('.skill-review-competence__row').should('have.lengthOf', numberOfResultsByCompetence);
 });
 
 When(`je vois la formation recommandée ayant le titre {string}`, (trainingName) => {

--- a/mon-pix/app/components/campaigns/assessment/campaign-skill-review-competence-result.hbs
+++ b/mon-pix/app/components/campaigns/assessment/campaign-skill-review-competence-result.hbs
@@ -10,7 +10,7 @@
   <tbody>
     {{#if @showCleaCompetences}}
       {{#each @skillSetResults as |skillSet|}}
-        <tr aria-label="{{t 'pages.skill-review.details.result-by-skill'}}">
+        <tr>
           <th scope="row">
             <span class="skill-review-competence__border" aria-hidden="true"></span>
             <span>{{skillSet.name}}</span>
@@ -22,7 +22,7 @@
       {{/each}}
     {{else}}
       {{#each @competenceResults as |competence|}}
-        <tr aria-label="{{t 'pages.skill-review.details.result-by-skill'}}">
+        <tr class="skill-review-competence__row">
           <th scope="row">
             <span
               class="skill-review-competence__border skill-review-competence__border--{{competence.areaColor}}"

--- a/mon-pix/app/components/campaigns/assessment/skill-review-competence-stages-result.hbs
+++ b/mon-pix/app/components/campaigns/assessment/skill-review-competence-stages-result.hbs
@@ -1,5 +1,5 @@
 <table class="skill-review-competence-stages-result__table">
-  <caption class="sr-only">{{t "pages.skill-review.details.caption"}}</caption>
+  <caption class="sr-only">{{t "pages.skill-review.stage.caption"}}</caption>
   <tbody>
     {{#each @competenceResults.competences as |competence|}}
       <tr>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1361,12 +1361,11 @@
       "badges-title": "Your thematic results",
       "details": {
         "title": "Your results by competence",
-        "caption": "Details of your results in percentage and stars according to competences",
+        "caption": "Details of your results in percentage according to competences",
         "flash-pix-score": "{score, number, ::.} Pix",
         "header-result": "Results",
         "header-skill": "Competences tested",
         "result": "Overall result",
-        "result-by-skill": "Your results for the competence",
         "percentage": "{rate, number, ::percent}"
       },
       "disabled-share": "This customised test has been deactivated by the organiser.'<br>'It is no longer possible to submit results.",
@@ -1389,6 +1388,7 @@
       "send-title": "Submit your results",
       "stage": {
         "title": "Competence results details",
+        "caption": "Details of your results in percentage and stars according to competences",
         "masteryPercentage": "Success rate: {rate, number, ::percent}",
         "starsAcquired": "{acquired, plural, =0 {no star} other {# stars}} acquired over {total}"
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1361,12 +1361,11 @@
       "badges-title": "Vos résultats thématiques",
       "details": {
         "title": "Vos résultats par compétence",
-        "caption": "Détails de vos résultats sous forme de pourcentage et d'étoiles en fonction des compétences",
+        "caption": "Détails de vos résultats sous forme de pourcentage en fonction des compétences",
         "flash-pix-score": "{score, number, ::.} Pix",
         "header-result": "Résultats",
         "header-skill": "Compétences testées",
         "result": "Résultat global",
-        "result-by-skill": "Votre résultat pour la compétence",
         "percentage": "{rate, number, ::percent}"
       },
       "disabled-share": "Ce parcours a été désactivé par l'organisateur.'<br>'L'envoi des résultats n'est plus possible.",
@@ -1389,6 +1388,7 @@
       "send-title": "Envoyez vos résultats",
       "stage": {
         "title": "Détails des compétences",
+        "caption": "Détails de vos résultats sous forme de pourcentage et d'étoiles en fonction des compétences",
         "masteryPercentage": "{rate, number, ::percent} de réussite",
         "starsAcquired": "{acquired, plural, =0 {aucune étoile acquise} other {# étoiles acquises}} sur {total}"
       },


### PR DESCRIPTION
## :unicorn: Problème
L'attribut `aria-label` sur les éléments `tr` sur le tableau des résultats des compétences en fin de campagne était redondant.

## :robot: Proposition
Comme on possède déjà un attribut `caption`, on enlève l'attribut qui n'est plus utile.

## :100: Pour tester
- Aller sur Pix-App
- Aller sur la campagne `PROCUSTOM`
- Vérifier en fin de campagne que le tableau est accessible.
