### PR TITLE
[TECH] Montée de version de Pix UI en v31.0.0 sur Pix-Certif (PIX-7753).

### DIFF
--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.1",
-        "@1024pix/pix-ui": "^30.0.0",
+        "@1024pix/pix-ui": "^31.0.0",
         "@1024pix/stylelint-config": "^2.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.5",
@@ -149,9 +149,9 @@
       "dev": true
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "30.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-30.0.0.tgz",
-      "integrity": "sha512-mVV15CQmXgdi+E+SCzoldX/ucSys4wcW2gPP5+aox1uQ6I69SMpKB7cFWN8zQEIqwJw6hgTn66jhNqzQpcIBjw==",
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-31.0.0.tgz",
+      "integrity": "sha512-DP16ke3UDHXNZLMJmhM7lrO7l6C+wrC/02Qvo0idbOIhyIGJ8egbDSAFN9p3gCSXVKoV2ojFl+vKGamf1JLUyw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -162,6 +162,7 @@
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-sass": "^11.0.1",
         "ember-click-outside": "^6.0.1",
+        "ember-popperjs": "^3.0.0",
         "ember-truth-helpers": "^3.1.1",
         "lodash.debounce": "^4.0.8"
       },
@@ -6305,6 +6306,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
+      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@simple-dom/interface": {
@@ -20362,6 +20373,20 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/ember-popperjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ember-popperjs/-/ember-popperjs-3.0.0.tgz",
+      "integrity": "sha512-6adPoWNeV5Q97d6nf5gsEYy/AQ8V3HKtofNcxO0xCQ2coOWWhBUGEwI3i9LPeOcfikFB6sbsLvwbeqLmqXeSoQ==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/addon-shim": "^1.7.1",
+        "@popperjs/core": "^2.11.1"
+      },
+      "peerDependencies": {
+        "ember-modifier": ">= 3.2.7",
+        "ember-source": ">= 3.25.0"
       }
     },
     "node_modules/ember-qunit": {
@@ -35249,9 +35274,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "30.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-30.0.0.tgz",
-      "integrity": "sha512-mVV15CQmXgdi+E+SCzoldX/ucSys4wcW2gPP5+aox1uQ6I69SMpKB7cFWN8zQEIqwJw6hgTn66jhNqzQpcIBjw==",
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-31.0.0.tgz",
+      "integrity": "sha512-DP16ke3UDHXNZLMJmhM7lrO7l6C+wrC/02Qvo0idbOIhyIGJ8egbDSAFN9p3gCSXVKoV2ojFl+vKGamf1JLUyw==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",
@@ -35261,6 +35286,7 @@
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-sass": "^11.0.1",
         "ember-click-outside": "^6.0.1",
+        "ember-popperjs": "^3.0.0",
         "ember-truth-helpers": "^3.1.1",
         "lodash.debounce": "^4.0.8"
       },
@@ -39943,6 +39969,12 @@
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
       }
+    },
+    "@popperjs/core": {
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
+      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
+      "dev": true
     },
     "@simple-dom/interface": {
       "version": "1.4.0",
@@ -51735,6 +51767,16 @@
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6"
+      }
+    },
+    "ember-popperjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ember-popperjs/-/ember-popperjs-3.0.0.tgz",
+      "integrity": "sha512-6adPoWNeV5Q97d6nf5gsEYy/AQ8V3HKtofNcxO0xCQ2coOWWhBUGEwI3i9LPeOcfikFB6sbsLvwbeqLmqXeSoQ==",
+      "dev": true,
+      "requires": {
+        "@embroider/addon-shim": "^1.7.1",
+        "@popperjs/core": "^2.11.1"
       }
     },
     "ember-qunit": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.1",
-    "@1024pix/pix-ui": "^30.0.0",
+    "@1024pix/pix-ui": "^31.0.0",
     "@1024pix/stylelint-config": "^2.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.5",


### PR DESCRIPTION
## :unicorn: Problème

La version de Pix UI sur Certif n'est pas la dernière.

## :robot: Proposition

Monter à la version 31.0.0.

Impacts : 
- ✨ Les `PixSelect` s'ouvrent maintenant là ou de l'espace est disponible (plus forcément en bas)
- ♿ Petit changement sur le orange `$pix-warning-60` pour un meilleur contraste.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier des écrans en petit écran ("mobile") avec des `PixSelect` et constater que la dropdown ne s'ouvre plus nécessairement en bas.
