### PR TITLE
[FEATURE] Afficher le statut d'un CF sur Pix Admin (PIX-7752).

### DIFF
--- a/admin/app/components/trainings/training-details-card.hbs
+++ b/admin/app/components/trainings/training-details-card.hbs
@@ -23,6 +23,12 @@
       <dd class="training-details-card__details-value">{{@training.editorName}}</dd>
       <dt class="training-details-card__details-label">Logo de l'éditeur&nbsp;:&nbsp;</dt>
       <dd class="training-details-card__details-value">{{@training.editorLogoUrl}}</dd>
+      <dt class="training-details-card__details-label">Statut&nbsp;:&nbsp;</dt>
+      {{#if this.isTrainingRecommendationEnabled}}
+        <dd class="training-details-card__details-value">{{if @training.isRecommendable "Actif" "Inactif"}}</dd>
+      {{else}}
+        <dd class="training-details-card__details-value">Actif</dd>
+      {{/if}}
     </dl>
   </div>
   <img class="training-details-card__editor-logo" src={{@training.editorLogoUrl}} alt={{@training.editorName}} />

--- a/admin/app/components/trainings/training-details-card.js
+++ b/admin/app/components/trainings/training-details-card.js
@@ -1,7 +1,10 @@
 import Component from '@glimmer/component';
 import { localeCategories } from '../../models/training';
+import { inject as service } from '@ember/service';
 
 export default class TrainingDetailsCard extends Component {
+  @service featureToggles;
+
   get formattedDuration() {
     const days = this.args.training.duration.days ? `${this.args.training.duration.days}j ` : '';
     const hours = this.args.training.duration.hours ? `${this.args.training.duration.hours}h ` : '';
@@ -11,5 +14,9 @@ export default class TrainingDetailsCard extends Component {
 
   get formattedLocale() {
     return localeCategories[this.args.training.locale];
+  }
+
+  get isTrainingRecommendationEnabled() {
+    return this.featureToggles.featureToggles.isTrainingRecommendationEnabled;
   }
 }

--- a/admin/app/models/training.js
+++ b/admin/app/models/training.js
@@ -24,6 +24,7 @@ export default class Training extends Model {
   @attr('string') locale;
   @attr('string') editorName;
   @attr('string') editorLogoUrl;
+  @attr('boolean') isRecommendable;
   @attr({
     defaultValue: () => ({
       days: 0,
@@ -36,6 +37,11 @@ export default class Training extends Model {
   @hasMany('training-trigger') trainingTriggers;
   @hasMany('target-profile-summary') targetProfileSummaries;
 
+  attachTargetProfiles = memberAction({
+    path: 'attach-target-profiles',
+    type: 'post',
+  });
+
   get prerequisiteTrigger() {
     return this.trainingTriggers.findBy('type', 'prerequisite');
   }
@@ -47,9 +53,4 @@ export default class Training extends Model {
   get sortedTargetProfileSummaries() {
     return this.targetProfileSummaries.sortBy('id');
   }
-
-  attachTargetProfiles = memberAction({
-    path: 'attach-target-profiles',
-    type: 'post',
-  });
 }

--- a/admin/tests/integration/components/trainings/training-details-card_test.js
+++ b/admin/tests/integration/components/trainings/training-details-card_test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@1024pix/ember-testing-library';
 import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
 
 module('Integration | Component | Trainings::TrainingDetailsCard', function (hooks) {
   setupRenderingTest(hooks);
@@ -17,10 +18,18 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
       duration: {
         days: 2,
       },
+      isRecommendable: true,
     });
   });
 
   test('it should display the details', async function (assert) {
+    // given
+    class FeatureTogglesStub extends Service {
+      featureToggles = { isTrainingRecommendationEnabled: true };
+    }
+
+    this.owner.register('service:feature-toggles', FeatureTogglesStub);
+
     // when
     const screen = await render(hbs`<Trainings::TrainingDetailsCard @training={{this.training}} />`);
 
@@ -33,5 +42,51 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
     assert.dom(screen.getByText('Un éditeur de contenu formatif')).exists();
     assert.dom(screen.getByText('un-logo.svg')).exists();
     assert.dom(screen.getByAltText('Un éditeur de contenu formatif')).exists();
+  });
+
+  module('when feature toggle is disabled', function () {
+    test('it should display always Actif', async function (assert) {
+      // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = { isTrainingRecommendationEnabled: false };
+      }
+
+      this.owner.register('service:feature-toggles', FeatureTogglesStub);
+      this.set('training.isRecommendable', false);
+      const screen = await render(hbs`<Trainings::TrainingDetailsCard @training={{this.training}} />`);
+
+      // then
+      assert.dom(screen.getByText('Actif')).exists();
+    });
+  });
+
+  module('when feature toggle is enabled', function () {
+    test('it should display "actif" when training is recommendable', async function (assert) {
+      // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = { isTrainingRecommendationEnabled: true };
+      }
+
+      this.owner.register('service:feature-toggles', FeatureTogglesStub);
+      this.set('training.isRecommendable', true);
+      const screen = await render(hbs`<Trainings::TrainingDetailsCard @training={{this.training}} />`);
+
+      // then
+      assert.dom(screen.getByText('Actif')).exists();
+    });
+
+    test('it should display "inactif" when training is recommendable', async function (assert) {
+      // given
+      class FeatureTogglesStub extends Service {
+        featureToggles = { isTrainingRecommendationEnabled: true };
+      }
+
+      this.owner.register('service:feature-toggles', FeatureTogglesStub);
+      this.set('training.isRecommendable', true);
+      const screen = await render(hbs`<Trainings::TrainingDetailsCard @training={{this.training}} />`);
+
+      // then
+      assert.dom(screen.getByText('Actif')).exists();
+    });
   });
 });

--- a/api/lib/domain/read-models/TrainingForAdmin.js
+++ b/api/lib/domain/read-models/TrainingForAdmin.js
@@ -22,6 +22,10 @@ class TrainingForAdmin {
     this.editorLogoUrl = editorLogoUrl;
     this.trainingTriggers = trainingTriggers;
   }
+
+  get isRecommendable() {
+    return this.trainingTriggers?.length > 0;
+  }
 }
 
 module.exports = TrainingForAdmin;

--- a/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/training-serializer.js
@@ -9,7 +9,7 @@ module.exports = {
         duration.hours = duration.hours || 0;
         duration.minutes = duration.minutes || 0;
 
-        return JSON.parse(JSON.stringify(record));
+        return JSON.parse(JSON.stringify({ ...record, isRecommendable: record.isRecommendable }));
       },
       attributes: [
         'id',
@@ -22,6 +22,7 @@ module.exports = {
         'editorLogoUrl',
         'trainingTriggers',
         'targetProfileSummaries',
+        'isRecommendable',
       ],
       trainingTriggers: {
         ref: 'id',

--- a/api/tests/acceptance/application/trainings/training-controller_test.js
+++ b/api/tests/acceptance/application/trainings/training-controller_test.js
@@ -91,6 +91,7 @@ describe('Acceptance | Controller | training-controller', function () {
           type: trainingAttributes.type,
           link: trainingAttributes.link,
           locale: trainingAttributes.locale,
+          'is-recommendable': true,
           duration: {
             days: 0,
             hours: 6,

--- a/api/tests/unit/domain/read-models/TrainingForAdmin_test.js
+++ b/api/tests/unit/domain/read-models/TrainingForAdmin_test.js
@@ -1,0 +1,67 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+
+describe('Unit | Domain | Read-Models | TrainingForAdmin', function () {
+  describe('#constructor', function () {
+    it('should have all properties', function () {
+      // given
+      const trainingTrigger = domainBuilder.buildTrainingTriggerForAdmin({});
+      const training = domainBuilder.buildTrainingForAdmin({
+        id: 1,
+        title: 'Training 1',
+        link: 'https://example.net',
+        type: 'webinar',
+        duration: { hours: 5 },
+        locale: 'fr-fr',
+        targetProfileIds: [1, 2, 3],
+        editorName: 'Editor name',
+        editorLogoUrl: 'https://editor.logo.url',
+        trainingTriggers: [trainingTrigger],
+      });
+
+      // then
+      expect(training.id).to.equal(1);
+      expect(training.title).to.equal('Training 1');
+      expect(training.link).to.equal('https://example.net');
+      expect(training.type).to.equal('webinar');
+      expect(training.duration).to.deep.equal({ hours: 5 });
+      expect(training.locale).to.equal('fr-fr');
+      expect(training.targetProfileIds).to.deep.equal([1, 2, 3]);
+      expect(training.editorName).to.equal('Editor name');
+      expect(training.editorLogoUrl).to.equal('https://editor.logo.url');
+      expect(training.trainingTriggers).to.deep.equal([trainingTrigger]);
+    });
+  });
+
+  describe('#isRecommendable', function () {
+    it('return true when training has at least one trigger', function () {
+      // given
+      const trainingTrigger = domainBuilder.buildTrainingTriggerForAdmin({});
+      const training = domainBuilder.buildTrainingForAdmin({
+        trainingTriggers: [trainingTrigger],
+      });
+
+      // then
+      expect(training.isRecommendable).to.be.true;
+    });
+
+    it('return false when training has no trigger', function () {
+      // given
+      const training = domainBuilder.buildTrainingForAdmin({
+        trainingTriggers: [],
+      });
+
+      // then
+      expect(training.isRecommendable).to.be.false;
+    });
+
+    it('return false when training trigger is undefined', function () {
+      // given
+      const training = domainBuilder.buildTrainingForAdmin({
+        trainingTriggers: undefined,
+      });
+
+      // then
+      expect(training.isRecommendable).to.equal(false);
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/training-serializer_test.js
@@ -52,6 +52,7 @@ describe('Unit | Serializer | JSONAPI | training-serializer', function () {
             },
             'editor-logo-url': 'https://images.pix.fr/contenu-formatif/editeur/editor_logo_url.svg',
             'editor-name': 'Ministère education nationale',
+            'is-recommendable': true,
             link: 'https://example.net',
             locale: 'fr-fr',
             title: 'Training 1',


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le seul moyen de savoir qu’un CF sera recommandé c’est de regarder s'il a des déclencheurs. Cependant, toutes les personnes du métier ne le savent pas. 

Nous souhaitons afficher clairement l’information si un CF sera recommandé ou non.

## :robot: Proposition
Cette PR ajoute l'information au niveau du détail d'un CF d'un profil cible (PC), les PR précédentes faisaient l'ajout au niveau de la liste des CF, etdans le détail d'un CF.

Dans les anciennes PR pour calculer le nouveau champ `isRecommendable`, nous avons renvoyé une colonne calculée en SQL, de cette manière : 
```javascript
  const query = knexConn(TABLE_NAME)
    .select(
      'id',
      'title',
      knex.raw(
        '(CASE WHEN EXISTS (SELECT 1 FROM "training-triggers" WHERE "training-triggers"."trainingId" = trainings.id) THEN true ELSE false END) AS "isRecommendable"'
      )
    )
    .orderBy('id', 'asc');
```

Cette manière de faire permet d'effectuer une unique requête à la base et celle-ci nous retourne directement tous les bons champs.

Ici, lorsqu'on récupère le détail d'un CF nous récupérons le CF et ces déclencheurs, nous avons donc directement toutes les informations dans le modèle pour calculer le champ. 

Le fait que ça soit un `getter` a posé problème lors de la serialization où nous faisons un `JSON.stringify`. En effet, la méthode stringify récupère uniquement les champs énumérables, ce qui n'est pas le cas par défaut des  `getters`. 
Une méthode aurait pu être de définir le getter comme énumérable avec un code ressemblant à : 
```
Object.defineProperty(TrainingForAdmin.prototype, 'isRecommendable', { enumerable: true });
```
Cependant, j'ai préféré partir sur l'ajout du champ calculé au moment du stringify : 
```
JSON.parse(JSON.stringify({ ...record, isRecommendable: record.isRecommendable }))
```

Pour rappel, nous faisons une copie de l'objet dans le serializer car la lib `json-api-serializer` a un problème pour la serialization d'objet interne qui sont eux-mêmes des instances de class. 

## :rainbow: Remarques
Lorsque le FT est désactivé le statut est toujours "actif" car c'est le comportement actuel, nous proposons tous les CF associé au profil cible de la campagne.

On peut voir que le `memberAction` du modèle `Training` est remonté, cela est du au linter au moment du save.

## :100: Pour tester
- Se connecter sur Pix Admin 
- Aller dans l'onglet CF
- Cliquer sur un CF 
- Constater le nouveau champ "Statut" (Pour que cela soit lié aux déclencheurs il faut activer le FT `FT_TRAINING_RECOMMENDATION`) 

