### PR TITLE
[BUGFIX] Permettre à un centre SCO qui ne gère pas d'élèves à importer en masse des sessions sur Pix Certif (PIX-7709).

### DIFF
--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -205,7 +205,12 @@ module.exports = {
 
     const parsedCsvData = await dependencies.csvHelpers.parseCsvWithHeader(request.payload.path);
 
-    const sessions = dependencies.csvSerializer.deserializeForSessionsImport(parsedCsvData);
+    const certificationCenter = await usecases.getCertificationCenter({ id: certificationCenterId });
+
+    const sessions = dependencies.csvSerializer.deserializeForSessionsImport({
+      parsedCsvData,
+      hasBillingMode: certificationCenter.hasBillingMode,
+    });
     const sessionMassImportReport = await usecases.validateSessions({
       sessions,
       certificationCenterId,

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -14,7 +14,6 @@ const map = require('lodash/map');
 const csvHelpers = require('../../../scripts/helpers/csvHelpers.js');
 const csvSerializer = require('../../infrastructure/serializers/csv/csv-serializer.js');
 const { getHeaders } = require('../../infrastructure/files/sessions-import.js');
-const { UnprocessableEntityError } = require('../../application/http-errors.js');
 
 module.exports = {
   async saveSession(request, _h, dependencies = { sessionSerializer }) {
@@ -205,9 +204,7 @@ module.exports = {
     const authenticatedUserId = request.auth.credentials.userId;
 
     const parsedCsvData = await dependencies.csvHelpers.parseCsvWithHeader(request.payload.path);
-    if (parsedCsvData.length === 0) {
-      throw new UnprocessableEntityError('No session data in csv', 'CSV_DATA_REQUIRED');
-    }
+
     const sessions = dependencies.csvSerializer.deserializeForSessionsImport(parsedCsvData);
     const sessionMassImportReport = await usecases.validateSessions({
       sessions,

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -25,11 +25,11 @@ function _csvSerializeValue(data) {
   }
 }
 
-function deserializeForSessionsImport(parsedCsvData) {
+function deserializeForSessionsImport({ parsedCsvData, hasBillingMode }) {
   const sessions = [];
   const csvLineKeys = Object.keys(headers);
 
-  _verifyHeaders({ csvLineKeys, headers, parsedCsvLine: parsedCsvData[0] });
+  _verifyHeaders({ csvLineKeys, headers, parsedCsvLine: parsedCsvData[0], hasBillingMode });
 
   parsedCsvData.forEach((lineDTO, index) => {
     const dataFromColumnName = _getDataFromColumnNames({ csvLineKeys, headers, line: lineDTO });
@@ -212,12 +212,20 @@ function _getComplementaryCertificationLabel(key, COMPLEMENTARY_CERTIFICATION_SU
   return key.replace(COMPLEMENTARY_CERTIFICATION_SUFFIX, '').trim();
 }
 
-function _verifyHeaders({ csvLineKeys, parsedCsvLine, headers }) {
+function _verifyHeaders({ csvLineKeys, parsedCsvLine, headers, hasBillingMode }) {
   csvLineKeys.forEach((key) => {
     if (parsedCsvLine[headers[key]] === undefined) {
+      if (_isBillingModeOptional(key, hasBillingMode)) {
+        return;
+      }
+
       throw new FileValidationError('CSV_HEADERS_NOT_VALID');
     }
   });
+}
+
+function _isBillingModeOptional(key, hasBillingMode) {
+  return (key === 'billingMode' || key === 'prepaymentCode') && !hasBillingMode;
 }
 
 function _hasSessionInformation({ address, room, date, time, examiner }) {

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -27,12 +27,12 @@ function _csvSerializeValue(data) {
 
 function deserializeForSessionsImport({ parsedCsvData, hasBillingMode }) {
   const sessions = [];
-  const csvLineKeys = Object.keys(headers);
+  const expectedHeadersKeys = Object.keys(headers);
 
-  _verifyHeaders({ csvLineKeys, headers, parsedCsvLine: parsedCsvData[0], hasBillingMode });
+  _verifyHeaders({ expectedHeadersKeys, headers, parsedCsvLine: parsedCsvData[0], hasBillingMode });
 
   parsedCsvData.forEach((lineDTO, index) => {
-    const dataFromColumnName = _getDataFromColumnNames({ csvLineKeys, headers, line: lineDTO });
+    const dataFromColumnName = _getDataFromColumnNames({ expectedHeadersKeys, headers, line: lineDTO });
     const FIRST_DATA_LINE = 2;
     const data = { ...dataFromColumnName, line: index + FIRST_DATA_LINE };
 
@@ -155,11 +155,11 @@ function _hasSessionIdAndCandidateInformation(data) {
   return _hasCandidateInformation(data) && data.sessionId;
 }
 
-function _getDataFromColumnNames({ csvLineKeys, headers, line }) {
+function _getDataFromColumnNames({ expectedHeadersKeys, headers, line }) {
   const data = {};
   data.complementaryCertifications = _extractComplementaryCertificationLabelsFromLine(line);
 
-  csvLineKeys.forEach((key) => {
+  expectedHeadersKeys.forEach((key) => {
     const headerKeyInCurrentLine = line[headers[key]];
     if (key === 'birthdate' || key === 'date') {
       data[key] =
@@ -212,9 +212,11 @@ function _getComplementaryCertificationLabel(key, COMPLEMENTARY_CERTIFICATION_SU
   return key.replace(COMPLEMENTARY_CERTIFICATION_SUFFIX, '').trim();
 }
 
-function _verifyHeaders({ csvLineKeys, parsedCsvLine, headers, hasBillingMode }) {
-  csvLineKeys.forEach((key) => {
-    if (parsedCsvLine[headers[key]] === undefined) {
+function _verifyHeaders({ expectedHeadersKeys, parsedCsvLine, headers, hasBillingMode }) {
+  expectedHeadersKeys.forEach((key) => {
+    const headerKey = parsedCsvLine[headers[key]];
+
+    if (headerKey === undefined) {
       if (_isBillingModeOptional(key, hasBillingMode)) {
         return;
       }

--- a/api/scripts/helpers/csvHelpers.js
+++ b/api/scripts/helpers/csvHelpers.js
@@ -4,6 +4,8 @@ const { difference, isEmpty } = require('lodash');
 const papa = require('papaparse');
 
 const { NotFoundError, FileValidationError } = require('../../lib/domain/errors');
+const { UnprocessableEntityError } = require('../../lib/application/http-errors');
+
 const ERRORS = {
   INVALID_FILE_EXTENSION: 'INVALID_FILE_EXTENSION',
   MISSING_REQUIRED_FIELD_NAMES: 'MISSING_REQUIRED_FIELD_NAMES',
@@ -78,8 +80,13 @@ async function parseCsvData(cleanedData, options) {
   return data;
 }
 
-function parseCsvWithHeader(filePath, options = optionsWithHeader) {
-  return parseCsv(filePath, options);
+async function parseCsvWithHeader(filePath, options = optionsWithHeader) {
+  const parsedCsvData = await parseCsv(filePath, options);
+  if (parsedCsvData.length === 0) {
+    throw new UnprocessableEntityError('No session data in csv', 'CSV_DATA_REQUIRED');
+  }
+
+  return parsedCsvData;
 }
 
 async function parseCsvWithHeaderAndRequiredFields({ filePath, requiredFieldNames }) {

--- a/api/tests/unit/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/unit/application/certification-centers/certification-center-controller_test.js
@@ -519,8 +519,10 @@ describe('Unit | Controller | certifications-center-controller', function () {
       };
 
       sinon.stub(usecases, 'validateSessions');
-      usecases.validateSessions.resolves({ cachedValidatedSessionsKey });
+      sinon.stub(usecases, 'getCertificationCenter');
 
+      usecases.validateSessions.resolves({ cachedValidatedSessionsKey });
+      usecases.getCertificationCenter.resolves(domainBuilder.buildCertificationCenter());
       // when
       await certificationCenterController.validateSessionsForMassImport(request, hFake, {
         csvHelpers: csvHelpersStub,
@@ -555,6 +557,7 @@ describe('Unit | Controller | certifications-center-controller', function () {
       };
 
       sinon.stub(usecases, 'validateSessions');
+      sinon.stub(usecases, 'getCertificationCenter');
 
       usecases.validateSessions.resolves({
         cachedValidatedSessionsKey,
@@ -562,6 +565,7 @@ describe('Unit | Controller | certifications-center-controller', function () {
         sessionsWithoutCandidatesCount,
         candidatesCount,
       });
+      usecases.getCertificationCenter.resolves(domainBuilder.buildCertificationCenter());
 
       // when
       const result = await certificationCenterController.validateSessionsForMassImport(request, hFake, {

--- a/api/tests/unit/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/unit/application/certification-centers/certification-center-controller_test.js
@@ -1,9 +1,8 @@
-const { expect, sinon, domainBuilder, hFake, catchErr } = require('../../../test-helper');
+const { expect, sinon, domainBuilder, hFake } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases/index.js');
 const Session = require('../../../../lib/domain/models/Session');
 
 const certificationCenterController = require('../../../../lib/application/certification-centers/certification-center-controller');
-const { UnprocessableEntityError } = require('../../../../lib/application/http-errors');
 
 describe('Unit | Controller | certifications-center-controller', function () {
   describe('#saveSession', function () {
@@ -576,31 +575,6 @@ describe('Unit | Controller | certifications-center-controller', function () {
         sessionsCount,
         sessionsWithoutCandidatesCount,
         candidatesCount,
-      });
-    });
-
-    describe('when the import session file contains only the header line', function () {
-      it(' should return an unprocessable entity error', async function () {
-        // given
-        const request = {
-          payload: { file: { path: 'csv-path' } },
-          params: { certificationCenterId: 123 },
-          auth: { credentials: { userId: 2 } },
-        };
-
-        const csvHelpersStub = {
-          parseCsvWithHeader: sinon.stub().resolves([]),
-        };
-
-        // when
-        const error = await catchErr(certificationCenterController.validateSessionsForMassImport)(request, hFake, {
-          csvHelpers: csvHelpersStub,
-        });
-
-        // then
-        expect(error).to.be.instanceOf(UnprocessableEntityError);
-        expect(error.message).to.equal('No session data in csv');
-        expect(error.code).to.equal('CSV_DATA_REQUIRED');
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -85,11 +85,88 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
         ];
 
         // when
-        const error = await catchErr(csvSerializer.deserializeForSessionsImport)(parsedCsvData);
+        const error = await catchErr(csvSerializer.deserializeForSessionsImport)({
+          parsedCsvData,
+          hasBillingMode: true,
+        });
 
         // then
         expect(error).to.be.instanceOf(FileValidationError);
         expect(error.code).to.equal('CSV_HEADERS_NOT_VALID');
+      });
+
+      context('when billing mode header is missing', function () {
+        context('when certification center has billing mode', function () {
+          it('should throw an error', async function () {
+            const parsedCsvData = [
+              {
+                'Numéro de session préexistante': '',
+                '* Nom du site': '',
+                '* Nom de la salle': '',
+                '* Date de début (format: JJ/MM/AAAA)': '',
+                '* Heure de début (heure locale format: HH:MM)': '',
+                '* Surveillant(s)': '',
+                'Observations (optionnel)': '',
+                '* Nom de naissance': 'Paul',
+                '* Prénom': 'Pierre',
+                '* Date de naissance (format: JJ/MM/AAAA)': '12/09/1987',
+                '* Sexe (M ou F)': 'M',
+                'Code INSEE de la commune de naissance': '',
+                'Code postal de la commune de naissance': '',
+                'Nom de la commune de naissance': '',
+                '* Pays de naissance': 'France',
+                'E-mail du destinataire des résultats (formateur, enseignant…)': '',
+                'E-mail de convocation': '',
+                'Identifiant externe': '',
+                'Temps majoré ? (exemple format: 33%)': '',
+              },
+            ];
+
+            // when
+            const error = await catchErr(csvSerializer.deserializeForSessionsImport)({
+              parsedCsvData,
+              hasBillingMode: true,
+            });
+
+            // then
+            expect(error).to.be.instanceOf(FileValidationError);
+            expect(error.code).to.equal('CSV_HEADERS_NOT_VALID');
+          });
+        });
+
+        context('when certification center does not have the billing mode', function () {
+          it('should not throw an error', async function () {
+            const parsedCsvData = [
+              {
+                'Numéro de session préexistante': '',
+                '* Nom du site': '',
+                '* Nom de la salle': '',
+                '* Date de début (format: JJ/MM/AAAA)': '',
+                '* Heure de début (heure locale format: HH:MM)': '',
+                '* Surveillant(s)': '',
+                'Observations (optionnel)': '',
+                '* Nom de naissance': 'Paul',
+                '* Prénom': 'Pierre',
+                '* Date de naissance (format: JJ/MM/AAAA)': '12/09/1987',
+                '* Sexe (M ou F)': 'M',
+                'Code INSEE de la commune de naissance': '',
+                'Code postal de la commune de naissance': '',
+                'Nom de la commune de naissance': '',
+                '* Pays de naissance': 'France',
+                'E-mail du destinataire des résultats (formateur, enseignant…)': '',
+                'E-mail de convocation': '',
+                'Identifiant externe': '',
+                'Temps majoré ? (exemple format: 33%)': '',
+              },
+            ];
+
+            // when
+            const result = await csvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: false });
+
+            // then
+            expect(result).to.deep.equal([emptySession]);
+          });
+        });
       });
     });
 
@@ -123,7 +200,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           ];
 
           // when
-          const result = await csvSerializer.deserializeForSessionsImport(parsedCsvData);
+          const result = await csvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
 
           // then
           expect(result).to.deep.equal([emptySession]);
@@ -162,7 +239,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           ];
 
           // when
-          const result = csvSerializer.deserializeForSessionsImport(parsedCsvData);
+          const result = csvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
 
           // then
           expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
@@ -199,7 +276,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           ];
 
           // when
-          const result = csvSerializer.deserializeForSessionsImport(parsedCsvData);
+          const result = csvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
 
           // then
           expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
@@ -229,7 +306,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           ];
 
           // when
-          const result = csvSerializer.deserializeForSessionsImport(parsedCsvData);
+          const result = csvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
 
           // then
           expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
@@ -258,7 +335,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
             ];
 
             // when
-            const result = csvSerializer.deserializeForSessionsImport(parsedCsvData);
+            const result = csvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
 
             // then
             expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
@@ -301,7 +378,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           ];
 
           // when
-          const result = csvSerializer.deserializeForSessionsImport(parsedCsvData);
+          const result = csvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
 
           // then
           expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
@@ -399,7 +476,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           ];
 
           // when
-          const result = csvSerializer.deserializeForSessionsImport(parsedCsvData);
+          const result = csvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
 
           // then
           expect(_omitUniqueKey(result)).to.deep.equal(expectedResult);
@@ -470,7 +547,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
           // when
           const result = csvSerializer
-            .deserializeForSessionsImport(parsedCsvData)
+            .deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true })
             .map((session) => _.omit(session, 'uniqueKey'));
 
           // then
@@ -523,7 +600,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
           // when
           const result = csvSerializer
-            .deserializeForSessionsImport(parsedCsvData)
+            .deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true })
             .map((session) => _.omit(session, 'uniqueKey'));
 
           // then
@@ -545,7 +622,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
             // when
             const result = csvSerializer
-              .deserializeForSessionsImport(csvLine)
+              .deserializeForSessionsImport({ parsedCsvData: csvLine, hasBillingMode: true })
               .map((session) => _.omit(session, 'uniqueKey'));
 
             // then
@@ -631,7 +708,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
         // when
         const result = csvSerializer
-          .deserializeForSessionsImport(parsedCsvData)
+          .deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true })
           .map((session) => _.omit(session, 'uniqueKey'));
 
         // then
@@ -813,7 +890,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
           ];
 
           // when
-          const [result] = csvSerializer.deserializeForSessionsImport(parsedCsvData);
+          const [result] = csvSerializer.deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true });
 
           // then
           expect(result.certificationCandidates).to.have.length(6);
@@ -841,7 +918,7 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
 
           // when
           const result = csvSerializer
-            .deserializeForSessionsImport(parsedCsvData)
+            .deserializeForSessionsImport({ parsedCsvData, hasBillingMode: true })
             .map((session) => _.omit(session, 'uniqueKey'));
 
           // then
@@ -869,7 +946,10 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
       ];
 
       // when
-      const [firstSession, secondSession] = csvSerializer.deserializeForSessionsImport(parsedCsvData);
+      const [firstSession, secondSession] = csvSerializer.deserializeForSessionsImport({
+        parsedCsvData,
+        hasBillingMode: true,
+      });
 
       // then
       expect(firstSession.line).to.equal(2);

--- a/api/tests/unit/scripts/helpers/csvHelpers_test.js
+++ b/api/tests/unit/scripts/helpers/csvHelpers_test.js
@@ -10,6 +10,7 @@ const {
 const {
   batchOrganizationOptionsWithHeader,
 } = require('../../../../scripts/create-organizations-with-tags-and-target-profiles');
+const { UnprocessableEntityError } = require('../../../../lib/application/http-errors');
 
 describe('Unit | Scripts | Helpers | csvHelpers.js', function () {
   const notExistFilePath = 'notExist.csv';
@@ -164,6 +165,18 @@ describe('Unit | Scripts | Helpers | csvHelpers.js', function () {
 
         // then
         expect(data[0].type).to.equal('PRO');
+      });
+    });
+
+    context('when csv file is empty or contains only the header line', function () {
+      it(' should return an unprocessable entity error', async function () {
+        // given & when
+        const error = await catchErr(parseCsvWithHeader)(emptyFilePath);
+
+        // then
+        expect(error).to.be.instanceOf(UnprocessableEntityError);
+        expect(error.message).to.equal('No session data in csv');
+        expect(error.code).to.equal('CSV_DATA_REQUIRED');
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix Certif, si un centre SCO qui ne gère pas d'élève (isManagingStudent = false) tente d'utiliser la fonctionnalité d'import en masse de sessions, il obtient une erreur lui indiquant que le modèle à été altéré. 
Or l'import devrait fonctionner pour eux.


## :robot: Proposition
Ne pas jeter d'erreur sur l'absence des colonnes "Tarification part Pix" et "Code de prépaiement" s'il s'agit d'un import fait par un centre SCO (isManagingStudent = false) 

## :rainbow: Remarques
En effet le fichier pour un centre SCO (isManagingStudent = false) n'a pas les colonnes "Tarification Pix" et "Code de prépaiement". Or pour les autres centres (SUP/PRO) , ces colonnes sont obligatoires. Le traitement des colonnes était pareil pour tous les centres.

---

Déplacement d'une erreur dans le csvHelper. (1er commit)

## :100: Pour tester

- Se connecter avec certifsco@example sur Pix Certif
- Aller sur le centre AEFE, centre SCO qui ne gère pas d'élèves
- Cliquer sur l'import en masse 
- Importer le fichier suivant (celui-ci n'a pas les colonnes "Tarification part Pix" et "Code de prépaiement")
```
"N° de session";"* Nom du site";"* Nom de la salle";"* Date de début";"* Heure de début (heure locale)";"* Surveillant(s)";"Observations (optionnel)";"* Nom de naissance";"* Prénom";"* Date de naissance (format: jj/mm/aaaa)";"* Sexe (M ou F)";"Code Insee";"Code postal";"Nom de la commune";"* Pays";"E-mail du destinataire des résultats (formateur, enseignant…)";"E-mail de convocation";"Identifiant local";"Temps majoré ?";
;Site;Salle;10/10/2029;12:00;Giroud;;Juliette;Durand;10/10/2000;M;;75015;paris;france;;;;;;

```
- Constater que l'import se déroule bien
- Se déconnecter pour se connecter avec certifsup@example.net
- Tenter l'import avec ce même fichier
- Constater qu'on reçoit l'erreur du modèle altéré (puisqu'on attend les 2 colonnes manquantes)