### PR TITLE
[FEATURE] Afficher Pix Orga dans la langue de l'utilisateur enregistrée dans son compte (PIX-5766)

### DIFF
--- a/admin/tests/helpers/setup-intl.js
+++ b/admin/tests/helpers/setup-intl.js
@@ -5,6 +5,5 @@ export default function setupIntl(hooks, locale = ['fr']) {
 
     this.dayjs = this.owner.lookup('service:dayjs');
     this.dayjs.setLocale(locale[0]);
-    this.dayjs.self.locale(locale[0]);
   });
 }

--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -58,6 +58,5 @@ export default class CurrentSessionService extends SessionService {
   _setLocale(locale) {
     this.intl.setLocale([locale, FRENCH_INTERNATIONAL_LOCALE]);
     this.dayjs.setLocale(locale);
-    this.dayjs.self.locale(locale);
   }
 }

--- a/certif/app/services/session.js
+++ b/certif/app/services/session.js
@@ -1,7 +1,6 @@
 import { inject as service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
 
-const DEFAULT_LOCALE = 'fr';
 const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 const FRENCH_FRANCE_LOCALE = 'fr-FR';
 
@@ -33,7 +32,7 @@ export default class CurrentSessionService extends SessionService {
   }
 
   async handleLocale({ isFranceDomain, localeFromQueryParam, userLocale }) {
-    if (localeFromQueryParam) {
+    if (localeFromQueryParam && this.intl.get('locales').includes(localeFromQueryParam)) {
       this._localeFromQueryParam = localeFromQueryParam;
     }
 
@@ -47,17 +46,17 @@ export default class CurrentSessionService extends SessionService {
       return;
     }
 
-    if (this._localeFromQueryParam && this.intl.get('locales').includes(this._localeFromQueryParam)) {
+    if (this._localeFromQueryParam) {
       this._setLocale(this._localeFromQueryParam);
       return;
     }
 
-    const locale = userLocale || DEFAULT_LOCALE;
+    const locale = userLocale || FRENCH_INTERNATIONAL_LOCALE;
     this._setLocale(locale);
   }
 
   _setLocale(locale) {
-    this.intl.setLocale([locale, DEFAULT_LOCALE]);
+    this.intl.setLocale([locale, FRENCH_INTERNATIONAL_LOCALE]);
     this.dayjs.setLocale(locale);
     this.dayjs.self.locale(locale);
   }

--- a/certif/tests/helpers/setup-intl.js
+++ b/certif/tests/helpers/setup-intl.js
@@ -5,6 +5,5 @@ export default function setupIntl(hooks, locale = ['fr']) {
 
     this.dayjs = this.owner.lookup('service:dayjs');
     this.dayjs.setLocale(locale[0]);
-    this.dayjs.self.locale(locale[0]);
   });
 }

--- a/certif/tests/unit/services/session_test.js
+++ b/certif/tests/unit/services/session_test.js
@@ -302,7 +302,6 @@ module('Unit | Service | session', function (hooks) {
       // then
       sinon.assert.calledWith(service.intl.setLocale, ['some locale', 'fr']);
       sinon.assert.calledWith(service.dayjs.setLocale, 'some locale');
-      sinon.assert.calledWith(service.dayjs.self.locale, 'some locale');
       assert.ok(true);
     });
   });

--- a/certif/tests/unit/services/session_test.js
+++ b/certif/tests/unit/services/session_test.js
@@ -11,15 +11,15 @@ module('Unit | Service | session', function (hooks) {
   setupTest(hooks);
 
   let routerService;
-  let sessionService;
+  let service;
   let localeService;
 
   hooks.beforeEach(function () {
     routerService = this.owner.lookup('service:router');
     routerService.transitionTo = sinon.stub();
 
-    sessionService = this.owner.lookup('service:session');
-    sessionService.currentUser = { load: sinon.stub(), certificationPointOfContact: null };
+    service = this.owner.lookup('service:session');
+    service.currentUser = { load: sinon.stub(), certificationPointOfContact: null };
 
     localeService = this.owner.lookup('service:locale');
     Object.assign(localeService, {
@@ -38,17 +38,17 @@ module('Unit | Service | session', function (hooks) {
       }
       this.owner.register('service:url', UrlStub);
 
-      sessionService.currentUser = {
+      service.currentUser = {
         load: sinon.stub(),
         certificationPointOfContact: { isMemberOfACertificationCenter: false },
       };
-      sessionService.handleLocale = sinon.stub();
+      service.handleLocale = sinon.stub();
 
       // when
-      await sessionService.handleAuthentication();
+      await service.handleAuthentication();
 
       // then
-      sinon.assert.called(sessionService.handleLocale);
+      sinon.assert.called(service.handleLocale);
       assert.ok(true);
     });
   });
@@ -64,7 +64,7 @@ module('Unit | Service | session', function (hooks) {
           const isFranceDomain = true;
           const localeFromQueryParam = undefined;
           const userLocale = undefined;
-          await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+          await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
           // then
           sinon.assert.calledWith(localeService.setLocaleCookie, FRENCH_FRANCE_LOCALE);
@@ -81,7 +81,7 @@ module('Unit | Service | session', function (hooks) {
           const isFranceDomain = true;
           const localeFromQueryParam = undefined;
           const userLocale = undefined;
-          await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+          await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
           // then
           sinon.assert.notCalled(localeService.setLocaleCookie);
@@ -93,16 +93,16 @@ module('Unit | Service | session', function (hooks) {
         module('when user is not loaded', function () {
           test('sets the locale to be French international in every case', async function (assert) {
             // given
-            sessionService._setLocale = sinon.stub();
+            service._setLocale = sinon.stub();
 
             // when
             const isFranceDomain = true;
             const localeFromQueryParam = undefined;
             const userLocale = undefined;
-            await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(sessionService._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            sinon.assert.calledWith(service._setLocale, FRENCH_INTERNATIONAL_LOCALE);
             assert.ok(true);
           });
         });
@@ -110,16 +110,16 @@ module('Unit | Service | session', function (hooks) {
         module('when user is loaded', function () {
           test('sets the locale to be French international in every case', async function (assert) {
             // given
-            sessionService._setLocale = sinon.stub();
+            service._setLocale = sinon.stub();
 
             // when
             const isFranceDomain = true;
             const localeFromQueryParam = undefined;
             const userLocale = 'user’s lang';
-            await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(sessionService._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            sinon.assert.calledWith(service._setLocale, FRENCH_INTERNATIONAL_LOCALE);
             assert.ok(true);
           });
         });
@@ -129,16 +129,16 @@ module('Unit | Service | session', function (hooks) {
         module('when user is not loaded', function () {
           test('sets the locale to be French international in every case', async function (assert) {
             // given
-            sessionService._setLocale = sinon.stub();
+            service._setLocale = sinon.stub();
 
             // when
             const isFranceDomain = true;
             const localeFromQueryParam = 'en';
             const userLocale = undefined;
-            await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(sessionService._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            sinon.assert.calledWith(service._setLocale, FRENCH_INTERNATIONAL_LOCALE);
             assert.ok(true);
           });
         });
@@ -146,16 +146,16 @@ module('Unit | Service | session', function (hooks) {
         module('when user is loaded', function () {
           test('sets the locale to be French international in every case', async function (assert) {
             // given
-            sessionService._setLocale = sinon.stub();
+            service._setLocale = sinon.stub();
 
             // when
             const isFranceDomain = true;
             const localeFromQueryParam = 'en';
             const userLocale = 'user’s lang';
-            await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(sessionService._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            sinon.assert.calledWith(service._setLocale, FRENCH_INTERNATIONAL_LOCALE);
             assert.ok(true);
           });
         });
@@ -171,7 +171,7 @@ module('Unit | Service | session', function (hooks) {
         const isFranceDomain = false;
         const localeFromQueryParam = undefined;
         const userLocale = undefined;
-        await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+        await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
         // then
         sinon.assert.notCalled(localeService.setLocaleCookie);
@@ -182,16 +182,16 @@ module('Unit | Service | session', function (hooks) {
         module('when user is not loaded', function () {
           test('sets the default locale', async function (assert) {
             // given
-            sessionService._setLocale = sinon.stub();
+            service._setLocale = sinon.stub();
 
             // when
             const isFranceDomain = false;
             const localeFromQueryParam = undefined;
             const userLocale = undefined;
-            await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(sessionService._setLocale, DEFAULT_LOCALE);
+            sinon.assert.calledWith(service._setLocale, DEFAULT_LOCALE);
             assert.ok(true);
           });
         });
@@ -199,16 +199,16 @@ module('Unit | Service | session', function (hooks) {
         module('when user is loaded', function () {
           test('sets the locale to the user’s lang', async function (assert) {
             // given
-            sessionService._setLocale = sinon.stub();
+            service._setLocale = sinon.stub();
 
             // when
             const isFranceDomain = false;
             const localeFromQueryParam = undefined;
             const userLocale = 'en';
-            await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
             // then
-            sinon.assert.calledWith(sessionService._setLocale, 'en');
+            sinon.assert.calledWith(service._setLocale, 'en');
             assert.ok(true);
           });
         });
@@ -219,16 +219,16 @@ module('Unit | Service | session', function (hooks) {
           module('when user is not loaded', function () {
             test('sets the default locale', async function (assert) {
               // given
-              sessionService._setLocale = sinon.stub();
+              service._setLocale = sinon.stub();
 
               // when
               const isFranceDomain = false;
               const localeFromQueryParam = 'an invalid locale';
               const userLocale = undefined;
-              await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+              await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(sessionService._setLocale, DEFAULT_LOCALE);
+              sinon.assert.calledWith(service._setLocale, DEFAULT_LOCALE);
               assert.ok(true);
             });
           });
@@ -236,16 +236,16 @@ module('Unit | Service | session', function (hooks) {
           module('when user is loaded', function () {
             test('sets the locale to the user’s lang', async function (assert) {
               // given
-              sessionService._setLocale = sinon.stub();
+              service._setLocale = sinon.stub();
 
               // when
               const isFranceDomain = false;
               const localeFromQueryParam = 'an invalid locale';
               const userLocale = 'en';
-              await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+              await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(sessionService._setLocale, 'en');
+              sinon.assert.calledWith(service._setLocale, 'en');
               assert.ok(true);
             });
           });
@@ -255,16 +255,16 @@ module('Unit | Service | session', function (hooks) {
           module('when user is not loaded', function () {
             test('sets the locale to the lang query param', async function (assert) {
               // given
-              sessionService._setLocale = sinon.stub();
+              service._setLocale = sinon.stub();
 
               // when
               const isFranceDomain = false;
               const localeFromQueryParam = 'en';
               const userLocale = undefined;
-              await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+              await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(sessionService._setLocale, 'en');
+              sinon.assert.calledWith(service._setLocale, 'en');
               assert.ok(true);
             });
           });
@@ -272,16 +272,16 @@ module('Unit | Service | session', function (hooks) {
           module('when user is loaded', function () {
             test('sets the locale to the lang query param which wins over', async function (assert) {
               // given
-              sessionService._setLocale = sinon.stub();
+              service._setLocale = sinon.stub();
 
               // when
               const isFranceDomain = false;
               const localeFromQueryParam = 'en';
               const userLocale = 'fr';
-              await sessionService.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+              await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
               // then
-              sinon.assert.calledWith(sessionService._setLocale, 'en');
+              sinon.assert.calledWith(service._setLocale, 'en');
               assert.ok(true);
             });
           });
@@ -293,16 +293,16 @@ module('Unit | Service | session', function (hooks) {
   module('#_setLocale', function () {
     test('calls intl and dayjs services', async function (assert) {
       // given
-      sessionService.intl = { setLocale: sinon.stub() };
-      sessionService.dayjs = { setLocale: sinon.stub(), self: { locale: sinon.stub() } };
+      service.intl = { setLocale: sinon.stub() };
+      service.dayjs = { setLocale: sinon.stub(), self: { locale: sinon.stub() } };
 
       // when
-      await sessionService._setLocale('some locale');
+      await service._setLocale('some locale');
 
       // then
-      sinon.assert.calledWith(sessionService.intl.setLocale, ['some locale', 'fr']);
-      sinon.assert.calledWith(sessionService.dayjs.setLocale, 'some locale');
-      sinon.assert.calledWith(sessionService.dayjs.self.locale, 'some locale');
+      sinon.assert.calledWith(service.intl.setLocale, ['some locale', 'fr']);
+      sinon.assert.calledWith(service.dayjs.setLocale, 'some locale');
+      sinon.assert.calledWith(service.dayjs.self.locale, 'some locale');
       assert.ok(true);
     });
   });

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -130,7 +130,6 @@ export default class CurrentSessionService extends SessionService {
     const defaultLocale = 'fr';
     this.intl.setLocale([locale, defaultLocale]);
     this.dayjs.setLocale(locale);
-    this.dayjs.self.locale(locale);
   }
 
   _getRouteAfterInvalidation() {

--- a/mon-pix/tests/helpers/setup-intl.js
+++ b/mon-pix/tests/helpers/setup-intl.js
@@ -5,6 +5,5 @@ export default function setupIntl(hooks, locale = ['fr']) {
 
     this.dayjs = this.owner.lookup('service:dayjs');
     this.dayjs.setLocale(locale[0]);
-    this.dayjs.self.locale(locale[0]);
   });
 }

--- a/orga/app/components/auth/login-form.js
+++ b/orga/app/components/auth/login-form.js
@@ -8,6 +8,7 @@ import ENV from 'pix-orga/config/environment';
 import isEmailValid from '../../utils/email-validator';
 
 export default class LoginForm extends Component {
+  @service currentDomain;
   @service url;
   @service intl;
   @service session;
@@ -21,7 +22,7 @@ export default class LoginForm extends Component {
   @tracked emailValidationMessage = null;
 
   get displayRecoveryLink() {
-    if (this.intl.t('current-lang') === 'en' || !this.url.isFrenchDomainExtension) {
+    if (this.intl.t('current-lang') === 'en' || !this.currentDomain.isFranceDomain) {
       return false;
     }
     return !this.args.isWithInvitation;

--- a/orga/app/controllers/authenticated/certifications.js
+++ b/orga/app/controllers/authenticated/certifications.js
@@ -4,12 +4,12 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class AuthenticatedCertificationsController extends Controller {
+  @service currentDomain;
   @service fileSaver;
   @service session;
   @service currentUser;
   @service notifications;
   @service intl;
-  @service url;
 
   @tracked selectedDivision = '';
 
@@ -67,7 +67,7 @@ export default class AuthenticatedCertificationsController extends Controller {
       }
 
       const organizationId = this.currentUser.organization.id;
-      const url = `/api/organizations/${organizationId}/certification-attestations?division=${this.selectedDivision}&isFrenchDomainExtension=${this.url.isFrenchDomainExtension}`;
+      const url = `/api/organizations/${organizationId}/certification-attestations?division=${this.selectedDivision}&isFrenchDomainExtension=${this.currentDomain.isFranceDomain}`;
       const fileName = 'attestations_pix.pdf';
 
       let token = '';

--- a/orga/app/routes/application.js
+++ b/orga/app/routes/application.js
@@ -3,11 +3,16 @@ import Route from '@ember/routing/route';
 
 export default class ApplicationRoute extends Route {
   @service featureToggles;
+  @service currentDomain;
+  @service currentUser;
   @service session;
 
   async beforeModel(transition) {
     await this.featureToggles.load();
-    const lang = transition.to.queryParams.lang;
-    return this.session.handlePrescriberLanguageAndLocale(lang);
+    const isFranceDomain = this.currentDomain.isFranceDomain;
+    const localeFromQueryParam = transition.to.queryParams.lang;
+    await this.currentUser.load();
+    const userLocale = this.currentUser.prescriber?.lang;
+    await this.session.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
   }
 }

--- a/orga/app/services/current-domain.js
+++ b/orga/app/services/current-domain.js
@@ -1,7 +1,13 @@
 import Service from '@ember/service';
 import last from 'lodash/last';
 
+const FRANCE_TLD = 'fr';
+
 export default class CurrentDomainService extends Service {
+  get isFranceDomain() {
+    return this.getExtension() === FRANCE_TLD;
+  }
+
   getExtension() {
     return last(location.hostname.split('.'));
   }

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -77,7 +77,6 @@ export default class CurrentSessionService extends SessionService {
 
     this.intl.setLocale([userLocale, DEFAULT_LOCALE]);
     this.dayjs.setLocale(userLocale);
-    this.dayjs.self.locale(userLocale);
   }
 
   _getRouteAfterInvalidation() {

--- a/orga/app/services/session.js
+++ b/orga/app/services/session.js
@@ -2,21 +2,26 @@ import { inject as service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
 import get from 'lodash/get';
 
-const DEFAULT_LOCALE = 'fr';
-const FRENCH_LOCALE = 'fr-FR';
+const FRENCH_INTERNATIONAL_LOCALE = 'fr';
+const FRENCH_FRANCE_LOCALE = 'fr-FR';
 
 export default class CurrentSessionService extends SessionService {
+  @service currentDomain;
   @service currentUser;
+  @service locale;
   @service intl;
   @service dayjs;
   @service url;
-  @service currentDomain;
-  @service locale;
+
+  _localeFromQueryParam;
 
   routeAfterAuthentication = 'authenticated';
 
   async handleAuthentication() {
-    await this.handlePrescriberLanguageAndLocale();
+    const isFranceDomain = this.currentDomain.isFranceDomain;
+    await this.currentUser.load();
+    const userLocale = this.currentUser.prescriber.lang;
+    await this.handleLocale({ isFranceDomain, userLocale });
     super.handleAuthentication(this.routeAfterAuthentication);
   }
 
@@ -25,35 +30,41 @@ export default class CurrentSessionService extends SessionService {
     await super.handleInvalidation(routeAfterInvalidation);
   }
 
-  async handlePrescriberLanguageAndLocale(localeFromQueryParam) {
-    const domain = this.currentDomain.getExtension();
-    const defaultLocale = 'fr';
-    const domainFr = 'fr';
+  async handleLocale({ isFranceDomain, localeFromQueryParam, userLocale }) {
+    if (localeFromQueryParam && this.intl.get('locales').includes(localeFromQueryParam)) {
+      this._localeFromQueryParam = localeFromQueryParam;
+    }
 
-    await this.currentUser.load();
-    await this._updatePrescriberLanguage(localeFromQueryParam);
-
-    if (domain === domainFr) {
-      this._setLocale(defaultLocale);
+    if (isFranceDomain) {
+      this._setLocale(FRENCH_INTERNATIONAL_LOCALE);
 
       if (!this.locale.hasLocaleCookie()) {
-        this.locale.setLocaleCookie(FRENCH_LOCALE);
+        this.locale.setLocaleCookie(FRENCH_FRANCE_LOCALE);
       }
 
       return;
     }
 
-    if (localeFromQueryParam) {
-      this._setLocale(localeFromQueryParam);
-    } else {
-      this._setLocale(defaultLocale);
+    if (this._localeFromQueryParam) {
+      await this._updatePrescriberLanguage(this._localeFromQueryParam);
+
+      this._setLocale(this._localeFromQueryParam);
+      return;
     }
+
+    const locale = userLocale || FRENCH_INTERNATIONAL_LOCALE;
+    this._setLocale(locale);
+  }
+
+  _setLocale(locale) {
+    this.intl.setLocale([locale, FRENCH_INTERNATIONAL_LOCALE]);
+    this.dayjs.setLocale(locale);
   }
 
   async _updatePrescriberLanguage(lang) {
     const prescriber = this.currentUser.prescriber;
 
-    if (!prescriber || !lang || prescriber.lang === lang) return;
+    if (!prescriber || prescriber.lang === lang) return;
 
     try {
       prescriber.lang = lang;
@@ -66,17 +77,6 @@ export default class CurrentSessionService extends SessionService {
         throw error;
       }
     }
-  }
-
-  _setLocale(locale) {
-    let userLocale = DEFAULT_LOCALE;
-
-    if (!this.url.isFrenchDomainExtension) {
-      userLocale = this.intl.get('locales').includes(locale) ? locale : DEFAULT_LOCALE;
-    }
-
-    this.intl.setLocale([userLocale, DEFAULT_LOCALE]);
-    this.dayjs.setLocale(userLocale);
   }
 
   _getRouteAfterInvalidation() {

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -2,7 +2,7 @@ import Service, { inject as service } from '@ember/service';
 
 import ENV from 'pix-orga/config/environment';
 
-const FRENCH_DOMAIN_EXTENSION = 'fr';
+const FRENCH_LOCALE = 'fr';
 const PIX_FR_DOMAIN = 'https://pix.fr';
 const PIX_ORG_DOMAIN_FR_LOCALE = 'https://pix.org/fr';
 const PIX_ORG_DOMAIN_EN_LOCALE = 'https://pix.org/en-gb';
@@ -35,10 +35,6 @@ export default class Url extends Service {
 
   definedHomeUrl = ENV.rootURL;
 
-  get isFrenchDomainExtension() {
-    return this.currentDomain.getExtension() === FRENCH_DOMAIN_EXTENSION;
-  }
-
   get campaignsRootUrl() {
     return this.definedCampaignsRootUrl
       ? this.definedCampaignsRootUrl
@@ -51,31 +47,23 @@ export default class Url extends Service {
   }
 
   get legalNoticeUrl() {
-    const domainExtension = this.currentDomain.getExtension();
     const { en, fr } = this.SHOWCASE_WEBSITE_LOCALE_PATH.LEGAL_NOTICE;
-
-    return this._computeShowcaseWebsiteUrl({ domainExtension, en, fr });
+    return this._computeShowcaseWebsiteUrl({ en, fr });
   }
 
   get cguUrl() {
-    const domainExtension = this.currentDomain.getExtension();
     const { en, fr } = this.SHOWCASE_WEBSITE_LOCALE_PATH.CGU;
-
-    return this._computeShowcaseWebsiteUrl({ domainExtension, en, fr });
+    return this._computeShowcaseWebsiteUrl({ en, fr });
   }
 
   get dataProtectionPolicyUrl() {
-    const domainExtension = this.currentDomain.getExtension();
     const { en, fr } = this.SHOWCASE_WEBSITE_LOCALE_PATH.DATA_PROTECTION_POLICY;
-
-    return this._computeShowcaseWebsiteUrl({ domainExtension, en, fr });
+    return this._computeShowcaseWebsiteUrl({ en, fr });
   }
 
   get accessibilityUrl() {
-    const domainExtension = this.currentDomain.getExtension();
     const { en, fr } = this.SHOWCASE_WEBSITE_LOCALE_PATH.ACCESSIBILITY;
-
-    return this._computeShowcaseWebsiteUrl({ domainExtension, en, fr });
+    return this._computeShowcaseWebsiteUrl({ en, fr });
   }
 
   get forgottenPasswordUrl() {
@@ -87,14 +75,14 @@ export default class Url extends Service {
     return url;
   }
 
-  _computeShowcaseWebsiteUrl({ domainExtension, en: englishPath, fr: frenchPath }) {
+  _computeShowcaseWebsiteUrl({ en: englishPath, fr: frenchPath }) {
     const currentLanguage = this.intl.t('current-lang');
 
-    if (domainExtension === FRENCH_DOMAIN_EXTENSION) {
+    if (this.currentDomain.isFranceDomain) {
       return `${PIX_FR_DOMAIN}${frenchPath}`;
     }
 
-    return currentLanguage === FRENCH_DOMAIN_EXTENSION
+    return currentLanguage === FRENCH_LOCALE
       ? `${PIX_ORG_DOMAIN_FR_LOCALE}${frenchPath}`
       : `${PIX_ORG_DOMAIN_EN_LOCALE}${englishPath}`;
   }

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -66,6 +66,7 @@ export default function () {
       id: user.id,
       firstName: user.firstName,
       lastName: user.lastName,
+      lang: 'fr',
     });
 
     return user;
@@ -74,6 +75,12 @@ export default function () {
   this.patch('/users/:id/pix-orga-terms-of-service-acceptance', (schema, request) => {
     const user = schema.users.find(request.params.id);
     user.update({ pixOrgaTermsOfServiceAccepted: true });
+    return user;
+  });
+
+  this.patch('/users/:id/lang/:lang', (schema, request) => {
+    const user = schema.users.find(request.params.id);
+    user.update({ lang: request.params.lang });
     return user;
   });
 

--- a/orga/tests/acceptance/authentication_test.js
+++ b/orga/tests/acceptance/authentication_test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { currentURL } from '@ember/test-helpers';
+import { visit as visitScreen } from '@1024pix/ember-testing-library';
 import { fillByLabel, clickByName, visit } from '@1024pix/ember-testing-library';
 import authenticateSession from '../helpers/authenticate-session';
 import { setupApplicationTest } from 'ember-qunit';
@@ -118,7 +119,7 @@ module('Acceptance | authentication', function (hooks) {
     module('When the organization has no credits and prescriber is ADMIN', function (hooks) {
       hooks.beforeEach(async () => {
         const user = createPrescriberForOrganization(
-          { firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com' },
+          { firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com', lang: 'fr' },
           { name: 'BRO & Evil Associates' },
           'ADMIN'
         );
@@ -176,12 +177,23 @@ module('Acceptance | authentication', function (hooks) {
         // then
         assert.strictEqual(currentURL(), '/campagnes/les-miennes');
       });
+
+      module('when a lang query param is present', function () {
+        test('sets and remembers the locale to the lang query param which wins over the user’s lang', async function (assert) {
+          // when
+          await visitScreen('/?lang=en');
+          const screen = await visitScreen('/');
+
+          // then
+          assert.dom(screen.getByRole('link', { name: 'Team' })).exists();
+        });
+      });
     });
 
     module('When the organization has credits and prescriber is ADMIN', function (hooks) {
       hooks.beforeEach(async () => {
         const user = createPrescriberForOrganization(
-          { firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com' },
+          { firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com', lang: 'fr' },
           { name: 'BRO & Evil Associates', credit: 10000 },
           'ADMIN'
         );
@@ -208,7 +220,7 @@ module('Acceptance | authentication', function (hooks) {
       module('When the organization has credits and prescriber is MEMBER', function (hooks) {
         hooks.beforeEach(async () => {
           const user = createPrescriberForOrganization(
-            { firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com' },
+            { firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com', lang: 'fr' },
             { name: 'BRO & Evil Associates', credit: 10000 },
             'MEMBER'
           );
@@ -228,7 +240,7 @@ module('Acceptance | authentication', function (hooks) {
     test('should redirect to main page when trying to access /certifications URL', async function (assert) {
       // given
       const user = createPrescriberForOrganization(
-        { firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com' },
+        { firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com', lang: 'fr' },
         { name: 'BRO & Evil Associates' },
         'ADMIN'
       );

--- a/orga/tests/acceptance/invitations-list_test.js
+++ b/orga/tests/acceptance/invitations-list_test.js
@@ -15,7 +15,7 @@ module('Acceptance | Invitations list', function (hooks) {
 
   test('it should be possible to cancel an invitation', async function (assert) {
     // given
-    const userAttributes = {};
+    const userAttributes = { lang: 'fr' };
     const invitationAttributes = {
       id: 123,
       email: 'gigi@example.net',

--- a/orga/tests/helpers/setup-intl.js
+++ b/orga/tests/helpers/setup-intl.js
@@ -5,6 +5,5 @@ export default function setupIntl(hooks, locale = ['fr']) {
 
     this.dayjs = this.owner.lookup('service:dayjs');
     this.dayjs.setLocale(locale[0]);
-    this.dayjs.self.locale(locale[0]);
   });
 }

--- a/orga/tests/helpers/test-init.js
+++ b/orga/tests/helpers/test-init.js
@@ -9,6 +9,7 @@ export function createPrescriberByUser(user, participantCount = 0) {
     id: user.id,
     firstName: user.firstName,
     lastName: user.lastName,
+    lang: user.lang,
     pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
     memberships: user.memberships,
     userOrgaSettings: user.userOrgaSettings,
@@ -22,8 +23,9 @@ export function createPrescriberWithPixOrgaTermsOfService({ pixOrgaTermsOfServic
   const firstName = 'Harry';
   const lastName = 'Cover';
   const email = 'harry@cover.com';
+  const lang = 'fr';
 
-  const user = server.create('user', { firstName, lastName, email, pixOrgaTermsOfServiceAccepted });
+  const user = server.create('user', { firstName, lastName, email, lang, pixOrgaTermsOfServiceAccepted });
 
   const organization = server.create('organization', {
     name: 'BRO & Evil Associates',
@@ -40,6 +42,7 @@ export function createPrescriberWithPixOrgaTermsOfService({ pixOrgaTermsOfServic
     id: user.id,
     firstName,
     lastName,
+    lang,
     pixOrgaTermsOfServiceAccepted,
     memberships: [membership],
     userOrgaSettings: userOrgaSettings,
@@ -67,6 +70,7 @@ export function createUserWithMembership() {
     firstName: 'Harry',
     lastName: 'Cover',
     email: 'harry@cover.com',
+    lang: 'fr',
     pixOrgaTermsOfServiceAccepted: false,
   });
 
@@ -79,6 +83,7 @@ export function createUserWithMembershipAndTermsOfServiceAccepted() {
     firstName: 'Harry',
     lastName: 'Cover',
     email: 'harry@cover.com',
+    lang: 'fr',
     pixOrgaTermsOfServiceAccepted: true,
   });
   server.create('member-identity', { id: user.id, firstName: 'Harry', lastName: 'Cover' });
@@ -90,6 +95,7 @@ export function createUserMembershipWithRole(organizationRole) {
     firstName: 'Harry',
     lastName: 'Cover',
     email: 'harry@cover.com',
+    lang: 'fr',
     pixOrgaTermsOfServiceAccepted: true,
   });
 
@@ -115,6 +121,7 @@ export function createUserWithMultipleMemberships() {
     firstName: 'Harry',
     lastName: 'Cover',
     email: 'harry@cover.com',
+    lang: 'fr',
     pixOrgaTermsOfServiceAccepted: true,
   });
 
@@ -181,6 +188,7 @@ export function createAdmin() {
     firstName: 'Harry',
     lastName: 'Cover',
     email: 'harry@cover.com',
+    lang: 'fr',
     pixOrgaTermsOfServiceAccepted: true,
   });
   const organization = server.create('organization', { name: 'BRO & Evil Associates' });
@@ -198,6 +206,7 @@ export function createAdmin() {
     id: user.id,
     firstName: user.firstName,
     lastName: user.lastName,
+    lang: user.lang,
     pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
     memberships: user.memberships,
     userOrgaSettings: user.userOrgaSettings,
@@ -211,6 +220,7 @@ export function createMember() {
     firstName: 'Harry',
     lastName: 'Cover',
     email: 'harry@cover.com',
+    lang: 'fr',
     pixOrgaTermsOfServiceAccepted: true,
   });
   server.create('member-identity', { id: user.id, firstName: 'Harry', lastName: 'Cover' });
@@ -229,6 +239,7 @@ export function createMember() {
     id: user.id,
     firstName: user.firstName,
     lastName: user.lastName,
+    lang: user.lang,
     pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
     memberships: user.memberships,
     userOrgaSettings: user.userOrgaSettings,
@@ -242,6 +253,7 @@ export function createUserManagingStudents(role = 'MEMBER', type = 'SCO') {
     firstName: 'Harry',
     lastName: 'Cover',
     email: 'harry@cover.com',
+    lang: 'fr',
     pixOrgaTermsOfServiceAccepted: true,
   });
 

--- a/orga/tests/integration/components/auth/login-form_test.js
+++ b/orga/tests/integration/components/auth/login-form_test.js
@@ -238,13 +238,13 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
 
   module('when domain is pix.org', function () {
     test('should not display recovery link', async function (assert) {
-      //given
-      class UrlStub extends Service {
-        get isFrenchDomainExtension() {
+      // given
+      class CurrentDomainServiceStub extends Service {
+        get isFranceDomain() {
           return false;
         }
       }
-      this.owner.register('service:url', UrlStub);
+      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
 
       // when
       await renderScreen(hbs`<Auth::LoginForm />`);
@@ -256,13 +256,13 @@ module('Integration | Component | Auth::LoginForm', function (hooks) {
 
   module('when domain is pix.fr', function () {
     test('should display recovery link', async function (assert) {
-      //given
-      class UrlStub extends Service {
-        get isFrenchDomainExtension() {
+      // given
+      class CurrentDomainServiceStub extends Service {
+        get isFranceDomain() {
           return true;
         }
       }
-      this.owner.register('service:url', UrlStub);
+      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
 
       // when
       await renderScreen(hbs`<Auth::LoginForm />`);

--- a/orga/tests/integration/components/auth/register-form_test.js
+++ b/orga/tests/integration/components/auth/register-form_test.js
@@ -57,7 +57,7 @@ module('Integration | Component | Auth::RegisterForm', function (hooks) {
   test('it should display legal mentions with related links', async function (assert) {
     // given
     const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+    service.currentDomain = { isFranceDomain: true };
 
     // when
     const screen = await renderScreen(hbs`<Auth::RegisterForm />`);

--- a/orga/tests/integration/components/layout/footer_test.js
+++ b/orga/tests/integration/components/layout/footer_test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { hbs } from 'ember-cli-htmlbars';
-import sinon from 'sinon';
 import { render as renderScreen } from '@1024pix/ember-testing-library';
 
 module('Integration | Component | Layout::Footer', function (hooks) {
@@ -22,7 +21,7 @@ module('Integration | Component | Layout::Footer', function (hooks) {
   test('should display legal notice link', async function (assert) {
     // given
     const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns('org') };
+    service.currentDomain = { isFranceDomain: false };
 
     // when
     const screen = await renderScreen(hbs`<Layout::Footer />}`);
@@ -35,7 +34,7 @@ module('Integration | Component | Layout::Footer', function (hooks) {
   test('should display accessibility link', async function (assert) {
     // given
     const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+    service.currentDomain = { isFranceDomain: true };
 
     // when
     const screen = await renderScreen(hbs`<Layout::Footer />}`);

--- a/orga/tests/integration/components/layout/sidebar_test.js
+++ b/orga/tests/integration/components/layout/sidebar_test.js
@@ -8,14 +8,14 @@ module('Integration | Component | Layout::Sidebar', function (hooks) {
   setupRenderingTest(hooks);
 
   module('when the user is authenticated on orga.pix.fr', function (hooks) {
-    class UrlServiceStub extends Service {
-      get isFrenchDomainExtension() {
+    class CurrentDomainServiceStub extends Service {
+      get isFranceDomain() {
         return true;
       }
     }
 
     hooks.beforeEach(function () {
-      this.owner.register('service:url', UrlServiceStub);
+      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
     });
 
     test('it should display documentation url given by current organization', async function (assert) {

--- a/orga/tests/unit/controllers/authenticated/certifications_test.js
+++ b/orga/tests/unit/controllers/authenticated/certifications_test.js
@@ -175,8 +175,8 @@ module('Unit | Controller | authenticated/certifications', function (hooks) {
         save: sinon.stub(),
       };
 
-      controller.url = {
-        isFrenchDomainExtension: true,
+      controller.currentDomain = {
+        isFranceDomain: true,
       };
 
       controller.model = {

--- a/orga/tests/unit/routes/application_test.js
+++ b/orga/tests/unit/routes/application_test.js
@@ -1,12 +1,27 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import Service from '@ember/service';
 
 module('Unit | Route | application', function (hooks) {
   setupTest(hooks);
 
+  hooks.beforeEach(function () {
+    class currentDomainStub extends Service {
+      get isFranceDomain() {
+        return true;
+      }
+    }
+    this.owner.register('service:currentDomain', currentDomainStub);
+
+    class CurrentUserStub extends Service {
+      load = sinon.stub();
+    }
+    this.owner.register('service:currentUser', CurrentUserStub);
+  });
+
   module('beforeModel', function () {
-    test('should load feature toggles', async function (assert) {
+    test('loads feature toggles', async function (assert) {
       // given
       const transition = { to: { queryParams: {} } };
       const route = this.owner.lookup('route:application');
@@ -14,8 +29,7 @@ module('Unit | Route | application', function (hooks) {
       sinon.stub(route.featureToggles, 'load');
       route.featureToggles.load.resolves();
 
-      sinon.stub(route.session, 'handlePrescriberLanguageAndLocale');
-      route.session.handlePrescriberLanguageAndLocale.resolves();
+      sinon.stub(route.session, 'handleLocale');
 
       // when
       await route.beforeModel(transition);
@@ -24,24 +38,27 @@ module('Unit | Route | application', function (hooks) {
       assert.ok(route.featureToggles.load.called);
     });
 
-    module('When lang parameter exist', function () {
-      test('should use lang parameter with session service method', async function (assert) {
-        // given
-        const transition = { to: { queryParams: { lang: 'fr' } } };
-        const route = this.owner.lookup('route:application');
+    test('calls handleLocale', async function (assert) {
+      // given
+      const transition = { to: { queryParams: { lang: 'fr' } } };
+      const route = this.owner.lookup('route:application');
 
-        sinon.stub(route.featureToggles, 'load');
-        route.featureToggles.load.resolves();
+      sinon.stub(route.featureToggles, 'load');
+      route.featureToggles.load.resolves();
 
-        sinon.stub(route.session, 'handlePrescriberLanguageAndLocale');
-        route.session.handlePrescriberLanguageAndLocale.resolves();
+      sinon.stub(route.session, 'handleLocale');
+      route.session.handleLocale.resolves();
 
-        // when
-        await route.beforeModel(transition);
+      // when
+      await route.beforeModel(transition);
 
-        // then
-        assert.ok(route.session.handlePrescriberLanguageAndLocale.calledWith('fr'));
+      // then
+      sinon.assert.calledWith(route.session.handleLocale, {
+        isFranceDomain: true,
+        localeFromQueryParam: 'fr',
+        userLocale: undefined,
       });
+      assert.ok(true);
     });
   });
 });

--- a/orga/tests/unit/services/current-domain_test.js
+++ b/orga/tests/unit/services/current-domain_test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+const FRANCE_TLD = 'fr';
+const INTERNATIONAL_TLD = 'org';
+
+module('Unit | Service | currentDomain', function (hooks) {
+  setupTest(hooks);
+
+  module('#isFranceDomain', function () {
+    test('returns true when TLD is the France domain (.fr)', function (assert) {
+      // given
+      const service = this.owner.lookup('service:currentDomain');
+      service.getExtension = sinon.stub().returns(FRANCE_TLD);
+
+      // when
+      const isFranceDomain = service.isFranceDomain;
+
+      // then
+      assert.true(isFranceDomain);
+    });
+
+    test('returns false when TLD is the international domain (.org)', function (assert) {
+      // given
+      const service = this.owner.lookup('service:currentDomain');
+      service.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
+
+      // when
+      const isFranceDomain = service.isFranceDomain;
+
+      // then
+      assert.false(isFranceDomain);
+    });
+  });
+});

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -2,101 +2,48 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
+const DEFAULT_LOCALE = 'fr';
+const FRENCH_INTERNATIONAL_LOCALE = 'fr';
+const FRENCH_FRANCE_LOCALE = 'fr-FR';
+
 module('Unit | Service | session', function (hooks) {
   setupTest(hooks);
 
+  let routerService;
   let service;
+  let localeService;
 
   hooks.beforeEach(function () {
+    routerService = this.owner.lookup('service:router');
+    routerService.transitionTo = sinon.stub();
+
     service = this.owner.lookup('service:session');
 
-    service.currentUser = {
-      load: sinon.stub(),
-    };
-    service.url = {
-      isFrenchDomainExtension: sinon.stub(),
-    };
-    service.intl = {
-      setLocale: sinon.stub(),
-      get: sinon.stub(),
-    };
-    service.dayjs = {
-      setLocale: sinon.stub(),
-    };
-
-    service.locale = {
+    localeService = this.owner.lookup('service:locale');
+    Object.assign(localeService, {
       setLocaleCookie: sinon.stub(),
       hasLocaleCookie: sinon.stub(),
-    };
-    service.currentDomain = {
-      getExtension: sinon.stub(),
-    };
-  });
-
-  module('#handlePrescriberLanguageAndLocale', function () {
-    module('when there is not prescriber', function () {
-      test('should call current user and set fr locale by default', async function (assert) {
-        // given
-        service.url.isFrenchDomainExtension.returns(true);
-
-        // when
-        await service.handlePrescriberLanguageAndLocale();
-
-        // then
-        assert.ok(service.currentUser.load.called);
-        assert.ok(service.intl.setLocale.calledWith(['fr', 'fr']));
-        assert.ok(service.dayjs.setLocale.calledWith('fr'));
-      });
-
-      module('when domain extension is not .fr', function () {
-        test('should set locale to en when language parameter is en', async function (assert) {
-          // given
-          service.url = {
-            isFrenchDomainExtension: false,
-          };
-          service.intl.get.withArgs('locales').returns(['fr', 'en']);
-
-          // when
-          await service.handlePrescriberLanguageAndLocale('en');
-
-          // then
-          assert.ok(service.intl.setLocale.calledWith(['en', 'fr']));
-          assert.ok(service.dayjs.setLocale.calledWith('en'));
-        });
-      });
-    });
-
-    module('when there is a prescriber', function () {
-      test('should update prescriber lang when it is different of language parameter', async function (assert) {
-        // given
-        service.currentUser = {
-          load: sinon.stub(),
-          prescriber: {
-            lang: 'fr',
-            save: sinon.stub(),
-          },
-        };
-        service.url.isFrenchDomainExtension.returns(true);
-
-        // when
-        await service.handlePrescriberLanguageAndLocale('en');
-
-        // then
-        assert.ok(
-          service.currentUser.prescriber.save.calledWith({
-            adapterOptions: {
-              lang: 'en',
-            },
-          })
-        );
-      });
     });
   });
 
   module('#handleAuthentication', function () {
-    test('should override handleAuthentication method', function (assert) {
-      // when & then
-      assert.ok(service.handleAuthentication instanceof Function);
+    test('calls handleLocale', async function (assert) {
+      // given
+      service.currentUser = {
+        load: sinon.stub(),
+        prescriber: {
+          lang: 'fr',
+          save: sinon.stub(),
+        },
+      };
+      service.handleLocale = sinon.stub();
+
+      // when
+      await service.handleAuthentication();
+
+      // then
+      sinon.assert.called(service.handleLocale);
+      assert.ok(true);
     });
   });
 
@@ -107,35 +54,318 @@ module('Unit | Service | session', function (hooks) {
     });
   });
 
-  module('when the current domain  is "fr"', function () {
-    module('when there is no cookie locale', function () {
-      test('add a cookie locale with "fr-FR" as value', async function (assert) {
-        // given
-        service.locale.hasLocaleCookie.returns(false);
-        service.currentDomain.getExtension.returns('fr');
+  module('#handleLocale', function () {
+    module('when domain is .fr', function () {
+      module('when there is no cookie locale', function () {
+        test('adds a cookie locale with "fr-FR" as value', async function (assert) {
+          // given
+          localeService.hasLocaleCookie.returns(false);
 
-        // when
-        await service.handlePrescriberLanguageAndLocale();
+          // when
+          const isFranceDomain = true;
+          const localeFromQueryParam = undefined;
+          const userLocale = undefined;
+          await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
-        // then
-        sinon.assert.calledWith(service.locale.setLocaleCookie, 'fr-FR');
-        assert.ok(true);
+          // then
+          sinon.assert.calledWith(localeService.setLocaleCookie, FRENCH_FRANCE_LOCALE);
+          assert.ok(true);
+        });
+      });
+
+      module('when there is a cookie locale', function () {
+        test('does not update cookie locale', async function (assert) {
+          // given
+          localeService.hasLocaleCookie.returns(true);
+
+          // when
+          const isFranceDomain = true;
+          const localeFromQueryParam = undefined;
+          const userLocale = undefined;
+          await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+          // then
+          sinon.assert.notCalled(localeService.setLocaleCookie);
+          assert.ok(true);
+        });
+      });
+
+      module('when no lang query param', function () {
+        module('when user is not loaded', function () {
+          test('sets the locale to be French international in every case', async function (assert) {
+            // given
+            service.currentUser = {
+              load: sinon.stub(),
+              prescriber: null,
+            };
+            service._setLocale = sinon.stub();
+
+            // when
+            const isFranceDomain = true;
+            const localeFromQueryParam = undefined;
+            const userLocale = undefined;
+            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+            // then
+            sinon.assert.calledWith(service._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            assert.ok(true);
+          });
+        });
+
+        module('when user is loaded', function () {
+          test('sets the locale to be French international in every case', async function (assert) {
+            // given
+            service.currentUser = {
+              load: sinon.stub(),
+              prescriber: {
+                lang: 'en',
+                save: sinon.stub(),
+              },
+            };
+            service._setLocale = sinon.stub();
+
+            // when
+            const isFranceDomain = true;
+            const localeFromQueryParam = undefined;
+            const userLocale = 'en';
+            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+            // then
+            sinon.assert.calledWith(service._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            sinon.assert.notCalled(service.currentUser.prescriber.save);
+            assert.ok(true);
+          });
+        });
+      });
+
+      module('when a lang query param is present', function () {
+        module('when user is not loaded', function () {
+          test('sets the locale to be French international in every case', async function (assert) {
+            // given
+            service.currentUser = {
+              load: sinon.stub(),
+              prescriber: null,
+            };
+            service._setLocale = sinon.stub();
+
+            // when
+            const isFranceDomain = true;
+            const localeFromQueryParam = 'en';
+            const userLocale = undefined;
+            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+            // then
+            sinon.assert.calledWith(service._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            assert.ok(true);
+          });
+        });
+
+        module('when user is loaded', function () {
+          test('sets the locale to be French international in every case', async function (assert) {
+            // given
+            service.currentUser = {
+              load: sinon.stub(),
+              prescriber: {
+                lang: 'en',
+                save: sinon.stub(),
+              },
+            };
+            service._setLocale = sinon.stub();
+
+            // when
+            const isFranceDomain = true;
+            const localeFromQueryParam = 'en';
+            const userLocale = 'en';
+            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+            // then
+            sinon.assert.calledWith(service._setLocale, FRENCH_INTERNATIONAL_LOCALE);
+            sinon.assert.notCalled(service.currentUser.prescriber.save);
+            assert.ok(true);
+          });
+        });
       });
     });
 
-    module('when there is a cookie locale', function () {
-      test('does not update cookie locale', async function (assert) {
+    module('when domain is .org', function () {
+      test('does not set the cookie locale', async function (assert) {
         // given
-        service.locale.hasLocaleCookie.returns(true);
-        service.currentDomain.getExtension.returns('fr');
+        localeService.hasLocaleCookie.returns(false);
 
         // when
-        await service.handlePrescriberLanguageAndLocale();
+        const isFranceDomain = false;
+        const localeFromQueryParam = undefined;
+        const userLocale = undefined;
+        await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
 
         // then
-        sinon.assert.notCalled(service.locale.setLocaleCookie);
+        sinon.assert.notCalled(localeService.setLocaleCookie);
         assert.ok(true);
       });
+
+      module('when no lang query param', function () {
+        module('when user is not loaded', function () {
+          test('sets the default locale', async function (assert) {
+            // given
+            service.currentUser = {
+              load: sinon.stub(),
+              prescriber: null,
+            };
+            service._setLocale = sinon.stub();
+
+            // when
+            const isFranceDomain = false;
+            const localeFromQueryParam = undefined;
+            const userLocale = undefined;
+            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+            // then
+            sinon.assert.calledWith(service._setLocale, DEFAULT_LOCALE);
+            assert.ok(true);
+          });
+        });
+
+        module('when user is loaded', function () {
+          test('sets the locale to the user’s lang', async function (assert) {
+            // given
+            service.currentUser = {
+              load: sinon.stub(),
+              prescriber: {
+                lang: 'en',
+                save: sinon.stub(),
+              },
+            };
+            service._setLocale = sinon.stub();
+
+            // when
+            const isFranceDomain = false;
+            const localeFromQueryParam = undefined;
+            const userLocale = 'en';
+            await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+            // then
+            sinon.assert.calledWith(service._setLocale, 'en');
+            sinon.assert.notCalled(service.currentUser.prescriber.save);
+            assert.ok(true);
+          });
+        });
+      });
+
+      module('when a lang query param is present', function () {
+        module('when the lang query param is invalid', function () {
+          module('when user is not loaded', function () {
+            test('sets the default locale', async function (assert) {
+              // given
+              service.currentUser = {
+                load: sinon.stub(),
+                prescriber: null,
+              };
+              service._setLocale = sinon.stub();
+
+              // when
+              const isFranceDomain = false;
+              const localeFromQueryParam = 'an invalid locale';
+              const userLocale = undefined;
+              await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+              // then
+              sinon.assert.calledWith(service._setLocale, DEFAULT_LOCALE);
+              assert.ok(true);
+            });
+          });
+
+          module('when user is loaded', function () {
+            test('sets the locale to the user’s lang', async function (assert) {
+              // given
+              service.currentUser = {
+                load: sinon.stub(),
+                prescriber: {
+                  lang: 'en',
+                  save: sinon.stub(),
+                },
+              };
+              service._setLocale = sinon.stub();
+
+              // when
+              const isFranceDomain = false;
+              const localeFromQueryParam = 'an invalid locale';
+              const userLocale = 'en';
+              await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+              // then
+              sinon.assert.calledWith(service._setLocale, 'en');
+              sinon.assert.notCalled(service.currentUser.prescriber.save);
+              assert.ok(true);
+            });
+          });
+        });
+
+        module('when the lang query param is valid', function () {
+          module('when user is not loaded', function () {
+            test('sets the locale to the lang query param', async function (assert) {
+              // given
+              service.currentUser = {
+                load: sinon.stub(),
+                prescriber: null,
+              };
+              service._setLocale = sinon.stub();
+
+              // when
+              const isFranceDomain = false;
+              const localeFromQueryParam = 'en';
+              const userLocale = undefined;
+              await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+              // then
+              sinon.assert.calledWith(service._setLocale, 'en');
+              assert.ok(true);
+            });
+          });
+
+          module('when user is loaded', function () {
+            test('sets the locale to the lang query param which wins over', async function (assert) {
+              // given
+              service.currentUser = {
+                load: sinon.stub(),
+                prescriber: {
+                  lang: 'fr',
+                  save: sinon.stub(),
+                },
+              };
+              service._setLocale = sinon.stub();
+
+              // when
+              const isFranceDomain = false;
+              const localeFromQueryParam = 'en';
+              const userLocale = 'fr';
+              await service.handleLocale({ isFranceDomain, localeFromQueryParam, userLocale });
+
+              // then
+              sinon.assert.calledWith(service._setLocale, 'en');
+              sinon.assert.calledWith(service.currentUser.prescriber.save, {
+                adapterOptions: { lang: 'en' },
+              });
+              assert.ok(true);
+            });
+          });
+        });
+      });
+    });
+  });
+
+  module('#_setLocale', function () {
+    test('calls intl and dayjs services', async function (assert) {
+      // given
+      service.intl = { setLocale: sinon.stub() };
+      service.dayjs = { setLocale: sinon.stub(), self: { locale: sinon.stub() } };
+
+      // when
+      await service._setLocale('some locale');
+
+      // then
+      sinon.assert.calledWith(service.intl.setLocale, ['some locale', 'fr']);
+      sinon.assert.calledWith(service.dayjs.setLocale, 'some locale');
+      assert.ok(true);
     });
   });
 });

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -22,9 +22,6 @@ module('Unit | Service | session', function (hooks) {
     };
     service.dayjs = {
       setLocale: sinon.stub(),
-      self: {
-        locale: sinon.stub(),
-      },
     };
 
     service.locale = {

--- a/orga/tests/unit/services/session_test.js
+++ b/orga/tests/unit/services/session_test.js
@@ -357,7 +357,7 @@ module('Unit | Service | session', function (hooks) {
     test('calls intl and dayjs services', async function (assert) {
       // given
       service.intl = { setLocale: sinon.stub() };
-      service.dayjs = { setLocale: sinon.stub(), self: { locale: sinon.stub() } };
+      service.dayjs = { setLocale: sinon.stub() };
 
       // when
       await service._setLocale('some locale');

--- a/orga/tests/unit/services/url_test.js
+++ b/orga/tests/unit/services/url_test.js
@@ -7,32 +7,6 @@ module('Unit | Service | url', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks);
 
-  module('#isFrenchDomainExtension', function () {
-    test('returns true when the current domain contains pix.fr', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
-
-      // when
-      const domainExtension = service.isFrenchDomainExtension;
-
-      // then
-      assert.true(domainExtension);
-    });
-
-    test('returns false when the current domain contains pix.org', function (assert) {
-      // given
-      const service = this.owner.lookup('service:url');
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
-
-      // when
-      const domainExtension = service.isFrenchDomainExtension;
-
-      // then
-      assert.false(domainExtension);
-    });
-  });
-
   module('#campaignsRootUrl', function () {
     test('returns default campaigns root url when is defined', function (assert) {
       // given
@@ -95,7 +69,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.fr/mentions-legales';
-      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+      service.currentDomain = { isFranceDomain: true };
 
       // when
       const url = service.legalNoticeUrl;
@@ -108,7 +82,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.org/en-gb/legal-notice';
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.currentDomain = { isFranceDomain: false };
       service.intl = { t: sinon.stub().returns('en') };
 
       // when
@@ -122,7 +96,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.org/fr/mentions-legales';
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.currentDomain = { isFranceDomain: false };
       service.intl = { t: sinon.stub().returns('fr') };
 
       // when
@@ -138,7 +112,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
-      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+      service.currentDomain = { isFranceDomain: true };
 
       // when
       const cguUrl = service.dataProtectionPolicyUrl;
@@ -151,7 +125,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.currentDomain = { isFranceDomain: false };
       service.intl = { t: sinon.stub().returns('en') };
 
       // when
@@ -165,7 +139,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.org/fr/politique-protection-donnees-personnelles-app';
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.currentDomain = { isFranceDomain: false };
       service.intl = { t: sinon.stub().returns('fr') };
 
       // when
@@ -181,7 +155,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
-      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+      service.currentDomain = { isFranceDomain: true };
 
       // when
       const cguUrl = service.cguUrl;
@@ -194,7 +168,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.org/en-gb/terms-and-conditions';
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.currentDomain = { isFranceDomain: false };
       service.intl = { t: sinon.stub().returns('en') };
 
       // when
@@ -208,7 +182,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedCguUrl = 'https://pix.org/fr/conditions-generales-d-utilisation';
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.currentDomain = { isFranceDomain: false };
       service.intl = { t: sinon.stub().returns('fr') };
 
       // when
@@ -224,7 +198,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.fr/accessibilite-pix-orga';
-      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+      service.currentDomain = { isFranceDomain: true };
 
       // when
       const url = service.accessibilityUrl;
@@ -237,7 +211,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.org/en-gb/accessibility-pix-orga';
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.currentDomain = { isFranceDomain: false };
       service.intl = { t: sinon.stub().returns('en') };
 
       // when
@@ -251,7 +225,7 @@ module('Unit | Service | url', function (hooks) {
       // given
       const service = this.owner.lookup('service:url');
       const expectedUrl = 'https://pix.org/fr/accessibilite-pix-orga';
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      service.currentDomain = { isFranceDomain: false };
       service.intl = { t: sinon.stub().returns('fr') };
 
       // when


### PR DESCRIPTION
## :unicorn: Problème

Quand un utilisateur se connecte sur orga.pix.org le site web n'est pas dans la langue que l'utilisateur a configurée dans son compte. On souhaite que l'application Pix Orga soit traduite dans la langue que l'utilisateur a configurée dans son compte.

On rappelle ci-dessous la règle de priorité de la lang/locale des différents éléments.

**Règle de priorité** : `lang` utilisateur < `lang` query param < `lang` domaine `.fr`

## :robot: Proposition

L'information de la `lang` du user est déjà envoyée par l'API lors de l'authentification, il suffit de l'utiliser en respectant la règle de priorité. 

## :rainbow: Remarques

### Comportement

Le comportement actuel de Pix Orga est de changer la `lang` de l'utilisateur si un query param `lang` est passé dans l'URL. Ce n'est pas le comportement qu'on veut à terme car :
* c'est fait sans demander son consentement à l'utilisateur
* tout changement, de langue ou de toute autre propriété/préférence de l'utilisateur, par le simple fait de visiter un URL (qui est donc une requête GET) ayant certains query params (ici lang) est une mauvaise pratique. Sources :
   * https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET
   * https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods

Néanmoins, ce comportement du patch de l'utilisateur, qui avait du sens avant cette PR, n'est pas modifié dans cette PR-ci, de manière à donner le temps à tous les utilisateurs, responsables du support, etc. de s'approprier la nouvelle fonctionnalité apportée par cette PR, à savoir afficher Pix Orga dans la langue de l'utilisateur enregistrée dans son compte.

### Implémentation

L'implémentation proposée est basée sur le fait que tous les utilisateurs ont obligatoirement la colonne `lang` remplie dans la table `users` comme l'exige le schéma de la BDD. Faire une requête en production pour s'assurer que c'est bien le cas.

### Nommage dans le code

_TLD_ veut dire [Top-level domain](https://en.wikipedia.org/wiki/Top-level_domain), _domaine de premier niveau_ en français. Et donc la constante `FRANCE_TLD = 'fr'` correspond au _domaine de premier niveau_ pour la France.

### Refactor

Cette PR inclut des commits _refactor_ qui suppriment `dayjs.self.locale(locale)`, qui sont des appels inutiles, dans toutes les applis.

En effet le `setLocale` de ember-dayjs _set_ aussi la locale du service : https://github.com/sinankeskin/ember-dayjs/blob/f62de54409f21043f91de55724c63002c70180e6/addon/services/dayjs.js#L16-L20
dayjs.js
```javascript
  setLocale(locale) {
    this.useLocale(locale);

    this.locale = locale;
  }
```

## :100: Pour tester

1. Choisir un utilisateur ayant accès à Pix Orga, par exemple `allorga@example.net`
2. Se connecter sur Pix App **.org** https://app-pr5991.review.pix.org/
3. Aller dans « Mon compte »
4. Changer la langue de « Français » à « Anglais »
5. Aller sur Pix Orga **.fr** https://orga-pr5991.review.pix.fr/connexion puis avec le même URL mais en passant en plus le paramètre `?lang=en`  https://orga-pr5991.review.pix.fr/connexion?lang=en et constater que dans les deux cas le domaine est l'élément le plus prioritaire pour la sélection de la langue d'affichage, c'est à dire que le site web est toujours en français peu importe la présence du paramètre `lang`
6. Se connecter sur Pix Orga **.fr** https://orga-pr5991.review.pix.fr/ avec le même user que précédemment choisi et constater que le domaine est l'élément le plus prioritaire pour la sélection de la langue d'affichage, c'est à dire que le site web est toujours en français peu importe que l'utilisateur soit connecté ou non
7. Aller sur Pix Orga **.org**  https://orga-pr5991.review.pix.org/ sans être connecté et constater que le site web est en français par défaut
8. Se connecter sur Pix Orga **.org**  https://orga-pr5991.review.pix.org/ avec le même user que précédemment choisi et constater que le site web passe en anglais, qui est la `lang` de l'utilisateur
9. Aller sur Pix Orga **.org** https://orga-pr5991.review.pix.org/ avec l'utilisateur toujours connecté en faisant varier les valeurs du paramètre `lang`, en mettant alternativement `?lang=fr` https://orga-pr5991.review.pix.org/?lang=fr et `?lang=en` https://orga-pr5991.review.pix.org/?lang=en et constater que : 
   * le query param est pris en compte prioritairement à la langue de l'utilisateur
   * la `lang` de l'utilisateur a été modifiée en base cf. _Remarques > Comportement_ ci-dessus
11. Recharger la page de Pix Orga **.org**  https://orga-pr5991.review.pix.org/ avec l'utilisateur toujours connecté et constater que le site web s'affiche en anglais, qui est la `lang` de l'utilisateur, c'est à dire que le query param qui était « mémorisé » dans l'application web Pix Orga pour la précédente visite du site web est oublié et que c'est maintenant la `lang` de l'utilisateur qui est prise en compte
12. Vérifier qu'une valeur invalide pour `lang`, c'est à dire autre que `fr` ou `en`, ne fait jamais planter l'application Ember Pix Orga https://orga-pr5991.review.pix.fr/?lang=invalid-value  https://orga-pr5991.review.pix.org/?lang=invalid-value : ouvrir la console et constater qu'il n'y a pas d'erreur et on doit pouvoir naviguer normalement sans que certaines actions soient impossibles
