### PR TITLE
[TECH] Supprime ember-cli-terser des applications qui utilisent embroider

### DIFF
--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -43,7 +43,6 @@
         "ember-cli-notifications": "^8.0.0",
         "ember-cli-sass": "^11.0.1",
         "ember-cli-sri": "^2.1.1",
-        "ember-cli-terser": "^4.0.2",
         "ember-composable-helpers": "^4.5.0",
         "ember-cookies": "^0.5.2",
         "ember-data": "^4.0.2",
@@ -11036,63 +11035,6 @@
         "matcher-collection": "^1.0.0"
       }
     },
-    "node_modules/broccoli-terser-sourcemap": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/broccoli-terser-sourcemap/-/broccoli-terser-sourcemap-4.1.0.tgz",
-      "integrity": "sha512-zkNnjsAbP+M5rG2aMM1EE4BmXPUSxFKmtLUkUs2D1DLTOJQoF1xlOjGWjjKYCFy5tw8t4+tgGJ+HVa2ucJZ8sw==",
-      "dev": true,
-      "dependencies": {
-        "async-promise-queue": "^1.0.5",
-        "broccoli-plugin": "^4.0.3",
-        "debug": "^4.1.0",
-        "lodash.defaultsdeep": "^4.6.1",
-        "matcher-collection": "^2.0.1",
-        "source-map-url": "^0.4.0",
-        "symlink-or-copy": "^1.3.1",
-        "terser": "^5.3.0",
-        "walk-sync": "^2.2.0",
-        "workerpool": "^6.0.0"
-      },
-      "engines": {
-        "node": "^10.12.0 || 12.* || >= 14"
-      }
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/source-map-url": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-      "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
-      "dev": true
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
-      "dev": true
-    },
     "node_modules/broccoli/node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -16088,18 +16030,6 @@
       "resolved": "https://registry.npmjs.org/ember-cli-string-utils/-/ember-cli-string-utils-1.1.0.tgz",
       "integrity": "sha1-ObZ3/CgF9VFzc1N2/O8njqpEUqE=",
       "dev": true
-    },
-    "node_modules/ember-cli-terser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-terser/-/ember-cli-terser-4.0.2.tgz",
-      "integrity": "sha512-Ej77K+YhCZImotoi/CU2cfsoZaswoPlGaM5TB3LvjvPDlVPRhxUHO2RsaUVC5lsGeRLRiHCOxVtoJ6GyqexzFA==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-terser-sourcemap": "^4.1.0"
-      },
-      "engines": {
-        "node": "10.* || 12.* || >= 14"
-      }
     },
     "node_modules/ember-cli-test-info": {
       "version": "1.0.0",
@@ -25705,12 +25635,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
-      "dev": true
-    },
-    "node_modules/lodash.defaultsdeep": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
-      "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
       "dev": true
     },
     "node_modules/lodash.find": {
@@ -44232,53 +44156,6 @@
         }
       }
     },
-    "broccoli-terser-sourcemap": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/broccoli-terser-sourcemap/-/broccoli-terser-sourcemap-4.1.0.tgz",
-      "integrity": "sha512-zkNnjsAbP+M5rG2aMM1EE4BmXPUSxFKmtLUkUs2D1DLTOJQoF1xlOjGWjjKYCFy5tw8t4+tgGJ+HVa2ucJZ8sw==",
-      "dev": true,
-      "requires": {
-        "async-promise-queue": "^1.0.5",
-        "broccoli-plugin": "^4.0.3",
-        "debug": "^4.1.0",
-        "lodash.defaultsdeep": "^4.6.1",
-        "matcher-collection": "^2.0.1",
-        "source-map-url": "^0.4.0",
-        "symlink-or-copy": "^1.3.1",
-        "terser": "^5.3.0",
-        "walk-sync": "^2.2.0",
-        "workerpool": "^6.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "source-map-url": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-          "dev": true
-        },
-        "workerpool": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-          "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
-          "dev": true
-        }
-      }
-    },
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -48676,15 +48553,6 @@
       "resolved": "https://registry.npmjs.org/ember-cli-string-utils/-/ember-cli-string-utils-1.1.0.tgz",
       "integrity": "sha1-ObZ3/CgF9VFzc1N2/O8njqpEUqE=",
       "dev": true
-    },
-    "ember-cli-terser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-terser/-/ember-cli-terser-4.0.2.tgz",
-      "integrity": "sha512-Ej77K+YhCZImotoi/CU2cfsoZaswoPlGaM5TB3LvjvPDlVPRhxUHO2RsaUVC5lsGeRLRiHCOxVtoJ6GyqexzFA==",
-      "dev": true,
-      "requires": {
-        "broccoli-terser-sourcemap": "^4.1.0"
-      }
     },
     "ember-cli-test-info": {
       "version": "1.0.0",
@@ -55945,12 +55813,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
-      "dev": true
-    },
-    "lodash.defaultsdeep": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
-      "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
       "dev": true
     },
     "lodash.find": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -70,7 +70,6 @@
     "ember-cli-notifications": "^8.0.0",
     "ember-cli-sass": "^11.0.1",
     "ember-cli-sri": "^2.1.1",
-    "ember-cli-terser": "^4.0.2",
     "ember-composable-helpers": "^4.5.0",
     "ember-cookies": "^0.5.2",
     "ember-data": "^4.0.2",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -50,7 +50,6 @@
         "ember-cli-mirage": "^2.3.2",
         "ember-cli-sass": "^11.0.1",
         "ember-cli-sri": "^2.1.1",
-        "ember-cli-terser": "^4.0.2",
         "ember-cli-test-loader": "^3.0.0",
         "ember-collapsible-panel": "^5.0.0",
         "ember-cookies": "^0.5.2",
@@ -13717,126 +13716,6 @@
         "node": "6.* || >= 8.*"
       }
     },
-    "node_modules/broccoli-terser-sourcemap": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/broccoli-terser-sourcemap/-/broccoli-terser-sourcemap-4.1.0.tgz",
-      "integrity": "sha512-zkNnjsAbP+M5rG2aMM1EE4BmXPUSxFKmtLUkUs2D1DLTOJQoF1xlOjGWjjKYCFy5tw8t4+tgGJ+HVa2ucJZ8sw==",
-      "dev": true,
-      "dependencies": {
-        "async-promise-queue": "^1.0.5",
-        "broccoli-plugin": "^4.0.3",
-        "debug": "^4.1.0",
-        "lodash.defaultsdeep": "^4.6.1",
-        "matcher-collection": "^2.0.1",
-        "source-map-url": "^0.4.0",
-        "symlink-or-copy": "^1.3.1",
-        "terser": "^5.3.0",
-        "walk-sync": "^2.2.0",
-        "workerpool": "^6.0.0"
-      },
-      "engines": {
-        "node": "^10.12.0 || 12.* || >= 14"
-      }
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/broccoli-plugin": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-node-api": "^1.7.0",
-        "broccoli-output-wrapper": "^3.2.5",
-        "fs-merger": "^3.2.1",
-        "promise-map-series": "^0.3.0",
-        "quick-temp": "^0.1.8",
-        "rimraf": "^3.0.2",
-        "symlink-or-copy": "^1.3.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/matcher-collection": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-      "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "minimatch": "^3.0.2"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/promise-map-series": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-      "dev": true,
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
-      "dev": true
-    },
     "node_modules/broccoli/node_modules/broccoli-source": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-3.0.1.tgz",
@@ -20212,18 +20091,6 @@
       "resolved": "https://registry.npmjs.org/ember-cli-string-utils/-/ember-cli-string-utils-1.1.0.tgz",
       "integrity": "sha1-ObZ3/CgF9VFzc1N2/O8njqpEUqE=",
       "dev": true
-    },
-    "node_modules/ember-cli-terser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-terser/-/ember-cli-terser-4.0.2.tgz",
-      "integrity": "sha512-Ej77K+YhCZImotoi/CU2cfsoZaswoPlGaM5TB3LvjvPDlVPRhxUHO2RsaUVC5lsGeRLRiHCOxVtoJ6GyqexzFA==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-terser-sourcemap": "^4.1.0"
-      },
-      "engines": {
-        "node": "10.* || 12.* || >= 14"
-      }
     },
     "node_modules/ember-cli-test-info": {
       "version": "1.0.0",
@@ -31801,12 +31668,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
-      "dev": true
-    },
-    "node_modules/lodash.defaultsdeep": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
-      "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
       "dev": true
     },
     "node_modules/lodash.find": {
@@ -52010,99 +51871,6 @@
         "walk-sync": "^0.3.3"
       }
     },
-    "broccoli-terser-sourcemap": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/broccoli-terser-sourcemap/-/broccoli-terser-sourcemap-4.1.0.tgz",
-      "integrity": "sha512-zkNnjsAbP+M5rG2aMM1EE4BmXPUSxFKmtLUkUs2D1DLTOJQoF1xlOjGWjjKYCFy5tw8t4+tgGJ+HVa2ucJZ8sw==",
-      "dev": true,
-      "requires": {
-        "async-promise-queue": "^1.0.5",
-        "broccoli-plugin": "^4.0.3",
-        "debug": "^4.1.0",
-        "lodash.defaultsdeep": "^4.6.1",
-        "matcher-collection": "^2.0.1",
-        "source-map-url": "^0.4.0",
-        "symlink-or-copy": "^1.3.1",
-        "terser": "^5.3.0",
-        "walk-sync": "^2.2.0",
-        "workerpool": "^6.0.0"
-      },
-      "dependencies": {
-        "broccoli-plugin": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-          "dev": true,
-          "requires": {
-            "broccoli-node-api": "^1.7.0",
-            "broccoli-output-wrapper": "^3.2.5",
-            "fs-merger": "^3.2.1",
-            "promise-map-series": "^0.3.0",
-            "quick-temp": "^0.1.8",
-            "rimraf": "^3.0.2",
-            "symlink-or-copy": "^1.3.1"
-          }
-        },
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "matcher-collection": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "minimatch": "^3.0.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "promise-map-series": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-          "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
-          }
-        },
-        "workerpool": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-          "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
-          "dev": true
-        }
-      }
-    },
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -57949,15 +57717,6 @@
       "resolved": "https://registry.npmjs.org/ember-cli-string-utils/-/ember-cli-string-utils-1.1.0.tgz",
       "integrity": "sha1-ObZ3/CgF9VFzc1N2/O8njqpEUqE=",
       "dev": true
-    },
-    "ember-cli-terser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-terser/-/ember-cli-terser-4.0.2.tgz",
-      "integrity": "sha512-Ej77K+YhCZImotoi/CU2cfsoZaswoPlGaM5TB3LvjvPDlVPRhxUHO2RsaUVC5lsGeRLRiHCOxVtoJ6GyqexzFA==",
-      "dev": true,
-      "requires": {
-        "broccoli-terser-sourcemap": "^4.1.0"
-      }
     },
     "ember-cli-test-info": {
       "version": "1.0.0",
@@ -65943,12 +65702,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
-      "dev": true
-    },
-    "lodash.defaultsdeep": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
-      "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
       "dev": true
     },
     "lodash.find": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -78,7 +78,6 @@
     "ember-cli-mirage": "^2.3.2",
     "ember-cli-sass": "^11.0.1",
     "ember-cli-sri": "^2.1.1",
-    "ember-cli-terser": "^4.0.2",
     "ember-cli-test-loader": "^3.0.0",
     "ember-collapsible-panel": "^5.0.0",
     "ember-cookies": "^0.5.2",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -50,7 +50,6 @@
         "ember-cli-sass": "^11.0.1",
         "ember-cli-showdown": "^6.0.1",
         "ember-cli-sri": "^2.1.1",
-        "ember-cli-terser": "^4.0.2",
         "ember-click-outside": "^5.0.1",
         "ember-cookies": "^0.5.2",
         "ember-data": "^4.0.2",
@@ -11757,118 +11756,6 @@
         "node": "6.* || >= 8.*"
       }
     },
-    "node_modules/broccoli-terser-sourcemap": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/broccoli-terser-sourcemap/-/broccoli-terser-sourcemap-4.1.0.tgz",
-      "integrity": "sha512-zkNnjsAbP+M5rG2aMM1EE4BmXPUSxFKmtLUkUs2D1DLTOJQoF1xlOjGWjjKYCFy5tw8t4+tgGJ+HVa2ucJZ8sw==",
-      "dev": true,
-      "dependencies": {
-        "async-promise-queue": "^1.0.5",
-        "broccoli-plugin": "^4.0.3",
-        "debug": "^4.1.0",
-        "lodash.defaultsdeep": "^4.6.1",
-        "matcher-collection": "^2.0.1",
-        "source-map-url": "^0.4.0",
-        "symlink-or-copy": "^1.3.1",
-        "terser": "^5.3.0",
-        "walk-sync": "^2.2.0",
-        "workerpool": "^6.0.0"
-      },
-      "engines": {
-        "node": "^10.12.0 || 12.* || >= 14"
-      }
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/broccoli-plugin": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.3.tgz",
-      "integrity": "sha512-CtAIEYq5K+4yQv8c/BHymOteuyjDAJfvy/asu4LudIWcMSS7dTn3yGI5gNBkwHG+qlRangYkHJNVAcDZMQbSVQ==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-node-api": "^1.6.0",
-        "broccoli-output-wrapper": "^3.2.1",
-        "fs-merger": "^3.1.0",
-        "promise-map-series": "^0.2.1",
-        "quick-temp": "^0.1.3",
-        "rimraf": "^3.0.0",
-        "symlink-or-copy": "^1.3.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/matcher-collection": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-      "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "minimatch": "^3.0.2"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/broccoli-terser-sourcemap/node_modules/workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
-      "dev": true
-    },
     "node_modules/broccoli/node_modules/broccoli-source": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-3.0.1.tgz",
@@ -17393,18 +17280,6 @@
       "resolved": "https://registry.npmjs.org/ember-cli-string-utils/-/ember-cli-string-utils-1.1.0.tgz",
       "integrity": "sha1-ObZ3/CgF9VFzc1N2/O8njqpEUqE=",
       "dev": true
-    },
-    "node_modules/ember-cli-terser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-terser/-/ember-cli-terser-4.0.2.tgz",
-      "integrity": "sha512-Ej77K+YhCZImotoi/CU2cfsoZaswoPlGaM5TB3LvjvPDlVPRhxUHO2RsaUVC5lsGeRLRiHCOxVtoJ6GyqexzFA==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-terser-sourcemap": "^4.1.0"
-      },
-      "engines": {
-        "node": "10.* || 12.* || >= 14"
-      }
     },
     "node_modules/ember-cli-test-info": {
       "version": "1.0.0",
@@ -27603,12 +27478,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
-      "dev": true
-    },
-    "node_modules/lodash.defaultsdeep": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
-      "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
       "dev": true
     },
     "node_modules/lodash.find": {
@@ -46420,93 +46289,6 @@
         "walk-sync": "^0.3.3"
       }
     },
-    "broccoli-terser-sourcemap": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/broccoli-terser-sourcemap/-/broccoli-terser-sourcemap-4.1.0.tgz",
-      "integrity": "sha512-zkNnjsAbP+M5rG2aMM1EE4BmXPUSxFKmtLUkUs2D1DLTOJQoF1xlOjGWjjKYCFy5tw8t4+tgGJ+HVa2ucJZ8sw==",
-      "dev": true,
-      "requires": {
-        "async-promise-queue": "^1.0.5",
-        "broccoli-plugin": "^4.0.3",
-        "debug": "^4.1.0",
-        "lodash.defaultsdeep": "^4.6.1",
-        "matcher-collection": "^2.0.1",
-        "source-map-url": "^0.4.0",
-        "symlink-or-copy": "^1.3.1",
-        "terser": "^5.3.0",
-        "walk-sync": "^2.2.0",
-        "workerpool": "^6.0.0"
-      },
-      "dependencies": {
-        "broccoli-plugin": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.3.tgz",
-          "integrity": "sha512-CtAIEYq5K+4yQv8c/BHymOteuyjDAJfvy/asu4LudIWcMSS7dTn3yGI5gNBkwHG+qlRangYkHJNVAcDZMQbSVQ==",
-          "dev": true,
-          "requires": {
-            "broccoli-node-api": "^1.6.0",
-            "broccoli-output-wrapper": "^3.2.1",
-            "fs-merger": "^3.1.0",
-            "promise-map-series": "^0.2.1",
-            "quick-temp": "^0.1.3",
-            "rimraf": "^3.0.0",
-            "symlink-or-copy": "^1.3.0"
-          }
-        },
-        "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "matcher-collection": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "minimatch": "^3.0.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "walk-sync": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0",
-            "minimatch": "^3.0.4"
-          }
-        },
-        "workerpool": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-          "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
-          "dev": true
-        }
-      }
-    },
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -51752,15 +51534,6 @@
       "resolved": "https://registry.npmjs.org/ember-cli-string-utils/-/ember-cli-string-utils-1.1.0.tgz",
       "integrity": "sha1-ObZ3/CgF9VFzc1N2/O8njqpEUqE=",
       "dev": true
-    },
-    "ember-cli-terser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-terser/-/ember-cli-terser-4.0.2.tgz",
-      "integrity": "sha512-Ej77K+YhCZImotoi/CU2cfsoZaswoPlGaM5TB3LvjvPDlVPRhxUHO2RsaUVC5lsGeRLRiHCOxVtoJ6GyqexzFA==",
-      "dev": true,
-      "requires": {
-        "broccoli-terser-sourcemap": "^4.1.0"
-      }
     },
     "ember-cli-test-info": {
       "version": "1.0.0",
@@ -58835,12 +58608,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
-      "dev": true
-    },
-    "lodash.defaultsdeep": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
-      "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
       "dev": true
     },
     "lodash.find": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -75,7 +75,6 @@
     "ember-cli-sass": "^11.0.1",
     "ember-cli-showdown": "^6.0.1",
     "ember-cli-sri": "^2.1.1",
-    "ember-cli-terser": "^4.0.2",
     "ember-click-outside": "^5.0.1",
     "ember-cookies": "^0.5.2",
     "ember-data": "^4.0.2",


### PR DESCRIPTION
## :unicorn: Problème
Depuis le passage a embroider, ember-cli-terser n'est plus utile. https://github.com/ember-cli/ember-cli-terser#embroider

## :robot: Proposition
Le supprimer des applis qui sont sur embroider.


## :100: Pour tester
1. Green tests
