### PR TITLE
[FEATURE] Amélioration A11y du fil d'Ariane d'import massif de sessions (PIX-7350)

### DIFF
--- a/certif/app/templates/authenticated/sessions/import.hbs
+++ b/certif/app/templates/authenticated/sessions/import.hbs
@@ -6,24 +6,17 @@
   </PixReturnTo>
   <h1 class="page-title">{{t "pages.sessions.import.title"}}</h1>
 
-  <nav
-    aria-label={{t "pages.sessions.import.breadcrumb.extra-information"}}
-    class="import-page__section--breadcrumb panel"
-  >
-    <ol>
-      <li class={{if this.isImportStepOne "active" ""}}>
-        <a href="">
-          {{t "pages.sessions.import.breadcrumb.import"}}
-        </a>
+  <div class="import-page__section--breadcrumb panel">
+    <ol aria-label={{t "pages.sessions.import.breadcrumb.extra-information"}}>
+      <li class={{if this.isImportStepOne "active" ""}} aria-current={{if this.isImportStepOne "step" ""}}>
+        {{t "pages.sessions.import.breadcrumb.import"}}
       </li>
       <FaIcon @icon="chevron-right" class="breadcrumb-icon" />
-      <li class={{if this.isImportStepOne "" "active"}}>
-        <a role="link" aria-disabled="true" class="import-page-section-breadcrumb__summary-link">
-          {{t "pages.sessions.import.breadcrumb.summary"}}
-        </a>
+      <li class={{if this.isImportStepOne "" "active"}} aria-current={{if this.isImportStepOne "" "step"}}>
+        {{t "pages.sessions.import.breadcrumb.summary"}}
       </li>
     </ol>
-  </nav>
+  </div>
 
   {{#if this.isImportStepOne}}
     <Import::StepOneSection

--- a/certif/tests/acceptance/session-import_test.js
+++ b/certif/tests/acceptance/session-import_test.js
@@ -147,20 +147,26 @@ module('Acceptance | Session Import', function (hooks) {
             // given
             const blob = new Blob(['foo']);
             const file = new File([blob], 'fichier.csv', { type: 'text/csv' });
-            screen = await visit('/sessions/import');
-            const importButton = screen.getByLabelText('Importer le modèle complété');
+            const { getAllByRole, getByLabelText, getByRole, queryByLabelText } = await visit('/sessions/import');
+            const importButton = getByLabelText('Importer le modèle complété');
             await triggerEvent(importButton, 'change', { files: [file] });
-            const importConfirmationButton = screen.getByRole('button', { name: 'Continuer' });
+            const importConfirmationButton = getByRole('button', { name: 'Continuer' });
             await click(importConfirmationButton);
 
             // when
-            const outLink = screen.getByRole('link', { name: 'Revenir à la liste des sessions' });
+            const outLink = getByRole('link', { name: 'Revenir à la liste des sessions' });
             await click(outLink);
-            await click(screen.getByRole('link', { name: 'Créer/éditer plusieurs sessions' }));
+            await click(getByRole('link', { name: 'Créer/éditer plusieurs sessions' }));
 
             // then
             assert.dom(importButton).exists();
-            assert.dom(screen.queryByLabelText('fichier.csv')).doesNotExist();
+            assert.dom(queryByLabelText('fichier.csv')).doesNotExist();
+            assert
+              .dom(getAllByRole('listitem').find((listItem) => listItem.textContent?.trim() === 'Import du modèle'))
+              .hasAttribute('aria-current', 'step');
+            assert
+              .dom(getAllByRole('listitem').find((listItem) => listItem.textContent?.trim() === 'Récapitulatif'))
+              .hasAttribute('aria-current', '');
           });
         });
 
@@ -201,16 +207,24 @@ module('Acceptance | Session Import', function (hooks) {
             });
 
             // when
-            screen = await visit('/sessions/import');
-            const input = screen.getByLabelText('Importer le modèle complété');
+            const { getAllByRole, getByLabelText, getByRole, getByText, queryByLabelText } = await visit(
+              '/sessions/import'
+            );
+            const input = getByLabelText('Importer le modèle complété');
             await triggerEvent(input, 'change', { files: [file] });
-            const importButton = screen.getByRole('button', { name: 'Continuer' });
+            const importButton = getByRole('button', { name: 'Continuer' });
             await click(importButton);
 
             // then
-            assert.dom(screen.getByText('2 sessions dont 1 session sans candidat')).exists();
-            assert.dom(screen.getByText('3 candidats')).exists();
-            assert.dom(screen.queryByLabelText('fichier.csv')).doesNotExist();
+            assert.dom(getByText('2 sessions dont 1 session sans candidat')).exists();
+            assert.dom(getByText('3 candidats')).exists();
+            assert
+              .dom(getAllByRole('listitem').find((listItem) => listItem.textContent?.trim() === 'Récapitulatif'))
+              .hasAttribute('aria-current', 'step');
+            assert
+              .dom(getAllByRole('listitem').find((listItem) => listItem.textContent?.trim() === 'Import du modèle'))
+              .hasAttribute('aria-current', '');
+            assert.dom(queryByLabelText('fichier.csv')).doesNotExist();
           });
 
           module('when there is only non blocking errors', function () {


### PR DESCRIPTION
## :unicorn: Problème
Le fil d'Arianne de l'import en masse de sessions sur pix-certif pourrait être plus accessible.

## :robot: Proposition
Retirer les liens des éléments de la liste, ajouter l'attribut ```aria-current``` à l'élément actif, ajouter l'attribut ```aria-label``` sur l'élément <ol>


## :100: Pour tester
 - Vérifier que les tests passent
 - Vérifier l'accessibilité de la page d'import en masse de session via le plugin ```wave```