### PR TITLE
[BUGFIX] Ne plus appeler le provider de mail lors de l'exécution des tests (PIX-7783)

### DIFF
--- a/api/lib/infrastructure/mail-check.js
+++ b/api/lib/infrastructure/mail-check.js
@@ -1,10 +1,10 @@
-const { promisify } = require('util');
-const dns = require('dns');
-const resolveMx = promisify(dns.resolveMx);
+const { Resolver } = require('node:dns').promises;
+
+const resolver = new Resolver();
 
 module.exports = {
-  checkDomainIsValid(address) {
-    const domain = address.replace(/.*@/g, '');
-    return resolveMx(domain).then(() => true);
+  checkDomainIsValid(emailAddress) {
+    const domain = emailAddress.replace(/.*@/g, '');
+    return resolver.resolveMx(domain).then(() => true);
   },
 };

--- a/api/lib/infrastructure/mailers/mailer.js
+++ b/api/lib/infrastructure/mailers/mailer.js
@@ -23,15 +23,16 @@ class Mailer {
 
   async sendEmail(options) {
     debugEmail(options);
+
+    if (!mailing.enabled) {
+      return EmailingAttempt.success(options.to);
+    }
+
     try {
       await mailCheck.checkDomainIsValid(options.to);
     } catch (err) {
       logger.warn({ err }, `Email is not valid '${options.to}'`);
       return EmailingAttempt.failure(options.to, EmailingAttempt.errorCode.INVALID_DOMAIN);
-    }
-
-    if (!mailing.enabled) {
-      return EmailingAttempt.success(options.to);
     }
 
     try {
@@ -93,6 +94,7 @@ class Mailer {
     return mailing[this._providerName].templates.acquiredCleaResultTemplateId;
   }
 }
+
 const mailer = new Mailer();
 
 module.exports = { mailer };

--- a/api/tests/unit/infrastructure/mailers/mailer_test.js
+++ b/api/tests/unit/infrastructure/mailers/mailer_test.js
@@ -38,25 +38,6 @@ describe('Unit | Infrastructure | Mailers | mailer', function () {
         expect(result).to.deep.equal(EmailingAttempt.success('test@example.net'));
         expect(mailingProvider.sendEmail).to.have.not.been.called;
       });
-
-      context('when email is invalid', function () {
-        it('should return an error status', async function () {
-          // given
-          _disableMailing();
-          const recipient = 'test@example.net';
-
-          const expectedError = new Error('fail');
-          _mailAddressIsInvalid(recipient, expectedError);
-
-          // when
-          const result = await mailer.sendEmail({ to: recipient });
-
-          // then
-          expect(result).to.deep.equal(
-            EmailingAttempt.failure('test@example.net', EmailingAttempt.errorCode.INVALID_DOMAIN)
-          );
-        });
-      });
     });
 
     context('when mailing is enabled', function () {


### PR DESCRIPTION
## :unicorn: Problème

En mode non-connecté au réseau, certains tests sortent à tort en erreur car l'on tente toujours de faire des appels vers l'extérieur.

## :robot: Proposition

Faire la vérification DNS uniquement lorsque l'envoi d'e-mail est activé.

## :rainbow: Remarques

Des tests ont été retiré, car ces derniers ne peuvent plus être testés. La condition qui permet d'éviter la vérification du domaine de l'e-mail a été ajouté avant cette action rendant obsolète les tests associés.

## :100: Pour tester

#### Les tests

- Se mettre hors ligne.
- Exécuter les tests.
- Vérifier qu'ils passent.

#### Les applications

- Activer l'envoi d'e-mail (en local ou sur la RA)
- Se créer un compte sur Pix App
- Vérifier que vous recevez bien l'e-mail d'inscription

En bonus

- Se connecter sur Pix Orga et/ou Pix Certif
- Envoyer une invitation à rejoindre PixOrga et/ou Pix Certif
- Vérifier que vous recevez bien l'e-mail d'invitation à rejoindre Pix Orga et/ou Pix Certif
