### PR TITLE
[FEATURE] Modification du wording des statuts des contenus formatifs (PIX-7785)

### DIFF
--- a/admin/app/components/trainings/list-summary-items.hbs
+++ b/admin/app/components/trainings/list-summary-items.hbs
@@ -28,6 +28,7 @@
                 aria-label="Filtrer les contenus formatifs par un titre"
               />
             </td>
+            <td></td>
           </tr>
         {{/if}}
       </thead>
@@ -44,9 +45,9 @@
               </td>
               <td headers="training-recommendable">
                 {{#if this.isTrainingRecommendationEnabled}}
-                  {{if summary.isRecommendable "Actif" "Inactif"}}
+                  {{if summary.isRecommendable "Déclenchable" "Non déclenchable"}}
                 {{else}}
-                  Actif
+                  Déclenchable
                 {{/if}}
               </td>
             </tr>

--- a/admin/app/components/trainings/training-details-card.hbs
+++ b/admin/app/components/trainings/training-details-card.hbs
@@ -4,7 +4,12 @@
     <dl class="training-details-card__details">
       <dt class="training-details-card__details-label">Publié sur&nbsp;:&nbsp;</dt>
       <dd class="training-details-card__details-value">
-        <a href={{@training.link}} target="_blank" rel="noopener noreferrer" aria-label="{{@training.link}} (nouvelle fenêtre)">
+        <a
+          href={{@training.link}}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="{{@training.link}} (nouvelle fenêtre)"
+        >
           {{@training.link}}
         </a>
       </dd>
@@ -20,7 +25,11 @@
       <dd class="training-details-card__details-value">{{@training.editorLogoUrl}}</dd>
       <dt class="training-details-card__details-label">Statut&nbsp;:&nbsp;</dt>
       {{#if this.isTrainingRecommendationEnabled}}
-        <dd class="training-details-card__details-value">{{if @training.isRecommendable "Déclenchable" "Non déclenchable"}}</dd>
+        <dd class="training-details-card__details-value">{{if
+            @training.isRecommendable
+            "Déclenchable"
+            "Non déclenchable"
+          }}</dd>
       {{else}}
         <dd class="training-details-card__details-value">Déclenchable</dd>
       {{/if}}

--- a/admin/app/components/trainings/training-details-card.hbs
+++ b/admin/app/components/trainings/training-details-card.hbs
@@ -4,12 +4,7 @@
     <dl class="training-details-card__details">
       <dt class="training-details-card__details-label">Publié sur&nbsp;:&nbsp;</dt>
       <dd class="training-details-card__details-value">
-        <a
-          href={{@training.link}}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="{{@training.link}} (nouvelle fenêtre)"
-        >
+        <a href={{@training.link}} target="_blank" rel="noopener noreferrer" aria-label="{{@training.link}} (nouvelle fenêtre)">
           {{@training.link}}
         </a>
       </dd>
@@ -25,9 +20,9 @@
       <dd class="training-details-card__details-value">{{@training.editorLogoUrl}}</dd>
       <dt class="training-details-card__details-label">Statut&nbsp;:&nbsp;</dt>
       {{#if this.isTrainingRecommendationEnabled}}
-        <dd class="training-details-card__details-value">{{if @training.isRecommendable "Actif" "Inactif"}}</dd>
+        <dd class="training-details-card__details-value">{{if @training.isRecommendable "Déclenchable" "Non déclenchable"}}</dd>
       {{else}}
-        <dd class="training-details-card__details-value">Actif</dd>
+        <dd class="training-details-card__details-value">Déclenchable</dd>
       {{/if}}
     </dl>
   </div>

--- a/admin/tests/acceptance/authenticated/trainings/list_test.js
+++ b/admin/tests/acceptance/authenticated/trainings/list_test.js
@@ -46,9 +46,9 @@ module('Acceptance | Trainings | List', function (hooks) {
 
         // then
         assert.dom(screen.getByText('Formation 11')).exists();
-        assert.dom(screen.getByText('Actif')).exists();
+        assert.dom(screen.getByText('Déclenchable')).exists();
         assert.dom(screen.getByText('Formation 12')).exists();
-        assert.dom(screen.getByText('Inactif')).exists();
+        assert.dom(screen.getByText('Non déclenchable')).exists();
       });
 
       module('when training recommendation feature toggle is disabled', function () {
@@ -65,9 +65,9 @@ module('Acceptance | Trainings | List', function (hooks) {
 
           // then
           assert.dom(screen.getByText('Formation 11')).exists();
-          assert.strictEqual(screen.queryAllByText('Actif').length, 2);
+          assert.strictEqual(screen.queryAllByText('Déclenchable').length, 2);
           assert.dom(screen.getByText('Formation 12')).exists();
-          assert.dom(screen.queryByText('Inactif')).doesNotExist();
+          assert.dom(screen.queryByText('Non déclenchable')).doesNotExist();
         });
       });
 

--- a/admin/tests/integration/components/trainings/training-details-card_test.js
+++ b/admin/tests/integration/components/trainings/training-details-card_test.js
@@ -45,7 +45,7 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
   });
 
   module('when feature toggle is disabled', function () {
-    test('it should display always Actif', async function (assert) {
+    test('it should display always Déclenchable', async function (assert) {
       // given
       class FeatureTogglesStub extends Service {
         featureToggles = { isTrainingRecommendationEnabled: false };
@@ -56,12 +56,12 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
       const screen = await render(hbs`<Trainings::TrainingDetailsCard @training={{this.training}} />`);
 
       // then
-      assert.dom(screen.getByText('Actif')).exists();
+      assert.dom(screen.getByText('Déclenchable')).exists();
     });
   });
 
   module('when feature toggle is enabled', function () {
-    test('it should display "actif" when training is recommendable', async function (assert) {
+    test('it should display "Déclenchable" when training is recommendable', async function (assert) {
       // given
       class FeatureTogglesStub extends Service {
         featureToggles = { isTrainingRecommendationEnabled: true };
@@ -72,21 +72,21 @@ module('Integration | Component | Trainings::TrainingDetailsCard', function (hoo
       const screen = await render(hbs`<Trainings::TrainingDetailsCard @training={{this.training}} />`);
 
       // then
-      assert.dom(screen.getByText('Actif')).exists();
+      assert.dom(screen.getByText('Déclenchable')).exists();
     });
 
-    test('it should display "inactif" when training is recommendable', async function (assert) {
+    test('it should display "Non déclenchable" when training is not recommendable', async function (assert) {
       // given
       class FeatureTogglesStub extends Service {
         featureToggles = { isTrainingRecommendationEnabled: true };
       }
 
       this.owner.register('service:feature-toggles', FeatureTogglesStub);
-      this.set('training.isRecommendable', true);
+      this.set('training.isRecommendable', false);
       const screen = await render(hbs`<Trainings::TrainingDetailsCard @training={{this.training}} />`);
 
       // then
-      assert.dom(screen.getByText('Actif')).exists();
+      assert.dom(screen.getByText('Non déclenchable')).exists();
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Admin, dans les contenus formatifs, le wording actuel ("actif", "inactif") ne permet pas une bonne compréhension par le métier. 

## :robot: Proposition
Remplacement du wording "actif" par "déclenchable", et "inactif" par "non déclenchable", en cohérence avec les termes "déclencheurs".

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter sur Pix Admin et aller dans l'onglet "Contenus formatifs" : 
- constater le nouveau wording dans la liste, 
- puis dans le détail du CF
Puis aller dans le détail d'un profil cible et dans l'onglet CF, constater le nouveau wording.
