### PR TITLE
[FEATURE] Traduction de la bannière de communication sur Pix Certif (PIX-6689).

### DIFF
--- a/certif/app/components/communication-banner.hbs
+++ b/certif/app/components/communication-banner.hbs
@@ -1,5 +1,5 @@
 {{#if this.isEnabled}}
   <PixBanner @type={{this.bannerType}} @canCloseBanner="true">
-    {{this.bannerContent}}
+    {{text-with-multiple-lang this.bannerContent}}
   </PixBanner>
 {{/if}}

--- a/certif/app/helpers/text-with-multiple-lang.js
+++ b/certif/app/helpers/text-with-multiple-lang.js
@@ -1,0 +1,29 @@
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
+import { htmlSafe, isHTMLSafe } from '@ember/template';
+
+export default class textWithMultipleLang extends Helper {
+  @service intl;
+
+  compute(params) {
+    let text = params[0];
+    if (isHTMLSafe(text)) {
+      text = text.toString();
+    }
+    const lang = this.intl.t('current-lang');
+    const listOfLocales = this.intl.locales;
+    let outputText = _clean(text, listOfLocales);
+
+    if (text && listOfLocales.includes(lang)) {
+      const multipleLangRegExp = new RegExp(`(\\[${lang}\\]){1}(.|\n)*?(\\[\\/${lang}\\]){1}`);
+      const textForLang = text.match(multipleLangRegExp);
+      outputText = textForLang ? _clean(textForLang[0], listOfLocales) : outputText;
+    }
+    return htmlSafe(outputText);
+  }
+}
+
+function _clean(text, listOfLocales) {
+  const regex = new RegExp(`\\[(\\/)?(${listOfLocales.join('|')})\\]`, 'g');
+  return text ? text.replace(regex, '') : text;
+}

--- a/certif/tests/unit/helpers/text-with-multiple-lang_test.js
+++ b/certif/tests/unit/helpers/text-with-multiple-lang_test.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+import textWithMultipleLang from 'pix-certif/helpers/text-with-multiple-lang';
+import { htmlSafe } from '@ember/template';
+
+module('Unit | Helper | text with multiple lang', function (hooks) {
+  let textWithMultipleLangHelper;
+
+  hooks.beforeEach(function () {
+    textWithMultipleLangHelper = new textWithMultipleLang();
+    textWithMultipleLangHelper.intl = { locales: ['fr', 'en'] };
+  });
+  [
+    { text: 'des mots', lang: 'fr', outputText: 'des mots' },
+    { text: 'des mots', lang: null, outputText: 'des mots' },
+    { text: null, lang: 'fr', outputText: '' },
+    { text: '[fr]des mots', lang: 'fr', outputText: 'des mots' },
+    { text: '[fr]des mots[/fr][en]some words[/en]', lang: 'fr', outputText: 'des mots' },
+    { text: '[fr]des mots[/fr][en]some words[/en]', lang: 'notexist', outputText: 'des motssome words' },
+    { text: htmlSafe('<div>une phrase</div>'), lang: 'fr', outputText: '<div>une phrase</div>' },
+    {
+      text: htmlSafe('[fr]<div>une phrase</div>[/fr][en]<div>one string</div>[/en]'),
+      lang: 'en',
+      outputText: '<div>one string</div>',
+    },
+  ].forEach((expected) => {
+    test(`should return the text "${expected.outputText}" if the text is "${expected.text}" in lang ${expected.lang}`, function (assert) {
+      textWithMultipleLangHelper.intl.t = () => expected.lang;
+
+      assert.strictEqual(
+        textWithMultipleLangHelper.compute([expected.text, expected.lang]).toString(),
+        expected.outputText
+      );
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix Certif, la bannière de communication (utilisé notamment en prod pour prévenir d'éventuels soucis rencontrés) n'est pas traduite. 

## :robot: Proposition
Permettre la traduction du contenu de la bannière.

Code iso aux autres apps

## :rainbow: Remarques
Le contenu de la bannière est fourni par une variable d'environnement `BANNER_CONTENT` dans ce format là : `[fr] brian est dans la cuisine [/fr] [en] brian is in the kitchen [/en]`
Le helper permet d'extraire et d'afficher le bon message selon la langue de l'utilisateur 

## :100: Pour tester
En RA (variables d'env `BANNER_CONTENT` et `BANNER_TYPE `déjà remplies, pas besoin d'y toucher ✨) 

- Aller sur Pix Certif et constater la présence de la bannière.
- Changer la langue et constater que la traduction est faite.

si vous testez en local : renseignez les variables lorsque vous lancez votre front en commande.
