### PR TITLE
[TECH] Utiliser les imports miragejs plutôt que ember-cli-mirage

### DIFF
--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -14,7 +14,7 @@ import {
   markTargetProfileAsSimplifiedAccess,
 } from './handlers/target-profiles';
 
-import { Response } from 'ember-cli-mirage';
+import { Response } from 'miragejs';
 import { createOrganizationMembership } from './handlers/organization-memberships';
 import { createStage } from './handlers/stages';
 import { findPaginatedAndFilteredSessions } from './handlers/find-paginated-and-filtered-sessions';

--- a/admin/mirage/handlers/find-paginated-and-filtered-sessions.js
+++ b/admin/mirage/handlers/find-paginated-and-filtered-sessions.js
@@ -1,6 +1,6 @@
 import filter from 'lodash/filter';
 
-import { Response } from 'ember-cli-mirage';
+import { Response } from 'miragejs';
 import { getPaginationFromQueryParams, applyPagination } from './pagination-utils';
 
 export function findPaginatedAndFilteredSessions(schema, request) {

--- a/admin/mirage/handlers/organization-memberships.js
+++ b/admin/mirage/handlers/organization-memberships.js
@@ -1,4 +1,4 @@
-import { Response } from 'ember-cli-mirage';
+import { Response } from 'miragejs';
 
 export function createOrganizationMembership(schema, request) {
   const params = JSON.parse(request.requestBody);

--- a/admin/mirage/handlers/target-profiles.js
+++ b/admin/mirage/handlers/target-profiles.js
@@ -1,4 +1,4 @@
-import { Response } from 'ember-cli-mirage';
+import { Response } from 'miragejs';
 import { getPaginationFromQueryParams, applyPagination } from './pagination-utils';
 
 function attachTargetProfiles(schema, request) {

--- a/admin/tests/acceptance/authenticated/organizations/information-management_test.js
+++ b/admin/tests/acceptance/authenticated/organizations/information-management_test.js
@@ -3,7 +3,7 @@ import { currentURL, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { clickByName, visit, fillByLabel } from '@1024pix/ember-testing-library';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { Response } from 'ember-cli-mirage';
+import { Response } from 'miragejs';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
 
 module('Acceptance | Organizations | Information management', function (hooks) {

--- a/admin/tests/acceptance/authenticated/team/add-member_test.js
+++ b/admin/tests/acceptance/authenticated/team/add-member_test.js
@@ -4,7 +4,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { visit } from '@1024pix/ember-testing-library';
 import { authenticateAdminMemberWithRole } from 'pix-admin/tests/helpers/test-init';
-import { Response } from 'ember-cli-mirage';
+import { Response } from 'miragejs';
 
 module('Acceptance | Team | Add member', function (hooks) {
   setupApplicationTest(hooks);


### PR DESCRIPTION
## :unicorn: Problème
Les imports des fonctions de miragejs via ember-cli-mirage sont dépréciés et seront supprimés dans la prochaine version de ember-cli-mirage.

## :robot: Proposition
Importer depuis miragejs.

## :100: Pour tester
Vérifier les tests.
