### PR TITLE
[TECH][MON-PIX] Montée de version de Pix UI en v31.1.0 (PIX-7780)

### DIFF
--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.1",
-        "@1024pix/pix-ui": "^31.0.0",
+        "@1024pix/pix-ui": "^31.1.0",
         "@1024pix/stylelint-config": "^2.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.2",
@@ -254,9 +254,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "31.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-31.0.0.tgz",
-      "integrity": "sha512-DP16ke3UDHXNZLMJmhM7lrO7l6C+wrC/02Qvo0idbOIhyIGJ8egbDSAFN9p3gCSXVKoV2ojFl+vKGamf1JLUyw==",
+      "version": "31.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-31.1.0.tgz",
+      "integrity": "sha512-Td7VGcay4Rol5DkEtHNbCYUpkc6nAgrJ39YPDydsT+tbsX3HpGLJkv73Q9KiayHiXYl5ySB86lWxX2y9yaLP+A==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -41192,9 +41192,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "31.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-31.0.0.tgz",
-      "integrity": "sha512-DP16ke3UDHXNZLMJmhM7lrO7l6C+wrC/02Qvo0idbOIhyIGJ8egbDSAFN9p3gCSXVKoV2ojFl+vKGamf1JLUyw==",
+      "version": "31.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-31.1.0.tgz",
+      "integrity": "sha512-Td7VGcay4Rol5DkEtHNbCYUpkc6nAgrJ39YPDydsT+tbsX3HpGLJkv73Q9KiayHiXYl5ySB86lWxX2y9yaLP+A==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.1",
-    "@1024pix/pix-ui": "^31.0.0",
+    "@1024pix/pix-ui": "^31.1.0",
     "@1024pix/stylelint-config": "^2.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.2",


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de l'internationalisation des applications Pix, et plus précisément la modification de la langue de l'application avant inscription ou connexion, nous avons modifié le composant PixSelect de la librairie de composants Pix UI pour afficher une icône liée au changement de langue.

## :robot: Proposition

Mettre à jour le package.json avec la nouvelle version de Pix UI (v31.1.0).

## :rainbow: Remarques

- Il y a 2 composants (en plus du changement de langue) qui utilisent le PixSelect : **ChallengeItemQroc** et **QrocProposal**. Je n'ai pas vérifié leur bon fonctionnement.

## :100: Pour tester

- Se connecter sur Pix App (domaine .org)
- Ouvrir la page `Mon Compte`, puis `Choisir ma langue`
- Vérifier que le composant PixSelect fonctionne