### PR TITLE
[FEATURE] Ajouter une boîte de dialogue de confirmation de sortie d'une campagne (PIX-7720).

### DIFF
--- a/mon-pix/app/components/assessment-banner.hbs
+++ b/mon-pix/app/components/assessment-banner.hbs
@@ -8,10 +8,34 @@
           }}</span>{{@title}}</h1>
     {{/if}}
     {{#if @displayHomeLink}}
-      <LinkTo @route="authenticated" class="assessment-banner__home-link">
+      <button type="button" class="assessment-banner__home-link" onclick={{this.toggleClosingModal}}>
         {{t "common.actions.quit"}}
         <FaIcon @icon="right-from-bracket" />
-      </LinkTo>
+      </button>
+      <PixModal
+        class="assessment-banner__closing-modal"
+        @title={{t "pages.assessment-banner.modal-title"}}
+        @showModal={{this.showClosingModal}}
+        @onCloseButtonClick={{this.toggleClosingModal}}
+      >
+        <:content>
+          <p>{{t "pages.assessment-banner.modal-content"}}</p>
+        </:content>
+        <:footer>
+          <div class="assessment-banner-closing-modal__footer">
+            <PixButton
+              @backgroundColor="transparent-light"
+              @isBorderVisible={{true}}
+              @triggerAction={{this.toggleClosingModal}}
+            >
+              {{t "common.actions.stay"}}
+            </PixButton>
+            <PixButtonLink @route="authenticated" title={{t "common.actions.quit"}}>
+              {{t "common.actions.quit"}}
+            </PixButtonLink>
+          </div>
+        </:footer>
+      </PixModal>
     {{/if}}
   </header>
 </div>

--- a/mon-pix/app/components/assessment-banner.js
+++ b/mon-pix/app/components/assessment-banner.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class AssessmentBanner extends Component {
+  @tracked showClosingModal = false;
+
+  @action toggleClosingModal() {
+    this.showClosingModal = !this.showClosingModal;
+  }
+}

--- a/mon-pix/app/styles/components/_assessment-banner.scss
+++ b/mon-pix/app/styles/components/_assessment-banner.scss
@@ -60,7 +60,7 @@
 
 .assessment-banner__home-link {
   z-index: 1;
-  width: 100px;
+  height: 1.5rem;
   margin-left: auto;
   color: $pix-neutral-0;
   font-weight: $font-medium;
@@ -71,5 +71,14 @@
 
   &:hover {
     color: rgb($pix-neutral-0, 0.8);
+  }
+}
+
+.assessment-banner-closing-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+
+  & > * + * {
+    margin-left: $pix-spacing-xs;
   }
 }

--- a/mon-pix/tests/acceptance/challenge-commons_test.js
+++ b/mon-pix/tests/acceptance/challenge-commons_test.js
@@ -86,7 +86,7 @@ module('Acceptance | Common behavior to all challenges', function (hooks) {
     });
 
     test('should come back to the home route when the back button is clicked', async function (assert) {
-      assert.strictEqual(find('.assessment-banner__home-link').getAttribute('href'), '/');
+      assert.strictEqual(find('.assessment-banner-closing-modal__footer a[title="Quitter"]').getAttribute('href'), '/');
     });
 
     test('should be able to send a feedback about the current challenge', function (assert) {

--- a/mon-pix/tests/acceptance/challenge-page-banner_test.js
+++ b/mon-pix/tests/acceptance/challenge-page-banner_test.js
@@ -1,4 +1,4 @@
-import { click } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { visit } from '@1024pix/ember-testing-library';
 import { authenticate } from '../helpers/authentication';
@@ -28,7 +28,7 @@ module('Acceptance | Challenge page banner', function (hooks) {
 
       // then
       assert.dom(screen.getByRole('img', { name: 'pix' })).exists();
-      assert.dom(screen.getByRole('link', { name: 'Quitter' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Quitter' })).exists();
     });
 
     test('should display accessibility information in the banner', async function (assert) {
@@ -41,6 +41,18 @@ module('Acceptance | Challenge page banner', function (hooks) {
 
       // then
       assert.dom(screen.getByRole('heading', { name: "Épreuve pour l'évaluation : SomeTitle", level: 1 })).exists();
+    });
+
+    test('should be able to leave the campaign', async function (assert) {
+      // when
+      const screen = await visit(`campagnes/${campaign.code}`);
+      await click(screen.getByRole('button', { name: 'Je commence' }));
+      await click(screen.getByRole('button', { name: 'Ignorer' }));
+      await click(screen.getByRole('button', { name: 'Quitter' }));
+      await click(screen.getByTitle('Quitter'));
+
+      // then
+      assert.strictEqual(currentURL(), '/accueil');
     });
   });
 });

--- a/mon-pix/tests/integration/components/assessment-banner_test.js
+++ b/mon-pix/tests/integration/components/assessment-banner_test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@1024pix/ember-testing-library';
+import { click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | assessment-banner', function (hooks) {
@@ -11,15 +12,51 @@ module('Integration | Component | assessment-banner', function (hooks) {
     const screen = await render(hbs`<AssessmentBanner @displayHomeLink={{false}} />`);
 
     // then
-    assert.dom(screen.queryByRole('link', { name: 'Quitter' })).doesNotExist();
+    assert.dom(screen.queryByRole('button', { name: 'Quitter' })).doesNotExist();
   });
 
-  test('should display home link button if requested', async function (assert) {
-    // given & when
-    const screen = await render(hbs`<AssessmentBanner @displayHomeLink={{true}} />`);
+  module('When home button is requested', function (hooks) {
+    let screen;
 
-    // then
-    assert.dom(screen.getByRole('link', { name: 'Quitter' })).exists();
+    hooks.beforeEach(async function () {
+      // given
+      screen = await render(hbs`<AssessmentBanner @displayHomeLink={{true}} />`);
+    });
+
+    test('it should display home button', function (assert) {
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Quitter' })).exists();
+      assert.dom(screen.getByText("Besoin d'une pause ?")).isVisible();
+    });
+
+    test('it should open modal', async function (assert) {
+      // when
+      await click(screen.queryByRole('button', { name: 'Quitter' }));
+
+      // then
+      assert.notOk(
+        screen
+          .getByText("Besoin d'une pause ?")
+          .closest('.pix-modal__overlay')
+          .classList.toString()
+          .includes('pix-modal__overlay--hidden')
+      );
+    });
+
+    test('it should close modal on stay button click', async function (assert) {
+      // when
+      await click(screen.queryByRole('button', { name: 'Quitter' }));
+      await click(screen.getByText('Rester'));
+
+      // then
+      assert.ok(
+        screen
+          .getByText("Besoin d'une pause ?")
+          .closest('.pix-modal__overlay')
+          .classList.toString()
+          .includes('pix-modal__overlay--hidden')
+      );
+    });
   });
 
   module('When assessment has a title', function () {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -41,7 +41,8 @@
       "cancel": "Cancel",
       "close": "Close",
       "quit": "Exit",
-      "sign-out": "Sign out"
+      "sign-out": "Sign out",
+      "stay": "Stay"
     },
     "api-error-messages": {
       "bad-request-error": "The data entered was not in the correct format.",
@@ -150,7 +151,9 @@
   },
   "pages": {
     "assessment-banner": {
-      "title": "Question for the assessment: "
+      "title": "Question for the assessment: ",
+      "modal-title": "Do you need a break?",
+      "modal-content": "All your progress is saved. You will able to resume where you stopped."
     },
     "assessment-results": {
       "title": "End of test",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -41,7 +41,8 @@
       "cancel": "Annuler",
       "close": "Fermer",
       "quit": "Quitter",
-      "sign-out": "Se déconnecter"
+      "sign-out": "Se déconnecter",
+      "stay": "Rester"
     },
     "api-error-messages": {
       "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
@@ -150,7 +151,9 @@
   },
   "pages": {
     "assessment-banner": {
-      "title": "Épreuve pour l'évaluation : "
+      "title": "Épreuve pour l'évaluation : ",
+      "modal-title": "Besoin d'une pause ?",
+      "modal-content": "Tous tes progrès sont enregistrés. Tu pourras reprendre là où tu t’es arrêté."
     },
     "assessment-results": {
       "title": "Fin du test",


### PR DESCRIPTION
## :unicorn: Problème

Jusqu'à présent, lorsque l'utilisateur était dans un écran d'épreuve et qu'il cliquait, même par inadvertance, sur "Quitter", il était directement dirigé vers l'écran d'accueil.

## :robot: Proposition

Pour éviter les sorties non désirées, on ajoute une boîte de dialogue qui demande à l'utilisateur si il est sûr de vouloir quitter.

## :rainbow: Remarques

Les traductions anglaises sont improvisées.

Il n'y a pas le bon padding-bottom en dessous des boutons de la modale.
Mais c'est dû au style dans pix-ui.
Revoir le padding dans le Design System ?

## :100: Pour tester

- Aller sur une épreuve de la RA de Pix App [en français](https://app-pr6008.review.pix.fr/) et [en anglais](https://app-pr6008.review.pix.org/) (changer la langue de l'utilisateur au besoin).
- Essayer de quitter et tester les 2 actions de la modale : "Rester" et "Quitter".
- Vérifier que les textes FR et EN de la modales sont bons.
