### PR TITLE
[TECH][ORGA] Montée de version de Pix UI en v31.1.0 (PIX-7781)

### DIFF
--- a/orga/app/styles/pages/authenticated/campaigns/details/activity.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/activity.scss
@@ -9,7 +9,8 @@
 
   .warning-text {
     @extend %pix-body-s;
-    @extend %pix-body-weight-medium
+
+    font-weight: $font-medium;
   }
 }
 

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.0",
-        "@1024pix/pix-ui": "^29.0.0",
+        "@1024pix/pix-ui": "^29.1.1",
         "@1024pix/stylelint-config": "^2.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.13",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.0",
-        "@1024pix/pix-ui": "^30.1.0",
+        "@1024pix/pix-ui": "^31.1.0",
         "@1024pix/stylelint-config": "^2.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.13",
@@ -239,9 +239,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-30.1.0.tgz",
-      "integrity": "sha512-h1ALhRtbOorB6XCYn5CtHvNjqxKadbSYPN9dXF8A6zBD90VoPmrBbiFIxwFYDIMeDuThu8U8QCHrytBpPrhTog==",
+      "version": "31.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-31.1.0.tgz",
+      "integrity": "sha512-Td7VGcay4Rol5DkEtHNbCYUpkc6nAgrJ39YPDydsT+tbsX3HpGLJkv73Q9KiayHiXYl5ySB86lWxX2y9yaLP+A==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -4392,9 +4392,9 @@
       }
     },
     "node_modules/@embroider/addon-shim/node_modules/semver": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6172,9 +6172,9 @@
       "dev": true
     },
     "node_modules/@formatjs/fast-memoize": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.8.tgz",
-      "integrity": "sha512-PemNUObyoIZcqdQ1ixTPugzAzhEj7j6AHIyrq/qR6x5BFTvOQeXHYsVZUqBEFduAIscUaDfou+U+xTqOiunJ3Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.0.1.tgz",
+      "integrity": "sha512-M2GgV+qJn5WJQAYewz7q2Cdl6fobQa69S1AzSM2y0P68ZDbK5cWrJIcPCO395Of1ksftGZoOt4LYCO/j9BKBSA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -6187,9 +6187,9 @@
       "dev": true
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
-      "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.1.tgz",
+      "integrity": "sha512-knF2AkAKN4Upv4oIiKY4Wd/dLH68TNMPgV/tJMu/T6FP9aQwbv8fpj7U3lkyniPaNVxvia56Gxax8MKOjtxLSQ==",
       "dev": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.14.3",
@@ -6240,21 +6240,21 @@
       "dev": true
     },
     "node_modules/@formatjs/intl": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.6.7.tgz",
-      "integrity": "sha512-9FvEJfUMzlmP5ZBK3EE0928kVsZmD5aeWXg+faP8+mKIvG3c0hkLEXQ2MiUrXQt4rsEzOPbYVtBdthzSM0e2fw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.7.1.tgz",
+      "integrity": "sha512-se6vxidsN3PCmzqTsDd3YDT4IX9ZySPy39LYhF7x2ssNvlGMOuW3umkrIhKkXB7ZskqsJGY53LVCdiHsSwhGng==",
       "dev": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.14.3",
-        "@formatjs/fast-memoize": "1.2.8",
-        "@formatjs/icu-messageformat-parser": "2.3.0",
-        "@formatjs/intl-displaynames": "6.2.6",
-        "@formatjs/intl-listformat": "7.1.9",
-        "intl-messageformat": "10.3.1",
+        "@formatjs/fast-memoize": "2.0.1",
+        "@formatjs/icu-messageformat-parser": "2.3.1",
+        "@formatjs/intl-displaynames": "6.3.1",
+        "@formatjs/intl-listformat": "7.2.1",
+        "intl-messageformat": "10.3.4",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
-        "typescript": "^4.7"
+        "typescript": "^4.7 || 5"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -6263,9 +6263,9 @@
       }
     },
     "node_modules/@formatjs/intl-displaynames": {
-      "version": "6.2.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.2.6.tgz",
-      "integrity": "sha512-scf5AQTk9EjpvPhboo5sizVOvidTdMOnajv9z+0cejvl7JNl9bl/aMrNBgC72UH+bP3l45usPUKAGskV6sNIrA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.3.1.tgz",
+      "integrity": "sha512-TlxguMDUbnFrJ4NA8fSyqXC62M7czvlRJ5mrJgtB91JVA+QPjjNdcRm1qPIC/DcU/pGUDcEzThn/x5A+jp15gg==",
       "dev": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.14.3",
@@ -6305,9 +6305,9 @@
       "dev": true
     },
     "node_modules/@formatjs/intl-listformat": {
-      "version": "7.1.9",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.1.9.tgz",
-      "integrity": "sha512-5YikxwRqRXTVWVujhswDOTCq6gs+m9IcNbNZLa6FLtyBStAjEsuE2vAU+lPsbz9ZTST57D5fodjIh2JXT6sMWQ==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.2.1.tgz",
+      "integrity": "sha512-fRJFWLrGa7d25I4JSxNjKX29oXGcIXx8fJjgURnvs2C3ijS4gurUgFrUwLbv/2KfPfyJ5g567pz2INelNJZBdw==",
       "dev": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.14.3",
@@ -6411,14 +6411,14 @@
       }
     },
     "node_modules/@formatjs/intl/node_modules/intl-messageformat": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.3.1.tgz",
-      "integrity": "sha512-mqHc6arhbogrdImIsEscdjWnJcg2bvg3MiyGXDsTSGmPbbM2KtRUe7oNgDUbkM3HMn4KbyOct2JyJScmwRgGSQ==",
+      "version": "10.3.4",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.3.4.tgz",
+      "integrity": "sha512-/FxUIrlbPtuykSNX85CB5sp2FjLVeTmdD7TfRkVFPft2n4FgcSlAcilFytYiFAEmPHc+0PvpLCIPXeaGFzIvOg==",
       "dev": true,
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.14.3",
-        "@formatjs/fast-memoize": "1.2.8",
-        "@formatjs/icu-messageformat-parser": "2.3.0",
+        "@formatjs/fast-memoize": "2.0.1",
+        "@formatjs/icu-messageformat-parser": "2.3.1",
         "tslib": "^2.4.0"
       }
     },
@@ -36963,9 +36963,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-30.1.0.tgz",
-      "integrity": "sha512-h1ALhRtbOorB6XCYn5CtHvNjqxKadbSYPN9dXF8A6zBD90VoPmrBbiFIxwFYDIMeDuThu8U8QCHrytBpPrhTog==",
+      "version": "31.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-31.1.0.tgz",
+      "integrity": "sha512-Td7VGcay4Rol5DkEtHNbCYUpkc6nAgrJ39YPDydsT+tbsX3HpGLJkv73Q9KiayHiXYl5ySB86lWxX2y9yaLP+A==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",
@@ -40040,9 +40040,9 @@
           }
         },
         "semver": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-          "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -41393,9 +41393,9 @@
       }
     },
     "@formatjs/fast-memoize": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-1.2.8.tgz",
-      "integrity": "sha512-PemNUObyoIZcqdQ1ixTPugzAzhEj7j6AHIyrq/qR6x5BFTvOQeXHYsVZUqBEFduAIscUaDfou+U+xTqOiunJ3Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.0.1.tgz",
+      "integrity": "sha512-M2GgV+qJn5WJQAYewz7q2Cdl6fobQa69S1AzSM2y0P68ZDbK5cWrJIcPCO395Of1ksftGZoOt4LYCO/j9BKBSA==",
       "dev": true,
       "requires": {
         "tslib": "^2.4.0"
@@ -41410,9 +41410,9 @@
       }
     },
     "@formatjs/icu-messageformat-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.0.tgz",
-      "integrity": "sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.1.tgz",
+      "integrity": "sha512-knF2AkAKN4Upv4oIiKY4Wd/dLH68TNMPgV/tJMu/T6FP9aQwbv8fpj7U3lkyniPaNVxvia56Gxax8MKOjtxLSQ==",
       "dev": true,
       "requires": {
         "@formatjs/ecma402-abstract": "1.14.3",
@@ -41467,17 +41467,17 @@
       }
     },
     "@formatjs/intl": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.6.7.tgz",
-      "integrity": "sha512-9FvEJfUMzlmP5ZBK3EE0928kVsZmD5aeWXg+faP8+mKIvG3c0hkLEXQ2MiUrXQt4rsEzOPbYVtBdthzSM0e2fw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.7.1.tgz",
+      "integrity": "sha512-se6vxidsN3PCmzqTsDd3YDT4IX9ZySPy39LYhF7x2ssNvlGMOuW3umkrIhKkXB7ZskqsJGY53LVCdiHsSwhGng==",
       "dev": true,
       "requires": {
         "@formatjs/ecma402-abstract": "1.14.3",
-        "@formatjs/fast-memoize": "1.2.8",
-        "@formatjs/icu-messageformat-parser": "2.3.0",
-        "@formatjs/intl-displaynames": "6.2.6",
-        "@formatjs/intl-listformat": "7.1.9",
-        "intl-messageformat": "10.3.1",
+        "@formatjs/fast-memoize": "2.0.1",
+        "@formatjs/icu-messageformat-parser": "2.3.1",
+        "@formatjs/intl-displaynames": "6.3.1",
+        "@formatjs/intl-listformat": "7.2.1",
+        "intl-messageformat": "10.3.4",
         "tslib": "^2.4.0"
       },
       "dependencies": {
@@ -41492,14 +41492,14 @@
           }
         },
         "intl-messageformat": {
-          "version": "10.3.1",
-          "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.3.1.tgz",
-          "integrity": "sha512-mqHc6arhbogrdImIsEscdjWnJcg2bvg3MiyGXDsTSGmPbbM2KtRUe7oNgDUbkM3HMn4KbyOct2JyJScmwRgGSQ==",
+          "version": "10.3.4",
+          "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.3.4.tgz",
+          "integrity": "sha512-/FxUIrlbPtuykSNX85CB5sp2FjLVeTmdD7TfRkVFPft2n4FgcSlAcilFytYiFAEmPHc+0PvpLCIPXeaGFzIvOg==",
           "dev": true,
           "requires": {
             "@formatjs/ecma402-abstract": "1.14.3",
-            "@formatjs/fast-memoize": "1.2.8",
-            "@formatjs/icu-messageformat-parser": "2.3.0",
+            "@formatjs/fast-memoize": "2.0.1",
+            "@formatjs/icu-messageformat-parser": "2.3.1",
             "tslib": "^2.4.0"
           }
         },
@@ -41512,9 +41512,9 @@
       }
     },
     "@formatjs/intl-displaynames": {
-      "version": "6.2.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.2.6.tgz",
-      "integrity": "sha512-scf5AQTk9EjpvPhboo5sizVOvidTdMOnajv9z+0cejvl7JNl9bl/aMrNBgC72UH+bP3l45usPUKAGskV6sNIrA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.3.1.tgz",
+      "integrity": "sha512-TlxguMDUbnFrJ4NA8fSyqXC62M7czvlRJ5mrJgtB91JVA+QPjjNdcRm1qPIC/DcU/pGUDcEzThn/x5A+jp15gg==",
       "dev": true,
       "requires": {
         "@formatjs/ecma402-abstract": "1.14.3",
@@ -41558,9 +41558,9 @@
       }
     },
     "@formatjs/intl-listformat": {
-      "version": "7.1.9",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.1.9.tgz",
-      "integrity": "sha512-5YikxwRqRXTVWVujhswDOTCq6gs+m9IcNbNZLa6FLtyBStAjEsuE2vAU+lPsbz9ZTST57D5fodjIh2JXT6sMWQ==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.2.1.tgz",
+      "integrity": "sha512-fRJFWLrGa7d25I4JSxNjKX29oXGcIXx8fJjgURnvs2C3ijS4gurUgFrUwLbv/2KfPfyJ5g567pz2INelNJZBdw==",
       "dev": true,
       "requires": {
         "@formatjs/ecma402-abstract": "1.14.3",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.0",
-        "@1024pix/pix-ui": "^29.1.1",
+        "@1024pix/pix-ui": "^30.1.0",
         "@1024pix/stylelint-config": "^2.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.13",
@@ -239,9 +239,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "29.1.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-29.1.1.tgz",
-      "integrity": "sha512-tvmlFSiH/1bn+1FghOeeveYWJn4ox3hJJ+sliFD4u8+9NBoFOMcdtHOEHb7E4OfTUBi8uU4IGTrPmU2IQB2eUg==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-30.1.0.tgz",
+      "integrity": "sha512-h1ALhRtbOorB6XCYn5CtHvNjqxKadbSYPN9dXF8A6zBD90VoPmrBbiFIxwFYDIMeDuThu8U8QCHrytBpPrhTog==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -252,6 +252,7 @@
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-sass": "^11.0.1",
         "ember-click-outside": "^6.0.1",
+        "ember-popperjs": "^3.0.0",
         "ember-truth-helpers": "^3.1.1",
         "lodash.debounce": "^4.0.8"
       },
@@ -7554,6 +7555,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
+      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@simple-dom/interface": {
@@ -21422,6 +21433,20 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/ember-popperjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ember-popperjs/-/ember-popperjs-3.0.0.tgz",
+      "integrity": "sha512-6adPoWNeV5Q97d6nf5gsEYy/AQ8V3HKtofNcxO0xCQ2coOWWhBUGEwI3i9LPeOcfikFB6sbsLvwbeqLmqXeSoQ==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/addon-shim": "^1.7.1",
+        "@popperjs/core": "^2.11.1"
+      },
+      "peerDependencies": {
+        "ember-modifier": ">= 3.2.7",
+        "ember-source": ">= 3.25.0"
       }
     },
     "node_modules/ember-qunit": {
@@ -36938,9 +36963,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "29.1.1",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-29.1.1.tgz",
-      "integrity": "sha512-tvmlFSiH/1bn+1FghOeeveYWJn4ox3hJJ+sliFD4u8+9NBoFOMcdtHOEHb7E4OfTUBi8uU4IGTrPmU2IQB2eUg==",
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-30.1.0.tgz",
+      "integrity": "sha512-h1ALhRtbOorB6XCYn5CtHvNjqxKadbSYPN9dXF8A6zBD90VoPmrBbiFIxwFYDIMeDuThu8U8QCHrytBpPrhTog==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",
@@ -36950,6 +36975,7 @@
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-sass": "^11.0.1",
         "ember-click-outside": "^6.0.1",
+        "ember-popperjs": "^3.0.0",
         "ember-truth-helpers": "^3.1.1",
         "lodash.debounce": "^4.0.8"
       },
@@ -42538,6 +42564,12 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@popperjs/core": {
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
+      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
+      "dev": true
     },
     "@simple-dom/interface": {
       "version": "1.4.0",
@@ -53895,6 +53927,16 @@
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6"
+      }
+    },
+    "ember-popperjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ember-popperjs/-/ember-popperjs-3.0.0.tgz",
+      "integrity": "sha512-6adPoWNeV5Q97d6nf5gsEYy/AQ8V3HKtofNcxO0xCQ2coOWWhBUGEwI3i9LPeOcfikFB6sbsLvwbeqLmqXeSoQ==",
+      "dev": true,
+      "requires": {
+        "@embroider/addon-shim": "^1.7.1",
+        "@popperjs/core": "^2.11.1"
       }
     },
     "ember-qunit": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.0",
-    "@1024pix/pix-ui": "^29.0.0",
+    "@1024pix/pix-ui": "^29.1.1",
     "@1024pix/stylelint-config": "^2.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.13",

--- a/orga/package.json
+++ b/orga/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.0",
-    "@1024pix/pix-ui": "^29.1.1",
+    "@1024pix/pix-ui": "^30.1.0",
     "@1024pix/stylelint-config": "^2.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.13",

--- a/orga/package.json
+++ b/orga/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.0",
-    "@1024pix/pix-ui": "^30.1.0",
+    "@1024pix/pix-ui": "^31.1.0",
     "@1024pix/stylelint-config": "^2.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.13",

--- a/orga/tests/integration/components/campaign/charts/participants-by-stage_test.js
+++ b/orga/tests/integration/components/campaign/charts/participants-by-stage_test.js
@@ -38,8 +38,10 @@ module('Integration | Component | Campaign::Charts::ParticipantsByStage', functi
   });
 
   test('it should display stage stars', async function (assert) {
-    assert.dom('[data-test-status=acquired]').isVisible({ count: 1 });
-    assert.dom('[data-test-status=unacquired]').isVisible({ count: 1 });
+    const [starNotAcquired, starAcquired] = document.querySelectorAll('.pix-stars__item');
+
+    assert.dom(starNotAcquired).doesNotHaveAttribute('data-acquired');
+    assert.dom(starAcquired).hasAttribute('data-acquired');
   });
 
   test('it should display participants number', async function (assert) {


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de l'internationalisation des applications Pix, et plus précisément la modification de la langue de l'application avant inscription ou connexion, nous avons modifié le composant PixSelect de la librairie de composants Pix UI pour afficher une icône liée au changement de langue.

## :robot: Proposition

Mettre à jour le package.json avec la nouvelle version de Pix UI (v31.1.0).

## :rainbow: Remarques

⚠️ Tests de non-régression à faire sur toute l'application Pix Orga

## :100: Pour tester

- Parcourir l'application Pix Orga
- Vérifier que tous les composants PixUI fonctionnent
