### PR TITLE
[FEATURE] Amélioration visuelle des boutons d'action des écrans d'épreuve (PIX-7718).

### DIFF
--- a/mon-pix/app/components/challenge-actions.hbs
+++ b/mon-pix/app/components/challenge-actions.hbs
@@ -64,6 +64,7 @@
         @triggerAction={{@validateAnswer}}
         @backgroundColor="green"
         @shape="rounded"
+        @iconAfter="arrow-right"
         class="challenge-actions__action-validate"
       >
         <span class="challenge-actions__action-validate-text">
@@ -84,7 +85,6 @@
           {{t "pages.challenge.actions.skip"}}<span class="sr-only"> {{t "pages.challenge.actions.go-to-next"}}</span>
         </span>
       </PixButton>
-
     </div>
   {{/if}}
 </div>

--- a/mon-pix/app/styles/components/_challenge-actions.scss
+++ b/mon-pix/app/styles/components/_challenge-actions.scss
@@ -31,27 +31,32 @@
   margin: 6px;
   background-color: $pix-neutral-10;
 
+  @include device-is('mobile') {
+    &__group {
+      display: flex;
+      flex-direction: column;
+      padding: 0 $pix-spacing-m;
+    }
+
+    &__action-validate {
+      margin-bottom: 1rem;
+    }
+  }
+
   @include device-is('tablet') {
     flex-direction: row;
     align-items: center;
     justify-content: flex-end;
-  }
 
-  &__group {
-    display: flex;
-    flex-direction: row-reverse;
-  }
+    &__group {
+      display: flex;
+      flex-direction: row-reverse;
+    }
 
-  &__action-skip {
-    @include action-button;
-  }
-
-  &__action-validate {
-    @include action-button;
-  }
-
-  &__action-continue {
-    @include action-button;
+    &__action-validate {
+      min-width: 12.5em;
+      margin-left: $pix-spacing-s;
+    }
   }
 
   &__already-answered {


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, les boutons d'action des écrans d'épreuve ne sont pas assez distinctifs.

## :robot: Proposition

Ajouter une flèche sur le bouton d'action principal et augmenter sa largeur.

## :rainbow: Remarques

Le responsive mobile a été amélioré

## :100: Pour tester

- Aller sur un écran d'épreuve sur [la RA](https://app-pr6011.review.pix.fr/)
- Vérifier que le nouveau style des boutons d'action soit bien aligné avec le design Figma : 

<img width="356" alt="image" src="https://user-images.githubusercontent.com/7335131/233075788-f4156bd9-acf5-430e-9111-b22e526378c2.png">

