### PR TITLE
[TECH][CERTIF] Montée de version de Pix UI en v31.1.0 (PIX-7782)

### DIFF
--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.1",
-        "@1024pix/pix-ui": "^31.0.0",
+        "@1024pix/pix-ui": "^31.1.0",
         "@1024pix/stylelint-config": "^2.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@babel/plugin-proposal-decorators": "^7.20.5",
@@ -148,9 +148,9 @@
       "dev": true
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "31.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-31.0.0.tgz",
-      "integrity": "sha512-DP16ke3UDHXNZLMJmhM7lrO7l6C+wrC/02Qvo0idbOIhyIGJ8egbDSAFN9p3gCSXVKoV2ojFl+vKGamf1JLUyw==",
+      "version": "31.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-31.1.0.tgz",
+      "integrity": "sha512-Td7VGcay4Rol5DkEtHNbCYUpkc6nAgrJ39YPDydsT+tbsX3HpGLJkv73Q9KiayHiXYl5ySB86lWxX2y9yaLP+A==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -35198,9 +35198,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "31.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-31.0.0.tgz",
-      "integrity": "sha512-DP16ke3UDHXNZLMJmhM7lrO7l6C+wrC/02Qvo0idbOIhyIGJ8egbDSAFN9p3gCSXVKoV2ojFl+vKGamf1JLUyw==",
+      "version": "31.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-31.1.0.tgz",
+      "integrity": "sha512-Td7VGcay4Rol5DkEtHNbCYUpkc6nAgrJ39YPDydsT+tbsX3HpGLJkv73Q9KiayHiXYl5ySB86lWxX2y9yaLP+A==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",

--- a/certif/package.json
+++ b/certif/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.1",
-    "@1024pix/pix-ui": "^31.0.0",
+    "@1024pix/pix-ui": "^31.1.0",
     "@1024pix/stylelint-config": "^2.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-decorators": "^7.20.5",


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de l'internationalisation des applications Pix, et plus précisément la modification de la langue de l'application avant inscription ou connexion, nous avons modifié le composant PixSelect de la librairie de composants Pix UI pour afficher une icône liée au changement de langue.

## :robot: Proposition

Mettre à jour le package.json avec la nouvelle version de Pix UI (v31.1.0).

## :rainbow: Remarques

⚠️ Tests de non-régression à faire sur toute l'application Pix Certif

## :100: Pour tester

- Parcourir l'application Pix Certif
- Vérifier que tous les composants PixUI fonctionnent
