### PR TITLE
[FEATURE] Ajouter une nouvelle bannière pour la période de certification (PIX-7665).

### DIFF
--- a/orga/app/components/banner/information.hbs
+++ b/orga/app/components/banner/information.hbs
@@ -7,6 +7,15 @@
       htmlSafe=true
     }}
   </PixBanner>
+{{else if this.displayCertificationBanner}}
+  <PixBanner @type="information">
+    {{t
+      "banners.certification.message"
+      documentationLink=this.certificationDocumentationLink
+      linkClasses="link link--banner link--bold link--underlined"
+      htmlSafe=true
+    }}
+  </PixBanner>
 {{else if this.displayNewYearCampaignsBanner}}
   <PixBanner @type="information">
     {{t

--- a/orga/app/components/banner/information.js
+++ b/orga/app/components/banner/information.js
@@ -1,9 +1,11 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
+import ENV from 'pix-orga/config/environment';
 
 export default class InformationBanner extends Component {
   @service currentUser;
   @service router;
+  @service dayjs;
 
   get _isOnCertificationsPage() {
     return this.router.currentRouteName === 'authenticated.certifications';
@@ -30,5 +32,15 @@ export default class InformationBanner extends Component {
       return 'https://view.genial.ly/62cd67b161c1e3001759e818?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba';
     }
     return 'https://view.genial.ly/5fea2c3d6157fe0d69196ed9?idSlide=16cedb0c-3c1c-4cd3-a00b-49c01b0afcc2';
+  }
+
+  get displayCertificationBanner() {
+    const timeToDisplay = ENV.APP.CERTIFICATION_BANNER_DISPLAY_DATES.split(' ');
+    const actualMonth = this.dayjs.self().format('MM');
+    return this.currentUser.isSCOManagingStudents && timeToDisplay.includes(actualMonth);
+  }
+
+  get certificationDocumentationLink() {
+    return 'https://view.genial.ly/62cd67b161c1e3001759e818?idSlide=0f1b3413-7fef-4c97-b890-675c5bafbe93';
   }
 }

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -36,6 +36,7 @@ module.exports = function (environment) {
     APP: {
       API_HOST: process.env.API_HOST || '',
       BANNER_CONTENT: process.env.BANNER_CONTENT || '',
+      CERTIFICATION_BANNER_DISPLAY_DATES: process.env.CERTIFICATION_BANNER_DISPLAY_DATES || '',
       BANNER_TYPE: process.env.BANNER_TYPE || '',
       CAMPAIGNS_ROOT_URL: process.env.CAMPAIGNS_ROOT_URL,
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({
@@ -113,6 +114,7 @@ module.exports = function (environment) {
 
   if (environment === 'development') {
     ENV.APP.CAMPAIGNS_ROOT_URL = 'http://localhost:4200/campagnes/';
+    ENV.APP.CERTIFICATION_BANNER_DISPLAY_DATES = '04 05 06 07';
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;
@@ -125,6 +127,7 @@ module.exports = function (environment) {
   }
 
   if (environment === 'test') {
+    ENV.APP.CERTIFICATION_BANNER_DISPLAY_DATES = '04 05 06 07';
     ENV.APP.API_HOST = 'http://localhost:3000';
     ENV.APP.CAMPAIGNS_ROOT_URL = 'http://localhost:4200/campagnes/';
 

--- a/orga/tests/acceptance/certifications_test.js
+++ b/orga/tests/acceptance/certifications_test.js
@@ -4,6 +4,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import authenticateSession from '../helpers/authenticate-session';
 import { createUserManagingStudents, createPrescriberByUser } from '../helpers/test-init';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import sinon from 'sinon';
 
 module('Acceptance | Certifications page', function (hooks) {
   setupApplicationTest(hooks);
@@ -16,13 +17,31 @@ module('Acceptance | Certifications page', function (hooks) {
     await authenticateSession(user.id);
   });
 
-  module('When user arrives on certifications page', function () {
-    test('should not show any banner', async function (assert) {
+  module('When user arrives on certifications page', function (hooks) {
+    let dayjs;
+    hooks.afterEach(function () {
+      sinon.restore();
+    });
+
+    test('should display certification banner when it is time to', async function (assert) {
+      dayjs = this.owner.lookup('service:dayjs');
+      sinon.stub(dayjs.self.prototype, 'format').returns('04');
+
       // given / when
       await visit('/certifications');
 
       // then
-      assert.dom('.information-banner').doesNotExist();
+      assert.dom('.pix-banner').exists();
+    });
+
+    test('should not show any banner outside certification period', async function (assert) {
+      dayjs = this.owner.lookup('service:dayjs');
+      sinon.stub(dayjs.self.prototype, 'format').returns('10');
+
+      // given / when
+      await visit('/certifications');
+
+      // then
       assert.dom('.pix-banner').doesNotExist();
     });
 

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -55,7 +55,7 @@
       "message": "'<strong>'Rentrée 2022 :'</strong>' l’administrateur doit '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'importer la base élèves'</a>' 2022 pour initialiser Pix Orga. '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Plus d’info'</a>'"
     },
     "certification": {
-      "message": "'<strong>'Certifications :'</strong>' n’oubliez pas de '<'a href={documentationLink} class=\"{linkClasses}\"'>'finaliser les sessions dans Pix Certif'</a>' puis de télécharger les attestations ici via l'onglet “Certifications” avant la rentrée 2023."
+      "message": "'<strong>'Certifications :'</strong>' n’oubliez pas de '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'finaliser les sessions dans Pix Certif'</a>' puis de télécharger les attestations ici via l'onglet “Certifications” avant la rentrée 2023."
     }
   },
   "cards": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -53,6 +53,9 @@
     },
     "import": {
       "message": "'<strong>'Rentrée 2022 :'</strong>' l’administrateur doit '<'a href=\"/eleves\" class=\"{linkClasses}\"'>'importer la base élèves'</a>' 2022 pour initialiser Pix Orga. '<'a href={documentationLink} class=\"{linkClasses}\" target=\"_blank\" rel=\"noopener noreferrer\"'>'Plus d’info'</a>'"
+    },
+    "certification": {
+      "message": "'<strong>'Certifications :'</strong>' n’oubliez pas de '<'a href={documentationLink} class=\"{linkClasses}\"'>'finaliser les sessions dans Pix Certif'</a>' puis de télécharger les attestations ici via l'onglet “Certifications” avant la rentrée 2023."
     }
   },
   "cards": {


### PR DESCRIPTION
## :unicorn: Problème
Dans les espaces Pix Orga SCO avec l’import activé, on affiche un bandeau d’information qui varie en fonction de la période de l’année (import des élèves à la rentrée, puis lancement des parcours de rentrée etc.)

Il faut mettre à jour ce texte en lien avec la période de certification et la fin d’année scolaire.

## :robot: Proposition
Ajouter une nouvelle condition pour l'affichage du bandeau dans Pix Orga (sco avec import seulement) 

## :rainbow: Remarques
Cette bannière s'affichera pendant la période de certification : de Avril à Juillet.

## :100: Pour tester
- Se connecter avec une orga sco avec import sur Pix Orga
- Verifier que la bannière de certification s'affiche bien ( Une fois que l'import a été éffectué ) 
- 🎉 
