### PR TITLE
[TECH] Aligner la version de Node entre les front (PIX-7803)

### DIFF
--- a/pix1d/package-lock.json
+++ b/pix1d/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "pix1d",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
         "@1024pix/pix-ui": "^30.0.0",
@@ -66,7 +67,8 @@
         "webpack": "^5.75.0"
       },
       "engines": {
-        "node": "14.* || 16.* || >= 18"
+        "node": "16",
+        "npm": ">=8.13.2 <9"
       }
     },
     "node_modules/@1024pix/ember-testing-library": {

--- a/pix1d/package.json
+++ b/pix1d/package.json
@@ -26,6 +26,7 @@
     "lint:hbs:fix": "ember-template-lint . --fix",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
+    "preinstall": "npx check-engine",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test --reporter dot",
     "test:ci": "npm run test",

--- a/pix1d/package.json
+++ b/pix1d/package.json
@@ -9,6 +9,10 @@
   },
   "license": "AGPL-3.0",
   "author": "GIP Pix",
+  "engines": {
+    "node": "16",
+    "npm": ">=8.13.2 <9"
+  },
   "directories": {
     "doc": "doc",
     "test": "tests"
@@ -76,9 +80,6 @@
     "stylelint-config-standard-scss": "^6.1.0",
     "tracked-built-ins": "^3.1.1",
     "webpack": "^5.75.0"
-  },
-  "engines": {
-    "node": "14.* || 16.* || >= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## :unicorn: Problème
Pix1d n'utilise pas la même version que les autres front-end.

## :robot: Proposition
Utiliser la même version.

## :rainbow: Remarques
Vérifier à l'installation avec `check-engine`.

## :100: Pour tester
Tester en local.
Vérifier que la RA est accessible.
