### PR TITLE
[BUGFIX] Corriger l'espacement avant la pagination dans la page "Mes formations" (PIX-7806).

### DIFF
--- a/mon-pix/app/styles/pages/_user-trainings.scss
+++ b/mon-pix/app/styles/pages/_user-trainings.scss
@@ -35,12 +35,12 @@
   flex-direction: column;
   width: 100%;
   min-height: inherit;
-  margin: 24px auto;
-  padding: 20px 32px;
+  margin: $pix-spacing-m auto 0;
+  padding: 20px 32px 0;
   color: $pix-neutral-90;
 
   @include device-is('tablet') {
-    padding: 40px 0;
+    padding: 40px 0 0;
   }
 
   &__title {
@@ -60,10 +60,10 @@
   &__list {
     display: grid;
     grid-template-columns: 1fr;
+    gap: 24px;
+    margin-bottom: $pix-spacing-l;
     padding: 0;
-    column-gap: 24px;
     list-style: none;
-    row-gap: 24px;
 
     @include device-is('tablet') {
       grid-template-columns: repeat(3, minmax(0, 1fr));


### PR DESCRIPTION
## :unicorn: Problème

La pagination de la page "Mes formations" est collée à la liste des contenus formatifs.

## :robot: Proposition

Ajouter une marge en dessous de la liste des contenus formatifs et retrouver une unité graphique avec la page "Mes tutos".

## :100: Pour tester

- Aller sur la [RA de Pix App](https://app-pr6016.review.pix.fr/)
- Se connecter avec l'utilisateur `userpix1@example.net`
- Visiter [la page "Mes formations"](https://app-pr6016.review.pix.fr/mes-formations)
- Constater que la pagination n'est plus collée avec le bloc du dessus
- Comparer avec la pagination de la page "Mes tutos"
