### PR TITLE
[TECH] Ajout du lint sur les fichiers de traduction de Certif (PIX-7807).

### DIFF
--- a/certif/.eslintrc.js
+++ b/certif/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
     'plugin:ember/recommended',
     'plugin:qunit/recommended',
     'plugin:prettier/recommended',
+    'plugin:i18n-json/recommended',
   ],
   env: {
     browser: true,

--- a/certif/.eslintrc.js
+++ b/certif/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
     'no-restricted-imports': ['error', { paths: ['lodash'] }],
     'no-console': 'error',
     'ember/no-array-prototype-extensions': 0,
+    'i18n-json/valid-message-syntax': 0,
   },
   overrides: [
     // node files

--- a/certif/.prettierignore
+++ b/certif/.prettierignore
@@ -1,0 +1,1 @@
+/translations

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -67,6 +67,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-ember": "^11.2.0",
         "eslint-plugin-eslint-comments": "^3.2.0",
+        "eslint-plugin-i18n-json": "^4.0.0",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-qunit": "^7.3.2",
         "eslint-plugin-yml": "^1.2.0",
@@ -21788,6 +21789,122 @@
         "eslint": ">=4.19.1"
       }
     },
+    "node_modules/eslint-plugin-i18n-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-i18n-json/-/eslint-plugin-i18n-json-4.0.0.tgz",
+      "integrity": "sha512-rglbr9f/UaPN/OeiSLVVFlIh4RrXPTzX5qr4tqOdTj1Ryr8xIhUzriDDuyuPWliektO86c/zy1RldmBIOfDNsQ==",
+      "dev": true,
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "^2.0.18",
+        "chalk": "^2.3.2",
+        "indent-string": "^3.2.0",
+        "jest-diff": "^22.0.3",
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.set": "^4.3.2",
+        "log-symbols": "^2.2.0",
+        "parse-json": "^5.2.0",
+        "plur": "^2.1.2",
+        "pretty-format": "^22.0.3"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-i18n-json/node_modules/ansi-regex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-i18n-json/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-i18n-json/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-i18n-json/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/eslint-plugin-i18n-json/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-i18n-json/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-i18n-json/node_modules/indent-string": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+      "integrity": "sha512-BYqTHXTGUIvg7t1r4sJNKcbDZkL92nkXA8YtRpbjFHRHGDL/NtUeiBJMeE60kIFN/Mg8ESaWQvftaYMGJzQZCQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-i18n-json/node_modules/pretty-format": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+      "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
+      }
+    },
+    "node_modules/eslint-plugin-i18n-json/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/eslint-plugin-prettier": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
@@ -24536,6 +24653,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/irregular-plurals": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+      "integrity": "sha512-kniTIJmaZYiwa17eTtWIfm0K342seyugl6vuC8DiiyiRAJWAVlLkqGCI0Im0neo0TkXw+pRcKaBPRdcKHnQJ6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -25116,6 +25242,114 @@
       "engines": {
         "node": ">=0.12"
       }
+    },
+    "node_modules/jest-diff": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
+      "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.0.1",
+        "diff": "^3.2.0",
+        "jest-get-type": "^22.4.3",
+        "pretty-format": "^22.4.3"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-regex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jest-diff/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jest-diff/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/jest-diff/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/jest-diff/node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+      "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+      "dev": true
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -25814,6 +26048,12 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+      "dev": true
+    },
+    "node_modules/lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
       "dev": true
     },
     "node_modules/lodash.snakecase": {
@@ -28258,6 +28498,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/plur": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+      "integrity": "sha512-WhcHk576xg9y/iv6RWOuroZgsqvCbJN+XGvAypCJwLAYs2iWDp5LUmvaCdV6JR2O0SMBf8l6p7A94AyLCFVMlQ==",
+      "dev": true,
+      "dependencies": {
+        "irregular-plurals": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/portfinder": {
@@ -52880,6 +53132,100 @@
         "ignore": "^5.0.5"
       }
     },
+    "eslint-plugin-i18n-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-i18n-json/-/eslint-plugin-i18n-json-4.0.0.tgz",
+      "integrity": "sha512-rglbr9f/UaPN/OeiSLVVFlIh4RrXPTzX5qr4tqOdTj1Ryr8xIhUzriDDuyuPWliektO86c/zy1RldmBIOfDNsQ==",
+      "dev": true,
+      "requires": {
+        "@formatjs/icu-messageformat-parser": "^2.0.18",
+        "chalk": "^2.3.2",
+        "indent-string": "^3.2.0",
+        "jest-diff": "^22.0.3",
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.set": "^4.3.2",
+        "log-symbols": "^2.2.0",
+        "parse-json": "^5.2.0",
+        "plur": "^2.1.2",
+        "pretty-format": "^22.0.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha512-BYqTHXTGUIvg7t1r4sJNKcbDZkL92nkXA8YtRpbjFHRHGDL/NtUeiBJMeE60kIFN/Mg8ESaWQvftaYMGJzQZCQ==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "22.4.3",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+          "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0",
+            "ansi-styles": "^3.2.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "eslint-plugin-prettier": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
@@ -54965,6 +55311,12 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true
     },
+    "irregular-plurals": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+      "integrity": "sha512-kniTIJmaZYiwa17eTtWIfm0K342seyugl6vuC8DiiyiRAJWAVlLkqGCI0Im0neo0TkXw+pRcKaBPRdcKHnQJ6Q==",
+      "dev": true
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -55374,6 +55726,98 @@
         "editions": "^1.1.1",
         "textextensions": "1 || 2"
       }
+    },
+    "jest-diff": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
+      "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "diff": "^3.2.0",
+        "jest-get-type": "^22.4.3",
+        "pretty-format": "^22.4.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+          "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "dev": true
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "22.4.3",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+          "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0",
+            "ansi-styles": "^3.2.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "jest-get-type": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+      "dev": true
     },
     "jest-worker": {
       "version": "27.5.1",
@@ -56002,6 +56446,12 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+      "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
       "dev": true
     },
     "lodash.snakecase": {
@@ -57998,6 +58448,15 @@
       "dev": true,
       "requires": {
         "find-up": "^2.1.0"
+      }
+    },
+    "plur": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+      "integrity": "sha512-WhcHk576xg9y/iv6RWOuroZgsqvCbJN+XGvAypCJwLAYs2iWDp5LUmvaCdV6JR2O0SMBf8l6p7A94AyLCFVMlQ==",
+      "dev": true,
+      "requires": {
+        "irregular-plurals": "^1.0.0"
       }
     },
     "portfinder": {

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -66,6 +66,7 @@
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-ember": "^11.2.0",
+        "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-qunit": "^7.3.2",
         "eslint-plugin-yml": "^1.2.0",
@@ -21767,6 +21768,25 @@
       "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
       "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
       "dev": true
+    },
+    "node_modules/eslint-plugin-eslint-comments": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
+      "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "ignore": "^5.0.5"
+      },
+      "engines": {
+        "node": ">=6.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
+      }
     },
     "node_modules/eslint-plugin-prettier": {
       "version": "4.2.1",
@@ -52848,6 +52868,16 @@
           "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-eslint-comments": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
+      "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "ignore": "^5.0.5"
       }
     },
     "eslint-plugin-prettier": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -93,6 +93,7 @@
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-ember": "^11.2.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-qunit": "^7.3.2",
     "eslint-plugin-yml": "^1.2.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -29,6 +29,7 @@
     "lint:js": "eslint . --cache --cache-strategy content",
     "lint:js:uncached": "eslint .",
     "lint:scss": "stylelint app/styles/*.scss app/styles/**/*.scss",
+    "lint:translations": "eslint --ext .json --format node_modules/eslint-plugin-i18n-json/formatter.js translations",
     "preinstall": "npx check-engine",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test --reporter dot",

--- a/certif/package.json
+++ b/certif/package.json
@@ -30,6 +30,7 @@
     "lint:js:uncached": "eslint .",
     "lint:scss": "stylelint app/styles/*.scss app/styles/**/*.scss",
     "lint:translations": "eslint --ext .json --format node_modules/eslint-plugin-i18n-json/formatter.js translations",
+    "lint-fix:translations": "eslint --fix --ext .json --format node_modules/eslint-plugin-i18n-json/formatter.js translations",
     "preinstall": "npx check-engine",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test --reporter dot",

--- a/certif/package.json
+++ b/certif/package.json
@@ -94,6 +94,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-ember": "^11.2.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-i18n-json": "^4.0.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-qunit": "^7.3.2",
     "eslint-plugin-yml": "^1.2.0",

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -8,18 +8,36 @@
       "close": "Close",
       "continue": "Continue",
       "delete": "Delete",
+      "exit": "Exit",
       "quit": "Quit",
       "update": "Edit",
-      "exit": "Exit",
       "validate": "Validate"
     },
     "api-error-messages": {
       "bad-request-error": "The data entered was not in the correct format.",
+      "gateway-timeout-error": "The service is being slow. Please try again later.",
       "internal-server-error": "An error occurred, our teams are working on finding a solution. Please try again later.",
       "login-unauthorized-error": "There was an error in the email address or password entered.",
-      "login-user-temporary-blocked-error": "You have reached too many failed login attempts. Please try again later or <a href=\"{url}\">reset your password here</a>.",
       "login-user-blocked-error": "Your account has reached the maximum number of failed login attempts and has been temporarily blocked. Please <a href=\"{url}\">contact us</a> to unblock it.",
-      "gateway-timeout-error": "The service is being slow. Please try again later."
+      "login-user-temporary-blocked-error": "You have reached too many failed login attempts. Please try again later or <a href=\"{url}\">reset your password here</a>."
+    },
+    "form-errors": {
+      "default": "The service is temporarily unavailable. Please try again later.",
+      "email": {
+        "already-exists": "This email address is already registered, please login.",
+        "format": "Your email address is invalid."
+      },
+      "firstname": {
+        "mandatory": "Please enter a first name."
+      },
+      "lastname": {
+        "mandatory": "Please enter a last name."
+      },
+      "mandatory-all-fields": "All fields are required.",
+      "password": {
+        "format": "Your password must contain at least 8 characters and include at least one uppercase letter, one lowercase letter and one number.",
+        "mandatory": "Your password can't be empty."
+      }
     },
     "forms": {
       "certification-labels": {
@@ -40,8 +58,8 @@
       },
       "login": {
         "email": "Email address",
-        "password": "Password",
-        "forgot-password": "Forgot your password?"
+        "forgot-password": "Forgot your password?",
+        "password": "Password"
       },
       "mandatory-fields": "The fields marked by <abbr title=\"required\" class=\"mandatory-mark\">*</abbr> are required.",
       "required": "Required",
@@ -59,24 +77,6 @@
         "time-start": "Starting time (local time in 24-hour format)"
       }
     },
-    "form-errors": {
-      "default": "The service is temporarily unavailable. Please try again later.",
-      "email": {
-        "already-exists": "This email address is already registered, please login.",
-        "format": "Your email address is invalid."
-      },
-      "firstname": {
-        "mandatory": "Please enter a first name."
-      },
-      "lastname": {
-        "mandatory": "Please enter a last name."
-      },
-      "password": {
-        "format": "Your password must contain at least 8 characters and include at least one uppercase letter, one lowercase letter and one number.",
-        "mandatory": "Your password can't be empty."
-      },
-      "mandatory-all-fields": "All fields are required."
-    },
     "labels": {
       "billing-mode": {
         "free": "Free",
@@ -87,14 +87,14 @@
         "birth-city": "Birth city",
         "birth-city-insee-code": "Birth city INSEE code (only for France)",
         "birth-city-postcode": "Birth city postcode",
-        "birth-geographical-code": "Geographical birth code",
         "birth-country": "Birth country",
         "birth-date": "Date of birth",
+        "birth-geographical-code": "Geographical birth code",
         "birth-name": "Birth name",
         "firstname": "First name",
         "gender": {
-          "title": "Gender",
           "man": "Man",
+          "title": "Gender",
           "woman": "Woman"
         },
         "insee-code": "INSEE code",
@@ -111,47 +111,40 @@
   "current-lang": "en",
   "navigation": {
     "external-link-title": "Open in a new window",
+    "footer": {
+      "a11y": "Accessibility",
+      "current-year": "© {currentYear} Pix",
+      "legal-notice": "Legal notice"
+    },
     "main": {
+      "documentation": "Documentation",
       "sessions": "Sessions",
       "sessions-label": "Certification sessions",
       "supervisor": "Invigilator’s Portal",
-      "team": "Team",
-      "documentation": "Documentation"
+      "team": "Team"
     },
     "user-logged-menu": {
       "logout": "Log out"
-    },
-    "footer": {
-      "a11y": "Accessibility",
-      "legal-notice": "Legal notice",
-      "current-year": "© {currentYear} Pix"
     }
   },
   "pages": {
-    "terms-of-service": {
-      "page-title": "Terms and conditions",
-      "title": "Terms and conditions of use of the Pix Certif platform",
-      "actions": {
-        "accept": "I accept the terms and conditions of use"
-      }
-    },
     "login": {
-      "title": "Login",
+      "accessible-to": "Pix Certif is only accessible to Pix certification centres.",
       "actions": {
         "login": {
           "label": "Log in"
         }
       },
       "errors": {
-        "should-change-password": "You currently have a temporary password. <a href=\"{url}\">Reset your password here</a>.",
+        "invitation-already-accepted": "This invitation has already been accepted.<br/>Please log in or contact the administrator of your Pix Certif space.",
         "invitation-was-cancelled": "This invitation is no longer valid.<br/>Please contact the administrator of your Pix Certif space.",
-        "invitation-already-accepted": "This invitation has already been accepted.<br/>Please log in or contact the administrator of your Pix Certif space."
+        "should-change-password": "You currently have a temporary password. <a href=\"{url}\">Reset your password here</a>."
       },
-      "accessible-to": "Pix Certif is only accessible to Pix certification centres."
+      "title": "Login"
     },
     "login-or-register": {
-      "title": "You have been invited to join the certification center {certificationCenterName}",
       "login-form": {
+        "button": "Log in",
         "errors": {
           "status": {
             "403": "Access to this Pix Certif space is limited to invited members. Each Pix Certif space is managed by an administrator specific to the organisation using it. Please contact your administrator to get invited.",
@@ -160,12 +153,10 @@
             "412": "This invitation has already been accepted."
           }
         },
-        "title": "Already have an account?",
         "login": "Log in",
-        "button": "Log in"
+        "title": "Already have an account?"
       },
       "register-form": {
-        "title": "Sign up",
         "actions": {
           "login": "Sign up",
           "login-button": "Sign up"
@@ -179,349 +170,26 @@
             "error": "You must agree to the Pix terms of use and personal data protection policy to create an account.",
             "terms-of-use": "Pix terms of use"
           }
-        }
-      }
-    },
-    "sessions": {
-      "actions": {
-        "return": "Return to the sessions list"
+        },
+        "title": "Sign up"
       },
-      "import": {
-        "breadcrumb": {
-          "extra-information": "Fil d'Arianne",
-          "import": "Import du modèle",
-          "summary": "Récapitulatif"
-        },
-        "title": "Créer/éditer plusieurs sessions",
-        "step-one": {
-          "actions": {
-            "cancel": {
-              "label": "Annuler l'import"
-            },
-            "session-import-upload": {
-              "extra-information": "Importer le modèle complété",
-              "label": "Importer (.csv)"
-            },
-            "session-import-template": {
-              "extra-information": "Télécharger le modèle vierge",
-              "label": "Télécharger (.csv)"
-            }
-          },
-          "errors": {
-            "download": "Une erreur s'est produite pendant le téléchargement",
-            "CSV_DATA_REQUIRED": "Le modèle importé n'a pas été rempli, merci de le compléter avant de l'importer à nouveau",
-            "CSV_HEADERS_NOT_VALID": "Le modèle a été altéré, merci de le télécharger à nouveau",
-            "forbidden": "La création et l'édition de plusieurs sessions à la fois n'est pas disponible pour votre centre de certification. Veuillez utiliser la création et l'édition individuelle de session."
-
-          },
-          "instructions": {
-            "creation": {
-              "title": "Pour créer des sessions ?",
-              "list": "Vous pouvez créer des sessions :",
-              "list-with-candidates": "<strong>Avec candidats</strong>, complétez le modèle dans son intégralité,",
-              "list-without-candidates": "<strong>Sans candidat</strong>, complétez uniquement les informations des sessions."
-            },
-            "edition": {
-              "title": "Pour éditer la liste des candidats de sessions déjà créées ?",
-              "replace": "<strong>Pour remplacer</strong> une liste pré-existante dans le fichier modèle,",
-              "subscription": "<strong>Pour inscrire</strong> des candidats dans une session vide.",
-              "warning": "Attention à renseigner le numéro de session sans les autres informations de sessions (ex: date, heure, etc.) pour éviter les doublons lors de la création."
-            },
-            "title": "Comment ça marche ?"
-          }
-        },
-        "step-two": {
-          "blocking-errors": {
-            "title": "{blockingErrorReportsCount} {blockingErrorReportsCount, plural,one {erreur bloquante} other {erreurs bloquantes}}",
-            "information": "Veuillez corriger toutes les erreurs bloquantes avant de re-importer le fichier .csv :",
-            "line": "Line",
-            "errors": {
-              "CANDIDATE_FIRST_NAME_REQUIRED": "Champ obligatoire \"Prénom\" manquant",
-              "CANDIDATE_LAST_NAME_REQUIRED": "Champ obligatoire \"Nom de naissance\" manquant",
-              "CANDIDATE_SEX_REQUIRED": "Champ obligatoire \"Sexe\" manquant",
-              "CANDIDATE_SEX_NOT_VALID": "Donnée du champ \"Sexe\" invalide (format accepté \"M\"/\"F\")",
-              "CANDIDATE_BIRTH_INSEE_CODE_NOT_VALID": "Donnée du champ \"Code INSEE\" invalide",
-              "CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED": "Renseigner soit un code INSEE, soit un code postal et un nom de commune de naissance",
-              "CANDIDATE_BIRTH_COUNTRY_REQUIRED": "Champ obligatoire \"Pays de naissance\" manquant",
-              "CANDIDATE_BIRTH_CITY_REQUIRED": "Champ obligatoire \"Nom de la commune\" manquant",
-              "CANDIDATE_BIRTH_COUNTRY_NOT_FOUND": "Champ \"Pays de naissance\" non trouvé",
-              "CANDIDATE_BIRTH_INFORMATION_REQUIRED": "Renseigner les données de naissance du candidat",
-              "CANDIDATE_BIRTH_POSTAL_CODE_CITY_NOT_VALID": "Le code postal et le nom de la commune ne correspondent pas",
-              "CANDIDATE_BIRTH_POSTAL_CODE_NOT_FOUND": "Champ \"Code postal\" non trouvé",
-              "CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED": "Champ obligatoire \"Code postal\" manquant",
-              "CANDIDATE_BIRTHDATE_REQUIRED": "Champ obligatoire \"Date de naissance\" manquant",
-              "CANDIDATE_BIRTHDATE_FORMAT_NOT_VALID": "Donnée du champ \"Date de naissance\" invalide (format accepté JJ/MM/AAAA)",
-              "CANDIDATE_BIRTHDATE_MUST_BE_GREATER": "Champ \"Date de naissance\" doit être supérieur à 01/01/1900",
-              "CANDIDATE_EXTRA_TIME_BELOW_ONE": "Donnée du champ \"Temps majoré\" invalide (exemple de format accepté: 30%)",
-              "CANDIDATE_EXTRA_TIME_INTEGER": "Donnée du champ \"Temps majoré\" invalide (exemple de format accepté: 30%)",
-              "CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID": "Candidat né à l'étranger, inscrire 99 dans le champ \"Code INSEE\"",
-              "CANDIDATE_FOREIGN_BIRTH_CITY_REQUIRED": "Candidat né à l'étranger, champ obligatoire \"Nom de la commune\" manquant",
-              "CANDIDATE_FOREIGN_POSTAL_CODE_MUST_BE_EMPTY": "Candidat né à l'étranger, le champ \"Code postal\" doit rester vide",
-              "CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION": "Inscription possible qu'à une seule certification complémentaire par candidat",
-              "CANDIDATE_BILLING_MODE_REQUIRED": "Champ obligatoire \"Tarification part Pix\" manquant",
-              "CANDIDATE_BILLING_MODE_NOT_VALID": "Donnée du champ \"Tarification part Pix\" invalide (formats acceptés \"Gratuite\", \"Payante\" ou \"Prépayée\")",
-              "CANDIDATE_PREPAYMENT_CODE_REQUIRED": "Champ obligatoire \"Code de prépaiement\" manquant (doit être renseigné en cas de tarification part Pix prépayée)",
-              "CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY": "Champ \"Code de prépaiement\" doit rester vide (dans le cas de tarification part Pix gratuite ou payante)",
-              "CANDIDATE_NOT_ALLOWED_FOR_STARTED_SESSION": "Édition des candidats impossible, le numéro de session correspond à une session déjà démarrée",
-              "CANDIDATE_EMAIL_NOT_VALID": "Donnée du champ \"E-mail de convocation\" invalide",
-              "CANDIDATE_RESULT_RECIPIENT_EMAIL_NOT_VALID": "Donnée du champ \"E-mail du destinataire des résultats (formateur, enseignant…)\" invalide",
-              "SESSION_ADDRESS_REQUIRED": "Champ obligatoire \"Nom du site\" manquant",
-              "SESSION_ROOM_REQUIRED": "Champ obligatoire \"Nom de la salle\" manquant",
-              "SESSION_DATE_REQUIRED": "Champ obligatoire \"Date de session\" manquant",
-              "SESSION_DATE_NOT_VALID": "Donnée du champ \"Date de session\" invalide (format accepté JJ/MM/AAAA)",
-              "SESSION_TIME_REQUIRED": "Champ obligatoire \"Heure de début\" manquant",
-              "SESSION_TIME_NOT_VALID": "Donnée du champ \"Heure de début\" invalide (format accepté HH:MM)",
-              "SESSION_EXAMINER_REQUIRED": "Champ obligatoire \"Surveillant(s)\" manquant",
-              "SESSION_WITH_DATE_AND_TIME_ALREADY_EXISTS": "Une session a déjà été créée avec ces informations. Pour ajouter des candidats à une session, indiquer uniquement le numéro de session sans les informations de session",
-              "SESSION_SCHEDULED_IN_THE_PAST": "Date et/ou heure indiquées antérieures à la date du jour",
-              "SESSION_ID_NOT_EXISTING": "Numéro de session inexistant",
-              "SESSION_ID_NOT_VALID": "Donnée du champ \"Numéro de session\" invalide",
-              "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées"
-            }
-          },
-          "non-blocking-errors": {
-            "title": "{nonBlockingErrorReportsCount} {nonBlockingErrorReportsCount, plural,one {Point d’attention non bloquant} other {Points d’attention non bloquants}}",
-            "information": "Nous avons détecté {nonBlockingErrorReportsCount, plural,one {un point d’attention non bloquant} other {des points d’attention non bloquants}} lors de l’import, consultez-{nonBlockingErrorReportsCount, plural,one {le} other {les}} avant de procéder à la création ou l’édition de vos sessions :",
-            "line": "Line",
-            "errors": {
-              "DUPLICATE_CANDIDATE_IN_SESSION": "Le candidat inscrit plusieurs fois à la même session, une seule inscription sera prise en compte.",
-              "EMPTY_SESSION": "La session ne contient pas de candidat"
-            }
-          },
-          "actions": {
-            "import-again": {
-              "label": "Importer à nouveau",
-              "extra-information": "Revenir à l'étape précédente pour importer le fichier à nouveau"
-            },
-            "confirm": {
-              "label": "Finaliser la création/édition"
-            },
-            "confirm-with-warning": {
-              "label": "Finaliser quand même la création/édition"
-            }
-          },
-          "sessions-and-empty-sessions-count": "{sessionsCount} {sessionsCount, plural,one {session} other {sessions}} including {sessionsWithoutCandidatesCount} {sessionsWithoutCandidatesCount, plural,one {session} other {sessions}} without candidates",
-          "candidates-count": "{candidatesCount} {candidatesCount, plural,one {candidate} other {candidates}}"
-        },
-        "success": "Success! {sessionsCount} {sessionsCount, plural, one {session} other {sessions}} dont {sessionsWithoutCandidatesCount} {sessionsWithoutCandidatesCount, plural, one {session} other {sessions}} created without candidate and {candidatesCount} {candidatesCount, plural, one {candidate} other {candidates}} created or updated"
-      },
-      "list": {
-        "title": "Certification sessions",
-        "actions": {
-          "creation": {
-            "label": "Create a session"
-          },
-          "delete-session": {
-            "disabled": "At least one candidate has joined the session, you can’t delete it.",
-            "label": "Delete the session {sessionSummaryId}"
-          },
-          "multiple-creation": {
-            "label": "Create several sessions"
-          },
-          "multiple-creation-edition": {
-            "label": "Create/edit several sessions"
-          }
-        },
-        "delete-modal": {
-          "title": "Delete the session",
-          "actions": {
-            "cancel": {
-              "extra-information": "Cancel the session's deletion."
-            },
-            "confirm": {
-              "extra-information": "Delete the session"
-            }
-          },
-          "content": "Do you want to delete the session <span>{sessionId}</span> ?",
-          "enrolled-candidates": "<span>{enrolledCandidatesCount} {enrolledCandidatesCount, plural,one {candidate} other {candidates}}</span> {enrolledCandidatesCount, plural,one {is} other {are}} enrolled in this session",
-
-          "success": "The session has been successfully deleted.",
-          "warning": "Warning, this action is irreversible."
-        },
-        "empty": {
-          "title": "Create my first certification session"
-        },
-        "status": {
-          "created": "Created",
-          "finalized": "Finalised",
-          "processed": "Results transmitted by Pix"
-        },
-        "table": {
-          "empty": "No session found",
-          "header": {
-            "actions": "Actions",
-            "effective-candidates": "Certifications taken",
-            "enrolled-candidates": "Signed up candidates"
-          },
-          "row": {
-            "label": "Certification session",
-            "session-and-id": "Session {sessionId}"
-          }
-        }
-      },
-      "detail": {
-        "candidates": {
-          "add-modal": {
-            "actions": {
-              "close-extra-information": "Close add candidate window modal",
-              "enrol-the-candidate": "Enrol the candidate"
-            },
-            "title": "Enrol a candidate",
-            "complementary-certification-none": "None",
-            "info-panel": "If this field isn’t filled in, the results won't be transmitted by email for the affected candidate(s).<br />The candidate will see their results displayed directly on their Pix account.",
-            "prepayment-information": "Prepayment code information",
-            "prepayment-tooltip": "Required in particular when purchasing combined credits)<br />It must be comprised of the organisation’s SIRET and of the invoice’s number. Ex : 12345678912345/FACT12345.<br />If you don’t have an invoice, a prepayment code must be set with Pix.",
-            "required-fields": "The fields marked by <span class=\"required-field-indicator\">*</span> are required.",
-            "notifications": {
-              "success-add": "The candidate has been successfully enrolled.",
-              "success-remove": "The candidate has been successfully deleted.Ï",
-              "error-add-duplicate": "This candidate is already in the list, you can't add them again.",
-              "error-add-unknown": "An error occurred while adding the candidate.",
-              "error-remove-already-in": "This candidate has already joined the session, you can’t delete them.",
-              "error-remove-unknown": "An error occurred while deleting the candidate."
-            }
-          },
-          "detail-modal": {
-            "title": "Candidate’s details",
-            "actions": {
-              "close-extra-information": "Close candidate's detail window modal"
-            }
-          },
-          "list": {
-            "title": "Candidates' list",
-            "actions": {
-              "delete": {
-                "extra-information": "Delete the candidate",
-                "tooltip": "This candidate has already joined the session, you can’t delete them."
-              },
-              "inscription": {
-                "label": "Enrol a candidate"
-              },
-              "inscription-multiple": {
-                "label": "Enrol candidates"
-              },
-              "details": {
-                "extra-information": "See the candidate’s details",
-                "label": "See details"
-              }
-            },
-            "with-details-description": "List of candidates enrolled in the session, ordered by birth name, with a link to see the candidate’s details and the possibility to delete a candidate in the last column.",
-            "empty": "Awaiting candidates",
-            "without-details-description": "List of candidates enrolled in the session, ordered by birth name, with the possibility to delete a candidate in the last column."
-          },
-          "panel-actions": {
-            "title": "Enrol candidates",
-            "actions": {
-              "download": {
-                "description": "To enrol candidates in the session, fill in their details (Last name, First name, …) in this document.. <br />When you first download the template for the candidates' list, it will be blank. Afterwards, it will contain the details of the candidates enrolled in the session.",
-                "extra-information": "Download the template for the candidates' list",
-                "label": "Download (.ods)"
-              },
-              "upload": {
-                "description": "Select the candidates' list previously filled in.<br /><strong>Warning, any new upload deletes the existing candidates' list.</strong>",
-                "extra-information": "Upload the candidates' list",
-                "label": "Upload (.ods)"
-              }
-            },
-            "warning": "The session has begun, you can’t upload a candidates' list anymore.<br />If you want to edit the list, you can enrol a candidate directly in the table below."
-          },
-          "page-title": "Candidates"
-        },
-        "downloads": {
-          "label": "Downloads:",
-          "attendance-sheet": {
-            "extra-information": "Download attendance sheet",
-            "label": "Attendance sheet"
-          },
-          "incident-report": {
-            "extra-information": "Download incident report",
-            "label": "Incident report"
-          },
-          "invigilator-kit": {
-            "extra-information": "Download invigilator’s kit",
-            "label": "Invigilator’s kit"
-          }
-        },
-        "page-title": "Details",
-        "tabs": {
-          "details": "Details"
-        },
-        "title": "Session {sessionId}",
-        "panel-clea": {
-          "title": "Des candidats ont obtenu le certificat CléA numérique",
-          "description": "Pour générer les certificats CléA numérique, téléchargez la liste des candidats, complétez-la, enregistrez-la au format .xlsx puis importez-la sur la ",
-          "link-text": "plateforme du CléA numérique.",
-          "download-button": "Télécharger la liste des candidats",
-          "error-message": "Une erreur est survenue lors du téléchargement du fichier. Veuillez réessayer ou contacter certif@pix.fr en indiquant le numéro de la session concernée."
-        },
-        "parameters": {
-          "actions": {
-            "finalizing": "Finalise the session",
-            "update": "Edit the details for session {sessionId}"
-          },
-          "finalization-info": "The finalisation information for the session has already been transmitted to Pix.",
-          "session": {
-            "copy-number": "Copy the session number",
-            "label": "Session number"
-          },
-          "access-code": {
-            "label": "Access code",
-            "candidate": "Candidate",
-            "copy-code": "Copy the session’s access code"
-          },
-          "password": {
-            "copy-password": "Copy the invigilator’s session password",
-            "label": "Session password"
-          }
-        }
-      },
-      "new": {
-        "title": "Creation of a certification session",
-        "actions": {
-          "cancel-extra-information": "Cancel the session creation and return to the previous page",
-          "create-session": "Create the session"
-        },
-        "address": "Location name",
-        "date": "Starting date",
-        "description": "Observations",
-        "errors": {
-          "SESSION_ADDRESS_REQUIRED": "Please indicate a location name.",
-          "SESSION_ROOM_REQUIRED": "Please indicate a room name.",
-          "SESSION_DATE_REQUIRED": "Please indicate a starting date.",
-          "SESSION_TIME_REQUIRED": "Please indicate a starting time in local time.",
-          "SESSION_EXAMINER_REQUIRED": "Please indicate the last name and first name of the invigilator(s)."
-        },
-        "examiner": "Invigilator(s)",
-        "extra-information": "Session scheduling | Pix Certif",
-        "required-fields": "The fields marked by <abbr title=\"required\" class=\"mandatory-mark\">*</abbr> are required.",
-        "room": "Room name",
-        "time": "Starting time (local time)"
-      },
-      "update": {
-        "title": "Certification session change",
-        "actions": {
-          "cancel-extra-information": "Cancel the session change and return to the previous page",
-          "edit-session": "Edit the session"
-        }
-      }
+      "title": "You have been invited to join the certification center {certificationCenterName}"
     },
     "session-finalization": {
-      "title": "Finalise the session {sessionId}",
       "actions": {
         "finalise": "Finalise"
       },
       "add-issue-modal": {
-        "title": "Reporting for candidate :",
         "actions": {
           "add-reporting": "Add the reporting",
           "cancel": "Cancel",
           "describe": "Describe the incident encountered",
           "enter-question-number": "Question number :",
-          "specify": "Specify",
           "select-category": "Please select a category",
           "select-category-label": "Select a category ",
           "select-subcategory": "Select a subcategory:",
           "select-subcategory-label": "Select a subcategory",
+          "specify": "Specify",
           "transmit-report": "Please transmit the fraud report filled in during the certification session by using <span><a class=\"link\" href=\"https://form-eu.123formbuilder.com/41052/form\" target=\"_blank\" rel=\"noreferrer\">this form</a></span>"
         },
         "category-labels": {
@@ -557,22 +225,31 @@
           "website-unavailable": "The website to visit is unavailable/under maintenance/unreachable"
         },
         "subcategory-to-textarea-labels": {
-          "name-or-birthdate": "Fill in the correct details",
-          "extra-time-percentage": "Specify extra time"
-        }
+          "extra-time-percentage": "Specify extra time",
+          "name-or-birthdate": "Fill in the correct details"
+        },
+        "title": "Reporting for candidate :"
+      },
+      "complementary-information": {
+        "candidates-joining-issue": {
+          "label": "At least one candidate was present during the certification session but couldn’t join the session.",
+          "link": "You may find <a class=\"link\" href=\"https://cloud.pix.fr/s/zf3fGimWwPQCeWF/download/Probl%C3%A8mes%20d%27acc%C3%A8s%20en%20session.pdf\" target=\"_blank\" rel=\"noreferrer noopener\">here a document to help you solve this kind of connection problem for the following sessions (PDF, 131ko).</a>"
+        },
+        "description": "You may indicate, if need be, the events that occurred during the session. It isn’t necessary to report any missing candidates.",
+        "incident": "Despite an incident having occurred during the session, the candidates have been able to finish their Pix certification exam. Additional time has been granted to at least one of the candidates.",
+        "title": "Additional information (optional)"
       },
       "issue-reports-modal": {
-        "title": "Reporting for candidate :",
-        "subtitle": "My reporting",
         "actions": {
           "add-reporting": "Add a reporting",
           "delete-reporting": "Delete the reporting"
         },
         "errors": {
           "delete-reporting": "An error has occurred while deleting the reporting. Please try again"
-        }
+        },
+        "subtitle": "My reporting",
+        "title": "Reporting for candidate :"
       },
-      "return-to": "Return to the session",
       "reporting": {
         "completed-reports-information": {
           "description": "Finished certification(s)",
@@ -584,6 +261,14 @@
           }
         },
         "description": "For the reporting to be taken into account, you must use the appropriate reporting category (examples : C1, C2, etc).",
+        "table": {
+          "labels": {
+            "certification-number": "Certification No.",
+            "reporting": "Reporting"
+          },
+          "reporting-count": "{reportingsCount, plural,one {1 reporting} other {# reportings}}"
+        },
+        "title": "Reporting: Signal, for each candidate, the incidents inputted into the incident report",
         "uncompleted-reports-information": {
           "description": "These candidates haven’t finished their Pix certification exam or the invigilator has ended their exam",
           "extra-information": "List of candidates who haven’t finished their certification exam, ordered by birth name, with a link to add a reporting if needed and a drop-down list enabling you to select the reason for abandonment",
@@ -602,76 +287,15 @@
               "technical-problem-description": "The candidate encountered a technical problem that prevented him from finishing his exam"
             }
           }
-        },
-        "table": {
-          "labels": {
-            "certification-number": "Certification No.",
-            "reporting": "Reporting"
-          },
-          "reporting-count": "{reportingsCount, plural,one {1 reporting} other {# reportings}}"
-        },
-        "title": "Reporting: Signal, for each candidate, the incidents inputted into the incident report"
-      },
-      "complementary-information": {
-        "title": "Additional information (optional)",
-        "description": "You may indicate, if need be, the events that occurred during the session. It isn’t necessary to report any missing candidates.",
-        "incident": "Despite an incident having occurred during the session, the candidates have been able to finish their Pix certification exam. Additional time has been granted to at least one of the candidates.",
-        "candidates-joining-issue": {
-          "label": "At least one candidate was present during the certification session but couldn’t join the session.",
-          "link": "You may find <a class=\"link\" href=\"https://cloud.pix.fr/s/zf3fGimWwPQCeWF/download/Probl%C3%A8mes%20d%27acc%C3%A8s%20en%20session.pdf\" target=\"_blank\" rel=\"noreferrer noopener\">here a document to help you solve this kind of connection problem for the following sessions (PDF, 131ko).</a>"
         }
-      }
+      },
+      "return-to": "Return to the session",
+      "title": "Finalise the session {sessionId}"
     },
     "session-supervising": {
-      "title": "Invigilate session n° {sessionId}",
-      "login": {
-        "title": "Log into the invigilator's portal",
-        "form": {
-          "title": "Invigilator’s portal",
-          "sub-title": "Invigilate a session",
-          "description": "The password for the session to be invigilated has been revealed to you by a Pix Certif administrator",
-          "session-number": "Session number",
-          "session-password": {
-            "label": "Session password",
-            "aria-label": "Show password"
-          },
-          "example": "Example : C-12345",
-          "errors": {
-            "mandatory-fields": "The fields “Session number” and “Session password” are required.",
-            "incorrect-data": "The session number and/or the session password entered are incorrect."
-          },
-          "actions": {
-            "invigilate": "Invigilate the session",
-            "switch-account": "Switch accounts"
-          }
-        }
-      },
-      "header": {
-        "actions": {
-          "confirmation": "Exit the invigilation",
-          "exit-extra-information": "Exit the session’s invigilation {sessionId}"
-        },
-        "access-code": "Access code (candidates)",
-        "information": "Warning, make sure that all the candidates have finished their exam before exiting the invigilation. To resume the invigilation of this session, you will have to enter again it’s session number and it’s password.",
-        "session-id": "Session {sessionId}"
-      },
-      "candidate-list": {
-        "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidate} other {candidates}} selected",
-        "clear-field": "Clear the field",
-        "indicate-candidates-attendance": "Check off each candidate present in the room to allow them to start their Pix certification exam.",
-        "no-candidate": "No candidate enrolled in this session",
-        "search-candidate": "Search for a candidate"
-      },
       "candidate-in-list": {
-        "display-candidate-options": "Display the candidate's options",
         "candidate-options": "Candidate's options",
-        "test-end-modal": {
-          "description": "Warning, this action triggers the end of their Pix certification exam and is irreversible.",
-          "instruction-with-name": "End the exam of {firstName} {lastName}?",
-          "end-assessment": "End the exam",
-          "success": "Success! {firstName} {lastName}'s test has been ended.",
-          "error": "An error occurred, {firstName} {lastName}'s test could not be ended."
-        },
+        "display-candidate-options": "Display the candidate's options",
         "resume-test-modal": {
           "actions": {
             "confirm": "I confirm permission"
@@ -682,36 +306,410 @@
           "error": " An error has occurred, {firstName} {lastName} couldn't be allowed to resume his/her Pix certification exam.",
           "instruction-with-name": "Allow {firstName} {lastName} to resume their test ?",
           "success": "Success ! {firstName} {lastName} can resume his/her Pix certification exam."
+        },
+        "test-end-modal": {
+          "description": "Warning, this action triggers the end of their Pix certification exam and is irreversible.",
+          "end-assessment": "End the exam",
+          "error": "An error occurred, {firstName} {lastName}'s test could not be ended.",
+          "instruction-with-name": "End the exam of {firstName} {lastName}?",
+          "success": "Success! {firstName} {lastName}'s test has been ended."
         }
-      }
+      },
+      "candidate-list": {
+        "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidate} other {candidates}} selected",
+        "clear-field": "Clear the field",
+        "indicate-candidates-attendance": "Check off each candidate present in the room to allow them to start their Pix certification exam.",
+        "no-candidate": "No candidate enrolled in this session",
+        "search-candidate": "Search for a candidate"
+      },
+      "header": {
+        "access-code": "Access code (candidates)",
+        "actions": {
+          "confirmation": "Exit the invigilation",
+          "exit-extra-information": "Exit the session’s invigilation {sessionId}"
+        },
+        "information": "Warning, make sure that all the candidates have finished their exam before exiting the invigilation. To resume the invigilation of this session, you will have to enter again it’s session number and it’s password.",
+        "session-id": "Session {sessionId}"
+      },
+      "login": {
+        "form": {
+          "actions": {
+            "invigilate": "Invigilate the session",
+            "switch-account": "Switch accounts"
+          },
+          "description": "The password for the session to be invigilated has been revealed to you by a Pix Certif administrator",
+          "errors": {
+            "incorrect-data": "The session number and/or the session password entered are incorrect.",
+            "mandatory-fields": "The fields “Session number” and “Session password” are required."
+          },
+          "example": "Example : C-12345",
+          "session-number": "Session number",
+          "session-password": {
+            "aria-label": "Show password",
+            "label": "Session password"
+          },
+          "sub-title": "Invigilate a session",
+          "title": "Invigilator’s portal"
+        },
+        "title": "Log into the invigilator's portal"
+      },
+      "title": "Invigilate session n° {sessionId}"
     },
     "session-supervising-error": {
-      "title": "An error occurred",
+      "description": "To access this session, click on the \"Invigilate a session\" button and fill in the details of the session",
       "page-title": "Access error to the session's invigilation",
-      "description": "To access this session, click on the \"Invigilate a session\" button and fill in the details of the session"
+      "title": "An error occurred"
+    },
+    "sessions": {
+      "actions": {
+        "return": "Return to the sessions list"
+      },
+      "detail": {
+        "candidates": {
+          "add-modal": {
+            "actions": {
+              "close-extra-information": "Close add candidate window modal",
+              "enrol-the-candidate": "Enrol the candidate"
+            },
+            "complementary-certification-none": "None",
+            "info-panel": "If this field isn’t filled in, the results won't be transmitted by email for the affected candidate(s).<br />The candidate will see their results displayed directly on their Pix account.",
+            "notifications": {
+              "error-add-duplicate": "This candidate is already in the list, you can't add them again.",
+              "error-add-unknown": "An error occurred while adding the candidate.",
+              "error-remove-already-in": "This candidate has already joined the session, you can’t delete them.",
+              "error-remove-unknown": "An error occurred while deleting the candidate.",
+              "success-add": "The candidate has been successfully enrolled.",
+              "success-remove": "The candidate has been successfully deleted.Ï"
+            },
+            "prepayment-information": "Prepayment code information",
+            "prepayment-tooltip": "Required in particular when purchasing combined credits)<br />It must be comprised of the organisation’s SIRET and of the invoice’s number. Ex : 12345678912345/FACT12345.<br />If you don’t have an invoice, a prepayment code must be set with Pix.",
+            "required-fields": "The fields marked by <span class=\"required-field-indicator\">*</span> are required.",
+            "title": "Enrol a candidate"
+          },
+          "detail-modal": {
+            "actions": {
+              "close-extra-information": "Close candidate's detail window modal"
+            },
+            "title": "Candidate’s details"
+          },
+          "list": {
+            "actions": {
+              "delete": {
+                "extra-information": "Delete the candidate",
+                "tooltip": "This candidate has already joined the session, you can’t delete them."
+              },
+              "details": {
+                "extra-information": "See the candidate’s details",
+                "label": "See details"
+              },
+              "inscription": {
+                "label": "Enrol a candidate"
+              },
+              "inscription-multiple": {
+                "label": "Enrol candidates"
+              }
+            },
+            "empty": "Awaiting candidates",
+            "title": "Candidates' list",
+            "with-details-description": "List of candidates enrolled in the session, ordered by birth name, with a link to see the candidate’s details and the possibility to delete a candidate in the last column.",
+            "without-details-description": "List of candidates enrolled in the session, ordered by birth name, with the possibility to delete a candidate in the last column."
+          },
+          "page-title": "Candidates",
+          "panel-actions": {
+            "actions": {
+              "download": {
+                "description": "To enrol candidates in the session, fill in their details (Last name, First name, …) in this document.. <br />When you first download the template for the candidates' list, it will be blank. Afterwards, it will contain the details of the candidates enrolled in the session.",
+                "extra-information": "Download the template for the candidates' list",
+                "label": "Download (.ods)"
+              },
+              "upload": {
+                "description": "Select the candidates' list previously filled in.<br /><strong>Warning, any new upload deletes the existing candidates' list.</strong>",
+                "extra-information": "Upload the candidates' list",
+                "label": "Upload (.ods)"
+              }
+            },
+            "title": "Enrol candidates",
+            "warning": "The session has begun, you can’t upload a candidates' list anymore.<br />If you want to edit the list, you can enrol a candidate directly in the table below."
+          }
+        },
+        "downloads": {
+          "attendance-sheet": {
+            "extra-information": "Download attendance sheet",
+            "label": "Attendance sheet"
+          },
+          "incident-report": {
+            "extra-information": "Download incident report",
+            "label": "Incident report"
+          },
+          "invigilator-kit": {
+            "extra-information": "Download invigilator’s kit",
+            "label": "Invigilator’s kit"
+          },
+          "label": "Downloads:"
+        },
+        "page-title": "Details",
+        "panel-clea": {
+          "description": "Pour générer les certificats CléA numérique, téléchargez la liste des candidats, complétez-la, enregistrez-la au format .xlsx puis importez-la sur la ",
+          "download-button": "Télécharger la liste des candidats",
+          "error-message": "Une erreur est survenue lors du téléchargement du fichier. Veuillez réessayer ou contacter certif@pix.fr en indiquant le numéro de la session concernée.",
+          "link-text": "plateforme du CléA numérique.",
+          "title": "Des candidats ont obtenu le certificat CléA numérique"
+        },
+        "parameters": {
+          "access-code": {
+            "candidate": "Candidate",
+            "copy-code": "Copy the session’s access code",
+            "label": "Access code"
+          },
+          "actions": {
+            "finalizing": "Finalise the session",
+            "update": "Edit the details for session {sessionId}"
+          },
+          "finalization-info": "The finalisation information for the session has already been transmitted to Pix.",
+          "password": {
+            "copy-password": "Copy the invigilator’s session password",
+            "label": "Session password"
+          },
+          "session": {
+            "copy-number": "Copy the session number",
+            "label": "Session number"
+          }
+        },
+        "tabs": {
+          "details": "Details"
+        },
+        "title": "Session {sessionId}"
+      },
+      "import": {
+        "breadcrumb": {
+          "extra-information": "Fil d'Arianne",
+          "import": "Import du modèle",
+          "summary": "Récapitulatif"
+        },
+        "step-one": {
+          "actions": {
+            "cancel": {
+              "label": "Annuler l'import"
+            },
+            "session-import-template": {
+              "extra-information": "Télécharger le modèle vierge",
+              "label": "Télécharger (.csv)"
+            },
+            "session-import-upload": {
+              "extra-information": "Importer le modèle complété",
+              "label": "Importer (.csv)"
+            }
+          },
+          "errors": {
+            "CSV_DATA_REQUIRED": "Le modèle importé n'a pas été rempli, merci de le compléter avant de l'importer à nouveau",
+            "CSV_HEADERS_NOT_VALID": "Le modèle a été altéré, merci de le télécharger à nouveau",
+            "download": "Une erreur s'est produite pendant le téléchargement",
+            "forbidden": "La création et l'édition de plusieurs sessions à la fois n'est pas disponible pour votre centre de certification. Veuillez utiliser la création et l'édition individuelle de session."
+          },
+          "instructions": {
+            "creation": {
+              "list": "Vous pouvez créer des sessions :",
+              "list-with-candidates": "<strong>Avec candidats</strong>, complétez le modèle dans son intégralité,",
+              "list-without-candidates": "<strong>Sans candidat</strong>, complétez uniquement les informations des sessions.",
+              "title": "Pour créer des sessions ?"
+            },
+            "edition": {
+              "replace": "<strong>Pour remplacer</strong> une liste pré-existante dans le fichier modèle,",
+              "subscription": "<strong>Pour inscrire</strong> des candidats dans une session vide.",
+              "title": "Pour éditer la liste des candidats de sessions déjà créées ?",
+              "warning": "Attention à renseigner le numéro de session sans les autres informations de sessions (ex: date, heure, etc.) pour éviter les doublons lors de la création."
+            },
+            "title": "Comment ça marche ?"
+          }
+        },
+        "step-two": {
+          "actions": {
+            "confirm": {
+              "label": "Finaliser la création/édition"
+            },
+            "confirm-with-warning": {
+              "label": "Finaliser quand même la création/édition"
+            },
+            "import-again": {
+              "extra-information": "Revenir à l'étape précédente pour importer le fichier à nouveau",
+              "label": "Importer à nouveau"
+            }
+          },
+          "blocking-errors": {
+            "errors": {
+              "CANDIDATE_BILLING_MODE_NOT_VALID": "Donnée du champ \"Tarification part Pix\" invalide (formats acceptés \"Gratuite\", \"Payante\" ou \"Prépayée\")",
+              "CANDIDATE_BILLING_MODE_REQUIRED": "Champ obligatoire \"Tarification part Pix\" manquant",
+              "CANDIDATE_BIRTHDATE_FORMAT_NOT_VALID": "Donnée du champ \"Date de naissance\" invalide (format accepté JJ/MM/AAAA)",
+              "CANDIDATE_BIRTHDATE_MUST_BE_GREATER": "Champ \"Date de naissance\" doit être supérieur à 01/01/1900",
+              "CANDIDATE_BIRTHDATE_REQUIRED": "Champ obligatoire \"Date de naissance\" manquant",
+              "CANDIDATE_BIRTH_CITY_REQUIRED": "Champ obligatoire \"Nom de la commune\" manquant",
+              "CANDIDATE_BIRTH_COUNTRY_NOT_FOUND": "Champ \"Pays de naissance\" non trouvé",
+              "CANDIDATE_BIRTH_COUNTRY_REQUIRED": "Champ obligatoire \"Pays de naissance\" manquant",
+              "CANDIDATE_BIRTH_INFORMATION_REQUIRED": "Renseigner les données de naissance du candidat",
+              "CANDIDATE_BIRTH_INSEE_CODE_NOT_VALID": "Donnée du champ \"Code INSEE\" invalide",
+              "CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED": "Renseigner soit un code INSEE, soit un code postal et un nom de commune de naissance",
+              "CANDIDATE_BIRTH_POSTAL_CODE_CITY_NOT_VALID": "Le code postal et le nom de la commune ne correspondent pas",
+              "CANDIDATE_BIRTH_POSTAL_CODE_NOT_FOUND": "Champ \"Code postal\" non trouvé",
+              "CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED": "Champ obligatoire \"Code postal\" manquant",
+              "CANDIDATE_EMAIL_NOT_VALID": "Donnée du champ \"E-mail de convocation\" invalide",
+              "CANDIDATE_EXTRA_TIME_BELOW_ONE": "Donnée du champ \"Temps majoré\" invalide (exemple de format accepté: 30%)",
+              "CANDIDATE_EXTRA_TIME_INTEGER": "Donnée du champ \"Temps majoré\" invalide (exemple de format accepté: 30%)",
+              "CANDIDATE_FIRST_NAME_REQUIRED": "Champ obligatoire \"Prénom\" manquant",
+              "CANDIDATE_FOREIGN_BIRTH_CITY_REQUIRED": "Candidat né à l'étranger, champ obligatoire \"Nom de la commune\" manquant",
+              "CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID": "Candidat né à l'étranger, inscrire 99 dans le champ \"Code INSEE\"",
+              "CANDIDATE_FOREIGN_POSTAL_CODE_MUST_BE_EMPTY": "Candidat né à l'étranger, le champ \"Code postal\" doit rester vide",
+              "CANDIDATE_LAST_NAME_REQUIRED": "Champ obligatoire \"Nom de naissance\" manquant",
+              "CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION": "Inscription possible qu'à une seule certification complémentaire par candidat",
+              "CANDIDATE_NOT_ALLOWED_FOR_STARTED_SESSION": "Édition des candidats impossible, le numéro de session correspond à une session déjà démarrée",
+              "CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY": "Champ \"Code de prépaiement\" doit rester vide (dans le cas de tarification part Pix gratuite ou payante)",
+              "CANDIDATE_PREPAYMENT_CODE_REQUIRED": "Champ obligatoire \"Code de prépaiement\" manquant (doit être renseigné en cas de tarification part Pix prépayée)",
+              "CANDIDATE_RESULT_RECIPIENT_EMAIL_NOT_VALID": "Donnée du champ \"E-mail du destinataire des résultats (formateur, enseignant…)\" invalide",
+              "CANDIDATE_SEX_NOT_VALID": "Donnée du champ \"Sexe\" invalide (format accepté \"M\"/\"F\")",
+              "CANDIDATE_SEX_REQUIRED": "Champ obligatoire \"Sexe\" manquant",
+              "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées",
+              "SESSION_ADDRESS_REQUIRED": "Champ obligatoire \"Nom du site\" manquant",
+              "SESSION_DATE_NOT_VALID": "Donnée du champ \"Date de session\" invalide (format accepté JJ/MM/AAAA)",
+              "SESSION_DATE_REQUIRED": "Champ obligatoire \"Date de session\" manquant",
+              "SESSION_EXAMINER_REQUIRED": "Champ obligatoire \"Surveillant(s)\" manquant",
+              "SESSION_ID_NOT_EXISTING": "Numéro de session inexistant",
+              "SESSION_ID_NOT_VALID": "Donnée du champ \"Numéro de session\" invalide",
+              "SESSION_ROOM_REQUIRED": "Champ obligatoire \"Nom de la salle\" manquant",
+              "SESSION_SCHEDULED_IN_THE_PAST": "Date et/ou heure indiquées antérieures à la date du jour",
+              "SESSION_TIME_NOT_VALID": "Donnée du champ \"Heure de début\" invalide (format accepté HH:MM)",
+              "SESSION_TIME_REQUIRED": "Champ obligatoire \"Heure de début\" manquant",
+              "SESSION_WITH_DATE_AND_TIME_ALREADY_EXISTS": "Une session a déjà été créée avec ces informations. Pour ajouter des candidats à une session, indiquer uniquement le numéro de session sans les informations de session"
+            },
+            "information": "Veuillez corriger toutes les erreurs bloquantes avant de re-importer le fichier .csv :",
+            "line": "Line",
+            "title": "{blockingErrorReportsCount} {blockingErrorReportsCount, plural,one {erreur bloquante} other {erreurs bloquantes}}"
+          },
+          "candidates-count": "{candidatesCount} {candidatesCount, plural,one {candidate} other {candidates}}",
+          "non-blocking-errors": {
+            "errors": {
+              "DUPLICATE_CANDIDATE_IN_SESSION": "Le candidat inscrit plusieurs fois à la même session, une seule inscription sera prise en compte.",
+              "EMPTY_SESSION": "La session ne contient pas de candidat"
+            },
+            "information": "Nous avons détecté {nonBlockingErrorReportsCount, plural,one {un point d’attention non bloquant} other {des points d’attention non bloquants}} lors de l’import, consultez-{nonBlockingErrorReportsCount, plural,one {le} other {les}} avant de procéder à la création ou l’édition de vos sessions :",
+            "line": "Line",
+            "title": "{nonBlockingErrorReportsCount} {nonBlockingErrorReportsCount, plural,one {Point d’attention non bloquant} other {Points d’attention non bloquants}}"
+          },
+          "sessions-and-empty-sessions-count": "{sessionsCount} {sessionsCount, plural,one {session} other {sessions}} including {sessionsWithoutCandidatesCount} {sessionsWithoutCandidatesCount, plural,one {session} other {sessions}} without candidates"
+        },
+        "success": "Success! {sessionsCount} {sessionsCount, plural, one {session} other {sessions}} dont {sessionsWithoutCandidatesCount} {sessionsWithoutCandidatesCount, plural, one {session} other {sessions}} created without candidate and {candidatesCount} {candidatesCount, plural, one {candidate} other {candidates}} created or updated",
+        "title": "Créer/éditer plusieurs sessions"
+      },
+      "list": {
+        "actions": {
+          "creation": {
+            "label": "Create a session"
+          },
+          "delete-session": {
+            "disabled": "At least one candidate has joined the session, you can’t delete it.",
+            "label": "Delete the session {sessionSummaryId}"
+          },
+          "multiple-creation": {
+            "label": "Create several sessions"
+          },
+          "multiple-creation-edition": {
+            "label": "Create/edit several sessions"
+          }
+        },
+        "delete-modal": {
+          "actions": {
+            "cancel": {
+              "extra-information": "Cancel the session's deletion."
+            },
+            "confirm": {
+              "extra-information": "Delete the session"
+            }
+          },
+          "content": "Do you want to delete the session <span>{sessionId}</span> ?",
+          "enrolled-candidates": "<span>{enrolledCandidatesCount} {enrolledCandidatesCount, plural,one {candidate} other {candidates}}</span> {enrolledCandidatesCount, plural,one {is} other {are}} enrolled in this session",
+          "success": "The session has been successfully deleted.",
+          "title": "Delete the session",
+          "warning": "Warning, this action is irreversible."
+        },
+        "empty": {
+          "title": "Create my first certification session"
+        },
+        "status": {
+          "created": "Created",
+          "finalized": "Finalised",
+          "processed": "Results transmitted by Pix"
+        },
+        "table": {
+          "empty": "No session found",
+          "header": {
+            "actions": "Actions",
+            "effective-candidates": "Certifications taken",
+            "enrolled-candidates": "Signed up candidates"
+          },
+          "row": {
+            "label": "Certification session",
+            "session-and-id": "Session {sessionId}"
+          }
+        },
+        "title": "Certification sessions"
+      },
+      "new": {
+        "actions": {
+          "cancel-extra-information": "Cancel the session creation and return to the previous page",
+          "create-session": "Create the session"
+        },
+        "address": "Location name",
+        "date": "Starting date",
+        "description": "Observations",
+        "errors": {
+          "SESSION_ADDRESS_REQUIRED": "Please indicate a location name.",
+          "SESSION_DATE_REQUIRED": "Please indicate a starting date.",
+          "SESSION_EXAMINER_REQUIRED": "Please indicate the last name and first name of the invigilator(s).",
+          "SESSION_ROOM_REQUIRED": "Please indicate a room name.",
+          "SESSION_TIME_REQUIRED": "Please indicate a starting time in local time."
+        },
+        "examiner": "Invigilator(s)",
+        "extra-information": "Session scheduling | Pix Certif",
+        "required-fields": "The fields marked by <abbr title=\"required\" class=\"mandatory-mark\">*</abbr> are required.",
+        "room": "Room name",
+        "time": "Starting time (local time)",
+        "title": "Creation of a certification session"
+      },
+      "update": {
+        "actions": {
+          "cancel-extra-information": "Cancel the session change and return to the previous page",
+          "edit-session": "Edit the session"
+        },
+        "title": "Certification session change"
+      }
     },
     "team": {
-      "title": "Team",
-      "referer": "Référent",
-      "pix-referer": "Référent Pix",
-      "update-referer-button": "Changer de référent",
-      "pix-referer-tooltip": "Le référent Pix est le contact privilégié des équipes de Pix. Il est le responsable du bon déroulement des sessions de certification.",
       "no-referer-section": {
-        "title": "Aucun référent Pix désigné",
         "description": "Le référent Pix est le contact privilégié des équipes de Pix. Il est le responsable du bon déroulement des sessions de certification.",
-        "select-referer-button": "Désigner un référent"
+        "select-referer-button": "Désigner un référent",
+        "title": "Aucun référent Pix désigné"
       },
+      "pix-referer": "Référent Pix",
+      "pix-referer-tooltip": "Le référent Pix est le contact privilégié des équipes de Pix. Il est le responsable du bon déroulement des sessions de certification.",
+      "referer": "Référent",
       "select-referer-modal": {
-        "title": "Sélection du référent Pix",
-        "label": "Sélectionner un référent Pix",
-        "empty-option": "--Sélectionner--",
-        "description": "Le Groupement d’intérêt public, sis 21-23 rue des Ardennes 75019 Paris PIX met en œuvre en tant que responsable de traitement un traitement de données à caractère personnel portant sur votre adresse email professionnel de référent Pix.<br />La finalité de ce traitement est la communication des informations nécessaires aux attributions du référent Pix au sein du centre de certification agréé. Le traitement de cette données repose sur l’exécution de la convention d’agrément de votre centre de certification.<br />Les données sont conservées pendant la durée de la convention d’agrément en vigueur entre le GIP Pix et le centre habilité auquel vous êtes rattaché.<br />Vous disposez de droits personnels, droits d'accès, de rectification et d’effacement des données, le droit de limitation ou d’opposition au traitement pour motif légitime et le droit d’introduire une réclamation auprès d’une autorité de contrôle ainsi que le droit de définir des directives relatives à la conservation, à l'effacement et à la communication de vos données à caractère personnel en cas de décès que vous pouvez exercer par courriel auprès de notre DPD en adressant votre demande à l’adresse électronique suivante : dpd@pix.fr .<br />Vous disposez de la possibilité d’introduire une réclamation auprès de Commission nationale Informatique et libertés « CNIL » à l’adresse suivante : 3 Place de Fontenoy – TSA 80715 – 75334 Paris Cedex 07.",
         "actions": {
+          "cancel-extra-information": "Annuler la sélection de référent",
           "validate": "Valider",
-          "validate-extra-information": "Valider la sélection de référent",
-          "cancel-extra-information": "Annuler la sélection de référent"
-        }
-      }
+          "validate-extra-information": "Valider la sélection de référent"
+        },
+        "description": "Le Groupement d’intérêt public, sis 21-23 rue des Ardennes 75019 Paris PIX met en œuvre en tant que responsable de traitement un traitement de données à caractère personnel portant sur votre adresse email professionnel de référent Pix.<br />La finalité de ce traitement est la communication des informations nécessaires aux attributions du référent Pix au sein du centre de certification agréé. Le traitement de cette données repose sur l’exécution de la convention d’agrément de votre centre de certification.<br />Les données sont conservées pendant la durée de la convention d’agrément en vigueur entre le GIP Pix et le centre habilité auquel vous êtes rattaché.<br />Vous disposez de droits personnels, droits d'accès, de rectification et d’effacement des données, le droit de limitation ou d’opposition au traitement pour motif légitime et le droit d’introduire une réclamation auprès d’une autorité de contrôle ainsi que le droit de définir des directives relatives à la conservation, à l'effacement et à la communication de vos données à caractère personnel en cas de décès que vous pouvez exercer par courriel auprès de notre DPD en adressant votre demande à l’adresse électronique suivante : dpd@pix.fr .<br />Vous disposez de la possibilité d’introduire une réclamation auprès de Commission nationale Informatique et libertés « CNIL » à l’adresse suivante : 3 Place de Fontenoy – TSA 80715 – 75334 Paris Cedex 07.",
+        "empty-option": "--Sélectionner--",
+        "label": "Sélectionner un référent Pix",
+        "title": "Sélection du référent Pix"
+      },
+      "title": "Team",
+      "update-referer-button": "Changer de référent"
+    },
+    "terms-of-service": {
+      "actions": {
+        "accept": "I accept the terms and conditions of use"
+      },
+      "page-title": "Terms and conditions",
+      "title": "Terms and conditions of use of the Pix Certif platform"
     }
   }
 }

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -8,18 +8,36 @@
       "close": "Fermer",
       "continue": "Continuer",
       "delete": "Supprimer",
+      "exit": "Quitter",
       "quit": "Quitter",
       "update": "Modifier",
-      "exit": "Quitter",
       "validate": "Valider"
     },
     "api-error-messages": {
       "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
+      "gateway-timeout-error": "Le service subit des ralentissements. Veuillez réessayer ultérieurement.",
       "internal-server-error": "Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.",
       "login-unauthorized-error": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects.",
-      "login-user-temporary-blocked-error": "Vous avez effectué trop de tentatives de connexion. Réessayez plus tard ou cliquez sur <a href=\"{url}\">mot de passe oublié</a> pour le réinitialiser.",
       "login-user-blocked-error": "Votre compte est bloqué car vous avez effectué trop de tentatives de connexion. Pour le débloquer, <a href=\"{url}\">contactez-nous</a>.",
-      "gateway-timeout-error": "Le service subit des ralentissements. Veuillez réessayer ultérieurement."
+      "login-user-temporary-blocked-error": "Vous avez effectué trop de tentatives de connexion. Réessayez plus tard ou cliquez sur <a href=\"{url}\">mot de passe oublié</a> pour le réinitialiser."
+    },
+    "form-errors": {
+      "default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
+      "email": {
+        "already-exists": "Cette adresse e-mail est déjà enregistrée, connectez-vous.",
+        "format": "Le champ adresse e-mail n’est pas valide."
+      },
+      "firstname": {
+        "mandatory": "Le champ prénom est obligatoire."
+      },
+      "lastname": {
+        "mandatory": "Le champ nom est obligatoire."
+      },
+      "mandatory-all-fields": "Tous les champs sont obligatoires.",
+      "password": {
+        "format": "Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.",
+        "mandatory": "Le champ mot de passe est obligatoire."
+      }
     },
     "forms": {
       "certification-labels": {
@@ -40,8 +58,8 @@
       },
       "login": {
         "email": "Adresse e-mail",
-        "password": "Mot de passe",
-        "forgot-password": "Mot de passe oublié ?"
+        "forgot-password": "Mot de passe oublié ?",
+        "password": "Mot de passe"
       },
       "mandatory-fields": "Les champs marqués de <abbr title=\"obligatoire\" class=\"mandatory-mark\">*</abbr>sont obligatoires.",
       "required": "Obligatoire",
@@ -59,24 +77,6 @@
         "time-start": "Heure de début (heure locale)"
       }
     },
-    "form-errors": {
-      "default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
-      "email": {
-        "already-exists": "Cette adresse e-mail est déjà enregistrée, connectez-vous.",
-        "format": "Le champ adresse e-mail n’est pas valide."
-      },
-      "firstname": {
-        "mandatory": "Le champ prénom est obligatoire."
-      },
-      "lastname": {
-        "mandatory": "Le champ nom est obligatoire."
-      },
-      "password": {
-        "format": "Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.",
-        "mandatory": "Le champ mot de passe est obligatoire."
-      },
-      "mandatory-all-fields": "Tous les champs sont obligatoires."
-    },
     "labels": {
       "billing-mode": {
         "free": "Gratuite",
@@ -87,14 +87,14 @@
         "birth-city": "Commune de naissance",
         "birth-city-insee-code": "Code INSEE de naissance",
         "birth-city-postcode": "Code postal de naissance",
-        "birth-geographical-code": "Code géographique de naissance",
         "birth-country": "Pays de naissance",
         "birth-date": "Date de naissance",
+        "birth-geographical-code": "Code géographique de naissance",
         "birth-name": "Nom de naissance",
         "firstname": "Prénom",
         "gender": {
-          "title": "Sexe",
           "man": "Homme",
+          "title": "Sexe",
           "woman": "Femme"
         },
         "insee-code": "Code INSEE",
@@ -111,47 +111,40 @@
   "current-lang": "fr",
   "navigation": {
     "external-link-title": "Ouverture dans une nouvelle fenêtre",
+    "footer": {
+      "a11y": "Accessibilité : partiellement conforme",
+      "current-year": "© {currentYear} Pix",
+      "legal-notice": "Mentions légales"
+    },
     "main": {
+      "documentation": "Documentation",
       "sessions": "Sessions",
       "sessions-label": "Sessions de certification",
       "supervisor": "Espace surveillant",
-      "team": "Équipe",
-      "documentation": "Documentation"
+      "team": "Équipe"
     },
     "user-logged-menu": {
       "logout": "Se déconnecter"
-    },
-    "footer": {
-      "a11y": "Accessibilité : partiellement conforme",
-      "legal-notice": "Mentions légales",
-      "current-year": "© {currentYear} Pix"
     }
   },
   "pages": {
-    "terms-of-service": {
-      "page-title": "Conditions générales",
-      "title": "Conditions générales d'utilisation de la plateforme Pix Certif",
-      "actions": {
-        "accept": "J’accepte les conditions d’utilisation"
-      }
-    },
     "login": {
-      "title": "Connectez-vous",
+      "accessible-to": "L'accès à Pix Certif est limité aux centres de certification Pix.",
       "actions": {
         "login": {
           "label": "Je me connecte"
         }
       },
       "errors": {
-        "should-change-password": "Vous avez actuellement un mot de passe temporaire. Cliquez sur <a href=\"{url}\">mot de passe oublié</a> pour le réinitialiser.",
+        "invitation-already-accepted": "Cette invitation a déjà été acceptée.<br/>Connectez-vous ou contactez l’administrateur de votre espace Pix Certif.",
         "invitation-was-cancelled": "Cette invitation n’est plus valide.<br/>Contactez l’administrateur de votre espace Pix Certif.",
-        "invitation-already-accepted": "Cette invitation a déjà été acceptée.<br/>Connectez-vous ou contactez l’administrateur de votre espace Pix Certif."
+        "should-change-password": "Vous avez actuellement un mot de passe temporaire. Cliquez sur <a href=\"{url}\">mot de passe oublié</a> pour le réinitialiser."
       },
-      "accessible-to": "L'accès à Pix Certif est limité aux centres de certification Pix."
+      "title": "Connectez-vous"
     },
     "login-or-register": {
-      "title": "Vous êtes invité(e) à rejoindre le centre de certification {certificationCenterName}",
       "login-form": {
+        "button": "Se connecter",
         "errors": {
           "status": {
             "403": "L'accès à Pix Certif est limité aux membres invités. Chaque espace est géré par un administrateur Pix Certif propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite.",
@@ -160,12 +153,10 @@
             "412": "Cette invitation a déjà été acceptée"
           }
         },
-        "title": "J'ai déjà un compte",
         "login": "Je me connecte",
-        "button": "Se connecter"
+        "title": "J'ai déjà un compte"
       },
       "register-form": {
-        "title": "Je m’inscris",
         "actions": {
           "login": "S'inscrire",
           "login-button": "Je m'inscris"
@@ -179,347 +170,26 @@
             "error": "Vous devez accepter les conditions d’utilisation de Pix et la politique de confidentialité pour créer un compte.",
             "terms-of-use": "conditions d'utilisation de Pix"
           }
-        }
-      }
-    },
-    "sessions": {
-      "actions": {
-        "return": "Revenir à la liste des sessions"
+        },
+        "title": "Je m’inscris"
       },
-      "import": {
-        "breadcrumb": {
-          "extra-information": "Fil d'Arianne",
-          "import": "Import du modèle",
-          "summary": "Récapitulatif"
-        },
-        "title": "Créer/éditer plusieurs sessions",
-        "step-one": {
-          "actions": {
-            "cancel": {
-              "label": "Annuler l'import"
-            },
-            "session-import-upload": {
-              "extra-information": "Importer le modèle complété",
-              "label": "Importer (.csv)"
-            },
-            "session-import-template": {
-              "extra-information": "Télécharger le modèle vierge",
-              "label": "Télécharger (.csv)"
-            }
-          },
-          "errors": {
-            "download": "Une erreur s'est produite pendant le téléchargement",
-            "CSV_DATA_REQUIRED": "Le modèle importé n'a pas été rempli, merci de le compléter avant de l'importer à nouveau",
-            "CSV_HEADERS_NOT_VALID": "Le modèle a été altéré, merci de le télécharger à nouveau",
-            "forbidden": "La création et l'édition de plusieurs sessions à la fois n'est pas disponible pour votre centre de certification. Veuillez utiliser la création et l'édition individuelle de session."
-          },
-          "instructions": {
-            "title": "Comment ça marche ?",
-            "creation": {
-              "title": "Pour créer des sessions ?",
-              "list": "Vous pouvez créer des sessions :",
-              "list-with-candidates": "<strong>Avec candidats</strong>, complétez le modèle dans son intégralité,",
-              "list-without-candidates": "<strong>Sans candidat</strong>, complétez uniquement les informations des sessions."
-            },
-            "edition": {
-              "title": "Pour éditer la liste des candidats de sessions déjà créées ?",
-              "replace": "<strong>Pour remplacer</strong> une liste pré-existante dans le fichier modèle,",
-              "subscription": "<strong>Pour inscrire</strong> des candidats dans une session vide.",
-              "warning": "Attention à renseigner le numéro de session sans les autres informations de sessions (ex: date, heure, etc.) pour éviter les doublons lors de la création."
-            }
-          }
-        },
-        "step-two": {
-          "blocking-errors": {
-            "title": "{blockingErrorReportsCount} {blockingErrorReportsCount, plural,one {erreur bloquante} other {erreurs bloquantes}}",
-            "information": "Veuillez corriger toutes les erreurs bloquantes avant de re-importer le fichier .csv :",
-            "line": "Ligne",
-            "errors": {
-              "CANDIDATE_FIRST_NAME_REQUIRED": "Champ obligatoire \"Prénom\" manquant",
-              "CANDIDATE_LAST_NAME_REQUIRED": "Champ obligatoire \"Nom de naissance\" manquant",
-              "CANDIDATE_SEX_REQUIRED": "Champ obligatoire \"Sexe\" manquant",
-              "CANDIDATE_SEX_NOT_VALID": "Donnée du champ \"Sexe\" invalide (format accepté \"M\"/\"F\")",
-              "CANDIDATE_BIRTH_INSEE_CODE_NOT_VALID": "Donnée du champ \"Code INSEE\" invalide",
-              "CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED": "Renseigner soit un code INSEE, soit un code postal et un nom de commune de naissance",
-              "CANDIDATE_BIRTH_COUNTRY_REQUIRED": "Champ obligatoire \"Pays de naissance\" manquant",
-              "CANDIDATE_BIRTH_CITY_REQUIRED": "Champ obligatoire \"Nom de la commune\" manquant",
-              "CANDIDATE_BIRTH_COUNTRY_NOT_FOUND": "Donnée du champ \"Pays de naissance\" n'existe pas",
-              "CANDIDATE_BIRTH_INFORMATION_REQUIRED": "Renseigner les données de naissance du candidat",
-              "CANDIDATE_BIRTH_POSTAL_CODE_CITY_NOT_VALID": "Le code postal et le nom de la commune ne correspondent pas",
-              "CANDIDATE_BIRTH_POSTAL_CODE_NOT_FOUND": "Donnée du champ \"Code postal\" n'existe pas",
-              "CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED": "Champ obligatoire \"Code postal\" manquant",
-              "CANDIDATE_BIRTHDATE_REQUIRED": "Champ obligatoire \"Date de naissance\" manquant",
-              "CANDIDATE_BIRTHDATE_FORMAT_NOT_VALID": "Donnée du champ \"Date de naissance\" invalide (format accepté JJ/MM/AAAA)",
-              "CANDIDATE_BIRTHDATE_MUST_BE_GREATER": "Champ \"Date de naissance\" doit être supérieur à 01/01/1900",
-              "CANDIDATE_EXTRA_TIME_BELOW_ONE": "Donnée du champ \"Temps majoré\" invalide (exemple de format accepté: 30%)",
-              "CANDIDATE_EXTRA_TIME_INTEGER": "Donnée du champ \"Temps majoré\" invalide (exemple de format accepté: 30%)",
-              "CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID": "Candidat né à l'étranger, inscrire 99 dans le champ \"Code INSEE\"",
-              "CANDIDATE_FOREIGN_BIRTH_CITY_REQUIRED": "Candidat né à l'étranger, champ obligatoire \"Nom de la commune\" manquant",
-              "CANDIDATE_FOREIGN_POSTAL_CODE_MUST_BE_EMPTY": "Candidat né à l'étranger, le champ \"Code postal\" doit rester vide",
-              "CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION": "Inscription possible qu'à une seule certification complémentaire par candidat",
-              "CANDIDATE_BILLING_MODE_REQUIRED": "Champ obligatoire \"Tarification part Pix\" manquant",
-              "CANDIDATE_BILLING_MODE_NOT_VALID": "Donnée du champ \"Tarification part Pix\" invalide (formats acceptés \"Gratuite\", \"Payante\" ou \"Prépayée\")",
-              "CANDIDATE_PREPAYMENT_CODE_REQUIRED": "Champ obligatoire \"Code de prépaiement\" manquant (doit être renseigné en cas de tarification part Pix prépayée)",
-              "CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY": "Champ \"Code de prépaiement\" doit rester vide (dans le cas de tarification part Pix gratuite ou payante)",
-              "CANDIDATE_NOT_ALLOWED_FOR_STARTED_SESSION": "Édition des candidats impossible, le numéro de session correspond à une session déjà démarrée",
-              "CANDIDATE_EMAIL_NOT_VALID": "Donnée du champ \"E-mail de convocation\" invalide",
-              "CANDIDATE_RESULT_RECIPIENT_EMAIL_NOT_VALID": "Donnée du champ \"E-mail du destinataire des résultats (formateur, enseignant…)\" invalide",
-              "SESSION_ADDRESS_REQUIRED": "Champ obligatoire \"Nom du site\" manquant",
-              "SESSION_ROOM_REQUIRED": "Champ obligatoire \"Nom de la salle\" manquant",
-              "SESSION_DATE_REQUIRED": "Champ obligatoire \"Date de session\" manquant",
-              "SESSION_DATE_NOT_VALID": "Donnée du champ \"Date de session\" invalide (format accepté JJ/MM/AAAA)",
-              "SESSION_TIME_REQUIRED": "Champ obligatoire \"Heure de début\" manquant",
-              "SESSION_TIME_NOT_VALID": "Donnée du champ \"Heure de début\" invalide (format accepté HH:MM)",
-              "SESSION_EXAMINER_REQUIRED": "Champ obligatoire \"Surveillant(s)\" manquant",
-              "SESSION_WITH_DATE_AND_TIME_ALREADY_EXISTS": "Une session a déjà été créée avec ces informations. Pour ajouter des candidats à une session, indiquer uniquement le numéro de session sans les informations de session",
-              "SESSION_SCHEDULED_IN_THE_PAST": "Date et/ou heure indiquées antérieures à la date du jour",
-              "SESSION_ID_NOT_EXISTING": "Numéro de session inexistant",
-              "SESSION_ID_NOT_VALID": "Donnée du champ \"Numéro de session\" invalide",
-              "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées"
-            }
-          },
-          "non-blocking-errors": {
-            "title": "{nonBlockingErrorReportsCount} {nonBlockingErrorReportsCount, plural,one {point d’attention non bloquant} other {points d’attention non bloquants}}",
-            "information": "Nous avons détecté {nonBlockingErrorReportsCount, plural,one {un point d’attention non bloquant} other {des points d’attention non bloquants}} lors de l’import, consultez-{nonBlockingErrorReportsCount, plural,one {le} other {les}} avant de procéder à la création ou l’édition de vos sessions :",
-            "line": "Ligne",
-            "errors": {
-              "DUPLICATE_CANDIDATE_IN_SESSION": "Le candidat est inscrit plusieurs fois à la même session, une seule inscription sera prise en compte.",
-              "EMPTY_SESSION": "La session ne contient pas de candidat"
-            }
-          },
-          "actions": {
-            "import-again": {
-              "label": "Importer à nouveau",
-              "extra-information": "Revenir à l'étape précédente pour importer le fichier à nouveau"
-            },
-            "confirm": {
-              "label": "Finaliser la création/édition"
-            },
-            "confirm-with-warning": {
-              "label": "Finaliser quand même la création/édition"
-            }
-          },
-          "sessions-and-empty-sessions-count": "{sessionsCount} {sessionsCount, plural,one {session} other {sessions}} dont {sessionsWithoutCandidatesCount} {sessionsWithoutCandidatesCount, plural,one {session} other {sessions}} sans candidat",
-          "candidates-count": "{candidatesCount} {candidatesCount, plural,one {candidat} other {candidats}}"
-        },
-        "success": "Succès ! {sessionsCount} {sessionsCount, plural, one {session} other {sessions}} dont {sessionsWithoutCandidatesCount} {sessionsWithoutCandidatesCount, plural, one {session} other {sessions}} sans candidat {sessionsCount, plural, one {créée} other {créées}} et {candidatesCount} {candidatesCount, plural, one {candidat créé ou édité} other {candidats créés ou édités}}"
-      },
-      "list": {
-        "title": "Sessions de certification",
-        "actions": {
-          "creation": {
-            "label": "Créer une session"
-          },
-          "delete-session": {
-            "disabled": "Au moins un candidat a rejoint la session, vous ne pouvez pas la supprimer.",
-            "label": "Supprimer la session {sessionSummaryId}"
-          },
-          "multiple-creation": {
-            "label": "Créer plusieurs sessions"
-          },
-          "multiple-creation-edition": {
-            "label": "Créer/éditer plusieurs sessions"
-          }
-        },
-        "delete-modal": {
-          "title": "Supprimer la session",
-          "actions": {
-            "cancel": {
-              "extra-information": "Annuler la suppression de la session"
-            },
-            "confirm": {
-              "extra-information": "Supprimer la session"
-            }
-          },
-          "content": "Souhaitez-vous supprimer la session <span>{sessionId}</span> ?",
-          "enrolled-candidates": "<span>{enrolledCandidatesCount} {enrolledCandidatesCount, plural,one {candidat} other {candidats}}</span> {enrolledCandidatesCount, plural,one {est inscrit} other {sont inscrits}} à cette session",
-          "success": "La session a été supprimée avec succès.",
-          "warning": "Attention, cette action est irréversible."
-        },
-        "empty": {
-          "title": "Créer ma première session de certification"
-        },
-        "status": {
-          "created": "Créée",
-          "finalized": "Finalisée",
-          "processed": "Résultats transmis par Pix"
-        },
-        "table": {
-          "empty": "Aucune session trouvée",
-          "header": {
-            "actions": "Actions",
-            "effective-candidates": "Certifications passées",
-            "enrolled-candidates": "Candidats inscrits"
-          },
-          "row": {
-            "label": "Session de certification",
-            "session-and-id": "Session {sessionId}"
-          }
-        }
-      },
-      "detail": {
-        "title": "Session {sessionId}",
-        "candidates": {
-          "add-modal": {
-            "title": "Inscrire un candidat",
-            "actions": {
-              "close-extra-information": "Fermer la modale d'ajout de candidat",
-              "enrol-the-candidate": "Inscrire le candidat"
-            },
-            "complementary-certification-none": "Aucune",
-            "info-panel": "Si le champ n’est pas renseigné, les résultats ne seront pas transmis par mail pour le/les candidats concernés.<br />Le candidat verra ses résultats affichés directement sur son compte Pix.",
-            "prepayment-information": "Information du code de prépaiement",
-            "prepayment-tooltip": "(Requis notamment dans le cas d'un achat de crédits combinés)<br />Doit être composé du SIRET de l’organisation et du numéro de facture. Ex : 12345678912345/FACT12345'.<br/>Si vous ne possédez pas de facture, un code de prépaiement doit être établi avec Pix.",
-            "required-fields": "Les champs marqués de <span class=\"required-field-indicator\">*</span> sont obligatoires.",
-            "notifications": {
-              "success-add": "Le candidat a été inscrit avec succès.",
-              "success-remove": "Le candidat a été supprimé avec succès.",
-              "error-add-duplicate": "Ce candidat est déjà dans la liste, vous ne pouvez pas l'ajouter à nouveau.",
-              "error-add-unknown": "Une erreur s'est produite lors de l'ajout du candidat.",
-              "error-remove-already-in": "Ce candidat a déjà rejoint la session. Vous ne pouvez pas le supprimer.",
-              "error-remove-unknown": "Une erreur s'est produite lors de la suppression du candidat."
-            }
-          },
-          "detail-modal": {
-            "title": "Détail du candidat",
-            "actions": {
-              "close-extra-information": "Fermer la fenêtre de détail du candidat"
-            }
-          },
-          "list": {
-            "title": "Liste des candidats",
-            "actions": {
-              "delete": {
-                "extra-information": "Supprimer le candidat",
-                "tooltip": "Ce candidat a déjà rejoint la session. Vous ne pouvez pas le supprimer."
-              },
-              "inscription": {
-                "label": "Inscrire un candidat"
-              },
-              "inscription-multiple": {
-                "label": "Inscrire des candidats"
-              },
-              "details": {
-                "extra-information": "Voir le détail du candidat",
-                "label": "Voir le détail"
-              }
-            },
-            "empty": "En attente de candidats",
-            "with-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec un lien pour voir les détails du candidat et la possibilité de supprimer un candidat dans la dernière colonne.",
-            "without-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec la possibilité de supprimer un candidat dans la dernière colonne."
-          },
-          "panel-actions": {
-            "title": "Inscrire des candidats",
-            "actions": {
-              "download": {
-                "description": "Pour inscrire des candidats à la session, renseignez leurs informations (Nom, Prénom, …) dans ce document. <br />Lors du premier téléchargement, le modèle de liste des candidats est vide. Il contiendra ensuite les informations des candidats inscrits à la session.",
-                "extra-information": "Télécharger le modèle de liste des candidats",
-                "label": "Télécharger (.ods)"
-              },
-              "upload": {
-                "description": "Sélectionnez la liste des candidats préalablement remplie.<br /><strong>Attention, tout nouvel import efface la liste des candidats existante.</strong>",
-                "extra-information": "Importer la liste des candidats",
-                "label": "Importer (.ods)"
-              }
-            },
-            "warning": "La session a débuté, vous ne pouvez plus importer une liste de candidats.<br />Si vous souhaitez modifier la liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous."
-          },
-          "page-title": "Candidats"
-        },
-        "downloads": {
-          "label": "Téléchargements :",
-          "attendance-sheet": {
-            "extra-information": "Télécharger la feuille d'émargement",
-            "label": "Feuille d'émargement"
-          },
-          "incident-report": {
-            "extra-information": "Télécharger le PV d'incident",
-            "label": "PV d'incident"
-          },
-          "invigilator-kit": {
-            "extra-information": "Télécharger le kit surveillant",
-            "label": "Kit surveillant"
-          }
-        },
-        "page-title": "Détails",
-        "panel-clea": {
-          "title": "Des candidats ont obtenu le certificat CléA numérique",
-          "description": "Pour générer les certificats CléA numérique, téléchargez la liste des candidats, complétez-la, enregistrez-la au format .xlsx puis importez-la sur la ",
-          "link-text": "plateforme du CléA numérique.",
-          "download-button": "Télécharger la liste des candidats",
-          "error-message": "Une erreur est survenue lors du téléchargement du fichier. Veuillez réessayer ou contacter certif@pix.fr en indiquant le numéro de la session concernée."
-        },
-        "parameters": {
-          "actions": {
-            "finalizing": "Finaliser la session",
-            "update": "Modifier les informations de la session {sessionId}"
-          },
-          "finalization-info": "Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix.",
-          "session": {
-            "copy-number": "Copier le numéro de session",
-            "label": "Numéro de session"
-          },
-          "access-code": {
-            "label": "Code d'accès",
-            "candidate": "Candidat",
-            "copy-code": "Copier le code d’accès à la session"
-          },
-          "password": {
-            "copy-password": "Copier le mot de passe de session pour le surveillant",
-            "label": "Mot de passe de session"
-          }
-        },
-        "tabs": {
-          "details": "Détails"
-        }
-      },
-      "new": {
-        "title": "Création d’une session de certification",
-        "actions": {
-          "cancel-extra-information": "Annuler la création de session et retourner vers la page précédente",
-          "create-session": "Créer la session"
-        },
-        "address": "Nom du site",
-        "date": "Date de début",
-        "description": "Observations",
-        "errors": {
-          "SESSION_ADDRESS_REQUIRED": "Veuillez indiquer un nom de site.",
-          "SESSION_ROOM_REQUIRED": "Veuillez indiquer un nom de salle.",
-          "SESSION_DATE_REQUIRED": "Veuillez indiquer une date de début.",
-          "SESSION_TIME_REQUIRED": "Veuillez indiquer une heure de début en heure locale.",
-          "SESSION_EXAMINER_REQUIRED": "Veuillez indiquer le nom et prénom du ou des surveillants."
-        },
-        "examiner": "Surveillant(s)",
-        "extra-information": "Planification d’une session | Pix Certif",
-        "required-fields": "Les champs marqués de <abbr title=\"obligatoire\" class=\"mandatory-mark\">*</abbr> sont obligatoires.",
-        "room": "Nom de la salle",
-        "time": "Heure de début (heure locale)"
-      },
-      "update": {
-        "title": "Modification d'une session de certification",
-        "actions": {
-          "cancel-extra-information": "Annuler la modification de la session et retourner vers la page précédente",
-          "edit-session": "Modifier la session"
-        }
-      }
+      "title": "Vous êtes invité(e) à rejoindre le centre de certification {certificationCenterName}"
     },
     "session-finalization": {
-      "title": "Finaliser la session {sessionId}",
       "actions": {
         "finalise": "Finaliser"
       },
       "add-issue-modal": {
-        "title": "Signalement du candidat :",
         "actions": {
           "add-reporting": "Ajouter le signalement",
           "cancel": "Annuler",
           "describe": "Décrivez l'incident rencontré",
           "enter-question-number": "Numéro de question :",
-          "specify": "Précisez",
           "select-category": "Veuillez selectionner une catégorie",
           "select-category-label": "Sélectionner la catégorie",
           "select-subcategory": "Sélectionnez une sous-catégorie :",
           "select-subcategory-label": "Sélectionner la sous-catégorie",
+          "specify": "Précisez",
           "transmit-report": "Merci de transmettre le procès-verbal de fraude rempli pendant la session de certification en utilisant <span><a class=\"link\" href=\"https://form-eu.123formbuilder.com/41052/form\" target=\"_blank\" rel=\"noreferrer\">ce formulaire</a></span>"
         },
         "category-labels": {
@@ -555,22 +225,31 @@
           "website-unavailable": "Le site à visiter est indisponible/en maintenance/inaccessible"
         },
         "subcategory-to-textarea-labels": {
-          "name-or-birthdate": "Renseignez les informations correctes",
-          "extra-time-percentage": "Précisez le temps majoré"
-        }
+          "extra-time-percentage": "Précisez le temps majoré",
+          "name-or-birthdate": "Renseignez les informations correctes"
+        },
+        "title": "Signalement du candidat :"
+      },
+      "complementary-information": {
+        "candidates-joining-issue": {
+          "label": "Un ou plusieurs candidats étaient présents en session de certification mais n'ont pas pu rejoindre la session.",
+          "link": "Vous trouverez <a class=\"link\" href=\"https://cloud.pix.fr/s/zf3fGimWwPQCeWF/download/Probl%C3%A8mes%20d%27acc%C3%A8s%20en%20session.pdf\" target=\"_blank\" rel=\"noreferrer noopener\">ici un document pour vous aider à résoudre ce type de problème de connexion pour les prochaines sessions (PDF, 131ko).</a>"
+        },
+        "description": "Vous pouvez indiquer, le cas échéant, les événements survenus lors de la session. Il n'est pas nécessaire de renseigner les candidats absents.",
+        "incident": "Malgré un incident survenu pendant la session, les candidats ont pu terminer leur test de certification. Un temps supplémentaire a été accordé à un ou plusieurs candidats.",
+        "title": "Informations complémentaires (facultatif)"
       },
       "issue-reports-modal": {
-        "title": "Signalement du candidat :",
-        "subtitle": "Mes signalements",
         "actions": {
           "add-reporting": "Ajouter un signalement",
           "delete-reporting": "Supprimer le signalement"
         },
         "errors": {
           "delete-reporting": "Une erreur s'est produite lors de la suppression du signalement. Merci de réessayer"
-        }
+        },
+        "subtitle": "Mes signalements",
+        "title": "Signalement du candidat :"
       },
-      "return-to": "Retour à la session",
       "reporting": {
         "completed-reports-information": {
           "description": "Certification(s) terminée(s)",
@@ -582,6 +261,14 @@
           }
         },
         "description": "Pour que le signalement soit pris en compte, il est nécessaire d’utiliser la catégorie de signalement appropriée (exemples : C1, C2, etc).",
+        "table": {
+          "labels": {
+            "certification-number": "N° de certification",
+            "reporting": "Signalement"
+          },
+          "reporting-count": "{reportingsCount, plural,one {1 signalement} other {# signalements}}"
+        },
+        "title": "Signalements : Reporter, pour chaque candidat, les signalements renseignés sur le PV d'incident",
         "uncompleted-reports-information": {
           "description": "Ces candidats n'ont pas fini leur test de certification ou le surveillant a mis fin à leur test",
           "extra-information": "Liste des candidats qui n’ont pas fini leur test de certification, triée par nom de naissance, avec un lien pour ajouter un ou plusieurs signalements le cas échéant et une liste déroulante permettant de sélectionner la raison de l’abandon.",
@@ -600,76 +287,15 @@
               "technical-problem-description": "Le candidat a rencontré un problème technique l'empêchant de poursuivre son test jusqu’à la fin"
             }
           }
-        },
-        "table": {
-          "labels": {
-            "certification-number": "N° de certification",
-            "reporting": "Signalement"
-          },
-          "reporting-count": "{reportingsCount, plural,one {1 signalement} other {# signalements}}"
-        },
-        "title": "Signalements : Reporter, pour chaque candidat, les signalements renseignés sur le PV d'incident"
-      },
-      "complementary-information": {
-        "title": "Informations complémentaires (facultatif)",
-        "description": "Vous pouvez indiquer, le cas échéant, les événements survenus lors de la session. Il n'est pas nécessaire de renseigner les candidats absents.",
-        "incident": "Malgré un incident survenu pendant la session, les candidats ont pu terminer leur test de certification. Un temps supplémentaire a été accordé à un ou plusieurs candidats.",
-        "candidates-joining-issue": {
-          "label": "Un ou plusieurs candidats étaient présents en session de certification mais n'ont pas pu rejoindre la session.",
-          "link": "Vous trouverez <a class=\"link\" href=\"https://cloud.pix.fr/s/zf3fGimWwPQCeWF/download/Probl%C3%A8mes%20d%27acc%C3%A8s%20en%20session.pdf\" target=\"_blank\" rel=\"noreferrer noopener\">ici un document pour vous aider à résoudre ce type de problème de connexion pour les prochaines sessions (PDF, 131ko).</a>"
         }
-      }
+      },
+      "return-to": "Retour à la session",
+      "title": "Finaliser la session {sessionId}"
     },
     "session-supervising": {
-      "title": "Surveiller la session n° {sessionId}",
-      "login": {
-        "title": "Connexion à l'espace surveillant",
-        "form": {
-          "title": "Espace Surveillant",
-          "sub-title": "Surveiller une session",
-          "description": "Le mot de passe de la session à surveiller vous a été communiqué par un administrateur Pix Certif",
-          "session-number": "Numéro de la session",
-          "session-password": {
-            "label": "Mot de passe de la session",
-            "aria-label": "Afficher le mot de passe"
-          },
-          "example": "Exemple : C-12345",
-          "errors": {
-            "mandatory-fields": "Les champs \"Numéro de la session\" et \"Mot de passe de session\" sont obligatoires.",
-            "incorrect-data": "Le numéro de session et/ou le mot de passe saisis sont incorrects."
-          },
-          "actions": {
-            "invigilate": "Surveiller la session",
-            "switch-account": "Changer de compte"
-          }
-        }
-      },
-      "header": {
-        "actions": {
-          "confirmation": "Quitter la surveillance",
-          "exit-extra-information": "Quitter la surveillance de la session {sessionId}"
-        },
-        "access-code": "Code d'accès (candidats)",
-        "information": "Attention, assurez-vous que tous les candidats aient terminé leur test avant de quitter la surveillance. Pour reprendre la surveillance de cette session, vous devrez entrer à nouveau son numéro de session et son mot de passe.",
-        "session-id": "Session {sessionId}"
-      },
-      "candidate-list": {
-        "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidat sélectionné} other {candidats sélectionnés}}",
-        "clear-field": "Vider le champ",
-        "indicate-candidates-attendance": "Cochez chaque candidat présent dans la salle de test pour l'autoriser à commencer son test de certification.",
-        "no-candidate": "Aucun candidat inscrit à cette session",
-        "search-candidate": "Rechercher un candidat"
-      },
       "candidate-in-list": {
-        "display-candidate-options": "Afficher les options du candidat",
         "candidate-options": "Options du candidat",
-        "test-end-modal": {
-          "description": "Attention : cette action entraîne la fin de son test de certification et est irréversible.",
-          "instruction-with-name": "Terminer le test de {firstName} {lastName} ?",
-          "end-assessment": "Terminer le test",
-          "success": "Succès ! Le test de {firstName} {lastName} est terminé.",
-          "error": "Une erreur est survenue, le test de {firstName} {lastName} n'a pas pu être terminé."
-        },
+        "display-candidate-options": "Afficher les options du candidat",
         "resume-test-modal": {
           "actions": {
             "confirm": "Je confirme l'autorisation"
@@ -680,36 +306,410 @@
           "error": "Une erreur est survenue, {firstName} {lastName} n'a a pu être autorisé à reprendre son test.",
           "instruction-with-name": "Autoriser {firstName} {lastName} à reprendre son test ?",
           "success": "Succès ! {firstName} {lastName} peut reprendre son test de certification."
+        },
+        "test-end-modal": {
+          "description": "Attention : cette action entraîne la fin de son test de certification et est irréversible.",
+          "end-assessment": "Terminer le test",
+          "error": "Une erreur est survenue, le test de {firstName} {lastName} n'a pas pu être terminé.",
+          "instruction-with-name": "Terminer le test de {firstName} {lastName} ?",
+          "success": "Succès ! Le test de {firstName} {lastName} est terminé."
         }
-      }
+      },
+      "candidate-list": {
+        "authorized-to-start-candidates": "{authorizedToStartCandidates}/{totalCandidates} {authorizedToStartCandidates, plural,one {candidat sélectionné} other {candidats sélectionnés}}",
+        "clear-field": "Vider le champ",
+        "indicate-candidates-attendance": "Cochez chaque candidat présent dans la salle de test pour l'autoriser à commencer son test de certification.",
+        "no-candidate": "Aucun candidat inscrit à cette session",
+        "search-candidate": "Rechercher un candidat"
+      },
+      "header": {
+        "access-code": "Code d'accès (candidats)",
+        "actions": {
+          "confirmation": "Quitter la surveillance",
+          "exit-extra-information": "Quitter la surveillance de la session {sessionId}"
+        },
+        "information": "Attention, assurez-vous que tous les candidats aient terminé leur test avant de quitter la surveillance. Pour reprendre la surveillance de cette session, vous devrez entrer à nouveau son numéro de session et son mot de passe.",
+        "session-id": "Session {sessionId}"
+      },
+      "login": {
+        "form": {
+          "actions": {
+            "invigilate": "Surveiller la session",
+            "switch-account": "Changer de compte"
+          },
+          "description": "Le mot de passe de la session à surveiller vous a été communiqué par un administrateur Pix Certif",
+          "errors": {
+            "incorrect-data": "Le numéro de session et/ou le mot de passe saisis sont incorrects.",
+            "mandatory-fields": "Les champs \"Numéro de la session\" et \"Mot de passe de session\" sont obligatoires."
+          },
+          "example": "Exemple : C-12345",
+          "session-number": "Numéro de la session",
+          "session-password": {
+            "aria-label": "Afficher le mot de passe",
+            "label": "Mot de passe de la session"
+          },
+          "sub-title": "Surveiller une session",
+          "title": "Espace Surveillant"
+        },
+        "title": "Connexion à l'espace surveillant"
+      },
+      "title": "Surveiller la session n° {sessionId}"
     },
     "session-supervising-error": {
-      "title": "Une erreur est survenue",
+      "description": "Pour accéder à cette session, cliquez sur le bouton \"Surveiller une session\" et renseignez les informations de la session",
       "page-title": "Erreur d'accès à la surveillance de session",
-      "description": "Pour accéder à cette session, cliquez sur le bouton \"Surveiller une session\" et renseignez les informations de la session"
+      "title": "Une erreur est survenue"
+    },
+    "sessions": {
+      "actions": {
+        "return": "Revenir à la liste des sessions"
+      },
+      "detail": {
+        "candidates": {
+          "add-modal": {
+            "actions": {
+              "close-extra-information": "Fermer la modale d'ajout de candidat",
+              "enrol-the-candidate": "Inscrire le candidat"
+            },
+            "complementary-certification-none": "Aucune",
+            "info-panel": "Si le champ n’est pas renseigné, les résultats ne seront pas transmis par mail pour le/les candidats concernés.<br />Le candidat verra ses résultats affichés directement sur son compte Pix.",
+            "notifications": {
+              "error-add-duplicate": "Ce candidat est déjà dans la liste, vous ne pouvez pas l'ajouter à nouveau.",
+              "error-add-unknown": "Une erreur s'est produite lors de l'ajout du candidat.",
+              "error-remove-already-in": "Ce candidat a déjà rejoint la session. Vous ne pouvez pas le supprimer.",
+              "error-remove-unknown": "Une erreur s'est produite lors de la suppression du candidat.",
+              "success-add": "Le candidat a été inscrit avec succès.",
+              "success-remove": "Le candidat a été supprimé avec succès."
+            },
+            "prepayment-information": "Information du code de prépaiement",
+            "prepayment-tooltip": "(Requis notamment dans le cas d'un achat de crédits combinés)<br />Doit être composé du SIRET de l’organisation et du numéro de facture. Ex : 12345678912345/FACT12345'.<br/>Si vous ne possédez pas de facture, un code de prépaiement doit être établi avec Pix.",
+            "required-fields": "Les champs marqués de <span class=\"required-field-indicator\">*</span> sont obligatoires.",
+            "title": "Inscrire un candidat"
+          },
+          "detail-modal": {
+            "actions": {
+              "close-extra-information": "Fermer la fenêtre de détail du candidat"
+            },
+            "title": "Détail du candidat"
+          },
+          "list": {
+            "actions": {
+              "delete": {
+                "extra-information": "Supprimer le candidat",
+                "tooltip": "Ce candidat a déjà rejoint la session. Vous ne pouvez pas le supprimer."
+              },
+              "details": {
+                "extra-information": "Voir le détail du candidat",
+                "label": "Voir le détail"
+              },
+              "inscription": {
+                "label": "Inscrire un candidat"
+              },
+              "inscription-multiple": {
+                "label": "Inscrire des candidats"
+              }
+            },
+            "empty": "En attente de candidats",
+            "title": "Liste des candidats",
+            "with-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec un lien pour voir les détails du candidat et la possibilité de supprimer un candidat dans la dernière colonne.",
+            "without-details-description": "Liste des candidats inscrits à la session, triée par nom de naissance, avec la possibilité de supprimer un candidat dans la dernière colonne."
+          },
+          "page-title": "Candidats",
+          "panel-actions": {
+            "actions": {
+              "download": {
+                "description": "Pour inscrire des candidats à la session, renseignez leurs informations (Nom, Prénom, …) dans ce document. <br />Lors du premier téléchargement, le modèle de liste des candidats est vide. Il contiendra ensuite les informations des candidats inscrits à la session.",
+                "extra-information": "Télécharger le modèle de liste des candidats",
+                "label": "Télécharger (.ods)"
+              },
+              "upload": {
+                "description": "Sélectionnez la liste des candidats préalablement remplie.<br /><strong>Attention, tout nouvel import efface la liste des candidats existante.</strong>",
+                "extra-information": "Importer la liste des candidats",
+                "label": "Importer (.ods)"
+              }
+            },
+            "title": "Inscrire des candidats",
+            "warning": "La session a débuté, vous ne pouvez plus importer une liste de candidats.<br />Si vous souhaitez modifier la liste, vous pouvez inscrire un candidat directement dans le tableau ci-dessous."
+          }
+        },
+        "downloads": {
+          "attendance-sheet": {
+            "extra-information": "Télécharger la feuille d'émargement",
+            "label": "Feuille d'émargement"
+          },
+          "incident-report": {
+            "extra-information": "Télécharger le PV d'incident",
+            "label": "PV d'incident"
+          },
+          "invigilator-kit": {
+            "extra-information": "Télécharger le kit surveillant",
+            "label": "Kit surveillant"
+          },
+          "label": "Téléchargements :"
+        },
+        "page-title": "Détails",
+        "panel-clea": {
+          "description": "Pour générer les certificats CléA numérique, téléchargez la liste des candidats, complétez-la, enregistrez-la au format .xlsx puis importez-la sur la ",
+          "download-button": "Télécharger la liste des candidats",
+          "error-message": "Une erreur est survenue lors du téléchargement du fichier. Veuillez réessayer ou contacter certif@pix.fr en indiquant le numéro de la session concernée.",
+          "link-text": "plateforme du CléA numérique.",
+          "title": "Des candidats ont obtenu le certificat CléA numérique"
+        },
+        "parameters": {
+          "access-code": {
+            "candidate": "Candidat",
+            "copy-code": "Copier le code d’accès à la session",
+            "label": "Code d'accès"
+          },
+          "actions": {
+            "finalizing": "Finaliser la session",
+            "update": "Modifier les informations de la session {sessionId}"
+          },
+          "finalization-info": "Les informations de finalisation de la session ont déjà été transmises aux équipes de Pix.",
+          "password": {
+            "copy-password": "Copier le mot de passe de session pour le surveillant",
+            "label": "Mot de passe de session"
+          },
+          "session": {
+            "copy-number": "Copier le numéro de session",
+            "label": "Numéro de session"
+          }
+        },
+        "tabs": {
+          "details": "Détails"
+        },
+        "title": "Session {sessionId}"
+      },
+      "import": {
+        "breadcrumb": {
+          "extra-information": "Fil d'Arianne",
+          "import": "Import du modèle",
+          "summary": "Récapitulatif"
+        },
+        "step-one": {
+          "actions": {
+            "cancel": {
+              "label": "Annuler l'import"
+            },
+            "session-import-template": {
+              "extra-information": "Télécharger le modèle vierge",
+              "label": "Télécharger (.csv)"
+            },
+            "session-import-upload": {
+              "extra-information": "Importer le modèle complété",
+              "label": "Importer (.csv)"
+            }
+          },
+          "errors": {
+            "CSV_DATA_REQUIRED": "Le modèle importé n'a pas été rempli, merci de le compléter avant de l'importer à nouveau",
+            "CSV_HEADERS_NOT_VALID": "Le modèle a été altéré, merci de le télécharger à nouveau",
+            "download": "Une erreur s'est produite pendant le téléchargement",
+            "forbidden": "La création et l'édition de plusieurs sessions à la fois n'est pas disponible pour votre centre de certification. Veuillez utiliser la création et l'édition individuelle de session."
+          },
+          "instructions": {
+            "creation": {
+              "list": "Vous pouvez créer des sessions :",
+              "list-with-candidates": "<strong>Avec candidats</strong>, complétez le modèle dans son intégralité,",
+              "list-without-candidates": "<strong>Sans candidat</strong>, complétez uniquement les informations des sessions.",
+              "title": "Pour créer des sessions ?"
+            },
+            "edition": {
+              "replace": "<strong>Pour remplacer</strong> une liste pré-existante dans le fichier modèle,",
+              "subscription": "<strong>Pour inscrire</strong> des candidats dans une session vide.",
+              "title": "Pour éditer la liste des candidats de sessions déjà créées ?",
+              "warning": "Attention à renseigner le numéro de session sans les autres informations de sessions (ex: date, heure, etc.) pour éviter les doublons lors de la création."
+            },
+            "title": "Comment ça marche ?"
+          }
+        },
+        "step-two": {
+          "actions": {
+            "confirm": {
+              "label": "Finaliser la création/édition"
+            },
+            "confirm-with-warning": {
+              "label": "Finaliser quand même la création/édition"
+            },
+            "import-again": {
+              "extra-information": "Revenir à l'étape précédente pour importer le fichier à nouveau",
+              "label": "Importer à nouveau"
+            }
+          },
+          "blocking-errors": {
+            "errors": {
+              "CANDIDATE_BILLING_MODE_NOT_VALID": "Donnée du champ \"Tarification part Pix\" invalide (formats acceptés \"Gratuite\", \"Payante\" ou \"Prépayée\")",
+              "CANDIDATE_BILLING_MODE_REQUIRED": "Champ obligatoire \"Tarification part Pix\" manquant",
+              "CANDIDATE_BIRTHDATE_FORMAT_NOT_VALID": "Donnée du champ \"Date de naissance\" invalide (format accepté JJ/MM/AAAA)",
+              "CANDIDATE_BIRTHDATE_MUST_BE_GREATER": "Champ \"Date de naissance\" doit être supérieur à 01/01/1900",
+              "CANDIDATE_BIRTHDATE_REQUIRED": "Champ obligatoire \"Date de naissance\" manquant",
+              "CANDIDATE_BIRTH_CITY_REQUIRED": "Champ obligatoire \"Nom de la commune\" manquant",
+              "CANDIDATE_BIRTH_COUNTRY_NOT_FOUND": "Donnée du champ \"Pays de naissance\" n'existe pas",
+              "CANDIDATE_BIRTH_COUNTRY_REQUIRED": "Champ obligatoire \"Pays de naissance\" manquant",
+              "CANDIDATE_BIRTH_INFORMATION_REQUIRED": "Renseigner les données de naissance du candidat",
+              "CANDIDATE_BIRTH_INSEE_CODE_NOT_VALID": "Donnée du champ \"Code INSEE\" invalide",
+              "CANDIDATE_BIRTH_INSEE_CODE_OR_BIRTH_POSTAL_CODE_AND_BIRTH_CITY_REQUIRED": "Renseigner soit un code INSEE, soit un code postal et un nom de commune de naissance",
+              "CANDIDATE_BIRTH_POSTAL_CODE_CITY_NOT_VALID": "Le code postal et le nom de la commune ne correspondent pas",
+              "CANDIDATE_BIRTH_POSTAL_CODE_NOT_FOUND": "Donnée du champ \"Code postal\" n'existe pas",
+              "CANDIDATE_BIRTH_POSTAL_CODE_REQUIRED": "Champ obligatoire \"Code postal\" manquant",
+              "CANDIDATE_EMAIL_NOT_VALID": "Donnée du champ \"E-mail de convocation\" invalide",
+              "CANDIDATE_EXTRA_TIME_BELOW_ONE": "Donnée du champ \"Temps majoré\" invalide (exemple de format accepté: 30%)",
+              "CANDIDATE_EXTRA_TIME_INTEGER": "Donnée du champ \"Temps majoré\" invalide (exemple de format accepté: 30%)",
+              "CANDIDATE_FIRST_NAME_REQUIRED": "Champ obligatoire \"Prénom\" manquant",
+              "CANDIDATE_FOREIGN_BIRTH_CITY_REQUIRED": "Candidat né à l'étranger, champ obligatoire \"Nom de la commune\" manquant",
+              "CANDIDATE_FOREIGN_INSEE_CODE_NOT_VALID": "Candidat né à l'étranger, inscrire 99 dans le champ \"Code INSEE\"",
+              "CANDIDATE_FOREIGN_POSTAL_CODE_MUST_BE_EMPTY": "Candidat né à l'étranger, le champ \"Code postal\" doit rester vide",
+              "CANDIDATE_LAST_NAME_REQUIRED": "Champ obligatoire \"Nom de naissance\" manquant",
+              "CANDIDATE_MAX_ONE_COMPLEMENTARY_CERTIFICATION": "Inscription possible qu'à une seule certification complémentaire par candidat",
+              "CANDIDATE_NOT_ALLOWED_FOR_STARTED_SESSION": "Édition des candidats impossible, le numéro de session correspond à une session déjà démarrée",
+              "CANDIDATE_PREPAYMENT_CODE_MUST_BE_EMPTY": "Champ \"Code de prépaiement\" doit rester vide (dans le cas de tarification part Pix gratuite ou payante)",
+              "CANDIDATE_PREPAYMENT_CODE_REQUIRED": "Champ obligatoire \"Code de prépaiement\" manquant (doit être renseigné en cas de tarification part Pix prépayée)",
+              "CANDIDATE_RESULT_RECIPIENT_EMAIL_NOT_VALID": "Donnée du champ \"E-mail du destinataire des résultats (formateur, enseignant…)\" invalide",
+              "CANDIDATE_SEX_NOT_VALID": "Donnée du champ \"Sexe\" invalide (format accepté \"M\"/\"F\")",
+              "CANDIDATE_SEX_REQUIRED": "Champ obligatoire \"Sexe\" manquant",
+              "INFORMATION_NOT_ALLOWED_WITH_SESSION_ID": "Numéro de session fourni, veuillez supprimer les informations de session associées",
+              "SESSION_ADDRESS_REQUIRED": "Champ obligatoire \"Nom du site\" manquant",
+              "SESSION_DATE_NOT_VALID": "Donnée du champ \"Date de session\" invalide (format accepté JJ/MM/AAAA)",
+              "SESSION_DATE_REQUIRED": "Champ obligatoire \"Date de session\" manquant",
+              "SESSION_EXAMINER_REQUIRED": "Champ obligatoire \"Surveillant(s)\" manquant",
+              "SESSION_ID_NOT_EXISTING": "Numéro de session inexistant",
+              "SESSION_ID_NOT_VALID": "Donnée du champ \"Numéro de session\" invalide",
+              "SESSION_ROOM_REQUIRED": "Champ obligatoire \"Nom de la salle\" manquant",
+              "SESSION_SCHEDULED_IN_THE_PAST": "Date et/ou heure indiquées antérieures à la date du jour",
+              "SESSION_TIME_NOT_VALID": "Donnée du champ \"Heure de début\" invalide (format accepté HH:MM)",
+              "SESSION_TIME_REQUIRED": "Champ obligatoire \"Heure de début\" manquant",
+              "SESSION_WITH_DATE_AND_TIME_ALREADY_EXISTS": "Une session a déjà été créée avec ces informations. Pour ajouter des candidats à une session, indiquer uniquement le numéro de session sans les informations de session"
+            },
+            "information": "Veuillez corriger toutes les erreurs bloquantes avant de re-importer le fichier .csv :",
+            "line": "Ligne",
+            "title": "{blockingErrorReportsCount} {blockingErrorReportsCount, plural,one {erreur bloquante} other {erreurs bloquantes}}"
+          },
+          "candidates-count": "{candidatesCount} {candidatesCount, plural,one {candidat} other {candidats}}",
+          "non-blocking-errors": {
+            "errors": {
+              "DUPLICATE_CANDIDATE_IN_SESSION": "Le candidat est inscrit plusieurs fois à la même session, une seule inscription sera prise en compte.",
+              "EMPTY_SESSION": "La session ne contient pas de candidat"
+            },
+            "information": "Nous avons détecté {nonBlockingErrorReportsCount, plural,one {un point d’attention non bloquant} other {des points d’attention non bloquants}} lors de l’import, consultez-{nonBlockingErrorReportsCount, plural,one {le} other {les}} avant de procéder à la création ou l’édition de vos sessions :",
+            "line": "Ligne",
+            "title": "{nonBlockingErrorReportsCount} {nonBlockingErrorReportsCount, plural,one {point d’attention non bloquant} other {points d’attention non bloquants}}"
+          },
+          "sessions-and-empty-sessions-count": "{sessionsCount} {sessionsCount, plural,one {session} other {sessions}} dont {sessionsWithoutCandidatesCount} {sessionsWithoutCandidatesCount, plural,one {session} other {sessions}} sans candidat"
+        },
+        "success": "Succès ! {sessionsCount} {sessionsCount, plural, one {session} other {sessions}} dont {sessionsWithoutCandidatesCount} {sessionsWithoutCandidatesCount, plural, one {session} other {sessions}} sans candidat {sessionsCount, plural, one {créée} other {créées}} et {candidatesCount} {candidatesCount, plural, one {candidat créé ou édité} other {candidats créés ou édités}}",
+        "title": "Créer/éditer plusieurs sessions"
+      },
+      "list": {
+        "actions": {
+          "creation": {
+            "label": "Créer une session"
+          },
+          "delete-session": {
+            "disabled": "Au moins un candidat a rejoint la session, vous ne pouvez pas la supprimer.",
+            "label": "Supprimer la session {sessionSummaryId}"
+          },
+          "multiple-creation": {
+            "label": "Créer plusieurs sessions"
+          },
+          "multiple-creation-edition": {
+            "label": "Créer/éditer plusieurs sessions"
+          }
+        },
+        "delete-modal": {
+          "actions": {
+            "cancel": {
+              "extra-information": "Annuler la suppression de la session"
+            },
+            "confirm": {
+              "extra-information": "Supprimer la session"
+            }
+          },
+          "content": "Souhaitez-vous supprimer la session <span>{sessionId}</span> ?",
+          "enrolled-candidates": "<span>{enrolledCandidatesCount} {enrolledCandidatesCount, plural,one {candidat} other {candidats}}</span> {enrolledCandidatesCount, plural,one {est inscrit} other {sont inscrits}} à cette session",
+          "success": "La session a été supprimée avec succès.",
+          "title": "Supprimer la session",
+          "warning": "Attention, cette action est irréversible."
+        },
+        "empty": {
+          "title": "Créer ma première session de certification"
+        },
+        "status": {
+          "created": "Créée",
+          "finalized": "Finalisée",
+          "processed": "Résultats transmis par Pix"
+        },
+        "table": {
+          "empty": "Aucune session trouvée",
+          "header": {
+            "actions": "Actions",
+            "effective-candidates": "Certifications passées",
+            "enrolled-candidates": "Candidats inscrits"
+          },
+          "row": {
+            "label": "Session de certification",
+            "session-and-id": "Session {sessionId}"
+          }
+        },
+        "title": "Sessions de certification"
+      },
+      "new": {
+        "actions": {
+          "cancel-extra-information": "Annuler la création de session et retourner vers la page précédente",
+          "create-session": "Créer la session"
+        },
+        "address": "Nom du site",
+        "date": "Date de début",
+        "description": "Observations",
+        "errors": {
+          "SESSION_ADDRESS_REQUIRED": "Veuillez indiquer un nom de site.",
+          "SESSION_DATE_REQUIRED": "Veuillez indiquer une date de début.",
+          "SESSION_EXAMINER_REQUIRED": "Veuillez indiquer le nom et prénom du ou des surveillants.",
+          "SESSION_ROOM_REQUIRED": "Veuillez indiquer un nom de salle.",
+          "SESSION_TIME_REQUIRED": "Veuillez indiquer une heure de début en heure locale."
+        },
+        "examiner": "Surveillant(s)",
+        "extra-information": "Planification d’une session | Pix Certif",
+        "required-fields": "Les champs marqués de <abbr title=\"obligatoire\" class=\"mandatory-mark\">*</abbr> sont obligatoires.",
+        "room": "Nom de la salle",
+        "time": "Heure de début (heure locale)",
+        "title": "Création d’une session de certification"
+      },
+      "update": {
+        "actions": {
+          "cancel-extra-information": "Annuler la modification de la session et retourner vers la page précédente",
+          "edit-session": "Modifier la session"
+        },
+        "title": "Modification d'une session de certification"
+      }
     },
     "team": {
-      "title": "Équipe",
-      "referer": "Référent",
-      "pix-referer": "Référent Pix",
-      "update-referer-button": "Changer de référent",
-      "pix-referer-tooltip": "Le référent Pix est le contact privilégié des équipes de Pix. Il est le responsable du bon déroulement des sessions de certification.",
       "no-referer-section": {
-        "title": "Aucun référent Pix désigné",
         "description": "Le référent Pix est le contact privilégié des équipes de Pix. Il est le responsable du bon déroulement des sessions de certification.",
-        "select-referer-button": "Désigner un référent"
+        "select-referer-button": "Désigner un référent",
+        "title": "Aucun référent Pix désigné"
       },
+      "pix-referer": "Référent Pix",
+      "pix-referer-tooltip": "Le référent Pix est le contact privilégié des équipes de Pix. Il est le responsable du bon déroulement des sessions de certification.",
+      "referer": "Référent",
       "select-referer-modal": {
-        "title": "Sélection du référent Pix",
-        "label": "Sélectionner le référent Pix",
-        "empty-option": "--Sélectionner--",
-        "description": "Le Groupement d’intérêt public, sis 21-23 rue des Ardennes 75019 Paris PIX met en œuvre en tant que responsable de traitement un traitement de données à caractère personnel portant sur votre adresse email professionnel de référent Pix.<br />La finalité de ce traitement est la communication des informations nécessaires aux attributions du référent Pix au sein du centre de certification agréé. Le traitement de cette données repose sur l’exécution de la convention d’agrément de votre centre de certification.<br />Les données sont conservées pendant la durée de la convention d’agrément en vigueur entre le GIP Pix et le centre habilité auquel vous êtes rattaché.<br />Vous disposez de droits personnels, droits d'accès, de rectification et d’effacement des données, le droit de limitation ou d’opposition au traitement pour motif légitime et le droit d’introduire une réclamation auprès d’une autorité de contrôle ainsi que le droit de définir des directives relatives à la conservation, à l'effacement et à la communication de vos données à caractère personnel en cas de décès que vous pouvez exercer par courriel auprès de notre DPD en adressant votre demande à l’adresse électronique suivante : dpd@pix.fr .<br />Vous disposez de la possibilité d’introduire une réclamation auprès de Commission nationale Informatique et libertés « CNIL » à l’adresse suivante : 3 Place de Fontenoy – TSA 80715 – 75334 Paris Cedex 07.",
         "actions": {
+          "cancel-extra-information": "Annuler la sélection de référent",
           "validate": "Valider",
-          "validate-extra-information": "Valider la sélection de référent",
-          "cancel-extra-information": "Annuler la sélection de référent"
-        }
-      }
+          "validate-extra-information": "Valider la sélection de référent"
+        },
+        "description": "Le Groupement d’intérêt public, sis 21-23 rue des Ardennes 75019 Paris PIX met en œuvre en tant que responsable de traitement un traitement de données à caractère personnel portant sur votre adresse email professionnel de référent Pix.<br />La finalité de ce traitement est la communication des informations nécessaires aux attributions du référent Pix au sein du centre de certification agréé. Le traitement de cette données repose sur l’exécution de la convention d’agrément de votre centre de certification.<br />Les données sont conservées pendant la durée de la convention d’agrément en vigueur entre le GIP Pix et le centre habilité auquel vous êtes rattaché.<br />Vous disposez de droits personnels, droits d'accès, de rectification et d’effacement des données, le droit de limitation ou d’opposition au traitement pour motif légitime et le droit d’introduire une réclamation auprès d’une autorité de contrôle ainsi que le droit de définir des directives relatives à la conservation, à l'effacement et à la communication de vos données à caractère personnel en cas de décès que vous pouvez exercer par courriel auprès de notre DPD en adressant votre demande à l’adresse électronique suivante : dpd@pix.fr .<br />Vous disposez de la possibilité d’introduire une réclamation auprès de Commission nationale Informatique et libertés « CNIL » à l’adresse suivante : 3 Place de Fontenoy – TSA 80715 – 75334 Paris Cedex 07.",
+        "empty-option": "--Sélectionner--",
+        "label": "Sélectionner le référent Pix",
+        "title": "Sélection du référent Pix"
+      },
+      "title": "Équipe",
+      "update-referer-button": "Changer de référent"
+    },
+    "terms-of-service": {
+      "actions": {
+        "accept": "J’accepte les conditions d’utilisation"
+      },
+      "page-title": "Conditions générales",
+      "title": "Conditions générales d'utilisation de la plateforme Pix Certif"
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème

Les fichiers de traductions de Pix-Certif ne sont pas lintés.

## :robot: Proposition

Rajout de la commande `npm run lint:translations` sur Pix-Certif.

## :rainbow: Remarques

Cette commande nécessite l'installation de deux packages : 
`eslint-plugin-eslint-comments`
`eslint-plugin-i18n-json` 


Un soucis de token nous bloquait lors du lint.
Ajout du /.prettierignore, d'après la PR : https://github.com/1024pix/pix/pull/5393/files

## :100: Pour tester

En local, dans le dossier `certif` : 
Executer la commande `npm run lint:translations`
Constater la présence d'erreurs
