### PR TITLE
[TECH][ADMIN] Montée de version de Pix UI en v31.1.0 (PIX-7784)

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -11,7 +11,7 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@1024pix/ember-testing-library": "^0.6.0",
-        "@1024pix/pix-ui": "^30.0.0",
+        "@1024pix/pix-ui": "^31.1.0",
         "@1024pix/stylelint-config": "^2.0.0",
         "@babel/eslint-parser": "^7.19.1",
         "@ember/optional-features": "^2.0.0",
@@ -1201,9 +1201,9 @@
       }
     },
     "node_modules/@1024pix/pix-ui": {
-      "version": "30.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-30.0.0.tgz",
-      "integrity": "sha512-mVV15CQmXgdi+E+SCzoldX/ucSys4wcW2gPP5+aox1uQ6I69SMpKB7cFWN8zQEIqwJw6hgTn66jhNqzQpcIBjw==",
+      "version": "31.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-31.1.0.tgz",
+      "integrity": "sha512-Td7VGcay4Rol5DkEtHNbCYUpkc6nAgrJ39YPDydsT+tbsX3HpGLJkv73Q9KiayHiXYl5ySB86lWxX2y9yaLP+A==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1214,6 +1214,7 @@
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-sass": "^11.0.1",
         "ember-click-outside": "^6.0.1",
+        "ember-popperjs": "^3.0.0",
         "ember-truth-helpers": "^3.1.1",
         "lodash.debounce": "^4.0.8"
       },
@@ -7053,6 +7054,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
+      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@simple-dom/interface": {
@@ -21803,6 +21814,20 @@
       },
       "engines": {
         "node": "12.* || 14.* || >= 16"
+      }
+    },
+    "node_modules/ember-popperjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ember-popperjs/-/ember-popperjs-3.0.0.tgz",
+      "integrity": "sha512-6adPoWNeV5Q97d6nf5gsEYy/AQ8V3HKtofNcxO0xCQ2coOWWhBUGEwI3i9LPeOcfikFB6sbsLvwbeqLmqXeSoQ==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/addon-shim": "^1.7.1",
+        "@popperjs/core": "^2.11.1"
+      },
+      "peerDependencies": {
+        "ember-modifier": ">= 3.2.7",
+        "ember-source": ">= 3.25.0"
       }
     },
     "node_modules/ember-qunit": {
@@ -38433,9 +38458,9 @@
       }
     },
     "@1024pix/pix-ui": {
-      "version": "30.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-30.0.0.tgz",
-      "integrity": "sha512-mVV15CQmXgdi+E+SCzoldX/ucSys4wcW2gPP5+aox1uQ6I69SMpKB7cFWN8zQEIqwJw6hgTn66jhNqzQpcIBjw==",
+      "version": "31.1.0",
+      "resolved": "https://registry.npmjs.org/@1024pix/pix-ui/-/pix-ui-31.1.0.tgz",
+      "integrity": "sha512-Td7VGcay4Rol5DkEtHNbCYUpkc6nAgrJ39YPDydsT+tbsX3HpGLJkv73Q9KiayHiXYl5ySB86lWxX2y9yaLP+A==",
       "dev": true,
       "requires": {
         "@formatjs/intl": "^2.5.1",
@@ -38445,6 +38470,7 @@
         "ember-cli-htmlbars": "^6.1.1",
         "ember-cli-sass": "^11.0.1",
         "ember-click-outside": "^6.0.1",
+        "ember-popperjs": "^3.0.0",
         "ember-truth-helpers": "^3.1.1",
         "lodash.debounce": "^4.0.8"
       }
@@ -42825,6 +42851,12 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@popperjs/core": {
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
+      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
+      "dev": true
     },
     "@simple-dom/interface": {
       "version": "1.4.0",
@@ -54963,6 +54995,16 @@
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.26.6"
+      }
+    },
+    "ember-popperjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ember-popperjs/-/ember-popperjs-3.0.0.tgz",
+      "integrity": "sha512-6adPoWNeV5Q97d6nf5gsEYy/AQ8V3HKtofNcxO0xCQ2coOWWhBUGEwI3i9LPeOcfikFB6sbsLvwbeqLmqXeSoQ==",
+      "dev": true,
+      "requires": {
+        "@embroider/addon-shim": "^1.7.1",
+        "@popperjs/core": "^2.11.1"
       }
     },
     "ember-qunit": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@1024pix/ember-testing-library": "^0.6.0",
-    "@1024pix/pix-ui": "^30.0.0",
+    "@1024pix/pix-ui": "^31.1.0",
     "@1024pix/stylelint-config": "^2.0.0",
     "@babel/eslint-parser": "^7.19.1",
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
## :unicorn: Problème

Pix UI sur Pix Admin n'est pas à la dernière version de la librairie de composants.

## :robot: Proposition

Mettre à jour le package.json avec la nouvelle version de Pix UI (v31.1.0).

## :rainbow: Remarques

⚠️ Tests de non-régression à faire sur toute l'application Pix Admin

## :100: Pour tester

- Parcourir l'application Pix Admin
- Vérifier que tous les composants PixUI fonctionnent
