### PR TITLE
[BUGFIX] Pix certif double scrollbar sur la liste des sessions (PIX-7413)

### DIFF
--- a/certif/app/styles/pages/authenticated.scss
+++ b/certif/app/styles/pages/authenticated.scss
@@ -67,7 +67,7 @@
 .main-content {
   display: flex;
   flex-direction: column;
-  overflow: auto;
+  overflow: hidden;
 
   &__topbar {
     background-color: $pix-neutral-0;


### PR DESCRIPTION
## :unicorn: Problème
Sur la page de la liste des sessions, il est possible parfois de faire apparaitre une double scrollbar.
Ce n'est pas évident à déclencher mais ce n'est pas uniquement sur Firefox.

## :robot: Proposition

Le composant `PixPagination` (pix-ui) dans le `SessionSummaryList` (certif) à un placement automatiquement. Il contient un `PixSelect` qui à un `@placement` automatique sur l'élément PopperJS.

Par défaut à top, il peut aussi, si besoin, se retrouver au bottom.

Quand la liste avec la class  `.pix-select__dropdown` (qui va jusque 100) est vers le bottom (même en mode closed avec visibility hidden), il n’y a pas la place suffisante et la liste dépasse sous le footer (certif).

Cela déclenche l’overflow sur `.main-content` qui est en auto et du coup, une scrollbar.

 D’après la [doc](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow)  :

> auto
> 
> Depends on the [user agent](https://developer.mozilla.org/en-US/docs/Glossary/User_agent). If content fits inside the > padding box, it looks the same as visible, but still establishes a new block formatting context. Desktop browsers > provide scrollbars if content overflows.

### Proposition de solution

On pourrait aller forcer le `@placement` du addon/components/pix-select.hbs dans pix-ui (v31.1.0) qui est implémenté dans addon/components/pix-pagination.hbs à  top mais ça demanderait une modification de pix-ui non triviale. **Ce qui semble overkill vu le cas.**

On peut soit passer l’overflow en `hidden` car en théorie rien n’est censé dépasser du main-content. C'est ce que j'ai choisi pour le moment.
Ou alors en `visible`, mais alors il y a une extension au-dela des autres éléments et ça dépasse après la sidebar et le footer (mais la sidebar habituelle s’applique bien et tout se passe bien).

## :rainbow: Remarques

* Si vous arrivez à trouver d'autres cas (le JIRA est peu descriptif sur la méthode de reproduction), n'éhsitez pas à mettre ici
* Si vous voulez créer des sessions en masses, vous pouvez executer le script `scripts/data-generation/generate-certif-cli.js random <number>` (par défaut 25 si pas d'argument <number>. Il faudra cependant installer les dev dependencies avant (`run bash npm ci --also=dev`)

## :100: Pour tester
* Sur la liste des sessions, réduire la fenêtre en assez petit (hauteur), par exemple sur la recette
* Constater qu'une double scrollbar apparait
* Refaire ce même test sur la RA de cette PR, constater la disparition du comportement
