### PR TITLE
[FEATURE] Création d'une vue pour l'affichage des prescrits actifs (PIX-7682).

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -111,7 +111,13 @@ module.exports = class DatabaseBuilder {
     const resultSet = await this.knex.raw(query, [this.knex.client.database()]);
     const rows = resultSet.rows;
     const tableNames = _.map(rows, 'table_name');
-    const tablesToDelete = _.without(tableNames, 'knex_migrations', 'knex_migrations_lock', 'features');
+    const tablesToDelete = _.without(
+      tableNames,
+      'knex_migrations',
+      'knex_migrations_lock',
+      'features',
+      'view-active-organization-learners'
+    );
     const tables = _.map(tablesToDelete, (tableToDelete) => `"${tableToDelete}"`).join();
     // eslint-disable-next-line knex/avoid-injections
     return this.knex.raw(`TRUNCATE ${tables}`);

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -99,7 +99,13 @@ async function listAllTableNames() {
 
 async function emptyAllTables() {
   const tableNames = await listAllTableNames();
-  const tablesToDelete = _.without(tableNames, 'knex_migrations', 'knex_migrations_lock', 'features');
+  const tablesToDelete = _.without(
+    tableNames,
+    'knex_migrations',
+    'knex_migrations_lock',
+    'features',
+    'view-active-organization-learners'
+  );
 
   const tables = _.map(tablesToDelete, (tableToDelete) => `"${tableToDelete}"`).join();
 

--- a/api/db/migrations/20230419155621_add-view-for-not-deleted-learners.js
+++ b/api/db/migrations/20230419155621_add-view-for-not-deleted-learners.js
@@ -1,0 +1,20 @@
+const VIEW_NAME = 'view-active-organization-learners';
+const REFERENCE_TABLE_NAME = 'organization-learners';
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  await knex.schema.createView(VIEW_NAME, function (view) {
+    view.as(knex(REFERENCE_TABLE_NAME).whereNull('deletedAt'));
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.dropView(VIEW_NAME);
+};


### PR DESCRIPTION
## :unicorn: Problème
Pour permettre de supprimer des prescrits tout en conservant des statistiques consolidées, nous avons retenu la solution avec “vue”.
Voir cet [ADR](https://github.com/1024pix/pix/pull/5967)


## :robot: Proposition
Créer une vue nommée “view-active-organization-learners“ pour afficher les prescrits actifs (= non supprimés) seulement.

## :rainbow: Remarques
On doit exclure cette vue de database-builder et de knex-database-connection pour la suppression car n'étant pas une table réelle, ça throw une erreur.

## :100: Pour tester

- Faire un npm run db:migrate
- Verifier que la view existe bien

Bonus : 

- Ajouter sur un learner dans la table `organization-learners` un deletedAt & un deletedBy
- Verifier que ce même learner n'apparait pas dans la vue
