### PR TITLE
[FEATURE] Agrandissement de la font du composant fil d'ariane (PIX-7659).

### DIFF
--- a/orga/app/styles/components/ui/breadcrumb.scss
+++ b/orga/app/styles/components/ui/breadcrumb.scss
@@ -7,7 +7,7 @@
   }
 
   li {
-    font-size: 0.875rem;
+    @extend %pix-body-m;
   }
 
   li:not(:last-child) {


### PR DESCRIPTION
## :unicorn: Problème
Nous avons récemment ajouté dans Pix Orga un composant fil d’Ariane sur les pages des campagnes et des participants, mais la font est un peu petite.

## :robot: Proposition
Augmenter la taille de la font du composant fil d’Ariane à 16px.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Se connecter a Pix Orga
- Aller sur la page de détail d'un participant et/ou d'une campagne 
- Verifier la taille de la font du fil d'ariane
- 🎉 
