### PR TITLE
[FEATURE] Empêcher validation et création des sessions en masse pour les centres sco isManagingStudent (PIX-7775)

### DIFF
--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -200,6 +200,10 @@ exports.register = async function (server) {
             method: securityPreHandlers.checkUserIsMemberOfCertificationCenter,
             assign: 'isMemberOfCertificationCenter',
           },
+          {
+            method: securityPreHandlers.checkCertificationCenterIsNotScoManagingStudents,
+            assign: 'isCertificationCenterNotScoManagingStudents',
+          },
         ],
         validate: {
           params: Joi.object({ certificationCenterId: identifiersType.certificationCenterId }),

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -179,6 +179,10 @@ exports.register = async function (server) {
             method: securityPreHandlers.checkUserIsMemberOfCertificationCenter,
             assign: 'isMemberOfCertificationCenter',
           },
+          {
+            method: securityPreHandlers.checkCertificationCenterIsNotScoManagingStudents,
+            assign: 'isCertificationCenterNotScoManagingStudents',
+          },
         ],
         validate: {
           params: Joi.object({ certificationCenterId: identifiersType.certificationCenterId }),

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -428,6 +428,10 @@ exports.register = async function (server) {
             method: securityPreHandlers.checkUserIsMemberOfCertificationCenter,
             assign: 'isMemberOfCertificationCenter',
           },
+          {
+            method: securityPreHandlers.checkCertificationCenterIsNotScoManagingStudents,
+            assign: 'isCertificationCenterNotScoManagingStudents',
+          },
         ],
         validate: {
           params: Joi.object({ certificationCenterId: identifiersType.certificationCenterId }),

--- a/api/lib/application/usecases/checkOrganizationIsScoAndManagingStudent.js
+++ b/api/lib/application/usecases/checkOrganizationIsScoAndManagingStudent.js
@@ -1,0 +1,14 @@
+const organizationRepository = require('../../infrastructure/repositories/organization-repository.js');
+
+module.exports = {
+  async execute({
+    organizationId,
+    dependencies = {
+      organizationRepository,
+    },
+  }) {
+    const organization = await dependencies.organizationRepository.get(organizationId);
+
+    return organization.isScoAndManagingStudents;
+  },
+};

--- a/api/tests/acceptance/application/certification-centers/certification-center-controller-get-import-template_test.js
+++ b/api/tests/acceptance/application/certification-centers/certification-center-controller-get-import-template_test.js
@@ -13,7 +13,8 @@ describe('Acceptance | Controller | certification-center-controller-get-import-t
       it('should return a csv file', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
-        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ externalId: 1234 }).id;
+        databaseBuilder.factory.buildOrganization({ externalId: 1234, type: 'SUP' });
         databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
         await databaseBuilder.commit();
 

--- a/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-create-sessions_test.js
+++ b/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-create-sessions_test.js
@@ -16,7 +16,11 @@ describe('Acceptance | Controller | certification-centers-controller-post-create
         // given
         const userId = databaseBuilder.factory.buildUser().id;
         const { name: certificationCenter, id: certificationCenterId } =
-          databaseBuilder.factory.buildCertificationCenter();
+          databaseBuilder.factory.buildCertificationCenter({
+            type: 'SUP',
+            externalId: '1234AB',
+          });
+        databaseBuilder.factory.buildOrganization({ externalId: '1234AB', isManagingStudents: false, type: 'SUP' });
         databaseBuilder.factory.buildCertificationCenterMembership({
           userId,
           certificationCenterId,

--- a/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-validate-sessions_test.js
+++ b/api/tests/acceptance/application/certification-centers/sessions-mass-import/certification-centers-controller-post-validate-sessions_test.js
@@ -40,7 +40,12 @@ describe('Acceptance | Controller | certification-centers-controller-post-valida
       it('should return status 200', async function () {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
-        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+          type: 'SUP',
+          externalId: '1234AB',
+        }).id;
+        databaseBuilder.factory.buildOrganization({ externalId: '1234AB', isManagingStudents: false, type: 'SUP' });
+
         databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
         await databaseBuilder.commit();
 
@@ -83,7 +88,11 @@ describe('Acceptance | Controller | certification-centers-controller-post-valida
           it('should throw and do nothing', async function () {
             // given
             const userId = databaseBuilder.factory.buildUser().id;
-            const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+            const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+              externalId: '1234AB',
+              type: 'SUP',
+            }).id;
+            databaseBuilder.factory.buildOrganization({ externalId: '1234AB', isManagingStudents: false, type: 'SUP' });
             databaseBuilder.factory.buildCertificationCpfCountry({
               commonName: 'FRANCE',
               matcher: 'ACEFNR',

--- a/api/tests/unit/application/certification-centers/index_test.js
+++ b/api/tests/unit/application/certification-centers/index_test.js
@@ -395,6 +395,9 @@ describe('Unit | Router | certification-center-router', function () {
     it('should exist', async function () {
       // given
       sinon.stub(securityPreHandlers, 'checkUserIsMemberOfCertificationCenter').callsFake((_, h) => h.response(true));
+      sinon
+        .stub(securityPreHandlers, 'checkCertificationCenterIsNotScoManagingStudents')
+        .callsFake((_, h) => h.response(true));
       sinon.stub(certificationCenterController, 'getSessionsImportTemplate').returns('ok');
       const httpTestServer = new HttpTestServer();
       await httpTestServer.register(moduleUnderTest);

--- a/api/tests/unit/application/usecases/checkOrganizationIsScoAndManagingStudent_test.js
+++ b/api/tests/unit/application/usecases/checkOrganizationIsScoAndManagingStudent_test.js
@@ -1,0 +1,59 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const useCase = require('../../../../lib/application/usecases/checkOrganizationIsScoAndManagingStudent');
+
+describe('Unit | Application | Use Case | checkOrganizationIsScoAndManagingStudent', function () {
+  context('When organization is SCO managing students', function () {
+    it('should return true', async function () {
+      // given
+      const organizationRepositoryStub = { get: sinon.stub() };
+      const dependencies = {
+        organizationRepository: organizationRepositoryStub,
+      };
+
+      const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: true });
+      dependencies.organizationRepository.get.resolves(organization);
+
+      // when
+      const response = await useCase.execute({ organizationId: organization.id, dependencies });
+
+      // then
+      expect(response).to.be.true;
+    });
+  });
+
+  context('When organization is SCO not managing students', function () {
+    it('should return false', async function () {
+      // given
+      const organizationRepositoryStub = { get: sinon.stub() };
+      const dependencies = {
+        organizationRepository: organizationRepositoryStub,
+      };
+      const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: false });
+      dependencies.organizationRepository.get.resolves(organization);
+
+      // when
+      const response = await useCase.execute({ organizationId: organization.id, dependencies });
+
+      // then
+      expect(response).to.be.false;
+    });
+  });
+
+  context('When organization is not SCO and not managing students', function () {
+    it('should return false', async function () {
+      // given
+      const organizationRepositoryStub = { get: sinon.stub() };
+      const dependencies = {
+        organizationRepository: organizationRepositoryStub,
+      };
+      const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: false });
+      dependencies.organizationRepository.get.resolves(organization);
+
+      // when
+      const response = await useCase.execute({ organizationId: organization.id, dependencies });
+
+      // then
+      expect(response).to.be.false;
+    });
+  });
+});

--- a/certif/app/controllers/authenticated/sessions/import.js
+++ b/certif/app/controllers/authenticated/sessions/import.js
@@ -37,7 +37,10 @@ export default class ImportController extends Controller {
     const token = this.session.data.authenticated.access_token;
     try {
       await this.fileSaver.save({ url, token });
-    } catch (e) {
+    } catch (error) {
+      if (error[0]?.code === 403) {
+        return this.notifications.error(this.intl.t('pages.sessions.import.step-one.errors.forbidden'));
+      }
       this.notifications.error(this.intl.t('pages.sessions.import.step-one.errors.download'));
     }
   }
@@ -76,6 +79,9 @@ export default class ImportController extends Controller {
       this.cachedValidatedSessionsKey = cachedValidatedSessionsKey;
       this.errorReports = errorReports;
     } catch (responseError) {
+      if (responseError.errors[0].code === 403) {
+        return this.notifications.error(this.intl.t('pages.sessions.import.step-one.errors.forbidden'));
+      }
       this.notifications.error(this.intl.t(this._handleApiError(responseError)));
       return;
     }

--- a/certif/tests/unit/controllers/authenticated/sessions/import_test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/import_test.js
@@ -75,6 +75,31 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
       sinon.assert.calledOnce(controller.notifications.error);
       assert.ok(controller);
     });
+
+    test('should call the notifications service when access is forbidden', async function (assert) {
+      // given
+      controller.session = {
+        isAuthenticated: true,
+        data: {
+          authenticated: {
+            access_token: 'wrong token',
+          },
+        },
+      };
+      controller.fileSaver = { save: sinon.stub().rejects([{ code: 403 }]) };
+      controller.notifications = { error: sinon.spy() };
+
+      // when
+      await controller.downloadSessionImportTemplate(event);
+
+      // then
+      sinon.assert.calledOnce(controller.notifications.error);
+      assert.ok(controller);
+      sinon.assert.calledWith(
+        controller.notifications.error,
+        "La création et l'édition de plusieurs sessions à la fois n'est pas disponible pour votre centre de certification. Veuillez utiliser la création et l'édition individuelle de session."
+      );
+    });
   });
 
   module('#validateSessions', function () {
@@ -156,6 +181,50 @@ module('Unit | Controller | authenticated/sessions/import', function (hooks) {
 
       // then
       sinon.assert.calledOnce(controller.notifications.error);
+      assert.ok(controller);
+    });
+
+    test('should call the notifications service when access is forbidden', async function (assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const adapter = store.adapterFor('validate-sessions-for-mass-import');
+      const sessionsImportStub = sinon.stub(adapter, 'validateSessionsForMassImport');
+      sessionsImportStub.rejects({
+        errors: [{ code: 403 }],
+      });
+      const currentAllowedCertificationCenterAccess = store.createRecord('allowed-certification-center-access', {
+        id: 123,
+        type: 'SCO',
+      });
+
+      class CurrentUserStub extends Service {
+        currentAllowedCertificationCenterAccess = currentAllowedCertificationCenterAccess;
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+      const token = 'a token';
+
+      controller.file = Symbol('file 1');
+
+      controller.session = {
+        isAuthenticated: true,
+        data: {
+          authenticated: {
+            access_token: token,
+          },
+        },
+      };
+
+      controller.notifications = { error: sinon.stub(), clearAll: sinon.stub() };
+
+      // when
+      await controller.validateSessions();
+
+      // then
+      sinon.assert.calledWith(
+        controller.notifications.error,
+        "La création et l'édition de plusieurs sessions à la fois n'est pas disponible pour votre centre de certification. Veuillez utiliser la création et l'édition individuelle de session."
+      );
       assert.ok(controller);
     });
   });

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -210,7 +210,9 @@
           "errors": {
             "download": "Une erreur s'est produite pendant le téléchargement",
             "CSV_DATA_REQUIRED": "Le modèle importé n'a pas été rempli, merci de le compléter avant de l'importer à nouveau",
-            "CSV_HEADERS_NOT_VALID": "Le modèle a été altéré, merci de le télécharger à nouveau"
+            "CSV_HEADERS_NOT_VALID": "Le modèle a été altéré, merci de le télécharger à nouveau",
+            "forbidden": "La création et l'édition de plusieurs sessions à la fois n'est pas disponible pour votre centre de certification. Veuillez utiliser la création et l'édition individuelle de session."
+
           },
           "instructions": {
             "creation": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -210,7 +210,8 @@
           "errors": {
             "download": "Une erreur s'est produite pendant le téléchargement",
             "CSV_DATA_REQUIRED": "Le modèle importé n'a pas été rempli, merci de le compléter avant de l'importer à nouveau",
-            "CSV_HEADERS_NOT_VALID": "Le modèle a été altéré, merci de le télécharger à nouveau"
+            "CSV_HEADERS_NOT_VALID": "Le modèle a été altéré, merci de le télécharger à nouveau",
+            "forbidden": "La création et l'édition de plusieurs sessions à la fois n'est pas disponible pour votre centre de certification. Veuillez utiliser la création et l'édition individuelle de session."
           },
           "instructions": {
             "title": "Comment ça marche ?",


### PR DESCRIPTION
## :unicorn: Problème
Côté front, on empêche un centre sco gérant des élèves d'accéder à l'import en masse. Mais les routes back n'en sont pas protégées.

## :robot: Proposition
Empêcher un centre de certif rattaché à une organization SCO gérant des élèves d'accéder aux routes back d'import en masse.

## :100: Pour tester
- Depuis pix-certif avec un centre sco gérant des élèves (certifsco@example.net)
- Depuis l'extension ember data, modifier le type du centre (SCO => SUP) pour avoir accès à l'import en masse

![image](https://user-images.githubusercontent.com/37305474/233571521-25f647d7-c21f-46c2-aa59-93d75249dc07.png)

- Tenter de valider un csv et constater une erreur 403 dans l'appel à l'api

![image](https://user-images.githubusercontent.com/37305474/233571816-1a0f4fe0-12ca-4c7b-93ed-d2ed2ba70fc2.png)
