### PR TITLE
[FEATURE] Ajouter un language switcher sur la page d'inscription de Pix App (PIX-7742)

### DIFF
--- a/mon-pix/app/components/signup-form.hbs
+++ b/mon-pix/app/components/signup-form.hbs
@@ -1,4 +1,4 @@
-<main class="sign-form__container" role="main">
+<div class="sign-form__container">
 
   <a href={{this.showcase.url}} class="pix-logo__link">
     <img class="pix-logo__image" src="/images/pix-logo.svg" alt="{{this.showcase.linkText}}" />
@@ -113,4 +113,4 @@
       </PixButton>
     </div>
   </form>
-</main>
+</div>

--- a/mon-pix/app/controllers/inscription.js
+++ b/mon-pix/app/controllers/inscription.js
@@ -1,0 +1,38 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+
+const DEFAULT_LOCALE = 'fr';
+
+export default class InscriptionController extends Controller {
+  @service intl;
+  @service dayjs;
+  @service currentDomain;
+  @service router;
+
+  @tracked selectedLanguage = this.intl.primaryLocale;
+
+  queryParams = ['lang'];
+  availableLanguages = [
+    { label: 'Français', value: 'fr' },
+    { label: 'English', value: 'en' },
+  ];
+
+  get isInternationalDomain() {
+    return !this.currentDomain.isFranceDomain;
+  }
+
+  @action
+  onLanguageChange(value) {
+    const queryParams = { lang: null };
+    this.selectedLanguage = value;
+    this._setLocale(this.selectedLanguage);
+    this.router.replaceWith('inscription', { queryParams });
+  }
+
+  _setLocale(language) {
+    this.intl.setLocale([language, DEFAULT_LOCALE]);
+    this.dayjs.setLocale(language);
+  }
+}

--- a/mon-pix/app/services/current-domain.js
+++ b/mon-pix/app/services/current-domain.js
@@ -1,8 +1,14 @@
 import Service from '@ember/service';
 import last from 'lodash/last';
 
+const FRANCE_TLD = 'fr';
+
 export default class CurrentDomainService extends Service {
   getExtension() {
     return last(location.hostname.split('.'));
+  }
+
+  get isFranceDomain() {
+    return this.getExtension() === FRANCE_TLD;
   }
 }

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -119,6 +119,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'pages/fill-in-campaign-code';
 @import 'pages/fill-in-certificate-verification-code';
 @import 'pages/fill-in-participant-external-id';
+@import 'pages/inscription';
 @import 'pages/join-restricted-campaign';
 @import 'pages/student-sco';
 @import 'pages/not-connected';

--- a/mon-pix/app/styles/pages/_inscription.scss
+++ b/mon-pix/app/styles/pages/_inscription.scss
@@ -1,0 +1,3 @@
+.sign-form-page__container {
+  margin: $pix-spacing-s;
+}

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -23,15 +23,13 @@
     flex-direction: column;
     gap: $pix-spacing-m;
     align-items: center;
-    width: 95%;
     max-width: 609px;
-    margin: 0 auto;
+    margin-bottom: $pix-spacing-s;
     padding: 20px 10px;
     background-color: $pix-neutral-0;
     border-radius: 10px;
 
     @include device-is('tablet') {
-      margin: 20px 0;
       padding: 40px 80px;
     }
   }

--- a/mon-pix/app/templates/inscription.hbs
+++ b/mon-pix/app/templates/inscription.hbs
@@ -1,4 +1,17 @@
 {{page-title (t "pages.sign-up.title")}}
-<div class="sign-form-page">
-  <SignupForm @user={{@model}} />
-</div>
+<main class="sign-form-page" role="main">
+  <section class="sign-form-page__container">
+    <SignupForm @user={{@model}} />
+    {{#if this.isInternationalDomain}}
+      <PixSelect
+        @id="language-switcher"
+        @value={{this.selectedLanguage}}
+        aria-label={{t "pages.inscription.choose-language-aria-label"}}
+        @icon="earth-europe"
+        @options={{this.availableLanguages}}
+        @onChange={{this.onLanguageChange}}
+        @hideDefaultOption="true"
+      />
+    {{/if}}
+  </section>
+</main>

--- a/mon-pix/config/icons.js
+++ b/mon-pix/config/icons.js
@@ -17,6 +17,7 @@ module.exports = function () {
       'circle-user',
       'circle-xmark',
       'copy',
+      'earth-europe',
       'eye',
       'eye-slash',
       'globe',

--- a/mon-pix/tests/acceptance/inscription_test.js
+++ b/mon-pix/tests/acceptance/inscription_test.js
@@ -1,0 +1,68 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { click, currentURL } from '@ember/test-helpers';
+import { visit } from '@1024pix/ember-testing-library';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import setupIntl from '../helpers/setup-intl';
+
+module('Acceptance | Inscription', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks, ['fr', 'en']);
+
+  module('International domain (.org)', function () {
+    module('when accessing the inscription page with "Français" as default language', function () {
+      test('displays the inscription page with "Français" as selected language', async function (assert) {
+        // given & when
+        const screen = await visit('/inscription');
+
+        // then
+        assert.strictEqual(currentURL(), '/inscription');
+        assert.dom(screen.getByRole('heading', { name: 'Inscrivez-vous', level: 1 })).exists();
+        assert.dom(screen.getByRole('button', { name: 'Français' })).exists();
+      });
+
+      module('when the user select "English" as his language', function () {
+        test('displays the inscription page with "English" as selected language', async function (assert) {
+          // given & when
+          const screen = await visit('/inscription');
+          await click(screen.getByRole('button', { name: 'Français' }));
+          await screen.findByRole('listbox');
+          await click(screen.getByRole('option', { name: 'English' }));
+
+          // then
+          assert.strictEqual(currentURL(), '/inscription');
+          assert.dom(screen.getByRole('heading', { name: 'Sign up', level: 1 })).exists();
+          assert.dom(screen.getByRole('button', { name: 'English' })).exists();
+        });
+      });
+    });
+
+    module('when accessing the inscription page with "English" as selected language', function () {
+      test('displays the inscription page with "English"', async function (assert) {
+        // given && when
+        const screen = await visit('/inscription?lang=en');
+
+        // then
+        assert.strictEqual(currentURL(), '/inscription?lang=en');
+        assert.dom(screen.getByRole('heading', { name: 'Sign up', level: 1 })).exists();
+        assert.dom(screen.getByRole('button', { name: 'English' })).exists();
+      });
+
+      module('when the user select "Français" as his language', function () {
+        test('displays the inscription page with "Français" as selected language', async function (assert) {
+          // given & when
+          const screen = await visit('/inscription?lang=en');
+          await click(screen.getByRole('button', { name: 'English' }));
+          await screen.findByRole('listbox');
+          await click(screen.getByRole('option', { name: 'Français' }));
+
+          // then
+          assert.strictEqual(currentURL(), '/inscription');
+          assert.dom(screen.getByRole('heading', { name: 'Inscrivez-vous', level: 1 })).exists();
+          assert.dom(screen.getByRole('button', { name: 'Français' })).exists();
+        });
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/components/signup-form_test.js
+++ b/mon-pix/tests/unit/components/signup-form_test.js
@@ -56,6 +56,7 @@ module('Unit | Component | signup-form', function (hooks) {
         firstName: userWithSpaces.firstName.trim(),
         lastName: userWithSpaces.lastName.trim(),
         email: userWithSpaces.email.trim(),
+        lang: 'fr',
       };
 
       // when
@@ -63,7 +64,7 @@ module('Unit | Component | signup-form', function (hooks) {
 
       // then
       const user = component.args.user;
-      assert.deepEqual(pick(user, ['firstName', 'lastName', 'email']), expectedUser);
+      assert.deepEqual(pick(user, ['firstName', 'lastName', 'email', 'lang']), expectedUser);
     });
 
     test('should authenticate user after sign up', async function (assert) {

--- a/mon-pix/tests/unit/services/current-domain_test.js
+++ b/mon-pix/tests/unit/services/current-domain_test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+const FRANCE_TLD = 'fr';
+const INTERNATIONAL_TLD = 'org';
+
+module('Unit | Service | currentDomain', function (hooks) {
+  setupTest(hooks);
+
+  module('#isFranceDomain', function () {
+    test('returns true when TLD is the France domain (.fr)', function (assert) {
+      // given
+      const service = this.owner.lookup('service:currentDomain');
+      service.getExtension = sinon.stub().returns(FRANCE_TLD);
+
+      // when
+      const isFranceDomain = service.isFranceDomain;
+
+      // then
+      assert.true(isFranceDomain);
+    });
+
+    test('returns false when TLD is the international domain (.org)', function (assert) {
+      // given
+      const service = this.owner.lookup('service:currentDomain');
+      service.getExtension = sinon.stub().returns(INTERNATIONAL_TLD);
+
+      // when
+      const isFranceDomain = service.isFranceDomain;
+
+      // then
+      assert.false(isFranceDomain);
+    });
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -833,6 +833,9 @@
       "title": "Focus mode",
       "description": "For the next question(s), you will not be allowed to leave the page."
     },
+    "inscription": {
+      "choose-language-aria-label": "Select a language"
+    },
     "join": {
       "title": "Join",
       "button": "Let's go!",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -833,6 +833,9 @@
       "title": "Mode focus",
       "description": "Pour la ou les prochaines questions, vous ne serez pas autorisé à sortir de la page."
     },
+    "inscription": {
+      "choose-language-aria-label": "Sélectionnez une langue"
+    },
     "join": {
       "title": "Rejoindre",
       "button": "C'est parti !",


### PR DESCRIPTION
## :unicorn: Problème

Actuellement pour pouvoir modifier la langue d'affichage de la page d'inscription, l'utilisateur n'a pas d'autre moyen que de modifier l'URL en ajoutant `?lang=<code_langue>`.

## :robot: Proposition

Pour faciliter le changement de langue, cette PR ajoute un sélecteur de langue en le positionnant sous le formulaire de la page d'inscription.

## :rainbow: Remarques

- ⚠️ Traiter dans un autre ticket, la gestion d'erreur lorsque l'on passe un code de langue qui n'est pas géré par la configuration de DayJS (voir fichier `ember-cli-build.js`).
- Lors du changement de langue, seul le contenu du site sera modifié avec le choix de langue, nous n'allons pas recharger l'application.
- La méthode `replaceWith` du service `router` de Ember va être utilisée :
  - pour retirer les queryParams de l'URL
  - pour éviter d'ajouter une nouvelle page dans l'historique du navigateur

## :100: Pour tester

#### Changer de langue Français vers English

- Ouvrir le lien https://app-pr6026.review.pix.org/inscription
- Vérifier que la page est bien en **Français**
- Vérifier que le sélecteur de langue affiche **Français** comme valeur
- Sélectionner **English** comme langue
- Constater que le contenu est en **Anglais** et que le sélecteur de langue affiche **English**

#### Changer de langue English vers Français

- Ouvrir le lien https://app-pr6026.review.pix.org/inscription?lang=en
- Vérifier que la page est bien en **Anglais**
- Vérifier que le sélecteur de langue affiche **English** comme valeur
- Sélectionner **Français** comme langue
- Constater que le contenu est en **Français** et que le sélecteur de langue affiche **Français**
- Constater que l'URL ne contient plus `?lang=en`
