### PR TITLE
[BUGFIX] Correction des marges des pages de checkpoints et résultats (PIX-7818).

### DIFF
--- a/mon-pix/app/styles/components/_checkpoint.scss
+++ b/mon-pix/app/styles/components/_checkpoint.scss
@@ -11,7 +11,7 @@
   justify-content: space-between;
   width: 80%;
   min-height: 50px;
-  margin-bottom: 35px;
+  margin: 12px 0 35px;
 
   @include device-is('tablet') {
     width: 800px;

--- a/mon-pix/app/styles/components/_progress-bar.scss
+++ b/mon-pix/app/styles/components/_progress-bar.scss
@@ -61,7 +61,7 @@
 }
 
 .assessment-progress {
-  margin-bottom: 10px;
+  margin: 12px 0 10px;
   color: $pix-neutral-0;
   text-align: right;
 

--- a/mon-pix/app/styles/pages/_assessment-results.scss
+++ b/mon-pix/app/styles/pages/_assessment-results.scss
@@ -12,7 +12,7 @@
 .assessment-results__content {
   width: 100%;
   max-width: 800px;
-  margin-top: -175px;
+  margin-top: -60px;
   padding: 30px;
   background: $pix-neutral-0;
   border-radius: 10px;


### PR DESCRIPTION
## :unicorn: Problème

Depuis la modification de la taille du logo des écrans d'évaluation, une régression visuelle a été contastée.

![image](https://user-images.githubusercontent.com/7335131/233382417-ec568558-c722-4b29-9703-a92c91837fa8.png)


## :robot: Proposition

Corriger les différents espacements entre l'en-tête et le contenu des pages de checkpoint et de résultats d'évaluation.

## :rainbow: Remarques

À l'avenir, réussir à trouver le bon alignement pour essayer de toujours avoir le bloc à la même position Y ?

## :100: Pour tester

- Se connecter à Pix App avec l'utilisateur `userpix1@example.net`
- Visiter les pages :
  1. [`/challenges/recfWAcyZCsLg3yrb/preview`](https://app-pr6027.review.pix.fr/) et cliquer sur `Passer`
  2. Reprendre la [compétence `Mener une recherche...`](https://app-pr6027.review.pix.fr/competences/recsvLz0W2ShyfD63/details) et aller jusqu'à un checkpoint
- Vérifier que le style des pages est acceptable
