### PR TITLE
[FEATURE] Harmonisation de la page de création de campagne (PIX-7663)

### DIFF
--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -25,7 +25,7 @@
     {{/if}}
   </div>
 
-  <div class="form__field-with-info form__field form__field-campaign-owner">
+  <div class="form__field form__field-with-info form__field-campaign-owner">
     <PixSelect
       @options={{this.campaignOwnerOptions}}
       @onChange={{this.onChangeCampaignOwner}}
@@ -97,7 +97,7 @@
   </div>
 
   {{#if this.isCampaignGoalAssessment}}
-    <div class="form__field-with-info form__field-with-info--small">
+    <div class="form__field form__field-with-info">
       <PixFilterableAndSearchableSelect
         @label={{t "pages.campaign-creation.target-profiles-list-label"}}
         @placeholder={{t "pages.campaign-creation.target-profiles-label"}}
@@ -171,14 +171,12 @@
       <abbr title={{t "common.form.mandatory-fields-title"}} class="mandatory-mark" aria-hidden="true">*</abbr>
       {{t "pages.campaign-creation.external-id-label.question-label"}}
     </p>
-
     <PixRadioButton
       name="external-id-label"
       @label={{t "pages.campaign-creation.no"}}
       @value="false"
       {{on "change" this.doNotAskLabelIdPix}}
     />
-
     <PixRadioButton
       name="external-id-label"
       @label={{t "pages.campaign-creation.yes"}}

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -25,7 +25,7 @@
     {{/if}}
   </div>
 
-  <div class="form__field-with-info form__field">
+  <div class="form__field-with-info form__field form__field-campaign-owner">
     <PixSelect
       @options={{this.campaignOwnerOptions}}
       @onChange={{this.onChangeCampaignOwner}}

--- a/orga/app/components/campaign/create-form.hbs
+++ b/orga/app/components/campaign/create-form.hbs
@@ -229,7 +229,7 @@
   </div>
 
   <div class="form__validation">
-    <PixButton @triggerAction={{@onCancel}} @backgroundColor="transparent-light">
+    <PixButton @triggerAction={{@onCancel}} @backgroundColor="transparent-light" @isBorderVisible={{true}}>
       {{t "common.actions.cancel"}}
     </PixButton>
 

--- a/orga/app/components/campaign/update-form.hbs
+++ b/orga/app/components/campaign/update-form.hbs
@@ -91,7 +91,11 @@
   </div>
 
   <div class="form__validation">
-    <PixButton @triggerAction={{fn @onCancel @campaign.id}} @backgroundColor="transparent-light">
+    <PixButton
+      @triggerAction={{fn @onCancel @campaign.id}}
+      @backgroundColor="transparent-light"
+      @isBorderVisible={{true}}
+    >
       {{t "common.actions.cancel"}}
     </PixButton>
     <PixButton @type="submit">

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -1,12 +1,12 @@
 .form {
   display: flex;
   flex-direction: column;
-  margin-bottom: 30px;
+  margin-bottom: $pix-spacing-l;
 
   &__field {
     display: flex;
     flex-direction: column;
-    margin: 16px 0;
+    margin: $pix-spacing-s 0;
 
     @include device-is('desktop') {
       width: 500px;
@@ -44,38 +44,40 @@
     border-radius: 8px;
     background: $pix-neutral-15;
     height: max-content;
-    padding: 16px;
+    padding: $pix-spacing-s;
     color: $pix-neutral-60;
     font-size: 0.875rem;
-    margin: 16px 0 0 0;
+    margin: $pix-spacing-s 0 0 0;
 
     @include device-is('desktop') {
       position: absolute;
-      margin: 0 0 0 16px;
+      margin: 0 0 0 $pix-spacing-s;
       left: 100%;
       width: calc(100vw - 100% - #{$app-sidebar-width} - 32px);
     }
 
     &-icon {
       color: $pix-primary;
-      margin-right: 8px;
+      margin-right: $pix-spacing-xs;
     }
 
     &-title {
-      font-weight: 500;
-      font-size: 0.875rem;
-      margin-bottom: 8px;
+      @extend %pix-body-m;
+
+      margin-bottom: $pix-spacing-xs;
       color: $pix-neutral-90;
+      font-weight: 500;
     }
 
     &-message {
-      font-size: 0.8125rem;
+      @extend %pix-body-s;
+
       color: $pix-neutral-60;
     }
   }
 
   &__field-filters {
-    margin-bottom: 16px;
+    margin-bottom: $pix-spacing-s;
     border: 0;
     padding: 0;
 
@@ -86,8 +88,8 @@
     }
 
     .pix-selectable-tag {
-      margin-top: 8px;
-      margin-inline-end: 8px;
+      margin-top: $pix-spacing-xs;
+      margin-inline-end: $pix-spacing-xs;
     }
 
     @include device-is('desktop') {
@@ -96,7 +98,7 @@
   }
 
   &__validation {
-    margin-top: 32px;
+    margin-top: $pix-spacing-l;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -107,11 +109,11 @@
   }
 
   &__error {
-    padding-top: 4px;
+    padding-top: $pix-spacing-xxs;
   }
 
   &__information {
-    margin-top: 7px;
+    margin-top: $pix-spacing-xs;
   }
 
   &__comment {
@@ -121,7 +123,7 @@
 
   &__mandatory-fields-information {
     font-size: 0.875rem;
-    margin: 0 0 35px 0;
+    margin: 0 0 $pix-spacing-l 0;
     color: $pix-neutral-70;
   }
 
@@ -134,14 +136,14 @@
 }
 
 .label {
-  @include label();
+  @include label;
 }
 
 .input-container {
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  margin-bottom: 22px;
+  margin-bottom: $pix-spacing-m;
 }
 
 .input {
@@ -149,7 +151,7 @@
   border: 1px solid $pix-neutral-40;
   border-radius: 4px;
   font-size: 0.875rem;
-  padding-left: 15px;
+  padding-left: $pix-spacing-s;
   color: $pix-neutral-100;
   outline: none;
 

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -134,14 +134,7 @@
 }
 
 .label {
-  display: inline-block;
-  color: $pix-neutral-70;
-  font-size: 0.875rem;
-  padding-bottom: 5px;
-}
-
-p.label {
-  margin: 0 0 16px;
+  @include label();
 }
 
 .input-container {

--- a/orga/app/styles/pages/authenticated/campaigns/create-form.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/create-form.scss
@@ -27,7 +27,13 @@
 
   .pix-select {
     @include device-is('desktop') {
-      width: 360px;
+      width: 355px;
+    }
+  }
+
+  &.form__field-campaign-owner {
+    .pix-select {
+      width: 100%;
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Les pages de création de campagne et de modification de campagne n'étaient pas ISO avec les maquettes

## :robot: Proposition
- avoir le même espacement label/input partout,
- augmenter la taille de l’input “propriétaire de la campagne” pour qu’il soit de la même longueur que les autres
- avoir le même espacement entre chaque section (titre, nom, objectif de la campagne etc.)
- mettre toutes les questions/rubriques en gras (“Titre de la campagne”, “Quel est l'objectif de votre campagne ?” etc.)
- augmenter la taille des font pour les descriptions : 16px pour les titres, 14px pour le texte
- passer le style du bouton “annuler” en secondary

## :rainbow: Remarques
Nous en avons profité pour utiliser les Designs Tokens pour les formulaires dans pixOrga.
La plupart des modifications faites sont misent en place pour tous les éléments de formulaires qu'on peut retrouver sur pix Orga.

## :100: Pour tester
- vérifier la page de connexion
- se connecter à PixOrga
- se rendre sur la page de création de campagne et vérifier les modifications ci-dessus
- se rendre sur la page de modification d'une campagne et, pareil, vérifier les modifications ci-dessus
- vérifier tous les autres formulaires existants sur PixOrga
- tada 🎉  votre review est terminée