### PR TITLE
[TECH] Amélioration du HTML de l'import en masse (PIX-7813).

### DIFF
--- a/certif/app/components/import/step-two-section.hbs
+++ b/certif/app/components/import/step-two-section.hbs
@@ -30,14 +30,18 @@
         @iconTitle="plus"
         class="import-page-section__collapsible-header--non-blocking"
       >
-        {{#each this.translatedNonBlockingErrorReport as |report|}}
-          <PixMessage @type="warning">
-            <p>{{t "pages.sessions.import.step-two.non-blocking-errors.line"}}
-              {{report.line}}
-              :
-              {{report.message}}</p>
-          </PixMessage>
-        {{/each}}
+        <ul>
+          {{#each this.translatedNonBlockingErrorReport as |report|}}
+            <li>
+              <PixMessage @type="warning">
+                {{t "pages.sessions.import.step-two.non-blocking-errors.line"}}
+                {{report.line}}
+                :
+                {{report.message}}
+              </PixMessage>
+            </li>
+          {{/each}}
+        </ul>
       </PixCollapsible>
     </div>
   {{/if}}
@@ -55,14 +59,18 @@
         @iconTitle="plus"
         class="import-page-section__collapsible-header--blocking"
       >
-        {{#each this.translatedBlockingErrorReport as |report|}}
-          <PixMessage @type="error">
-            <p>{{t "pages.sessions.import.step-two.blocking-errors.line"}}
-              {{report.line}}
-              :
-              {{report.message}}</p>
-          </PixMessage>
-        {{/each}}
+        <ul>
+          {{#each this.translatedBlockingErrorReport as |report|}}
+            <li>
+              <PixMessage @type="error">
+                {{t "pages.sessions.import.step-two.blocking-errors.line"}}
+                {{report.line}}
+                :
+                {{report.message}}
+              </PixMessage>
+            </li>
+          {{/each}}
+        </ul>
       </PixCollapsible>
     </div>
   {{/if}}


### PR DESCRIPTION
## :unicorn: Problème

Actuellement coté code, la liste d'erreurs (bloquantes ou non) se compose d’un enchaînement de Pix Message avec un `p` à l’intérieur.

## :robot: Proposition

Créer une liste d'erreurs avec `ul > li`

## :rainbow: Remarques

J'ai supprimé les `p` qui me paraissent superflus, mais pas sûr pour le coup 🤔

## :100: Pour tester

Importer le fichier suivant et constater que les `p` ont été remplacés par une liste dans l'inspecteur.

```
Numéro de session préexistante;* Nom du site;* Nom de la salle;* Date de début (format: JJ/MM/AAAA);* Heure de début (heure locale format: HH:MM);* Surveillant(s);Observations (optionnel);* Nom de naissance;* Prénom;* Date de naissance (format: JJ/MM/AAAA);* Sexe (M ou F);Code INSEE de la commune de naissance;Code postal de la commune de naissance;Nom de la commune de naissance;* Pays de naissance;E-mail du destinataire des résultats (formateur, enseignant…);E-mail de convocation;Identifiant externe;Temps majoré ? (exemple format: 33%);* Tarification part Pix (Gratuite, Prépayée ou Payante);Code de prépaiement (si Tarification part Pix Prépayée)
;10 rue des églantines;salle A113;28/01/2024;15:00;José;observations;Nom;Prénom;19/09/1988;M;75115;;;France;;;;;;;;
;10 rue des églantines;salle A113;28/01/2024;15:00;José;observations;Nom;Prénom;19/09/1988;M;75115;;;France;;;;;;;;
;10 rue des églantines;salle A113;28/01/2024;15:00;José;observations;Nom;Prénom;19/09/1988;M;75115;;;France;;;;;;;;
```