### PR TITLE
[FEATURE] align left header info content (PIX-7661)

### DIFF
--- a/orga/app/styles/components/ui/information.scss
+++ b/orga/app/styles/components/ui/information.scss
@@ -10,7 +10,7 @@
   padding: 0 $pix-spacing-xs;
   border-left: 1px solid $pix-neutral-22;
   font-size: 0.875rem;
-  text-align: center;
+  text-align: left;
 
   &__title {
     margin-bottom: $pix-spacing-xs;
@@ -30,6 +30,7 @@
 
   &--certifiable {
     padding-bottom: $pix-spacing-xxs;
+    text-align: center;
   }
 
   &:first-of-type {


### PR DESCRIPTION
## :unicorn: Problème
Nous avons ajouté un composant d’en-tête sur la page de détail d’un prescrit et son contenu est centré alors qu'il est justifié à gauche sur la maquette.

## :robot: Proposition
Justifier à gauche le contenu du composant d’en-tête pour les groupes classe et méthodes de connexions

## :rainbow: Remarques


## :100: Pour tester

- Se connecter à Pix Orga en tant que sco, sup ou pro
- Aller sur la page d'un utilisateur
- Dans l'en-tête d'information, vérifier que le contenu des groupe classe et méthodes de connexions est justifié à gauche
