### PR TITLE
[BUGFIX] Mettre en anglais la traduction anglaise de la légende des filtres sur la liste de campagnes (PIX-7729)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -558,7 +558,7 @@
       "no-campaign": "No campaign. To start, click on 'Create a campaign'.",
       "filter": {
         "clear": "Clear filters",
-        "legend": "Filtres pour le tableau des campagnes, des champs de saisie permettent de filtrer le tableau par le nom de la campagne et par nom du propriétaire. Des boutons permettent de filtrer les campagnes actives et archivées.",
+        "legend": "Filters for the campaigns table, input fields allow to filter the table by campaign name and/or by owner name. Buttons allow to switch between ongoing and archived campaigns.",
         "title": "Filters",
         "by-owner": "Search for an owner",
         "by-name": "Search for a campaign",


### PR DESCRIPTION
## :unicorn: Problème
La traduction anglaise était en fait en français...

## :robot: Proposition
La mettre en anglais 🤡 

## :rainbow: Remarques
Oui...

## :100: Pour tester
- Se connecter à PixOrga
- Switcher sur la version anglaise
- Aller sur la page des campagnes
- Avec voice over, aller vérifier la légende des filtres
- Tada, la review est terminée 🎉 