### PR TITLE
[TECH] Injecter les dépendances pour préparer la migration ESM

### DIFF
--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -38,17 +38,29 @@ function _replyForbiddenError(h) {
   return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
 }
 
-async function checkIfUserIsBlocked(request, h) {
+async function checkIfUserIsBlocked(
+  request,
+  h,
+  dependencies = {
+    checkIfUserIsBlockedUseCase,
+  }
+) {
   const { username, grant_type: grantType } = request.payload;
 
   if (grantType === 'password') {
-    await checkIfUserIsBlockedUseCase.execute(username);
+    await dependencies.checkIfUserIsBlockedUseCase.execute(username);
   }
 
   return h.response(true);
 }
 
-async function checkAdminMemberHasRoleSuperAdmin(request, h) {
+async function checkAdminMemberHasRoleSuperAdmin(
+  request,
+  h,
+  dependencies = {
+    checkAdminMemberHasRoleSuperAdminUseCase,
+  }
+) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyForbiddenError(h);
   }
@@ -56,7 +68,7 @@ async function checkAdminMemberHasRoleSuperAdmin(request, h) {
   const userId = request.auth.credentials.userId;
 
   try {
-    const hasRoleSuperAdmin = await checkAdminMemberHasRoleSuperAdminUseCase.execute(userId);
+    const hasRoleSuperAdmin = await dependencies.checkAdminMemberHasRoleSuperAdminUseCase.execute(userId);
     if (!hasRoleSuperAdmin) {
       throw new ForbiddenAccess(apps.PIX_ADMIN.NOT_ALLOWED_MSG);
     }
@@ -66,7 +78,7 @@ async function checkAdminMemberHasRoleSuperAdmin(request, h) {
   }
 }
 
-async function checkAdminMemberHasRoleCertif(request, h) {
+async function checkAdminMemberHasRoleCertif(request, h, dependencies = { checkAdminMemberHasRoleCertifUseCase }) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyForbiddenError(h);
   }
@@ -74,7 +86,7 @@ async function checkAdminMemberHasRoleCertif(request, h) {
   const userId = request.auth.credentials.userId;
 
   try {
-    const hasRoleCertif = await checkAdminMemberHasRoleCertifUseCase.execute(userId);
+    const hasRoleCertif = await dependencies.checkAdminMemberHasRoleCertifUseCase.execute(userId);
     if (!hasRoleCertif) {
       throw new ForbiddenAccess(apps.PIX_ADMIN.NOT_ALLOWED_MSG);
     }
@@ -84,7 +96,7 @@ async function checkAdminMemberHasRoleCertif(request, h) {
   }
 }
 
-async function checkAdminMemberHasRoleSupport(request, h) {
+async function checkAdminMemberHasRoleSupport(request, h, dependencies = { checkAdminMemberHasRoleSupportUseCase }) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyForbiddenError(h);
   }
@@ -92,7 +104,7 @@ async function checkAdminMemberHasRoleSupport(request, h) {
   const userId = request.auth.credentials.userId;
 
   try {
-    const hasRoleSupport = await checkAdminMemberHasRoleSupportUseCase.execute(userId);
+    const hasRoleSupport = await dependencies.checkAdminMemberHasRoleSupportUseCase.execute(userId);
     if (!hasRoleSupport) {
       throw new ForbiddenAccess(apps.PIX_ADMIN.NOT_ALLOWED_MSG);
     }
@@ -102,7 +114,7 @@ async function checkAdminMemberHasRoleSupport(request, h) {
   }
 }
 
-async function checkAdminMemberHasRoleMetier(request, h) {
+async function checkAdminMemberHasRoleMetier(request, h, dependencies = { checkAdminMemberHasRoleMetierUseCase }) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyForbiddenError(h);
   }
@@ -110,7 +122,7 @@ async function checkAdminMemberHasRoleMetier(request, h) {
   const userId = request.auth.credentials.userId;
 
   try {
-    const hasRoleMetier = await checkAdminMemberHasRoleMetierUseCase.execute(userId);
+    const hasRoleMetier = await dependencies.checkAdminMemberHasRoleMetierUseCase.execute(userId);
     if (!hasRoleMetier) {
       throw new ForbiddenAccess(apps.PIX_ADMIN.NOT_ALLOWED_MSG);
     }
@@ -131,7 +143,7 @@ function checkRequestedUserIsAuthenticatedUser(request, h) {
   return authenticatedUserId === requestedUserId ? h.response(true) : _replyForbiddenError(h);
 }
 
-function checkUserIsAdminInOrganization(request, h) {
+function checkUserIsAdminInOrganization(request, h, dependencies = { checkUserIsAdminInOrganizationUseCase }) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyForbiddenError(h);
   }
@@ -144,7 +156,7 @@ function checkUserIsAdminInOrganization(request, h) {
       ? request.payload.data.relationships.organization.data.id
       : parseInt(request.params.id);
 
-  return checkUserIsAdminInOrganizationUseCase
+  return dependencies.checkUserIsAdminInOrganizationUseCase
     .execute(userId, organizationId)
     .then((isAdminInOrganization) => {
       if (isAdminInOrganization) {
@@ -155,7 +167,11 @@ function checkUserIsAdminInOrganization(request, h) {
     .catch(() => _replyForbiddenError(h));
 }
 
-function checkUserIsMemberOfCertificationCenter(request, h) {
+function checkUserIsMemberOfCertificationCenter(
+  request,
+  h,
+  dependencies = { checkUserIsMemberOfCertificationCenterUsecase }
+) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyForbiddenError(h);
   }
@@ -163,7 +179,7 @@ function checkUserIsMemberOfCertificationCenter(request, h) {
   const userId = request.auth.credentials.userId;
   const certificationCenterId = parseInt(request.params.certificationCenterId);
 
-  return checkUserIsMemberOfCertificationCenterUsecase
+  return dependencies.checkUserIsMemberOfCertificationCenterUsecase
     .execute(userId, certificationCenterId)
     .then((isMemberInCertificationCenter) => {
       if (isMemberInCertificationCenter) {
@@ -174,7 +190,11 @@ function checkUserIsMemberOfCertificationCenter(request, h) {
     .catch(() => _replyForbiddenError(h));
 }
 
-async function checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId(request, h) {
+async function checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId(
+  request,
+  h,
+  dependencies = { checkUserIsMemberOfCertificationCenterSessionUsecase, certificationIssueReportRepository }
+) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyForbiddenError(h);
   }
@@ -183,8 +203,10 @@ async function checkUserIsMemberOfCertificationCenterSessionFromCertificationIss
   const certificationIssueReportId = parseInt(request.params.id);
 
   try {
-    const certificationIssueReport = await certificationIssueReportRepository.get(certificationIssueReportId);
-    const isMemberOfSession = await checkUserIsMemberOfCertificationCenterSessionUsecase.execute({
+    const certificationIssueReport = await dependencies.certificationIssueReportRepository.get(
+      certificationIssueReportId
+    );
+    const isMemberOfSession = await dependencies.checkUserIsMemberOfCertificationCenterSessionUsecase.execute({
       userId,
       certificationCourseId: certificationIssueReport.certificationCourseId,
     });
@@ -194,7 +216,13 @@ async function checkUserIsMemberOfCertificationCenterSessionFromCertificationIss
   }
 }
 
-async function checkUserIsMemberOfCertificationCenterSessionFromCertificationCourseId(request, h) {
+async function checkUserIsMemberOfCertificationCenterSessionFromCertificationCourseId(
+  request,
+  h,
+  dependencies = {
+    checkUserIsMemberOfCertificationCenterSessionUsecase,
+  }
+) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyForbiddenError(h);
   }
@@ -203,7 +231,7 @@ async function checkUserIsMemberOfCertificationCenterSessionFromCertificationCou
   const certificationCourseId = parseInt(request.params.id);
 
   try {
-    const isMemberOfSession = await checkUserIsMemberOfCertificationCenterSessionUsecase.execute({
+    const isMemberOfSession = await dependencies.checkUserIsMemberOfCertificationCenterSessionUsecase.execute({
       userId,
       certificationCourseId,
     });
@@ -213,7 +241,11 @@ async function checkUserIsMemberOfCertificationCenterSessionFromCertificationCou
   }
 }
 
-async function checkUserBelongsToOrganizationManagingStudents(request, h) {
+async function checkUserBelongsToOrganizationManagingStudents(
+  request,
+  h,
+  dependencies = { checkUserBelongsToOrganizationManagingStudentsUseCase }
+) {
   if (!has(request, 'auth.credentials.userId')) {
     return _replyForbiddenError(h);
   }
@@ -222,7 +254,7 @@ async function checkUserBelongsToOrganizationManagingStudents(request, h) {
   const organizationId = parseInt(request.params.id);
 
   try {
-    if (await checkUserBelongsToOrganizationManagingStudentsUseCase.execute(userId, organizationId)) {
+    if (await dependencies.checkUserBelongsToOrganizationManagingStudentsUseCase.execute(userId, organizationId)) {
       return h.response(true);
     }
   } catch (err) {
@@ -231,7 +263,11 @@ async function checkUserBelongsToOrganizationManagingStudents(request, h) {
   return _replyForbiddenError(h);
 }
 
-async function checkUserBelongsToScoOrganizationAndManagesStudents(request, h) {
+async function checkUserBelongsToScoOrganizationAndManagesStudents(
+  request,
+  h,
+  dependencies = { checkUserBelongsToScoOrganizationAndManagesStudentsUseCase }
+) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyForbiddenError(h);
   }
@@ -242,7 +278,7 @@ async function checkUserBelongsToScoOrganizationAndManagesStudents(request, h) {
   let belongsToScoOrganizationAndManageStudents;
   try {
     belongsToScoOrganizationAndManageStudents =
-      await checkUserBelongsToScoOrganizationAndManagesStudentsUseCase.execute(userId, organizationId);
+      await dependencies.checkUserBelongsToScoOrganizationAndManagesStudentsUseCase.execute(userId, organizationId);
   } catch (err) {
     return _replyForbiddenError(h);
   }
@@ -254,7 +290,11 @@ async function checkUserBelongsToScoOrganizationAndManagesStudents(request, h) {
   return _replyForbiddenError(h);
 }
 
-async function checkUserBelongsToSupOrganizationAndManagesStudents(request, h) {
+async function checkUserBelongsToSupOrganizationAndManagesStudents(
+  request,
+  h,
+  dependencies = { checkUserBelongsToSupOrganizationAndManagesStudentsUseCase }
+) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyForbiddenError(h);
   }
@@ -265,7 +305,7 @@ async function checkUserBelongsToSupOrganizationAndManagesStudents(request, h) {
   let belongsToSupOrganizationAndManageStudents;
   try {
     belongsToSupOrganizationAndManageStudents =
-      await checkUserBelongsToSupOrganizationAndManagesStudentsUseCase.execute(userId, organizationId);
+      await dependencies.checkUserBelongsToSupOrganizationAndManagesStudentsUseCase.execute(userId, organizationId);
   } catch (err) {
     return _replyForbiddenError(h);
   }
@@ -277,24 +317,40 @@ async function checkUserBelongsToSupOrganizationAndManagesStudents(request, h) {
   return _replyForbiddenError(h);
 }
 
-async function checkUserIsAdminInSCOOrganizationManagingStudents(request, h) {
+async function checkUserIsAdminInSCOOrganizationManagingStudents(
+  request,
+  h,
+  dependencies = { checkUserIsAdminAndManagingStudentsForOrganization }
+) {
   const userId = request.auth.credentials.userId;
   const organizationId = parseInt(request.params.id);
 
   if (
-    await checkUserIsAdminAndManagingStudentsForOrganization.execute(userId, organizationId, Organization.types.SCO)
+    await dependencies.checkUserIsAdminAndManagingStudentsForOrganization.execute(
+      userId,
+      organizationId,
+      Organization.types.SCO
+    )
   ) {
     return h.response(true);
   }
   return _replyForbiddenError(h);
 }
 
-async function checkUserIsAdminInSUPOrganizationManagingStudents(request, h) {
+async function checkUserIsAdminInSUPOrganizationManagingStudents(
+  request,
+  h,
+  dependencies = { checkUserIsAdminAndManagingStudentsForOrganization }
+) {
   const userId = request.auth.credentials.userId;
   const organizationId = parseInt(request.params.id);
 
   if (
-    await checkUserIsAdminAndManagingStudentsForOrganization.execute(userId, organizationId, Organization.types.SUP)
+    await dependencies.checkUserIsAdminAndManagingStudentsForOrganization.execute(
+      userId,
+      organizationId,
+      Organization.types.SUP
+    )
   ) {
     return h.response(true);
   }
@@ -302,7 +358,11 @@ async function checkUserIsAdminInSUPOrganizationManagingStudents(request, h) {
   return _replyForbiddenError(h);
 }
 
-async function checkUserBelongsToLearnersOrganization(request, h) {
+async function checkUserBelongsToLearnersOrganization(
+  request,
+  h,
+  dependencies = { checkUserBelongsToLearnersOrganizationUseCase }
+) {
   if (!request.auth.credentials) {
     return _replyForbiddenError(h);
   }
@@ -313,7 +373,7 @@ async function checkUserBelongsToLearnersOrganization(request, h) {
   let belongsToLearnersOrganization;
 
   try {
-    belongsToLearnersOrganization = await checkUserBelongsToLearnersOrganizationUseCase.execute(
+    belongsToLearnersOrganization = await dependencies.checkUserBelongsToLearnersOrganizationUseCase.execute(
       userId,
       organizationLearnerId
     );
@@ -326,7 +386,7 @@ async function checkUserBelongsToLearnersOrganization(request, h) {
   return _replyForbiddenError(h);
 }
 
-async function checkUserBelongsToOrganization(request, h) {
+async function checkUserBelongsToOrganization(request, h, dependencies = { checkUserBelongsToOrganizationUseCase }) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyForbiddenError(h);
   }
@@ -334,14 +394,21 @@ async function checkUserBelongsToOrganization(request, h) {
   const userId = request.auth.credentials.userId;
   const organizationId = parseInt(request.params.id);
 
-  const belongsToOrganization = await checkUserBelongsToOrganizationUseCase.execute(userId, organizationId);
+  const belongsToOrganization = await dependencies.checkUserBelongsToOrganizationUseCase.execute(
+    userId,
+    organizationId
+  );
   if (belongsToOrganization) {
     return h.response(true);
   }
   return _replyForbiddenError(h);
 }
 
-async function checkUserIsMemberOfAnOrganization(request, h) {
+async function checkUserIsMemberOfAnOrganization(
+  request,
+  h,
+  dependencies = { checkUserIsMemberOfAnOrganizationUseCase }
+) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyForbiddenError(h);
   }
@@ -350,7 +417,7 @@ async function checkUserIsMemberOfAnOrganization(request, h) {
 
   let isMemberOfAnOrganization;
   try {
-    isMemberOfAnOrganization = await checkUserIsMemberOfAnOrganizationUseCase.execute(userId);
+    isMemberOfAnOrganization = await dependencies.checkUserIsMemberOfAnOrganizationUseCase.execute(userId);
   } catch (err) {
     return _replyForbiddenError(h);
   }
@@ -361,10 +428,14 @@ async function checkUserIsMemberOfAnOrganization(request, h) {
   return _replyForbiddenError(h);
 }
 
-async function checkAuthorizationToManageCampaign(request, h) {
+async function checkAuthorizationToManageCampaign(
+  request,
+  h,
+  dependencies = { checkAuthorizationToManageCampaignUsecase }
+) {
   const userId = request.auth.credentials.userId;
   const campaignId = request.params.id;
-  const isAdminOrOwnerOfTheCampaign = await checkAuthorizationToManageCampaignUsecase.execute({
+  const isAdminOrOwnerOfTheCampaign = await dependencies.checkAuthorizationToManageCampaignUsecase.execute({
     userId,
     campaignId,
   });
@@ -380,14 +451,18 @@ function adminMemberHasAtLeastOneAccessOf(securityChecks) {
     return hasAccess ? hasAccess : _replyForbiddenError(h);
   };
 }
-async function checkPix1dActivated(request, h) {
-  const isPix1dEnabled = await checkPix1dEnabled.execute();
+async function checkPix1dActivated(request, h, dependencies = { checkPix1dEnabled }) {
+  const isPix1dEnabled = await dependencies.checkPix1dEnabled.execute();
 
   if (isPix1dEnabled) return h.response(true);
   return _replyForbiddenError(h);
 }
 
-async function checkUserOwnsCertificationCourse(request, h) {
+async function checkUserOwnsCertificationCourse(
+  request,
+  h,
+  dependencies = { checkUserOwnsCertificationCourseUseCase }
+) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyForbiddenError(h);
   }
@@ -396,7 +471,7 @@ async function checkUserOwnsCertificationCourse(request, h) {
   const certificationCourseId = parseInt(request.params.id);
 
   try {
-    const ownsCertificationCourse = await checkUserOwnsCertificationCourseUseCase.execute({
+    const ownsCertificationCourse = await dependencies.checkUserOwnsCertificationCourseUseCase.execute({
       userId,
       certificationCourseId,
     });

--- a/api/lib/domain/services/token-service.js
+++ b/api/lib/domain/services/token-service.js
@@ -197,8 +197,30 @@ async function extractExternalUserFromIdToken(token) {
     samlId: externalUser['saml_id'],
   };
 }
+const tokenService = {
+  createAccessTokenFromUser,
+  createAccessTokenForSaml,
+  createAccessTokenFromApplication,
+  createAccessTokenFromAnonymousUser,
+  createTokenForCampaignResults,
+  createIdTokenForUserReconciliation,
+  createCertificationResultsByRecipientEmailLinkToken,
+  createCertificationResultsLinkToken,
+  createPasswordResetToken,
+  decodeIfValid,
+  getDecodedToken,
+  extractExternalUserFromIdToken,
+  extractResultRecipientEmailAndSessionId,
+  extractSamlId,
+  extractSessionId,
+  extractTokenFromAuthChain,
+  extractUserId,
+  extractClientId,
+  extractCampaignResultsTokenContent,
+};
 
 module.exports = {
+  tokenService,
   createAccessTokenFromUser,
   createAccessTokenForSaml,
   createAccessTokenFromApplication,

--- a/api/lib/domain/services/verify-certificate-code-service.js
+++ b/api/lib/domain/services/verify-certificate-code-service.js
@@ -17,10 +17,13 @@ function _randomCharacter() {
 }
 
 module.exports = {
-  async generateCertificateVerificationCode(generateCode = _generateCode) {
+  async generateCertificateVerificationCode({
+    generateCode = _generateCode,
+    dependencies = { certificationCourseRepository },
+  } = {}) {
     for (let i = 0; i < NB_OF_TRIALS; i++) {
       const code = generateCode();
-      const isCodeAvailable = await certificationCourseRepository.isVerificationCodeAvailable(code);
+      const isCodeAvailable = await dependencies.certificationCourseRepository.isVerificationCodeAvailable(code);
       if (isCodeAvailable) return code;
     }
     throw new CertificateVerificationCodeGenerationTooManyTrials(NB_OF_TRIALS);

--- a/api/tests/unit/application/security-pre-handlers_test.js
+++ b/api/tests/unit/application/security-pre-handlers_test.js
@@ -2,41 +2,26 @@ const { expect, sinon, hFake, domainBuilder } = require('../../test-helper');
 
 const securityPreHandlers = require('../../../lib/application/security-pre-handlers');
 const tokenService = require('../../../lib/domain/services/token-service');
-const checkAdminMemberHasRoleSuperAdminUseCase = require('../../../lib/application/usecases/checkAdminMemberHasRoleSuperAdmin');
-const checkAdminMemberHasRoleCertifUseCase = require('../../../lib/application/usecases/checkAdminMemberHasRoleCertif');
-const checkAdminMemberHasRoleSupportUseCase = require('../../../lib/application/usecases/checkAdminMemberHasRoleSupport');
-const checkAdminMemberHasRoleMetierUseCase = require('../../../lib/application/usecases/checkAdminMemberHasRoleMetier');
-const checkUserIsAdminInOrganizationUseCase = require('../../../lib/application/usecases/checkUserIsAdminInOrganization');
-const checkUserBelongsToLearnersOrganizationUseCase = require('../../../lib/application/usecases/checkUserBelongsToLearnersOrganization');
-const checkUserBelongsToOrganizationManagingStudentsUseCase = require('../../../lib/application/usecases/checkUserBelongsToOrganizationManagingStudents');
-const checkUserBelongsToScoOrganizationAndManagesStudentsUseCase = require('../../../lib/application/usecases/checkUserBelongsToScoOrganizationAndManagesStudents');
-const checkUserIsMemberOfAnOrganizationUseCase = require('../../../lib/application/usecases/checkUserIsMemberOfAnOrganization');
-const checkUserIsMemberOfCertificationCenterUseCase = require('../../../lib/application/usecases/checkUserIsMemberOfCertificationCenter');
-const checkAuthorizationToManageCampaignUsecase = require('../../../lib/application/usecases/checkAuthorizationToManageCampaign');
-const checkUserIsMemberOfCertificationCenterSessionUsecase = require('../../../lib/application/usecases/checkUserIsMemberOfCertificationCenterSession');
-const certificationIssueReportRepository = require('../../../lib/infrastructure/repositories/certification-issue-report-repository');
-const checkUserOwnsCertificationCourseUseCase = require('../../../lib/application/usecases/checkUserOwnsCertificationCourse');
+
 describe('Unit | Application | SecurityPreHandlers', function () {
   describe('#checkAdminMemberHasRoleSuperAdmin', function () {
-    let hasRoleSuperAdminStub;
     let request;
 
     beforeEach(function () {
       sinon.stub(tokenService, 'extractTokenFromAuthChain');
-      hasRoleSuperAdminStub = sinon.stub(checkAdminMemberHasRoleSuperAdminUseCase, 'execute');
       request = { auth: { credentials: { accessToken: 'valid.access.token', userId: 1234 } } };
     });
 
     context('Successful case', function () {
-      beforeEach(function () {
-        hasRoleSuperAdminStub.resolves({ user_id: 1234 });
-      });
-
       it('should authorize access to resource when the user is authenticated and has role Super Admin', async function () {
         // given
-
+        const checkAdminMemberHasRoleSuperAdminUseCaseStub = {
+          execute: sinon.stub().resolves({ user_id: 1234 }),
+        };
         // when
-        const response = await securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(request, hFake);
+        const response = await securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(request, hFake, {
+          checkAdminMemberHasRoleSuperAdminUseCase: checkAdminMemberHasRoleSuperAdminUseCaseStub,
+        });
 
         // then
         expect(response.source).to.equal(true);
@@ -47,9 +32,13 @@ describe('Unit | Application | SecurityPreHandlers', function () {
       it('should forbid resource access when user was not previously authenticated', async function () {
         // given
         delete request.auth.credentials;
-
+        const checkAdminMemberHasRoleSuperAdminUseCaseStub = {
+          execute: sinon.stub(),
+        };
         // when
-        const response = await securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(request, hFake);
+        const response = await securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(request, hFake, {
+          checkAdminMemberHasRoleSuperAdminUseCase: checkAdminMemberHasRoleSuperAdminUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -58,10 +47,14 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when user does not have role Super Admin', async function () {
         // given
-        checkAdminMemberHasRoleSuperAdminUseCase.execute.resolves(false);
+        const checkAdminMemberHasRoleSuperAdminUseCaseStub = {
+          execute: sinon.stub().resolves(false),
+        };
 
         // when
-        const response = await securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(request, hFake);
+        const response = await securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(request, hFake, {
+          checkAdminMemberHasRoleSuperAdminUseCase: checkAdminMemberHasRoleSuperAdminUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -70,10 +63,14 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when an error is thrown by use case', async function () {
         // given
-        checkAdminMemberHasRoleSuperAdminUseCase.execute.rejects(new Error('Some error'));
+        const checkAdminMemberHasRoleSuperAdminUseCaseStub = {
+          execute: sinon.stub().rejects(new Error('Some error')),
+        };
 
         // when
-        const response = await securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(request, hFake);
+        const response = await securityPreHandlers.checkAdminMemberHasRoleSuperAdmin(request, hFake, {
+          checkAdminMemberHasRoleSuperAdminUseCase: checkAdminMemberHasRoleSuperAdminUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -83,25 +80,21 @@ describe('Unit | Application | SecurityPreHandlers', function () {
   });
 
   describe('#checkAdminMemberHasRoleCertif', function () {
-    let hasRoleCertifStub;
     let request;
 
     beforeEach(function () {
       sinon.stub(tokenService, 'extractTokenFromAuthChain');
-      hasRoleCertifStub = sinon.stub(checkAdminMemberHasRoleCertifUseCase, 'execute');
       request = { auth: { credentials: { accessToken: 'valid.access.token', userId: 1234 } } };
     });
 
     context('Successful case', function () {
-      beforeEach(function () {
-        hasRoleCertifStub.resolves({ user_id: 1234 });
-      });
-
       it('should authorize access to resource when the user is authenticated and has role Certif', async function () {
         // given
-
+        const checkAdminMemberHasRoleCertifUseCaseStub = { execute: sinon.stub().returns({ user_id: 1234 }) };
         // when
-        const response = await securityPreHandlers.checkAdminMemberHasRoleCertif(request, hFake);
+        const response = await securityPreHandlers.checkAdminMemberHasRoleCertif(request, hFake, {
+          checkAdminMemberHasRoleCertifUseCase: checkAdminMemberHasRoleCertifUseCaseStub,
+        });
 
         // then
         expect(response.source).to.equal(true);
@@ -112,9 +105,12 @@ describe('Unit | Application | SecurityPreHandlers', function () {
       it('should forbid resource access when user was not previously authenticated', async function () {
         // given
         delete request.auth.credentials;
+        const checkAdminMemberHasRoleCertifUseCaseStub = { execute: sinon.stub() };
 
         // when
-        const response = await securityPreHandlers.checkAdminMemberHasRoleCertif(request, hFake);
+        const response = await securityPreHandlers.checkAdminMemberHasRoleCertif(request, hFake, {
+          checkAdminMemberHasRoleCertifUseCase: checkAdminMemberHasRoleCertifUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -123,10 +119,12 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when user does not have role Certif', async function () {
         // given
-        checkAdminMemberHasRoleCertifUseCase.execute.resolves(false);
+        const checkAdminMemberHasRoleCertifUseCaseStub = { execute: sinon.stub().resolves(false) };
 
         // when
-        const response = await securityPreHandlers.checkAdminMemberHasRoleCertif(request, hFake);
+        const response = await securityPreHandlers.checkAdminMemberHasRoleCertif(request, hFake, {
+          checkAdminMemberHasRoleCertifUseCase: checkAdminMemberHasRoleCertifUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -135,10 +133,12 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when an error is thrown by use case', async function () {
         // given
-        checkAdminMemberHasRoleCertifUseCase.execute.rejects(new Error('Some error'));
+        const checkAdminMemberHasRoleCertifUseCaseStub = { execute: sinon.stub().rejects(new Error('Some error')) };
 
         // when
-        const response = await securityPreHandlers.checkAdminMemberHasRoleCertif(request, hFake);
+        const response = await securityPreHandlers.checkAdminMemberHasRoleCertif(request, hFake, {
+          checkAdminMemberHasRoleCertifUseCase: checkAdminMemberHasRoleCertifUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -148,25 +148,22 @@ describe('Unit | Application | SecurityPreHandlers', function () {
   });
 
   describe('#checkAdminMemberHasRoleSupport', function () {
-    let hasRoleSupportStub;
     let request;
 
     beforeEach(function () {
       sinon.stub(tokenService, 'extractTokenFromAuthChain');
-      hasRoleSupportStub = sinon.stub(checkAdminMemberHasRoleSupportUseCase, 'execute');
       request = { auth: { credentials: { accessToken: 'valid.access.token', userId: 1234 } } };
     });
 
     context('Successful case', function () {
-      beforeEach(function () {
-        hasRoleSupportStub.resolves({ user_id: 1234 });
-      });
-
       it('should authorize access to resource when the user is authenticated and has role Support', async function () {
         // given
+        const checkAdminMemberHasRoleSupportUseCaseStub = { execute: sinon.stub().resolves({ user_id: 1234 }) };
 
         // when
-        const response = await securityPreHandlers.checkAdminMemberHasRoleSupport(request, hFake);
+        const response = await securityPreHandlers.checkAdminMemberHasRoleSupport(request, hFake, {
+          checkAdminMemberHasRoleSupportUseCase: checkAdminMemberHasRoleSupportUseCaseStub,
+        });
 
         // then
         expect(response.source).to.equal(true);
@@ -177,9 +174,12 @@ describe('Unit | Application | SecurityPreHandlers', function () {
       it('should forbid resource access when user was not previously authenticated', async function () {
         // given
         delete request.auth.credentials;
+        const checkAdminMemberHasRoleSupportUseCaseStub = { execute: sinon.stub() };
 
         // when
-        const response = await securityPreHandlers.checkAdminMemberHasRoleSupport(request, hFake);
+        const response = await securityPreHandlers.checkAdminMemberHasRoleSupport(request, hFake, {
+          checkAdminMemberHasRoleSupportUseCase: checkAdminMemberHasRoleSupportUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -188,10 +188,11 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when user does not have role Support', async function () {
         // given
-        checkAdminMemberHasRoleSupportUseCase.execute.resolves(false);
-
+        const checkAdminMemberHasRoleSupportUseCaseStub = { execute: sinon.stub().resolves(false) };
         // when
-        const response = await securityPreHandlers.checkAdminMemberHasRoleSupport(request, hFake);
+        const response = await securityPreHandlers.checkAdminMemberHasRoleSupport(request, hFake, {
+          checkAdminMemberHasRoleSupportUseCase: checkAdminMemberHasRoleSupportUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -200,10 +201,12 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when an error is thrown by use case', async function () {
         // given
-        checkAdminMemberHasRoleSupportUseCase.execute.rejects(new Error('Some error'));
+        const checkAdminMemberHasRoleSupportUseCaseStub = { execute: sinon.stub().rejects(new Error('Some error')) };
 
         // when
-        const response = await securityPreHandlers.checkAdminMemberHasRoleSupport(request, hFake);
+        const response = await securityPreHandlers.checkAdminMemberHasRoleSupport(request, hFake, {
+          checkAdminMemberHasRoleSupportUseCase: checkAdminMemberHasRoleSupportUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -213,25 +216,21 @@ describe('Unit | Application | SecurityPreHandlers', function () {
   });
 
   describe('#checkAdminMemberHasRoleMetier', function () {
-    let hasRoleMetierStub;
     let request;
 
     beforeEach(function () {
       sinon.stub(tokenService, 'extractTokenFromAuthChain');
-      hasRoleMetierStub = sinon.stub(checkAdminMemberHasRoleMetierUseCase, 'execute');
       request = { auth: { credentials: { accessToken: 'valid.access.token', userId: 1234 } } };
     });
 
     context('Successful case', function () {
-      beforeEach(function () {
-        hasRoleMetierStub.resolves({ user_id: 1234 });
-      });
-
       it('should authorize access to resource when the user is authenticated and has role Metier', async function () {
         // given
-
+        const checkAdminMemberHasRoleMetierUseCaseStub = { execute: sinon.stub().resolves({ user_id: 1234 }) };
         // when
-        const response = await securityPreHandlers.checkAdminMemberHasRoleMetier(request, hFake);
+        const response = await securityPreHandlers.checkAdminMemberHasRoleMetier(request, hFake, {
+          checkAdminMemberHasRoleMetierUseCase: checkAdminMemberHasRoleMetierUseCaseStub,
+        });
 
         // then
         expect(response.source).to.equal(true);
@@ -242,9 +241,11 @@ describe('Unit | Application | SecurityPreHandlers', function () {
       it('should forbid resource access when user was not previously authenticated', async function () {
         // given
         delete request.auth.credentials;
-
+        const checkAdminMemberHasRoleMetierUseCaseStub = { execute: sinon.stub() };
         // when
-        const response = await securityPreHandlers.checkAdminMemberHasRoleMetier(request, hFake);
+        const response = await securityPreHandlers.checkAdminMemberHasRoleMetier(request, hFake, {
+          checkAdminMemberHasRoleMetierUseCase: checkAdminMemberHasRoleMetierUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -253,10 +254,12 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when user does not have role Metier', async function () {
         // given
-        checkAdminMemberHasRoleMetierUseCase.execute.resolves(false);
+        const checkAdminMemberHasRoleMetierUseCaseStub = { execute: sinon.stub().resolves(false) };
 
         // when
-        const response = await securityPreHandlers.checkAdminMemberHasRoleMetier(request, hFake);
+        const response = await securityPreHandlers.checkAdminMemberHasRoleMetier(request, hFake, {
+          checkAdminMemberHasRoleMetierUseCase: checkAdminMemberHasRoleMetierUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -265,10 +268,12 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when an error is thrown by use case', async function () {
         // given
-        checkAdminMemberHasRoleMetierUseCase.execute.rejects(new Error('Some error'));
+        const checkAdminMemberHasRoleMetierUseCase = { execute: sinon.stub().rejects(new Error('Some error')) };
 
         // when
-        const response = await securityPreHandlers.checkAdminMemberHasRoleMetier(request, hFake);
+        const response = await securityPreHandlers.checkAdminMemberHasRoleMetier(request, hFake, {
+          checkAdminMemberHasRoleMetierUseCase: checkAdminMemberHasRoleMetierUseCase,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -334,18 +339,14 @@ describe('Unit | Application | SecurityPreHandlers', function () {
   });
 
   describe('#checkUserIsAdminInOrganization', function () {
-    let isAdminInOrganizationStub;
-
     beforeEach(function () {
       sinon.stub(tokenService, 'extractTokenFromAuthChain');
-      isAdminInOrganizationStub = sinon.stub(checkUserIsAdminInOrganizationUseCase, 'execute');
     });
 
     context('Successful case', function () {
       let request;
 
       beforeEach(function () {
-        isAdminInOrganizationStub.resolves(true);
         request = {
           auth: { credentials: { accessToken: 'valid.access.token', userId: 1234 } },
           params: { id: 5678 },
@@ -354,9 +355,11 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should authorize access to resource when the user is authenticated and is ADMIN in Organization', async function () {
         // given
-
+        const checkUserIsAdminInOrganizationUseCaseStub = { execute: sinon.stub().resolves(true) };
         // when
-        const response = await securityPreHandlers.checkUserIsAdminInOrganization(request, hFake);
+        const response = await securityPreHandlers.checkUserIsAdminInOrganization(request, hFake, {
+          checkUserIsAdminInOrganizationUseCase: checkUserIsAdminInOrganizationUseCaseStub,
+        });
 
         // then
         expect(response.source).to.equal(true);
@@ -367,16 +370,18 @@ describe('Unit | Application | SecurityPreHandlers', function () {
       let request;
 
       beforeEach(function () {
-        isAdminInOrganizationStub.resolves(true);
         request = { auth: { credentials: { accessToken: 'valid.access.token' } }, params: { id: 5678 } };
       });
 
       it('should forbid resource access when user was not previously authenticated', async function () {
         // given
         delete request.auth.credentials;
+        const checkUserIsAdminInOrganizationUseCaseStub = { execute: sinon.stub() };
 
         // when
-        const response = await securityPreHandlers.checkUserIsAdminInOrganization(request, hFake);
+        const response = await securityPreHandlers.checkUserIsAdminInOrganization(request, hFake, {
+          checkUserIsAdminInOrganizationUseCase: checkUserIsAdminInOrganizationUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -385,10 +390,12 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when user is not ADMIN in Organization', async function () {
         // given
-        checkUserIsAdminInOrganizationUseCase.execute.resolves(false);
+        const checkUserIsAdminInOrganizationUseCaseStub = { execute: sinon.stub().resolves(false) };
 
         // when
-        const response = await securityPreHandlers.checkUserIsAdminInOrganization(request, hFake);
+        const response = await securityPreHandlers.checkUserIsAdminInOrganization(request, hFake, {
+          checkUserIsAdminInOrganizationUseCase: checkUserIsAdminInOrganizationUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -397,10 +404,12 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when an error is thrown by use case', async function () {
         // given
-        checkUserIsAdminInOrganizationUseCase.execute.rejects(new Error('Some error'));
+        const checkUserIsAdminInOrganizationUseCaseStub = { execute: sinon.stub().rejects(new Error('Some error')) };
 
         // when
-        const response = await securityPreHandlers.checkUserIsAdminInOrganization(request, hFake);
+        const response = await securityPreHandlers.checkUserIsAdminInOrganization(request, hFake, {
+          checkUserIsAdminInOrganizationUseCase: checkUserIsAdminInOrganizationUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -410,13 +419,8 @@ describe('Unit | Application | SecurityPreHandlers', function () {
   });
 
   describe('#checkUserBelongsToOrganizationManagingStudents', function () {
-    let belongToOrganizationManagingStudentsStub;
     let request;
     beforeEach(function () {
-      belongToOrganizationManagingStudentsStub = sinon.stub(
-        checkUserBelongsToOrganizationManagingStudentsUseCase,
-        'execute'
-      );
       request = {
         auth: {
           credentials: {
@@ -431,10 +435,13 @@ describe('Unit | Application | SecurityPreHandlers', function () {
     context('Successful case', function () {
       it('should authorize access to resource when the user is authenticated, belongs to an Organization and manages students', async function () {
         // given
-        belongToOrganizationManagingStudentsStub.resolves(true);
+        const checkUserBelongsToOrganizationManagingStudentsUseCaseStub = { execute: sinon.stub().resolves(true) };
 
         // when
-        const response = await securityPreHandlers.checkUserBelongsToOrganizationManagingStudents(request, hFake);
+        const response = await securityPreHandlers.checkUserBelongsToOrganizationManagingStudents(request, hFake, {
+          checkUserBelongsToOrganizationManagingStudentsUseCase:
+            checkUserBelongsToOrganizationManagingStudentsUseCaseStub,
+        });
 
         // then
         expect(response.source).to.equal(true);
@@ -445,9 +452,13 @@ describe('Unit | Application | SecurityPreHandlers', function () {
       it('should forbid resource access when user was not previously authenticated', async function () {
         // given
         delete request.auth.credentials;
+        const checkUserBelongsToOrganizationManagingStudentsUseCaseStub = { execute: sinon.stub() };
 
         // when
-        const response = await securityPreHandlers.checkUserBelongsToOrganizationManagingStudents(request, hFake);
+        const response = await securityPreHandlers.checkUserBelongsToOrganizationManagingStudents(request, hFake, {
+          checkUserBelongsToOrganizationManagingStudentsUseCase:
+            checkUserBelongsToOrganizationManagingStudentsUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -456,10 +467,13 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when user does not belong to an Organization or manage students', async function () {
         // given
-        belongToOrganizationManagingStudentsStub.resolves(false);
+        const checkUserBelongsToOrganizationManagingStudentsUseCaseStub = { execute: sinon.stub().resolves(false) };
 
         // when
-        const response = await securityPreHandlers.checkUserBelongsToOrganizationManagingStudents(request, hFake);
+        const response = await securityPreHandlers.checkUserBelongsToOrganizationManagingStudents(request, hFake, {
+          checkUserBelongsToOrganizationManagingStudentsUseCase:
+            checkUserBelongsToOrganizationManagingStudentsUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -468,10 +482,15 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when an error is thrown by use case', async function () {
         // given
-        belongToOrganizationManagingStudentsStub.rejects(new Error('Some error'));
+        const checkUserBelongsToOrganizationManagingStudentsUseCaseStub = {
+          execute: sinon.stub().rejects(new Error('Some error')),
+        };
 
         // when
-        const response = await securityPreHandlers.checkUserBelongsToOrganizationManagingStudents(request, hFake);
+        const response = await securityPreHandlers.checkUserBelongsToOrganizationManagingStudents(request, hFake, {
+          checkUserBelongsToOrganizationManagingStudentsUseCase:
+            checkUserBelongsToOrganizationManagingStudentsUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -481,10 +500,8 @@ describe('Unit | Application | SecurityPreHandlers', function () {
   });
 
   describe('#checkUserBelongsToOrganizationLearnerOrganization', function () {
-    let belongsToLearnerOrganizationStub;
     let request;
     beforeEach(function () {
-      belongsToLearnerOrganizationStub = sinon.stub(checkUserBelongsToLearnersOrganizationUseCase, 'execute');
       request = {
         auth: {
           credentials: {
@@ -499,10 +516,14 @@ describe('Unit | Application | SecurityPreHandlers', function () {
     context('Successful case', function () {
       it('should authorize access to resource when the user is authenticated and belongs to the same organization as the learner', async function () {
         // given
-        belongsToLearnerOrganizationStub.resolves(true);
+        const checkUserBelongsToLearnersOrganizationUseCaseStub = {
+          execute: sinon.stub().resolves(true),
+        };
 
         // when
-        const response = await securityPreHandlers.checkUserBelongsToLearnersOrganization(request, hFake);
+        const response = await securityPreHandlers.checkUserBelongsToLearnersOrganization(request, hFake, {
+          checkUserBelongsToLearnersOrganizationUseCase: checkUserBelongsToLearnersOrganizationUseCaseStub,
+        });
 
         // then
         expect(response.source).to.equal(true);
@@ -513,9 +534,14 @@ describe('Unit | Application | SecurityPreHandlers', function () {
       it('should forbid resource access when user was not previously authenticated', async function () {
         // given
         delete request.auth.credentials;
+        const checkUserBelongsToLearnersOrganizationUseCaseStub = {
+          execute: sinon.stub(),
+        };
 
         // when
-        const response = await securityPreHandlers.checkUserBelongsToLearnersOrganization(request, hFake);
+        const response = await securityPreHandlers.checkUserBelongsToLearnersOrganization(request, hFake, {
+          checkUserBelongsToLearnersOrganizationUseCase: checkUserBelongsToLearnersOrganizationUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -524,10 +550,14 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it("should forbid resource access when user does not belong to the learner's organization", async function () {
         // given
-        belongsToLearnerOrganizationStub.resolves(false);
+        const checkUserBelongsToLearnersOrganizationUseCaseStub = {
+          execute: sinon.stub().resolves(false),
+        };
 
         // when
-        const response = await securityPreHandlers.checkUserBelongsToLearnersOrganization(request, hFake);
+        const response = await securityPreHandlers.checkUserBelongsToLearnersOrganization(request, hFake, {
+          checkUserBelongsToLearnersOrganizationUseCase: checkUserBelongsToLearnersOrganizationUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -538,10 +568,14 @@ describe('Unit | Application | SecurityPreHandlers', function () {
         // if organization learner ressource is missing, a 403 error response is sent not to give further information to unauthorized people
 
         // given
-        belongsToLearnerOrganizationStub.rejects(new Error());
+        const checkUserBelongsToLearnersOrganizationUseCaseStub = {
+          execute: sinon.stub().rejects(new Error('Some error')),
+        };
 
         // when
-        const response = await securityPreHandlers.checkUserBelongsToLearnersOrganization(request, hFake);
+        const response = await securityPreHandlers.checkUserBelongsToLearnersOrganization(request, hFake, {
+          checkUserBelongsToLearnersOrganizationUseCase: checkUserBelongsToLearnersOrganizationUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -551,14 +585,9 @@ describe('Unit | Application | SecurityPreHandlers', function () {
   });
 
   describe('#checkUserBelongsToScoOrganizationAndManagesStudents', function () {
-    let belongToScoOrganizationAndManageStudentsStub;
     let request;
 
     beforeEach(function () {
-      belongToScoOrganizationAndManageStudentsStub = sinon.stub(
-        checkUserBelongsToScoOrganizationAndManagesStudentsUseCase,
-        'execute'
-      );
       request = {
         auth: {
           credentials: {
@@ -576,12 +605,17 @@ describe('Unit | Application | SecurityPreHandlers', function () {
       context('when organization id is in request params', function () {
         it('should authorize access to resource when the user is authenticated, belongs to SCO Organization and manages students', async function () {
           // given
-          belongToScoOrganizationAndManageStudentsStub.resolves(true);
-
+          const checkUserBelongsToScoOrganizationAndManagesStudentsUseCaseStub = {
+            execute: sinon.stub().resolves(true),
+          };
           // when
           const response = await securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents(
             request,
-            hFake
+            hFake,
+            {
+              checkUserBelongsToScoOrganizationAndManagesStudentsUseCase:
+                checkUserBelongsToScoOrganizationAndManagesStudentsUseCaseStub,
+            }
           );
 
           // then
@@ -599,12 +633,18 @@ describe('Unit | Application | SecurityPreHandlers', function () {
               },
             },
           };
-          belongToScoOrganizationAndManageStudentsStub.resolves(true);
+          const checkUserBelongsToScoOrganizationAndManagesStudentsUseCaseStub = {
+            execute: sinon.stub().resolves(true),
+          };
 
           // when
           const response = await securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents(
             request,
-            hFake
+            hFake,
+            {
+              checkUserBelongsToScoOrganizationAndManagesStudentsUseCase:
+                checkUserBelongsToScoOrganizationAndManagesStudentsUseCaseStub,
+            }
           );
 
           // then
@@ -617,9 +657,15 @@ describe('Unit | Application | SecurityPreHandlers', function () {
       it('should forbid resource access when user was not previously authenticated', async function () {
         // given
         delete request.auth.credentials;
+        const checkUserBelongsToScoOrganizationAndManagesStudentsUseCaseStub = {
+          execute: sinon.stub(),
+        };
 
         // when
-        const response = await securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents(request, hFake);
+        const response = await securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents(request, hFake, {
+          checkUserBelongsToScoOrganizationAndManagesStudentsUseCase:
+            checkUserBelongsToScoOrganizationAndManagesStudentsUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -628,10 +674,15 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when user does not belong to SCO Organization or manage students', async function () {
         // given
-        belongToScoOrganizationAndManageStudentsStub.resolves(false);
+        const checkUserBelongsToScoOrganizationAndManagesStudentsUseCaseStub = {
+          execute: sinon.stub().resolves(false),
+        };
 
         // when
-        const response = await securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents(request, hFake);
+        const response = await securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents(request, hFake, {
+          checkUserBelongsToScoOrganizationAndManagesStudentsUseCase:
+            checkUserBelongsToScoOrganizationAndManagesStudentsUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -640,10 +691,14 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when an error is thrown by use case', async function () {
         // given
-        belongToScoOrganizationAndManageStudentsStub.rejects(new Error('Some error'));
-
+        const checkUserBelongsToScoOrganizationAndManagesStudentsUseCaseStub = {
+          execute: sinon.stub().rejects(new Error('Some error')),
+        };
         // when
-        const response = await securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents(request, hFake);
+        const response = await securityPreHandlers.checkUserBelongsToScoOrganizationAndManagesStudents(request, hFake, {
+          checkUserBelongsToScoOrganizationAndManagesStudentsUseCase:
+            checkUserBelongsToScoOrganizationAndManagesStudentsUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -738,11 +793,9 @@ describe('Unit | Application | SecurityPreHandlers', function () {
   });
 
   describe('#checkUserIsMemberOfAnOrganization', function () {
-    let isMemberOfAnOrganizationStub;
     let request;
 
     beforeEach(function () {
-      isMemberOfAnOrganizationStub = sinon.stub(checkUserIsMemberOfAnOrganizationUseCase, 'execute');
       request = {
         auth: {
           credentials: {
@@ -756,10 +809,14 @@ describe('Unit | Application | SecurityPreHandlers', function () {
     context('Successful case', function () {
       it('should authorize access to resource when the user is authenticated and member of an organization', async function () {
         // given
-        isMemberOfAnOrganizationStub.resolves(true);
+        const checkUserIsMemberOfAnOrganizationUseCaseStub = {
+          execute: sinon.stub().resolves(true),
+        };
 
         // when
-        const response = await securityPreHandlers.checkUserIsMemberOfAnOrganization(request, hFake);
+        const response = await securityPreHandlers.checkUserIsMemberOfAnOrganization(request, hFake, {
+          checkUserIsMemberOfAnOrganizationUseCase: checkUserIsMemberOfAnOrganizationUseCaseStub,
+        });
         // then
         expect(response.source).to.equal(true);
       });
@@ -769,9 +826,14 @@ describe('Unit | Application | SecurityPreHandlers', function () {
       it('should forbid resource access when user was not previously authenticated', async function () {
         // given
         delete request.auth.credentials;
+        const checkUserIsMemberOfAnOrganizationUseCaseStub = {
+          execute: sinon.stub(),
+        };
 
         // when
-        const response = await securityPreHandlers.checkUserIsMemberOfAnOrganization(request, hFake);
+        const response = await securityPreHandlers.checkUserIsMemberOfAnOrganization(request, hFake, {
+          checkUserIsMemberOfAnOrganizationUseCase: checkUserIsMemberOfAnOrganizationUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -780,10 +842,14 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when user is not a member of any organization', async function () {
         // given
-        isMemberOfAnOrganizationStub.resolves(false);
+        const checkUserIsMemberOfAnOrganizationUseCaseStub = {
+          execute: sinon.stub().resolves(false),
+        };
 
         // when
-        const response = await securityPreHandlers.checkUserIsMemberOfAnOrganization(request, hFake);
+        const response = await securityPreHandlers.checkUserIsMemberOfAnOrganization(request, hFake, {
+          checkUserIsMemberOfAnOrganizationUseCase: checkUserIsMemberOfAnOrganizationUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -792,10 +858,14 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when an error is thrown by use case', async function () {
         // given
-        isMemberOfAnOrganizationStub.rejects(new Error('Some error'));
+        const checkUserIsMemberOfAnOrganizationUseCaseStub = {
+          execute: sinon.stub().rejects(new Error('Some error')),
+        };
 
         // when
-        const response = await securityPreHandlers.checkUserIsMemberOfAnOrganization(request, hFake);
+        const response = await securityPreHandlers.checkUserIsMemberOfAnOrganization(request, hFake, {
+          checkUserIsMemberOfAnOrganizationUseCase: checkUserIsMemberOfAnOrganizationUseCaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -820,10 +890,14 @@ describe('Unit | Application | SecurityPreHandlers', function () {
         };
 
         sinon.stub(tokenService, 'extractTokenFromAuthChain');
-        sinon.stub(checkUserIsMemberOfCertificationCenterUseCase, 'execute').resolves(true);
+        const checkUserIsMemberOfCertificationCenterUsecaseStub = {
+          execute: sinon.stub().resolves(true),
+        };
 
         // when
-        const response = await securityPreHandlers.checkUserIsMemberOfCertificationCenter(request, hFake);
+        const response = await securityPreHandlers.checkUserIsMemberOfCertificationCenter(request, hFake, {
+          checkUserIsMemberOfCertificationCenterUsecase: checkUserIsMemberOfCertificationCenterUsecaseStub,
+        });
 
         // then
         expect(response.source).to.equal(true);
@@ -841,10 +915,14 @@ describe('Unit | Application | SecurityPreHandlers', function () {
         };
 
         sinon.stub(tokenService, 'extractTokenFromAuthChain');
-        sinon.stub(checkUserIsMemberOfCertificationCenterUseCase, 'execute').resolves(false);
+        const checkUserIsMemberOfCertificationCenterUsecaseStub = {
+          execute: sinon.stub().resolves(false),
+        };
 
         // when
-        const response = await securityPreHandlers.checkUserIsMemberOfCertificationCenter(request, hFake);
+        const response = await securityPreHandlers.checkUserIsMemberOfCertificationCenter(request, hFake, {
+          checkUserIsMemberOfCertificationCenterUsecase: checkUserIsMemberOfCertificationCenterUsecaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -867,13 +945,13 @@ describe('Unit | Application | SecurityPreHandlers', function () {
         };
 
         sinon.stub(tokenService, 'extractTokenFromAuthChain');
-        sinon
-          .stub(checkAuthorizationToManageCampaignUsecase, 'execute')
-          .withArgs({ userId: user.id, campaignId: campaign.id })
-          .resolves(true);
-
+        const checkAuthorizationToManageCampaignUsecaseStub = {
+          execute: sinon.stub().resolves(true),
+        };
         // when
-        const response = await securityPreHandlers.checkAuthorizationToManageCampaign(request, hFake);
+        const response = await securityPreHandlers.checkAuthorizationToManageCampaign(request, hFake, {
+          checkAuthorizationToManageCampaignUsecase: checkAuthorizationToManageCampaignUsecaseStub,
+        });
 
         // then
         expect(response.source).to.equal(true);
@@ -895,13 +973,14 @@ describe('Unit | Application | SecurityPreHandlers', function () {
         };
 
         sinon.stub(tokenService, 'extractTokenFromAuthChain');
-        sinon
-          .stub(checkAuthorizationToManageCampaignUsecase, 'execute')
-          .withArgs({ userId: user.id, campaignId: campaign.id })
-          .resolves(false);
+        const checkAuthorizationToManageCampaignUsecaseStub = {
+          execute: sinon.stub().resolves(false),
+        };
 
         // when
-        const response = await securityPreHandlers.checkAuthorizationToManageCampaign(request, hFake);
+        const response = await securityPreHandlers.checkAuthorizationToManageCampaign(request, hFake, {
+          checkAuthorizationToManageCampaignUsecase: checkAuthorizationToManageCampaignUsecaseStub,
+        });
 
         // then
         expect(response.statusCode).to.equal(403);
@@ -914,12 +993,9 @@ describe('Unit | Application | SecurityPreHandlers', function () {
     context('Successful case', function () {
       it('should authorize access to resource when the user is a member of the organization center', async function () {
         // given
-        const userId = 123;
-        const certificationCourseId = 7;
-        sinon
-          .stub(checkUserIsMemberOfCertificationCenterSessionUsecase, 'execute')
-          .withArgs({ userId, certificationCourseId })
-          .resolves(true);
+        const checkUserIsMemberOfCertificationCenterSessionUsecaseStub = {
+          execute: sinon.stub().resolves(true),
+        };
 
         // when
         const response =
@@ -928,7 +1004,11 @@ describe('Unit | Application | SecurityPreHandlers', function () {
               auth: { credentials: { accessToken: 'valid.access.token', userId: 123 } },
               params: { id: 7 },
             },
-            hFake
+            hFake,
+            {
+              checkUserIsMemberOfCertificationCenterSessionUsecase:
+                checkUserIsMemberOfCertificationCenterSessionUsecaseStub,
+            }
           );
 
         // then
@@ -938,11 +1018,20 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
     context('Error cases', function () {
       it('should forbid resource access when user was not previously authenticated', async function () {
-        // given & when
+        // given
+        const checkUserIsMemberOfCertificationCenterSessionUsecaseStub = {
+          execute: sinon.stub(),
+        };
+
+        // when
         const response =
           await securityPreHandlers.checkUserIsMemberOfCertificationCenterSessionFromCertificationCourseId(
             { auth: { credentials: {} }, params: { id: 5678 } },
-            hFake
+            hFake,
+            {
+              checkUserIsMemberOfCertificationCenterSessionUsecase:
+                checkUserIsMemberOfCertificationCenterSessionUsecaseStub,
+            }
           );
 
         // then
@@ -952,13 +1041,19 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when user is not a member of the organization center', async function () {
         // given
-        sinon.stub(checkUserIsMemberOfCertificationCenterSessionUsecase, 'execute').resolves(false);
+        const checkUserIsMemberOfCertificationCenterSessionUsecaseStub = {
+          execute: sinon.stub().resolves(false),
+        };
 
         // when
         const response =
           await securityPreHandlers.checkUserIsMemberOfCertificationCenterSessionFromCertificationCourseId(
             { auth: { credentials: { accessToken: 'valid.access.token', userId: 1 } }, params: { id: 5678 } },
-            hFake
+            hFake,
+            {
+              checkUserIsMemberOfCertificationCenterSessionUsecase:
+                checkUserIsMemberOfCertificationCenterSessionUsecaseStub,
+            }
           );
 
         // then
@@ -968,13 +1063,19 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when an error is thrown by use case', async function () {
         // given
-        sinon.stub(checkUserIsMemberOfCertificationCenterSessionUsecase, 'execute').rejects(new Error('Some error'));
+        const checkUserIsMemberOfCertificationCenterSessionUsecaseStub = {
+          execute: sinon.stub().rejects(new Error('Some error')),
+        };
 
         // when
         const response =
           await securityPreHandlers.checkUserIsMemberOfCertificationCenterSessionFromCertificationCourseId(
             { auth: { credentials: { accessToken: 'valid.access.token', userId: 1 } }, params: { id: 5678 } },
-            hFake
+            hFake,
+            {
+              checkUserIsMemberOfCertificationCenterSessionUsecase:
+                checkUserIsMemberOfCertificationCenterSessionUsecaseStub,
+            }
           );
 
         // then
@@ -988,18 +1089,14 @@ describe('Unit | Application | SecurityPreHandlers', function () {
     context('Successful case', function () {
       it('should authorize access to resource when the user is a member of the organization center', async function () {
         // given
-        const userId = 123;
         const certificationCourseId = 7;
-        const certificationIssueReportId = 666;
-        sinon
-          .stub(certificationIssueReportRepository, 'get')
-          .withArgs(certificationIssueReportId)
-          .resolves({ certificationCourseId });
-        sinon
-          .stub(checkUserIsMemberOfCertificationCenterSessionUsecase, 'execute')
-          .withArgs({ userId, certificationCourseId })
-          .resolves(true);
 
+        const certificationIssueReportRepositoryStub = {
+          get: sinon.stub().withArgs(certificationCourseId).resolves({ certificationCourseId }),
+        };
+        const checkUserIsMemberOfCertificationCenterSessionUsecaseStub = {
+          execute: sinon.stub().resolves(true),
+        };
         // when
         const response =
           await securityPreHandlers.checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId(
@@ -1007,7 +1104,12 @@ describe('Unit | Application | SecurityPreHandlers', function () {
               auth: { credentials: { accessToken: 'valid.access.token', userId: 123 } },
               params: { id: 666 },
             },
-            hFake
+            hFake,
+            {
+              certificationIssueReportRepository: certificationIssueReportRepositoryStub,
+              checkUserIsMemberOfCertificationCenterSessionUsecase:
+                checkUserIsMemberOfCertificationCenterSessionUsecaseStub,
+            }
           );
 
         // then
@@ -1017,11 +1119,25 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
     context('Error cases', function () {
       it('should forbid resource access when user was not previously authenticated', async function () {
-        // given & when
+        // given
+        const certificationIssueReportRepositoryStub = {
+          get: sinon.stub(),
+        };
+
+        const checkUserIsMemberOfCertificationCenterSessionUsecaseStub = {
+          execute: sinon.stub(),
+        };
+
+        // when
         const response =
           await securityPreHandlers.checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId(
             { auth: { credentials: {} }, params: { id: 5678 } },
-            hFake
+            hFake,
+            {
+              certificationIssueReportRepository: certificationIssueReportRepositoryStub,
+              checkUserIsMemberOfCertificationCenterSessionUsecase:
+                checkUserIsMemberOfCertificationCenterSessionUsecaseStub,
+            }
           );
 
         // then
@@ -1031,14 +1147,23 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when user is not a member of the organization center', async function () {
         // given
-        sinon.stub(certificationIssueReportRepository, 'get').resolves({ certificationCourseId: 7 });
-        sinon.stub(checkUserIsMemberOfCertificationCenterSessionUsecase, 'execute').resolves(false);
+        const checkUserIsMemberOfCertificationCenterSessionUsecaseStub = {
+          execute: sinon.stub().resolves(false),
+        };
+        const certificationIssueReportRepositoryStub = {
+          get: sinon.stub().resolves({ certificationCourseId: 7 }),
+        };
 
         // when
         const response =
           await securityPreHandlers.checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId(
             { auth: { credentials: { accessToken: 'valid.access.token', userId: 1 } }, params: { id: 666 } },
-            hFake
+            hFake,
+            {
+              certificationIssueReportRepository: certificationIssueReportRepositoryStub,
+              checkUserIsMemberOfCertificationCenterSessionUsecase:
+                checkUserIsMemberOfCertificationCenterSessionUsecaseStub,
+            }
           );
 
         // then
@@ -1048,14 +1173,23 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when an error is thrown by use case', async function () {
         // given
-        sinon.stub(certificationIssueReportRepository, 'get').resolves({ certificationCourseId: 7 });
-        sinon.stub(checkUserIsMemberOfCertificationCenterSessionUsecase, 'execute').rejects(new Error('Some error'));
+        const certificationIssueReportRepositoryStub = {
+          get: sinon.stub().resolves({ certificationCourseId: 7 }),
+        };
+        const checkUserIsMemberOfCertificationCenterSessionUsecaseStub = {
+          execute: sinon.stub().rejects(new Error('Some error')),
+        };
 
         // when
         const response =
           await securityPreHandlers.checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId(
             { auth: { credentials: { accessToken: 'valid.access.token', userId: 1 } }, params: { id: 666 } },
-            hFake
+            hFake,
+            {
+              certificationIssueReportRepository: certificationIssueReportRepositoryStub,
+              checkUserIsMemberOfCertificationCenterSessionUsecase:
+                checkUserIsMemberOfCertificationCenterSessionUsecaseStub,
+            }
           );
 
         // then
@@ -1065,13 +1199,22 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when an error is thrown by repo', async function () {
         // given
-        sinon.stub(certificationIssueReportRepository, 'get').rejects(new Error('Some error'));
-
+        const certificationIssueReportRepositoryStub = {
+          get: sinon.stub().rejects(new Error('Some error')),
+        };
+        const checkUserIsMemberOfCertificationCenterSessionUsecaseStub = {
+          execute: sinon.stub(),
+        };
         // when
         const response =
           await securityPreHandlers.checkUserIsMemberOfCertificationCenterSessionFromCertificationIssueReportId(
             { auth: { credentials: { accessToken: 'valid.access.token', userId: 1 } }, params: { id: 666 } },
-            hFake
+            hFake,
+            {
+              certificationIssueReportRepository: certificationIssueReportRepositoryStub,
+              checkUserIsMemberOfCertificationCenterSessionUsecase:
+                checkUserIsMemberOfCertificationCenterSessionUsecaseStub,
+            }
           );
 
         // then
@@ -1085,12 +1228,9 @@ describe('Unit | Application | SecurityPreHandlers', function () {
     context('Successful case', function () {
       it('should authorize access to resource when the user owns the certification course', async function () {
         // given
-        const userId = 123;
-        const certificationCourseId = 7;
-        sinon
-          .stub(checkUserOwnsCertificationCourseUseCase, 'execute')
-          .withArgs({ userId, certificationCourseId })
-          .resolves(true);
+        const checkUserOwnsCertificationCourseUseCaseStub = {
+          execute: sinon.stub().resolves(true),
+        };
 
         // when
         const response = await securityPreHandlers.checkUserOwnsCertificationCourse(
@@ -1098,7 +1238,10 @@ describe('Unit | Application | SecurityPreHandlers', function () {
             auth: { credentials: { accessToken: 'valid.access.token', userId: 123 } },
             params: { id: 7 },
           },
-          hFake
+          hFake,
+          {
+            checkUserOwnsCertificationCourseUseCase: checkUserOwnsCertificationCourseUseCaseStub,
+          }
         );
 
         // then
@@ -1108,10 +1251,18 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
     context('Error cases', function () {
       it('should forbid resource access when user was not previously authenticated', async function () {
-        // given & when
+        // given
+        const checkUserOwnsCertificationCourseUseCaseStub = {
+          execute: sinon.stub(),
+        };
+
+        // when
         const response = await securityPreHandlers.checkUserOwnsCertificationCourse(
           { auth: { credentials: {} }, params: { id: 5678 } },
-          hFake
+          hFake,
+          {
+            checkUserOwnsCertificationCourseUseCase: checkUserOwnsCertificationCourseUseCaseStub,
+          }
         );
 
         // then
@@ -1121,12 +1272,17 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when user does not own the certification course', async function () {
         // given
-        sinon.stub(checkUserOwnsCertificationCourseUseCase, 'execute').resolves(false);
+        const checkUserOwnsCertificationCourseUseCaseStub = {
+          execute: sinon.stub().resolves(false),
+        };
 
         // when
         const response = await securityPreHandlers.checkUserOwnsCertificationCourse(
           { auth: { credentials: { accessToken: 'valid.access.token', userId: 1 } }, params: { id: 5678 } },
-          hFake
+          hFake,
+          {
+            checkUserOwnsCertificationCourseUseCase: checkUserOwnsCertificationCourseUseCaseStub,
+          }
         );
 
         // then
@@ -1136,12 +1292,17 @@ describe('Unit | Application | SecurityPreHandlers', function () {
 
       it('should forbid resource access when an error is thrown by use case', async function () {
         // given
-        sinon.stub(checkUserOwnsCertificationCourseUseCase, 'execute').rejects(new Error('Some error'));
+        const checkUserOwnsCertificationCourseUseCaseStub = {
+          execute: sinon.stub().rejects(new Error('Some error')),
+        };
 
         // when
         const response = await securityPreHandlers.checkUserOwnsCertificationCourse(
           { auth: { credentials: { accessToken: 'valid.access.token', userId: 1 } }, params: { id: 5678 } },
-          hFake
+          hFake,
+          {
+            checkUserOwnsCertificationCourseUseCase: checkUserOwnsCertificationCourseUseCaseStub,
+          }
         );
 
         // then


### PR DESCRIPTION
## :unicorn: Problème
Le passage des modules en ESM est bloqué par nos stub de dépendances. Pour régler cela nous devons injecter les dépendances.

## :robot: Proposition
Faire de l'injection de dépendances quand cela est nécessaire.

## :rainbow: Remarques
Un wrapper a été créé pour le tokenService afin de ne pas avoir à réécrire trop de tests. Cela permet de gagner du temps et de faire fonctionner le stub sinon sur le token service. Cependant, on n'exclu pas de réaliser une injection de dépendance dans un second temps afin de se passer des wrapper qui alourdissent le code.

## :100: Pour tester
- CI OK 