### PR TITLE
[TECH] S'aligner sur les standards utilisés sur Certif dans Pix App, concernant i18N(PIX-7556)

### DIFF
--- a/mon-pix/app/adapters/application.js
+++ b/mon-pix/app/adapters/application.js
@@ -2,9 +2,9 @@ import { inject as service } from '@ember/service';
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import ENV from 'mon-pix/config/environment';
 
-const FRENCH_DOMAIN_EXTENSION = 'fr';
-const FRENCH_LOCALE = 'fr-fr';
-const FRENCHSPOKEN_LOCALE = 'fr';
+const FRANCE_TLD = 'fr';
+const FRENCH_FRANCE_LOCALE = 'fr-fr';
+const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 
 export default class Application extends JSONAPIAdapter {
   @service currentDomain;
@@ -30,8 +30,8 @@ export default class Application extends JSONAPIAdapter {
 
   get _locale() {
     const currentLocale = this.intl.get('locale')[0];
-    if (currentLocale === 'fr') {
-      return this.currentDomain.getExtension() === FRENCH_DOMAIN_EXTENSION ? FRENCH_LOCALE : FRENCHSPOKEN_LOCALE;
+    if (currentLocale === FRENCH_INTERNATIONAL_LOCALE) {
+      return this.currentDomain.getExtension() === FRANCE_TLD ? FRENCH_FRANCE_LOCALE : FRENCH_INTERNATIONAL_LOCALE;
     }
     return currentLocale;
   }

--- a/mon-pix/app/components/dashboard/content.js
+++ b/mon-pix/app/components/dashboard/content.js
@@ -7,7 +7,7 @@ export default class Content extends Component {
   MAX_SCORECARDS_TO_DISPLAY = 4;
 
   @service currentUser;
-  @service url;
+  @service currentDomain;
   @service intl;
 
   get hasNothingToShow() {
@@ -88,8 +88,8 @@ export default class Content extends Component {
 
   get newDashboardInfoLink() {
     return {
-      text: this.url.isFrenchDomainExtension ? this.intl.t('pages.dashboard.presentation.link.text') : null,
-      url: this.url.isFrenchDomainExtension ? this.intl.t('pages.dashboard.presentation.link.url') : null,
+      text: this.currentDomain.isFranceDomain ? this.intl.t('pages.dashboard.presentation.link.text') : null,
+      url: this.currentDomain.isFranceDomain ? this.intl.t('pages.dashboard.presentation.link.url') : null,
     };
   }
 }

--- a/mon-pix/app/components/footer.js
+++ b/mon-pix/app/components/footer.js
@@ -7,7 +7,7 @@ export default class Footer extends Component {
   @service currentDomain;
 
   get shouldShowTheMarianneLogo() {
-    return this.url.isFrenchDomainExtension;
+    return this.currentDomain.isFranceDomain;
   }
 
   get currentYear() {

--- a/mon-pix/app/components/inaccessible-campaign.js
+++ b/mon-pix/app/components/inaccessible-campaign.js
@@ -2,9 +2,9 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 
 export default class InaccessibleCampaign extends Component {
-  @service url;
+  @service currentDomain;
 
   get shouldShowTheMarianneLogo() {
-    return this.url.isFrenchDomainExtension;
+    return this.currentDomain.isFranceDomain;
   }
 }

--- a/mon-pix/app/components/navbar-header.js
+++ b/mon-pix/app/components/navbar-header.js
@@ -2,9 +2,9 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class NavbarHeader extends Component {
-  @service url;
+  @service currentDomain;
 
   get isFrenchDomainExtension() {
-    return this.url.isFrenchDomainExtension;
+    return this.currentDomain.isFranceDomain;
   }
 }

--- a/mon-pix/app/components/signin-form.js
+++ b/mon-pix/app/components/signin-form.js
@@ -8,6 +8,7 @@ import get from 'lodash/get';
 
 export default class SigninForm extends Component {
   @service url;
+  @service currentDomain;
   @service intl;
   @service featureToggles;
   @service session;
@@ -25,7 +26,7 @@ export default class SigninForm extends Component {
   }
 
   get displayPoleEmploiButton() {
-    return this.url.isFrenchDomainExtension;
+    return this.currentDomain.isFranceDomain;
   }
 
   get displayFwbButton() {

--- a/mon-pix/app/components/user-certifications-detail-header.js
+++ b/mon-pix/app/components/user-certifications-detail-header.js
@@ -8,7 +8,7 @@ export default class UserCertificationsDetailHeader extends Component {
   @service intl;
   @service fileSaver;
   @service session;
-  @service url;
+  @service currentDomain;
 
   @tracked tooltipText = this.intl.t('pages.certificate.verification-code.copy');
   @tracked attestationDownloadErrorMessage = null;
@@ -26,7 +26,7 @@ export default class UserCertificationsDetailHeader extends Component {
   async downloadAttestation() {
     this.attestationDownloadErrorMessage = null;
     const certifId = this.args.certification.id;
-    const url = `/api/attestation/${certifId}?isFrenchDomainExtension=${this.url.isFrenchDomainExtension}`;
+    const url = `/api/attestation/${certifId}?isFrenchDomainExtension=${this.currentDomain.isFranceDomain}`;
     const fileName = 'attestation_pix.pdf';
     const token = this.session.data.authenticated.access_token;
     try {

--- a/mon-pix/app/controllers/authenticated/user-account.js
+++ b/mon-pix/app/controllers/authenticated/user-account.js
@@ -2,9 +2,9 @@ import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 
 export default class UserAccountController extends Controller {
-  @service url;
+  @service currentDomain;
 
-  get displayLanguageSwitch() {
-    return !this.url.isFrenchDomainExtension;
+  get isInternationalDomain() {
+    return !this.currentDomain.isFranceDomain;
   }
 }

--- a/mon-pix/app/controllers/authenticated/user-account/language.js
+++ b/mon-pix/app/controllers/authenticated/user-account/language.js
@@ -4,12 +4,12 @@ import { inject as service } from '@ember/service';
 
 export default class UserAccountPersonalInformationController extends Controller {
   @service intl;
-  @service url;
+  @service currentDomain;
   @service location;
 
   @action
   async onLanguageChange(value) {
-    if (!this.url.isFrenchDomainExtension) {
+    if (!this.currentDomain.isFranceDomain) {
       this.location.replace(`/mon-compte/langue?lang=${value}`);
     }
   }

--- a/mon-pix/app/models/certification.js
+++ b/mon-pix/app/models/certification.js
@@ -9,7 +9,7 @@ export const ACQUIRED = 'acquired';
 const professionalizingDate = new Date('2022-01-01');
 
 export default class Certification extends Model {
-  @service url;
+  @service currentDomain;
 
   static PARTNER_KEY_CLEA = 'PIX_EMPLOI_CLEA';
   // attributes
@@ -43,7 +43,7 @@ export default class Certification extends Model {
   }
 
   get shouldDisplayProfessionalizingWarning() {
-    return this.url.isFrenchDomainExtension && new Date(this.deliveredAt).getTime() >= professionalizingDate.getTime();
+    return this.currentDomain.isFranceDomain && new Date(this.deliveredAt).getTime() >= professionalizingDate.getTime();
   }
 
   get maxReachablePixCountOnCertificationDate() {

--- a/mon-pix/app/services/current-domain.js
+++ b/mon-pix/app/services/current-domain.js
@@ -7,7 +7,6 @@ export default class CurrentDomainService extends Service {
   getExtension() {
     return last(location.hostname.split('.'));
   }
-
   get isFranceDomain() {
     return this.getExtension() === FRANCE_TLD;
   }

--- a/mon-pix/app/services/session.js
+++ b/mon-pix/app/services/session.js
@@ -2,7 +2,9 @@ import { inject as service } from '@ember/service';
 import SessionService from 'ember-simple-auth/services/session';
 import get from 'lodash/get';
 
-const FRENCH_LOCALE = 'fr-FR';
+const DEFAULT_LOCALE = 'fr';
+const FRENCH_FRANCE_LOCALE = 'fr-FR';
+const FRANCE_TLD = 'fr';
 
 export default class CurrentSessionService extends SessionService {
   @service currentUser;
@@ -89,13 +91,12 @@ export default class CurrentSessionService extends SessionService {
   async _handleLocale(localeFromQueryParam = null) {
     const isUserLoaded = !!this.currentUser.user;
     const domain = this.currentDomain.getExtension();
-    const defaultLocale = 'fr';
 
-    if (domain === 'fr') {
-      await this._setLocale(defaultLocale);
+    if (domain === FRANCE_TLD) {
+      await this._setLocale(DEFAULT_LOCALE);
 
       if (!this.locale.hasLocaleCookie()) {
-        this.locale.setLocaleCookie(FRENCH_LOCALE);
+        this.locale.setLocaleCookie(FRENCH_FRANCE_LOCALE);
       }
       return;
     }
@@ -122,14 +123,13 @@ export default class CurrentSessionService extends SessionService {
       if (localeFromQueryParam) {
         await this._setLocale(localeFromQueryParam);
       } else {
-        await this._setLocale(defaultLocale);
+        await this._setLocale(DEFAULT_LOCALE);
       }
     }
   }
 
   _setLocale(locale) {
-    const defaultLocale = 'fr';
-    this.intl.setLocale([locale, defaultLocale]);
+    this.intl.setLocale([locale, DEFAULT_LOCALE]);
     this.dayjs.setLocale(locale);
   }
 

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -2,7 +2,9 @@ import Service from '@ember/service';
 import { inject as service } from '@ember/service';
 import ENV from 'mon-pix/config/environment';
 
-const FRENCH_DOMAIN_EXTENSION = 'fr';
+const FRANCE_TLD = 'fr';
+const FRENCH_INTERNATIONAL_LOCALE = 'fr';
+const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 
 export default class Url extends Service {
   @service currentDomain;
@@ -11,7 +13,7 @@ export default class Url extends Service {
   definedHomeUrl = ENV.rootURL;
 
   get isFrenchDomainExtension() {
-    return this.currentDomain.getExtension() === FRENCH_DOMAIN_EXTENSION;
+    return this.currentDomain.getExtension() === FRANCE_TLD;
   }
 
   get showcase() {
@@ -26,10 +28,10 @@ export default class Url extends Service {
   get cguUrl() {
     const tld = this.currentDomain.getExtension();
     const currentLanguage = this.intl.t('current-lang');
-    if (tld === 'fr') {
+    if (tld === FRANCE_TLD) {
       return `https://pix.fr/conditions-generales-d-utilisation`;
     }
-    return currentLanguage === 'fr'
+    return currentLanguage === FRENCH_INTERNATIONAL_LOCALE
       ? 'https://pix.org/fr/conditions-generales-d-utilisation'
       : 'https://pix.org/en-gb/terms-and-conditions';
   }
@@ -37,11 +39,11 @@ export default class Url extends Service {
   get dataProtectionPolicyUrl() {
     const tld = this.currentDomain.getExtension();
     const currentLanguage = this.intl.t('current-lang');
-    if (tld === 'fr') {
+    if (tld === FRANCE_TLD) {
       return `https://pix.fr/politique-protection-donnees-personnelles-app`;
     }
 
-    return currentLanguage === 'fr'
+    return currentLanguage === FRENCH_INTERNATIONAL_LOCALE
       ? 'https://pix.org/fr/politique-protection-donnees-personnelles-app'
       : 'https://pix.org/en-gb/personal-data-protection-policy';
   }
@@ -49,7 +51,7 @@ export default class Url extends Service {
   get _showcaseWebsiteUrl() {
     const currentLanguage = this.intl.t('current-lang');
 
-    if (currentLanguage === 'en') {
+    if (currentLanguage === ENGLISH_INTERNATIONAL_LOCALE) {
       return `https://pix.${this.currentDomain.getExtension()}/en-gb`;
     }
     return `https://pix.${this.currentDomain.getExtension()}`;
@@ -63,16 +65,18 @@ export default class Url extends Service {
     const tld = this.currentDomain.getExtension();
     const currentLanguage = this.intl.t('current-lang');
 
-    if (tld === 'fr') {
+    if (tld === FRANCE_TLD) {
       return `https://pix.fr/accessibilite`;
     }
-    return currentLanguage === 'fr' ? `https://pix.org/fr/accessibilite` : `https://pix.org/en-gb/accessibility`;
+    return currentLanguage === FRENCH_INTERNATIONAL_LOCALE
+      ? `https://pix.org/fr/accessibilite`
+      : `https://pix.org/en-gb/accessibility`;
   }
 
   get accessibilityHelpUrl() {
     const currentLanguage = this.intl.t('current-lang');
 
-    if (currentLanguage === 'en') {
+    if (currentLanguage === ENGLISH_INTERNATIONAL_LOCALE) {
       return `https://pix.${this.currentDomain.getExtension()}/en-gb/help-accessibility`;
     }
     return `https://pix.${this.currentDomain.getExtension()}/aide-accessibilite`;
@@ -81,7 +85,7 @@ export default class Url extends Service {
   get supportHomeUrl() {
     const currentLanguage = this.intl.t('current-lang');
 
-    if (currentLanguage === 'en') {
+    if (currentLanguage === ENGLISH_INTERNATIONAL_LOCALE) {
       return 'https://support.pix.org/en/support/home';
     }
     return 'https://support.pix.org/fr/support/home';

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -2,7 +2,6 @@ import Service from '@ember/service';
 import { inject as service } from '@ember/service';
 import ENV from 'mon-pix/config/environment';
 
-const FRANCE_TLD = 'fr';
 const FRENCH_INTERNATIONAL_LOCALE = 'fr';
 const ENGLISH_INTERNATIONAL_LOCALE = 'en';
 
@@ -11,10 +10,6 @@ export default class Url extends Service {
   @service intl;
 
   definedHomeUrl = ENV.rootURL;
-
-  get isFrenchDomainExtension() {
-    return this.currentDomain.getExtension() === FRANCE_TLD;
-  }
 
   get showcase() {
     return { url: this._showcaseWebsiteUrl, linkText: this._showcaseWebsiteLinkText };
@@ -26,9 +21,8 @@ export default class Url extends Service {
   }
 
   get cguUrl() {
-    const tld = this.currentDomain.getExtension();
     const currentLanguage = this.intl.t('current-lang');
-    if (tld === FRANCE_TLD) {
+    if (this.currentDomain.isFranceDomain) {
       return `https://pix.fr/conditions-generales-d-utilisation`;
     }
     return currentLanguage === FRENCH_INTERNATIONAL_LOCALE
@@ -37,9 +31,8 @@ export default class Url extends Service {
   }
 
   get dataProtectionPolicyUrl() {
-    const tld = this.currentDomain.getExtension();
     const currentLanguage = this.intl.t('current-lang');
-    if (tld === FRANCE_TLD) {
+    if (this.currentDomain.isFranceDomain) {
       return `https://pix.fr/politique-protection-donnees-personnelles-app`;
     }
 
@@ -62,10 +55,8 @@ export default class Url extends Service {
   }
 
   get accessibilityUrl() {
-    const tld = this.currentDomain.getExtension();
     const currentLanguage = this.intl.t('current-lang');
-
-    if (tld === FRANCE_TLD) {
+    if (this.currentDomain.isFranceDomain) {
       return `https://pix.fr/accessibilite`;
     }
     return currentLanguage === FRENCH_INTERNATIONAL_LOCALE
@@ -75,7 +66,6 @@ export default class Url extends Service {
 
   get accessibilityHelpUrl() {
     const currentLanguage = this.intl.t('current-lang');
-
     if (currentLanguage === ENGLISH_INTERNATIONAL_LOCALE) {
       return `https://pix.${this.currentDomain.getExtension()}/en-gb/help-accessibility`;
     }

--- a/mon-pix/app/templates/authenticated/user-account.hbs
+++ b/mon-pix/app/templates/authenticated/user-account.hbs
@@ -24,7 +24,7 @@
                 {{t "pages.user-account.connexion-methods.menu-link-title"}}
               </LinkTo>
             </li>
-            {{#if this.displayLanguageSwitch}}
+            {{#if this.isInternationalDomain}}
               <li>
                 <LinkTo @route="authenticated.user-account.language" class="user-account-menu__link">
                   <FaIcon @icon="globe" />

--- a/mon-pix/tests/integration/components/Sitemap/content_test.js
+++ b/mon-pix/tests/integration/components/Sitemap/content_test.js
@@ -4,6 +4,8 @@ import { render } from '@1024pix/ember-testing-library';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
+const FRANCE_TLD = 'fr';
+
 module('Integration | Component | Sitemap::Content', function (hooks) {
   setupIntlRenderingTest(hooks);
 
@@ -64,7 +66,7 @@ module('Integration | Component | Sitemap::Content', function (hooks) {
   test('should contain an external link to the list of recipient processors of Pix users ’personal data', async function (assert) {
     // given
     const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+    service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD), isFranceDomain: true };
 
     // when
     const screen = await render(hbs`<Sitemap::Content />`);
@@ -82,7 +84,7 @@ module('Integration | Component | Sitemap::Content', function (hooks) {
   test('should contain an external link to help accessibility page', async function (assert) {
     // given
     const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+    service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD), isFranceDomain: true };
 
     // when
     const screen = await render(hbs`<Sitemap::Content />`);
@@ -114,7 +116,7 @@ module('Integration | Component | Sitemap::Content', function (hooks) {
   test('should contain an external link to accessibility page', async function (assert) {
     // given
     const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+    service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD), isFranceDomain: true };
 
     // when
     const screen = await render(hbs`<Sitemap::Content />`);
@@ -132,7 +134,7 @@ module('Integration | Component | Sitemap::Content', function (hooks) {
   test('should contain an external link to cgu page', async function (assert) {
     // given
     const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+    service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD), isFranceDomain: true };
 
     // when
     const screen = await render(hbs`<Sitemap::Content />`);
@@ -150,7 +152,7 @@ module('Integration | Component | Sitemap::Content', function (hooks) {
   test('should contain an external link to data protection policy page', async function (assert) {
     // given
     const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+    service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD), isFranceDomain: true };
 
     // when
     const screen = await render(hbs`<Sitemap::Content />`);

--- a/mon-pix/tests/integration/components/dashboard/content_test.js
+++ b/mon-pix/tests/integration/components/dashboard/content_test.js
@@ -426,8 +426,8 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
 
     test('should display link on new dashboard banner when domain is pix.fr', async function (assert) {
       // given
-      class UrlStub extends Service {
-        get isFrenchDomainExtension() {
+      class CurrentDomainServiceStub extends Service {
+        get isFranceDomain() {
           return true;
         }
       }
@@ -445,7 +445,7 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       }
 
       this.owner.register('service:currentUser', CurrentUserStub);
-      this.owner.register('service:url', UrlStub);
+      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
       this.set('model', {
         campaignParticipationOverviews: [],
         campaignParticipations: [],
@@ -463,12 +463,11 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
 
     test('should hide link on new dashboard banner when domain is pix.org', async function (assert) {
       // given
-      class UrlStub extends Service {
-        get isFrenchDomainExtension() {
+      class CurrentDomainServiceStub extends Service {
+        get isFranceDomain() {
           return false;
         }
       }
-
       class CurrentUserStub extends Service {
         user = store.createRecord('user', {
           firstName: 'Banana',
@@ -482,7 +481,7 @@ module('Integration | Component | Dashboard | Content', function (hooks) {
       }
 
       this.owner.register('service:currentUser', CurrentUserStub);
-      this.owner.register('service:url', UrlStub);
+      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
       this.set('model', {
         campaignParticipationOverviews: [],
         campaignParticipations: [],

--- a/mon-pix/tests/integration/components/footer_test.js
+++ b/mon-pix/tests/integration/components/footer_test.js
@@ -30,12 +30,12 @@ module('Integration | Component | Footer', function (hooks) {
 
   test('should not display marianne logo when url does not have frenchDomainExtension', async function (assert) {
     // given
-    class UrlServiceStub extends Service {
-      get isFrenchDomainExtension() {
+    class CurrentDomainServiceStub extends Service {
+      get isFranceDomain() {
         return false;
       }
     }
-    this.owner.register('service:url', UrlServiceStub);
+    this.owner.register('service:currentDomain', CurrentDomainServiceStub);
 
     // when
     const screen = await render(hbs`<Footer />`);
@@ -46,12 +46,12 @@ module('Integration | Component | Footer', function (hooks) {
 
   test('should display marianne logo when url does have frenchDomainExtension', async function (assert) {
     // given
-    class UrlServiceStub extends Service {
-      get isFrenchDomainExtension() {
+    class CurrentDomainServiceStub extends Service {
+      get isFranceDomain() {
         return true;
       }
     }
-    this.owner.register('service:url', UrlServiceStub);
+    this.owner.register('service:currentDomain', CurrentDomainServiceStub);
 
     // when
     const screen = await render(hbs`<Footer />`);

--- a/mon-pix/tests/integration/components/inaccessible-campaign_test.js
+++ b/mon-pix/tests/integration/components/inaccessible-campaign_test.js
@@ -12,7 +12,7 @@ module('Integration | Component | inaccessible-campaign', function (hooks) {
 
   test('should not display marianne logo when url does not have frenchDomainExtension', async function (assert) {
     // given
-    this.owner.register('service:url', Service.extend({ isFrenchDomainExtension: false }));
+    this.owner.register('service:currentDomain', Service.extend({ isFranceDomain: false }));
 
     // when
     await render(hbs`<InaccessibleCampaign></InaccessibleCampaign>`);
@@ -23,7 +23,7 @@ module('Integration | Component | inaccessible-campaign', function (hooks) {
 
   test('should display marianne logo when url does have frenchDomainExtension', async function (assert) {
     // given
-    this.owner.register('service:url', Service.extend({ isFrenchDomainExtension: true }));
+    this.owner.register('service:currentDomain', Service.extend({ isFranceDomain: true }));
 
     // when
     await render(hbs`<InaccessibleCampaign></InaccessibleCampaign>`);

--- a/mon-pix/tests/integration/components/password-reset-demand-form_test.js
+++ b/mon-pix/tests/integration/components/password-reset-demand-form_test.js
@@ -11,13 +11,15 @@ import { clickByLabel } from '../../helpers/click-by-label';
 import { render } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
 
+const INTERNATIONAL_TLD = 'org';
+
 module('Integration | Component | password reset demand form', function (hooks) {
   setupIntlRenderingTest(hooks);
 
   test('renders all the necessary elements of the form', async function (assert) {
     // given
     const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns('org') };
+    service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
 
     // when
     const screen = await render(hbs`<PasswordResetDemandForm />`);

--- a/mon-pix/tests/integration/components/reset-password-form_test.js
+++ b/mon-pix/tests/integration/components/reset-password-form_test.js
@@ -8,6 +8,8 @@ import { clickByLabel } from '../../helpers/click-by-label';
 import { render } from '@1024pix/ember-testing-library';
 import sinon from 'sinon';
 
+const INTERNATIONAL_TLD = 'org';
+
 module('Integration | Component | reset password form', function (hooks) {
   setupIntlRenderingTest(hooks);
 
@@ -16,7 +18,7 @@ module('Integration | Component | reset password form', function (hooks) {
       test(`renders all the necessary elements of the form `, async function (assert) {
         // given
         const service = this.owner.lookup('service:url');
-        service.currentDomain = { getExtension: sinon.stub().returns('org') };
+        service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
 
         // when
         const screen = await render(hbs`<ResetPasswordForm />`);

--- a/mon-pix/tests/integration/components/signin-form_test.js
+++ b/mon-pix/tests/integration/components/signin-form_test.js
@@ -11,6 +11,8 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import ENV from '../../../config/environment';
 const ApiErrorMessages = ENV.APP.API_ERROR_MESSAGES;
 
+const INTERNATIONAL_TLD = 'org';
+
 module('Integration | Component | signin form', function (hooks) {
   setupIntlRenderingTest(hooks);
 
@@ -253,17 +255,21 @@ module('Integration | Component | signin form', function (hooks) {
       module('when domain is pix.org', function () {
         test('only displays a FWB button and not Pole emploi button', async function (assert) {
           // given
-          class UrlServiceStub extends Service {
-            get isFrenchDomainExtension() {
+          class CurrentDomainServiceStub extends Service {
+            get isFranceDomain() {
               return false;
             }
           }
+
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
+
           class OidcIdentityProvidersServiceStub extends Service {
             isFwbActivated() {
               return true;
             }
           }
-          this.owner.register('service:url', UrlServiceStub);
+          this.owner.register('service:currentDomain', CurrentDomainServiceStub);
           this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersServiceStub);
 
           // when
@@ -287,20 +293,25 @@ module('Integration | Component | signin form', function (hooks) {
             )
             .doesNotExist();
         });
+
         module('when fwb provider is not activated', function () {
           test("don't displays a FWB nor Pole emploi button", async function (assert) {
             // given
-            class UrlServiceStub extends Service {
-              get isFrenchDomainExtension() {
+            class CurrentDomainServiceStub extends Service {
+              get isFranceDomain() {
                 return false;
               }
             }
+
+            const service = this.owner.lookup('service:url');
+            service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
+
             class OidcIdentityProvidersServiceStub extends Service {
               isFwbActivated() {
                 return false;
               }
             }
-            this.owner.register('service:url', UrlServiceStub);
+            this.owner.register('service:currentDomain', CurrentDomainServiceStub);
             this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersServiceStub);
 
             // when
@@ -330,17 +341,21 @@ module('Integration | Component | signin form', function (hooks) {
       module('when domain is pix.fr', function () {
         test('only displays a Pole emploi button and not FWB button even if fwb connect is activated', async function (assert) {
           // given
-          class UrlServiceStub extends Service {
-            get isFrenchDomainExtension() {
+          class CurrentDomainServiceStub extends Service {
+            get isFranceDomain() {
               return true;
             }
           }
+
+          const service = this.owner.lookup('service:url');
+          service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
+
           class OidcIdentityProvidersServiceStub extends Service {
             isFwbActivated() {
               return true;
             }
           }
-          this.owner.register('service:url', UrlServiceStub);
+          this.owner.register('service:currentDomain', CurrentDomainServiceStub);
           this.owner.register('service:oidcIdentityProviders', OidcIdentityProvidersServiceStub);
 
           // when

--- a/mon-pix/tests/integration/components/user-certifications-detail-header_test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-header_test.js
@@ -90,13 +90,13 @@ module('Integration | Component | user certifications detail header', function (
 
   module('when domain is french', function (hooks) {
     hooks.beforeEach(function () {
-      class UrlServiceStub extends Service {
-        get isFrenchDomainExtension() {
+      class CurrentDomainServiceStub extends Service {
+        get isFranceDomain() {
           return true;
         }
       }
 
-      this.owner.register('service:url', UrlServiceStub);
+      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
     });
 
     module('when certification is delivered after 2022-01-01', function () {
@@ -209,13 +209,14 @@ module('Integration | Component | user certifications detail header', function (
   module('when domain is not french', function () {
     test('should not display the professionalizing warning', async function (assert) {
       // given
-      class UrlServiceStub extends Service {
-        get isFrenchDomainExtension() {
+      class CurrentDomainServiceStub extends Service {
+        get isFranceDomain() {
           return false;
         }
       }
 
-      this.owner.register('service:url', UrlServiceStub);
+      this.owner.register('service:currentDomain', CurrentDomainServiceStub);
+
       const store = this.owner.lookup('service:store');
       const certification = store.createRecord('certification', {
         id: 1,

--- a/mon-pix/tests/unit/adapters/application_test.js
+++ b/mon-pix/tests/unit/adapters/application_test.js
@@ -3,6 +3,11 @@ import { setupTest } from 'ember-qunit';
 import REST from '@ember-data/adapter/rest';
 import sinon from 'sinon';
 
+const FRENCH_INTERNATIONAL_LOCALE = 'fr';
+const FRANCE_TLD = 'fr';
+const ENGLISH_INTERNATIONAL_LOCALE = 'en';
+const FRENCH_FRANCE_LOCALE = 'fr-fr';
+
 module('Unit | Adapters | ApplicationAdapter', function (hooks) {
   setupTest(hooks);
 
@@ -15,70 +20,74 @@ module('Unit | Adapters | ApplicationAdapter', function (hooks) {
   });
 
   module('get headers()', function () {
-    test('should add header with authentication token when the session is authenticated', function (assert) {
-      // Given
-      const access_token = '23456789';
-      const applicationAdapter = this.owner.lookup('adapter:application');
+    module('Authorization headers', function () {
+      test('should add header with authentication token when the session is authenticated', function (assert) {
+        // Given
+        const access_token = '23456789';
+        const applicationAdapter = this.owner.lookup('adapter:application');
 
-      // When
-      applicationAdapter.set('session', { isAuthenticated: true, data: { authenticated: { access_token } } });
+        // When
+        applicationAdapter.set('session', { isAuthenticated: true, data: { authenticated: { access_token } } });
 
-      // Then
-      assert.strictEqual(applicationAdapter.headers['Authorization'], `Bearer ${access_token}`);
-    });
-
-    test('should not add header authentication token when the session is not authenticated', function (assert) {
-      // Given
-      const applicationAdapter = this.owner.lookup('adapter:application');
-
-      // When
-      applicationAdapter.set('session', {});
-
-      // Then
-      assert.notOk(applicationAdapter.headers['Authorization']);
-    });
-
-    test('should add Accept-Language header set to fr-fr when the current domain contains pix.fr and locale is "fr"', function (assert) {
-      // Given
-      const applicationAdapter = this.owner.lookup('adapter:application');
-      applicationAdapter.intl = { get: () => ['fr'] };
-
-      // When
-      applicationAdapter.set('currentDomain', {
-        getExtension() {
-          return 'fr';
-        },
+        // Then
+        assert.strictEqual(applicationAdapter.headers['Authorization'], `Bearer ${access_token}`);
       });
 
-      // Then
-      assert.strictEqual(applicationAdapter.headers['Accept-Language'], 'fr-fr');
+      test('should not add header authentication token when the session is not authenticated', function (assert) {
+        // Given
+        const applicationAdapter = this.owner.lookup('adapter:application');
+
+        // When
+        applicationAdapter.set('session', {});
+
+        // Then
+        assert.notOk(applicationAdapter.headers['Authorization']);
+      });
     });
 
-    test('should add Accept-Language header set to fr when the current domain contains pix.digital and locale is "fr"', function (assert) {
-      // Given
-      const applicationAdapter = this.owner.lookup('adapter:application');
-      applicationAdapter.intl = { get: () => ['fr'] };
+    module('Accept-Language headers', function () {
+      test('should add Accept-Language header set to fr-fr when the current domain contains pix.fr and locale is "fr"', function (assert) {
+        // Given
+        const applicationAdapter = this.owner.lookup('adapter:application');
+        applicationAdapter.intl = { get: () => [FRENCH_INTERNATIONAL_LOCALE] };
 
-      // When
-      applicationAdapter.set('currentDomain', {
-        getExtension() {
-          return 'digital';
-        },
+        // When
+        applicationAdapter.set('currentDomain', {
+          getExtension() {
+            return FRANCE_TLD;
+          },
+        });
+
+        // Then
+        assert.strictEqual(applicationAdapter.headers['Accept-Language'], FRENCH_FRANCE_LOCALE);
       });
 
-      // Then
-      assert.strictEqual(applicationAdapter.headers['Accept-Language'], 'fr');
-    });
+      test('should add Accept-Language header set to fr when the current domain contains pix.digital and locale is "fr"', function (assert) {
+        // Given
+        const applicationAdapter = this.owner.lookup('adapter:application');
+        applicationAdapter.intl = { get: () => [FRENCH_INTERNATIONAL_LOCALE] };
 
-    test('should add Accept-Language header set to en when locale is "en"', function (assert) {
-      // Given
-      const applicationAdapter = this.owner.lookup('adapter:application');
+        // When
+        applicationAdapter.set('currentDomain', {
+          getExtension() {
+            return 'digital';
+          },
+        });
 
-      // When
-      applicationAdapter.intl = { get: () => ['en'] };
+        // Then
+        assert.strictEqual(applicationAdapter.headers['Accept-Language'], FRENCH_INTERNATIONAL_LOCALE);
+      });
 
-      // Then
-      assert.strictEqual(applicationAdapter.headers['Accept-Language'], 'en');
+      test('should add Accept-Language header set to en when locale is "en"', function (assert) {
+        // Given
+        const applicationAdapter = this.owner.lookup('adapter:application');
+
+        // When
+        applicationAdapter.intl = { get: () => [ENGLISH_INTERNATIONAL_LOCALE] };
+
+        // Then
+        assert.strictEqual(applicationAdapter.headers['Accept-Language'], ENGLISH_INTERNATIONAL_LOCALE);
+      });
     });
   });
 

--- a/mon-pix/tests/unit/controllers/authenticated/user-account/language_test.js
+++ b/mon-pix/tests/unit/controllers/authenticated/user-account/language_test.js
@@ -9,7 +9,7 @@ module('Unit | Controller | user-account/language', function (hooks) {
     test('should refresh page on change lang if domain is not french', function (assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/user-account/language');
-      controller.url = { isFrenchDomainExtension: false };
+      controller.url = { isFranceDomain: false };
       const replaceStub = sinon.stub();
       controller.location = { replace: replaceStub };
 

--- a/mon-pix/tests/unit/controllers/authenticated/user-account_test.js
+++ b/mon-pix/tests/unit/controllers/authenticated/user-account_test.js
@@ -4,23 +4,23 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Controller | user-account', function (hooks) {
   setupTest(hooks);
 
-  module('#displayLanguageSwitch', function () {
+  module('#isInternationalDomain', function () {
     test('should return false if domain is french', function (assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/user-account');
-      controller.url = { isFrenchDomainExtension: true };
+      controller.currentDomain = { isFranceDomain: true };
 
       // when / then
-      assert.false(controller.displayLanguageSwitch);
+      assert.false(controller.isInternationalDomain);
     });
 
     test('should return true if domain is not french', function (assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/user-account');
-      controller.url = { isFrenchDomainExtension: false };
+      controller.currentDomain = { isFranceDomain: false };
 
       // when / then
-      assert.true(controller.displayLanguageSwitch);
+      assert.true(controller.isInternationalDomain);
     });
   });
 });

--- a/mon-pix/tests/unit/models/certification_test.js
+++ b/mon-pix/tests/unit/models/certification_test.js
@@ -26,13 +26,12 @@ module('Unit | Model | certification', function (hooks) {
   module('#shouldDisplayProfessionalizingWarning', function () {
     module('when domain is french', function (hooks) {
       hooks.beforeEach(function () {
-        class UrlServiceStub extends Service {
-          get isFrenchDomainExtension() {
+        class CurrentDomainServiceStub extends Service {
+          get isFranceDomain() {
             return true;
           }
         }
-
-        this.owner.register('service:url', UrlServiceStub);
+        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
       });
 
       test('should be true when deliveredAt >= 2022-01-01 ', function (assert) {
@@ -55,13 +54,13 @@ module('Unit | Model | certification', function (hooks) {
     module('when domain is not french', function () {
       test('should be false', function (assert) {
         // given
-        class UrlServiceStub extends Service {
-          get isFrenchDomainExtension() {
+        class CurrentDomainServiceStub extends Service {
+          get isFranceDomain() {
             return false;
           }
         }
 
-        this.owner.register('service:url', UrlServiceStub);
+        this.owner.register('service:currentDomain', CurrentDomainServiceStub);
         const model = store.createRecord('certification', { deliveredAt: '2022-01-01' });
 
         // when / then

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -2,6 +2,12 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
+const FRANCE_TLD = 'fr';
+const INTERNATIONAL_TLD = 'org';
+
+const ENGLISH_INTERNATIONAL_LOCALE = 'en';
+const FRENCH_INTERNATIONAL_LOCALE = 'fr';
+
 import setupIntl from 'mon-pix/tests/helpers/setup-intl';
 
 module('Unit | Service | locale', function (hooks) {
@@ -11,7 +17,7 @@ module('Unit | Service | locale', function (hooks) {
   test('should have a frenchDomainExtension when the current domain contains pix.fr', function (assert) {
     // given
     const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+    service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD) };
 
     // when
     const domainExtension = service.isFrenchDomainExtension;
@@ -23,7 +29,7 @@ module('Unit | Service | locale', function (hooks) {
   test('should not have frenchDomainExtension when the current domain contains pix.org', function (assert) {
     // given
     const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns('org') };
+    service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
 
     // when
     const domainExtension = service.isFrenchDomainExtension;
@@ -60,26 +66,26 @@ module('Unit | Service | locale', function (hooks) {
 
     [
       {
-        language: 'fr',
-        currentDomainExtension: 'fr',
+        language: FRENCH_INTERNATIONAL_LOCALE,
+        currentDomainExtension: FRANCE_TLD,
         expectedShowcaseUrl: 'https://pix.fr',
         expectedShowcaseLinkText: "Page d'accueil de Pix.fr",
       },
       {
-        language: 'fr',
-        currentDomainExtension: 'org',
+        language: FRENCH_INTERNATIONAL_LOCALE,
+        currentDomainExtension: INTERNATIONAL_TLD,
         expectedShowcaseUrl: 'https://pix.org',
         expectedShowcaseLinkText: "Page d'accueil de Pix.org",
       },
       {
-        language: 'en',
-        currentDomainExtension: 'fr',
+        language: ENGLISH_INTERNATIONAL_LOCALE,
+        currentDomainExtension: FRANCE_TLD,
         expectedShowcaseUrl: 'https://pix.fr/en-gb',
         expectedShowcaseLinkText: "Pix.fr's Homepage",
       },
       {
-        language: 'en',
-        currentDomainExtension: 'org',
+        language: ENGLISH_INTERNATIONAL_LOCALE,
+        currentDomainExtension: INTERNATIONAL_TLD,
         expectedShowcaseUrl: 'https://pix.org/en-gb',
         expectedShowcaseLinkText: "Pix.org's Homepage",
       },
@@ -107,7 +113,7 @@ module('Unit | Service | locale', function (hooks) {
         // given
         const service = this.owner.lookup('service:url');
         const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
-        service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+        service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD) };
 
         // when
         const cguUrl = service.cguUrl;
@@ -121,8 +127,8 @@ module('Unit | Service | locale', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
-          service.currentDomain = { getExtension: sinon.stub().returns('fr') };
-          service.intl = { t: sinon.stub().returns('en') };
+          service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD) };
+          service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
 
           // when
           const cguUrl = service.cguUrl;
@@ -139,8 +145,8 @@ module('Unit | Service | locale', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           const expectedCguUrl = 'https://pix.org/fr/conditions-generales-d-utilisation';
-          service.currentDomain = { getExtension: sinon.stub().returns('org') };
-          service.intl = { t: sinon.stub().returns('fr') };
+          service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
+          service.intl = { t: sinon.stub().returns(FRENCH_INTERNATIONAL_LOCALE) };
 
           // when
           const cguUrl = service.cguUrl;
@@ -155,8 +161,8 @@ module('Unit | Service | locale', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           const expectedCguUrl = 'https://pix.org/en-gb/terms-and-conditions';
-          service.currentDomain = { getExtension: sinon.stub().returns('org') };
-          service.intl = { t: sinon.stub().returns('en') };
+          service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
+          service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
 
           // when
           const cguUrl = service.cguUrl;
@@ -174,7 +180,7 @@ module('Unit | Service | locale', function (hooks) {
         // given
         const service = this.owner.lookup('service:url');
         const expectedCguUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
-        service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+        service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD) };
 
         // when
         const cguUrl = service.dataProtectionPolicyUrl;
@@ -188,8 +194,8 @@ module('Unit | Service | locale', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           const expectedCguUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
-          service.currentDomain = { getExtension: sinon.stub().returns('fr') };
-          service.intl = { t: sinon.stub().returns('en') };
+          service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD) };
+          service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
 
           // when
           const cguUrl = service.dataProtectionPolicyUrl;
@@ -206,8 +212,8 @@ module('Unit | Service | locale', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           const expectedCguUrl = 'https://pix.org/fr/politique-protection-donnees-personnelles-app';
-          service.currentDomain = { getExtension: sinon.stub().returns('org') };
-          service.intl = { t: sinon.stub().returns('fr') };
+          service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
+          service.intl = { t: sinon.stub().returns(FRENCH_INTERNATIONAL_LOCALE) };
 
           // when
           const cguUrl = service.dataProtectionPolicyUrl;
@@ -222,8 +228,8 @@ module('Unit | Service | locale', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           const expectedCguUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
-          service.currentDomain = { getExtension: sinon.stub().returns('org') };
-          service.intl = { t: sinon.stub().returns('en') };
+          service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
+          service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
 
           // when
           const cguUrl = service.dataProtectionPolicyUrl;
@@ -241,7 +247,7 @@ module('Unit | Service | locale', function (hooks) {
         // given
         const service = this.owner.lookup('service:url');
         const expectedAccessibilityUrl = 'https://pix.fr/accessibilite';
-        service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+        service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD) };
 
         // when
         const accessibilityUrl = service.accessibilityUrl;
@@ -255,8 +261,8 @@ module('Unit | Service | locale', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           const expectedAccessibilityUrl = 'https://pix.fr/accessibilite';
-          service.currentDomain = { getExtension: sinon.stub().returns('fr') };
-          service.intl = { t: sinon.stub().returns('en') };
+          service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD) };
+          service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
 
           // when
           const accessibilityUrl = service.accessibilityUrl;
@@ -273,8 +279,8 @@ module('Unit | Service | locale', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           const expectedAccessibilityUrl = 'https://pix.org/fr/accessibilite';
-          service.currentDomain = { getExtension: sinon.stub().returns('org') };
-          service.intl = { t: sinon.stub().returns('fr') };
+          service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
+          service.intl = { t: sinon.stub().returns(FRENCH_INTERNATIONAL_LOCALE) };
 
           // when
           const accessibilityUrl = service.accessibilityUrl;
@@ -289,8 +295,8 @@ module('Unit | Service | locale', function (hooks) {
           // given
           const service = this.owner.lookup('service:url');
           const expectedAccessibilityUrl = 'https://pix.org/en-gb/accessibility';
-          service.currentDomain = { getExtension: sinon.stub().returns('org') };
-          service.intl = { t: sinon.stub().returns('en') };
+          service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
+          service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
 
           // when
           const accessibilityUrl = service.accessibilityUrl;

--- a/mon-pix/tests/unit/services/url_test.js
+++ b/mon-pix/tests/unit/services/url_test.js
@@ -14,30 +14,6 @@ module('Unit | Service | locale', function (hooks) {
   setupTest(hooks);
   setupIntl(hooks);
 
-  test('should have a frenchDomainExtension when the current domain contains pix.fr', function (assert) {
-    // given
-    const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD) };
-
-    // when
-    const domainExtension = service.isFrenchDomainExtension;
-
-    // then
-    assert.true(domainExtension);
-  });
-
-  test('should not have frenchDomainExtension when the current domain contains pix.org', function (assert) {
-    // given
-    const service = this.owner.lookup('service:url');
-    service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
-
-    // when
-    const domainExtension = service.isFrenchDomainExtension;
-
-    // then
-    assert.false(domainExtension);
-  });
-
   module('#homeUrl', function () {
     test('should get home url', function (assert) {
       // given
@@ -112,8 +88,8 @@ module('Unit | Service | locale', function (hooks) {
       test('returns the French page URL', function (assert) {
         // given
         const service = this.owner.lookup('service:url');
+        service.currentDomain = { isFranceDomain: true };
         const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
-        service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD) };
 
         // when
         const cguUrl = service.cguUrl;
@@ -126,9 +102,9 @@ module('Unit | Service | locale', function (hooks) {
         test('returns the French page URL', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
-          const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
-          service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD) };
+          service.currentDomain = { isFranceDomain: true };
           service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
+          const expectedCguUrl = 'https://pix.fr/conditions-generales-d-utilisation';
 
           // when
           const cguUrl = service.cguUrl;
@@ -144,9 +120,9 @@ module('Unit | Service | locale', function (hooks) {
         test('returns the French page URL', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
-          const expectedCguUrl = 'https://pix.org/fr/conditions-generales-d-utilisation';
-          service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
+          service.currentDomain = { isFranceDomain: false };
           service.intl = { t: sinon.stub().returns(FRENCH_INTERNATIONAL_LOCALE) };
+          const expectedCguUrl = 'https://pix.org/fr/conditions-generales-d-utilisation';
 
           // when
           const cguUrl = service.cguUrl;
@@ -160,6 +136,7 @@ module('Unit | Service | locale', function (hooks) {
         test('returns the English page URL', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
+          service.currentDomain = { isFranceDomain: false };
           const expectedCguUrl = 'https://pix.org/en-gb/terms-and-conditions';
           service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
           service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
@@ -179,8 +156,8 @@ module('Unit | Service | locale', function (hooks) {
       test('returns the French page URL', function (assert) {
         // given
         const service = this.owner.lookup('service:url');
+        service.currentDomain = { isFranceDomain: true };
         const expectedCguUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
-        service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD) };
 
         // when
         const cguUrl = service.dataProtectionPolicyUrl;
@@ -193,9 +170,9 @@ module('Unit | Service | locale', function (hooks) {
         test('returns the French page URL', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
-          const expectedCguUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
-          service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD) };
+          service.currentDomain = { isFranceDomain: true };
           service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
+          const expectedCguUrl = 'https://pix.fr/politique-protection-donnees-personnelles-app';
 
           // when
           const cguUrl = service.dataProtectionPolicyUrl;
@@ -211,9 +188,9 @@ module('Unit | Service | locale', function (hooks) {
         test('returns the French page URL', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
-          const expectedCguUrl = 'https://pix.org/fr/politique-protection-donnees-personnelles-app';
-          service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
+          service.currentDomain = { isFranceDomain: false };
           service.intl = { t: sinon.stub().returns(FRENCH_INTERNATIONAL_LOCALE) };
+          const expectedCguUrl = 'https://pix.org/fr/politique-protection-donnees-personnelles-app';
 
           // when
           const cguUrl = service.dataProtectionPolicyUrl;
@@ -227,9 +204,9 @@ module('Unit | Service | locale', function (hooks) {
         test('returns the English page URL', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
-          const expectedCguUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
-          service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
+          service.currentDomain = { isFranceDomain: false };
           service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
+          const expectedCguUrl = 'https://pix.org/en-gb/personal-data-protection-policy';
 
           // when
           const cguUrl = service.dataProtectionPolicyUrl;
@@ -246,8 +223,8 @@ module('Unit | Service | locale', function (hooks) {
       test('returns the French page URL', function (assert) {
         // given
         const service = this.owner.lookup('service:url');
+        service.currentDomain = { isFranceDomain: true };
         const expectedAccessibilityUrl = 'https://pix.fr/accessibilite';
-        service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD) };
 
         // when
         const accessibilityUrl = service.accessibilityUrl;
@@ -260,9 +237,9 @@ module('Unit | Service | locale', function (hooks) {
         test('returns the French page URL', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
-          const expectedAccessibilityUrl = 'https://pix.fr/accessibilite';
-          service.currentDomain = { getExtension: sinon.stub().returns(FRANCE_TLD) };
+          service.currentDomain = { isFranceDomain: true };
           service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
+          const expectedAccessibilityUrl = 'https://pix.fr/accessibilite';
 
           // when
           const accessibilityUrl = service.accessibilityUrl;
@@ -278,9 +255,9 @@ module('Unit | Service | locale', function (hooks) {
         test('returns the French page URL', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
-          const expectedAccessibilityUrl = 'https://pix.org/fr/accessibilite';
-          service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
+          service.currentDomain = { isFranceDomain: false };
           service.intl = { t: sinon.stub().returns(FRENCH_INTERNATIONAL_LOCALE) };
+          const expectedAccessibilityUrl = 'https://pix.org/fr/accessibilite';
 
           // when
           const accessibilityUrl = service.accessibilityUrl;
@@ -294,9 +271,9 @@ module('Unit | Service | locale', function (hooks) {
         test('returns the English page URL', function (assert) {
           // given
           const service = this.owner.lookup('service:url');
-          const expectedAccessibilityUrl = 'https://pix.org/en-gb/accessibility';
-          service.currentDomain = { getExtension: sinon.stub().returns(INTERNATIONAL_TLD) };
+          service.currentDomain = { isFranceDomain: false };
           service.intl = { t: sinon.stub().returns(ENGLISH_INTERNATIONAL_LOCALE) };
+          const expectedAccessibilityUrl = 'https://pix.org/en-gb/accessibility';
 
           // when
           const accessibilityUrl = service.accessibilityUrl;

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1562,14 +1562,6 @@
         }
       },
       "language": {
-        "fields": {
-          "select": {
-            "labels": {
-              "english": "English",
-              "french": "French"
-            }
-          }
-        },
         "lang": "Language",
         "menu-link-title": "Language"
       },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1562,14 +1562,6 @@
         }
       },
       "language": {
-        "fields": {
-          "select": {
-            "labels": {
-              "english": "Anglais",
-              "french": "Français"
-            }
-          }
-        },
         "lang": "Langue",
         "menu-link-title": "Choisir ma langue"
       },


### PR DESCRIPTION
## :unicorn: Problème

Nous avons améliorer notre code durant cette epix. Nous souhaitons uniformiser notre code d'une app à une autre.


## :robot: Proposition

- utilisation de constantes pour les locales/langues de manière uniforme à travers toutes nos app
- utilisation de isFranceDomain au lieu du service url

## :rainbow: Remarques


## :100: Pour tester

- Aller sur [App (.org)](https://app-pr6036.review.pix.org/)
- Se connecter
- Se rendre sur Mon compte
- Cliquer sur "Choisir ma langue"
- Vérifier la présence de l'icône et le bon wording des options

Suite au refacto :
- passer en .fr et vérifier les liens du footer ainsi que l'affichage du logo de la Marianne ou pas
