### PR TITLE
[FEATURE] Empêcher l'entrée à la tabulation sur l'embed si le simulateur n'est pas lancé sur Pix-App (PIX-7826)

### DIFF
--- a/mon-pix/app/components/challenge-embed-simulator.hbs
+++ b/mon-pix/app/components/challenge-embed-simulator.hbs
@@ -17,6 +17,7 @@
 
     <div class="embed__simulator {{unless this.isSimulatorLaunched 'blurred'}}">
       <iframe
+        tabindex={{unless this.isSimulatorLaunched "-1"}}
         class="embed__iframe"
         src="{{@embedDocument.url}}"
         title="{{@embedDocument.title}}"


### PR DESCRIPTION
## :unicorn: Problème
Suite aux retours de l'INJA, on peut accéder au simulateur à la tabulation lorsque celui-ci n'est pas encore lancé.

## :robot: Proposition
Empêcher l'entrée dans le simulateur avec un `tabindex` tant que l'app n'est pas lancé.

## :100: Pour tester
Aller sur une épreuve avec embed et vérifier que l'on ne peut pas rentrer dans l'embed s'il n'est pas lancé.
