### PR TITLE
[FEATURE] Traduction du date picker de création et de modification de session (PIX-7811).

### DIFF
--- a/certif/app/controllers/authenticated/sessions/new.js
+++ b/certif/app/controllers/authenticated/sessions/new.js
@@ -21,6 +21,10 @@ export default class SessionsNewController extends Controller {
     return this.intl.t('pages.sessions.new.extra-information');
   }
 
+  get currentLocale() {
+    return this.intl.locale[0];
+  }
+
   @action
   async createSession(event) {
     event.preventDefault();

--- a/certif/app/controllers/authenticated/sessions/update.js
+++ b/certif/app/controllers/authenticated/sessions/update.js
@@ -21,6 +21,10 @@ export default class SessionsUpdateController extends Controller {
     return `${this.intl.t('pages.sessions.update.title')} | Session ${this.session.id} | Pix Certif`;
   }
 
+  get currentLocale() {
+    return this.intl.locale[0];
+  }
+
   @action
   async updateSession(event) {
     event.preventDefault();

--- a/certif/app/templates/authenticated/sessions/new.hbs
+++ b/certif/app/templates/authenticated/sessions/new.hbs
@@ -68,7 +68,7 @@
         @onChange={{this.onDatePicked}}
         @date=""
         @dateFormat="Y-m-d"
-        @locale="fr"
+        @locale={{this.currentLocale}}
         @minDate="today"
         @name="session-date"
         class="input input--small"

--- a/certif/app/templates/authenticated/sessions/update.hbs
+++ b/certif/app/templates/authenticated/sessions/update.hbs
@@ -64,7 +64,7 @@
         @altInput={{true}}
         @onChange={{this.onDatePicked}}
         @dateFormat="Y-m-d"
-        @locale="fr"
+        @locale={{this.currentLocale}}
         @name="session-date"
         class="input input--small"
         @date={{readonly this.session.date}}


### PR DESCRIPTION
## :unicorn: Problème

Le date picker visibles dans la création de sessions unique et la modification de session ne sont pas traduits.

## :robot: Proposition

Modification de la locale passée en paramètre du date-picker

## :rainbow: Remarques

Nous ne traduisons que le date picker de sélection de date, et non celui de sélection d'heure.

Quid des tests pour current locale ?
Unitaire: Pas forcément pertinent si c'est pour avoir à tout stubber ?
Integration: Pas possible vu qu'il s'agit d'un composant tiers.
Acceptation: Le date-picker est un input que l'on remplit, on ne voit jamais la mention du mois (français ou anglais)

## :100: Pour tester

Se connecter à pix-certif en `.org` avec `?lang=en`
Créer une session unique
Constater que les choix de mois dans le date picker sont traduits en anglais
Editer la session nouvellement créée
Constater que les choix de mois dans le date picker sont traduits en anglais
