### PR TITLE
[TECH] Afficher un message explicite à l'utilisateur lorsque l'API retourne une erreur sur Pix Certif (PIX-7673).

### DIFF
--- a/admin/tests/acceptance/authenticated/team/list_test.js
+++ b/admin/tests/acceptance/authenticated/team/list_test.js
@@ -119,7 +119,7 @@ module('Acceptance | Team | List', function (hooks) {
           errors: [
             {
               code: 'UPDATE_ADMIN_MEMBER_ERROR',
-              detail: 'A problem occured while trying to update an admin member role',
+              detail: 'A problem occurred while trying to update an admin member role',
               status: '422',
               title: 'Unprocessable entity',
             },

--- a/admin/tests/unit/controllers/authenticated/certification-centers/get/invitations_test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-centers/get/invitations_test.js
@@ -7,7 +7,7 @@ module('Unit | Controller | authenticated/certification-centers/get/invitations'
   setupTest(hooks);
 
   module('#createInvitation', function () {
-    test('it should send a notification error if an error occured', async function (assert) {
+    test('it should send a notification error if an error occurred', async function (assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/certification-centers/get/invitations');
       const store = this.owner.lookup('service:store');

--- a/admin/tests/unit/controllers/authenticated/organizations/get/invitations_test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/invitations_test.js
@@ -72,7 +72,7 @@ module('Unit | Controller | authenticated/organizations/get/invitations', functi
       assert.strictEqual(controller.userEmailToInviteError, "L'adresse e-mail saisie n'est pas valide.");
     });
 
-    test('it should send a notification error if an error occured', async function (assert) {
+    test('it should send a notification error if an error occurred', async function (assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/organizations/get/invitations');
       const store = this.owner.lookup('service:store');

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -909,7 +909,7 @@ class PasswordResetDemandNotFoundError extends DomainError {
 }
 
 class AdminMemberError extends DomainError {
-  constructor(message = 'An error occured on admin member', code = 'ADMIN_MEMBER_ERROR') {
+  constructor(message = 'An error occurred on admin member', code = 'ADMIN_MEMBER_ERROR') {
     super(message, code);
     this.code = code;
     this.message = message;

--- a/api/lib/infrastructure/repositories/admin-member-repository.js
+++ b/api/lib/infrastructure/repositories/admin-member-repository.js
@@ -48,7 +48,7 @@ module.exports = {
 
     if (!updatedAdminMember) {
       throw new AdminMemberError(
-        'A problem occured while trying to update an admin member role',
+        'A problem occurred while trying to update an admin member role',
         'UPDATE_ADMIN_MEMBER_ERROR'
       );
     }
@@ -72,7 +72,7 @@ module.exports = {
 
     if (!deactivateddAdminMember) {
       throw new AdminMemberError(
-        'A problem occured while trying to deactivate an admin member',
+        'A problem occurred while trying to deactivate an admin member',
         'DEACTIVATE_ADMIN_MEMBER_ERROR'
       );
     }

--- a/api/tests/acceptance/application/passwords/password-controller_test.js
+++ b/api/tests/acceptance/application/passwords/password-controller_test.js
@@ -64,7 +64,7 @@ describe('Acceptance | Controller | password-controller', function () {
       });
     });
 
-    context('when existing email is provided, but some internal error has occured', function () {
+    context('when existing email is provided, but some internal error has occurred', function () {
       it('should reply with 500', async function () {
         // given
         sinon.stub(resetPasswordDemandRepository, 'create').rejects(new Error());

--- a/certif/app/components/select-referer-modal.hbs
+++ b/certif/app/components/select-referer-modal.hbs
@@ -1,6 +1,6 @@
 <PixModal
   class="select-referer-modal"
-  @title={{(t "pages.team.select-referer-modal.title")}}
+  @title={{t "pages.team.select-referer-modal.title"}}
   @onCloseButtonClick={{@toggleRefererModal}}
   @showModal={{@showModal}}
 >
@@ -13,7 +13,7 @@
         @id="referer"
         @options={{@options}}
         @value={{@selectedReferer}}
-        @placeholder={{(t "pages.team.select-referer-modal.empty-option")}}
+        @placeholder={{t "pages.team.select-referer-modal.empty-option"}}
         @hideDefaultOption={{true}}
         @onChange={{@onSelectReferer}}
         @emptyOptionNotSelectable={{true}}

--- a/certif/app/controllers/authenticated/sessions/new.js
+++ b/certif/app/controllers/authenticated/sessions/new.js
@@ -32,16 +32,12 @@ export default class SessionsNewController extends Controller {
     try {
       await this.session.save();
     } catch (error) {
-      if (error.errors) {
-        switch (error.errors[0].status) {
-          case '400':
-            this.notifications.error(this.intl.t('common.api-error-messages.bad-request-error'));
-            break;
-          default:
-            this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
-            break;
-        }
+      const status = error?.errors?.[0]?.status;
+
+      if (status === '400') {
+        return this.notifications.error(this.intl.t('common.api-error-messages.bad-request-error'));
       }
+      return this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
     }
     this.router.transitionTo('authenticated.sessions.details', this.session.id);
   }

--- a/certif/app/controllers/authenticated/sessions/new.js
+++ b/certif/app/controllers/authenticated/sessions/new.js
@@ -37,11 +37,8 @@ export default class SessionsNewController extends Controller {
           case '400':
             this.notifications.error(this.intl.t('common.api-error-messages.bad-request-error'));
             break;
-          case '500':
-            this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
-            break;
           default:
-            this.notifications.error(this.intl.t('common.api-error-messages.internal-error'));
+            this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
             break;
         }
       }

--- a/certif/app/controllers/authenticated/sessions/update.js
+++ b/certif/app/controllers/authenticated/sessions/update.js
@@ -32,16 +32,12 @@ export default class SessionsUpdateController extends Controller {
     try {
       await this.session.save();
     } catch (error) {
-      if (error.errors) {
-        switch (error.errors[0].status) {
-          case '400':
-            this.notifications.error(this.intl.t('common.api-error-messages.bad-request-error'));
-            break;
-          default:
-            this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
-            break;
-        }
+      const status = error?.errors?.[0]?.status;
+
+      if (status === '400') {
+        return this.notifications.error(this.intl.t('common.api-error-messages.bad-request-error'));
       }
+      return this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
     }
     this.router.transitionTo('authenticated.sessions.details', this.session.id);
   }

--- a/certif/app/controllers/authenticated/sessions/update.js
+++ b/certif/app/controllers/authenticated/sessions/update.js
@@ -37,11 +37,8 @@ export default class SessionsUpdateController extends Controller {
           case '400':
             this.notifications.error(this.intl.t('common.api-error-messages.bad-request-error'));
             break;
-          case '500':
-            this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
-            break;
           default:
-            this.notifications.error(this.intl.t('common.api-error-messages.internal-error'));
+            this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
             break;
         }
       }

--- a/certif/app/controllers/authenticated/team.js
+++ b/certif/app/controllers/authenticated/team.js
@@ -6,6 +6,9 @@ import { tracked } from '@glimmer/tracking';
 export default class Team extends Controller {
   @service featureToggles;
   @service router;
+  @service notifications;
+  @service intl;
+
   @tracked shouldShowRefererSelectionModal = false;
   @tracked selectedReferer = '';
 
@@ -43,9 +46,14 @@ export default class Team extends Controller {
     if (this.selectedReferer !== '') {
       const userId = this.selectedReferer;
       const member = this.model.members.toArray().find((member) => member.id === userId);
-      await member.updateReferer({ userId: member.id, isReferer: true });
-      this.shouldShowRefererSelectionModal = !this.shouldShowRefererSelectionModal;
-      this.send('refreshModel');
+
+      try {
+        await member.updateReferer({ userId: member.id, isReferer: true });
+        this.shouldShowRefererSelectionModal = !this.shouldShowRefererSelectionModal;
+        this.send('refreshModel');
+      } catch (responseError) {
+        this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
+      }
     }
   }
 

--- a/certif/app/controllers/terms-of-service.js
+++ b/certif/app/controllers/terms-of-service.js
@@ -20,7 +20,7 @@ export default class TermsOfServiceController extends Controller {
       this.currentUser.certificationPointOfContact.pixCertifTermsOfServiceAccepted = true;
       this.router.transitionTo('authenticated.sessions.list');
     } catch (errorResponse) {
-      this.notifications.error('Une erreur est survenue.');
+      this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
     }
   }
 }

--- a/certif/app/routes/authenticated/sessions/finalize.js
+++ b/certif/app/routes/authenticated/sessions/finalize.js
@@ -5,16 +5,23 @@ export default class SessionsFinalizeRoute extends Route {
   @service notifications;
   @service currentUser;
   @service store;
+  @service router;
+  @service intl;
 
   beforeModel() {
     this.currentUser.checkRestrictedAccess();
   }
 
   async model({ session_id }) {
-    const session = await this.store.findRecord('session', session_id, { reload: true });
-    await session.certificationReports;
+    try {
+      const session = await this.store.findRecord('session', session_id, { reload: true });
+      await session.certificationReports;
 
-    return session;
+      return session;
+    } catch (responseError) {
+      this.notifications.error(this.intl.t('common.api-error-messages.internal-server-error'));
+      this.router.transitionTo('authenticated.sessions.details', session_id);
+    }
   }
 
   async afterModel(model, transition) {

--- a/certif/app/templates/session-supervising-error.hbs
+++ b/certif/app/templates/session-supervising-error.hbs
@@ -1,9 +1,9 @@
-{{page-title (t "pages.session-supervising-error.title")}}
+{{page-title (t "pages.session-supervising-error.page-title")}}
 
 <div class="session-supervising-error-page">
   <div class="session-supervising-error-page__panel">
     <img src="/images/supervisor_no-access.svg" alt="" role="presentation" />
-    <h1 class="session-supervising-error-page__panel__title">{{t "common.api-error-messages.internal-error"}}</h1>
+    <h1 class="session-supervising-error-page__panel__title">{{t "pages.session-supervising-error.title"}}</h1>
     <p class="session-supervising-error-page__panel__subtitle">
       {{t "pages.session-supervising-error.description"}}
     </p>

--- a/certif/tests/acceptance/team_test.js
+++ b/certif/tests/acceptance/team_test.js
@@ -26,11 +26,7 @@ module('Acceptance | authenticated | team', function (hooks) {
           module('when there is no referer', function () {
             test('it should be possible to see the "no referer" section', async function (assert) {
               // given
-              const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-              server.create('featureToggle', { isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: true });
-              server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false });
-              server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
-              await authenticateSession(certificationPointOfContact.id);
+              await _createAndAuthenticateMember();
 
               // when
               const screen = await visitScreen('/equipe');
@@ -48,18 +44,7 @@ module('Acceptance | authenticated | team', function (hooks) {
 
             test('it should be possible to select a referer', async function (assert) {
               // given
-              const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-              server.create('featureToggle', { isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: true });
-              server.create('member', {
-                id: 102,
-                firstName: 'Lili',
-                lastName: 'Dupont',
-                isReferer: false,
-              });
-              server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
-              await authenticateSession(certificationPointOfContact.id);
-
-              // when
+              await _createAndAuthenticateMember();
               const screen = await visitScreen('/equipe');
 
               assert.dom(screen.queryByRole('cell', { name: 'Référent Pix' })).doesNotExist();
@@ -74,6 +59,8 @@ module('Acceptance | authenticated | team', function (hooks) {
                   name: 'Lili Dupont',
                 })
               );
+
+              // when
               await click(screen.getByRole('button', { name: 'Valider la sélection de référent' }));
               await waitForDialogClose();
 
@@ -87,18 +74,7 @@ module('Acceptance | authenticated | team', function (hooks) {
             module('when no referer is selected', function () {
               test('it should not be possible to validate', async function (assert) {
                 // given
-                const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-                server.create('featureToggle', {
-                  isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: true,
-                });
-                server.create('member', {
-                  id: 102,
-                  firstName: 'Lili',
-                  lastName: 'Dupont',
-                  isReferer: false,
-                });
-                server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
-                await authenticateSession(certificationPointOfContact.id);
+                await _createAndAuthenticateMember();
 
                 // when
                 const screen = await visitScreen('/equipe');
@@ -118,18 +94,7 @@ module('Acceptance | authenticated | team', function (hooks) {
             module('when referer registration failed', function () {
               test('it should return error message', async function (assert) {
                 // given
-                const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-                server.create('featureToggle', {
-                  isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: true,
-                });
-                server.create('member', {
-                  id: 102,
-                  firstName: 'Lili',
-                  lastName: 'Dupont',
-                  isReferer: false,
-                });
-                server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
-                await authenticateSession(certificationPointOfContact.id);
+                await _createAndAuthenticateMember();
                 const screen = await visitScreen('/equipe');
                 this.server.post('certif/certification-centers/:id/update-referer', () => {
                   return new Response(500, {}, { errors: [{ status: '500' }] });
@@ -215,4 +180,12 @@ module('Acceptance | authenticated | team', function (hooks) {
       });
     });
   });
+
+  async function _createAndAuthenticateMember() {
+    const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
+    server.create('featureToggle', { isCleaResultsRetrievalByHabilitatedCertificationCentersEnabled: true });
+    server.create('member', { firstName: 'Lili', lastName: 'Dupont', isReferer: false });
+    server.create('allowed-certification-center-access', { id: 1, habilitations: [{ key: 'CLEA' }] });
+    await authenticateSession(certificationPointOfContact.id);
+  }
 });

--- a/certif/tests/integration/components/login-form_test.js
+++ b/certif/tests/integration/components/login-form_test.js
@@ -181,7 +181,7 @@ module('Integration | Component | login-form', function (hooks) {
     // given
     const msgErrorNotLinkedCertification = {
       status: Number(ApiErrorMessages.GATEWAY_TIMEOUT.CODE),
-      errors: [{ status: '502', title: 'Bad Gateway', detail: 'Bad gateway occured' }],
+      errors: [{ status: '502', title: 'Bad Gateway', detail: 'Bad gateway occurred' }],
     };
 
     sessionStub.authenticate.callsFake(() => reject(msgErrorNotLinkedCertification));

--- a/certif/tests/unit/controllers/terms-of-service_test.js
+++ b/certif/tests/unit/controllers/terms-of-service_test.js
@@ -38,6 +38,7 @@ module('Unit | Controller | terms-of-service', function (hooks) {
       test('it should display a notification error', async function (assert) {
         // given
         controller.notifications = { error: sinon.stub() };
+        controller.intl = { t: sinon.stub() };
         controller.currentUser = { certificationPointOfContact: { save: sinon.stub().rejects() } };
 
         // when

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -19,8 +19,7 @@
       "login-unauthorized-error": "There was an error in the email address or password entered.",
       "login-user-temporary-blocked-error": "You have reached too many failed login attempts. Please try again later or <a href=\"{url}\">reset your password here</a>.",
       "login-user-blocked-error": "Your account has reached the maximum number of failed login attempts and has been temporarily blocked. Please <a href=\"{url}\">contact us</a> to unblock it.",
-      "gateway-timeout-error": "The service is being slow. Please try again later.",
-      "internal-error": "An error occurred"
+      "gateway-timeout-error": "The service is being slow. Please try again later."
     },
     "forms": {
       "certification-labels": {
@@ -684,7 +683,8 @@
       }
     },
     "session-supervising-error": {
-      "title": "Access error to the session's invigilation",
+      "title": "An error occurred",
+      "page-title": "Access error to the session's invigilation",
       "description": "To access this session, click on the \"Invigilate a session\" button and fill in the details of the session"
     },
     "team": {

--- a/certif/translations/en.json
+++ b/certif/translations/en.json
@@ -667,7 +667,7 @@
           "instruction-with-name": "End the exam of {firstName} {lastName}?",
           "end-assessment": "End the exam",
           "success": "Success! {firstName} {lastName}'s test has been ended.",
-          "error": "An error occured, {firstName} {lastName}'s test could not be ended."
+          "error": "An error occurred, {firstName} {lastName}'s test could not be ended."
         },
         "resume-test-modal": {
           "actions": {

--- a/certif/translations/fr.json
+++ b/certif/translations/fr.json
@@ -19,8 +19,7 @@
       "login-unauthorized-error": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects.",
       "login-user-temporary-blocked-error": "Vous avez effectué trop de tentatives de connexion. Réessayez plus tard ou cliquez sur <a href=\"{url}\">mot de passe oublié</a> pour le réinitialiser.",
       "login-user-blocked-error": "Votre compte est bloqué car vous avez effectué trop de tentatives de connexion. Pour le débloquer, <a href=\"{url}\">contactez-nous</a>.",
-      "gateway-timeout-error": "Le service subit des ralentissements. Veuillez réessayer ultérieurement.",
-      "internal-error": "Une erreur est survenue"
+      "gateway-timeout-error": "Le service subit des ralentissements. Veuillez réessayer ultérieurement."
     },
     "forms": {
       "certification-labels": {
@@ -683,7 +682,8 @@
       }
     },
     "session-supervising-error": {
-      "title": "Erreur d'accès à la surveillance de session",
+      "title": "Une erreur est survenue",
+      "page-title": "Erreur d'accès à la surveillance de session",
       "description": "Pour accéder à cette session, cliquez sur le bouton \"Surveiller une session\" et renseignez les informations de la session"
     },
     "team": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -61,7 +61,7 @@
       "error": "You must agree to the Pix terms of use and personal data protection policy to create an account.",
       "label": "Agree Pix terms of use and personal data protection policy"
     },
-    "error": "An error has occured. Please try again or contact the support.",
+    "error": "An error has occurred. Please try again or contact the support.",
     "form": {
       "error": "error",
       "invisible-password": "Hide password",
@@ -865,7 +865,7 @@
         "associate": "Link",
         "continue-with-pix": "Continue with my Pix account",
         "error-not-found": "If you're a pupil '<br>' Check your information (first name, last name and date of birth) or contact a teacher.'<br><br>' If you're a teacher '<br>' Access to this customised test is not available at the moment.",
-        "invalid-reconciliation-error": "An error has occured. <br> Please contact the support.",
+        "invalid-reconciliation-error": "An error has occurred. <br> Please contact the support.",
         "first-title": "{ organizationName }",
         "login-information-message": "The Pix account  '<b>'{ connectionMethod }'</b>' will be linked with the pupil:  '<b>'{ firstName }  { lastName }'</b>'.'<b>'If this is you, click on \"Link\". Otherwise, log out.",
         "login-information-title": "Pix account information",
@@ -1495,7 +1495,7 @@
             "empty-password": "Your password can't be empty.",
             "invalid-password": "There was an error in the password entered.",
             "mismatching-email": "The email addresses you entered do not match. Please check your entry for spelling errors.",
-            "unknown-error": "An error has occured. Please try again or contact the support.",
+            "unknown-error": "An error has occurred. Please try again or contact the support.",
             "wrong-email-format": "Your email address is invalid."
           },
           "new-email": {

--- a/orga/tests/integration/components/sup-organization-participant/edit-student-number-modal_test.js
+++ b/orga/tests/integration/components/sup-organization-participant/edit-student-number-modal_test.js
@@ -265,7 +265,7 @@ module('Integration | Component | ScoOrganizationParticipant::EditStudentNumberM
           errors: [
             {
               status: '412',
-              detail: 'Error occured',
+              detail: 'Error occurred',
             },
           ],
         };
@@ -301,7 +301,7 @@ module('Integration | Component | ScoOrganizationParticipant::EditStudentNumberM
           errors: [
             {
               status: '412',
-              detail: 'Error occured',
+              detail: 'Error occurred',
             },
           ],
         };


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'implémentation de l'import en masse des sessions, nous avions constaté l'affichage d'un `[Object Object]` en message lorsque l'API retournait une erreur.

La gestion d'erreurs de cette fonctionnalité a été traité mais d'autres fonctionnalités de l'API manquent d'une gestion.
Conséquences : 
-  Aucun message n'est retourné à l'utilisateur lorsque quelque chose se passe mal.
- L'affichage de l'appli plante et l'utilisateur voit une belle page blanche

## :robot: Proposition
Afficher un message par défaut lorsque l'API retourne une erreur.

## :rainbow: Remarques
J'ai fait une passe rapide sur différentes fonctionnalités, j'ai du passer à coté de certaines. Mais le but ici était d'améliorer les principales fonctionnalités

## :100: Pour tester
- Se connecter avec certifpro@example.net

Pour tester les erreurs 500, ouvrir la console => onglet network et le passer en offline

Le message 500 par défaut est le suivant : `Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.`

- 1 / A la validation des CGU, passer en offline avant de valider. Constater qu'un message d'erreur apparaît.
- 2 / Création et modification d'une session : passer en offline avant validation et constater que le nouveau message apparaît bien.
- 3 / Dans l'onglet Équipe, cliquer sur le bouton pour désigner un référent. Sélectionner un référent, et passer en offline avant de valider. Constater qu'un message d'erreur apparaît.
- 4 / Se connecter avec certifsup, sélectionner une session et passer en offline avant de la finaliser. Constater qu'un message d'erreur apparaît. (en restant sur la page de détails d'une session)