### PR TITLE
[FEATURE] Empêcher l'import en masse pour un centre SCO isNotManagingStudent utilisant un modèle csv SUP/PRO (PIX-7774)

### DIFF
--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -175,20 +175,21 @@ function _getDataFromColumnNames({ expectedHeadersKeys, headers, line }) {
   data.complementaryCertifications = _extractComplementaryCertificationLabelsFromLine(line);
 
   expectedHeadersKeys.forEach((key) => {
-    const headerKeyInCurrentLine = line[headers[key]];
+    const headerLabel = headers[key];
+    const currentValue = line[headerLabel];
     if (key === 'birthdate' || key === 'date') {
       data[key] =
         convertDateValue({
-          dateString: headerKeyInCurrentLine,
+          dateString: currentValue,
           inputFormat: 'DD/MM/YYYY',
           outputFormat: 'YYYY-MM-DD',
-        }) ?? headerKeyInCurrentLine;
+        }) ?? currentValue;
     } else if (key === 'extraTimePercentage') {
-      data[key] = headerKeyInCurrentLine !== '' ? headerKeyInCurrentLine : null;
+      data[key] = currentValue || null;
     } else if (key === 'prepaymentCode') {
-      data[key] = headerKeyInCurrentLine !== '' ? headerKeyInCurrentLine : null;
+      data[key] = currentValue || null;
     } else {
-      data[key] = headerKeyInCurrentLine;
+      data[key] = currentValue;
     }
   });
   return data;

--- a/api/lib/infrastructure/serializers/csv/csv-serializer.js
+++ b/api/lib/infrastructure/serializers/csv/csv-serializer.js
@@ -29,6 +29,20 @@ function deserializeForSessionsImport({ parsedCsvData, hasBillingMode }) {
   const sessions = [];
   const expectedHeadersKeys = Object.keys(headers);
 
+  const csvBillingModeKey = headers.billingMode;
+  const csvPrepaymentCodeKey = headers.prepaymentCode;
+
+  if (
+    _isScoAndHasBillingModeColumnsInCsv({
+      hasBillingMode,
+      parsedCsvLine: parsedCsvData[0],
+      csvBillingModeKey,
+      csvPrepaymentCodeKey,
+    })
+  ) {
+    throw new FileValidationError('CSV_HEADERS_NOT_VALID');
+  }
+
   _verifyHeaders({ expectedHeadersKeys, headers, parsedCsvLine: parsedCsvData[0], hasBillingMode });
 
   parsedCsvData.forEach((lineDTO, index) => {
@@ -224,6 +238,15 @@ function _verifyHeaders({ expectedHeadersKeys, parsedCsvLine, headers, hasBillin
       throw new FileValidationError('CSV_HEADERS_NOT_VALID');
     }
   });
+}
+
+function _isScoAndHasBillingModeColumnsInCsv({
+  hasBillingMode,
+  parsedCsvLine,
+  csvBillingModeKey,
+  csvPrepaymentCodeKey,
+}) {
+  return !hasBillingMode && (csvBillingModeKey in parsedCsvLine || csvPrepaymentCodeKey in parsedCsvLine);
 }
 
 function _isBillingModeOptional(key, hasBillingMode) {

--- a/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-serializer_test.js
@@ -170,6 +170,48 @@ describe('Unit | Serializer | CSV | csv-serializer', function () {
       });
     });
 
+    describe('when certification center does not have billing mode', function () {
+      context('when billing mode header is present', function () {
+        it('should throw an error', async function () {
+          const parsedCsvData = [
+            {
+              'Numéro de session préexistante': '',
+              '* Nom du site': '',
+              '* Nom de la salle': '',
+              '* Date de début (format: JJ/MM/AAAA)': '',
+              '* Heure de début (heure locale format: HH:MM)': '',
+              '* Surveillant(s)': '',
+              'Observations (optionnel)': '',
+              '* Nom de naissance': 'Paul',
+              '* Prénom': 'Pierre',
+              '* Date de naissance (format: JJ/MM/AAAA)': '12/09/1987',
+              '* Sexe (M ou F)': 'M',
+              'Code INSEE de la commune de naissance': '',
+              'Code postal de la commune de naissance': '',
+              'Nom de la commune de naissance': '',
+              '* Pays de naissance': 'France',
+              'E-mail du destinataire des résultats (formateur, enseignant…)': '',
+              'E-mail de convocation': '',
+              'Identifiant externe': '',
+              'Temps majoré ? (exemple format: 33%)': '',
+              '* Tarification part Pix (Gratuite, Prépayée ou Payante)': '',
+              'Code de prépaiement (si Tarification part Pix Prépayée)': '',
+            },
+          ];
+
+          // when
+          const error = await catchErr(csvSerializer.deserializeForSessionsImport)({
+            parsedCsvData,
+            hasBillingMode: false,
+          });
+
+          // then
+          expect(error).to.be.instanceOf(FileValidationError);
+          expect(error.code).to.equal('CSV_HEADERS_NOT_VALID');
+        });
+      });
+    });
+
     describe('when importing sessions', function () {
       describe('when every mandatory information is missing', function () {
         it('should not throw an error', async function () {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lorsque qu’un utilisateur d’un centre SCO isNotManagingStudent importe en masse en utilisant un modèle de centre SUP/PRO (colonnes “Tarification Part Pix” et “Code de prépaiement” en plus), il passe à l'étape 2 de confirmation, avec une erreur bloquante.

L’utilisateur devrait être bloqué à l'étape 1 car il utilise un modèle avec 2 colonnes que l’on ne veut pas avoir dans son cas de figure. 

## :robot: Proposition
Bloquer la validation si l'utilisateur d'un centre sco ne gérant pas d'élève utilise un template pro ou sup.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Sur Pix-certif, tenter d'importer des sessions avec un csv pro ou sup (contenant les colonnes de tarification) avec le compte ```Centre AEFE SCO NO MANAGING STUDENTS des Anne-Étoiles (1237457E)```

- Constater l'erreur suivante 

![image](https://user-images.githubusercontent.com/37305474/233648387-bedbea30-f8eb-423f-aed0-4e68bade028e.png)
