### PR TITLE
[FEATURE] Pouvoir ajouter un palier "1er acquis" à la collection des paliers d'un profil cible (PIX-7334)

### DIFF
--- a/admin/app/adapters/stage-collection.js
+++ b/admin/app/adapters/stage-collection.js
@@ -11,6 +11,7 @@ export default class StageCollectionAdapter extends ApplicationAdapter {
       id: stage.id,
       level: stage.level && parseInt(stage.level),
       threshold: stage.threshold && parseInt(stage.threshold),
+      isFirstSkill: stage.isFirstSkill,
       title: stage.title,
       message: stage.message,
       prescriberTitle: stage.prescriberTitle,

--- a/admin/app/components/stages/stage.hbs
+++ b/admin/app/components/stages/stage.hbs
@@ -14,7 +14,7 @@
   {{#if @isEditMode}}
     <Stages::UpdateStage
       @stage={{@stage}}
-      @isTypeLevel={{this.isTypeLevel}}
+      @isTypeLevel={{@stage.isTypeLevel}}
       @stageTypeName={{this.stageTypeName}}
       @toggleEditMode={{@toggleEditMode}}
       @availableLevels={{@availableLevels}}
@@ -24,7 +24,7 @@
   {{else}}
     <Stages::ViewStage
       @stage={{@stage}}
-      @isTypeLevel={{this.isTypeLevel}}
+      @isTypeLevel={{@stage.isTypeLevel}}
       @stageTypeName={{this.stageTypeName}}
       @toggleEditMode={{@toggleEditMode}}
     />

--- a/admin/app/components/stages/stage.js
+++ b/admin/app/components/stages/stage.js
@@ -4,11 +4,7 @@ const LEVEL = 'Niveau';
 const THRESHOLD = 'Seuil';
 
 export default class Stage extends Component {
-  get isTypeLevel() {
-    return this.args.stage.isTypeLevel;
-  }
-
   get stageTypeName() {
-    return this.isTypeLevel ? LEVEL : THRESHOLD;
+    return this.args.stage.isTypeLevel ? LEVEL : THRESHOLD;
   }
 }

--- a/admin/app/components/stages/update-stage.hbs
+++ b/admin/app/components/stages/update-stage.hbs
@@ -1,10 +1,13 @@
 <section class="page-section">
   <form class="form stage-form" {{on "submit" this.updateStage}}>
     <div class="form-field">
-      <label for="threshold-or-level" class="form-field__label">
-        {{@stageTypeName}}
-      </label>
-      {{#if @isTypeLevel}}
+      {{#if @stage.isFirstSkill}}
+        <label class="form-field__label">Premier acquis</label>
+        <br/>
+      {{else if @isTypeLevel}}
+        <label for="threshold-or-level" class="form-field__label">
+          {{@stageTypeName}}
+        </label>
         <Stages::StageLevelSelect
           @id="threshold-or-level"
           @availableLevels={{@availableLevels}}
@@ -13,6 +16,9 @@
           @value={{this.level}}
         />
       {{else}}
+        <label for="threshold-or-level" class="form-field__label">
+          {{@stageTypeName}}
+        </label>
         <PixInput
           @id="threshold-or-level"
           @errorMessage="Le seuil est invalide"

--- a/admin/app/components/stages/update-stage.hbs
+++ b/admin/app/components/stages/update-stage.hbs
@@ -2,7 +2,7 @@
   <form class="form stage-form" {{on "submit" this.updateStage}}>
     <div class="form-field">
       {{#if @stage.isFirstSkill}}
-        <label class="form-field__label">Premier acquis</label>
+        <label class="form-field__label">1er acquis</label>
         <br/>
       {{else if @isTypeLevel}}
         <label for="threshold-or-level" class="form-field__label">

--- a/admin/app/components/stages/update-stage.hbs
+++ b/admin/app/components/stages/update-stage.hbs
@@ -3,7 +3,7 @@
     <div class="form-field">
       {{#if @stage.isFirstSkill}}
         <label class="form-field__label">1er acquis</label>
-        <br/>
+        <br />
       {{else if @isTypeLevel}}
         <label for="threshold-or-level" class="form-field__label">
           {{@stageTypeName}}

--- a/admin/app/components/stages/view-stage.hbs
+++ b/admin/app/components/stages/view-stage.hbs
@@ -17,7 +17,7 @@
             {{@stage.threshold}}
           {{/if}}
         {{/if}}
-        </li>
+      </li>
       <li>Titre : {{@stage.title}}</li>
       <li>Message : {{@stage.message}}</li>
       <li>Titre pour le prescripteur : {{@stage.prescriberTitle}}</li>

--- a/admin/app/components/stages/view-stage.hbs
+++ b/admin/app/components/stages/view-stage.hbs
@@ -5,13 +5,19 @@
   <div class="page-section__details">
     <ul class="stage-data__list">
       <li>ID : {{@stage.id}}</li>
-      <li>{{@stageTypeName}}
-        :
-        {{#if @isTypeLevel}}
-          {{@stage.level}}
+      <li>
+        {{#if @stage.isFirstSkill}}
+          Premier acquis
         {{else}}
-          {{@stage.threshold}}
-        {{/if}}</li>
+          {{@stageTypeName}}
+          :
+          {{#if @isTypeLevel}}
+            {{@stage.level}}
+          {{else}}
+            {{@stage.threshold}}
+          {{/if}}
+        {{/if}}
+        </li>
       <li>Titre : {{@stage.title}}</li>
       <li>Message : {{@stage.message}}</li>
       <li>Titre pour le prescripteur : {{@stage.prescriberTitle}}</li>

--- a/admin/app/components/stages/view-stage.hbs
+++ b/admin/app/components/stages/view-stage.hbs
@@ -7,7 +7,7 @@
       <li>ID : {{@stage.id}}</li>
       <li>
         {{#if @stage.isFirstSkill}}
-          Premier acquis
+          1er acquis
         {{else}}
           {{@stageTypeName}}
           :

--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -23,7 +23,6 @@
             {{#each @stageCollection.stages as |stage index|}}
               {{#if stage.isBeingCreated}}
                 <TargetProfiles::Stages::NewStage
-                  @setFirstStage={{(and this.setFirstStage (eq index 0))}}
                   @stage={{stage}}
                   @imageUrl={{@imageUrl}}
                   @availableLevels={{this.availableLevels}}
@@ -63,16 +62,30 @@
         {{on "change" this.onStageTypeChange}}
       />
     {{/if}}
-    <PixButton
-      class="stages-new-stage"
-      @backgroundColor="transparent-light"
-      @isBorderVisible={{true}}
-      @triggerAction={{this.addStage}}
-      @isDisabled={{this.isAddStageDisabled}}
-      @iconBefore="plus"
-    >
-      Nouveau palier
-    </PixButton>
+    <div class="add-stage-actions">
+      <PixButton
+        class="stages-new-stage"
+        @backgroundColor="transparent-light"
+        @isBorderVisible={{true}}
+        @triggerAction={{this.addStage}}
+        @isDisabled={{this.isAddStageDisabled}}
+        @iconBefore="plus"
+      >
+        Nouveau palier
+      </PixButton>
+      {{#if @stageCollection.hasStages}}
+        <PixButton
+          class="stages-new-stage"
+          @backgroundColor="transparent-light"
+          @isBorderVisible={{true}}
+          @triggerAction={{this.addFirstSkillStage}}
+          @isDisabled={{this.isAddFirstSkillStageDisabled}}
+          @iconBefore="plus"
+        >
+          Nouveau palier "1er acquis"
+        </PixButton>
+      {{/if}}
+    </div>
     {{#if this.hasNewStage}}
       <div class="stages-actions form-actions">
         <PixButton

--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -15,7 +15,7 @@
             </tr>
           </thead>
           <tbody>
-            {{#each @stageCollection.sortedStages as |stage index|}}
+            {{#each @stageCollection.sortedStages as |stage|}}
               {{#if stage.isBeingCreated}}
                 <TargetProfiles::Stages::NewStage
                   @stage={{stage}}

--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -1,12 +1,7 @@
 {{! template-lint-disable require-input-label }}
 <div class="content-text content-text--small">
   <form class="form" {{on "submit" this.createStages}}>
-    {{#if this.hasStages}}
-      {{#if this.displayNoZeroStage}}
-        <PixMessage type="warning">
-          Attention ! Il n'y a pas de palier à 0
-        </PixMessage>
-      {{/if}}
+    {{#if @stageCollection.stages}}
       <div class="table-admin">
         <table class="stages-table">
           <thead>
@@ -20,7 +15,7 @@
             </tr>
           </thead>
           <tbody>
-            {{#each @stageCollection.stages as |stage index|}}
+            {{#each @stageCollection.sortedStages as |stage index|}}
               {{#if stage.isBeingCreated}}
                 <TargetProfiles::Stages::NewStage
                   @stage={{stage}}

--- a/admin/app/components/target-profiles/stages.js
+++ b/admin/app/components/target-profiles/stages.js
@@ -31,25 +31,12 @@ export default class Stages extends Component {
     return this.args.stageCollection.isLevelType;
   }
 
-  get hasStages() {
-    const stages = this.args.stageCollection.stages;
-    return stages && stages.length > 0;
-  }
-
   get hasNewStage() {
     return this.args.stageCollection.stages.any((stage) => stage.isBeingCreated);
   }
 
   get newStages() {
     return this.args.stageCollection.stages.filter((stage) => stage.isBeingCreated);
-  }
-
-  get displayNoZeroStage() {
-    if (!this.hasStages) return false;
-    if (this.isLevelType) {
-      return !this.args.stageCollection.stages.any((stage) => stage.level === 0);
-    }
-    return !this.args.stageCollection.stages.any((stage) => stage.threshold === 0);
   }
 
   get columnNameByStageType() {
@@ -63,7 +50,7 @@ export default class Stages extends Component {
   }
 
   get mustChooseStageType() {
-    return !this.hasStages;
+    return !this.args.stageCollection.hasStages;
   }
 
   get collectionHasNonZeroStages() {

--- a/admin/app/components/target-profiles/stages.js
+++ b/admin/app/components/target-profiles/stages.js
@@ -16,8 +16,8 @@ export default class Stages extends Component {
 
   get setFirstStage() {
     return (
-      (this.isTypeLevel && this.availableLevels.includes(0)) ||
-      (!this.isTypeLevel && !this.unavailableThresholds.includes(0))
+      (this.isLevelType && this.availableLevels.includes(0)) ||
+      (!this.isLevelType && !this.unavailableThresholds.includes(0))
     );
   }
 
@@ -33,8 +33,8 @@ export default class Stages extends Component {
     return this.args.stageCollection.stages.map((stage) => (stage.isBeingCreated ? null : stage.threshold));
   }
 
-  get isTypeLevel() {
-    return this.args.stageCollection.stages?.firstObject?.isTypeLevel ?? this.firstStageType == 'level';
+  get isLevelType() {
+    return this.args.stageCollection.isLevelType;
   }
 
   get hasStages() {
@@ -52,20 +52,20 @@ export default class Stages extends Component {
 
   get displayNoZeroStage() {
     if (!this.hasStages) return false;
-    if (this.isTypeLevel) {
+    if (this.isLevelType) {
       return !this.args.stageCollection.stages.any((stage) => stage.level === 0);
     }
     return !this.args.stageCollection.stages.any((stage) => stage.threshold === 0);
   }
 
   get columnNameByStageType() {
-    return this.isTypeLevel ? LEVEL_COLUMN_NAME : THRESHOLD_COLUMN_NAME;
+    return this.isLevelType ? LEVEL_COLUMN_NAME : THRESHOLD_COLUMN_NAME;
   }
 
   get hasAvailableStages() {
     const allNewStages = this.args.stageCollection.stages.filter((stage) => stage.isBeingCreated) || [];
 
-    return (this.isTypeLevel && this.availableLevels.length > allNewStages.length) || !this.isTypeLevel;
+    return (this.isLevelType && this.availableLevels.length > allNewStages.length) || !this.isLevelType;
   }
 
   get mustChooseStageType() {
@@ -82,10 +82,10 @@ export default class Stages extends Component {
   @action
   addStage() {
     const isFirstStage = this.args.stageCollection.stages.length === 0;
-    const nextLowestLevelAvailable = this.isTypeLevel ? this.availableLevels?.[0] : undefined;
+    const nextLowestLevelAvailable = this.isLevelType ? this.availableLevels?.[0] : undefined;
     const stage = this.store.createRecord('stage', {
-      level: this.isTypeLevel ? nextLowestLevelAvailable.toString() : undefined,
-      threshold: !this.isTypeLevel && this.setFirstStage ? '0' : undefined,
+      level: this.isLevelType ? nextLowestLevelAvailable.toString() : undefined,
+      threshold: !this.isLevelType && this.setFirstStage ? '0' : undefined,
       title: isFirstStage ? 'Parcours terminé !' : null,
       message: isFirstStage
         ? 'Vous n’êtes visiblement pas tombé sur vos sujets préférés...Ou peut-être avez-vous besoin d’aide ? Dans tous les cas, rien n’est perdu d’avance ! Avec de l’accompagnement et un peu d’entraînement vous développerez à coup sûr vos compétences numériques !'

--- a/admin/app/components/target-profiles/stages/new-stage.hbs
+++ b/admin/app/components/target-profiles/stages/new-stage.hbs
@@ -1,27 +1,31 @@
 <tr aria-label="Informations sur le palier {{@title}}">
   <td>
-    {{#if @stage.isTypeLevel}}
-      <Stages::StageLevelSelect
-        @availableLevels={{@availableLevels}}
-        @onChange={{@setLevel}}
-        @value={{@stage.level}}
-        class="stages-table__level-select"
-        required="true"
-        @isDisabled={{@setFirstStage}}
-        @label="Niveau du palier"
-      />
+    {{#if @stage.isFirstSkill}}
+      1er acquis
     {{else}}
-      <PixInput
-        @id="threshold"
-        @errorMessage="Le seuil est invalide"
-        @validationStatus={{this.thresholdStatus}}
-        @requiredLabel="Champ obligatoire"
-        type="number"
-        @value={{this.threshold}}
-        readonly={{@setFirstStage}}
-        @ariaLabel="Seuil du palier"
-        {{on "focusout" this.checkThresholdValidity}}
-      />
+      {{#if @stage.isTypeLevel}}
+        <Stages::StageLevelSelect
+          @availableLevels={{@availableLevels}}
+          @onChange={{@setLevel}}
+          @value={{@stage.levelAsString}}
+          class="stages-table__level-select"
+          required="true"
+          @isDisabled={{@stage.isZeroStage}}
+          @label="Niveau du palier"
+        />
+      {{else}}
+        <PixInput
+          @id="threshold"
+          @errorMessage="Le seuil est invalide"
+          @validationStatus={{this.thresholdStatus}}
+          @requiredLabel="Champ obligatoire"
+          type="number"
+          @value={{this.threshold}}
+          readonly={{@stage.isZeroStage}}
+          @ariaLabel="Seuil du palier"
+          {{on "focusout" this.checkThresholdValidity}}
+        />
+      {{/if}}
     {{/if}}
   </td>
   <td>
@@ -53,7 +57,7 @@
     À renseigner ultérieurement
   </td>
   <td>
-    {{#unless @setFirstStage}}
+    {{#unless @stage.isZeroStage}}
       <PixButton
         @backgroundColor="red"
         @size="small"

--- a/admin/app/components/target-profiles/stages/stage.hbs
+++ b/admin/app/components/target-profiles/stages/stage.hbs
@@ -1,7 +1,7 @@
 <tr aria-label="Informations sur le palier {{@stage.title}}">
   <td>
     {{#if @stage.isFirstSkill}}
-      Premier acquis
+      1er acquis
     {{else if @stage.isTypeLevel}}
       {{@stage.level}}
     {{else}}

--- a/admin/app/components/target-profiles/stages/stage.hbs
+++ b/admin/app/components/target-profiles/stages/stage.hbs
@@ -1,6 +1,8 @@
 <tr aria-label="Informations sur le palier {{@stage.title}}">
   <td>
-    {{#if @stage.isTypeLevel}}
+    {{#if @stage.isFirstSkill}}
+      Premier acquis
+    {{else if @stage.isTypeLevel}}
       {{@stage.level}}
     {{else}}
       {{@stage.threshold}}

--- a/admin/app/models/stage-collection.js
+++ b/admin/app/models/stage-collection.js
@@ -4,7 +4,11 @@ export default class StageCollection extends Model {
   @hasMany('stage') stages;
 
   get isLevelType() {
-    const zeroStage = this.stages.find((stage) => stage.level === 0 || stage.threshold === 0);
-    return zeroStage.level === 0;
+    const zeroStage = this.stages.find((stage) => stage.isZeroStage);
+    return zeroStage?.isTypeLevel;
+  }
+
+  get hasStages() {
+    return this.stages.length > 0;
   }
 }

--- a/admin/app/models/stage-collection.js
+++ b/admin/app/models/stage-collection.js
@@ -2,4 +2,9 @@ import Model, { hasMany } from '@ember-data/model';
 
 export default class StageCollection extends Model {
   @hasMany('stage') stages;
+
+  get isLevelType() {
+    const zeroStage = this.stages.find((stage) => stage.level === 0 || stage.threshold === 0);
+    return zeroStage.level === 0;
+  }
 }

--- a/admin/app/models/stage-collection.js
+++ b/admin/app/models/stage-collection.js
@@ -11,4 +11,23 @@ export default class StageCollection extends Model {
   get hasStages() {
     return this.stages.length > 0;
   }
+
+  get sortedStages() {
+    const persistedStages = this.stages.filter((stage) => !stage.isBeingCreated);
+    const beingCreatedStages = this.stages.filter((stage) => stage.isBeingCreated);
+    return [
+      ...persistedStages.sort((stageA, stageB) => {
+        let stageAValue, stageBValue;
+        if (this.isLevelType) {
+          stageAValue = stageA.isFirstSkill ? 0.5 : stageA.level;
+          stageBValue = stageB.isFirstSkill ? 0.5 : stageB.level;
+        } else {
+          stageAValue = stageA.isFirstSkill ? 0.5 : stageA.threshold;
+          stageBValue = stageB.isFirstSkill ? 0.5 : stageB.threshold;
+        }
+        return stageAValue - stageBValue;
+      }),
+      ...beingCreatedStages,
+    ];
+  }
 }

--- a/admin/app/models/stage.js
+++ b/admin/app/models/stage.js
@@ -20,10 +20,18 @@ export default class Stage extends Model {
   }
 
   get isTypeLevel() {
-    return this.level != null;
+    return this.level !== null;
   }
 
   get isBeingCreated() {
     return !this.id;
+  }
+
+  get isZeroStage() {
+    return this.level === 0 || this.threshold === 0;
+  }
+
+  get levelAsString() {
+    return this.level.toString();
   }
 }

--- a/admin/app/models/stage.js
+++ b/admin/app/models/stage.js
@@ -5,6 +5,7 @@ export default class Stage extends Model {
 
   @attr('number') threshold;
   @attr('number') level;
+  @attr() isFirstSkill;
   @attr('string') title;
   @attr('string') message;
   @attr('string') prescriberTitle;

--- a/admin/app/styles/components/target-profiles/stages.scss
+++ b/admin/app/styles/components/target-profiles/stages.scss
@@ -28,8 +28,12 @@
   margin-bottom: 0;
 }
 
-.stages-new-stage {
-  margin: 10px 0;
+.add-stage-actions {
+  display: flex;
+
+  .stages-new-stage {
+    margin: 10px 8px 10px 0;
+  }
 }
 
 .stages-actions {

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -163,12 +163,16 @@ module('Acceptance | Target Profile Insights', function (hooks) {
           await clickByName('Palier par niveau');
           await clickByName('Nouveau palier');
           await clickByName('Nouveau palier');
+          await clickByName('Nouveau palier "1er acquis"');
 
-          const [firstStageTitleInput, secondStageTitleInput] = screen.getAllByLabelText('Titre du palier');
+          const [firstStageTitleInput, secondStageTitleInput, firstSkillStageTitleInput] =
+            screen.getAllByLabelText('Titre du palier');
           const [firstStageLevelButton, secondStageLevelButton] = screen.getAllByLabelText('Niveau du palier');
-          const [firstStageLevelMessage, secondStageLevelMessage] = screen.getAllByLabelText('Message du palier');
+          const [firstStageLevelMessage, secondStageLevelMessage, firstSkillStageLevelMessage] =
+            screen.getAllByLabelText('Message du palier');
           await fillIn(firstStageTitleInput, 'mon premier palier');
           await fillIn(secondStageTitleInput, 'mon deuxième palier');
+          await fillIn(firstSkillStageTitleInput, 'mon palier premier acquis');
 
           await click(secondStageLevelButton);
           await screen.findByRole('listbox');
@@ -177,6 +181,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
 
           await fillIn(firstStageLevelMessage, 'mon message un');
           await fillIn(secondStageLevelMessage, 'mon message deux');
+          await fillIn(firstSkillStageLevelMessage, 'mon message premier acquis');
 
           await clickByName('Enregistrer');
 
@@ -184,10 +189,13 @@ module('Acceptance | Target Profile Insights', function (hooks) {
           assert.true(firstStageLevelButton.hasAttributes('aria-disabled', 'true'));
           assert.dom(screen.getAllByText('mon premier palier')[0]).exists();
           assert.dom(screen.getAllByText('mon deuxième palier')[0]).exists();
+          assert.dom(screen.getAllByText('mon palier premier acquis')[0]).exists();
           assert.dom(screen.getAllByText('3')[0]).exists();
           assert.dom(screen.getAllByText('0')[0]).exists();
+          assert.dom(screen.getAllByText('1er acquis')[0]).exists();
           assert.dom(screen.getByText('mon message un')).exists();
           assert.dom(screen.getByText('mon message deux')).exists();
+          assert.dom(screen.getByText('mon message premier acquis')).exists();
           assert.dom(screen.queryByText('Enregistrer')).doesNotExist();
         });
 

--- a/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/target-profile/insights_test.js
@@ -103,6 +103,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
           id: 100,
           level: 1,
           threshold: null,
+          isFirstSkill: false,
           title: 'premier palier',
           message: 'message palier',
           prescriberTitle: 'titre prescripteur',
@@ -236,6 +237,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
           const stage = server.create('stage', {
             id: 100,
             level: 2,
+            threshold: null,
             title: 'ancien titre',
             message: 'ancien message',
             prescriberTitle: 'ancien titre prescripteur',
@@ -336,6 +338,7 @@ module('Acceptance | Target Profile Insights', function (hooks) {
           const stage = server.create('stage', {
             id: 100,
             threshold: 10,
+            level: null,
             title: 'ancien titre',
             message: 'ancien message',
             prescriberTitle: 'ancien titre prescripteur',

--- a/admin/tests/integration/components/stages/stage_test.js
+++ b/admin/tests/integration/components/stages/stage_test.js
@@ -12,6 +12,69 @@ module('Integration | Component | Stages::Stage', function (hooks) {
 
   setupRenderingTest(hooks);
 
+  module('when stage is firstSkill', function (hooks) {
+    hooks.beforeEach(function () {
+      isEditMode = false;
+      toggleEditMode = sinon.stub();
+      const store = this.owner.lookup('service:store');
+      stage = store.createRecord('stage', {
+        id: 34,
+        threshold: null,
+        level: null,
+        isFirstSkill: true,
+        title: 'palier premier acquis',
+        message: 'mon message',
+        prescriberTitle: 'titre du prescriteur',
+        prescriberDescription: 'description de prescripteur',
+      });
+
+      this.set('isEditMode', isEditMode);
+      this.set('stage', stage);
+      this.set('toggleEditMode', toggleEditMode);
+    });
+
+    test('should render all details about the stage when the isEditMode is false', async function (assert) {
+      //when
+      const screen = await render(
+        hbs`<Stages::Stage @stage={{this.stage}} @toggleEditMode={{this.toggleEditMode}} @isEditMode={{this.isEditMode}} />`
+      );
+
+      //then
+      assert.dom(screen.getByRole('button', { name: 'Éditer' })).exists();
+      assert.dom(screen.getByText('ID : 34', { exact: false })).exists();
+      assert.dom(screen.getByText('1er acquis', { exact: false })).exists();
+      assert.dom(screen.getByText('Titre : palier premier acquis', { exact: false })).exists();
+      assert.dom(screen.getByText('Message : mon message', { exact: false })).exists();
+    });
+
+    test('should call toggleEditMode function when the edit button is clicked', async function (assert) {
+      //when
+      await render(
+        hbs`<Stages::Stage @stage={{this.stage}} @toggleEditMode={{this.toggleEditMode}} @isEditMode={{this.isEditMode}} />`
+      );
+
+      await click('button');
+
+      //then
+      assert.ok(toggleEditMode.called);
+    });
+
+    test('should render updateStage component when the isEditMode is true', async function (assert) {
+      //given
+      this.set('isEditMode', true);
+
+      //when
+      const screen = await render(
+        hbs`<Stages::Stage @stage={{this.stage}} @toggleEditMode={{this.toggleEditMode}} @isEditMode={{this.isEditMode}} />`
+      );
+
+      //then
+      assert.dom(screen.getByRole('button', { name: 'Annuler' })).exists();
+      assert.dom(screen.getByRole('button', { name: 'Enregistrer' })).exists();
+      assert.dom(screen.getByRole('textbox', { name: 'Titre pour le prescripteur' })).exists();
+    });
+  });
+
   module('when stage type is threshold', function (hooks) {
     hooks.beforeEach(function () {
       isEditMode = false;

--- a/admin/tests/integration/components/target-profiles/stages_test.js
+++ b/admin/tests/integration/components/target-profiles/stages_test.js
@@ -197,6 +197,7 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       const stage = store.createRecord('stage', {
         id: 1,
         threshold: 100,
+        level: null,
         title: 'My title',
         message: 'My message',
       });
@@ -229,52 +230,6 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       assert.dom(screen.getByRole('button', { name: /Supprimer/ })).exists();
       assert.dom(screen.queryByText('Aucun résultat thématique associé')).doesNotExist();
     });
-
-    test('it should display a warning when there is no threshold at 0', async function (assert) {
-      // given
-      const stage = store.createRecord('stage', {
-        id: 1,
-        threshold: 100,
-        title: 'My title',
-        message: 'My message',
-      });
-      const stageCollection = store.createRecord('stage-collection', {
-        stages: [stage],
-      });
-      this.set('stageCollection', stageCollection);
-      this.set('maxLevel', 2);
-
-      // when
-      const screen = await render(
-        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}}/>`
-      );
-
-      // then
-      assert.dom(screen.getByText("Attention ! Il n'y a pas de palier à 0")).exists();
-    });
-
-    test('it should not display warning message when there is a stage with threshold 0', async function (assert) {
-      // given
-      const stage = store.createRecord('stage', {
-        id: 1,
-        threshold: 0,
-        title: 'My title',
-        message: 'My message',
-      });
-      const stageCollection = store.createRecord('stage-collection', {
-        stages: [stage],
-      });
-      this.set('stageCollection', stageCollection);
-      this.set('maxLevel', 2);
-
-      // when
-      const screen = await render(
-        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}}/>`
-      );
-
-      // then
-      assert.dom(screen.queryByText("Attention ! Il n'y a pas de palier à 0")).doesNotExist();
-    });
   });
 
   module('when stage type is level', function () {
@@ -282,7 +237,8 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       // given
       const stage = store.createRecord('stage', {
         id: 1,
-        level: 6,
+        level: 0,
+        threshold: null,
         title: 'My title',
         message: 'My message',
       });
@@ -308,37 +264,12 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       assert.dom(screen.getByText('Description prescripteur')).exists();
       assert.dom(screen.getByText('Actions')).exists();
       assert.dom('tbody tr').exists({ count: 1 });
-      assert.strictEqual(find('tbody tr td:nth-child(1)').textContent.trim(), '6');
+      assert.strictEqual(find('tbody tr td:nth-child(1)').textContent.trim(), '0');
       assert.strictEqual(find('tbody tr td:nth-child(2)').textContent.trim(), 'My title');
       assert.strictEqual(find('tbody tr td:nth-child(3)').textContent.trim(), 'My message');
       assert.dom(screen.getByText('Voir détail')).exists();
       assert.dom(screen.getByRole('button', { name: /Supprimer/ })).exists();
       assert.dom(screen.queryByText('Aucun résultat thématique associé')).doesNotExist();
-    });
-
-    module('when one stage with level 0', function () {
-      test('it should not display warning message', async function (assert) {
-        // given
-        const stage = store.createRecord('stage', {
-          id: 1,
-          level: 0,
-          title: 'My title',
-          message: 'My message',
-        });
-        const stageCollection = store.createRecord('stage-collection', {
-          stages: [stage],
-        });
-        this.set('stageCollection', stageCollection);
-        this.set('maxLevel', 2);
-
-        // when
-        const screen = await render(
-          hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}}/>`
-        );
-
-        // then
-        assert.dom(screen.queryByText("Attention ! Il n'y a pas de palier à 0")).doesNotExist();
-      });
     });
   });
 });

--- a/admin/tests/integration/components/target-profiles/stages_test.js
+++ b/admin/tests/integration/components/target-profiles/stages_test.js
@@ -22,11 +22,10 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
     });
     this.set('stageCollection', stageCollection);
     this.set('maxLevel', 2);
-    this.set('isNewFormat', true);
 
     // when
     const screen = await render(
-      hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}} @isNewFormat={{this.isNewFormat}}/>`
+      hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}}/>`
     );
 
     // then
@@ -41,11 +40,10 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       });
       this.set('stageCollection', stageCollection);
       this.set('maxLevel', 2);
-      this.set('isNewFormat', true);
 
       // when
       const screen = await render(
-        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}} @isNewFormat={{this.isNewFormat}}/>`
+        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}}/>`
       );
 
       // then
@@ -64,7 +62,7 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
 
         // when
         const screen = await render(
-          hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}} @isNewFormat={{this.isNewFormat}}/>`
+          hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}}/>`
         );
 
         // then
@@ -90,7 +88,7 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
 
       // when
       const screen = await render(
-        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}} @isNewFormat={{this.isNewFormat}}/>`
+        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}}/>`
       );
 
       // then
@@ -111,7 +109,7 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
 
       // when
       const screen = await render(
-        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}} @isNewFormat={{this.isNewFormat}}/>`
+        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}}/>`
       );
 
       // then
@@ -132,7 +130,7 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
 
       // when
       const screen = await render(
-        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}} @isNewFormat={{this.isNewFormat}}/>`
+        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}}/>`
       );
       await click(screen.getByRole('button', { name: /Supprimer/ }));
       await screen.findByRole('dialog');
@@ -140,6 +138,56 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       // then
       assert.dom(screen.getByText('Confirmer la suppression')).exists();
       assert.dom(screen.getByRole('button', { name: 'Valider' })).exists();
+    });
+
+    test('it should display add "firstSkill" button', async function (assert) {
+      // given
+      const stage = store.createRecord('stage', {
+        level: 1,
+      });
+      const stageCollection = store.createRecord('stage-collection', {
+        stages: [stage],
+      });
+      this.set('stageCollection', stageCollection);
+      this.set('maxLevel', 2);
+
+      // when
+      const screen = await render(
+        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}}/>`
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Nouveau palier "1er acquis"' })).exists();
+      assert.dom(screen.queryByRole('button', { name: 'Nouveau palier "1er acquis"' })).hasNoAttribute('disabled');
+    });
+  });
+
+  module('when a firstSkill stage is already in the collection', function () {
+    test('it should disable add "firstSkill" button', async function (assert) {
+      // given
+      const stage = store.createRecord('stage', {
+        level: 0,
+        isFirstSkill: false,
+      });
+      const firstSkillStage = store.createRecord('stage', {
+        level: null,
+        threshold: null,
+        isFirstSkill: true,
+      });
+      const stageCollection = store.createRecord('stage-collection', {
+        stages: [stage, firstSkillStage],
+      });
+      this.set('stageCollection', stageCollection);
+      this.set('maxLevel', 2);
+
+      // when
+      const screen = await render(
+        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}}/>`
+      );
+
+      // then
+      assert.dom(screen.queryByRole('button', { name: 'Nouveau palier "1er acquis"' })).exists();
+      assert.dom(screen.queryByRole('button', { name: 'Nouveau palier "1er acquis"' })).hasAttribute('disabled');
     });
   });
 
@@ -157,11 +205,10 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       });
       this.set('stageCollection', stageCollection);
       this.set('maxLevel', 2);
-      this.set('isNewFormat', true);
 
       // when
       const screen = await render(
-        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}} @isNewFormat={{this.isNewFormat}}/>`
+        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}}/>`
       );
 
       // then
@@ -196,11 +243,10 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       });
       this.set('stageCollection', stageCollection);
       this.set('maxLevel', 2);
-      this.set('isNewFormat', true);
 
       // when
       const screen = await render(
-        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}} @isNewFormat={{this.isNewFormat}}/>`
+        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}}/>`
       );
 
       // then
@@ -220,11 +266,10 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       });
       this.set('stageCollection', stageCollection);
       this.set('maxLevel', 2);
-      this.set('isNewFormat', true);
 
       // when
       const screen = await render(
-        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}} @isNewFormat={{this.isNewFormat}}/>`
+        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}}/>`
       );
 
       // then
@@ -246,11 +291,10 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
       });
       this.set('stageCollection', stageCollection);
       this.set('maxLevel', 2);
-      this.set('isNewFormat', true);
 
       // when
       const screen = await render(
-        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}} @isNewFormat={{this.isNewFormat}}/>`
+        hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}}/>`
       );
 
       // then
@@ -286,11 +330,10 @@ module('Integration | Component | TargetProfiles::Stages', function (hooks) {
         });
         this.set('stageCollection', stageCollection);
         this.set('maxLevel', 2);
-        this.set('isNewFormat', true);
 
         // when
         const screen = await render(
-          hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}} @isNewFormat={{this.isNewFormat}}/>`
+          hbs`<TargetProfiles::Stages @targetProfileId={{123}} @stageCollection={{this.stageCollection}} @maxLevel={{this.maxLevel}}/>`
         );
 
         // then

--- a/api/db/seeds/data/learning-content/target-profiles-builder.js
+++ b/api/db/seeds/data/learning-content/target-profiles-builder.js
@@ -12,12 +12,14 @@ module.exports = {
 
 async function _createTargetProfile500(databaseBuilder) {
   const configTargetProfile = {
-    frameworks: [{
-      chooseCoreFramework: true,
-      countTubes: 30,
-      minLevel: 3,
-      maxLevel: 5,
-    }],
+    frameworks: [
+      {
+        chooseCoreFramework: true,
+        countTubes: 30,
+        minLevel: 3,
+        maxLevel: 5,
+      },
+    ],
   };
   const configBadge = {
     criteria: [
@@ -38,7 +40,8 @@ async function _createTargetProfile500(databaseBuilder) {
     isPublic: true,
     ownerOrganizationId: PRO_COMPANY_ID,
     isSimplifiedAccess: false,
-    description: 'Profil cible pur pix (Niv3 ~ 5) avec 1 RT double critère (tube et participation) et des paliers NIVEAUX',
+    description:
+      'Profil cible pur pix (Niv3 ~ 5) avec 1 RT double critère (tube et participation) et des paliers NIVEAUX',
     configTargetProfile,
   });
   createBadge({
@@ -60,23 +63,27 @@ async function _createTargetProfile500(databaseBuilder) {
     targetProfileId,
     cappedTubesDTO,
     type: 'LEVEL',
-    countStages: 3,
+    countStages: 4,
+    includeFirstSkill: true,
   });
 }
 
 async function _createTargetProfile501(databaseBuilder) {
   const configTargetProfile = {
-    frameworks: [{
-      chooseCoreFramework: true,
-      countTubes: 5,
-      minLevel: 1,
-      maxLevel: 8,
-    }, {
-      chooseCoreFramework: false,
-      countTubes: 3,
-      minLevel: 1,
-      maxLevel: 8,
-    }],
+    frameworks: [
+      {
+        chooseCoreFramework: true,
+        countTubes: 5,
+        minLevel: 1,
+        maxLevel: 8,
+      },
+      {
+        chooseCoreFramework: false,
+        countTubes: 3,
+        minLevel: 1,
+        maxLevel: 8,
+      },
+    ],
   };
   const { targetProfileId, cappedTubesDTO } = await createTargetProfile({
     databaseBuilder,

--- a/api/lib/domain/models/target-profile-management/StageCollection.js
+++ b/api/lib/domain/models/target-profile-management/StageCollection.js
@@ -4,19 +4,18 @@ class StageCollection {
     this._maxLevel = maxLevel;
     this._stages = [];
 
-    stages.forEach((stage, index) => {
+    stages.forEach((stage) => {
       this._stages.push({
         id: stage.id,
         targetProfileId: id,
         level: stage.level,
         threshold: stage.threshold,
+        isFirstSkill: stage.isFirstSkill,
         title: stage.title,
         message: stage.message,
         prescriberTitle: stage.prescriberTitle,
         prescriberDescription: stage.prescriberDescription,
       });
-
-      if (index === 0) this._canAddStageTypeOfLevel = stage.level !== null;
     });
   }
 
@@ -40,6 +39,7 @@ class StageCollection {
         id: stage.id,
         level: stage.level,
         threshold: stage.threshold,
+        isFirstSkill: stage.isFirstSkill,
         title: stage.title,
         message: stage.message,
         prescriberTitle: stage.prescriberTitle,

--- a/api/lib/domain/models/target-profile-management/StageCollectionUpdate.js
+++ b/api/lib/domain/models/target-profile-management/StageCollectionUpdate.js
@@ -7,8 +7,8 @@ class StageCollectionUpdate {
   constructor({ stagesDTO, stageCollection }) {
     this._stagesDTO = stagesDTO.map((stageDTO) => ({
       id: _.isNil(stageDTO.id) ? null : parseInt(stageDTO.id),
-      threshold: _.isNil(stageDTO.threshold) ? null : parseInt(stageDTO.threshold), // null
-      level: _.isNil(stageDTO.level) ? null : parseInt(stageDTO.level), // null
+      threshold: _.isNil(stageDTO.threshold) ? null : parseInt(stageDTO.threshold),
+      level: _.isNil(stageDTO.level) ? null : parseInt(stageDTO.level),
       isFirstSkill: Boolean(stageDTO.isFirstSkill),
       title: _.isEmpty(stageDTO.title) ? '' : stageDTO.title,
       message: _.isEmpty(stageDTO.message) ? '' : stageDTO.message,
@@ -44,11 +44,28 @@ class StageCollectionUpdate {
 }
 
 function _checkValidity(stagesDTO, stageCollection) {
+  if (stagesDTO.length === 0) return;
+  const thresholds = stagesDTO.filter(({ threshold }) => threshold !== null);
+  const levels = stagesDTO.filter(({ level }) => level !== null);
+  _checkZeroStagePresence(stagesDTO);
+  _checkFirstSkillStageValidity(stagesDTO);
+  _checkAllStagesHaveValue(stagesDTO);
+  _checkAllStageAreOfTheSameType(thresholds, levels);
+  _checkAllStagesHaveUniqueValue(stagesDTO);
+  _checkAllStagesHaveTitleAndMessage(stagesDTO);
+  _checkLevelValues(levels, stageCollection.maxLevel);
+  _checkThresholdValues(thresholds);
+  _checkTargetProfileIds(stagesDTO, stageCollection);
+}
+
+function _checkZeroStagePresence(stagesDTO) {
   const hasZeroStage = stagesDTO.find(({ threshold, level }) => threshold === 0 || level === 0);
   if (!hasZeroStage && stagesDTO.length > 0) {
     throw new InvalidStageError('La présence du palier zéro est obligatoire.');
   }
+}
 
+function _checkFirstSkillStageValidity(stagesDTO) {
   const firstSkills = stagesDTO.filter(({ isFirstSkill }) => isFirstSkill);
   if (firstSkills.length > 1) {
     throw new InvalidStageError("Il ne peut y avoir qu'un seul palier premier acquis.");
@@ -56,21 +73,24 @@ function _checkValidity(stagesDTO, stageCollection) {
   if (firstSkills.length === 1 && (firstSkills[0].level !== null || firstSkills[0].threshold !== null)) {
     throw new InvalidStageError('Un palier de premier acquis ne peut pas avoir de niveau ou de seuil.');
   }
+}
 
+function _checkAllStagesHaveValue(stagesDTO) {
   const stagesWithoutValue = stagesDTO.filter(
     ({ threshold, level, isFirstSkill }) => threshold === null && level === null && !isFirstSkill
   );
   if (stagesWithoutValue.length > 0) {
     throw new InvalidStageError('Les paliers doivent avoir une valeur de seuil ou de niveau.');
   }
+}
 
-  const thresholds = stagesDTO.filter(({ threshold }) => threshold !== null);
-  const levels = stagesDTO.filter(({ level }) => level !== null);
-
+function _checkAllStageAreOfTheSameType(thresholds, levels) {
   if (thresholds.length !== 0 && levels.length !== 0) {
     throw new InvalidStageError('Les paliers doivent être tous en niveau ou seuil.');
   }
+}
 
+function _checkAllStagesHaveUniqueValue(stagesDTO) {
   const uniqValues = new Set(
     stagesDTO.map(({ level, threshold, isFirstSkill }) => {
       if (isFirstSkill) {
@@ -82,20 +102,26 @@ function _checkValidity(stagesDTO, stageCollection) {
   if (uniqValues.size !== stagesDTO.length) {
     throw new InvalidStageError('Les valeurs de seuil/niveau doivent être uniques.');
   }
+}
 
+function _checkAllStagesHaveTitleAndMessage(stagesDTO) {
   if (stagesDTO.find(({ title, message }) => title === '' || message === '')) {
     throw new InvalidStageError("Le titre et le message d'un palier sont obligatoires.");
   }
+}
 
+function _checkLevelValues(levels, maxLevel) {
   if (levels.length > 0) {
-    if (Math.max(...levels.map(({ level }) => level)) > stageCollection.maxLevel) {
+    if (Math.max(...levels.map(({ level }) => level)) > maxLevel) {
       throw new InvalidStageError("Le niveau d'un palier dépasse le niveau maximum du profil cible.");
     }
     if (Math.min(...levels.map(({ level }) => level)) < 0) {
       throw new InvalidStageError("Le niveau d'un palier doit être supérieur à zéro.");
     }
   }
+}
 
+function _checkThresholdValues(thresholds) {
   if (thresholds.length > 0) {
     if (Math.max(...thresholds.map(({ threshold }) => threshold)) > 100) {
       throw new InvalidStageError('Le seuil ne doit pas dépasser 100.');
@@ -104,7 +130,9 @@ function _checkValidity(stagesDTO, stageCollection) {
       throw new InvalidStageError('Le seuil doit être supérieur à zéro.');
     }
   }
+}
 
+function _checkTargetProfileIds(stagesDTO, stageCollection) {
   const currentStageIds = stageCollection.stages.map(({ id }) => id);
   const difference = stagesDTO.filter(({ id }) => id !== null && !currentStageIds.includes(id));
   if (difference.length > 0) {

--- a/api/lib/infrastructure/repositories/target-profile-management/stage-collection-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-management/stage-collection-repository.js
@@ -18,6 +18,7 @@ module.exports = {
       id: stage.id,
       level: stage.level,
       threshold: stage.threshold,
+      isFirstSkill: stage.isFirstSkill,
       title: stage.title,
       message: stage.message,
       prescriberTitle: stage.prescriberTitle,
@@ -27,6 +28,7 @@ module.exports = {
     const stagesToCreate = stageCollectionUpdate.stagesToCreate.map((stage) => ({
       level: stage.level,
       threshold: stage.threshold,
+      isFirstSkill: stage.isFirstSkill,
       title: stage.title,
       message: stage.message,
       prescriberTitle: stage.prescriberTitle,

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer.js
@@ -53,7 +53,15 @@ module.exports = {
         stages: {
           ref: 'id',
           included: true,
-          attributes: ['threshold', 'level', 'title', 'message', 'prescriberTitle', 'prescriberDescription'],
+          attributes: [
+            'threshold',
+            'level',
+            'isFirstSkill',
+            'title',
+            'message',
+            'prescriberTitle',
+            'prescriberDescription',
+          ],
         },
       },
       areas: {

--- a/api/tests/integration/application/stage-collections/stage-collection-controller_test.js
+++ b/api/tests/integration/application/stage-collections/stage-collection-controller_test.js
@@ -64,9 +64,10 @@ describe('Integration | Application | stage-collection-controller', function () 
                   prescriberDescription: 'Palier niveau 0 description prescripteur',
                 },
                 {
-                  id: 456,
+                  id: '456',
                   level: 1,
                   threshold: null,
+                  isFirstSkill: false,
                   title: 'Palier niveau 1 titre',
                   message: 'Palier niveau 1 message',
                   prescriberTitle: 'Palier niveau 1 titre prescripteur',
@@ -81,6 +82,16 @@ describe('Integration | Application | stage-collection-controller', function () 
                   prescriberTitle: 'Palier niveau 2 titre prescripteur',
                   prescriberDescription: 'Palier niveau 2 description prescripteur',
                 },
+                {
+                  id: null,
+                  level: null,
+                  threshold: null,
+                  isFirstSkill: true,
+                  title: 'Palier premier acquis titre',
+                  message: 'Palier premier acquis message',
+                  prescriberTitle: 'Palier premier acquis titre prescripteur',
+                  prescriberDescription: 'Palier premier acquis description prescripteur',
+                },
               ],
             },
           },
@@ -92,26 +103,39 @@ describe('Integration | Application | stage-collection-controller', function () 
 
       // then
       const currentStageCollection = await stageCollectionRepository.getByTargetProfileId(targetProfileId);
-      const newStageId = currentStageCollection.stages
+      const newStageIds = currentStageCollection.stages
         .map(({ id }) => id)
-        .filter((value) => ![123, 456, 789].includes(value))[0];
+        .filter((value) => ![123, 456, 789].includes(value))
+        .sort();
       expect(currentStageCollection.toDTO()).to.deep.equal({
         id: targetProfileId,
         targetProfileId,
         stages: [
           {
-            id: newStageId,
+            id: newStageIds[0],
             level: 2,
             threshold: null,
+            isFirstSkill: false,
             title: 'Palier niveau 2 titre',
             message: 'Palier niveau 2 message',
             prescriberTitle: 'Palier niveau 2 titre prescripteur',
             prescriberDescription: 'Palier niveau 2 description prescripteur',
           },
           {
+            id: newStageIds[1],
+            level: null,
+            threshold: null,
+            isFirstSkill: true,
+            title: 'Palier premier acquis titre',
+            message: 'Palier premier acquis message',
+            prescriberTitle: 'Palier premier acquis titre prescripteur',
+            prescriberDescription: 'Palier premier acquis description prescripteur',
+          },
+          {
             id: 123,
             level: 0,
             threshold: null,
+            isFirstSkill: false,
             title: 'Palier niveau 0 titre',
             message: 'Palier niveau 0 message',
             prescriberTitle: 'Palier niveau 0 titre prescripteur',
@@ -121,6 +145,7 @@ describe('Integration | Application | stage-collection-controller', function () 
             id: 456,
             level: 1,
             threshold: null,
+            isFirstSkill: false,
             title: 'Palier niveau 1 titre',
             message: 'Palier niveau 1 message',
             prescriberTitle: 'Palier niveau 1 titre prescripteur',

--- a/api/tests/unit/domain/models/target-profile-management/StageCollectionUpdate_test.js
+++ b/api/tests/unit/domain/models/target-profile-management/StageCollectionUpdate_test.js
@@ -12,7 +12,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
             const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 8 });
             const stagesDTO = [
               {
-                id: 123,
+                id: null,
                 level: null,
                 threshold: 10,
                 title: 'Palier seuil 10 titre',
@@ -21,7 +21,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
                 prescriberDescription: 'Palier seuil 10 message prescripteur',
               },
               {
-                id: 456,
+                id: null,
                 level: null,
                 threshold: 50,
                 title: 'Palier seuil 50 titre',
@@ -48,7 +48,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
             const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 8 });
             const stagesDTO = [
               {
-                id: 123,
+                id: null,
                 level: null,
                 threshold: 0,
                 title: 'Palier seuil 0 titre',
@@ -57,7 +57,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
                 prescriberDescription: 'Palier seuil 0 message prescripteur',
               },
               {
-                id: 456,
+                id: null,
                 level: null,
                 threshold: null,
                 title: 'Palier seuil titre',
@@ -84,7 +84,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
             const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 8 });
             const stagesDTO = [
               {
-                id: 123,
+                id: null,
                 level: null,
                 threshold: 0,
                 title: 'Palier seuil 0 titre',
@@ -93,7 +93,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
                 prescriberDescription: 'Palier seuil 0 message prescripteur',
               },
               {
-                id: 456,
+                id: null,
                 level: null,
                 threshold: 50,
                 title: 'Palier seuil 50 titre',
@@ -102,7 +102,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
                 prescriberDescription: 'Palier seuil 50 message prescripteur',
               },
               {
-                id: 789,
+                id: null,
                 level: 5,
                 threshold: null,
                 title: 'Palier niveau 5 titre',
@@ -129,7 +129,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
             const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 8 });
             const stagesDTO = [
               {
-                id: 123,
+                id: null,
                 level: null,
                 threshold: 0,
                 title: 'Palier seuil 0 titre',
@@ -138,7 +138,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
                 prescriberDescription: 'Palier seuil 0 message prescripteur',
               },
               {
-                id: 456,
+                id: null,
                 level: null,
                 threshold: 50,
                 title: 'Palier seuil 50 titre',
@@ -147,7 +147,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
                 prescriberDescription: 'Palier seuil 50 message prescripteur',
               },
               {
-                id: 789,
+                id: null,
                 level: null,
                 threshold: 60,
                 title: 'Palier seuil 60 titre',
@@ -183,7 +183,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
             const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 8 });
             const stagesDTO = [
               {
-                id: 123,
+                id: null,
                 level: null,
                 threshold: 0,
                 title: null,
@@ -210,7 +210,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
             const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 8 });
             const stagesDTO = [
               {
-                id: 123,
+                id: null,
                 level: null,
                 threshold: 0,
                 title: 'Palier seuil 0 titre',
@@ -237,7 +237,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
             const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 2 });
             const stagesDTO = [
               {
-                id: 123,
+                id: null,
                 level: null,
                 threshold: 101,
                 title: 'Palier seuil 10 titre',
@@ -246,7 +246,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
                 prescriberDescription: 'Palier seuil 10 message prescripteur',
               },
               {
-                id: 456,
+                id: null,
                 level: null,
                 threshold: 0,
                 title: 'Palier seuil 0 titre',
@@ -273,7 +273,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
             const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 2 });
             const stagesDTO = [
               {
-                id: 123,
+                id: null,
                 level: null,
                 threshold: -1,
                 title: 'Palier seuil 10 titre',
@@ -282,7 +282,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
                 prescriberDescription: 'Palier seuil 10 message prescripteur',
               },
               {
-                id: 456,
+                id: null,
                 level: null,
                 threshold: 0,
                 title: 'Palier seuil 0 titre',
@@ -358,6 +358,91 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
             });
           }
         );
+        context('when collection has several first skill stages', function () {
+          it('should throw an error', function () {
+            // given
+            const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 2 });
+            const stagesDTO = [
+              {
+                id: null,
+                level: null,
+                threshold: null,
+                isFirstSkill: true,
+                title: 'Palier premier acquis 1 titre',
+                message: 'Palier premier acquis 1 message',
+                prescriberTitle: 'Palier premier acquis 1 titre prescripteur',
+                prescriberDescription: 'Palier premier acquis 1 message prescripteur',
+              },
+              {
+                id: null,
+                level: null,
+                threshold: 0,
+                isFirstSkill: false,
+                title: 'Palier seuil 0 titre',
+                message: 'Palier seuil 0 message',
+                prescriberTitle: 'Palier seuil 0 titre prescripteur',
+                prescriberDescription: 'Palier seuil 0 message prescripteur',
+              },
+              {
+                id: null,
+                level: null,
+                threshold: null,
+                isFirstSkill: true,
+                title: 'Palier premier acquis 2 titre',
+                message: 'Palier premier acquis 2 message',
+                prescriberTitle: 'Palier premier acquis 2 titre prescripteur',
+                prescriberDescription: 'Palier premier acquis 2 message prescripteur',
+              },
+            ];
+
+            // when
+            try {
+              new StageCollectionUpdate({ stagesDTO, stageCollection });
+              expect.fail('Expected error to have been thrown');
+            } catch (err) {
+              // then
+              expect(err).to.be.instanceOf(InvalidStageError);
+              expect(err.message).to.equal("Il ne peut y avoir qu'un seul palier premier acquis.");
+            }
+          });
+        });
+        context('when collection has a first skill stage with a threshold', function () {
+          it('should throw an error', function () {
+            // given
+            const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 2 });
+            const stagesDTO = [
+              {
+                id: null,
+                level: null,
+                threshold: 0,
+                title: 'Palier seuil 0 titre',
+                message: 'Palier seuil 0 message',
+                prescriberTitle: 'Palier seuil 0 titre prescripteur',
+                prescriberDescription: 'Palier seuil 0 message prescripteur',
+              },
+              {
+                id: null,
+                level: null,
+                threshold: 20,
+                isFirstSkill: true,
+                title: 'Palier premier acquis invalide titre',
+                message: 'Palier premier acquis invalide message',
+                prescriberTitle: 'Palier premier acquis invalide titre prescripteur',
+                prescriberDescription: 'Palier premier acquis invalide message prescripteur',
+              },
+            ];
+
+            // when
+            try {
+              new StageCollectionUpdate({ stagesDTO, stageCollection });
+              expect.fail('Expected error to have been thrown');
+            } catch (err) {
+              // then
+              expect(err).to.be.instanceOf(InvalidStageError);
+              expect(err.message).to.equal('Un palier de premier acquis ne peut pas avoir de niveau ou de seuil.');
+            }
+          });
+        });
       });
       context('when in a level collection', function () {
         context('when collection has no zero stage but has some other stages', function () {
@@ -366,7 +451,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
             const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 8 });
             const stagesDTO = [
               {
-                id: 123,
+                id: null,
                 level: 1,
                 threshold: null,
                 title: 'Palier niveau 1 titre',
@@ -375,7 +460,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
                 prescriberDescription: 'Palier niveau 1 message prescripteur',
               },
               {
-                id: 456,
+                id: null,
                 level: 5,
                 threshold: null,
                 title: 'Palier niveau 5 titre',
@@ -402,7 +487,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
             const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 8 });
             const stagesDTO = [
               {
-                id: 123,
+                id: null,
                 level: 0,
                 threshold: null,
                 title: 'Palier niveau 0 titre',
@@ -411,7 +496,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
                 prescriberDescription: 'Palier niveau 0 message prescripteur',
               },
               {
-                id: 456,
+                id: null,
                 level: null,
                 threshold: null,
                 title: 'Palier niveau titre',
@@ -438,7 +523,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
             const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 8 });
             const stagesDTO = [
               {
-                id: 123,
+                id: null,
                 level: null,
                 threshold: 0,
                 title: 'Palier seuil 0 titre',
@@ -447,7 +532,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
                 prescriberDescription: 'Palier seuil 0 message prescripteur',
               },
               {
-                id: 456,
+                id: null,
                 level: 5,
                 threshold: null,
                 title: 'Palier niveau 5 titre',
@@ -456,7 +541,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
                 prescriberDescription: 'Palier niveau 5 message prescripteur',
               },
               {
-                id: 789,
+                id: null,
                 level: null,
                 threshold: 50,
                 title: 'Palier seuil 50 titre',
@@ -483,7 +568,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
             const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 8 });
             const stagesDTO = [
               {
-                id: 123,
+                id: null,
                 level: 0,
                 threshold: null,
                 title: 'Palier niveau 0 titre',
@@ -492,7 +577,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
                 prescriberDescription: 'Palier niveau 1 message prescripteur',
               },
               {
-                id: 456,
+                id: null,
                 level: 5,
                 threshold: null,
                 title: 'Palier niveau 5 titre',
@@ -501,7 +586,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
                 prescriberDescription: 'Palier niveau 5 message prescripteur',
               },
               {
-                id: 789,
+                id: null,
                 level: 7,
                 threshold: null,
                 title: 'Palier niveau 7 titre',
@@ -537,7 +622,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
             const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 8 });
             const stagesDTO = [
               {
-                id: 123,
+                id: null,
                 level: 0,
                 threshold: null,
                 title: null,
@@ -564,7 +649,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
             const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 8 });
             const stagesDTO = [
               {
-                id: 123,
+                id: null,
                 level: 0,
                 threshold: null,
                 title: 'Palier niveau 0 titre',
@@ -591,7 +676,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
             const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 2 });
             const stagesDTO = [
               {
-                id: 123,
+                id: null,
                 level: 0,
                 threshold: null,
                 title: 'Palier niveau 0 titre',
@@ -600,7 +685,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
                 prescriberDescription: 'Palier niveau 0 message prescripteur',
               },
               {
-                id: 456,
+                id: null,
                 level: 2,
                 threshold: null,
                 title: 'Palier niveau 2 titre',
@@ -609,7 +694,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
                 prescriberDescription: 'Palier niveau 2 message prescripteur',
               },
               {
-                id: 789,
+                id: null,
                 level: 3,
                 threshold: null,
                 title: 'Palier niveau 3 titre',
@@ -636,7 +721,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
             const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 2 });
             const stagesDTO = [
               {
-                id: 123,
+                id: null,
                 level: 0,
                 threshold: null,
                 title: 'Palier niveau 0 titre',
@@ -645,7 +730,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
                 prescriberDescription: 'Palier niveau 0 message prescripteur',
               },
               {
-                id: 456,
+                id: null,
                 level: 2,
                 threshold: null,
                 title: 'Palier niveau 2 titre',
@@ -654,7 +739,7 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
                 prescriberDescription: 'Palier niveau 2 message prescripteur',
               },
               {
-                id: 789,
+                id: null,
                 level: -1,
                 threshold: null,
                 title: 'Palier niveau 3 titre',
@@ -730,6 +815,91 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
             });
           }
         );
+        context('when collection has several first skill stages', function () {
+          it('should throw an error', function () {
+            // given
+            const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 2 });
+            const stagesDTO = [
+              {
+                id: null,
+                level: 0,
+                threshold: null,
+                isFirstSkill: false,
+                title: 'Palier niveau 0 titre',
+                message: 'Palier niveau 0 message',
+                prescriberTitle: 'Palier niveau 0 titre prescripteur',
+                prescriberDescription: 'Palier niveau 0 message prescripteur',
+              },
+              {
+                id: null,
+                level: null,
+                threshold: null,
+                isFirstSkill: true,
+                title: 'Palier premier acquis 1 titre',
+                message: 'Palier premier acquis 1 message',
+                prescriberTitle: 'Palier premier acquis 1 titre prescripteur',
+                prescriberDescription: 'Palier premier acquis 1 message prescripteur',
+              },
+              {
+                id: null,
+                level: null,
+                threshold: null,
+                isFirstSkill: true,
+                title: 'Palier premier acquis 2 titre',
+                message: 'Palier premier acquis 2 message',
+                prescriberTitle: 'Palier premier acquis 2 titre prescripteur',
+                prescriberDescription: 'Palier premier acquis 2 message prescripteur',
+              },
+            ];
+
+            // when
+            try {
+              new StageCollectionUpdate({ stagesDTO, stageCollection });
+              expect.fail('Expected error to have been thrown');
+            } catch (err) {
+              // then
+              expect(err).to.be.instanceOf(InvalidStageError);
+              expect(err.message).to.equal("Il ne peut y avoir qu'un seul palier premier acquis.");
+            }
+          });
+        });
+        context('when collection has a first skill stage with a level', function () {
+          it('should throw an error', function () {
+            // given
+            const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({ maxLevel: 2 });
+            const stagesDTO = [
+              {
+                id: null,
+                level: 0,
+                threshold: null,
+                title: 'Palier niveau 0 titre',
+                message: 'Palier niveau 0 message',
+                prescriberTitle: 'Palier niveau 0 titre prescripteur',
+                prescriberDescription: 'Palier niveau 0 message prescripteur',
+              },
+              {
+                id: null,
+                level: 1,
+                threshold: null,
+                isFirstSkill: true,
+                title: 'Palier premier acquis invalide titre',
+                message: 'Palier premier acquis invalide message',
+                prescriberTitle: 'Palier premier acquis invalide titre prescripteur',
+                prescriberDescription: 'Palier premier acquis invalide message prescripteur',
+              },
+            ];
+
+            // when
+            try {
+              new StageCollectionUpdate({ stagesDTO, stageCollection });
+              expect.fail('Expected error to have been thrown');
+            } catch (err) {
+              // then
+              expect(err).to.be.instanceOf(InvalidStageError);
+              expect(err.message).to.equal('Un palier de premier acquis ne peut pas avoir de niveau ou de seuil.');
+            }
+          });
+        });
       });
     });
     context('when business rules are valid', function () {
@@ -814,6 +984,101 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
           // then
           expect(collection).to.be.instanceOf(StageCollectionUpdate);
         });
+
+        it('should successfully build the collection with a first skill stage', function () {
+          // given
+          const oldStages = [
+            {
+              id: 123,
+              level: null,
+              threshold: 0,
+              title: 'Palier seuil 0 titre',
+              message: 'Palier seuil 0 message',
+              prescriberTitle: 'Palier seuil 0 titre prescripteur',
+              prescriberDescription: 'Palier seuil 0 message prescripteur',
+            },
+            {
+              id: 456,
+              level: null,
+              threshold: 50,
+              title: 'Palier seuil 50 titre',
+              message: 'Palier seuil 50 message',
+              prescriberTitle: 'Palier seuil 50 titre prescripteur',
+              prescriberDescription: 'Palier seuil 50 message prescripteur',
+            },
+            {
+              id: 789,
+              level: null,
+              threshold: 60,
+              title: 'Palier seuil 60 titre',
+              message: 'Palier seuil 60 message',
+              prescriberTitle: 'Palier seuil 60 titre prescripteur',
+              prescriberDescription: 'Palier seuil 60 message prescripteur',
+            },
+          ];
+          const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({
+            stages: oldStages,
+            maxLevel: 8,
+          });
+          const stagesDTO = [
+            {
+              id: '123',
+              level: null,
+              threshold: 0,
+              isFirstSkill: false,
+              title: 'Palier seuil 0 titre',
+              message: 'Palier seuil 0 message',
+              prescriberTitle: 'Palier seuil 0 titre prescripteur',
+              prescriberDescription: 'Palier seuil 0 message prescripteur',
+            },
+            {
+              id: 456,
+              level: null,
+              threshold: 50,
+              isFirstSkill: false,
+              title: 'Palier seuil 50 titre',
+              message: 'Palier seuil 50 message',
+              prescriberTitle: 'Palier seuil 50 titre prescripteur',
+              prescriberDescription: 'Palier seuil 50 message prescripteur',
+            },
+            {
+              id: 789,
+              level: null,
+              threshold: 60,
+              isFirstSkill: false,
+              title: 'Palier seuil 60 titre',
+              message: 'Palier seuil 60 message',
+              prescriberTitle: 'Palier seuil 60 titre prescripteur',
+              prescriberDescription: 'Palier seuil 60 message prescripteur',
+            },
+            {
+              id: null,
+              level: null,
+              threshold: 80,
+              isFirstSkill: false,
+              title: 'Palier seuil 80 titre',
+              message: 'Palier seuil 80 message',
+              prescriberTitle: 'Palier seuil 80 prescripteur',
+              prescriberDescription: 'Palier seuil 80 prescripteur',
+            },
+            {
+              id: null,
+              level: null,
+              threshold: null,
+              isFirstSkill: true,
+              title: 'Palier premier acquis titre',
+              message: 'Palier premier acquis message',
+              prescriberTitle: 'Palier premier acquis prescripteur',
+              prescriberDescription: 'Palier premier acquis prescripteur',
+            },
+          ];
+
+          // when
+          const collection = new StageCollectionUpdate({ stagesDTO, stageCollection });
+
+          // then
+          expect(collection).to.be.instanceOf(StageCollectionUpdate);
+        });
       });
       context('when in a level collection', function () {
         it('should successfully build the collection', function () {
@@ -887,6 +1152,97 @@ describe('Unit | Domain | Models | target-profile-management/StageCollectionUpda
               message: 'Palier niveau 3 message',
               prescriberTitle: 'Palier niveau 3 titre prescripteur',
               prescriberDescription: 'Palier niveau 3 message prescripteur',
+            },
+          ];
+
+          // when
+          const collection = new StageCollectionUpdate({ stagesDTO, stageCollection });
+
+          // then
+          expect(collection).to.be.instanceOf(StageCollectionUpdate);
+        });
+        it('should successfully build the collection with a first skill stage', function () {
+          // given
+          const oldStages = [
+            {
+              id: 123,
+              level: 0,
+              threshold: null,
+              title: 'Palier niveau 0 titre',
+              message: 'Palier niveau 0 message',
+              prescriberTitle: 'Palier niveau 0 titre prescripteur',
+              prescriberDescription: 'Palier niveau 0 message prescripteur',
+            },
+            {
+              id: 456,
+              level: 1,
+              threshold: null,
+              title: 'Palier niveau 1 titre',
+              message: 'Palier niveau 1 message',
+              prescriberTitle: 'Palier niveau 1 titre prescripteur',
+              prescriberDescription: 'Palier niveau 1 message prescripteur',
+            },
+            {
+              id: 789,
+              level: 2,
+              threshold: null,
+              title: 'Palier niveau 2 titre',
+              message: 'Palier niveau 2 message',
+              prescriberTitle: 'Palier niveau 2 titre prescripteur',
+              prescriberDescription: 'Palier niveau 2 message prescripteur',
+            },
+          ];
+          const stageCollection = domainBuilder.buildStageCollectionForTargetProfileManagement({
+            stages: oldStages,
+            maxLevel: 8,
+          });
+          const stagesDTO = [
+            {
+              id: 123,
+              level: 0,
+              threshold: null,
+              title: 'Palier niveau 0 titre',
+              message: 'Palier niveau 0 message',
+              prescriberTitle: 'Palier niveau 0 titre prescripteur',
+              prescriberDescription: 'Palier niveau 0 message prescripteur',
+            },
+            {
+              id: 456,
+              level: 1,
+              threshold: null,
+              title: 'Palier niveau 1 titre',
+              message: 'Palier niveau 1 message',
+              prescriberTitle: 'Palier niveau 1 titre prescripteur',
+              prescriberDescription: 'Palier niveau 1 message prescripteur',
+            },
+            {
+              id: 789,
+              level: 2,
+              threshold: null,
+              title: 'Palier niveau 2 titre',
+              message: 'Palier niveau 2 message',
+              prescriberTitle: 'Palier niveau 2 titre prescripteur',
+              prescriberDescription: 'Palier niveau 2 message prescripteur',
+            },
+            {
+              id: null,
+              level: 3,
+              threshold: null,
+              isFirstSkill: false,
+              title: 'Palier niveau 3 titre',
+              message: 'Palier niveau 3 message',
+              prescriberTitle: 'Palier niveau 3 titre prescripteur',
+              prescriberDescription: 'Palier niveau 3 message prescripteur',
+            },
+            {
+              id: null,
+              level: null,
+              threshold: null,
+              isFirstSkill: true,
+              title: 'Palier premier acquis titre',
+              message: 'Palier premier acquis message',
+              prescriberTitle: 'Palier premier acquis titre prescripteur',
+              prescriberDescription: 'Palier premier acquis message prescripteur',
             },
           ];
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-for-admin-serializer_test.js
@@ -49,6 +49,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
             id: 500,
             level: 4,
             threshold: null,
+            isFirstSkill: false,
             title: 'titre 500',
             message: 'message 500',
             prescriberTitle: 'titre prescripteur 500',
@@ -58,10 +59,21 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
             id: 501,
             level: 5,
             threshold: null,
+            isFirstSkill: false,
             title: 'titre 501',
             message: 'message 501',
             prescriberTitle: 'titre prescripteur 501',
             prescriberDescription: 'description prescripteur 501',
+          },
+          {
+            id: 502,
+            level: null,
+            threshold: null,
+            isFirstSkill: true,
+            title: 'titre 502',
+            message: 'message 502',
+            prescriberTitle: 'titre prescripteur 502',
+            prescriberDescription: 'description prescripteur 502',
           },
         ],
       });
@@ -290,6 +302,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
           {
             attributes: {
               level: 4,
+              'is-first-skill': false,
               message: 'message 500',
               'prescriber-description': 'description prescripteur 500',
               'prescriber-title': 'titre prescripteur 500',
@@ -302,6 +315,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
           {
             attributes: {
               level: 5,
+              'is-first-skill': false,
               message: 'message 501',
               'prescriber-description': 'description prescripteur 501',
               'prescriber-title': 'titre prescripteur 501',
@@ -309,6 +323,19 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
               title: 'titre 501',
             },
             id: '501',
+            type: 'stages',
+          },
+          {
+            attributes: {
+              level: null,
+              'is-first-skill': true,
+              message: 'message 502',
+              'prescriber-description': 'description prescripteur 502',
+              'prescriber-title': 'titre prescripteur 502',
+              threshold: null,
+              title: 'titre 502',
+            },
+            id: '502',
             type: 'stages',
           },
           {
@@ -325,6 +352,10 @@ describe('Unit | Serializer | JSONAPI | target-profile-for-admin-serializer', fu
                   },
                   {
                     id: '501',
+                    type: 'stages',
+                  },
+                  {
+                    id: '502',
                     type: 'stages',
                   },
                 ],


### PR DESCRIPTION
## :unicorn: Problème
Le métier doit pouvoir ajouter un palier 1er acquis à un profil cible

## :robot: Proposition
- Gestion des règles métier relatives à l'ajout d'un palier premier acquis dans la collection de paliers
- Affichage correct du palier premier acquis dans tous les écrans pertinents (ajout / affichages / modification)
- Ajouter un bouton dédié pour pouvoir ajouter un seul et unique palier "1er acquis"

## :rainbow: Remarques
On ne peut pas modifier un palier premier acquis en changeant sa valeur, cad le transformer en palier niveau 3 par exemple.

## :100: Pour tester
Tester toutes les features autour des paliers 
